### PR TITLE
Fix resource accessors compilation when there are huge number of resource files.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
@@ -56,7 +56,7 @@ internal abstract class GenerateResClassTask : DefaultTask() {
                     }
                     .groupBy { it.type }
                     .mapValues { (_, items) -> items.groupBy { it.name } }
-                getResFileSpec(resources, packageName.get()).writeTo(kotlinDir)
+                getResFileSpecs(resources, packageName.get()).forEach { it.writeTo(kotlinDir) }
             } else {
                 logger.info("Generation Res class is disabled")
             }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -4,6 +4,7 @@ import org.jetbrains.compose.test.utils.*
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.util.zip.ZipFile
+import kotlin.io.path.relativeTo
 import kotlin.test.*
 
 class ResourcesTest : GradlePluginTestBase() {
@@ -11,9 +12,9 @@ class ResourcesTest : GradlePluginTestBase() {
     fun testGeneratedAccessors(): Unit = with(testProject("misc/commonResources")) {
         //check generated resource's accessors
         gradle("generateComposeResClass").checks {
-            assertEqualTextFiles(
-                file("build/generated/compose/resourceGenerator/kotlin/app/group/resources_test/generated/resources/Res.kt"),
-                file("expected/Res.kt")
+            assertDirectoriesContentEquals(
+                file("build/generated/compose/resourceGenerator/kotlin/app/group/resources_test/generated/resources"),
+                file("expected")
             )
         }
 
@@ -23,8 +24,8 @@ class ResourcesTest : GradlePluginTestBase() {
         )
         gradle("generateComposeResClass").checks {
             assertNotEqualTextFiles(
-                file("build/generated/compose/resourceGenerator/kotlin/app/group/resources_test/generated/resources/Res.kt"),
-                file("expected/Res.kt")
+                file("build/generated/compose/resourceGenerator/kotlin/app/group/resources_test/generated/resources/Drawable0.kt"),
+                file("expected/Drawable0.kt")
             )
         }
 
@@ -123,6 +124,12 @@ class ResourcesTest : GradlePluginTestBase() {
         file("src/commonMain/composeResources/drawable/vector_3.xml").renameTo(
             file("src/commonMain/composeResources/drawable/vector_2.xml")
         )
+        gradle("generateComposeResClass").checks {
+            assertDirectoriesContentEquals(
+                file("build/generated/compose/resourceGenerator/kotlin/app/group/resources_test/generated/resources"),
+                file("expected")
+            )
+        }
     }
 
     @Test
@@ -271,9 +278,9 @@ class ResourcesTest : GradlePluginTestBase() {
     @Test
     fun testEmptyResClass(): Unit = with(testProject("misc/emptyResources")) {
         gradle("generateComposeResClass").checks {
-            assertEqualTextFiles(
-                file("build/generated/compose/resourceGenerator/kotlin/app/group/empty_res/generated/resources/Res.kt"),
-                file("expected/Res.kt")
+            assertDirectoriesContentEquals(
+                file("build/generated/compose/resourceGenerator/kotlin/app/group/empty_res/generated/resources"),
+                file("expected")
             )
         }
     }
@@ -281,96 +288,30 @@ class ResourcesTest : GradlePluginTestBase() {
     @Test
     fun testJvmOnlyProject(): Unit = with(testProject("misc/jvmOnlyResources")) {
         gradle("generateComposeResClass").checks {
-            assertEqualTextFiles(
-                file("build/generated/compose/resourceGenerator/kotlin/me/app/jvmonlyresources/generated/resources/Res.kt"),
-                file("expected/Res.kt")
+            assertDirectoriesContentEquals(
+                file("build/generated/compose/resourceGenerator/kotlin/me/app/jvmonlyresources/generated/resources"),
+                file("expected")
             )
         }
         gradle("jar")
     }
 
     //https://github.com/JetBrains/compose-multiplatform/issues/4194
+    //https://github.com/JetBrains/compose-multiplatform/issues/4285
+    //
+    // 25_000 icons + 25_000 strings!!!
     @Test
-    fun testHugeNumberOfStrings(): Unit = with(
-        //disable cache for the test because the generateStringFiles task doesn't support it
-        testProject("misc/commonResources", defaultTestEnvironment.copy(useGradleConfigurationCache = false))
+    fun testHugeNumberOfResources(): Unit = with(
+        //disable cache for the test because the generateResourceFiles task doesn't support it
+        testProject("misc/hugeResources", defaultTestEnvironment.copy(useGradleConfigurationCache = false))
     ) {
-        file("build.gradle.kts").let { f ->
-            val originText = f.readText()
-            f.writeText(
-                buildString {
-                    appendLine("import java.util.Locale")
-                    append(originText)
-                    appendLine()
-                    append("""
-                        val template = ""${'"'}
-                            <resources>
-                                <string name="app_name">Compose Resources App</string>
-                                <string name="hello">😊 Hello world!</string>
-                                <string name="multi_line">Lorem ipsum dolor sit amet,
-                                    consectetur adipiscing elit.
-                                    Donec eget turpis ac sem ultricies consequat.</string>
-                                <string name="str_template">Hello, %1${'$'}{"$"}s! You have %2${'$'}{"$"}d new messages.</string>
-                                <string-array name="str_arr">
-                                    <item>item 1</item>
-                                    <item>item 2</item>
-                                    <item>item 3</item>
-                                </string-array>
-                                [ADDITIONAL_STRINGS]
-                            </resources>    
-                        ""${'"'}.trimIndent()
-
-                        val generateStringFiles = tasks.register("generateStringFiles") {
-                            val numberOfLanguages = 20
-                            val numberOfStrings = 500
-                            val langs = Locale.getAvailableLocales()
-                                .map { it.language }
-                                .filter { it.count() == 2 }
-                                .sorted()
-                                .distinct()
-                                .take(numberOfLanguages)
-                                .toList()
-
-                            val resourcesFolder = project.file("src/commonMain/composeResources")
-
-                            doLast {
-                                // THIS REMOVES THE `values` FOLDER IN `composeResources`
-                                // THIS REMOVES THE `values` FOLDER IN `composeResources`
-                                // Necessary when reducing the number of languages.
-                                resourcesFolder.listFiles()?.filter { it.name.startsWith("values") }?.forEach {
-                                    it.deleteRecursively()
-                                }
-
-                                langs.forEachIndexed { langIndex, lang ->
-                                    val additionalStrings =
-                                        (0 until numberOfStrings).joinToString(System.lineSeparator()) { index ->
-                                            ""${'"'}
-                                            <string name="string_${'$'}{index.toString().padStart(4, '0')}">String ${'$'}index in lang ${'$'}lang</string>
-                                            ""${'"'}.trimIndent()
-                                        }
-
-                                    val langFile = if (langIndex == 0) {
-                                        File(resourcesFolder, "values/strings.xml")
-                                    } else {
-                                        File(resourcesFolder, "values-${'$'}lang/strings.xml")
-                                    }
-                                    langFile.parentFile.mkdirs()
-                                    langFile.writeText(template.replace("[ADDITIONAL_STRINGS]", additionalStrings))
-                                }
-                            }
-                        }
-
-                        tasks.named("generateComposeResClass") {
-                            dependsOn(generateStringFiles)
-                        }
-                    """.trimIndent())
-                }
-            )
-        }
-        gradle("desktopJar").checks {
-            check.taskSuccessful(":generateStringFiles")
+        gradle("compileKotlinDesktop").checks {
+            check.taskSuccessful(":generateResourceFiles")
             check.taskSuccessful(":generateComposeResClass")
-            assertEquals(513, file("src/commonMain/composeResources/values/strings.xml").readLines().size)
+            assertDirectoriesContentEquals(
+                file("build/generated/compose/resourceGenerator/kotlin/app/group/huge/generated/resources"),
+                file("expected")
+            )
         }
     }
 
@@ -378,5 +319,26 @@ class ResourcesTest : GradlePluginTestBase() {
     @Test
     fun testBundledKotlinPoet(): Unit = with(testProject("misc/bundledKotlinPoet")) {
         gradle("generateBuildConfig")
+    }
+
+    private fun assertDirectoriesContentEquals(actual: File, expected: File) {
+        require(expected.isDirectory)
+        require(actual.isDirectory)
+        assertEquals(expected.exists(), actual.exists())
+
+        val expectedPath = expected.toPath()
+        val actualPath = actual.toPath()
+        expected.walkTopDown().forEach { expectedFile ->
+            if (!expectedFile.isDirectory) {
+                val actualFile = actualPath.resolve(expectedFile.toPath().relativeTo(expectedPath)).toFile()
+                assertEqualTextFiles(actualFile, expectedFile)
+            }
+        }
+
+        val expectedFilesCount = expected.walkTopDown()
+            .map { it.toPath().relativeTo(expectedPath) }.sorted().joinToString("\n")
+        val actualFilesCount = actual.walkTopDown()
+            .map { it.toPath().relativeTo(actualPath) }.sorted().joinToString("\n")
+        assertEquals(expectedFilesCount, actualFilesCount)
     }
 }

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/Drawable0.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/Drawable0.kt
@@ -1,0 +1,64 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.resources_test.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable0 {
+  public val _3_strange_name: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:_3_strange_name",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/3-strange-name.xml"),
+          )
+      )
+
+  public val camelCaseName: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:camelCaseName",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/camelCaseName.xml"),
+          )
+      )
+
+  public val vector: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:vector",
+          setOf(
+           
+          org.jetbrains.compose.resources.ResourceItem(setOf(org.jetbrains.compose.resources.LanguageQualifier("au"),
+          org.jetbrains.compose.resources.RegionQualifier("US"), ), "drawable-au-rUS/vector.xml"),
+           
+          org.jetbrains.compose.resources.ResourceItem(setOf(org.jetbrains.compose.resources.ThemeQualifier.DARK,
+          org.jetbrains.compose.resources.LanguageQualifier("ge"), ),
+          "drawable-dark-ge/vector.xml"),
+           
+          org.jetbrains.compose.resources.ResourceItem(setOf(org.jetbrains.compose.resources.LanguageQualifier("en"),
+          ), "drawable-en/vector.xml"),
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/vector.xml"),
+          )
+      )
+
+  public val vector_2: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:vector_2",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/vector_2.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable._3_strange_name: DrawableResource
+  get() = Drawable0._3_strange_name
+
+@ExperimentalResourceApi
+internal val Res.drawable.camelCaseName: DrawableResource
+  get() = Drawable0.camelCaseName
+
+@ExperimentalResourceApi
+internal val Res.drawable.vector: DrawableResource
+  get() = Drawable0.vector
+
+@ExperimentalResourceApi
+internal val Res.drawable.vector_2: DrawableResource
+  get() = Drawable0.vector_2

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/Font0.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/Font0.kt
@@ -1,0 +1,21 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.resources_test.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.FontResource
+
+@ExperimentalResourceApi
+private object Font0 {
+  public val emptyFont: FontResource = org.jetbrains.compose.resources.FontResource(
+        "font:emptyFont",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "font/emptyFont.otf"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.font.emptyFont: FontResource
+  get() = Font0.emptyFont

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/String0.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/String0.kt
@@ -1,0 +1,98 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.resources_test.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String0 {
+    public val PascalCase: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:PascalCase", "PascalCase",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+
+    public val _1_kebab_case: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:_1_kebab_case", "_1_kebab_case",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+
+    public val app_name: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:app_name", "app_name",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+
+    public val camelCase: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:camelCase", "camelCase",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+
+    public val hello: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:hello", "hello",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+
+    public val multi_line: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:multi_line", "multi_line",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+
+    public val str_arr: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_arr", "str_arr",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+
+    public val str_template: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_template", "str_template",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+        )
+    )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.PascalCase: StringResource
+    get() = String0.PascalCase
+
+@ExperimentalResourceApi
+internal val Res.string._1_kebab_case: StringResource
+    get() = String0._1_kebab_case
+
+@ExperimentalResourceApi
+internal val Res.string.app_name: StringResource
+    get() = String0.app_name
+
+@ExperimentalResourceApi
+internal val Res.string.camelCase: StringResource
+    get() = String0.camelCase
+
+@ExperimentalResourceApi
+internal val Res.string.hello: StringResource
+    get() = String0.hello
+
+@ExperimentalResourceApi
+internal val Res.string.multi_line: StringResource
+    get() = String0.multi_line
+
+@ExperimentalResourceApi
+internal val Res.string.str_arr: StringResource
+    get() = String0.str_arr
+
+@ExperimentalResourceApi
+internal val Res.string.str_template: StringResource
+    get() = String0.str_template

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/src/commonMain/kotlin/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/src/commonMain/kotlin/App.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import app.group.resources_test.generated.resources.Res
+import app.group.resources_test.generated.resources.app_name
+import app.group.resources_test.generated.resources.emptyFont
+import app.group.resources_test.generated.resources.vector
 import org.jetbrains.compose.resources.*
 
 @OptIn(ExperimentalResourceApi::class)

--- a/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/Res.kt
@@ -22,4 +22,10 @@ internal object Res {
      * @return The content of the file as a byte array.
      */
     public suspend fun readBytes(path: String): ByteArray = readResourceBytes(path)
+
+    public object drawable
+
+    public object string
+
+    public object font
 }

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    kotlin("multiplatform")
+    id("org.jetbrains.compose")
+}
+
+group = "app.group"
+
+kotlin {
+    jvm("desktop")
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.material)
+                implementation(compose.components.resources)
+            }
+        }
+    }
+}
+
+val generateResourceFiles = tasks.register("generateResourceFiles") {
+    val resourcesFolder = project.file("src/commonMain/composeResources")
+    val count = 25_000
+    doLast {
+        val txt = buildString {
+            appendLine("<resources>")
+            repeat(count) {
+                appendLine("    <string name=\"str_${it}\">str_${it}</string>")
+            }
+            appendLine("</resources>")
+        }
+        File(resourcesFolder, "values/strings.xml").apply {
+            parentFile.mkdirs()
+            writeText(txt)
+        }
+    }
+    doLast {
+        repeat(count) {
+            File(resourcesFolder, "drawable/icon_$it.xml").apply {
+                parentFile.mkdirs()
+                createNewFile() //empty file
+            }
+        }
+    }
+}
+
+tasks.named("generateComposeResClass") {
+    dependsOn(generateResourceFiles)
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable0.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable0.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable0 {
+  public val icon_0: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_0",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_0.xml"),
+          )
+      )
+
+  public val icon_1: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1.xml"),
+          )
+      )
+
+  public val icon_10: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10.xml"),
+          )
+      )
+
+  public val icon_100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_100.xml"),
+          )
+      )
+
+  public val icon_1000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1000.xml"),
+          )
+      )
+
+  public val icon_10000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10000.xml"),
+          )
+      )
+
+  public val icon_10001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10001.xml"),
+          )
+      )
+
+  public val icon_10002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10002.xml"),
+          )
+      )
+
+  public val icon_10003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10003.xml"),
+          )
+      )
+
+  public val icon_10004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10004.xml"),
+          )
+      )
+
+  public val icon_10005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10005.xml"),
+          )
+      )
+
+  public val icon_10006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10006.xml"),
+          )
+      )
+
+  public val icon_10007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10007.xml"),
+          )
+      )
+
+  public val icon_10008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10008.xml"),
+          )
+      )
+
+  public val icon_10009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10009.xml"),
+          )
+      )
+
+  public val icon_1001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1001.xml"),
+          )
+      )
+
+  public val icon_10010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10010.xml"),
+          )
+      )
+
+  public val icon_10011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10011.xml"),
+          )
+      )
+
+  public val icon_10012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10012.xml"),
+          )
+      )
+
+  public val icon_10013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10013.xml"),
+          )
+      )
+
+  public val icon_10014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10014.xml"),
+          )
+      )
+
+  public val icon_10015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10015.xml"),
+          )
+      )
+
+  public val icon_10016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10016.xml"),
+          )
+      )
+
+  public val icon_10017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10017.xml"),
+          )
+      )
+
+  public val icon_10018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10018.xml"),
+          )
+      )
+
+  public val icon_10019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10019.xml"),
+          )
+      )
+
+  public val icon_1002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1002.xml"),
+          )
+      )
+
+  public val icon_10020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10020.xml"),
+          )
+      )
+
+  public val icon_10021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10021.xml"),
+          )
+      )
+
+  public val icon_10022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10022.xml"),
+          )
+      )
+
+  public val icon_10023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10023.xml"),
+          )
+      )
+
+  public val icon_10024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10024.xml"),
+          )
+      )
+
+  public val icon_10025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10025.xml"),
+          )
+      )
+
+  public val icon_10026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10026.xml"),
+          )
+      )
+
+  public val icon_10027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10027.xml"),
+          )
+      )
+
+  public val icon_10028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10028.xml"),
+          )
+      )
+
+  public val icon_10029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10029.xml"),
+          )
+      )
+
+  public val icon_1003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1003.xml"),
+          )
+      )
+
+  public val icon_10030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10030.xml"),
+          )
+      )
+
+  public val icon_10031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10031.xml"),
+          )
+      )
+
+  public val icon_10032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10032.xml"),
+          )
+      )
+
+  public val icon_10033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10033.xml"),
+          )
+      )
+
+  public val icon_10034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10034.xml"),
+          )
+      )
+
+  public val icon_10035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10035.xml"),
+          )
+      )
+
+  public val icon_10036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10036.xml"),
+          )
+      )
+
+  public val icon_10037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10037.xml"),
+          )
+      )
+
+  public val icon_10038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10038.xml"),
+          )
+      )
+
+  public val icon_10039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10039.xml"),
+          )
+      )
+
+  public val icon_1004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1004.xml"),
+          )
+      )
+
+  public val icon_10040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10040.xml"),
+          )
+      )
+
+  public val icon_10041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10041.xml"),
+          )
+      )
+
+  public val icon_10042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10042.xml"),
+          )
+      )
+
+  public val icon_10043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10043.xml"),
+          )
+      )
+
+  public val icon_10044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10044.xml"),
+          )
+      )
+
+  public val icon_10045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10045.xml"),
+          )
+      )
+
+  public val icon_10046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10046.xml"),
+          )
+      )
+
+  public val icon_10047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10047.xml"),
+          )
+      )
+
+  public val icon_10048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10048.xml"),
+          )
+      )
+
+  public val icon_10049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10049.xml"),
+          )
+      )
+
+  public val icon_1005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1005.xml"),
+          )
+      )
+
+  public val icon_10050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10050.xml"),
+          )
+      )
+
+  public val icon_10051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10051.xml"),
+          )
+      )
+
+  public val icon_10052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10052.xml"),
+          )
+      )
+
+  public val icon_10053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10053.xml"),
+          )
+      )
+
+  public val icon_10054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10054.xml"),
+          )
+      )
+
+  public val icon_10055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10055.xml"),
+          )
+      )
+
+  public val icon_10056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10056.xml"),
+          )
+      )
+
+  public val icon_10057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10057.xml"),
+          )
+      )
+
+  public val icon_10058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10058.xml"),
+          )
+      )
+
+  public val icon_10059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10059.xml"),
+          )
+      )
+
+  public val icon_1006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1006.xml"),
+          )
+      )
+
+  public val icon_10060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10060.xml"),
+          )
+      )
+
+  public val icon_10061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10061.xml"),
+          )
+      )
+
+  public val icon_10062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10062.xml"),
+          )
+      )
+
+  public val icon_10063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10063.xml"),
+          )
+      )
+
+  public val icon_10064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10064.xml"),
+          )
+      )
+
+  public val icon_10065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10065.xml"),
+          )
+      )
+
+  public val icon_10066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10066.xml"),
+          )
+      )
+
+  public val icon_10067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10067.xml"),
+          )
+      )
+
+  public val icon_10068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10068.xml"),
+          )
+      )
+
+  public val icon_10069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10069.xml"),
+          )
+      )
+
+  public val icon_1007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1007.xml"),
+          )
+      )
+
+  public val icon_10070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10070.xml"),
+          )
+      )
+
+  public val icon_10071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10071.xml"),
+          )
+      )
+
+  public val icon_10072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10072.xml"),
+          )
+      )
+
+  public val icon_10073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10073.xml"),
+          )
+      )
+
+  public val icon_10074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10074.xml"),
+          )
+      )
+
+  public val icon_10075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10075.xml"),
+          )
+      )
+
+  public val icon_10076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10076.xml"),
+          )
+      )
+
+  public val icon_10077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10077.xml"),
+          )
+      )
+
+  public val icon_10078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10078.xml"),
+          )
+      )
+
+  public val icon_10079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10079.xml"),
+          )
+      )
+
+  public val icon_1008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1008.xml"),
+          )
+      )
+
+  public val icon_10080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10080.xml"),
+          )
+      )
+
+  public val icon_10081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10081.xml"),
+          )
+      )
+
+  public val icon_10082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10082.xml"),
+          )
+      )
+
+  public val icon_10083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10083.xml"),
+          )
+      )
+
+  public val icon_10084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10084.xml"),
+          )
+      )
+
+  public val icon_10085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10085.xml"),
+          )
+      )
+
+  public val icon_10086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10086.xml"),
+          )
+      )
+
+  public val icon_10087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10087.xml"),
+          )
+      )
+
+  public val icon_10088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10088.xml"),
+          )
+      )
+
+  public val icon_10089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10089.xml"),
+          )
+      )
+
+  public val icon_1009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1009.xml"),
+          )
+      )
+
+  public val icon_10090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10090.xml"),
+          )
+      )
+
+  public val icon_10091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10091.xml"),
+          )
+      )
+
+  public val icon_10092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10092.xml"),
+          )
+      )
+
+  public val icon_10093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10093.xml"),
+          )
+      )
+
+  public val icon_10094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10094.xml"),
+          )
+      )
+
+  public val icon_10095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10095.xml"),
+          )
+      )
+
+  public val icon_10096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10096.xml"),
+          )
+      )
+
+  public val icon_10097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10097.xml"),
+          )
+      )
+
+  public val icon_10098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10098.xml"),
+          )
+      )
+
+  public val icon_10099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10099.xml"),
+          )
+      )
+
+  public val icon_101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_101.xml"),
+          )
+      )
+
+  public val icon_1010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1010.xml"),
+          )
+      )
+
+  public val icon_10100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10100.xml"),
+          )
+      )
+
+  public val icon_10101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10101.xml"),
+          )
+      )
+
+  public val icon_10102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10102.xml"),
+          )
+      )
+
+  public val icon_10103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10103.xml"),
+          )
+      )
+
+  public val icon_10104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10104.xml"),
+          )
+      )
+
+  public val icon_10105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10105.xml"),
+          )
+      )
+
+  public val icon_10106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10106.xml"),
+          )
+      )
+
+  public val icon_10107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10107.xml"),
+          )
+      )
+
+  public val icon_10108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10108.xml"),
+          )
+      )
+
+  public val icon_10109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10109.xml"),
+          )
+      )
+
+  public val icon_1011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1011.xml"),
+          )
+      )
+
+  public val icon_10110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10110.xml"),
+          )
+      )
+
+  public val icon_10111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10111.xml"),
+          )
+      )
+
+  public val icon_10112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10112.xml"),
+          )
+      )
+
+  public val icon_10113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10113.xml"),
+          )
+      )
+
+  public val icon_10114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10114.xml"),
+          )
+      )
+
+  public val icon_10115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10115.xml"),
+          )
+      )
+
+  public val icon_10116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10116.xml"),
+          )
+      )
+
+  public val icon_10117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10117.xml"),
+          )
+      )
+
+  public val icon_10118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10118.xml"),
+          )
+      )
+
+  public val icon_10119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10119.xml"),
+          )
+      )
+
+  public val icon_1012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1012.xml"),
+          )
+      )
+
+  public val icon_10120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10120.xml"),
+          )
+      )
+
+  public val icon_10121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10121.xml"),
+          )
+      )
+
+  public val icon_10122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10122.xml"),
+          )
+      )
+
+  public val icon_10123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10123.xml"),
+          )
+      )
+
+  public val icon_10124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10124.xml"),
+          )
+      )
+
+  public val icon_10125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10125.xml"),
+          )
+      )
+
+  public val icon_10126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10126.xml"),
+          )
+      )
+
+  public val icon_10127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10127.xml"),
+          )
+      )
+
+  public val icon_10128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10128.xml"),
+          )
+      )
+
+  public val icon_10129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10129.xml"),
+          )
+      )
+
+  public val icon_1013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1013.xml"),
+          )
+      )
+
+  public val icon_10130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10130.xml"),
+          )
+      )
+
+  public val icon_10131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10131.xml"),
+          )
+      )
+
+  public val icon_10132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10132.xml"),
+          )
+      )
+
+  public val icon_10133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10133.xml"),
+          )
+      )
+
+  public val icon_10134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10134.xml"),
+          )
+      )
+
+  public val icon_10135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10135.xml"),
+          )
+      )
+
+  public val icon_10136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10136.xml"),
+          )
+      )
+
+  public val icon_10137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10137.xml"),
+          )
+      )
+
+  public val icon_10138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10138.xml"),
+          )
+      )
+
+  public val icon_10139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10139.xml"),
+          )
+      )
+
+  public val icon_1014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1014.xml"),
+          )
+      )
+
+  public val icon_10140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10140.xml"),
+          )
+      )
+
+  public val icon_10141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10141.xml"),
+          )
+      )
+
+  public val icon_10142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10142.xml"),
+          )
+      )
+
+  public val icon_10143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10143.xml"),
+          )
+      )
+
+  public val icon_10144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10144.xml"),
+          )
+      )
+
+  public val icon_10145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10145.xml"),
+          )
+      )
+
+  public val icon_10146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10146.xml"),
+          )
+      )
+
+  public val icon_10147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10147.xml"),
+          )
+      )
+
+  public val icon_10148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10148.xml"),
+          )
+      )
+
+  public val icon_10149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10149.xml"),
+          )
+      )
+
+  public val icon_1015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1015.xml"),
+          )
+      )
+
+  public val icon_10150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10150.xml"),
+          )
+      )
+
+  public val icon_10151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10151.xml"),
+          )
+      )
+
+  public val icon_10152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10152.xml"),
+          )
+      )
+
+  public val icon_10153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10153.xml"),
+          )
+      )
+
+  public val icon_10154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10154.xml"),
+          )
+      )
+
+  public val icon_10155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10155.xml"),
+          )
+      )
+
+  public val icon_10156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10156.xml"),
+          )
+      )
+
+  public val icon_10157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10157.xml"),
+          )
+      )
+
+  public val icon_10158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10158.xml"),
+          )
+      )
+
+  public val icon_10159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10159.xml"),
+          )
+      )
+
+  public val icon_1016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1016.xml"),
+          )
+      )
+
+  public val icon_10160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10160.xml"),
+          )
+      )
+
+  public val icon_10161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10161.xml"),
+          )
+      )
+
+  public val icon_10162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10162.xml"),
+          )
+      )
+
+  public val icon_10163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10163.xml"),
+          )
+      )
+
+  public val icon_10164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10164.xml"),
+          )
+      )
+
+  public val icon_10165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10165.xml"),
+          )
+      )
+
+  public val icon_10166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10166.xml"),
+          )
+      )
+
+  public val icon_10167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10167.xml"),
+          )
+      )
+
+  public val icon_10168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10168.xml"),
+          )
+      )
+
+  public val icon_10169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10169.xml"),
+          )
+      )
+
+  public val icon_1017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1017.xml"),
+          )
+      )
+
+  public val icon_10170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10170.xml"),
+          )
+      )
+
+  public val icon_10171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10171.xml"),
+          )
+      )
+
+  public val icon_10172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10172.xml"),
+          )
+      )
+
+  public val icon_10173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10173.xml"),
+          )
+      )
+
+  public val icon_10174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10174.xml"),
+          )
+      )
+
+  public val icon_10175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10175.xml"),
+          )
+      )
+
+  public val icon_10176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10176.xml"),
+          )
+      )
+
+  public val icon_10177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10177.xml"),
+          )
+      )
+
+  public val icon_10178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10178.xml"),
+          )
+      )
+
+  public val icon_10179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10179.xml"),
+          )
+      )
+
+  public val icon_1018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1018.xml"),
+          )
+      )
+
+  public val icon_10180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10180.xml"),
+          )
+      )
+
+  public val icon_10181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10181.xml"),
+          )
+      )
+
+  public val icon_10182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10182.xml"),
+          )
+      )
+
+  public val icon_10183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10183.xml"),
+          )
+      )
+
+  public val icon_10184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10184.xml"),
+          )
+      )
+
+  public val icon_10185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10185.xml"),
+          )
+      )
+
+  public val icon_10186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10186.xml"),
+          )
+      )
+
+  public val icon_10187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10187.xml"),
+          )
+      )
+
+  public val icon_10188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10188.xml"),
+          )
+      )
+
+  public val icon_10189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10189.xml"),
+          )
+      )
+
+  public val icon_1019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1019.xml"),
+          )
+      )
+
+  public val icon_10190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10190.xml"),
+          )
+      )
+
+  public val icon_10191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10191.xml"),
+          )
+      )
+
+  public val icon_10192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10192.xml"),
+          )
+      )
+
+  public val icon_10193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10193.xml"),
+          )
+      )
+
+  public val icon_10194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10194.xml"),
+          )
+      )
+
+  public val icon_10195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10195.xml"),
+          )
+      )
+
+  public val icon_10196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10196.xml"),
+          )
+      )
+
+  public val icon_10197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10197.xml"),
+          )
+      )
+
+  public val icon_10198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10198.xml"),
+          )
+      )
+
+  public val icon_10199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10199.xml"),
+          )
+      )
+
+  public val icon_102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_102.xml"),
+          )
+      )
+
+  public val icon_1020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1020.xml"),
+          )
+      )
+
+  public val icon_10200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10200.xml"),
+          )
+      )
+
+  public val icon_10201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10201.xml"),
+          )
+      )
+
+  public val icon_10202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10202.xml"),
+          )
+      )
+
+  public val icon_10203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10203.xml"),
+          )
+      )
+
+  public val icon_10204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10204.xml"),
+          )
+      )
+
+  public val icon_10205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10205.xml"),
+          )
+      )
+
+  public val icon_10206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10206.xml"),
+          )
+      )
+
+  public val icon_10207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10207.xml"),
+          )
+      )
+
+  public val icon_10208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10208.xml"),
+          )
+      )
+
+  public val icon_10209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10209.xml"),
+          )
+      )
+
+  public val icon_1021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1021.xml"),
+          )
+      )
+
+  public val icon_10210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10210.xml"),
+          )
+      )
+
+  public val icon_10211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10211.xml"),
+          )
+      )
+
+  public val icon_10212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10212.xml"),
+          )
+      )
+
+  public val icon_10213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10213.xml"),
+          )
+      )
+
+  public val icon_10214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10214.xml"),
+          )
+      )
+
+  public val icon_10215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10215.xml"),
+          )
+      )
+
+  public val icon_10216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10216.xml"),
+          )
+      )
+
+  public val icon_10217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10217.xml"),
+          )
+      )
+
+  public val icon_10218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10218.xml"),
+          )
+      )
+
+  public val icon_10219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10219.xml"),
+          )
+      )
+
+  public val icon_1022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1022.xml"),
+          )
+      )
+
+  public val icon_10220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10220.xml"),
+          )
+      )
+
+  public val icon_10221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10221.xml"),
+          )
+      )
+
+  public val icon_10222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10222.xml"),
+          )
+      )
+
+  public val icon_10223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10223.xml"),
+          )
+      )
+
+  public val icon_10224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10224.xml"),
+          )
+      )
+
+  public val icon_10225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10225.xml"),
+          )
+      )
+
+  public val icon_10226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10226.xml"),
+          )
+      )
+
+  public val icon_10227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10227.xml"),
+          )
+      )
+
+  public val icon_10228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10228.xml"),
+          )
+      )
+
+  public val icon_10229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10229.xml"),
+          )
+      )
+
+  public val icon_1023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1023.xml"),
+          )
+      )
+
+  public val icon_10230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10230.xml"),
+          )
+      )
+
+  public val icon_10231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10231.xml"),
+          )
+      )
+
+  public val icon_10232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10232.xml"),
+          )
+      )
+
+  public val icon_10233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10233.xml"),
+          )
+      )
+
+  public val icon_10234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10234.xml"),
+          )
+      )
+
+  public val icon_10235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10235.xml"),
+          )
+      )
+
+  public val icon_10236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10236.xml"),
+          )
+      )
+
+  public val icon_10237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10237.xml"),
+          )
+      )
+
+  public val icon_10238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10238.xml"),
+          )
+      )
+
+  public val icon_10239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10239.xml"),
+          )
+      )
+
+  public val icon_1024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1024.xml"),
+          )
+      )
+
+  public val icon_10240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10240.xml"),
+          )
+      )
+
+  public val icon_10241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10241.xml"),
+          )
+      )
+
+  public val icon_10242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10242.xml"),
+          )
+      )
+
+  public val icon_10243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10243.xml"),
+          )
+      )
+
+  public val icon_10244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10244.xml"),
+          )
+      )
+
+  public val icon_10245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10245.xml"),
+          )
+      )
+
+  public val icon_10246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10246.xml"),
+          )
+      )
+
+  public val icon_10247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10247.xml"),
+          )
+      )
+
+  public val icon_10248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10248.xml"),
+          )
+      )
+
+  public val icon_10249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10249.xml"),
+          )
+      )
+
+  public val icon_1025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1025.xml"),
+          )
+      )
+
+  public val icon_10250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10250.xml"),
+          )
+      )
+
+  public val icon_10251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10251.xml"),
+          )
+      )
+
+  public val icon_10252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10252.xml"),
+          )
+      )
+
+  public val icon_10253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10253.xml"),
+          )
+      )
+
+  public val icon_10254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10254.xml"),
+          )
+      )
+
+  public val icon_10255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10255.xml"),
+          )
+      )
+
+  public val icon_10256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10256.xml"),
+          )
+      )
+
+  public val icon_10257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10257.xml"),
+          )
+      )
+
+  public val icon_10258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10258.xml"),
+          )
+      )
+
+  public val icon_10259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10259.xml"),
+          )
+      )
+
+  public val icon_1026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1026.xml"),
+          )
+      )
+
+  public val icon_10260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10260.xml"),
+          )
+      )
+
+  public val icon_10261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10261.xml"),
+          )
+      )
+
+  public val icon_10262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10262.xml"),
+          )
+      )
+
+  public val icon_10263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10263.xml"),
+          )
+      )
+
+  public val icon_10264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10264.xml"),
+          )
+      )
+
+  public val icon_10265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10265.xml"),
+          )
+      )
+
+  public val icon_10266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10266.xml"),
+          )
+      )
+
+  public val icon_10267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10267.xml"),
+          )
+      )
+
+  public val icon_10268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10268.xml"),
+          )
+      )
+
+  public val icon_10269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10269.xml"),
+          )
+      )
+
+  public val icon_1027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1027.xml"),
+          )
+      )
+
+  public val icon_10270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10270.xml"),
+          )
+      )
+
+  public val icon_10271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10271.xml"),
+          )
+      )
+
+  public val icon_10272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10272.xml"),
+          )
+      )
+
+  public val icon_10273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10273.xml"),
+          )
+      )
+
+  public val icon_10274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10274.xml"),
+          )
+      )
+
+  public val icon_10275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10275.xml"),
+          )
+      )
+
+  public val icon_10276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10276.xml"),
+          )
+      )
+
+  public val icon_10277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10277.xml"),
+          )
+      )
+
+  public val icon_10278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10278.xml"),
+          )
+      )
+
+  public val icon_10279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10279.xml"),
+          )
+      )
+
+  public val icon_1028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1028.xml"),
+          )
+      )
+
+  public val icon_10280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10280.xml"),
+          )
+      )
+
+  public val icon_10281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10281.xml"),
+          )
+      )
+
+  public val icon_10282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10282.xml"),
+          )
+      )
+
+  public val icon_10283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10283.xml"),
+          )
+      )
+
+  public val icon_10284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10284.xml"),
+          )
+      )
+
+  public val icon_10285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10285.xml"),
+          )
+      )
+
+  public val icon_10286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10286.xml"),
+          )
+      )
+
+  public val icon_10287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10287.xml"),
+          )
+      )
+
+  public val icon_10288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10288.xml"),
+          )
+      )
+
+  public val icon_10289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10289.xml"),
+          )
+      )
+
+  public val icon_1029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1029.xml"),
+          )
+      )
+
+  public val icon_10290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10290.xml"),
+          )
+      )
+
+  public val icon_10291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10291.xml"),
+          )
+      )
+
+  public val icon_10292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10292.xml"),
+          )
+      )
+
+  public val icon_10293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10293.xml"),
+          )
+      )
+
+  public val icon_10294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10294.xml"),
+          )
+      )
+
+  public val icon_10295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10295.xml"),
+          )
+      )
+
+  public val icon_10296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10296.xml"),
+          )
+      )
+
+  public val icon_10297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10297.xml"),
+          )
+      )
+
+  public val icon_10298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10298.xml"),
+          )
+      )
+
+  public val icon_10299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10299.xml"),
+          )
+      )
+
+  public val icon_103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_103.xml"),
+          )
+      )
+
+  public val icon_1030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1030.xml"),
+          )
+      )
+
+  public val icon_10300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10300.xml"),
+          )
+      )
+
+  public val icon_10301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10301.xml"),
+          )
+      )
+
+  public val icon_10302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10302.xml"),
+          )
+      )
+
+  public val icon_10303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10303.xml"),
+          )
+      )
+
+  public val icon_10304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10304.xml"),
+          )
+      )
+
+  public val icon_10305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10305.xml"),
+          )
+      )
+
+  public val icon_10306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10306.xml"),
+          )
+      )
+
+  public val icon_10307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10307.xml"),
+          )
+      )
+
+  public val icon_10308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10308.xml"),
+          )
+      )
+
+  public val icon_10309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10309.xml"),
+          )
+      )
+
+  public val icon_1031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1031.xml"),
+          )
+      )
+
+  public val icon_10310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10310.xml"),
+          )
+      )
+
+  public val icon_10311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10311.xml"),
+          )
+      )
+
+  public val icon_10312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10312.xml"),
+          )
+      )
+
+  public val icon_10313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10313.xml"),
+          )
+      )
+
+  public val icon_10314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10314.xml"),
+          )
+      )
+
+  public val icon_10315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10315.xml"),
+          )
+      )
+
+  public val icon_10316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10316.xml"),
+          )
+      )
+
+  public val icon_10317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10317.xml"),
+          )
+      )
+
+  public val icon_10318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10318.xml"),
+          )
+      )
+
+  public val icon_10319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10319.xml"),
+          )
+      )
+
+  public val icon_1032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1032.xml"),
+          )
+      )
+
+  public val icon_10320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10320.xml"),
+          )
+      )
+
+  public val icon_10321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10321.xml"),
+          )
+      )
+
+  public val icon_10322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10322.xml"),
+          )
+      )
+
+  public val icon_10323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10323.xml"),
+          )
+      )
+
+  public val icon_10324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10324.xml"),
+          )
+      )
+
+  public val icon_10325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10325.xml"),
+          )
+      )
+
+  public val icon_10326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10326.xml"),
+          )
+      )
+
+  public val icon_10327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10327.xml"),
+          )
+      )
+
+  public val icon_10328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10328.xml"),
+          )
+      )
+
+  public val icon_10329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10329.xml"),
+          )
+      )
+
+  public val icon_1033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1033.xml"),
+          )
+      )
+
+  public val icon_10330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10330.xml"),
+          )
+      )
+
+  public val icon_10331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10331.xml"),
+          )
+      )
+
+  public val icon_10332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10332.xml"),
+          )
+      )
+
+  public val icon_10333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10333.xml"),
+          )
+      )
+
+  public val icon_10334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10334.xml"),
+          )
+      )
+
+  public val icon_10335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10335.xml"),
+          )
+      )
+
+  public val icon_10336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10336.xml"),
+          )
+      )
+
+  public val icon_10337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10337.xml"),
+          )
+      )
+
+  public val icon_10338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10338.xml"),
+          )
+      )
+
+  public val icon_10339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10339.xml"),
+          )
+      )
+
+  public val icon_1034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1034.xml"),
+          )
+      )
+
+  public val icon_10340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10340.xml"),
+          )
+      )
+
+  public val icon_10341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10341.xml"),
+          )
+      )
+
+  public val icon_10342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10342.xml"),
+          )
+      )
+
+  public val icon_10343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10343.xml"),
+          )
+      )
+
+  public val icon_10344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10344.xml"),
+          )
+      )
+
+  public val icon_10345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10345.xml"),
+          )
+      )
+
+  public val icon_10346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10346.xml"),
+          )
+      )
+
+  public val icon_10347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10347.xml"),
+          )
+      )
+
+  public val icon_10348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10348.xml"),
+          )
+      )
+
+  public val icon_10349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10349.xml"),
+          )
+      )
+
+  public val icon_1035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1035.xml"),
+          )
+      )
+
+  public val icon_10350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10350.xml"),
+          )
+      )
+
+  public val icon_10351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10351.xml"),
+          )
+      )
+
+  public val icon_10352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10352.xml"),
+          )
+      )
+
+  public val icon_10353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10353.xml"),
+          )
+      )
+
+  public val icon_10354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10354.xml"),
+          )
+      )
+
+  public val icon_10355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10355.xml"),
+          )
+      )
+
+  public val icon_10356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10356.xml"),
+          )
+      )
+
+  public val icon_10357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10357.xml"),
+          )
+      )
+
+  public val icon_10358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10358.xml"),
+          )
+      )
+
+  public val icon_10359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10359.xml"),
+          )
+      )
+
+  public val icon_1036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1036.xml"),
+          )
+      )
+
+  public val icon_10360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10360.xml"),
+          )
+      )
+
+  public val icon_10361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10361.xml"),
+          )
+      )
+
+  public val icon_10362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10362.xml"),
+          )
+      )
+
+  public val icon_10363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10363.xml"),
+          )
+      )
+
+  public val icon_10364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10364.xml"),
+          )
+      )
+
+  public val icon_10365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10365.xml"),
+          )
+      )
+
+  public val icon_10366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10366.xml"),
+          )
+      )
+
+  public val icon_10367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10367.xml"),
+          )
+      )
+
+  public val icon_10368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10368.xml"),
+          )
+      )
+
+  public val icon_10369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10369.xml"),
+          )
+      )
+
+  public val icon_1037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1037.xml"),
+          )
+      )
+
+  public val icon_10370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10370.xml"),
+          )
+      )
+
+  public val icon_10371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10371.xml"),
+          )
+      )
+
+  public val icon_10372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10372.xml"),
+          )
+      )
+
+  public val icon_10373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10373.xml"),
+          )
+      )
+
+  public val icon_10374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10374.xml"),
+          )
+      )
+
+  public val icon_10375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10375.xml"),
+          )
+      )
+
+  public val icon_10376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10376.xml"),
+          )
+      )
+
+  public val icon_10377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10377.xml"),
+          )
+      )
+
+  public val icon_10378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10378.xml"),
+          )
+      )
+
+  public val icon_10379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10379.xml"),
+          )
+      )
+
+  public val icon_1038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1038.xml"),
+          )
+      )
+
+  public val icon_10380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10380.xml"),
+          )
+      )
+
+  public val icon_10381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10381.xml"),
+          )
+      )
+
+  public val icon_10382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10382.xml"),
+          )
+      )
+
+  public val icon_10383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10383.xml"),
+          )
+      )
+
+  public val icon_10384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10384.xml"),
+          )
+      )
+
+  public val icon_10385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10385.xml"),
+          )
+      )
+
+  public val icon_10386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10386.xml"),
+          )
+      )
+
+  public val icon_10387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10387.xml"),
+          )
+      )
+
+  public val icon_10388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10388.xml"),
+          )
+      )
+
+  public val icon_10389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10389.xml"),
+          )
+      )
+
+  public val icon_1039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1039.xml"),
+          )
+      )
+
+  public val icon_10390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10390.xml"),
+          )
+      )
+
+  public val icon_10391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10391.xml"),
+          )
+      )
+
+  public val icon_10392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10392.xml"),
+          )
+      )
+
+  public val icon_10393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10393.xml"),
+          )
+      )
+
+  public val icon_10394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10394.xml"),
+          )
+      )
+
+  public val icon_10395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10395.xml"),
+          )
+      )
+
+  public val icon_10396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10396.xml"),
+          )
+      )
+
+  public val icon_10397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10397.xml"),
+          )
+      )
+
+  public val icon_10398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10398.xml"),
+          )
+      )
+
+  public val icon_10399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10399.xml"),
+          )
+      )
+
+  public val icon_104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_104.xml"),
+          )
+      )
+
+  public val icon_1040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1040.xml"),
+          )
+      )
+
+  public val icon_10400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10400.xml"),
+          )
+      )
+
+  public val icon_10401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10401.xml"),
+          )
+      )
+
+  public val icon_10402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10402.xml"),
+          )
+      )
+
+  public val icon_10403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10403.xml"),
+          )
+      )
+
+  public val icon_10404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10404.xml"),
+          )
+      )
+
+  public val icon_10405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10405.xml"),
+          )
+      )
+
+  public val icon_10406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10406.xml"),
+          )
+      )
+
+  public val icon_10407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10407.xml"),
+          )
+      )
+
+  public val icon_10408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10408.xml"),
+          )
+      )
+
+  public val icon_10409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10409.xml"),
+          )
+      )
+
+  public val icon_1041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1041.xml"),
+          )
+      )
+
+  public val icon_10410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10410.xml"),
+          )
+      )
+
+  public val icon_10411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10411.xml"),
+          )
+      )
+
+  public val icon_10412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10412.xml"),
+          )
+      )
+
+  public val icon_10413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10413.xml"),
+          )
+      )
+
+  public val icon_10414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10414.xml"),
+          )
+      )
+
+  public val icon_10415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10415.xml"),
+          )
+      )
+
+  public val icon_10416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10416.xml"),
+          )
+      )
+
+  public val icon_10417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10417.xml"),
+          )
+      )
+
+  public val icon_10418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10418.xml"),
+          )
+      )
+
+  public val icon_10419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10419.xml"),
+          )
+      )
+
+  public val icon_1042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1042.xml"),
+          )
+      )
+
+  public val icon_10420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10420.xml"),
+          )
+      )
+
+  public val icon_10421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10421.xml"),
+          )
+      )
+
+  public val icon_10422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10422.xml"),
+          )
+      )
+
+  public val icon_10423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10423.xml"),
+          )
+      )
+
+  public val icon_10424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10424.xml"),
+          )
+      )
+
+  public val icon_10425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10425.xml"),
+          )
+      )
+
+  public val icon_10426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10426.xml"),
+          )
+      )
+
+  public val icon_10427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10427.xml"),
+          )
+      )
+
+  public val icon_10428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10428.xml"),
+          )
+      )
+
+  public val icon_10429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10429.xml"),
+          )
+      )
+
+  public val icon_1043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1043.xml"),
+          )
+      )
+
+  public val icon_10430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10430.xml"),
+          )
+      )
+
+  public val icon_10431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10431.xml"),
+          )
+      )
+
+  public val icon_10432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10432.xml"),
+          )
+      )
+
+  public val icon_10433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10433.xml"),
+          )
+      )
+
+  public val icon_10434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10434.xml"),
+          )
+      )
+
+  public val icon_10435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10435.xml"),
+          )
+      )
+
+  public val icon_10436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10436.xml"),
+          )
+      )
+
+  public val icon_10437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10437.xml"),
+          )
+      )
+
+  public val icon_10438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10438.xml"),
+          )
+      )
+
+  public val icon_10439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10439.xml"),
+          )
+      )
+
+  public val icon_1044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1044.xml"),
+          )
+      )
+
+  public val icon_10440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10440.xml"),
+          )
+      )
+
+  public val icon_10441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10441.xml"),
+          )
+      )
+
+  public val icon_10442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10442.xml"),
+          )
+      )
+
+  public val icon_10443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10443.xml"),
+          )
+      )
+
+  public val icon_10444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10444.xml"),
+          )
+      )
+
+  public val icon_10445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10445.xml"),
+          )
+      )
+
+  public val icon_10446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10446.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_0: DrawableResource
+  get() = Drawable0.icon_0
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1: DrawableResource
+  get() = Drawable0.icon_1
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10: DrawableResource
+  get() = Drawable0.icon_10
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_100: DrawableResource
+  get() = Drawable0.icon_100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1000: DrawableResource
+  get() = Drawable0.icon_1000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10000: DrawableResource
+  get() = Drawable0.icon_10000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10001: DrawableResource
+  get() = Drawable0.icon_10001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10002: DrawableResource
+  get() = Drawable0.icon_10002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10003: DrawableResource
+  get() = Drawable0.icon_10003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10004: DrawableResource
+  get() = Drawable0.icon_10004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10005: DrawableResource
+  get() = Drawable0.icon_10005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10006: DrawableResource
+  get() = Drawable0.icon_10006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10007: DrawableResource
+  get() = Drawable0.icon_10007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10008: DrawableResource
+  get() = Drawable0.icon_10008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10009: DrawableResource
+  get() = Drawable0.icon_10009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1001: DrawableResource
+  get() = Drawable0.icon_1001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10010: DrawableResource
+  get() = Drawable0.icon_10010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10011: DrawableResource
+  get() = Drawable0.icon_10011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10012: DrawableResource
+  get() = Drawable0.icon_10012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10013: DrawableResource
+  get() = Drawable0.icon_10013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10014: DrawableResource
+  get() = Drawable0.icon_10014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10015: DrawableResource
+  get() = Drawable0.icon_10015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10016: DrawableResource
+  get() = Drawable0.icon_10016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10017: DrawableResource
+  get() = Drawable0.icon_10017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10018: DrawableResource
+  get() = Drawable0.icon_10018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10019: DrawableResource
+  get() = Drawable0.icon_10019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1002: DrawableResource
+  get() = Drawable0.icon_1002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10020: DrawableResource
+  get() = Drawable0.icon_10020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10021: DrawableResource
+  get() = Drawable0.icon_10021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10022: DrawableResource
+  get() = Drawable0.icon_10022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10023: DrawableResource
+  get() = Drawable0.icon_10023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10024: DrawableResource
+  get() = Drawable0.icon_10024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10025: DrawableResource
+  get() = Drawable0.icon_10025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10026: DrawableResource
+  get() = Drawable0.icon_10026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10027: DrawableResource
+  get() = Drawable0.icon_10027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10028: DrawableResource
+  get() = Drawable0.icon_10028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10029: DrawableResource
+  get() = Drawable0.icon_10029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1003: DrawableResource
+  get() = Drawable0.icon_1003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10030: DrawableResource
+  get() = Drawable0.icon_10030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10031: DrawableResource
+  get() = Drawable0.icon_10031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10032: DrawableResource
+  get() = Drawable0.icon_10032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10033: DrawableResource
+  get() = Drawable0.icon_10033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10034: DrawableResource
+  get() = Drawable0.icon_10034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10035: DrawableResource
+  get() = Drawable0.icon_10035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10036: DrawableResource
+  get() = Drawable0.icon_10036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10037: DrawableResource
+  get() = Drawable0.icon_10037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10038: DrawableResource
+  get() = Drawable0.icon_10038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10039: DrawableResource
+  get() = Drawable0.icon_10039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1004: DrawableResource
+  get() = Drawable0.icon_1004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10040: DrawableResource
+  get() = Drawable0.icon_10040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10041: DrawableResource
+  get() = Drawable0.icon_10041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10042: DrawableResource
+  get() = Drawable0.icon_10042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10043: DrawableResource
+  get() = Drawable0.icon_10043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10044: DrawableResource
+  get() = Drawable0.icon_10044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10045: DrawableResource
+  get() = Drawable0.icon_10045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10046: DrawableResource
+  get() = Drawable0.icon_10046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10047: DrawableResource
+  get() = Drawable0.icon_10047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10048: DrawableResource
+  get() = Drawable0.icon_10048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10049: DrawableResource
+  get() = Drawable0.icon_10049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1005: DrawableResource
+  get() = Drawable0.icon_1005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10050: DrawableResource
+  get() = Drawable0.icon_10050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10051: DrawableResource
+  get() = Drawable0.icon_10051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10052: DrawableResource
+  get() = Drawable0.icon_10052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10053: DrawableResource
+  get() = Drawable0.icon_10053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10054: DrawableResource
+  get() = Drawable0.icon_10054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10055: DrawableResource
+  get() = Drawable0.icon_10055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10056: DrawableResource
+  get() = Drawable0.icon_10056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10057: DrawableResource
+  get() = Drawable0.icon_10057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10058: DrawableResource
+  get() = Drawable0.icon_10058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10059: DrawableResource
+  get() = Drawable0.icon_10059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1006: DrawableResource
+  get() = Drawable0.icon_1006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10060: DrawableResource
+  get() = Drawable0.icon_10060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10061: DrawableResource
+  get() = Drawable0.icon_10061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10062: DrawableResource
+  get() = Drawable0.icon_10062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10063: DrawableResource
+  get() = Drawable0.icon_10063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10064: DrawableResource
+  get() = Drawable0.icon_10064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10065: DrawableResource
+  get() = Drawable0.icon_10065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10066: DrawableResource
+  get() = Drawable0.icon_10066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10067: DrawableResource
+  get() = Drawable0.icon_10067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10068: DrawableResource
+  get() = Drawable0.icon_10068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10069: DrawableResource
+  get() = Drawable0.icon_10069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1007: DrawableResource
+  get() = Drawable0.icon_1007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10070: DrawableResource
+  get() = Drawable0.icon_10070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10071: DrawableResource
+  get() = Drawable0.icon_10071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10072: DrawableResource
+  get() = Drawable0.icon_10072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10073: DrawableResource
+  get() = Drawable0.icon_10073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10074: DrawableResource
+  get() = Drawable0.icon_10074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10075: DrawableResource
+  get() = Drawable0.icon_10075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10076: DrawableResource
+  get() = Drawable0.icon_10076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10077: DrawableResource
+  get() = Drawable0.icon_10077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10078: DrawableResource
+  get() = Drawable0.icon_10078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10079: DrawableResource
+  get() = Drawable0.icon_10079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1008: DrawableResource
+  get() = Drawable0.icon_1008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10080: DrawableResource
+  get() = Drawable0.icon_10080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10081: DrawableResource
+  get() = Drawable0.icon_10081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10082: DrawableResource
+  get() = Drawable0.icon_10082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10083: DrawableResource
+  get() = Drawable0.icon_10083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10084: DrawableResource
+  get() = Drawable0.icon_10084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10085: DrawableResource
+  get() = Drawable0.icon_10085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10086: DrawableResource
+  get() = Drawable0.icon_10086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10087: DrawableResource
+  get() = Drawable0.icon_10087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10088: DrawableResource
+  get() = Drawable0.icon_10088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10089: DrawableResource
+  get() = Drawable0.icon_10089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1009: DrawableResource
+  get() = Drawable0.icon_1009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10090: DrawableResource
+  get() = Drawable0.icon_10090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10091: DrawableResource
+  get() = Drawable0.icon_10091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10092: DrawableResource
+  get() = Drawable0.icon_10092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10093: DrawableResource
+  get() = Drawable0.icon_10093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10094: DrawableResource
+  get() = Drawable0.icon_10094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10095: DrawableResource
+  get() = Drawable0.icon_10095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10096: DrawableResource
+  get() = Drawable0.icon_10096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10097: DrawableResource
+  get() = Drawable0.icon_10097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10098: DrawableResource
+  get() = Drawable0.icon_10098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10099: DrawableResource
+  get() = Drawable0.icon_10099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_101: DrawableResource
+  get() = Drawable0.icon_101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1010: DrawableResource
+  get() = Drawable0.icon_1010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10100: DrawableResource
+  get() = Drawable0.icon_10100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10101: DrawableResource
+  get() = Drawable0.icon_10101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10102: DrawableResource
+  get() = Drawable0.icon_10102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10103: DrawableResource
+  get() = Drawable0.icon_10103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10104: DrawableResource
+  get() = Drawable0.icon_10104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10105: DrawableResource
+  get() = Drawable0.icon_10105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10106: DrawableResource
+  get() = Drawable0.icon_10106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10107: DrawableResource
+  get() = Drawable0.icon_10107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10108: DrawableResource
+  get() = Drawable0.icon_10108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10109: DrawableResource
+  get() = Drawable0.icon_10109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1011: DrawableResource
+  get() = Drawable0.icon_1011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10110: DrawableResource
+  get() = Drawable0.icon_10110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10111: DrawableResource
+  get() = Drawable0.icon_10111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10112: DrawableResource
+  get() = Drawable0.icon_10112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10113: DrawableResource
+  get() = Drawable0.icon_10113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10114: DrawableResource
+  get() = Drawable0.icon_10114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10115: DrawableResource
+  get() = Drawable0.icon_10115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10116: DrawableResource
+  get() = Drawable0.icon_10116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10117: DrawableResource
+  get() = Drawable0.icon_10117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10118: DrawableResource
+  get() = Drawable0.icon_10118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10119: DrawableResource
+  get() = Drawable0.icon_10119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1012: DrawableResource
+  get() = Drawable0.icon_1012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10120: DrawableResource
+  get() = Drawable0.icon_10120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10121: DrawableResource
+  get() = Drawable0.icon_10121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10122: DrawableResource
+  get() = Drawable0.icon_10122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10123: DrawableResource
+  get() = Drawable0.icon_10123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10124: DrawableResource
+  get() = Drawable0.icon_10124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10125: DrawableResource
+  get() = Drawable0.icon_10125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10126: DrawableResource
+  get() = Drawable0.icon_10126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10127: DrawableResource
+  get() = Drawable0.icon_10127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10128: DrawableResource
+  get() = Drawable0.icon_10128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10129: DrawableResource
+  get() = Drawable0.icon_10129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1013: DrawableResource
+  get() = Drawable0.icon_1013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10130: DrawableResource
+  get() = Drawable0.icon_10130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10131: DrawableResource
+  get() = Drawable0.icon_10131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10132: DrawableResource
+  get() = Drawable0.icon_10132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10133: DrawableResource
+  get() = Drawable0.icon_10133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10134: DrawableResource
+  get() = Drawable0.icon_10134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10135: DrawableResource
+  get() = Drawable0.icon_10135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10136: DrawableResource
+  get() = Drawable0.icon_10136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10137: DrawableResource
+  get() = Drawable0.icon_10137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10138: DrawableResource
+  get() = Drawable0.icon_10138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10139: DrawableResource
+  get() = Drawable0.icon_10139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1014: DrawableResource
+  get() = Drawable0.icon_1014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10140: DrawableResource
+  get() = Drawable0.icon_10140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10141: DrawableResource
+  get() = Drawable0.icon_10141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10142: DrawableResource
+  get() = Drawable0.icon_10142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10143: DrawableResource
+  get() = Drawable0.icon_10143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10144: DrawableResource
+  get() = Drawable0.icon_10144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10145: DrawableResource
+  get() = Drawable0.icon_10145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10146: DrawableResource
+  get() = Drawable0.icon_10146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10147: DrawableResource
+  get() = Drawable0.icon_10147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10148: DrawableResource
+  get() = Drawable0.icon_10148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10149: DrawableResource
+  get() = Drawable0.icon_10149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1015: DrawableResource
+  get() = Drawable0.icon_1015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10150: DrawableResource
+  get() = Drawable0.icon_10150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10151: DrawableResource
+  get() = Drawable0.icon_10151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10152: DrawableResource
+  get() = Drawable0.icon_10152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10153: DrawableResource
+  get() = Drawable0.icon_10153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10154: DrawableResource
+  get() = Drawable0.icon_10154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10155: DrawableResource
+  get() = Drawable0.icon_10155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10156: DrawableResource
+  get() = Drawable0.icon_10156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10157: DrawableResource
+  get() = Drawable0.icon_10157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10158: DrawableResource
+  get() = Drawable0.icon_10158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10159: DrawableResource
+  get() = Drawable0.icon_10159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1016: DrawableResource
+  get() = Drawable0.icon_1016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10160: DrawableResource
+  get() = Drawable0.icon_10160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10161: DrawableResource
+  get() = Drawable0.icon_10161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10162: DrawableResource
+  get() = Drawable0.icon_10162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10163: DrawableResource
+  get() = Drawable0.icon_10163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10164: DrawableResource
+  get() = Drawable0.icon_10164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10165: DrawableResource
+  get() = Drawable0.icon_10165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10166: DrawableResource
+  get() = Drawable0.icon_10166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10167: DrawableResource
+  get() = Drawable0.icon_10167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10168: DrawableResource
+  get() = Drawable0.icon_10168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10169: DrawableResource
+  get() = Drawable0.icon_10169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1017: DrawableResource
+  get() = Drawable0.icon_1017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10170: DrawableResource
+  get() = Drawable0.icon_10170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10171: DrawableResource
+  get() = Drawable0.icon_10171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10172: DrawableResource
+  get() = Drawable0.icon_10172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10173: DrawableResource
+  get() = Drawable0.icon_10173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10174: DrawableResource
+  get() = Drawable0.icon_10174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10175: DrawableResource
+  get() = Drawable0.icon_10175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10176: DrawableResource
+  get() = Drawable0.icon_10176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10177: DrawableResource
+  get() = Drawable0.icon_10177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10178: DrawableResource
+  get() = Drawable0.icon_10178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10179: DrawableResource
+  get() = Drawable0.icon_10179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1018: DrawableResource
+  get() = Drawable0.icon_1018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10180: DrawableResource
+  get() = Drawable0.icon_10180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10181: DrawableResource
+  get() = Drawable0.icon_10181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10182: DrawableResource
+  get() = Drawable0.icon_10182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10183: DrawableResource
+  get() = Drawable0.icon_10183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10184: DrawableResource
+  get() = Drawable0.icon_10184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10185: DrawableResource
+  get() = Drawable0.icon_10185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10186: DrawableResource
+  get() = Drawable0.icon_10186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10187: DrawableResource
+  get() = Drawable0.icon_10187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10188: DrawableResource
+  get() = Drawable0.icon_10188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10189: DrawableResource
+  get() = Drawable0.icon_10189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1019: DrawableResource
+  get() = Drawable0.icon_1019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10190: DrawableResource
+  get() = Drawable0.icon_10190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10191: DrawableResource
+  get() = Drawable0.icon_10191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10192: DrawableResource
+  get() = Drawable0.icon_10192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10193: DrawableResource
+  get() = Drawable0.icon_10193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10194: DrawableResource
+  get() = Drawable0.icon_10194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10195: DrawableResource
+  get() = Drawable0.icon_10195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10196: DrawableResource
+  get() = Drawable0.icon_10196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10197: DrawableResource
+  get() = Drawable0.icon_10197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10198: DrawableResource
+  get() = Drawable0.icon_10198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10199: DrawableResource
+  get() = Drawable0.icon_10199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_102: DrawableResource
+  get() = Drawable0.icon_102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1020: DrawableResource
+  get() = Drawable0.icon_1020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10200: DrawableResource
+  get() = Drawable0.icon_10200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10201: DrawableResource
+  get() = Drawable0.icon_10201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10202: DrawableResource
+  get() = Drawable0.icon_10202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10203: DrawableResource
+  get() = Drawable0.icon_10203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10204: DrawableResource
+  get() = Drawable0.icon_10204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10205: DrawableResource
+  get() = Drawable0.icon_10205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10206: DrawableResource
+  get() = Drawable0.icon_10206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10207: DrawableResource
+  get() = Drawable0.icon_10207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10208: DrawableResource
+  get() = Drawable0.icon_10208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10209: DrawableResource
+  get() = Drawable0.icon_10209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1021: DrawableResource
+  get() = Drawable0.icon_1021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10210: DrawableResource
+  get() = Drawable0.icon_10210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10211: DrawableResource
+  get() = Drawable0.icon_10211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10212: DrawableResource
+  get() = Drawable0.icon_10212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10213: DrawableResource
+  get() = Drawable0.icon_10213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10214: DrawableResource
+  get() = Drawable0.icon_10214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10215: DrawableResource
+  get() = Drawable0.icon_10215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10216: DrawableResource
+  get() = Drawable0.icon_10216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10217: DrawableResource
+  get() = Drawable0.icon_10217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10218: DrawableResource
+  get() = Drawable0.icon_10218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10219: DrawableResource
+  get() = Drawable0.icon_10219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1022: DrawableResource
+  get() = Drawable0.icon_1022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10220: DrawableResource
+  get() = Drawable0.icon_10220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10221: DrawableResource
+  get() = Drawable0.icon_10221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10222: DrawableResource
+  get() = Drawable0.icon_10222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10223: DrawableResource
+  get() = Drawable0.icon_10223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10224: DrawableResource
+  get() = Drawable0.icon_10224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10225: DrawableResource
+  get() = Drawable0.icon_10225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10226: DrawableResource
+  get() = Drawable0.icon_10226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10227: DrawableResource
+  get() = Drawable0.icon_10227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10228: DrawableResource
+  get() = Drawable0.icon_10228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10229: DrawableResource
+  get() = Drawable0.icon_10229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1023: DrawableResource
+  get() = Drawable0.icon_1023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10230: DrawableResource
+  get() = Drawable0.icon_10230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10231: DrawableResource
+  get() = Drawable0.icon_10231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10232: DrawableResource
+  get() = Drawable0.icon_10232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10233: DrawableResource
+  get() = Drawable0.icon_10233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10234: DrawableResource
+  get() = Drawable0.icon_10234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10235: DrawableResource
+  get() = Drawable0.icon_10235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10236: DrawableResource
+  get() = Drawable0.icon_10236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10237: DrawableResource
+  get() = Drawable0.icon_10237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10238: DrawableResource
+  get() = Drawable0.icon_10238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10239: DrawableResource
+  get() = Drawable0.icon_10239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1024: DrawableResource
+  get() = Drawable0.icon_1024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10240: DrawableResource
+  get() = Drawable0.icon_10240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10241: DrawableResource
+  get() = Drawable0.icon_10241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10242: DrawableResource
+  get() = Drawable0.icon_10242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10243: DrawableResource
+  get() = Drawable0.icon_10243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10244: DrawableResource
+  get() = Drawable0.icon_10244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10245: DrawableResource
+  get() = Drawable0.icon_10245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10246: DrawableResource
+  get() = Drawable0.icon_10246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10247: DrawableResource
+  get() = Drawable0.icon_10247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10248: DrawableResource
+  get() = Drawable0.icon_10248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10249: DrawableResource
+  get() = Drawable0.icon_10249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1025: DrawableResource
+  get() = Drawable0.icon_1025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10250: DrawableResource
+  get() = Drawable0.icon_10250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10251: DrawableResource
+  get() = Drawable0.icon_10251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10252: DrawableResource
+  get() = Drawable0.icon_10252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10253: DrawableResource
+  get() = Drawable0.icon_10253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10254: DrawableResource
+  get() = Drawable0.icon_10254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10255: DrawableResource
+  get() = Drawable0.icon_10255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10256: DrawableResource
+  get() = Drawable0.icon_10256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10257: DrawableResource
+  get() = Drawable0.icon_10257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10258: DrawableResource
+  get() = Drawable0.icon_10258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10259: DrawableResource
+  get() = Drawable0.icon_10259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1026: DrawableResource
+  get() = Drawable0.icon_1026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10260: DrawableResource
+  get() = Drawable0.icon_10260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10261: DrawableResource
+  get() = Drawable0.icon_10261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10262: DrawableResource
+  get() = Drawable0.icon_10262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10263: DrawableResource
+  get() = Drawable0.icon_10263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10264: DrawableResource
+  get() = Drawable0.icon_10264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10265: DrawableResource
+  get() = Drawable0.icon_10265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10266: DrawableResource
+  get() = Drawable0.icon_10266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10267: DrawableResource
+  get() = Drawable0.icon_10267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10268: DrawableResource
+  get() = Drawable0.icon_10268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10269: DrawableResource
+  get() = Drawable0.icon_10269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1027: DrawableResource
+  get() = Drawable0.icon_1027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10270: DrawableResource
+  get() = Drawable0.icon_10270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10271: DrawableResource
+  get() = Drawable0.icon_10271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10272: DrawableResource
+  get() = Drawable0.icon_10272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10273: DrawableResource
+  get() = Drawable0.icon_10273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10274: DrawableResource
+  get() = Drawable0.icon_10274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10275: DrawableResource
+  get() = Drawable0.icon_10275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10276: DrawableResource
+  get() = Drawable0.icon_10276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10277: DrawableResource
+  get() = Drawable0.icon_10277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10278: DrawableResource
+  get() = Drawable0.icon_10278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10279: DrawableResource
+  get() = Drawable0.icon_10279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1028: DrawableResource
+  get() = Drawable0.icon_1028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10280: DrawableResource
+  get() = Drawable0.icon_10280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10281: DrawableResource
+  get() = Drawable0.icon_10281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10282: DrawableResource
+  get() = Drawable0.icon_10282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10283: DrawableResource
+  get() = Drawable0.icon_10283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10284: DrawableResource
+  get() = Drawable0.icon_10284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10285: DrawableResource
+  get() = Drawable0.icon_10285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10286: DrawableResource
+  get() = Drawable0.icon_10286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10287: DrawableResource
+  get() = Drawable0.icon_10287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10288: DrawableResource
+  get() = Drawable0.icon_10288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10289: DrawableResource
+  get() = Drawable0.icon_10289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1029: DrawableResource
+  get() = Drawable0.icon_1029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10290: DrawableResource
+  get() = Drawable0.icon_10290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10291: DrawableResource
+  get() = Drawable0.icon_10291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10292: DrawableResource
+  get() = Drawable0.icon_10292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10293: DrawableResource
+  get() = Drawable0.icon_10293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10294: DrawableResource
+  get() = Drawable0.icon_10294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10295: DrawableResource
+  get() = Drawable0.icon_10295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10296: DrawableResource
+  get() = Drawable0.icon_10296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10297: DrawableResource
+  get() = Drawable0.icon_10297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10298: DrawableResource
+  get() = Drawable0.icon_10298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10299: DrawableResource
+  get() = Drawable0.icon_10299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_103: DrawableResource
+  get() = Drawable0.icon_103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1030: DrawableResource
+  get() = Drawable0.icon_1030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10300: DrawableResource
+  get() = Drawable0.icon_10300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10301: DrawableResource
+  get() = Drawable0.icon_10301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10302: DrawableResource
+  get() = Drawable0.icon_10302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10303: DrawableResource
+  get() = Drawable0.icon_10303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10304: DrawableResource
+  get() = Drawable0.icon_10304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10305: DrawableResource
+  get() = Drawable0.icon_10305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10306: DrawableResource
+  get() = Drawable0.icon_10306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10307: DrawableResource
+  get() = Drawable0.icon_10307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10308: DrawableResource
+  get() = Drawable0.icon_10308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10309: DrawableResource
+  get() = Drawable0.icon_10309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1031: DrawableResource
+  get() = Drawable0.icon_1031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10310: DrawableResource
+  get() = Drawable0.icon_10310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10311: DrawableResource
+  get() = Drawable0.icon_10311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10312: DrawableResource
+  get() = Drawable0.icon_10312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10313: DrawableResource
+  get() = Drawable0.icon_10313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10314: DrawableResource
+  get() = Drawable0.icon_10314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10315: DrawableResource
+  get() = Drawable0.icon_10315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10316: DrawableResource
+  get() = Drawable0.icon_10316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10317: DrawableResource
+  get() = Drawable0.icon_10317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10318: DrawableResource
+  get() = Drawable0.icon_10318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10319: DrawableResource
+  get() = Drawable0.icon_10319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1032: DrawableResource
+  get() = Drawable0.icon_1032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10320: DrawableResource
+  get() = Drawable0.icon_10320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10321: DrawableResource
+  get() = Drawable0.icon_10321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10322: DrawableResource
+  get() = Drawable0.icon_10322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10323: DrawableResource
+  get() = Drawable0.icon_10323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10324: DrawableResource
+  get() = Drawable0.icon_10324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10325: DrawableResource
+  get() = Drawable0.icon_10325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10326: DrawableResource
+  get() = Drawable0.icon_10326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10327: DrawableResource
+  get() = Drawable0.icon_10327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10328: DrawableResource
+  get() = Drawable0.icon_10328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10329: DrawableResource
+  get() = Drawable0.icon_10329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1033: DrawableResource
+  get() = Drawable0.icon_1033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10330: DrawableResource
+  get() = Drawable0.icon_10330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10331: DrawableResource
+  get() = Drawable0.icon_10331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10332: DrawableResource
+  get() = Drawable0.icon_10332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10333: DrawableResource
+  get() = Drawable0.icon_10333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10334: DrawableResource
+  get() = Drawable0.icon_10334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10335: DrawableResource
+  get() = Drawable0.icon_10335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10336: DrawableResource
+  get() = Drawable0.icon_10336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10337: DrawableResource
+  get() = Drawable0.icon_10337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10338: DrawableResource
+  get() = Drawable0.icon_10338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10339: DrawableResource
+  get() = Drawable0.icon_10339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1034: DrawableResource
+  get() = Drawable0.icon_1034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10340: DrawableResource
+  get() = Drawable0.icon_10340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10341: DrawableResource
+  get() = Drawable0.icon_10341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10342: DrawableResource
+  get() = Drawable0.icon_10342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10343: DrawableResource
+  get() = Drawable0.icon_10343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10344: DrawableResource
+  get() = Drawable0.icon_10344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10345: DrawableResource
+  get() = Drawable0.icon_10345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10346: DrawableResource
+  get() = Drawable0.icon_10346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10347: DrawableResource
+  get() = Drawable0.icon_10347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10348: DrawableResource
+  get() = Drawable0.icon_10348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10349: DrawableResource
+  get() = Drawable0.icon_10349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1035: DrawableResource
+  get() = Drawable0.icon_1035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10350: DrawableResource
+  get() = Drawable0.icon_10350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10351: DrawableResource
+  get() = Drawable0.icon_10351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10352: DrawableResource
+  get() = Drawable0.icon_10352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10353: DrawableResource
+  get() = Drawable0.icon_10353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10354: DrawableResource
+  get() = Drawable0.icon_10354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10355: DrawableResource
+  get() = Drawable0.icon_10355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10356: DrawableResource
+  get() = Drawable0.icon_10356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10357: DrawableResource
+  get() = Drawable0.icon_10357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10358: DrawableResource
+  get() = Drawable0.icon_10358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10359: DrawableResource
+  get() = Drawable0.icon_10359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1036: DrawableResource
+  get() = Drawable0.icon_1036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10360: DrawableResource
+  get() = Drawable0.icon_10360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10361: DrawableResource
+  get() = Drawable0.icon_10361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10362: DrawableResource
+  get() = Drawable0.icon_10362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10363: DrawableResource
+  get() = Drawable0.icon_10363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10364: DrawableResource
+  get() = Drawable0.icon_10364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10365: DrawableResource
+  get() = Drawable0.icon_10365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10366: DrawableResource
+  get() = Drawable0.icon_10366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10367: DrawableResource
+  get() = Drawable0.icon_10367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10368: DrawableResource
+  get() = Drawable0.icon_10368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10369: DrawableResource
+  get() = Drawable0.icon_10369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1037: DrawableResource
+  get() = Drawable0.icon_1037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10370: DrawableResource
+  get() = Drawable0.icon_10370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10371: DrawableResource
+  get() = Drawable0.icon_10371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10372: DrawableResource
+  get() = Drawable0.icon_10372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10373: DrawableResource
+  get() = Drawable0.icon_10373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10374: DrawableResource
+  get() = Drawable0.icon_10374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10375: DrawableResource
+  get() = Drawable0.icon_10375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10376: DrawableResource
+  get() = Drawable0.icon_10376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10377: DrawableResource
+  get() = Drawable0.icon_10377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10378: DrawableResource
+  get() = Drawable0.icon_10378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10379: DrawableResource
+  get() = Drawable0.icon_10379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1038: DrawableResource
+  get() = Drawable0.icon_1038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10380: DrawableResource
+  get() = Drawable0.icon_10380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10381: DrawableResource
+  get() = Drawable0.icon_10381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10382: DrawableResource
+  get() = Drawable0.icon_10382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10383: DrawableResource
+  get() = Drawable0.icon_10383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10384: DrawableResource
+  get() = Drawable0.icon_10384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10385: DrawableResource
+  get() = Drawable0.icon_10385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10386: DrawableResource
+  get() = Drawable0.icon_10386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10387: DrawableResource
+  get() = Drawable0.icon_10387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10388: DrawableResource
+  get() = Drawable0.icon_10388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10389: DrawableResource
+  get() = Drawable0.icon_10389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1039: DrawableResource
+  get() = Drawable0.icon_1039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10390: DrawableResource
+  get() = Drawable0.icon_10390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10391: DrawableResource
+  get() = Drawable0.icon_10391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10392: DrawableResource
+  get() = Drawable0.icon_10392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10393: DrawableResource
+  get() = Drawable0.icon_10393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10394: DrawableResource
+  get() = Drawable0.icon_10394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10395: DrawableResource
+  get() = Drawable0.icon_10395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10396: DrawableResource
+  get() = Drawable0.icon_10396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10397: DrawableResource
+  get() = Drawable0.icon_10397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10398: DrawableResource
+  get() = Drawable0.icon_10398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10399: DrawableResource
+  get() = Drawable0.icon_10399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_104: DrawableResource
+  get() = Drawable0.icon_104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1040: DrawableResource
+  get() = Drawable0.icon_1040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10400: DrawableResource
+  get() = Drawable0.icon_10400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10401: DrawableResource
+  get() = Drawable0.icon_10401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10402: DrawableResource
+  get() = Drawable0.icon_10402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10403: DrawableResource
+  get() = Drawable0.icon_10403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10404: DrawableResource
+  get() = Drawable0.icon_10404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10405: DrawableResource
+  get() = Drawable0.icon_10405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10406: DrawableResource
+  get() = Drawable0.icon_10406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10407: DrawableResource
+  get() = Drawable0.icon_10407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10408: DrawableResource
+  get() = Drawable0.icon_10408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10409: DrawableResource
+  get() = Drawable0.icon_10409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1041: DrawableResource
+  get() = Drawable0.icon_1041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10410: DrawableResource
+  get() = Drawable0.icon_10410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10411: DrawableResource
+  get() = Drawable0.icon_10411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10412: DrawableResource
+  get() = Drawable0.icon_10412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10413: DrawableResource
+  get() = Drawable0.icon_10413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10414: DrawableResource
+  get() = Drawable0.icon_10414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10415: DrawableResource
+  get() = Drawable0.icon_10415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10416: DrawableResource
+  get() = Drawable0.icon_10416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10417: DrawableResource
+  get() = Drawable0.icon_10417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10418: DrawableResource
+  get() = Drawable0.icon_10418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10419: DrawableResource
+  get() = Drawable0.icon_10419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1042: DrawableResource
+  get() = Drawable0.icon_1042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10420: DrawableResource
+  get() = Drawable0.icon_10420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10421: DrawableResource
+  get() = Drawable0.icon_10421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10422: DrawableResource
+  get() = Drawable0.icon_10422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10423: DrawableResource
+  get() = Drawable0.icon_10423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10424: DrawableResource
+  get() = Drawable0.icon_10424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10425: DrawableResource
+  get() = Drawable0.icon_10425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10426: DrawableResource
+  get() = Drawable0.icon_10426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10427: DrawableResource
+  get() = Drawable0.icon_10427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10428: DrawableResource
+  get() = Drawable0.icon_10428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10429: DrawableResource
+  get() = Drawable0.icon_10429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1043: DrawableResource
+  get() = Drawable0.icon_1043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10430: DrawableResource
+  get() = Drawable0.icon_10430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10431: DrawableResource
+  get() = Drawable0.icon_10431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10432: DrawableResource
+  get() = Drawable0.icon_10432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10433: DrawableResource
+  get() = Drawable0.icon_10433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10434: DrawableResource
+  get() = Drawable0.icon_10434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10435: DrawableResource
+  get() = Drawable0.icon_10435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10436: DrawableResource
+  get() = Drawable0.icon_10436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10437: DrawableResource
+  get() = Drawable0.icon_10437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10438: DrawableResource
+  get() = Drawable0.icon_10438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10439: DrawableResource
+  get() = Drawable0.icon_10439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1044: DrawableResource
+  get() = Drawable0.icon_1044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10440: DrawableResource
+  get() = Drawable0.icon_10440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10441: DrawableResource
+  get() = Drawable0.icon_10441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10442: DrawableResource
+  get() = Drawable0.icon_10442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10443: DrawableResource
+  get() = Drawable0.icon_10443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10444: DrawableResource
+  get() = Drawable0.icon_10444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10445: DrawableResource
+  get() = Drawable0.icon_10445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10446: DrawableResource
+  get() = Drawable0.icon_10446

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable1.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable1.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable1 {
+  public val icon_10447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10447.xml"),
+          )
+      )
+
+  public val icon_10448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10448.xml"),
+          )
+      )
+
+  public val icon_10449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10449.xml"),
+          )
+      )
+
+  public val icon_1045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1045.xml"),
+          )
+      )
+
+  public val icon_10450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10450.xml"),
+          )
+      )
+
+  public val icon_10451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10451.xml"),
+          )
+      )
+
+  public val icon_10452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10452.xml"),
+          )
+      )
+
+  public val icon_10453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10453.xml"),
+          )
+      )
+
+  public val icon_10454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10454.xml"),
+          )
+      )
+
+  public val icon_10455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10455.xml"),
+          )
+      )
+
+  public val icon_10456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10456.xml"),
+          )
+      )
+
+  public val icon_10457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10457.xml"),
+          )
+      )
+
+  public val icon_10458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10458.xml"),
+          )
+      )
+
+  public val icon_10459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10459.xml"),
+          )
+      )
+
+  public val icon_1046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1046.xml"),
+          )
+      )
+
+  public val icon_10460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10460.xml"),
+          )
+      )
+
+  public val icon_10461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10461.xml"),
+          )
+      )
+
+  public val icon_10462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10462.xml"),
+          )
+      )
+
+  public val icon_10463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10463.xml"),
+          )
+      )
+
+  public val icon_10464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10464.xml"),
+          )
+      )
+
+  public val icon_10465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10465.xml"),
+          )
+      )
+
+  public val icon_10466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10466.xml"),
+          )
+      )
+
+  public val icon_10467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10467.xml"),
+          )
+      )
+
+  public val icon_10468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10468.xml"),
+          )
+      )
+
+  public val icon_10469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10469.xml"),
+          )
+      )
+
+  public val icon_1047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1047.xml"),
+          )
+      )
+
+  public val icon_10470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10470.xml"),
+          )
+      )
+
+  public val icon_10471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10471.xml"),
+          )
+      )
+
+  public val icon_10472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10472.xml"),
+          )
+      )
+
+  public val icon_10473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10473.xml"),
+          )
+      )
+
+  public val icon_10474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10474.xml"),
+          )
+      )
+
+  public val icon_10475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10475.xml"),
+          )
+      )
+
+  public val icon_10476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10476.xml"),
+          )
+      )
+
+  public val icon_10477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10477.xml"),
+          )
+      )
+
+  public val icon_10478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10478.xml"),
+          )
+      )
+
+  public val icon_10479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10479.xml"),
+          )
+      )
+
+  public val icon_1048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1048.xml"),
+          )
+      )
+
+  public val icon_10480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10480.xml"),
+          )
+      )
+
+  public val icon_10481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10481.xml"),
+          )
+      )
+
+  public val icon_10482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10482.xml"),
+          )
+      )
+
+  public val icon_10483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10483.xml"),
+          )
+      )
+
+  public val icon_10484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10484.xml"),
+          )
+      )
+
+  public val icon_10485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10485.xml"),
+          )
+      )
+
+  public val icon_10486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10486.xml"),
+          )
+      )
+
+  public val icon_10487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10487.xml"),
+          )
+      )
+
+  public val icon_10488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10488.xml"),
+          )
+      )
+
+  public val icon_10489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10489.xml"),
+          )
+      )
+
+  public val icon_1049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1049.xml"),
+          )
+      )
+
+  public val icon_10490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10490.xml"),
+          )
+      )
+
+  public val icon_10491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10491.xml"),
+          )
+      )
+
+  public val icon_10492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10492.xml"),
+          )
+      )
+
+  public val icon_10493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10493.xml"),
+          )
+      )
+
+  public val icon_10494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10494.xml"),
+          )
+      )
+
+  public val icon_10495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10495.xml"),
+          )
+      )
+
+  public val icon_10496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10496.xml"),
+          )
+      )
+
+  public val icon_10497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10497.xml"),
+          )
+      )
+
+  public val icon_10498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10498.xml"),
+          )
+      )
+
+  public val icon_10499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10499.xml"),
+          )
+      )
+
+  public val icon_105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_105.xml"),
+          )
+      )
+
+  public val icon_1050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1050.xml"),
+          )
+      )
+
+  public val icon_10500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10500.xml"),
+          )
+      )
+
+  public val icon_10501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10501.xml"),
+          )
+      )
+
+  public val icon_10502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10502.xml"),
+          )
+      )
+
+  public val icon_10503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10503.xml"),
+          )
+      )
+
+  public val icon_10504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10504.xml"),
+          )
+      )
+
+  public val icon_10505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10505.xml"),
+          )
+      )
+
+  public val icon_10506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10506.xml"),
+          )
+      )
+
+  public val icon_10507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10507.xml"),
+          )
+      )
+
+  public val icon_10508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10508.xml"),
+          )
+      )
+
+  public val icon_10509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10509.xml"),
+          )
+      )
+
+  public val icon_1051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1051.xml"),
+          )
+      )
+
+  public val icon_10510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10510.xml"),
+          )
+      )
+
+  public val icon_10511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10511.xml"),
+          )
+      )
+
+  public val icon_10512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10512.xml"),
+          )
+      )
+
+  public val icon_10513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10513.xml"),
+          )
+      )
+
+  public val icon_10514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10514.xml"),
+          )
+      )
+
+  public val icon_10515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10515.xml"),
+          )
+      )
+
+  public val icon_10516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10516.xml"),
+          )
+      )
+
+  public val icon_10517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10517.xml"),
+          )
+      )
+
+  public val icon_10518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10518.xml"),
+          )
+      )
+
+  public val icon_10519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10519.xml"),
+          )
+      )
+
+  public val icon_1052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1052.xml"),
+          )
+      )
+
+  public val icon_10520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10520.xml"),
+          )
+      )
+
+  public val icon_10521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10521.xml"),
+          )
+      )
+
+  public val icon_10522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10522.xml"),
+          )
+      )
+
+  public val icon_10523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10523.xml"),
+          )
+      )
+
+  public val icon_10524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10524.xml"),
+          )
+      )
+
+  public val icon_10525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10525.xml"),
+          )
+      )
+
+  public val icon_10526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10526.xml"),
+          )
+      )
+
+  public val icon_10527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10527.xml"),
+          )
+      )
+
+  public val icon_10528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10528.xml"),
+          )
+      )
+
+  public val icon_10529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10529.xml"),
+          )
+      )
+
+  public val icon_1053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1053.xml"),
+          )
+      )
+
+  public val icon_10530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10530.xml"),
+          )
+      )
+
+  public val icon_10531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10531.xml"),
+          )
+      )
+
+  public val icon_10532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10532.xml"),
+          )
+      )
+
+  public val icon_10533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10533.xml"),
+          )
+      )
+
+  public val icon_10534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10534.xml"),
+          )
+      )
+
+  public val icon_10535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10535.xml"),
+          )
+      )
+
+  public val icon_10536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10536.xml"),
+          )
+      )
+
+  public val icon_10537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10537.xml"),
+          )
+      )
+
+  public val icon_10538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10538.xml"),
+          )
+      )
+
+  public val icon_10539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10539.xml"),
+          )
+      )
+
+  public val icon_1054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1054.xml"),
+          )
+      )
+
+  public val icon_10540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10540.xml"),
+          )
+      )
+
+  public val icon_10541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10541.xml"),
+          )
+      )
+
+  public val icon_10542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10542.xml"),
+          )
+      )
+
+  public val icon_10543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10543.xml"),
+          )
+      )
+
+  public val icon_10544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10544.xml"),
+          )
+      )
+
+  public val icon_10545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10545.xml"),
+          )
+      )
+
+  public val icon_10546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10546.xml"),
+          )
+      )
+
+  public val icon_10547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10547.xml"),
+          )
+      )
+
+  public val icon_10548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10548.xml"),
+          )
+      )
+
+  public val icon_10549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10549.xml"),
+          )
+      )
+
+  public val icon_1055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1055.xml"),
+          )
+      )
+
+  public val icon_10550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10550.xml"),
+          )
+      )
+
+  public val icon_10551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10551.xml"),
+          )
+      )
+
+  public val icon_10552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10552.xml"),
+          )
+      )
+
+  public val icon_10553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10553.xml"),
+          )
+      )
+
+  public val icon_10554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10554.xml"),
+          )
+      )
+
+  public val icon_10555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10555.xml"),
+          )
+      )
+
+  public val icon_10556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10556.xml"),
+          )
+      )
+
+  public val icon_10557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10557.xml"),
+          )
+      )
+
+  public val icon_10558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10558.xml"),
+          )
+      )
+
+  public val icon_10559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10559.xml"),
+          )
+      )
+
+  public val icon_1056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1056.xml"),
+          )
+      )
+
+  public val icon_10560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10560.xml"),
+          )
+      )
+
+  public val icon_10561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10561.xml"),
+          )
+      )
+
+  public val icon_10562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10562.xml"),
+          )
+      )
+
+  public val icon_10563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10563.xml"),
+          )
+      )
+
+  public val icon_10564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10564.xml"),
+          )
+      )
+
+  public val icon_10565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10565.xml"),
+          )
+      )
+
+  public val icon_10566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10566.xml"),
+          )
+      )
+
+  public val icon_10567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10567.xml"),
+          )
+      )
+
+  public val icon_10568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10568.xml"),
+          )
+      )
+
+  public val icon_10569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10569.xml"),
+          )
+      )
+
+  public val icon_1057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1057.xml"),
+          )
+      )
+
+  public val icon_10570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10570.xml"),
+          )
+      )
+
+  public val icon_10571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10571.xml"),
+          )
+      )
+
+  public val icon_10572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10572.xml"),
+          )
+      )
+
+  public val icon_10573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10573.xml"),
+          )
+      )
+
+  public val icon_10574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10574.xml"),
+          )
+      )
+
+  public val icon_10575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10575.xml"),
+          )
+      )
+
+  public val icon_10576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10576.xml"),
+          )
+      )
+
+  public val icon_10577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10577.xml"),
+          )
+      )
+
+  public val icon_10578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10578.xml"),
+          )
+      )
+
+  public val icon_10579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10579.xml"),
+          )
+      )
+
+  public val icon_1058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1058.xml"),
+          )
+      )
+
+  public val icon_10580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10580.xml"),
+          )
+      )
+
+  public val icon_10581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10581.xml"),
+          )
+      )
+
+  public val icon_10582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10582.xml"),
+          )
+      )
+
+  public val icon_10583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10583.xml"),
+          )
+      )
+
+  public val icon_10584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10584.xml"),
+          )
+      )
+
+  public val icon_10585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10585.xml"),
+          )
+      )
+
+  public val icon_10586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10586.xml"),
+          )
+      )
+
+  public val icon_10587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10587.xml"),
+          )
+      )
+
+  public val icon_10588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10588.xml"),
+          )
+      )
+
+  public val icon_10589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10589.xml"),
+          )
+      )
+
+  public val icon_1059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1059.xml"),
+          )
+      )
+
+  public val icon_10590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10590.xml"),
+          )
+      )
+
+  public val icon_10591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10591.xml"),
+          )
+      )
+
+  public val icon_10592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10592.xml"),
+          )
+      )
+
+  public val icon_10593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10593.xml"),
+          )
+      )
+
+  public val icon_10594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10594.xml"),
+          )
+      )
+
+  public val icon_10595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10595.xml"),
+          )
+      )
+
+  public val icon_10596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10596.xml"),
+          )
+      )
+
+  public val icon_10597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10597.xml"),
+          )
+      )
+
+  public val icon_10598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10598.xml"),
+          )
+      )
+
+  public val icon_10599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10599.xml"),
+          )
+      )
+
+  public val icon_106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_106.xml"),
+          )
+      )
+
+  public val icon_1060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1060.xml"),
+          )
+      )
+
+  public val icon_10600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10600.xml"),
+          )
+      )
+
+  public val icon_10601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10601.xml"),
+          )
+      )
+
+  public val icon_10602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10602.xml"),
+          )
+      )
+
+  public val icon_10603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10603.xml"),
+          )
+      )
+
+  public val icon_10604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10604.xml"),
+          )
+      )
+
+  public val icon_10605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10605.xml"),
+          )
+      )
+
+  public val icon_10606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10606.xml"),
+          )
+      )
+
+  public val icon_10607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10607.xml"),
+          )
+      )
+
+  public val icon_10608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10608.xml"),
+          )
+      )
+
+  public val icon_10609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10609.xml"),
+          )
+      )
+
+  public val icon_1061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1061.xml"),
+          )
+      )
+
+  public val icon_10610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10610.xml"),
+          )
+      )
+
+  public val icon_10611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10611.xml"),
+          )
+      )
+
+  public val icon_10612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10612.xml"),
+          )
+      )
+
+  public val icon_10613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10613.xml"),
+          )
+      )
+
+  public val icon_10614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10614.xml"),
+          )
+      )
+
+  public val icon_10615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10615.xml"),
+          )
+      )
+
+  public val icon_10616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10616.xml"),
+          )
+      )
+
+  public val icon_10617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10617.xml"),
+          )
+      )
+
+  public val icon_10618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10618.xml"),
+          )
+      )
+
+  public val icon_10619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10619.xml"),
+          )
+      )
+
+  public val icon_1062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1062.xml"),
+          )
+      )
+
+  public val icon_10620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10620.xml"),
+          )
+      )
+
+  public val icon_10621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10621.xml"),
+          )
+      )
+
+  public val icon_10622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10622.xml"),
+          )
+      )
+
+  public val icon_10623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10623.xml"),
+          )
+      )
+
+  public val icon_10624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10624.xml"),
+          )
+      )
+
+  public val icon_10625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10625.xml"),
+          )
+      )
+
+  public val icon_10626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10626.xml"),
+          )
+      )
+
+  public val icon_10627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10627.xml"),
+          )
+      )
+
+  public val icon_10628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10628.xml"),
+          )
+      )
+
+  public val icon_10629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10629.xml"),
+          )
+      )
+
+  public val icon_1063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1063.xml"),
+          )
+      )
+
+  public val icon_10630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10630.xml"),
+          )
+      )
+
+  public val icon_10631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10631.xml"),
+          )
+      )
+
+  public val icon_10632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10632.xml"),
+          )
+      )
+
+  public val icon_10633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10633.xml"),
+          )
+      )
+
+  public val icon_10634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10634.xml"),
+          )
+      )
+
+  public val icon_10635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10635.xml"),
+          )
+      )
+
+  public val icon_10636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10636.xml"),
+          )
+      )
+
+  public val icon_10637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10637.xml"),
+          )
+      )
+
+  public val icon_10638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10638.xml"),
+          )
+      )
+
+  public val icon_10639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10639.xml"),
+          )
+      )
+
+  public val icon_1064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1064.xml"),
+          )
+      )
+
+  public val icon_10640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10640.xml"),
+          )
+      )
+
+  public val icon_10641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10641.xml"),
+          )
+      )
+
+  public val icon_10642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10642.xml"),
+          )
+      )
+
+  public val icon_10643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10643.xml"),
+          )
+      )
+
+  public val icon_10644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10644.xml"),
+          )
+      )
+
+  public val icon_10645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10645.xml"),
+          )
+      )
+
+  public val icon_10646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10646.xml"),
+          )
+      )
+
+  public val icon_10647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10647.xml"),
+          )
+      )
+
+  public val icon_10648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10648.xml"),
+          )
+      )
+
+  public val icon_10649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10649.xml"),
+          )
+      )
+
+  public val icon_1065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1065.xml"),
+          )
+      )
+
+  public val icon_10650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10650.xml"),
+          )
+      )
+
+  public val icon_10651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10651.xml"),
+          )
+      )
+
+  public val icon_10652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10652.xml"),
+          )
+      )
+
+  public val icon_10653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10653.xml"),
+          )
+      )
+
+  public val icon_10654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10654.xml"),
+          )
+      )
+
+  public val icon_10655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10655.xml"),
+          )
+      )
+
+  public val icon_10656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10656.xml"),
+          )
+      )
+
+  public val icon_10657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10657.xml"),
+          )
+      )
+
+  public val icon_10658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10658.xml"),
+          )
+      )
+
+  public val icon_10659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10659.xml"),
+          )
+      )
+
+  public val icon_1066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1066.xml"),
+          )
+      )
+
+  public val icon_10660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10660.xml"),
+          )
+      )
+
+  public val icon_10661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10661.xml"),
+          )
+      )
+
+  public val icon_10662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10662.xml"),
+          )
+      )
+
+  public val icon_10663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10663.xml"),
+          )
+      )
+
+  public val icon_10664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10664.xml"),
+          )
+      )
+
+  public val icon_10665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10665.xml"),
+          )
+      )
+
+  public val icon_10666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10666.xml"),
+          )
+      )
+
+  public val icon_10667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10667.xml"),
+          )
+      )
+
+  public val icon_10668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10668.xml"),
+          )
+      )
+
+  public val icon_10669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10669.xml"),
+          )
+      )
+
+  public val icon_1067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1067.xml"),
+          )
+      )
+
+  public val icon_10670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10670.xml"),
+          )
+      )
+
+  public val icon_10671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10671.xml"),
+          )
+      )
+
+  public val icon_10672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10672.xml"),
+          )
+      )
+
+  public val icon_10673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10673.xml"),
+          )
+      )
+
+  public val icon_10674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10674.xml"),
+          )
+      )
+
+  public val icon_10675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10675.xml"),
+          )
+      )
+
+  public val icon_10676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10676.xml"),
+          )
+      )
+
+  public val icon_10677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10677.xml"),
+          )
+      )
+
+  public val icon_10678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10678.xml"),
+          )
+      )
+
+  public val icon_10679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10679.xml"),
+          )
+      )
+
+  public val icon_1068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1068.xml"),
+          )
+      )
+
+  public val icon_10680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10680.xml"),
+          )
+      )
+
+  public val icon_10681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10681.xml"),
+          )
+      )
+
+  public val icon_10682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10682.xml"),
+          )
+      )
+
+  public val icon_10683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10683.xml"),
+          )
+      )
+
+  public val icon_10684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10684.xml"),
+          )
+      )
+
+  public val icon_10685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10685.xml"),
+          )
+      )
+
+  public val icon_10686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10686.xml"),
+          )
+      )
+
+  public val icon_10687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10687.xml"),
+          )
+      )
+
+  public val icon_10688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10688.xml"),
+          )
+      )
+
+  public val icon_10689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10689.xml"),
+          )
+      )
+
+  public val icon_1069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1069.xml"),
+          )
+      )
+
+  public val icon_10690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10690.xml"),
+          )
+      )
+
+  public val icon_10691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10691.xml"),
+          )
+      )
+
+  public val icon_10692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10692.xml"),
+          )
+      )
+
+  public val icon_10693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10693.xml"),
+          )
+      )
+
+  public val icon_10694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10694.xml"),
+          )
+      )
+
+  public val icon_10695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10695.xml"),
+          )
+      )
+
+  public val icon_10696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10696.xml"),
+          )
+      )
+
+  public val icon_10697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10697.xml"),
+          )
+      )
+
+  public val icon_10698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10698.xml"),
+          )
+      )
+
+  public val icon_10699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10699.xml"),
+          )
+      )
+
+  public val icon_107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_107.xml"),
+          )
+      )
+
+  public val icon_1070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1070.xml"),
+          )
+      )
+
+  public val icon_10700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10700.xml"),
+          )
+      )
+
+  public val icon_10701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10701.xml"),
+          )
+      )
+
+  public val icon_10702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10702.xml"),
+          )
+      )
+
+  public val icon_10703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10703.xml"),
+          )
+      )
+
+  public val icon_10704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10704.xml"),
+          )
+      )
+
+  public val icon_10705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10705.xml"),
+          )
+      )
+
+  public val icon_10706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10706.xml"),
+          )
+      )
+
+  public val icon_10707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10707.xml"),
+          )
+      )
+
+  public val icon_10708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10708.xml"),
+          )
+      )
+
+  public val icon_10709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10709.xml"),
+          )
+      )
+
+  public val icon_1071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1071.xml"),
+          )
+      )
+
+  public val icon_10710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10710.xml"),
+          )
+      )
+
+  public val icon_10711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10711.xml"),
+          )
+      )
+
+  public val icon_10712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10712.xml"),
+          )
+      )
+
+  public val icon_10713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10713.xml"),
+          )
+      )
+
+  public val icon_10714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10714.xml"),
+          )
+      )
+
+  public val icon_10715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10715.xml"),
+          )
+      )
+
+  public val icon_10716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10716.xml"),
+          )
+      )
+
+  public val icon_10717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10717.xml"),
+          )
+      )
+
+  public val icon_10718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10718.xml"),
+          )
+      )
+
+  public val icon_10719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10719.xml"),
+          )
+      )
+
+  public val icon_1072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1072.xml"),
+          )
+      )
+
+  public val icon_10720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10720.xml"),
+          )
+      )
+
+  public val icon_10721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10721.xml"),
+          )
+      )
+
+  public val icon_10722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10722.xml"),
+          )
+      )
+
+  public val icon_10723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10723.xml"),
+          )
+      )
+
+  public val icon_10724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10724.xml"),
+          )
+      )
+
+  public val icon_10725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10725.xml"),
+          )
+      )
+
+  public val icon_10726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10726.xml"),
+          )
+      )
+
+  public val icon_10727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10727.xml"),
+          )
+      )
+
+  public val icon_10728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10728.xml"),
+          )
+      )
+
+  public val icon_10729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10729.xml"),
+          )
+      )
+
+  public val icon_1073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1073.xml"),
+          )
+      )
+
+  public val icon_10730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10730.xml"),
+          )
+      )
+
+  public val icon_10731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10731.xml"),
+          )
+      )
+
+  public val icon_10732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10732.xml"),
+          )
+      )
+
+  public val icon_10733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10733.xml"),
+          )
+      )
+
+  public val icon_10734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10734.xml"),
+          )
+      )
+
+  public val icon_10735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10735.xml"),
+          )
+      )
+
+  public val icon_10736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10736.xml"),
+          )
+      )
+
+  public val icon_10737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10737.xml"),
+          )
+      )
+
+  public val icon_10738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10738.xml"),
+          )
+      )
+
+  public val icon_10739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10739.xml"),
+          )
+      )
+
+  public val icon_1074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1074.xml"),
+          )
+      )
+
+  public val icon_10740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10740.xml"),
+          )
+      )
+
+  public val icon_10741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10741.xml"),
+          )
+      )
+
+  public val icon_10742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10742.xml"),
+          )
+      )
+
+  public val icon_10743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10743.xml"),
+          )
+      )
+
+  public val icon_10744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10744.xml"),
+          )
+      )
+
+  public val icon_10745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10745.xml"),
+          )
+      )
+
+  public val icon_10746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10746.xml"),
+          )
+      )
+
+  public val icon_10747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10747.xml"),
+          )
+      )
+
+  public val icon_10748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10748.xml"),
+          )
+      )
+
+  public val icon_10749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10749.xml"),
+          )
+      )
+
+  public val icon_1075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1075.xml"),
+          )
+      )
+
+  public val icon_10750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10750.xml"),
+          )
+      )
+
+  public val icon_10751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10751.xml"),
+          )
+      )
+
+  public val icon_10752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10752.xml"),
+          )
+      )
+
+  public val icon_10753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10753.xml"),
+          )
+      )
+
+  public val icon_10754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10754.xml"),
+          )
+      )
+
+  public val icon_10755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10755.xml"),
+          )
+      )
+
+  public val icon_10756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10756.xml"),
+          )
+      )
+
+  public val icon_10757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10757.xml"),
+          )
+      )
+
+  public val icon_10758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10758.xml"),
+          )
+      )
+
+  public val icon_10759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10759.xml"),
+          )
+      )
+
+  public val icon_1076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1076.xml"),
+          )
+      )
+
+  public val icon_10760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10760.xml"),
+          )
+      )
+
+  public val icon_10761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10761.xml"),
+          )
+      )
+
+  public val icon_10762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10762.xml"),
+          )
+      )
+
+  public val icon_10763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10763.xml"),
+          )
+      )
+
+  public val icon_10764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10764.xml"),
+          )
+      )
+
+  public val icon_10765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10765.xml"),
+          )
+      )
+
+  public val icon_10766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10766.xml"),
+          )
+      )
+
+  public val icon_10767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10767.xml"),
+          )
+      )
+
+  public val icon_10768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10768.xml"),
+          )
+      )
+
+  public val icon_10769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10769.xml"),
+          )
+      )
+
+  public val icon_1077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1077.xml"),
+          )
+      )
+
+  public val icon_10770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10770.xml"),
+          )
+      )
+
+  public val icon_10771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10771.xml"),
+          )
+      )
+
+  public val icon_10772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10772.xml"),
+          )
+      )
+
+  public val icon_10773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10773.xml"),
+          )
+      )
+
+  public val icon_10774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10774.xml"),
+          )
+      )
+
+  public val icon_10775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10775.xml"),
+          )
+      )
+
+  public val icon_10776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10776.xml"),
+          )
+      )
+
+  public val icon_10777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10777.xml"),
+          )
+      )
+
+  public val icon_10778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10778.xml"),
+          )
+      )
+
+  public val icon_10779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10779.xml"),
+          )
+      )
+
+  public val icon_1078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1078.xml"),
+          )
+      )
+
+  public val icon_10780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10780.xml"),
+          )
+      )
+
+  public val icon_10781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10781.xml"),
+          )
+      )
+
+  public val icon_10782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10782.xml"),
+          )
+      )
+
+  public val icon_10783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10783.xml"),
+          )
+      )
+
+  public val icon_10784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10784.xml"),
+          )
+      )
+
+  public val icon_10785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10785.xml"),
+          )
+      )
+
+  public val icon_10786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10786.xml"),
+          )
+      )
+
+  public val icon_10787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10787.xml"),
+          )
+      )
+
+  public val icon_10788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10788.xml"),
+          )
+      )
+
+  public val icon_10789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10789.xml"),
+          )
+      )
+
+  public val icon_1079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1079.xml"),
+          )
+      )
+
+  public val icon_10790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10790.xml"),
+          )
+      )
+
+  public val icon_10791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10791.xml"),
+          )
+      )
+
+  public val icon_10792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10792.xml"),
+          )
+      )
+
+  public val icon_10793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10793.xml"),
+          )
+      )
+
+  public val icon_10794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10794.xml"),
+          )
+      )
+
+  public val icon_10795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10795.xml"),
+          )
+      )
+
+  public val icon_10796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10796.xml"),
+          )
+      )
+
+  public val icon_10797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10797.xml"),
+          )
+      )
+
+  public val icon_10798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10798.xml"),
+          )
+      )
+
+  public val icon_10799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10799.xml"),
+          )
+      )
+
+  public val icon_108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_108.xml"),
+          )
+      )
+
+  public val icon_1080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1080.xml"),
+          )
+      )
+
+  public val icon_10800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10800.xml"),
+          )
+      )
+
+  public val icon_10801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10801.xml"),
+          )
+      )
+
+  public val icon_10802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10802.xml"),
+          )
+      )
+
+  public val icon_10803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10803.xml"),
+          )
+      )
+
+  public val icon_10804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10804.xml"),
+          )
+      )
+
+  public val icon_10805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10805.xml"),
+          )
+      )
+
+  public val icon_10806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10806.xml"),
+          )
+      )
+
+  public val icon_10807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10807.xml"),
+          )
+      )
+
+  public val icon_10808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10808.xml"),
+          )
+      )
+
+  public val icon_10809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10809.xml"),
+          )
+      )
+
+  public val icon_1081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1081.xml"),
+          )
+      )
+
+  public val icon_10810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10810.xml"),
+          )
+      )
+
+  public val icon_10811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10811.xml"),
+          )
+      )
+
+  public val icon_10812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10812.xml"),
+          )
+      )
+
+  public val icon_10813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10813.xml"),
+          )
+      )
+
+  public val icon_10814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10814.xml"),
+          )
+      )
+
+  public val icon_10815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10815.xml"),
+          )
+      )
+
+  public val icon_10816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10816.xml"),
+          )
+      )
+
+  public val icon_10817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10817.xml"),
+          )
+      )
+
+  public val icon_10818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10818.xml"),
+          )
+      )
+
+  public val icon_10819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10819.xml"),
+          )
+      )
+
+  public val icon_1082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1082.xml"),
+          )
+      )
+
+  public val icon_10820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10820.xml"),
+          )
+      )
+
+  public val icon_10821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10821.xml"),
+          )
+      )
+
+  public val icon_10822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10822.xml"),
+          )
+      )
+
+  public val icon_10823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10823.xml"),
+          )
+      )
+
+  public val icon_10824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10824.xml"),
+          )
+      )
+
+  public val icon_10825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10825.xml"),
+          )
+      )
+
+  public val icon_10826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10826.xml"),
+          )
+      )
+
+  public val icon_10827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10827.xml"),
+          )
+      )
+
+  public val icon_10828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10828.xml"),
+          )
+      )
+
+  public val icon_10829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10829.xml"),
+          )
+      )
+
+  public val icon_1083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1083.xml"),
+          )
+      )
+
+  public val icon_10830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10830.xml"),
+          )
+      )
+
+  public val icon_10831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10831.xml"),
+          )
+      )
+
+  public val icon_10832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10832.xml"),
+          )
+      )
+
+  public val icon_10833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10833.xml"),
+          )
+      )
+
+  public val icon_10834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10834.xml"),
+          )
+      )
+
+  public val icon_10835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10835.xml"),
+          )
+      )
+
+  public val icon_10836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10836.xml"),
+          )
+      )
+
+  public val icon_10837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10837.xml"),
+          )
+      )
+
+  public val icon_10838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10838.xml"),
+          )
+      )
+
+  public val icon_10839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10839.xml"),
+          )
+      )
+
+  public val icon_1084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1084.xml"),
+          )
+      )
+
+  public val icon_10840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10840.xml"),
+          )
+      )
+
+  public val icon_10841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10841.xml"),
+          )
+      )
+
+  public val icon_10842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10842.xml"),
+          )
+      )
+
+  public val icon_10843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10843.xml"),
+          )
+      )
+
+  public val icon_10844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10844.xml"),
+          )
+      )
+
+  public val icon_10845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10845.xml"),
+          )
+      )
+
+  public val icon_10846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10846.xml"),
+          )
+      )
+
+  public val icon_10847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10847.xml"),
+          )
+      )
+
+  public val icon_10848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10848.xml"),
+          )
+      )
+
+  public val icon_10849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10849.xml"),
+          )
+      )
+
+  public val icon_1085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1085.xml"),
+          )
+      )
+
+  public val icon_10850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10850.xml"),
+          )
+      )
+
+  public val icon_10851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10851.xml"),
+          )
+      )
+
+  public val icon_10852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10852.xml"),
+          )
+      )
+
+  public val icon_10853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10853.xml"),
+          )
+      )
+
+  public val icon_10854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10854.xml"),
+          )
+      )
+
+  public val icon_10855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10855.xml"),
+          )
+      )
+
+  public val icon_10856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10856.xml"),
+          )
+      )
+
+  public val icon_10857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10857.xml"),
+          )
+      )
+
+  public val icon_10858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10858.xml"),
+          )
+      )
+
+  public val icon_10859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10859.xml"),
+          )
+      )
+
+  public val icon_1086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1086.xml"),
+          )
+      )
+
+  public val icon_10860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10860.xml"),
+          )
+      )
+
+  public val icon_10861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10861.xml"),
+          )
+      )
+
+  public val icon_10862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10862.xml"),
+          )
+      )
+
+  public val icon_10863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10863.xml"),
+          )
+      )
+
+  public val icon_10864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10864.xml"),
+          )
+      )
+
+  public val icon_10865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10865.xml"),
+          )
+      )
+
+  public val icon_10866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10866.xml"),
+          )
+      )
+
+  public val icon_10867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10867.xml"),
+          )
+      )
+
+  public val icon_10868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10868.xml"),
+          )
+      )
+
+  public val icon_10869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10869.xml"),
+          )
+      )
+
+  public val icon_1087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1087.xml"),
+          )
+      )
+
+  public val icon_10870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10870.xml"),
+          )
+      )
+
+  public val icon_10871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10871.xml"),
+          )
+      )
+
+  public val icon_10872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10872.xml"),
+          )
+      )
+
+  public val icon_10873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10873.xml"),
+          )
+      )
+
+  public val icon_10874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10874.xml"),
+          )
+      )
+
+  public val icon_10875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10875.xml"),
+          )
+      )
+
+  public val icon_10876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10876.xml"),
+          )
+      )
+
+  public val icon_10877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10877.xml"),
+          )
+      )
+
+  public val icon_10878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10878.xml"),
+          )
+      )
+
+  public val icon_10879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10879.xml"),
+          )
+      )
+
+  public val icon_1088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1088.xml"),
+          )
+      )
+
+  public val icon_10880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10880.xml"),
+          )
+      )
+
+  public val icon_10881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10881.xml"),
+          )
+      )
+
+  public val icon_10882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10882.xml"),
+          )
+      )
+
+  public val icon_10883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10883.xml"),
+          )
+      )
+
+  public val icon_10884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10884.xml"),
+          )
+      )
+
+  public val icon_10885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10885.xml"),
+          )
+      )
+
+  public val icon_10886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10886.xml"),
+          )
+      )
+
+  public val icon_10887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10887.xml"),
+          )
+      )
+
+  public val icon_10888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10888.xml"),
+          )
+      )
+
+  public val icon_10889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10889.xml"),
+          )
+      )
+
+  public val icon_1089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1089.xml"),
+          )
+      )
+
+  public val icon_10890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10890.xml"),
+          )
+      )
+
+  public val icon_10891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10891.xml"),
+          )
+      )
+
+  public val icon_10892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10892.xml"),
+          )
+      )
+
+  public val icon_10893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10893.xml"),
+          )
+      )
+
+  public val icon_10894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10894.xml"),
+          )
+      )
+
+  public val icon_10895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10895.xml"),
+          )
+      )
+
+  public val icon_10896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10896.xml"),
+          )
+      )
+
+  public val icon_10897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10897.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10447: DrawableResource
+  get() = Drawable1.icon_10447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10448: DrawableResource
+  get() = Drawable1.icon_10448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10449: DrawableResource
+  get() = Drawable1.icon_10449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1045: DrawableResource
+  get() = Drawable1.icon_1045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10450: DrawableResource
+  get() = Drawable1.icon_10450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10451: DrawableResource
+  get() = Drawable1.icon_10451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10452: DrawableResource
+  get() = Drawable1.icon_10452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10453: DrawableResource
+  get() = Drawable1.icon_10453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10454: DrawableResource
+  get() = Drawable1.icon_10454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10455: DrawableResource
+  get() = Drawable1.icon_10455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10456: DrawableResource
+  get() = Drawable1.icon_10456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10457: DrawableResource
+  get() = Drawable1.icon_10457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10458: DrawableResource
+  get() = Drawable1.icon_10458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10459: DrawableResource
+  get() = Drawable1.icon_10459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1046: DrawableResource
+  get() = Drawable1.icon_1046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10460: DrawableResource
+  get() = Drawable1.icon_10460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10461: DrawableResource
+  get() = Drawable1.icon_10461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10462: DrawableResource
+  get() = Drawable1.icon_10462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10463: DrawableResource
+  get() = Drawable1.icon_10463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10464: DrawableResource
+  get() = Drawable1.icon_10464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10465: DrawableResource
+  get() = Drawable1.icon_10465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10466: DrawableResource
+  get() = Drawable1.icon_10466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10467: DrawableResource
+  get() = Drawable1.icon_10467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10468: DrawableResource
+  get() = Drawable1.icon_10468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10469: DrawableResource
+  get() = Drawable1.icon_10469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1047: DrawableResource
+  get() = Drawable1.icon_1047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10470: DrawableResource
+  get() = Drawable1.icon_10470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10471: DrawableResource
+  get() = Drawable1.icon_10471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10472: DrawableResource
+  get() = Drawable1.icon_10472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10473: DrawableResource
+  get() = Drawable1.icon_10473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10474: DrawableResource
+  get() = Drawable1.icon_10474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10475: DrawableResource
+  get() = Drawable1.icon_10475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10476: DrawableResource
+  get() = Drawable1.icon_10476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10477: DrawableResource
+  get() = Drawable1.icon_10477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10478: DrawableResource
+  get() = Drawable1.icon_10478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10479: DrawableResource
+  get() = Drawable1.icon_10479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1048: DrawableResource
+  get() = Drawable1.icon_1048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10480: DrawableResource
+  get() = Drawable1.icon_10480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10481: DrawableResource
+  get() = Drawable1.icon_10481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10482: DrawableResource
+  get() = Drawable1.icon_10482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10483: DrawableResource
+  get() = Drawable1.icon_10483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10484: DrawableResource
+  get() = Drawable1.icon_10484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10485: DrawableResource
+  get() = Drawable1.icon_10485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10486: DrawableResource
+  get() = Drawable1.icon_10486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10487: DrawableResource
+  get() = Drawable1.icon_10487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10488: DrawableResource
+  get() = Drawable1.icon_10488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10489: DrawableResource
+  get() = Drawable1.icon_10489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1049: DrawableResource
+  get() = Drawable1.icon_1049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10490: DrawableResource
+  get() = Drawable1.icon_10490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10491: DrawableResource
+  get() = Drawable1.icon_10491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10492: DrawableResource
+  get() = Drawable1.icon_10492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10493: DrawableResource
+  get() = Drawable1.icon_10493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10494: DrawableResource
+  get() = Drawable1.icon_10494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10495: DrawableResource
+  get() = Drawable1.icon_10495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10496: DrawableResource
+  get() = Drawable1.icon_10496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10497: DrawableResource
+  get() = Drawable1.icon_10497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10498: DrawableResource
+  get() = Drawable1.icon_10498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10499: DrawableResource
+  get() = Drawable1.icon_10499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_105: DrawableResource
+  get() = Drawable1.icon_105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1050: DrawableResource
+  get() = Drawable1.icon_1050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10500: DrawableResource
+  get() = Drawable1.icon_10500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10501: DrawableResource
+  get() = Drawable1.icon_10501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10502: DrawableResource
+  get() = Drawable1.icon_10502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10503: DrawableResource
+  get() = Drawable1.icon_10503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10504: DrawableResource
+  get() = Drawable1.icon_10504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10505: DrawableResource
+  get() = Drawable1.icon_10505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10506: DrawableResource
+  get() = Drawable1.icon_10506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10507: DrawableResource
+  get() = Drawable1.icon_10507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10508: DrawableResource
+  get() = Drawable1.icon_10508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10509: DrawableResource
+  get() = Drawable1.icon_10509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1051: DrawableResource
+  get() = Drawable1.icon_1051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10510: DrawableResource
+  get() = Drawable1.icon_10510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10511: DrawableResource
+  get() = Drawable1.icon_10511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10512: DrawableResource
+  get() = Drawable1.icon_10512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10513: DrawableResource
+  get() = Drawable1.icon_10513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10514: DrawableResource
+  get() = Drawable1.icon_10514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10515: DrawableResource
+  get() = Drawable1.icon_10515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10516: DrawableResource
+  get() = Drawable1.icon_10516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10517: DrawableResource
+  get() = Drawable1.icon_10517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10518: DrawableResource
+  get() = Drawable1.icon_10518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10519: DrawableResource
+  get() = Drawable1.icon_10519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1052: DrawableResource
+  get() = Drawable1.icon_1052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10520: DrawableResource
+  get() = Drawable1.icon_10520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10521: DrawableResource
+  get() = Drawable1.icon_10521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10522: DrawableResource
+  get() = Drawable1.icon_10522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10523: DrawableResource
+  get() = Drawable1.icon_10523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10524: DrawableResource
+  get() = Drawable1.icon_10524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10525: DrawableResource
+  get() = Drawable1.icon_10525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10526: DrawableResource
+  get() = Drawable1.icon_10526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10527: DrawableResource
+  get() = Drawable1.icon_10527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10528: DrawableResource
+  get() = Drawable1.icon_10528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10529: DrawableResource
+  get() = Drawable1.icon_10529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1053: DrawableResource
+  get() = Drawable1.icon_1053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10530: DrawableResource
+  get() = Drawable1.icon_10530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10531: DrawableResource
+  get() = Drawable1.icon_10531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10532: DrawableResource
+  get() = Drawable1.icon_10532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10533: DrawableResource
+  get() = Drawable1.icon_10533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10534: DrawableResource
+  get() = Drawable1.icon_10534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10535: DrawableResource
+  get() = Drawable1.icon_10535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10536: DrawableResource
+  get() = Drawable1.icon_10536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10537: DrawableResource
+  get() = Drawable1.icon_10537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10538: DrawableResource
+  get() = Drawable1.icon_10538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10539: DrawableResource
+  get() = Drawable1.icon_10539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1054: DrawableResource
+  get() = Drawable1.icon_1054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10540: DrawableResource
+  get() = Drawable1.icon_10540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10541: DrawableResource
+  get() = Drawable1.icon_10541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10542: DrawableResource
+  get() = Drawable1.icon_10542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10543: DrawableResource
+  get() = Drawable1.icon_10543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10544: DrawableResource
+  get() = Drawable1.icon_10544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10545: DrawableResource
+  get() = Drawable1.icon_10545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10546: DrawableResource
+  get() = Drawable1.icon_10546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10547: DrawableResource
+  get() = Drawable1.icon_10547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10548: DrawableResource
+  get() = Drawable1.icon_10548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10549: DrawableResource
+  get() = Drawable1.icon_10549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1055: DrawableResource
+  get() = Drawable1.icon_1055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10550: DrawableResource
+  get() = Drawable1.icon_10550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10551: DrawableResource
+  get() = Drawable1.icon_10551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10552: DrawableResource
+  get() = Drawable1.icon_10552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10553: DrawableResource
+  get() = Drawable1.icon_10553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10554: DrawableResource
+  get() = Drawable1.icon_10554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10555: DrawableResource
+  get() = Drawable1.icon_10555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10556: DrawableResource
+  get() = Drawable1.icon_10556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10557: DrawableResource
+  get() = Drawable1.icon_10557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10558: DrawableResource
+  get() = Drawable1.icon_10558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10559: DrawableResource
+  get() = Drawable1.icon_10559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1056: DrawableResource
+  get() = Drawable1.icon_1056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10560: DrawableResource
+  get() = Drawable1.icon_10560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10561: DrawableResource
+  get() = Drawable1.icon_10561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10562: DrawableResource
+  get() = Drawable1.icon_10562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10563: DrawableResource
+  get() = Drawable1.icon_10563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10564: DrawableResource
+  get() = Drawable1.icon_10564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10565: DrawableResource
+  get() = Drawable1.icon_10565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10566: DrawableResource
+  get() = Drawable1.icon_10566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10567: DrawableResource
+  get() = Drawable1.icon_10567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10568: DrawableResource
+  get() = Drawable1.icon_10568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10569: DrawableResource
+  get() = Drawable1.icon_10569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1057: DrawableResource
+  get() = Drawable1.icon_1057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10570: DrawableResource
+  get() = Drawable1.icon_10570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10571: DrawableResource
+  get() = Drawable1.icon_10571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10572: DrawableResource
+  get() = Drawable1.icon_10572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10573: DrawableResource
+  get() = Drawable1.icon_10573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10574: DrawableResource
+  get() = Drawable1.icon_10574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10575: DrawableResource
+  get() = Drawable1.icon_10575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10576: DrawableResource
+  get() = Drawable1.icon_10576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10577: DrawableResource
+  get() = Drawable1.icon_10577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10578: DrawableResource
+  get() = Drawable1.icon_10578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10579: DrawableResource
+  get() = Drawable1.icon_10579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1058: DrawableResource
+  get() = Drawable1.icon_1058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10580: DrawableResource
+  get() = Drawable1.icon_10580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10581: DrawableResource
+  get() = Drawable1.icon_10581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10582: DrawableResource
+  get() = Drawable1.icon_10582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10583: DrawableResource
+  get() = Drawable1.icon_10583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10584: DrawableResource
+  get() = Drawable1.icon_10584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10585: DrawableResource
+  get() = Drawable1.icon_10585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10586: DrawableResource
+  get() = Drawable1.icon_10586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10587: DrawableResource
+  get() = Drawable1.icon_10587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10588: DrawableResource
+  get() = Drawable1.icon_10588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10589: DrawableResource
+  get() = Drawable1.icon_10589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1059: DrawableResource
+  get() = Drawable1.icon_1059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10590: DrawableResource
+  get() = Drawable1.icon_10590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10591: DrawableResource
+  get() = Drawable1.icon_10591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10592: DrawableResource
+  get() = Drawable1.icon_10592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10593: DrawableResource
+  get() = Drawable1.icon_10593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10594: DrawableResource
+  get() = Drawable1.icon_10594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10595: DrawableResource
+  get() = Drawable1.icon_10595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10596: DrawableResource
+  get() = Drawable1.icon_10596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10597: DrawableResource
+  get() = Drawable1.icon_10597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10598: DrawableResource
+  get() = Drawable1.icon_10598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10599: DrawableResource
+  get() = Drawable1.icon_10599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_106: DrawableResource
+  get() = Drawable1.icon_106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1060: DrawableResource
+  get() = Drawable1.icon_1060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10600: DrawableResource
+  get() = Drawable1.icon_10600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10601: DrawableResource
+  get() = Drawable1.icon_10601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10602: DrawableResource
+  get() = Drawable1.icon_10602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10603: DrawableResource
+  get() = Drawable1.icon_10603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10604: DrawableResource
+  get() = Drawable1.icon_10604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10605: DrawableResource
+  get() = Drawable1.icon_10605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10606: DrawableResource
+  get() = Drawable1.icon_10606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10607: DrawableResource
+  get() = Drawable1.icon_10607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10608: DrawableResource
+  get() = Drawable1.icon_10608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10609: DrawableResource
+  get() = Drawable1.icon_10609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1061: DrawableResource
+  get() = Drawable1.icon_1061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10610: DrawableResource
+  get() = Drawable1.icon_10610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10611: DrawableResource
+  get() = Drawable1.icon_10611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10612: DrawableResource
+  get() = Drawable1.icon_10612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10613: DrawableResource
+  get() = Drawable1.icon_10613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10614: DrawableResource
+  get() = Drawable1.icon_10614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10615: DrawableResource
+  get() = Drawable1.icon_10615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10616: DrawableResource
+  get() = Drawable1.icon_10616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10617: DrawableResource
+  get() = Drawable1.icon_10617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10618: DrawableResource
+  get() = Drawable1.icon_10618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10619: DrawableResource
+  get() = Drawable1.icon_10619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1062: DrawableResource
+  get() = Drawable1.icon_1062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10620: DrawableResource
+  get() = Drawable1.icon_10620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10621: DrawableResource
+  get() = Drawable1.icon_10621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10622: DrawableResource
+  get() = Drawable1.icon_10622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10623: DrawableResource
+  get() = Drawable1.icon_10623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10624: DrawableResource
+  get() = Drawable1.icon_10624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10625: DrawableResource
+  get() = Drawable1.icon_10625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10626: DrawableResource
+  get() = Drawable1.icon_10626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10627: DrawableResource
+  get() = Drawable1.icon_10627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10628: DrawableResource
+  get() = Drawable1.icon_10628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10629: DrawableResource
+  get() = Drawable1.icon_10629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1063: DrawableResource
+  get() = Drawable1.icon_1063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10630: DrawableResource
+  get() = Drawable1.icon_10630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10631: DrawableResource
+  get() = Drawable1.icon_10631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10632: DrawableResource
+  get() = Drawable1.icon_10632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10633: DrawableResource
+  get() = Drawable1.icon_10633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10634: DrawableResource
+  get() = Drawable1.icon_10634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10635: DrawableResource
+  get() = Drawable1.icon_10635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10636: DrawableResource
+  get() = Drawable1.icon_10636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10637: DrawableResource
+  get() = Drawable1.icon_10637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10638: DrawableResource
+  get() = Drawable1.icon_10638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10639: DrawableResource
+  get() = Drawable1.icon_10639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1064: DrawableResource
+  get() = Drawable1.icon_1064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10640: DrawableResource
+  get() = Drawable1.icon_10640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10641: DrawableResource
+  get() = Drawable1.icon_10641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10642: DrawableResource
+  get() = Drawable1.icon_10642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10643: DrawableResource
+  get() = Drawable1.icon_10643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10644: DrawableResource
+  get() = Drawable1.icon_10644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10645: DrawableResource
+  get() = Drawable1.icon_10645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10646: DrawableResource
+  get() = Drawable1.icon_10646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10647: DrawableResource
+  get() = Drawable1.icon_10647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10648: DrawableResource
+  get() = Drawable1.icon_10648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10649: DrawableResource
+  get() = Drawable1.icon_10649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1065: DrawableResource
+  get() = Drawable1.icon_1065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10650: DrawableResource
+  get() = Drawable1.icon_10650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10651: DrawableResource
+  get() = Drawable1.icon_10651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10652: DrawableResource
+  get() = Drawable1.icon_10652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10653: DrawableResource
+  get() = Drawable1.icon_10653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10654: DrawableResource
+  get() = Drawable1.icon_10654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10655: DrawableResource
+  get() = Drawable1.icon_10655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10656: DrawableResource
+  get() = Drawable1.icon_10656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10657: DrawableResource
+  get() = Drawable1.icon_10657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10658: DrawableResource
+  get() = Drawable1.icon_10658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10659: DrawableResource
+  get() = Drawable1.icon_10659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1066: DrawableResource
+  get() = Drawable1.icon_1066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10660: DrawableResource
+  get() = Drawable1.icon_10660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10661: DrawableResource
+  get() = Drawable1.icon_10661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10662: DrawableResource
+  get() = Drawable1.icon_10662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10663: DrawableResource
+  get() = Drawable1.icon_10663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10664: DrawableResource
+  get() = Drawable1.icon_10664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10665: DrawableResource
+  get() = Drawable1.icon_10665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10666: DrawableResource
+  get() = Drawable1.icon_10666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10667: DrawableResource
+  get() = Drawable1.icon_10667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10668: DrawableResource
+  get() = Drawable1.icon_10668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10669: DrawableResource
+  get() = Drawable1.icon_10669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1067: DrawableResource
+  get() = Drawable1.icon_1067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10670: DrawableResource
+  get() = Drawable1.icon_10670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10671: DrawableResource
+  get() = Drawable1.icon_10671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10672: DrawableResource
+  get() = Drawable1.icon_10672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10673: DrawableResource
+  get() = Drawable1.icon_10673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10674: DrawableResource
+  get() = Drawable1.icon_10674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10675: DrawableResource
+  get() = Drawable1.icon_10675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10676: DrawableResource
+  get() = Drawable1.icon_10676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10677: DrawableResource
+  get() = Drawable1.icon_10677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10678: DrawableResource
+  get() = Drawable1.icon_10678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10679: DrawableResource
+  get() = Drawable1.icon_10679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1068: DrawableResource
+  get() = Drawable1.icon_1068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10680: DrawableResource
+  get() = Drawable1.icon_10680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10681: DrawableResource
+  get() = Drawable1.icon_10681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10682: DrawableResource
+  get() = Drawable1.icon_10682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10683: DrawableResource
+  get() = Drawable1.icon_10683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10684: DrawableResource
+  get() = Drawable1.icon_10684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10685: DrawableResource
+  get() = Drawable1.icon_10685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10686: DrawableResource
+  get() = Drawable1.icon_10686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10687: DrawableResource
+  get() = Drawable1.icon_10687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10688: DrawableResource
+  get() = Drawable1.icon_10688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10689: DrawableResource
+  get() = Drawable1.icon_10689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1069: DrawableResource
+  get() = Drawable1.icon_1069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10690: DrawableResource
+  get() = Drawable1.icon_10690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10691: DrawableResource
+  get() = Drawable1.icon_10691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10692: DrawableResource
+  get() = Drawable1.icon_10692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10693: DrawableResource
+  get() = Drawable1.icon_10693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10694: DrawableResource
+  get() = Drawable1.icon_10694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10695: DrawableResource
+  get() = Drawable1.icon_10695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10696: DrawableResource
+  get() = Drawable1.icon_10696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10697: DrawableResource
+  get() = Drawable1.icon_10697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10698: DrawableResource
+  get() = Drawable1.icon_10698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10699: DrawableResource
+  get() = Drawable1.icon_10699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_107: DrawableResource
+  get() = Drawable1.icon_107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1070: DrawableResource
+  get() = Drawable1.icon_1070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10700: DrawableResource
+  get() = Drawable1.icon_10700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10701: DrawableResource
+  get() = Drawable1.icon_10701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10702: DrawableResource
+  get() = Drawable1.icon_10702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10703: DrawableResource
+  get() = Drawable1.icon_10703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10704: DrawableResource
+  get() = Drawable1.icon_10704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10705: DrawableResource
+  get() = Drawable1.icon_10705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10706: DrawableResource
+  get() = Drawable1.icon_10706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10707: DrawableResource
+  get() = Drawable1.icon_10707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10708: DrawableResource
+  get() = Drawable1.icon_10708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10709: DrawableResource
+  get() = Drawable1.icon_10709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1071: DrawableResource
+  get() = Drawable1.icon_1071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10710: DrawableResource
+  get() = Drawable1.icon_10710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10711: DrawableResource
+  get() = Drawable1.icon_10711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10712: DrawableResource
+  get() = Drawable1.icon_10712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10713: DrawableResource
+  get() = Drawable1.icon_10713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10714: DrawableResource
+  get() = Drawable1.icon_10714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10715: DrawableResource
+  get() = Drawable1.icon_10715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10716: DrawableResource
+  get() = Drawable1.icon_10716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10717: DrawableResource
+  get() = Drawable1.icon_10717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10718: DrawableResource
+  get() = Drawable1.icon_10718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10719: DrawableResource
+  get() = Drawable1.icon_10719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1072: DrawableResource
+  get() = Drawable1.icon_1072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10720: DrawableResource
+  get() = Drawable1.icon_10720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10721: DrawableResource
+  get() = Drawable1.icon_10721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10722: DrawableResource
+  get() = Drawable1.icon_10722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10723: DrawableResource
+  get() = Drawable1.icon_10723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10724: DrawableResource
+  get() = Drawable1.icon_10724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10725: DrawableResource
+  get() = Drawable1.icon_10725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10726: DrawableResource
+  get() = Drawable1.icon_10726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10727: DrawableResource
+  get() = Drawable1.icon_10727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10728: DrawableResource
+  get() = Drawable1.icon_10728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10729: DrawableResource
+  get() = Drawable1.icon_10729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1073: DrawableResource
+  get() = Drawable1.icon_1073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10730: DrawableResource
+  get() = Drawable1.icon_10730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10731: DrawableResource
+  get() = Drawable1.icon_10731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10732: DrawableResource
+  get() = Drawable1.icon_10732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10733: DrawableResource
+  get() = Drawable1.icon_10733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10734: DrawableResource
+  get() = Drawable1.icon_10734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10735: DrawableResource
+  get() = Drawable1.icon_10735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10736: DrawableResource
+  get() = Drawable1.icon_10736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10737: DrawableResource
+  get() = Drawable1.icon_10737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10738: DrawableResource
+  get() = Drawable1.icon_10738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10739: DrawableResource
+  get() = Drawable1.icon_10739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1074: DrawableResource
+  get() = Drawable1.icon_1074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10740: DrawableResource
+  get() = Drawable1.icon_10740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10741: DrawableResource
+  get() = Drawable1.icon_10741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10742: DrawableResource
+  get() = Drawable1.icon_10742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10743: DrawableResource
+  get() = Drawable1.icon_10743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10744: DrawableResource
+  get() = Drawable1.icon_10744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10745: DrawableResource
+  get() = Drawable1.icon_10745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10746: DrawableResource
+  get() = Drawable1.icon_10746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10747: DrawableResource
+  get() = Drawable1.icon_10747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10748: DrawableResource
+  get() = Drawable1.icon_10748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10749: DrawableResource
+  get() = Drawable1.icon_10749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1075: DrawableResource
+  get() = Drawable1.icon_1075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10750: DrawableResource
+  get() = Drawable1.icon_10750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10751: DrawableResource
+  get() = Drawable1.icon_10751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10752: DrawableResource
+  get() = Drawable1.icon_10752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10753: DrawableResource
+  get() = Drawable1.icon_10753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10754: DrawableResource
+  get() = Drawable1.icon_10754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10755: DrawableResource
+  get() = Drawable1.icon_10755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10756: DrawableResource
+  get() = Drawable1.icon_10756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10757: DrawableResource
+  get() = Drawable1.icon_10757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10758: DrawableResource
+  get() = Drawable1.icon_10758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10759: DrawableResource
+  get() = Drawable1.icon_10759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1076: DrawableResource
+  get() = Drawable1.icon_1076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10760: DrawableResource
+  get() = Drawable1.icon_10760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10761: DrawableResource
+  get() = Drawable1.icon_10761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10762: DrawableResource
+  get() = Drawable1.icon_10762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10763: DrawableResource
+  get() = Drawable1.icon_10763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10764: DrawableResource
+  get() = Drawable1.icon_10764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10765: DrawableResource
+  get() = Drawable1.icon_10765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10766: DrawableResource
+  get() = Drawable1.icon_10766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10767: DrawableResource
+  get() = Drawable1.icon_10767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10768: DrawableResource
+  get() = Drawable1.icon_10768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10769: DrawableResource
+  get() = Drawable1.icon_10769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1077: DrawableResource
+  get() = Drawable1.icon_1077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10770: DrawableResource
+  get() = Drawable1.icon_10770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10771: DrawableResource
+  get() = Drawable1.icon_10771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10772: DrawableResource
+  get() = Drawable1.icon_10772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10773: DrawableResource
+  get() = Drawable1.icon_10773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10774: DrawableResource
+  get() = Drawable1.icon_10774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10775: DrawableResource
+  get() = Drawable1.icon_10775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10776: DrawableResource
+  get() = Drawable1.icon_10776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10777: DrawableResource
+  get() = Drawable1.icon_10777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10778: DrawableResource
+  get() = Drawable1.icon_10778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10779: DrawableResource
+  get() = Drawable1.icon_10779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1078: DrawableResource
+  get() = Drawable1.icon_1078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10780: DrawableResource
+  get() = Drawable1.icon_10780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10781: DrawableResource
+  get() = Drawable1.icon_10781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10782: DrawableResource
+  get() = Drawable1.icon_10782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10783: DrawableResource
+  get() = Drawable1.icon_10783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10784: DrawableResource
+  get() = Drawable1.icon_10784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10785: DrawableResource
+  get() = Drawable1.icon_10785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10786: DrawableResource
+  get() = Drawable1.icon_10786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10787: DrawableResource
+  get() = Drawable1.icon_10787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10788: DrawableResource
+  get() = Drawable1.icon_10788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10789: DrawableResource
+  get() = Drawable1.icon_10789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1079: DrawableResource
+  get() = Drawable1.icon_1079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10790: DrawableResource
+  get() = Drawable1.icon_10790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10791: DrawableResource
+  get() = Drawable1.icon_10791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10792: DrawableResource
+  get() = Drawable1.icon_10792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10793: DrawableResource
+  get() = Drawable1.icon_10793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10794: DrawableResource
+  get() = Drawable1.icon_10794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10795: DrawableResource
+  get() = Drawable1.icon_10795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10796: DrawableResource
+  get() = Drawable1.icon_10796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10797: DrawableResource
+  get() = Drawable1.icon_10797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10798: DrawableResource
+  get() = Drawable1.icon_10798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10799: DrawableResource
+  get() = Drawable1.icon_10799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_108: DrawableResource
+  get() = Drawable1.icon_108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1080: DrawableResource
+  get() = Drawable1.icon_1080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10800: DrawableResource
+  get() = Drawable1.icon_10800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10801: DrawableResource
+  get() = Drawable1.icon_10801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10802: DrawableResource
+  get() = Drawable1.icon_10802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10803: DrawableResource
+  get() = Drawable1.icon_10803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10804: DrawableResource
+  get() = Drawable1.icon_10804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10805: DrawableResource
+  get() = Drawable1.icon_10805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10806: DrawableResource
+  get() = Drawable1.icon_10806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10807: DrawableResource
+  get() = Drawable1.icon_10807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10808: DrawableResource
+  get() = Drawable1.icon_10808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10809: DrawableResource
+  get() = Drawable1.icon_10809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1081: DrawableResource
+  get() = Drawable1.icon_1081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10810: DrawableResource
+  get() = Drawable1.icon_10810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10811: DrawableResource
+  get() = Drawable1.icon_10811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10812: DrawableResource
+  get() = Drawable1.icon_10812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10813: DrawableResource
+  get() = Drawable1.icon_10813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10814: DrawableResource
+  get() = Drawable1.icon_10814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10815: DrawableResource
+  get() = Drawable1.icon_10815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10816: DrawableResource
+  get() = Drawable1.icon_10816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10817: DrawableResource
+  get() = Drawable1.icon_10817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10818: DrawableResource
+  get() = Drawable1.icon_10818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10819: DrawableResource
+  get() = Drawable1.icon_10819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1082: DrawableResource
+  get() = Drawable1.icon_1082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10820: DrawableResource
+  get() = Drawable1.icon_10820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10821: DrawableResource
+  get() = Drawable1.icon_10821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10822: DrawableResource
+  get() = Drawable1.icon_10822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10823: DrawableResource
+  get() = Drawable1.icon_10823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10824: DrawableResource
+  get() = Drawable1.icon_10824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10825: DrawableResource
+  get() = Drawable1.icon_10825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10826: DrawableResource
+  get() = Drawable1.icon_10826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10827: DrawableResource
+  get() = Drawable1.icon_10827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10828: DrawableResource
+  get() = Drawable1.icon_10828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10829: DrawableResource
+  get() = Drawable1.icon_10829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1083: DrawableResource
+  get() = Drawable1.icon_1083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10830: DrawableResource
+  get() = Drawable1.icon_10830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10831: DrawableResource
+  get() = Drawable1.icon_10831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10832: DrawableResource
+  get() = Drawable1.icon_10832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10833: DrawableResource
+  get() = Drawable1.icon_10833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10834: DrawableResource
+  get() = Drawable1.icon_10834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10835: DrawableResource
+  get() = Drawable1.icon_10835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10836: DrawableResource
+  get() = Drawable1.icon_10836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10837: DrawableResource
+  get() = Drawable1.icon_10837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10838: DrawableResource
+  get() = Drawable1.icon_10838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10839: DrawableResource
+  get() = Drawable1.icon_10839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1084: DrawableResource
+  get() = Drawable1.icon_1084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10840: DrawableResource
+  get() = Drawable1.icon_10840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10841: DrawableResource
+  get() = Drawable1.icon_10841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10842: DrawableResource
+  get() = Drawable1.icon_10842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10843: DrawableResource
+  get() = Drawable1.icon_10843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10844: DrawableResource
+  get() = Drawable1.icon_10844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10845: DrawableResource
+  get() = Drawable1.icon_10845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10846: DrawableResource
+  get() = Drawable1.icon_10846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10847: DrawableResource
+  get() = Drawable1.icon_10847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10848: DrawableResource
+  get() = Drawable1.icon_10848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10849: DrawableResource
+  get() = Drawable1.icon_10849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1085: DrawableResource
+  get() = Drawable1.icon_1085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10850: DrawableResource
+  get() = Drawable1.icon_10850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10851: DrawableResource
+  get() = Drawable1.icon_10851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10852: DrawableResource
+  get() = Drawable1.icon_10852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10853: DrawableResource
+  get() = Drawable1.icon_10853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10854: DrawableResource
+  get() = Drawable1.icon_10854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10855: DrawableResource
+  get() = Drawable1.icon_10855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10856: DrawableResource
+  get() = Drawable1.icon_10856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10857: DrawableResource
+  get() = Drawable1.icon_10857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10858: DrawableResource
+  get() = Drawable1.icon_10858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10859: DrawableResource
+  get() = Drawable1.icon_10859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1086: DrawableResource
+  get() = Drawable1.icon_1086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10860: DrawableResource
+  get() = Drawable1.icon_10860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10861: DrawableResource
+  get() = Drawable1.icon_10861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10862: DrawableResource
+  get() = Drawable1.icon_10862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10863: DrawableResource
+  get() = Drawable1.icon_10863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10864: DrawableResource
+  get() = Drawable1.icon_10864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10865: DrawableResource
+  get() = Drawable1.icon_10865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10866: DrawableResource
+  get() = Drawable1.icon_10866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10867: DrawableResource
+  get() = Drawable1.icon_10867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10868: DrawableResource
+  get() = Drawable1.icon_10868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10869: DrawableResource
+  get() = Drawable1.icon_10869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1087: DrawableResource
+  get() = Drawable1.icon_1087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10870: DrawableResource
+  get() = Drawable1.icon_10870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10871: DrawableResource
+  get() = Drawable1.icon_10871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10872: DrawableResource
+  get() = Drawable1.icon_10872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10873: DrawableResource
+  get() = Drawable1.icon_10873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10874: DrawableResource
+  get() = Drawable1.icon_10874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10875: DrawableResource
+  get() = Drawable1.icon_10875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10876: DrawableResource
+  get() = Drawable1.icon_10876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10877: DrawableResource
+  get() = Drawable1.icon_10877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10878: DrawableResource
+  get() = Drawable1.icon_10878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10879: DrawableResource
+  get() = Drawable1.icon_10879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1088: DrawableResource
+  get() = Drawable1.icon_1088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10880: DrawableResource
+  get() = Drawable1.icon_10880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10881: DrawableResource
+  get() = Drawable1.icon_10881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10882: DrawableResource
+  get() = Drawable1.icon_10882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10883: DrawableResource
+  get() = Drawable1.icon_10883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10884: DrawableResource
+  get() = Drawable1.icon_10884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10885: DrawableResource
+  get() = Drawable1.icon_10885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10886: DrawableResource
+  get() = Drawable1.icon_10886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10887: DrawableResource
+  get() = Drawable1.icon_10887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10888: DrawableResource
+  get() = Drawable1.icon_10888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10889: DrawableResource
+  get() = Drawable1.icon_10889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1089: DrawableResource
+  get() = Drawable1.icon_1089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10890: DrawableResource
+  get() = Drawable1.icon_10890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10891: DrawableResource
+  get() = Drawable1.icon_10891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10892: DrawableResource
+  get() = Drawable1.icon_10892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10893: DrawableResource
+  get() = Drawable1.icon_10893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10894: DrawableResource
+  get() = Drawable1.icon_10894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10895: DrawableResource
+  get() = Drawable1.icon_10895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10896: DrawableResource
+  get() = Drawable1.icon_10896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10897: DrawableResource
+  get() = Drawable1.icon_10897

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable10.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable10.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable10 {
+  public val icon_14498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14498.xml"),
+          )
+      )
+
+  public val icon_14499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14499.xml"),
+          )
+      )
+
+  public val icon_145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_145.xml"),
+          )
+      )
+
+  public val icon_1450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1450.xml"),
+          )
+      )
+
+  public val icon_14500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14500.xml"),
+          )
+      )
+
+  public val icon_14501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14501.xml"),
+          )
+      )
+
+  public val icon_14502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14502.xml"),
+          )
+      )
+
+  public val icon_14503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14503.xml"),
+          )
+      )
+
+  public val icon_14504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14504.xml"),
+          )
+      )
+
+  public val icon_14505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14505.xml"),
+          )
+      )
+
+  public val icon_14506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14506.xml"),
+          )
+      )
+
+  public val icon_14507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14507.xml"),
+          )
+      )
+
+  public val icon_14508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14508.xml"),
+          )
+      )
+
+  public val icon_14509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14509.xml"),
+          )
+      )
+
+  public val icon_1451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1451.xml"),
+          )
+      )
+
+  public val icon_14510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14510.xml"),
+          )
+      )
+
+  public val icon_14511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14511.xml"),
+          )
+      )
+
+  public val icon_14512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14512.xml"),
+          )
+      )
+
+  public val icon_14513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14513.xml"),
+          )
+      )
+
+  public val icon_14514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14514.xml"),
+          )
+      )
+
+  public val icon_14515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14515.xml"),
+          )
+      )
+
+  public val icon_14516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14516.xml"),
+          )
+      )
+
+  public val icon_14517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14517.xml"),
+          )
+      )
+
+  public val icon_14518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14518.xml"),
+          )
+      )
+
+  public val icon_14519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14519.xml"),
+          )
+      )
+
+  public val icon_1452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1452.xml"),
+          )
+      )
+
+  public val icon_14520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14520.xml"),
+          )
+      )
+
+  public val icon_14521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14521.xml"),
+          )
+      )
+
+  public val icon_14522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14522.xml"),
+          )
+      )
+
+  public val icon_14523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14523.xml"),
+          )
+      )
+
+  public val icon_14524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14524.xml"),
+          )
+      )
+
+  public val icon_14525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14525.xml"),
+          )
+      )
+
+  public val icon_14526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14526.xml"),
+          )
+      )
+
+  public val icon_14527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14527.xml"),
+          )
+      )
+
+  public val icon_14528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14528.xml"),
+          )
+      )
+
+  public val icon_14529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14529.xml"),
+          )
+      )
+
+  public val icon_1453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1453.xml"),
+          )
+      )
+
+  public val icon_14530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14530.xml"),
+          )
+      )
+
+  public val icon_14531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14531.xml"),
+          )
+      )
+
+  public val icon_14532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14532.xml"),
+          )
+      )
+
+  public val icon_14533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14533.xml"),
+          )
+      )
+
+  public val icon_14534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14534.xml"),
+          )
+      )
+
+  public val icon_14535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14535.xml"),
+          )
+      )
+
+  public val icon_14536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14536.xml"),
+          )
+      )
+
+  public val icon_14537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14537.xml"),
+          )
+      )
+
+  public val icon_14538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14538.xml"),
+          )
+      )
+
+  public val icon_14539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14539.xml"),
+          )
+      )
+
+  public val icon_1454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1454.xml"),
+          )
+      )
+
+  public val icon_14540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14540.xml"),
+          )
+      )
+
+  public val icon_14541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14541.xml"),
+          )
+      )
+
+  public val icon_14542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14542.xml"),
+          )
+      )
+
+  public val icon_14543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14543.xml"),
+          )
+      )
+
+  public val icon_14544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14544.xml"),
+          )
+      )
+
+  public val icon_14545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14545.xml"),
+          )
+      )
+
+  public val icon_14546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14546.xml"),
+          )
+      )
+
+  public val icon_14547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14547.xml"),
+          )
+      )
+
+  public val icon_14548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14548.xml"),
+          )
+      )
+
+  public val icon_14549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14549.xml"),
+          )
+      )
+
+  public val icon_1455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1455.xml"),
+          )
+      )
+
+  public val icon_14550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14550.xml"),
+          )
+      )
+
+  public val icon_14551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14551.xml"),
+          )
+      )
+
+  public val icon_14552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14552.xml"),
+          )
+      )
+
+  public val icon_14553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14553.xml"),
+          )
+      )
+
+  public val icon_14554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14554.xml"),
+          )
+      )
+
+  public val icon_14555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14555.xml"),
+          )
+      )
+
+  public val icon_14556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14556.xml"),
+          )
+      )
+
+  public val icon_14557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14557.xml"),
+          )
+      )
+
+  public val icon_14558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14558.xml"),
+          )
+      )
+
+  public val icon_14559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14559.xml"),
+          )
+      )
+
+  public val icon_1456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1456.xml"),
+          )
+      )
+
+  public val icon_14560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14560.xml"),
+          )
+      )
+
+  public val icon_14561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14561.xml"),
+          )
+      )
+
+  public val icon_14562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14562.xml"),
+          )
+      )
+
+  public val icon_14563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14563.xml"),
+          )
+      )
+
+  public val icon_14564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14564.xml"),
+          )
+      )
+
+  public val icon_14565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14565.xml"),
+          )
+      )
+
+  public val icon_14566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14566.xml"),
+          )
+      )
+
+  public val icon_14567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14567.xml"),
+          )
+      )
+
+  public val icon_14568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14568.xml"),
+          )
+      )
+
+  public val icon_14569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14569.xml"),
+          )
+      )
+
+  public val icon_1457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1457.xml"),
+          )
+      )
+
+  public val icon_14570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14570.xml"),
+          )
+      )
+
+  public val icon_14571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14571.xml"),
+          )
+      )
+
+  public val icon_14572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14572.xml"),
+          )
+      )
+
+  public val icon_14573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14573.xml"),
+          )
+      )
+
+  public val icon_14574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14574.xml"),
+          )
+      )
+
+  public val icon_14575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14575.xml"),
+          )
+      )
+
+  public val icon_14576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14576.xml"),
+          )
+      )
+
+  public val icon_14577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14577.xml"),
+          )
+      )
+
+  public val icon_14578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14578.xml"),
+          )
+      )
+
+  public val icon_14579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14579.xml"),
+          )
+      )
+
+  public val icon_1458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1458.xml"),
+          )
+      )
+
+  public val icon_14580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14580.xml"),
+          )
+      )
+
+  public val icon_14581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14581.xml"),
+          )
+      )
+
+  public val icon_14582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14582.xml"),
+          )
+      )
+
+  public val icon_14583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14583.xml"),
+          )
+      )
+
+  public val icon_14584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14584.xml"),
+          )
+      )
+
+  public val icon_14585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14585.xml"),
+          )
+      )
+
+  public val icon_14586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14586.xml"),
+          )
+      )
+
+  public val icon_14587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14587.xml"),
+          )
+      )
+
+  public val icon_14588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14588.xml"),
+          )
+      )
+
+  public val icon_14589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14589.xml"),
+          )
+      )
+
+  public val icon_1459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1459.xml"),
+          )
+      )
+
+  public val icon_14590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14590.xml"),
+          )
+      )
+
+  public val icon_14591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14591.xml"),
+          )
+      )
+
+  public val icon_14592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14592.xml"),
+          )
+      )
+
+  public val icon_14593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14593.xml"),
+          )
+      )
+
+  public val icon_14594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14594.xml"),
+          )
+      )
+
+  public val icon_14595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14595.xml"),
+          )
+      )
+
+  public val icon_14596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14596.xml"),
+          )
+      )
+
+  public val icon_14597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14597.xml"),
+          )
+      )
+
+  public val icon_14598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14598.xml"),
+          )
+      )
+
+  public val icon_14599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14599.xml"),
+          )
+      )
+
+  public val icon_146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_146.xml"),
+          )
+      )
+
+  public val icon_1460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1460.xml"),
+          )
+      )
+
+  public val icon_14600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14600.xml"),
+          )
+      )
+
+  public val icon_14601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14601.xml"),
+          )
+      )
+
+  public val icon_14602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14602.xml"),
+          )
+      )
+
+  public val icon_14603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14603.xml"),
+          )
+      )
+
+  public val icon_14604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14604.xml"),
+          )
+      )
+
+  public val icon_14605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14605.xml"),
+          )
+      )
+
+  public val icon_14606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14606.xml"),
+          )
+      )
+
+  public val icon_14607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14607.xml"),
+          )
+      )
+
+  public val icon_14608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14608.xml"),
+          )
+      )
+
+  public val icon_14609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14609.xml"),
+          )
+      )
+
+  public val icon_1461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1461.xml"),
+          )
+      )
+
+  public val icon_14610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14610.xml"),
+          )
+      )
+
+  public val icon_14611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14611.xml"),
+          )
+      )
+
+  public val icon_14612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14612.xml"),
+          )
+      )
+
+  public val icon_14613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14613.xml"),
+          )
+      )
+
+  public val icon_14614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14614.xml"),
+          )
+      )
+
+  public val icon_14615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14615.xml"),
+          )
+      )
+
+  public val icon_14616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14616.xml"),
+          )
+      )
+
+  public val icon_14617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14617.xml"),
+          )
+      )
+
+  public val icon_14618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14618.xml"),
+          )
+      )
+
+  public val icon_14619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14619.xml"),
+          )
+      )
+
+  public val icon_1462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1462.xml"),
+          )
+      )
+
+  public val icon_14620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14620.xml"),
+          )
+      )
+
+  public val icon_14621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14621.xml"),
+          )
+      )
+
+  public val icon_14622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14622.xml"),
+          )
+      )
+
+  public val icon_14623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14623.xml"),
+          )
+      )
+
+  public val icon_14624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14624.xml"),
+          )
+      )
+
+  public val icon_14625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14625.xml"),
+          )
+      )
+
+  public val icon_14626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14626.xml"),
+          )
+      )
+
+  public val icon_14627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14627.xml"),
+          )
+      )
+
+  public val icon_14628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14628.xml"),
+          )
+      )
+
+  public val icon_14629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14629.xml"),
+          )
+      )
+
+  public val icon_1463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1463.xml"),
+          )
+      )
+
+  public val icon_14630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14630.xml"),
+          )
+      )
+
+  public val icon_14631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14631.xml"),
+          )
+      )
+
+  public val icon_14632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14632.xml"),
+          )
+      )
+
+  public val icon_14633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14633.xml"),
+          )
+      )
+
+  public val icon_14634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14634.xml"),
+          )
+      )
+
+  public val icon_14635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14635.xml"),
+          )
+      )
+
+  public val icon_14636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14636.xml"),
+          )
+      )
+
+  public val icon_14637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14637.xml"),
+          )
+      )
+
+  public val icon_14638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14638.xml"),
+          )
+      )
+
+  public val icon_14639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14639.xml"),
+          )
+      )
+
+  public val icon_1464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1464.xml"),
+          )
+      )
+
+  public val icon_14640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14640.xml"),
+          )
+      )
+
+  public val icon_14641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14641.xml"),
+          )
+      )
+
+  public val icon_14642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14642.xml"),
+          )
+      )
+
+  public val icon_14643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14643.xml"),
+          )
+      )
+
+  public val icon_14644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14644.xml"),
+          )
+      )
+
+  public val icon_14645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14645.xml"),
+          )
+      )
+
+  public val icon_14646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14646.xml"),
+          )
+      )
+
+  public val icon_14647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14647.xml"),
+          )
+      )
+
+  public val icon_14648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14648.xml"),
+          )
+      )
+
+  public val icon_14649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14649.xml"),
+          )
+      )
+
+  public val icon_1465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1465.xml"),
+          )
+      )
+
+  public val icon_14650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14650.xml"),
+          )
+      )
+
+  public val icon_14651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14651.xml"),
+          )
+      )
+
+  public val icon_14652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14652.xml"),
+          )
+      )
+
+  public val icon_14653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14653.xml"),
+          )
+      )
+
+  public val icon_14654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14654.xml"),
+          )
+      )
+
+  public val icon_14655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14655.xml"),
+          )
+      )
+
+  public val icon_14656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14656.xml"),
+          )
+      )
+
+  public val icon_14657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14657.xml"),
+          )
+      )
+
+  public val icon_14658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14658.xml"),
+          )
+      )
+
+  public val icon_14659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14659.xml"),
+          )
+      )
+
+  public val icon_1466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1466.xml"),
+          )
+      )
+
+  public val icon_14660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14660.xml"),
+          )
+      )
+
+  public val icon_14661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14661.xml"),
+          )
+      )
+
+  public val icon_14662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14662.xml"),
+          )
+      )
+
+  public val icon_14663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14663.xml"),
+          )
+      )
+
+  public val icon_14664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14664.xml"),
+          )
+      )
+
+  public val icon_14665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14665.xml"),
+          )
+      )
+
+  public val icon_14666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14666.xml"),
+          )
+      )
+
+  public val icon_14667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14667.xml"),
+          )
+      )
+
+  public val icon_14668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14668.xml"),
+          )
+      )
+
+  public val icon_14669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14669.xml"),
+          )
+      )
+
+  public val icon_1467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1467.xml"),
+          )
+      )
+
+  public val icon_14670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14670.xml"),
+          )
+      )
+
+  public val icon_14671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14671.xml"),
+          )
+      )
+
+  public val icon_14672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14672.xml"),
+          )
+      )
+
+  public val icon_14673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14673.xml"),
+          )
+      )
+
+  public val icon_14674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14674.xml"),
+          )
+      )
+
+  public val icon_14675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14675.xml"),
+          )
+      )
+
+  public val icon_14676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14676.xml"),
+          )
+      )
+
+  public val icon_14677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14677.xml"),
+          )
+      )
+
+  public val icon_14678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14678.xml"),
+          )
+      )
+
+  public val icon_14679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14679.xml"),
+          )
+      )
+
+  public val icon_1468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1468.xml"),
+          )
+      )
+
+  public val icon_14680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14680.xml"),
+          )
+      )
+
+  public val icon_14681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14681.xml"),
+          )
+      )
+
+  public val icon_14682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14682.xml"),
+          )
+      )
+
+  public val icon_14683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14683.xml"),
+          )
+      )
+
+  public val icon_14684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14684.xml"),
+          )
+      )
+
+  public val icon_14685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14685.xml"),
+          )
+      )
+
+  public val icon_14686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14686.xml"),
+          )
+      )
+
+  public val icon_14687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14687.xml"),
+          )
+      )
+
+  public val icon_14688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14688.xml"),
+          )
+      )
+
+  public val icon_14689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14689.xml"),
+          )
+      )
+
+  public val icon_1469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1469.xml"),
+          )
+      )
+
+  public val icon_14690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14690.xml"),
+          )
+      )
+
+  public val icon_14691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14691.xml"),
+          )
+      )
+
+  public val icon_14692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14692.xml"),
+          )
+      )
+
+  public val icon_14693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14693.xml"),
+          )
+      )
+
+  public val icon_14694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14694.xml"),
+          )
+      )
+
+  public val icon_14695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14695.xml"),
+          )
+      )
+
+  public val icon_14696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14696.xml"),
+          )
+      )
+
+  public val icon_14697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14697.xml"),
+          )
+      )
+
+  public val icon_14698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14698.xml"),
+          )
+      )
+
+  public val icon_14699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14699.xml"),
+          )
+      )
+
+  public val icon_147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_147.xml"),
+          )
+      )
+
+  public val icon_1470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1470.xml"),
+          )
+      )
+
+  public val icon_14700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14700.xml"),
+          )
+      )
+
+  public val icon_14701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14701.xml"),
+          )
+      )
+
+  public val icon_14702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14702.xml"),
+          )
+      )
+
+  public val icon_14703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14703.xml"),
+          )
+      )
+
+  public val icon_14704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14704.xml"),
+          )
+      )
+
+  public val icon_14705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14705.xml"),
+          )
+      )
+
+  public val icon_14706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14706.xml"),
+          )
+      )
+
+  public val icon_14707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14707.xml"),
+          )
+      )
+
+  public val icon_14708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14708.xml"),
+          )
+      )
+
+  public val icon_14709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14709.xml"),
+          )
+      )
+
+  public val icon_1471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1471.xml"),
+          )
+      )
+
+  public val icon_14710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14710.xml"),
+          )
+      )
+
+  public val icon_14711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14711.xml"),
+          )
+      )
+
+  public val icon_14712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14712.xml"),
+          )
+      )
+
+  public val icon_14713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14713.xml"),
+          )
+      )
+
+  public val icon_14714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14714.xml"),
+          )
+      )
+
+  public val icon_14715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14715.xml"),
+          )
+      )
+
+  public val icon_14716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14716.xml"),
+          )
+      )
+
+  public val icon_14717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14717.xml"),
+          )
+      )
+
+  public val icon_14718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14718.xml"),
+          )
+      )
+
+  public val icon_14719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14719.xml"),
+          )
+      )
+
+  public val icon_1472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1472.xml"),
+          )
+      )
+
+  public val icon_14720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14720.xml"),
+          )
+      )
+
+  public val icon_14721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14721.xml"),
+          )
+      )
+
+  public val icon_14722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14722.xml"),
+          )
+      )
+
+  public val icon_14723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14723.xml"),
+          )
+      )
+
+  public val icon_14724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14724.xml"),
+          )
+      )
+
+  public val icon_14725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14725.xml"),
+          )
+      )
+
+  public val icon_14726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14726.xml"),
+          )
+      )
+
+  public val icon_14727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14727.xml"),
+          )
+      )
+
+  public val icon_14728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14728.xml"),
+          )
+      )
+
+  public val icon_14729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14729.xml"),
+          )
+      )
+
+  public val icon_1473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1473.xml"),
+          )
+      )
+
+  public val icon_14730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14730.xml"),
+          )
+      )
+
+  public val icon_14731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14731.xml"),
+          )
+      )
+
+  public val icon_14732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14732.xml"),
+          )
+      )
+
+  public val icon_14733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14733.xml"),
+          )
+      )
+
+  public val icon_14734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14734.xml"),
+          )
+      )
+
+  public val icon_14735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14735.xml"),
+          )
+      )
+
+  public val icon_14736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14736.xml"),
+          )
+      )
+
+  public val icon_14737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14737.xml"),
+          )
+      )
+
+  public val icon_14738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14738.xml"),
+          )
+      )
+
+  public val icon_14739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14739.xml"),
+          )
+      )
+
+  public val icon_1474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1474.xml"),
+          )
+      )
+
+  public val icon_14740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14740.xml"),
+          )
+      )
+
+  public val icon_14741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14741.xml"),
+          )
+      )
+
+  public val icon_14742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14742.xml"),
+          )
+      )
+
+  public val icon_14743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14743.xml"),
+          )
+      )
+
+  public val icon_14744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14744.xml"),
+          )
+      )
+
+  public val icon_14745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14745.xml"),
+          )
+      )
+
+  public val icon_14746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14746.xml"),
+          )
+      )
+
+  public val icon_14747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14747.xml"),
+          )
+      )
+
+  public val icon_14748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14748.xml"),
+          )
+      )
+
+  public val icon_14749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14749.xml"),
+          )
+      )
+
+  public val icon_1475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1475.xml"),
+          )
+      )
+
+  public val icon_14750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14750.xml"),
+          )
+      )
+
+  public val icon_14751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14751.xml"),
+          )
+      )
+
+  public val icon_14752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14752.xml"),
+          )
+      )
+
+  public val icon_14753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14753.xml"),
+          )
+      )
+
+  public val icon_14754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14754.xml"),
+          )
+      )
+
+  public val icon_14755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14755.xml"),
+          )
+      )
+
+  public val icon_14756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14756.xml"),
+          )
+      )
+
+  public val icon_14757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14757.xml"),
+          )
+      )
+
+  public val icon_14758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14758.xml"),
+          )
+      )
+
+  public val icon_14759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14759.xml"),
+          )
+      )
+
+  public val icon_1476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1476.xml"),
+          )
+      )
+
+  public val icon_14760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14760.xml"),
+          )
+      )
+
+  public val icon_14761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14761.xml"),
+          )
+      )
+
+  public val icon_14762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14762.xml"),
+          )
+      )
+
+  public val icon_14763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14763.xml"),
+          )
+      )
+
+  public val icon_14764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14764.xml"),
+          )
+      )
+
+  public val icon_14765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14765.xml"),
+          )
+      )
+
+  public val icon_14766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14766.xml"),
+          )
+      )
+
+  public val icon_14767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14767.xml"),
+          )
+      )
+
+  public val icon_14768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14768.xml"),
+          )
+      )
+
+  public val icon_14769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14769.xml"),
+          )
+      )
+
+  public val icon_1477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1477.xml"),
+          )
+      )
+
+  public val icon_14770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14770.xml"),
+          )
+      )
+
+  public val icon_14771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14771.xml"),
+          )
+      )
+
+  public val icon_14772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14772.xml"),
+          )
+      )
+
+  public val icon_14773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14773.xml"),
+          )
+      )
+
+  public val icon_14774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14774.xml"),
+          )
+      )
+
+  public val icon_14775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14775.xml"),
+          )
+      )
+
+  public val icon_14776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14776.xml"),
+          )
+      )
+
+  public val icon_14777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14777.xml"),
+          )
+      )
+
+  public val icon_14778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14778.xml"),
+          )
+      )
+
+  public val icon_14779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14779.xml"),
+          )
+      )
+
+  public val icon_1478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1478.xml"),
+          )
+      )
+
+  public val icon_14780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14780.xml"),
+          )
+      )
+
+  public val icon_14781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14781.xml"),
+          )
+      )
+
+  public val icon_14782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14782.xml"),
+          )
+      )
+
+  public val icon_14783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14783.xml"),
+          )
+      )
+
+  public val icon_14784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14784.xml"),
+          )
+      )
+
+  public val icon_14785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14785.xml"),
+          )
+      )
+
+  public val icon_14786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14786.xml"),
+          )
+      )
+
+  public val icon_14787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14787.xml"),
+          )
+      )
+
+  public val icon_14788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14788.xml"),
+          )
+      )
+
+  public val icon_14789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14789.xml"),
+          )
+      )
+
+  public val icon_1479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1479.xml"),
+          )
+      )
+
+  public val icon_14790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14790.xml"),
+          )
+      )
+
+  public val icon_14791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14791.xml"),
+          )
+      )
+
+  public val icon_14792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14792.xml"),
+          )
+      )
+
+  public val icon_14793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14793.xml"),
+          )
+      )
+
+  public val icon_14794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14794.xml"),
+          )
+      )
+
+  public val icon_14795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14795.xml"),
+          )
+      )
+
+  public val icon_14796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14796.xml"),
+          )
+      )
+
+  public val icon_14797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14797.xml"),
+          )
+      )
+
+  public val icon_14798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14798.xml"),
+          )
+      )
+
+  public val icon_14799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14799.xml"),
+          )
+      )
+
+  public val icon_148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_148.xml"),
+          )
+      )
+
+  public val icon_1480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1480.xml"),
+          )
+      )
+
+  public val icon_14800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14800.xml"),
+          )
+      )
+
+  public val icon_14801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14801.xml"),
+          )
+      )
+
+  public val icon_14802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14802.xml"),
+          )
+      )
+
+  public val icon_14803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14803.xml"),
+          )
+      )
+
+  public val icon_14804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14804.xml"),
+          )
+      )
+
+  public val icon_14805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14805.xml"),
+          )
+      )
+
+  public val icon_14806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14806.xml"),
+          )
+      )
+
+  public val icon_14807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14807.xml"),
+          )
+      )
+
+  public val icon_14808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14808.xml"),
+          )
+      )
+
+  public val icon_14809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14809.xml"),
+          )
+      )
+
+  public val icon_1481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1481.xml"),
+          )
+      )
+
+  public val icon_14810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14810.xml"),
+          )
+      )
+
+  public val icon_14811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14811.xml"),
+          )
+      )
+
+  public val icon_14812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14812.xml"),
+          )
+      )
+
+  public val icon_14813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14813.xml"),
+          )
+      )
+
+  public val icon_14814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14814.xml"),
+          )
+      )
+
+  public val icon_14815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14815.xml"),
+          )
+      )
+
+  public val icon_14816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14816.xml"),
+          )
+      )
+
+  public val icon_14817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14817.xml"),
+          )
+      )
+
+  public val icon_14818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14818.xml"),
+          )
+      )
+
+  public val icon_14819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14819.xml"),
+          )
+      )
+
+  public val icon_1482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1482.xml"),
+          )
+      )
+
+  public val icon_14820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14820.xml"),
+          )
+      )
+
+  public val icon_14821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14821.xml"),
+          )
+      )
+
+  public val icon_14822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14822.xml"),
+          )
+      )
+
+  public val icon_14823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14823.xml"),
+          )
+      )
+
+  public val icon_14824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14824.xml"),
+          )
+      )
+
+  public val icon_14825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14825.xml"),
+          )
+      )
+
+  public val icon_14826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14826.xml"),
+          )
+      )
+
+  public val icon_14827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14827.xml"),
+          )
+      )
+
+  public val icon_14828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14828.xml"),
+          )
+      )
+
+  public val icon_14829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14829.xml"),
+          )
+      )
+
+  public val icon_1483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1483.xml"),
+          )
+      )
+
+  public val icon_14830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14830.xml"),
+          )
+      )
+
+  public val icon_14831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14831.xml"),
+          )
+      )
+
+  public val icon_14832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14832.xml"),
+          )
+      )
+
+  public val icon_14833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14833.xml"),
+          )
+      )
+
+  public val icon_14834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14834.xml"),
+          )
+      )
+
+  public val icon_14835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14835.xml"),
+          )
+      )
+
+  public val icon_14836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14836.xml"),
+          )
+      )
+
+  public val icon_14837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14837.xml"),
+          )
+      )
+
+  public val icon_14838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14838.xml"),
+          )
+      )
+
+  public val icon_14839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14839.xml"),
+          )
+      )
+
+  public val icon_1484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1484.xml"),
+          )
+      )
+
+  public val icon_14840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14840.xml"),
+          )
+      )
+
+  public val icon_14841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14841.xml"),
+          )
+      )
+
+  public val icon_14842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14842.xml"),
+          )
+      )
+
+  public val icon_14843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14843.xml"),
+          )
+      )
+
+  public val icon_14844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14844.xml"),
+          )
+      )
+
+  public val icon_14845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14845.xml"),
+          )
+      )
+
+  public val icon_14846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14846.xml"),
+          )
+      )
+
+  public val icon_14847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14847.xml"),
+          )
+      )
+
+  public val icon_14848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14848.xml"),
+          )
+      )
+
+  public val icon_14849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14849.xml"),
+          )
+      )
+
+  public val icon_1485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1485.xml"),
+          )
+      )
+
+  public val icon_14850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14850.xml"),
+          )
+      )
+
+  public val icon_14851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14851.xml"),
+          )
+      )
+
+  public val icon_14852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14852.xml"),
+          )
+      )
+
+  public val icon_14853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14853.xml"),
+          )
+      )
+
+  public val icon_14854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14854.xml"),
+          )
+      )
+
+  public val icon_14855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14855.xml"),
+          )
+      )
+
+  public val icon_14856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14856.xml"),
+          )
+      )
+
+  public val icon_14857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14857.xml"),
+          )
+      )
+
+  public val icon_14858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14858.xml"),
+          )
+      )
+
+  public val icon_14859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14859.xml"),
+          )
+      )
+
+  public val icon_1486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1486.xml"),
+          )
+      )
+
+  public val icon_14860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14860.xml"),
+          )
+      )
+
+  public val icon_14861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14861.xml"),
+          )
+      )
+
+  public val icon_14862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14862.xml"),
+          )
+      )
+
+  public val icon_14863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14863.xml"),
+          )
+      )
+
+  public val icon_14864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14864.xml"),
+          )
+      )
+
+  public val icon_14865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14865.xml"),
+          )
+      )
+
+  public val icon_14866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14866.xml"),
+          )
+      )
+
+  public val icon_14867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14867.xml"),
+          )
+      )
+
+  public val icon_14868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14868.xml"),
+          )
+      )
+
+  public val icon_14869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14869.xml"),
+          )
+      )
+
+  public val icon_1487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1487.xml"),
+          )
+      )
+
+  public val icon_14870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14870.xml"),
+          )
+      )
+
+  public val icon_14871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14871.xml"),
+          )
+      )
+
+  public val icon_14872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14872.xml"),
+          )
+      )
+
+  public val icon_14873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14873.xml"),
+          )
+      )
+
+  public val icon_14874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14874.xml"),
+          )
+      )
+
+  public val icon_14875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14875.xml"),
+          )
+      )
+
+  public val icon_14876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14876.xml"),
+          )
+      )
+
+  public val icon_14877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14877.xml"),
+          )
+      )
+
+  public val icon_14878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14878.xml"),
+          )
+      )
+
+  public val icon_14879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14879.xml"),
+          )
+      )
+
+  public val icon_1488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1488.xml"),
+          )
+      )
+
+  public val icon_14880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14880.xml"),
+          )
+      )
+
+  public val icon_14881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14881.xml"),
+          )
+      )
+
+  public val icon_14882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14882.xml"),
+          )
+      )
+
+  public val icon_14883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14883.xml"),
+          )
+      )
+
+  public val icon_14884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14884.xml"),
+          )
+      )
+
+  public val icon_14885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14885.xml"),
+          )
+      )
+
+  public val icon_14886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14886.xml"),
+          )
+      )
+
+  public val icon_14887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14887.xml"),
+          )
+      )
+
+  public val icon_14888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14888.xml"),
+          )
+      )
+
+  public val icon_14889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14889.xml"),
+          )
+      )
+
+  public val icon_1489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1489.xml"),
+          )
+      )
+
+  public val icon_14890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14890.xml"),
+          )
+      )
+
+  public val icon_14891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14891.xml"),
+          )
+      )
+
+  public val icon_14892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14892.xml"),
+          )
+      )
+
+  public val icon_14893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14893.xml"),
+          )
+      )
+
+  public val icon_14894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14894.xml"),
+          )
+      )
+
+  public val icon_14895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14895.xml"),
+          )
+      )
+
+  public val icon_14896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14896.xml"),
+          )
+      )
+
+  public val icon_14897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14897.xml"),
+          )
+      )
+
+  public val icon_14898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14898.xml"),
+          )
+      )
+
+  public val icon_14899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14899.xml"),
+          )
+      )
+
+  public val icon_149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_149.xml"),
+          )
+      )
+
+  public val icon_1490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1490.xml"),
+          )
+      )
+
+  public val icon_14900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14900.xml"),
+          )
+      )
+
+  public val icon_14901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14901.xml"),
+          )
+      )
+
+  public val icon_14902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14902.xml"),
+          )
+      )
+
+  public val icon_14903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14903.xml"),
+          )
+      )
+
+  public val icon_14904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14904.xml"),
+          )
+      )
+
+  public val icon_14905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14905.xml"),
+          )
+      )
+
+  public val icon_14906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14906.xml"),
+          )
+      )
+
+  public val icon_14907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14907.xml"),
+          )
+      )
+
+  public val icon_14908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14908.xml"),
+          )
+      )
+
+  public val icon_14909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14909.xml"),
+          )
+      )
+
+  public val icon_1491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1491.xml"),
+          )
+      )
+
+  public val icon_14910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14910.xml"),
+          )
+      )
+
+  public val icon_14911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14911.xml"),
+          )
+      )
+
+  public val icon_14912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14912.xml"),
+          )
+      )
+
+  public val icon_14913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14913.xml"),
+          )
+      )
+
+  public val icon_14914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14914.xml"),
+          )
+      )
+
+  public val icon_14915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14915.xml"),
+          )
+      )
+
+  public val icon_14916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14916.xml"),
+          )
+      )
+
+  public val icon_14917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14917.xml"),
+          )
+      )
+
+  public val icon_14918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14918.xml"),
+          )
+      )
+
+  public val icon_14919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14919.xml"),
+          )
+      )
+
+  public val icon_1492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1492.xml"),
+          )
+      )
+
+  public val icon_14920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14920.xml"),
+          )
+      )
+
+  public val icon_14921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14921.xml"),
+          )
+      )
+
+  public val icon_14922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14922.xml"),
+          )
+      )
+
+  public val icon_14923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14923.xml"),
+          )
+      )
+
+  public val icon_14924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14924.xml"),
+          )
+      )
+
+  public val icon_14925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14925.xml"),
+          )
+      )
+
+  public val icon_14926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14926.xml"),
+          )
+      )
+
+  public val icon_14927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14927.xml"),
+          )
+      )
+
+  public val icon_14928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14928.xml"),
+          )
+      )
+
+  public val icon_14929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14929.xml"),
+          )
+      )
+
+  public val icon_1493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1493.xml"),
+          )
+      )
+
+  public val icon_14930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14930.xml"),
+          )
+      )
+
+  public val icon_14931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14931.xml"),
+          )
+      )
+
+  public val icon_14932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14932.xml"),
+          )
+      )
+
+  public val icon_14933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14933.xml"),
+          )
+      )
+
+  public val icon_14934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14934.xml"),
+          )
+      )
+
+  public val icon_14935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14935.xml"),
+          )
+      )
+
+  public val icon_14936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14936.xml"),
+          )
+      )
+
+  public val icon_14937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14937.xml"),
+          )
+      )
+
+  public val icon_14938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14938.xml"),
+          )
+      )
+
+  public val icon_14939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14939.xml"),
+          )
+      )
+
+  public val icon_1494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1494.xml"),
+          )
+      )
+
+  public val icon_14940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14940.xml"),
+          )
+      )
+
+  public val icon_14941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14941.xml"),
+          )
+      )
+
+  public val icon_14942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14942.xml"),
+          )
+      )
+
+  public val icon_14943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14943.xml"),
+          )
+      )
+
+  public val icon_14944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14944.xml"),
+          )
+      )
+
+  public val icon_14945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14945.xml"),
+          )
+      )
+
+  public val icon_14946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14946.xml"),
+          )
+      )
+
+  public val icon_14947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14947.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14498: DrawableResource
+  get() = Drawable10.icon_14498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14499: DrawableResource
+  get() = Drawable10.icon_14499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_145: DrawableResource
+  get() = Drawable10.icon_145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1450: DrawableResource
+  get() = Drawable10.icon_1450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14500: DrawableResource
+  get() = Drawable10.icon_14500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14501: DrawableResource
+  get() = Drawable10.icon_14501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14502: DrawableResource
+  get() = Drawable10.icon_14502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14503: DrawableResource
+  get() = Drawable10.icon_14503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14504: DrawableResource
+  get() = Drawable10.icon_14504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14505: DrawableResource
+  get() = Drawable10.icon_14505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14506: DrawableResource
+  get() = Drawable10.icon_14506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14507: DrawableResource
+  get() = Drawable10.icon_14507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14508: DrawableResource
+  get() = Drawable10.icon_14508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14509: DrawableResource
+  get() = Drawable10.icon_14509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1451: DrawableResource
+  get() = Drawable10.icon_1451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14510: DrawableResource
+  get() = Drawable10.icon_14510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14511: DrawableResource
+  get() = Drawable10.icon_14511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14512: DrawableResource
+  get() = Drawable10.icon_14512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14513: DrawableResource
+  get() = Drawable10.icon_14513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14514: DrawableResource
+  get() = Drawable10.icon_14514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14515: DrawableResource
+  get() = Drawable10.icon_14515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14516: DrawableResource
+  get() = Drawable10.icon_14516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14517: DrawableResource
+  get() = Drawable10.icon_14517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14518: DrawableResource
+  get() = Drawable10.icon_14518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14519: DrawableResource
+  get() = Drawable10.icon_14519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1452: DrawableResource
+  get() = Drawable10.icon_1452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14520: DrawableResource
+  get() = Drawable10.icon_14520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14521: DrawableResource
+  get() = Drawable10.icon_14521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14522: DrawableResource
+  get() = Drawable10.icon_14522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14523: DrawableResource
+  get() = Drawable10.icon_14523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14524: DrawableResource
+  get() = Drawable10.icon_14524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14525: DrawableResource
+  get() = Drawable10.icon_14525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14526: DrawableResource
+  get() = Drawable10.icon_14526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14527: DrawableResource
+  get() = Drawable10.icon_14527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14528: DrawableResource
+  get() = Drawable10.icon_14528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14529: DrawableResource
+  get() = Drawable10.icon_14529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1453: DrawableResource
+  get() = Drawable10.icon_1453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14530: DrawableResource
+  get() = Drawable10.icon_14530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14531: DrawableResource
+  get() = Drawable10.icon_14531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14532: DrawableResource
+  get() = Drawable10.icon_14532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14533: DrawableResource
+  get() = Drawable10.icon_14533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14534: DrawableResource
+  get() = Drawable10.icon_14534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14535: DrawableResource
+  get() = Drawable10.icon_14535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14536: DrawableResource
+  get() = Drawable10.icon_14536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14537: DrawableResource
+  get() = Drawable10.icon_14537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14538: DrawableResource
+  get() = Drawable10.icon_14538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14539: DrawableResource
+  get() = Drawable10.icon_14539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1454: DrawableResource
+  get() = Drawable10.icon_1454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14540: DrawableResource
+  get() = Drawable10.icon_14540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14541: DrawableResource
+  get() = Drawable10.icon_14541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14542: DrawableResource
+  get() = Drawable10.icon_14542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14543: DrawableResource
+  get() = Drawable10.icon_14543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14544: DrawableResource
+  get() = Drawable10.icon_14544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14545: DrawableResource
+  get() = Drawable10.icon_14545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14546: DrawableResource
+  get() = Drawable10.icon_14546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14547: DrawableResource
+  get() = Drawable10.icon_14547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14548: DrawableResource
+  get() = Drawable10.icon_14548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14549: DrawableResource
+  get() = Drawable10.icon_14549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1455: DrawableResource
+  get() = Drawable10.icon_1455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14550: DrawableResource
+  get() = Drawable10.icon_14550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14551: DrawableResource
+  get() = Drawable10.icon_14551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14552: DrawableResource
+  get() = Drawable10.icon_14552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14553: DrawableResource
+  get() = Drawable10.icon_14553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14554: DrawableResource
+  get() = Drawable10.icon_14554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14555: DrawableResource
+  get() = Drawable10.icon_14555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14556: DrawableResource
+  get() = Drawable10.icon_14556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14557: DrawableResource
+  get() = Drawable10.icon_14557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14558: DrawableResource
+  get() = Drawable10.icon_14558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14559: DrawableResource
+  get() = Drawable10.icon_14559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1456: DrawableResource
+  get() = Drawable10.icon_1456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14560: DrawableResource
+  get() = Drawable10.icon_14560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14561: DrawableResource
+  get() = Drawable10.icon_14561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14562: DrawableResource
+  get() = Drawable10.icon_14562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14563: DrawableResource
+  get() = Drawable10.icon_14563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14564: DrawableResource
+  get() = Drawable10.icon_14564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14565: DrawableResource
+  get() = Drawable10.icon_14565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14566: DrawableResource
+  get() = Drawable10.icon_14566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14567: DrawableResource
+  get() = Drawable10.icon_14567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14568: DrawableResource
+  get() = Drawable10.icon_14568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14569: DrawableResource
+  get() = Drawable10.icon_14569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1457: DrawableResource
+  get() = Drawable10.icon_1457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14570: DrawableResource
+  get() = Drawable10.icon_14570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14571: DrawableResource
+  get() = Drawable10.icon_14571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14572: DrawableResource
+  get() = Drawable10.icon_14572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14573: DrawableResource
+  get() = Drawable10.icon_14573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14574: DrawableResource
+  get() = Drawable10.icon_14574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14575: DrawableResource
+  get() = Drawable10.icon_14575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14576: DrawableResource
+  get() = Drawable10.icon_14576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14577: DrawableResource
+  get() = Drawable10.icon_14577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14578: DrawableResource
+  get() = Drawable10.icon_14578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14579: DrawableResource
+  get() = Drawable10.icon_14579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1458: DrawableResource
+  get() = Drawable10.icon_1458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14580: DrawableResource
+  get() = Drawable10.icon_14580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14581: DrawableResource
+  get() = Drawable10.icon_14581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14582: DrawableResource
+  get() = Drawable10.icon_14582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14583: DrawableResource
+  get() = Drawable10.icon_14583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14584: DrawableResource
+  get() = Drawable10.icon_14584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14585: DrawableResource
+  get() = Drawable10.icon_14585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14586: DrawableResource
+  get() = Drawable10.icon_14586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14587: DrawableResource
+  get() = Drawable10.icon_14587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14588: DrawableResource
+  get() = Drawable10.icon_14588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14589: DrawableResource
+  get() = Drawable10.icon_14589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1459: DrawableResource
+  get() = Drawable10.icon_1459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14590: DrawableResource
+  get() = Drawable10.icon_14590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14591: DrawableResource
+  get() = Drawable10.icon_14591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14592: DrawableResource
+  get() = Drawable10.icon_14592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14593: DrawableResource
+  get() = Drawable10.icon_14593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14594: DrawableResource
+  get() = Drawable10.icon_14594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14595: DrawableResource
+  get() = Drawable10.icon_14595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14596: DrawableResource
+  get() = Drawable10.icon_14596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14597: DrawableResource
+  get() = Drawable10.icon_14597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14598: DrawableResource
+  get() = Drawable10.icon_14598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14599: DrawableResource
+  get() = Drawable10.icon_14599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_146: DrawableResource
+  get() = Drawable10.icon_146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1460: DrawableResource
+  get() = Drawable10.icon_1460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14600: DrawableResource
+  get() = Drawable10.icon_14600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14601: DrawableResource
+  get() = Drawable10.icon_14601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14602: DrawableResource
+  get() = Drawable10.icon_14602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14603: DrawableResource
+  get() = Drawable10.icon_14603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14604: DrawableResource
+  get() = Drawable10.icon_14604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14605: DrawableResource
+  get() = Drawable10.icon_14605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14606: DrawableResource
+  get() = Drawable10.icon_14606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14607: DrawableResource
+  get() = Drawable10.icon_14607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14608: DrawableResource
+  get() = Drawable10.icon_14608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14609: DrawableResource
+  get() = Drawable10.icon_14609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1461: DrawableResource
+  get() = Drawable10.icon_1461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14610: DrawableResource
+  get() = Drawable10.icon_14610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14611: DrawableResource
+  get() = Drawable10.icon_14611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14612: DrawableResource
+  get() = Drawable10.icon_14612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14613: DrawableResource
+  get() = Drawable10.icon_14613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14614: DrawableResource
+  get() = Drawable10.icon_14614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14615: DrawableResource
+  get() = Drawable10.icon_14615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14616: DrawableResource
+  get() = Drawable10.icon_14616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14617: DrawableResource
+  get() = Drawable10.icon_14617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14618: DrawableResource
+  get() = Drawable10.icon_14618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14619: DrawableResource
+  get() = Drawable10.icon_14619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1462: DrawableResource
+  get() = Drawable10.icon_1462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14620: DrawableResource
+  get() = Drawable10.icon_14620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14621: DrawableResource
+  get() = Drawable10.icon_14621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14622: DrawableResource
+  get() = Drawable10.icon_14622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14623: DrawableResource
+  get() = Drawable10.icon_14623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14624: DrawableResource
+  get() = Drawable10.icon_14624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14625: DrawableResource
+  get() = Drawable10.icon_14625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14626: DrawableResource
+  get() = Drawable10.icon_14626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14627: DrawableResource
+  get() = Drawable10.icon_14627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14628: DrawableResource
+  get() = Drawable10.icon_14628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14629: DrawableResource
+  get() = Drawable10.icon_14629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1463: DrawableResource
+  get() = Drawable10.icon_1463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14630: DrawableResource
+  get() = Drawable10.icon_14630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14631: DrawableResource
+  get() = Drawable10.icon_14631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14632: DrawableResource
+  get() = Drawable10.icon_14632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14633: DrawableResource
+  get() = Drawable10.icon_14633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14634: DrawableResource
+  get() = Drawable10.icon_14634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14635: DrawableResource
+  get() = Drawable10.icon_14635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14636: DrawableResource
+  get() = Drawable10.icon_14636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14637: DrawableResource
+  get() = Drawable10.icon_14637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14638: DrawableResource
+  get() = Drawable10.icon_14638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14639: DrawableResource
+  get() = Drawable10.icon_14639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1464: DrawableResource
+  get() = Drawable10.icon_1464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14640: DrawableResource
+  get() = Drawable10.icon_14640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14641: DrawableResource
+  get() = Drawable10.icon_14641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14642: DrawableResource
+  get() = Drawable10.icon_14642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14643: DrawableResource
+  get() = Drawable10.icon_14643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14644: DrawableResource
+  get() = Drawable10.icon_14644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14645: DrawableResource
+  get() = Drawable10.icon_14645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14646: DrawableResource
+  get() = Drawable10.icon_14646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14647: DrawableResource
+  get() = Drawable10.icon_14647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14648: DrawableResource
+  get() = Drawable10.icon_14648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14649: DrawableResource
+  get() = Drawable10.icon_14649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1465: DrawableResource
+  get() = Drawable10.icon_1465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14650: DrawableResource
+  get() = Drawable10.icon_14650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14651: DrawableResource
+  get() = Drawable10.icon_14651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14652: DrawableResource
+  get() = Drawable10.icon_14652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14653: DrawableResource
+  get() = Drawable10.icon_14653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14654: DrawableResource
+  get() = Drawable10.icon_14654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14655: DrawableResource
+  get() = Drawable10.icon_14655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14656: DrawableResource
+  get() = Drawable10.icon_14656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14657: DrawableResource
+  get() = Drawable10.icon_14657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14658: DrawableResource
+  get() = Drawable10.icon_14658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14659: DrawableResource
+  get() = Drawable10.icon_14659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1466: DrawableResource
+  get() = Drawable10.icon_1466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14660: DrawableResource
+  get() = Drawable10.icon_14660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14661: DrawableResource
+  get() = Drawable10.icon_14661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14662: DrawableResource
+  get() = Drawable10.icon_14662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14663: DrawableResource
+  get() = Drawable10.icon_14663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14664: DrawableResource
+  get() = Drawable10.icon_14664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14665: DrawableResource
+  get() = Drawable10.icon_14665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14666: DrawableResource
+  get() = Drawable10.icon_14666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14667: DrawableResource
+  get() = Drawable10.icon_14667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14668: DrawableResource
+  get() = Drawable10.icon_14668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14669: DrawableResource
+  get() = Drawable10.icon_14669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1467: DrawableResource
+  get() = Drawable10.icon_1467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14670: DrawableResource
+  get() = Drawable10.icon_14670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14671: DrawableResource
+  get() = Drawable10.icon_14671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14672: DrawableResource
+  get() = Drawable10.icon_14672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14673: DrawableResource
+  get() = Drawable10.icon_14673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14674: DrawableResource
+  get() = Drawable10.icon_14674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14675: DrawableResource
+  get() = Drawable10.icon_14675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14676: DrawableResource
+  get() = Drawable10.icon_14676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14677: DrawableResource
+  get() = Drawable10.icon_14677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14678: DrawableResource
+  get() = Drawable10.icon_14678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14679: DrawableResource
+  get() = Drawable10.icon_14679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1468: DrawableResource
+  get() = Drawable10.icon_1468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14680: DrawableResource
+  get() = Drawable10.icon_14680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14681: DrawableResource
+  get() = Drawable10.icon_14681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14682: DrawableResource
+  get() = Drawable10.icon_14682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14683: DrawableResource
+  get() = Drawable10.icon_14683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14684: DrawableResource
+  get() = Drawable10.icon_14684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14685: DrawableResource
+  get() = Drawable10.icon_14685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14686: DrawableResource
+  get() = Drawable10.icon_14686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14687: DrawableResource
+  get() = Drawable10.icon_14687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14688: DrawableResource
+  get() = Drawable10.icon_14688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14689: DrawableResource
+  get() = Drawable10.icon_14689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1469: DrawableResource
+  get() = Drawable10.icon_1469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14690: DrawableResource
+  get() = Drawable10.icon_14690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14691: DrawableResource
+  get() = Drawable10.icon_14691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14692: DrawableResource
+  get() = Drawable10.icon_14692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14693: DrawableResource
+  get() = Drawable10.icon_14693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14694: DrawableResource
+  get() = Drawable10.icon_14694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14695: DrawableResource
+  get() = Drawable10.icon_14695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14696: DrawableResource
+  get() = Drawable10.icon_14696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14697: DrawableResource
+  get() = Drawable10.icon_14697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14698: DrawableResource
+  get() = Drawable10.icon_14698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14699: DrawableResource
+  get() = Drawable10.icon_14699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_147: DrawableResource
+  get() = Drawable10.icon_147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1470: DrawableResource
+  get() = Drawable10.icon_1470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14700: DrawableResource
+  get() = Drawable10.icon_14700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14701: DrawableResource
+  get() = Drawable10.icon_14701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14702: DrawableResource
+  get() = Drawable10.icon_14702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14703: DrawableResource
+  get() = Drawable10.icon_14703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14704: DrawableResource
+  get() = Drawable10.icon_14704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14705: DrawableResource
+  get() = Drawable10.icon_14705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14706: DrawableResource
+  get() = Drawable10.icon_14706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14707: DrawableResource
+  get() = Drawable10.icon_14707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14708: DrawableResource
+  get() = Drawable10.icon_14708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14709: DrawableResource
+  get() = Drawable10.icon_14709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1471: DrawableResource
+  get() = Drawable10.icon_1471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14710: DrawableResource
+  get() = Drawable10.icon_14710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14711: DrawableResource
+  get() = Drawable10.icon_14711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14712: DrawableResource
+  get() = Drawable10.icon_14712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14713: DrawableResource
+  get() = Drawable10.icon_14713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14714: DrawableResource
+  get() = Drawable10.icon_14714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14715: DrawableResource
+  get() = Drawable10.icon_14715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14716: DrawableResource
+  get() = Drawable10.icon_14716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14717: DrawableResource
+  get() = Drawable10.icon_14717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14718: DrawableResource
+  get() = Drawable10.icon_14718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14719: DrawableResource
+  get() = Drawable10.icon_14719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1472: DrawableResource
+  get() = Drawable10.icon_1472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14720: DrawableResource
+  get() = Drawable10.icon_14720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14721: DrawableResource
+  get() = Drawable10.icon_14721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14722: DrawableResource
+  get() = Drawable10.icon_14722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14723: DrawableResource
+  get() = Drawable10.icon_14723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14724: DrawableResource
+  get() = Drawable10.icon_14724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14725: DrawableResource
+  get() = Drawable10.icon_14725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14726: DrawableResource
+  get() = Drawable10.icon_14726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14727: DrawableResource
+  get() = Drawable10.icon_14727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14728: DrawableResource
+  get() = Drawable10.icon_14728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14729: DrawableResource
+  get() = Drawable10.icon_14729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1473: DrawableResource
+  get() = Drawable10.icon_1473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14730: DrawableResource
+  get() = Drawable10.icon_14730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14731: DrawableResource
+  get() = Drawable10.icon_14731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14732: DrawableResource
+  get() = Drawable10.icon_14732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14733: DrawableResource
+  get() = Drawable10.icon_14733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14734: DrawableResource
+  get() = Drawable10.icon_14734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14735: DrawableResource
+  get() = Drawable10.icon_14735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14736: DrawableResource
+  get() = Drawable10.icon_14736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14737: DrawableResource
+  get() = Drawable10.icon_14737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14738: DrawableResource
+  get() = Drawable10.icon_14738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14739: DrawableResource
+  get() = Drawable10.icon_14739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1474: DrawableResource
+  get() = Drawable10.icon_1474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14740: DrawableResource
+  get() = Drawable10.icon_14740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14741: DrawableResource
+  get() = Drawable10.icon_14741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14742: DrawableResource
+  get() = Drawable10.icon_14742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14743: DrawableResource
+  get() = Drawable10.icon_14743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14744: DrawableResource
+  get() = Drawable10.icon_14744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14745: DrawableResource
+  get() = Drawable10.icon_14745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14746: DrawableResource
+  get() = Drawable10.icon_14746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14747: DrawableResource
+  get() = Drawable10.icon_14747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14748: DrawableResource
+  get() = Drawable10.icon_14748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14749: DrawableResource
+  get() = Drawable10.icon_14749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1475: DrawableResource
+  get() = Drawable10.icon_1475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14750: DrawableResource
+  get() = Drawable10.icon_14750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14751: DrawableResource
+  get() = Drawable10.icon_14751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14752: DrawableResource
+  get() = Drawable10.icon_14752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14753: DrawableResource
+  get() = Drawable10.icon_14753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14754: DrawableResource
+  get() = Drawable10.icon_14754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14755: DrawableResource
+  get() = Drawable10.icon_14755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14756: DrawableResource
+  get() = Drawable10.icon_14756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14757: DrawableResource
+  get() = Drawable10.icon_14757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14758: DrawableResource
+  get() = Drawable10.icon_14758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14759: DrawableResource
+  get() = Drawable10.icon_14759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1476: DrawableResource
+  get() = Drawable10.icon_1476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14760: DrawableResource
+  get() = Drawable10.icon_14760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14761: DrawableResource
+  get() = Drawable10.icon_14761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14762: DrawableResource
+  get() = Drawable10.icon_14762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14763: DrawableResource
+  get() = Drawable10.icon_14763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14764: DrawableResource
+  get() = Drawable10.icon_14764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14765: DrawableResource
+  get() = Drawable10.icon_14765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14766: DrawableResource
+  get() = Drawable10.icon_14766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14767: DrawableResource
+  get() = Drawable10.icon_14767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14768: DrawableResource
+  get() = Drawable10.icon_14768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14769: DrawableResource
+  get() = Drawable10.icon_14769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1477: DrawableResource
+  get() = Drawable10.icon_1477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14770: DrawableResource
+  get() = Drawable10.icon_14770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14771: DrawableResource
+  get() = Drawable10.icon_14771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14772: DrawableResource
+  get() = Drawable10.icon_14772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14773: DrawableResource
+  get() = Drawable10.icon_14773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14774: DrawableResource
+  get() = Drawable10.icon_14774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14775: DrawableResource
+  get() = Drawable10.icon_14775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14776: DrawableResource
+  get() = Drawable10.icon_14776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14777: DrawableResource
+  get() = Drawable10.icon_14777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14778: DrawableResource
+  get() = Drawable10.icon_14778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14779: DrawableResource
+  get() = Drawable10.icon_14779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1478: DrawableResource
+  get() = Drawable10.icon_1478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14780: DrawableResource
+  get() = Drawable10.icon_14780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14781: DrawableResource
+  get() = Drawable10.icon_14781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14782: DrawableResource
+  get() = Drawable10.icon_14782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14783: DrawableResource
+  get() = Drawable10.icon_14783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14784: DrawableResource
+  get() = Drawable10.icon_14784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14785: DrawableResource
+  get() = Drawable10.icon_14785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14786: DrawableResource
+  get() = Drawable10.icon_14786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14787: DrawableResource
+  get() = Drawable10.icon_14787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14788: DrawableResource
+  get() = Drawable10.icon_14788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14789: DrawableResource
+  get() = Drawable10.icon_14789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1479: DrawableResource
+  get() = Drawable10.icon_1479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14790: DrawableResource
+  get() = Drawable10.icon_14790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14791: DrawableResource
+  get() = Drawable10.icon_14791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14792: DrawableResource
+  get() = Drawable10.icon_14792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14793: DrawableResource
+  get() = Drawable10.icon_14793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14794: DrawableResource
+  get() = Drawable10.icon_14794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14795: DrawableResource
+  get() = Drawable10.icon_14795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14796: DrawableResource
+  get() = Drawable10.icon_14796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14797: DrawableResource
+  get() = Drawable10.icon_14797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14798: DrawableResource
+  get() = Drawable10.icon_14798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14799: DrawableResource
+  get() = Drawable10.icon_14799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_148: DrawableResource
+  get() = Drawable10.icon_148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1480: DrawableResource
+  get() = Drawable10.icon_1480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14800: DrawableResource
+  get() = Drawable10.icon_14800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14801: DrawableResource
+  get() = Drawable10.icon_14801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14802: DrawableResource
+  get() = Drawable10.icon_14802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14803: DrawableResource
+  get() = Drawable10.icon_14803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14804: DrawableResource
+  get() = Drawable10.icon_14804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14805: DrawableResource
+  get() = Drawable10.icon_14805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14806: DrawableResource
+  get() = Drawable10.icon_14806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14807: DrawableResource
+  get() = Drawable10.icon_14807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14808: DrawableResource
+  get() = Drawable10.icon_14808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14809: DrawableResource
+  get() = Drawable10.icon_14809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1481: DrawableResource
+  get() = Drawable10.icon_1481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14810: DrawableResource
+  get() = Drawable10.icon_14810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14811: DrawableResource
+  get() = Drawable10.icon_14811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14812: DrawableResource
+  get() = Drawable10.icon_14812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14813: DrawableResource
+  get() = Drawable10.icon_14813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14814: DrawableResource
+  get() = Drawable10.icon_14814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14815: DrawableResource
+  get() = Drawable10.icon_14815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14816: DrawableResource
+  get() = Drawable10.icon_14816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14817: DrawableResource
+  get() = Drawable10.icon_14817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14818: DrawableResource
+  get() = Drawable10.icon_14818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14819: DrawableResource
+  get() = Drawable10.icon_14819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1482: DrawableResource
+  get() = Drawable10.icon_1482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14820: DrawableResource
+  get() = Drawable10.icon_14820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14821: DrawableResource
+  get() = Drawable10.icon_14821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14822: DrawableResource
+  get() = Drawable10.icon_14822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14823: DrawableResource
+  get() = Drawable10.icon_14823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14824: DrawableResource
+  get() = Drawable10.icon_14824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14825: DrawableResource
+  get() = Drawable10.icon_14825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14826: DrawableResource
+  get() = Drawable10.icon_14826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14827: DrawableResource
+  get() = Drawable10.icon_14827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14828: DrawableResource
+  get() = Drawable10.icon_14828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14829: DrawableResource
+  get() = Drawable10.icon_14829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1483: DrawableResource
+  get() = Drawable10.icon_1483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14830: DrawableResource
+  get() = Drawable10.icon_14830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14831: DrawableResource
+  get() = Drawable10.icon_14831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14832: DrawableResource
+  get() = Drawable10.icon_14832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14833: DrawableResource
+  get() = Drawable10.icon_14833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14834: DrawableResource
+  get() = Drawable10.icon_14834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14835: DrawableResource
+  get() = Drawable10.icon_14835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14836: DrawableResource
+  get() = Drawable10.icon_14836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14837: DrawableResource
+  get() = Drawable10.icon_14837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14838: DrawableResource
+  get() = Drawable10.icon_14838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14839: DrawableResource
+  get() = Drawable10.icon_14839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1484: DrawableResource
+  get() = Drawable10.icon_1484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14840: DrawableResource
+  get() = Drawable10.icon_14840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14841: DrawableResource
+  get() = Drawable10.icon_14841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14842: DrawableResource
+  get() = Drawable10.icon_14842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14843: DrawableResource
+  get() = Drawable10.icon_14843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14844: DrawableResource
+  get() = Drawable10.icon_14844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14845: DrawableResource
+  get() = Drawable10.icon_14845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14846: DrawableResource
+  get() = Drawable10.icon_14846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14847: DrawableResource
+  get() = Drawable10.icon_14847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14848: DrawableResource
+  get() = Drawable10.icon_14848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14849: DrawableResource
+  get() = Drawable10.icon_14849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1485: DrawableResource
+  get() = Drawable10.icon_1485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14850: DrawableResource
+  get() = Drawable10.icon_14850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14851: DrawableResource
+  get() = Drawable10.icon_14851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14852: DrawableResource
+  get() = Drawable10.icon_14852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14853: DrawableResource
+  get() = Drawable10.icon_14853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14854: DrawableResource
+  get() = Drawable10.icon_14854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14855: DrawableResource
+  get() = Drawable10.icon_14855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14856: DrawableResource
+  get() = Drawable10.icon_14856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14857: DrawableResource
+  get() = Drawable10.icon_14857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14858: DrawableResource
+  get() = Drawable10.icon_14858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14859: DrawableResource
+  get() = Drawable10.icon_14859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1486: DrawableResource
+  get() = Drawable10.icon_1486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14860: DrawableResource
+  get() = Drawable10.icon_14860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14861: DrawableResource
+  get() = Drawable10.icon_14861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14862: DrawableResource
+  get() = Drawable10.icon_14862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14863: DrawableResource
+  get() = Drawable10.icon_14863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14864: DrawableResource
+  get() = Drawable10.icon_14864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14865: DrawableResource
+  get() = Drawable10.icon_14865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14866: DrawableResource
+  get() = Drawable10.icon_14866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14867: DrawableResource
+  get() = Drawable10.icon_14867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14868: DrawableResource
+  get() = Drawable10.icon_14868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14869: DrawableResource
+  get() = Drawable10.icon_14869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1487: DrawableResource
+  get() = Drawable10.icon_1487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14870: DrawableResource
+  get() = Drawable10.icon_14870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14871: DrawableResource
+  get() = Drawable10.icon_14871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14872: DrawableResource
+  get() = Drawable10.icon_14872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14873: DrawableResource
+  get() = Drawable10.icon_14873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14874: DrawableResource
+  get() = Drawable10.icon_14874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14875: DrawableResource
+  get() = Drawable10.icon_14875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14876: DrawableResource
+  get() = Drawable10.icon_14876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14877: DrawableResource
+  get() = Drawable10.icon_14877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14878: DrawableResource
+  get() = Drawable10.icon_14878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14879: DrawableResource
+  get() = Drawable10.icon_14879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1488: DrawableResource
+  get() = Drawable10.icon_1488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14880: DrawableResource
+  get() = Drawable10.icon_14880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14881: DrawableResource
+  get() = Drawable10.icon_14881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14882: DrawableResource
+  get() = Drawable10.icon_14882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14883: DrawableResource
+  get() = Drawable10.icon_14883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14884: DrawableResource
+  get() = Drawable10.icon_14884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14885: DrawableResource
+  get() = Drawable10.icon_14885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14886: DrawableResource
+  get() = Drawable10.icon_14886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14887: DrawableResource
+  get() = Drawable10.icon_14887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14888: DrawableResource
+  get() = Drawable10.icon_14888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14889: DrawableResource
+  get() = Drawable10.icon_14889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1489: DrawableResource
+  get() = Drawable10.icon_1489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14890: DrawableResource
+  get() = Drawable10.icon_14890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14891: DrawableResource
+  get() = Drawable10.icon_14891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14892: DrawableResource
+  get() = Drawable10.icon_14892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14893: DrawableResource
+  get() = Drawable10.icon_14893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14894: DrawableResource
+  get() = Drawable10.icon_14894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14895: DrawableResource
+  get() = Drawable10.icon_14895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14896: DrawableResource
+  get() = Drawable10.icon_14896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14897: DrawableResource
+  get() = Drawable10.icon_14897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14898: DrawableResource
+  get() = Drawable10.icon_14898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14899: DrawableResource
+  get() = Drawable10.icon_14899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_149: DrawableResource
+  get() = Drawable10.icon_149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1490: DrawableResource
+  get() = Drawable10.icon_1490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14900: DrawableResource
+  get() = Drawable10.icon_14900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14901: DrawableResource
+  get() = Drawable10.icon_14901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14902: DrawableResource
+  get() = Drawable10.icon_14902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14903: DrawableResource
+  get() = Drawable10.icon_14903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14904: DrawableResource
+  get() = Drawable10.icon_14904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14905: DrawableResource
+  get() = Drawable10.icon_14905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14906: DrawableResource
+  get() = Drawable10.icon_14906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14907: DrawableResource
+  get() = Drawable10.icon_14907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14908: DrawableResource
+  get() = Drawable10.icon_14908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14909: DrawableResource
+  get() = Drawable10.icon_14909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1491: DrawableResource
+  get() = Drawable10.icon_1491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14910: DrawableResource
+  get() = Drawable10.icon_14910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14911: DrawableResource
+  get() = Drawable10.icon_14911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14912: DrawableResource
+  get() = Drawable10.icon_14912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14913: DrawableResource
+  get() = Drawable10.icon_14913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14914: DrawableResource
+  get() = Drawable10.icon_14914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14915: DrawableResource
+  get() = Drawable10.icon_14915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14916: DrawableResource
+  get() = Drawable10.icon_14916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14917: DrawableResource
+  get() = Drawable10.icon_14917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14918: DrawableResource
+  get() = Drawable10.icon_14918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14919: DrawableResource
+  get() = Drawable10.icon_14919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1492: DrawableResource
+  get() = Drawable10.icon_1492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14920: DrawableResource
+  get() = Drawable10.icon_14920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14921: DrawableResource
+  get() = Drawable10.icon_14921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14922: DrawableResource
+  get() = Drawable10.icon_14922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14923: DrawableResource
+  get() = Drawable10.icon_14923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14924: DrawableResource
+  get() = Drawable10.icon_14924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14925: DrawableResource
+  get() = Drawable10.icon_14925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14926: DrawableResource
+  get() = Drawable10.icon_14926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14927: DrawableResource
+  get() = Drawable10.icon_14927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14928: DrawableResource
+  get() = Drawable10.icon_14928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14929: DrawableResource
+  get() = Drawable10.icon_14929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1493: DrawableResource
+  get() = Drawable10.icon_1493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14930: DrawableResource
+  get() = Drawable10.icon_14930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14931: DrawableResource
+  get() = Drawable10.icon_14931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14932: DrawableResource
+  get() = Drawable10.icon_14932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14933: DrawableResource
+  get() = Drawable10.icon_14933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14934: DrawableResource
+  get() = Drawable10.icon_14934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14935: DrawableResource
+  get() = Drawable10.icon_14935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14936: DrawableResource
+  get() = Drawable10.icon_14936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14937: DrawableResource
+  get() = Drawable10.icon_14937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14938: DrawableResource
+  get() = Drawable10.icon_14938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14939: DrawableResource
+  get() = Drawable10.icon_14939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1494: DrawableResource
+  get() = Drawable10.icon_1494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14940: DrawableResource
+  get() = Drawable10.icon_14940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14941: DrawableResource
+  get() = Drawable10.icon_14941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14942: DrawableResource
+  get() = Drawable10.icon_14942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14943: DrawableResource
+  get() = Drawable10.icon_14943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14944: DrawableResource
+  get() = Drawable10.icon_14944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14945: DrawableResource
+  get() = Drawable10.icon_14945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14946: DrawableResource
+  get() = Drawable10.icon_14946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14947: DrawableResource
+  get() = Drawable10.icon_14947

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable11.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable11.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable11 {
+  public val icon_14948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14948.xml"),
+          )
+      )
+
+  public val icon_14949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14949.xml"),
+          )
+      )
+
+  public val icon_1495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1495.xml"),
+          )
+      )
+
+  public val icon_14950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14950.xml"),
+          )
+      )
+
+  public val icon_14951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14951.xml"),
+          )
+      )
+
+  public val icon_14952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14952.xml"),
+          )
+      )
+
+  public val icon_14953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14953.xml"),
+          )
+      )
+
+  public val icon_14954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14954.xml"),
+          )
+      )
+
+  public val icon_14955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14955.xml"),
+          )
+      )
+
+  public val icon_14956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14956.xml"),
+          )
+      )
+
+  public val icon_14957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14957.xml"),
+          )
+      )
+
+  public val icon_14958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14958.xml"),
+          )
+      )
+
+  public val icon_14959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14959.xml"),
+          )
+      )
+
+  public val icon_1496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1496.xml"),
+          )
+      )
+
+  public val icon_14960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14960.xml"),
+          )
+      )
+
+  public val icon_14961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14961.xml"),
+          )
+      )
+
+  public val icon_14962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14962.xml"),
+          )
+      )
+
+  public val icon_14963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14963.xml"),
+          )
+      )
+
+  public val icon_14964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14964.xml"),
+          )
+      )
+
+  public val icon_14965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14965.xml"),
+          )
+      )
+
+  public val icon_14966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14966.xml"),
+          )
+      )
+
+  public val icon_14967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14967.xml"),
+          )
+      )
+
+  public val icon_14968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14968.xml"),
+          )
+      )
+
+  public val icon_14969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14969.xml"),
+          )
+      )
+
+  public val icon_1497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1497.xml"),
+          )
+      )
+
+  public val icon_14970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14970.xml"),
+          )
+      )
+
+  public val icon_14971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14971.xml"),
+          )
+      )
+
+  public val icon_14972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14972.xml"),
+          )
+      )
+
+  public val icon_14973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14973.xml"),
+          )
+      )
+
+  public val icon_14974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14974.xml"),
+          )
+      )
+
+  public val icon_14975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14975.xml"),
+          )
+      )
+
+  public val icon_14976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14976.xml"),
+          )
+      )
+
+  public val icon_14977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14977.xml"),
+          )
+      )
+
+  public val icon_14978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14978.xml"),
+          )
+      )
+
+  public val icon_14979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14979.xml"),
+          )
+      )
+
+  public val icon_1498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1498.xml"),
+          )
+      )
+
+  public val icon_14980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14980.xml"),
+          )
+      )
+
+  public val icon_14981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14981.xml"),
+          )
+      )
+
+  public val icon_14982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14982.xml"),
+          )
+      )
+
+  public val icon_14983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14983.xml"),
+          )
+      )
+
+  public val icon_14984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14984.xml"),
+          )
+      )
+
+  public val icon_14985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14985.xml"),
+          )
+      )
+
+  public val icon_14986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14986.xml"),
+          )
+      )
+
+  public val icon_14987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14987.xml"),
+          )
+      )
+
+  public val icon_14988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14988.xml"),
+          )
+      )
+
+  public val icon_14989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14989.xml"),
+          )
+      )
+
+  public val icon_1499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1499.xml"),
+          )
+      )
+
+  public val icon_14990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14990.xml"),
+          )
+      )
+
+  public val icon_14991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14991.xml"),
+          )
+      )
+
+  public val icon_14992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14992.xml"),
+          )
+      )
+
+  public val icon_14993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14993.xml"),
+          )
+      )
+
+  public val icon_14994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14994.xml"),
+          )
+      )
+
+  public val icon_14995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14995.xml"),
+          )
+      )
+
+  public val icon_14996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14996.xml"),
+          )
+      )
+
+  public val icon_14997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14997.xml"),
+          )
+      )
+
+  public val icon_14998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14998.xml"),
+          )
+      )
+
+  public val icon_14999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14999.xml"),
+          )
+      )
+
+  public val icon_15: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15.xml"),
+          )
+      )
+
+  public val icon_150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_150.xml"),
+          )
+      )
+
+  public val icon_1500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1500.xml"),
+          )
+      )
+
+  public val icon_15000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15000.xml"),
+          )
+      )
+
+  public val icon_15001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15001.xml"),
+          )
+      )
+
+  public val icon_15002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15002.xml"),
+          )
+      )
+
+  public val icon_15003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15003.xml"),
+          )
+      )
+
+  public val icon_15004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15004.xml"),
+          )
+      )
+
+  public val icon_15005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15005.xml"),
+          )
+      )
+
+  public val icon_15006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15006.xml"),
+          )
+      )
+
+  public val icon_15007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15007.xml"),
+          )
+      )
+
+  public val icon_15008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15008.xml"),
+          )
+      )
+
+  public val icon_15009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15009.xml"),
+          )
+      )
+
+  public val icon_1501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1501.xml"),
+          )
+      )
+
+  public val icon_15010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15010.xml"),
+          )
+      )
+
+  public val icon_15011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15011.xml"),
+          )
+      )
+
+  public val icon_15012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15012.xml"),
+          )
+      )
+
+  public val icon_15013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15013.xml"),
+          )
+      )
+
+  public val icon_15014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15014.xml"),
+          )
+      )
+
+  public val icon_15015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15015.xml"),
+          )
+      )
+
+  public val icon_15016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15016.xml"),
+          )
+      )
+
+  public val icon_15017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15017.xml"),
+          )
+      )
+
+  public val icon_15018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15018.xml"),
+          )
+      )
+
+  public val icon_15019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15019.xml"),
+          )
+      )
+
+  public val icon_1502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1502.xml"),
+          )
+      )
+
+  public val icon_15020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15020.xml"),
+          )
+      )
+
+  public val icon_15021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15021.xml"),
+          )
+      )
+
+  public val icon_15022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15022.xml"),
+          )
+      )
+
+  public val icon_15023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15023.xml"),
+          )
+      )
+
+  public val icon_15024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15024.xml"),
+          )
+      )
+
+  public val icon_15025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15025.xml"),
+          )
+      )
+
+  public val icon_15026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15026.xml"),
+          )
+      )
+
+  public val icon_15027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15027.xml"),
+          )
+      )
+
+  public val icon_15028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15028.xml"),
+          )
+      )
+
+  public val icon_15029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15029.xml"),
+          )
+      )
+
+  public val icon_1503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1503.xml"),
+          )
+      )
+
+  public val icon_15030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15030.xml"),
+          )
+      )
+
+  public val icon_15031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15031.xml"),
+          )
+      )
+
+  public val icon_15032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15032.xml"),
+          )
+      )
+
+  public val icon_15033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15033.xml"),
+          )
+      )
+
+  public val icon_15034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15034.xml"),
+          )
+      )
+
+  public val icon_15035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15035.xml"),
+          )
+      )
+
+  public val icon_15036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15036.xml"),
+          )
+      )
+
+  public val icon_15037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15037.xml"),
+          )
+      )
+
+  public val icon_15038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15038.xml"),
+          )
+      )
+
+  public val icon_15039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15039.xml"),
+          )
+      )
+
+  public val icon_1504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1504.xml"),
+          )
+      )
+
+  public val icon_15040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15040.xml"),
+          )
+      )
+
+  public val icon_15041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15041.xml"),
+          )
+      )
+
+  public val icon_15042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15042.xml"),
+          )
+      )
+
+  public val icon_15043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15043.xml"),
+          )
+      )
+
+  public val icon_15044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15044.xml"),
+          )
+      )
+
+  public val icon_15045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15045.xml"),
+          )
+      )
+
+  public val icon_15046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15046.xml"),
+          )
+      )
+
+  public val icon_15047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15047.xml"),
+          )
+      )
+
+  public val icon_15048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15048.xml"),
+          )
+      )
+
+  public val icon_15049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15049.xml"),
+          )
+      )
+
+  public val icon_1505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1505.xml"),
+          )
+      )
+
+  public val icon_15050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15050.xml"),
+          )
+      )
+
+  public val icon_15051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15051.xml"),
+          )
+      )
+
+  public val icon_15052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15052.xml"),
+          )
+      )
+
+  public val icon_15053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15053.xml"),
+          )
+      )
+
+  public val icon_15054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15054.xml"),
+          )
+      )
+
+  public val icon_15055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15055.xml"),
+          )
+      )
+
+  public val icon_15056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15056.xml"),
+          )
+      )
+
+  public val icon_15057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15057.xml"),
+          )
+      )
+
+  public val icon_15058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15058.xml"),
+          )
+      )
+
+  public val icon_15059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15059.xml"),
+          )
+      )
+
+  public val icon_1506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1506.xml"),
+          )
+      )
+
+  public val icon_15060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15060.xml"),
+          )
+      )
+
+  public val icon_15061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15061.xml"),
+          )
+      )
+
+  public val icon_15062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15062.xml"),
+          )
+      )
+
+  public val icon_15063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15063.xml"),
+          )
+      )
+
+  public val icon_15064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15064.xml"),
+          )
+      )
+
+  public val icon_15065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15065.xml"),
+          )
+      )
+
+  public val icon_15066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15066.xml"),
+          )
+      )
+
+  public val icon_15067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15067.xml"),
+          )
+      )
+
+  public val icon_15068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15068.xml"),
+          )
+      )
+
+  public val icon_15069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15069.xml"),
+          )
+      )
+
+  public val icon_1507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1507.xml"),
+          )
+      )
+
+  public val icon_15070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15070.xml"),
+          )
+      )
+
+  public val icon_15071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15071.xml"),
+          )
+      )
+
+  public val icon_15072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15072.xml"),
+          )
+      )
+
+  public val icon_15073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15073.xml"),
+          )
+      )
+
+  public val icon_15074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15074.xml"),
+          )
+      )
+
+  public val icon_15075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15075.xml"),
+          )
+      )
+
+  public val icon_15076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15076.xml"),
+          )
+      )
+
+  public val icon_15077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15077.xml"),
+          )
+      )
+
+  public val icon_15078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15078.xml"),
+          )
+      )
+
+  public val icon_15079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15079.xml"),
+          )
+      )
+
+  public val icon_1508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1508.xml"),
+          )
+      )
+
+  public val icon_15080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15080.xml"),
+          )
+      )
+
+  public val icon_15081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15081.xml"),
+          )
+      )
+
+  public val icon_15082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15082.xml"),
+          )
+      )
+
+  public val icon_15083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15083.xml"),
+          )
+      )
+
+  public val icon_15084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15084.xml"),
+          )
+      )
+
+  public val icon_15085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15085.xml"),
+          )
+      )
+
+  public val icon_15086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15086.xml"),
+          )
+      )
+
+  public val icon_15087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15087.xml"),
+          )
+      )
+
+  public val icon_15088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15088.xml"),
+          )
+      )
+
+  public val icon_15089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15089.xml"),
+          )
+      )
+
+  public val icon_1509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1509.xml"),
+          )
+      )
+
+  public val icon_15090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15090.xml"),
+          )
+      )
+
+  public val icon_15091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15091.xml"),
+          )
+      )
+
+  public val icon_15092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15092.xml"),
+          )
+      )
+
+  public val icon_15093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15093.xml"),
+          )
+      )
+
+  public val icon_15094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15094.xml"),
+          )
+      )
+
+  public val icon_15095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15095.xml"),
+          )
+      )
+
+  public val icon_15096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15096.xml"),
+          )
+      )
+
+  public val icon_15097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15097.xml"),
+          )
+      )
+
+  public val icon_15098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15098.xml"),
+          )
+      )
+
+  public val icon_15099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15099.xml"),
+          )
+      )
+
+  public val icon_151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_151.xml"),
+          )
+      )
+
+  public val icon_1510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1510.xml"),
+          )
+      )
+
+  public val icon_15100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15100.xml"),
+          )
+      )
+
+  public val icon_15101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15101.xml"),
+          )
+      )
+
+  public val icon_15102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15102.xml"),
+          )
+      )
+
+  public val icon_15103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15103.xml"),
+          )
+      )
+
+  public val icon_15104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15104.xml"),
+          )
+      )
+
+  public val icon_15105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15105.xml"),
+          )
+      )
+
+  public val icon_15106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15106.xml"),
+          )
+      )
+
+  public val icon_15107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15107.xml"),
+          )
+      )
+
+  public val icon_15108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15108.xml"),
+          )
+      )
+
+  public val icon_15109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15109.xml"),
+          )
+      )
+
+  public val icon_1511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1511.xml"),
+          )
+      )
+
+  public val icon_15110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15110.xml"),
+          )
+      )
+
+  public val icon_15111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15111.xml"),
+          )
+      )
+
+  public val icon_15112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15112.xml"),
+          )
+      )
+
+  public val icon_15113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15113.xml"),
+          )
+      )
+
+  public val icon_15114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15114.xml"),
+          )
+      )
+
+  public val icon_15115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15115.xml"),
+          )
+      )
+
+  public val icon_15116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15116.xml"),
+          )
+      )
+
+  public val icon_15117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15117.xml"),
+          )
+      )
+
+  public val icon_15118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15118.xml"),
+          )
+      )
+
+  public val icon_15119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15119.xml"),
+          )
+      )
+
+  public val icon_1512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1512.xml"),
+          )
+      )
+
+  public val icon_15120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15120.xml"),
+          )
+      )
+
+  public val icon_15121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15121.xml"),
+          )
+      )
+
+  public val icon_15122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15122.xml"),
+          )
+      )
+
+  public val icon_15123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15123.xml"),
+          )
+      )
+
+  public val icon_15124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15124.xml"),
+          )
+      )
+
+  public val icon_15125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15125.xml"),
+          )
+      )
+
+  public val icon_15126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15126.xml"),
+          )
+      )
+
+  public val icon_15127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15127.xml"),
+          )
+      )
+
+  public val icon_15128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15128.xml"),
+          )
+      )
+
+  public val icon_15129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15129.xml"),
+          )
+      )
+
+  public val icon_1513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1513.xml"),
+          )
+      )
+
+  public val icon_15130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15130.xml"),
+          )
+      )
+
+  public val icon_15131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15131.xml"),
+          )
+      )
+
+  public val icon_15132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15132.xml"),
+          )
+      )
+
+  public val icon_15133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15133.xml"),
+          )
+      )
+
+  public val icon_15134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15134.xml"),
+          )
+      )
+
+  public val icon_15135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15135.xml"),
+          )
+      )
+
+  public val icon_15136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15136.xml"),
+          )
+      )
+
+  public val icon_15137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15137.xml"),
+          )
+      )
+
+  public val icon_15138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15138.xml"),
+          )
+      )
+
+  public val icon_15139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15139.xml"),
+          )
+      )
+
+  public val icon_1514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1514.xml"),
+          )
+      )
+
+  public val icon_15140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15140.xml"),
+          )
+      )
+
+  public val icon_15141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15141.xml"),
+          )
+      )
+
+  public val icon_15142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15142.xml"),
+          )
+      )
+
+  public val icon_15143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15143.xml"),
+          )
+      )
+
+  public val icon_15144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15144.xml"),
+          )
+      )
+
+  public val icon_15145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15145.xml"),
+          )
+      )
+
+  public val icon_15146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15146.xml"),
+          )
+      )
+
+  public val icon_15147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15147.xml"),
+          )
+      )
+
+  public val icon_15148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15148.xml"),
+          )
+      )
+
+  public val icon_15149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15149.xml"),
+          )
+      )
+
+  public val icon_1515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1515.xml"),
+          )
+      )
+
+  public val icon_15150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15150.xml"),
+          )
+      )
+
+  public val icon_15151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15151.xml"),
+          )
+      )
+
+  public val icon_15152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15152.xml"),
+          )
+      )
+
+  public val icon_15153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15153.xml"),
+          )
+      )
+
+  public val icon_15154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15154.xml"),
+          )
+      )
+
+  public val icon_15155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15155.xml"),
+          )
+      )
+
+  public val icon_15156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15156.xml"),
+          )
+      )
+
+  public val icon_15157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15157.xml"),
+          )
+      )
+
+  public val icon_15158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15158.xml"),
+          )
+      )
+
+  public val icon_15159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15159.xml"),
+          )
+      )
+
+  public val icon_1516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1516.xml"),
+          )
+      )
+
+  public val icon_15160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15160.xml"),
+          )
+      )
+
+  public val icon_15161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15161.xml"),
+          )
+      )
+
+  public val icon_15162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15162.xml"),
+          )
+      )
+
+  public val icon_15163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15163.xml"),
+          )
+      )
+
+  public val icon_15164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15164.xml"),
+          )
+      )
+
+  public val icon_15165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15165.xml"),
+          )
+      )
+
+  public val icon_15166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15166.xml"),
+          )
+      )
+
+  public val icon_15167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15167.xml"),
+          )
+      )
+
+  public val icon_15168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15168.xml"),
+          )
+      )
+
+  public val icon_15169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15169.xml"),
+          )
+      )
+
+  public val icon_1517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1517.xml"),
+          )
+      )
+
+  public val icon_15170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15170.xml"),
+          )
+      )
+
+  public val icon_15171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15171.xml"),
+          )
+      )
+
+  public val icon_15172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15172.xml"),
+          )
+      )
+
+  public val icon_15173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15173.xml"),
+          )
+      )
+
+  public val icon_15174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15174.xml"),
+          )
+      )
+
+  public val icon_15175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15175.xml"),
+          )
+      )
+
+  public val icon_15176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15176.xml"),
+          )
+      )
+
+  public val icon_15177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15177.xml"),
+          )
+      )
+
+  public val icon_15178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15178.xml"),
+          )
+      )
+
+  public val icon_15179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15179.xml"),
+          )
+      )
+
+  public val icon_1518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1518.xml"),
+          )
+      )
+
+  public val icon_15180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15180.xml"),
+          )
+      )
+
+  public val icon_15181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15181.xml"),
+          )
+      )
+
+  public val icon_15182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15182.xml"),
+          )
+      )
+
+  public val icon_15183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15183.xml"),
+          )
+      )
+
+  public val icon_15184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15184.xml"),
+          )
+      )
+
+  public val icon_15185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15185.xml"),
+          )
+      )
+
+  public val icon_15186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15186.xml"),
+          )
+      )
+
+  public val icon_15187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15187.xml"),
+          )
+      )
+
+  public val icon_15188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15188.xml"),
+          )
+      )
+
+  public val icon_15189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15189.xml"),
+          )
+      )
+
+  public val icon_1519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1519.xml"),
+          )
+      )
+
+  public val icon_15190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15190.xml"),
+          )
+      )
+
+  public val icon_15191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15191.xml"),
+          )
+      )
+
+  public val icon_15192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15192.xml"),
+          )
+      )
+
+  public val icon_15193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15193.xml"),
+          )
+      )
+
+  public val icon_15194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15194.xml"),
+          )
+      )
+
+  public val icon_15195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15195.xml"),
+          )
+      )
+
+  public val icon_15196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15196.xml"),
+          )
+      )
+
+  public val icon_15197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15197.xml"),
+          )
+      )
+
+  public val icon_15198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15198.xml"),
+          )
+      )
+
+  public val icon_15199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15199.xml"),
+          )
+      )
+
+  public val icon_152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_152.xml"),
+          )
+      )
+
+  public val icon_1520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1520.xml"),
+          )
+      )
+
+  public val icon_15200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15200.xml"),
+          )
+      )
+
+  public val icon_15201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15201.xml"),
+          )
+      )
+
+  public val icon_15202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15202.xml"),
+          )
+      )
+
+  public val icon_15203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15203.xml"),
+          )
+      )
+
+  public val icon_15204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15204.xml"),
+          )
+      )
+
+  public val icon_15205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15205.xml"),
+          )
+      )
+
+  public val icon_15206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15206.xml"),
+          )
+      )
+
+  public val icon_15207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15207.xml"),
+          )
+      )
+
+  public val icon_15208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15208.xml"),
+          )
+      )
+
+  public val icon_15209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15209.xml"),
+          )
+      )
+
+  public val icon_1521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1521.xml"),
+          )
+      )
+
+  public val icon_15210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15210.xml"),
+          )
+      )
+
+  public val icon_15211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15211.xml"),
+          )
+      )
+
+  public val icon_15212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15212.xml"),
+          )
+      )
+
+  public val icon_15213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15213.xml"),
+          )
+      )
+
+  public val icon_15214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15214.xml"),
+          )
+      )
+
+  public val icon_15215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15215.xml"),
+          )
+      )
+
+  public val icon_15216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15216.xml"),
+          )
+      )
+
+  public val icon_15217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15217.xml"),
+          )
+      )
+
+  public val icon_15218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15218.xml"),
+          )
+      )
+
+  public val icon_15219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15219.xml"),
+          )
+      )
+
+  public val icon_1522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1522.xml"),
+          )
+      )
+
+  public val icon_15220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15220.xml"),
+          )
+      )
+
+  public val icon_15221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15221.xml"),
+          )
+      )
+
+  public val icon_15222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15222.xml"),
+          )
+      )
+
+  public val icon_15223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15223.xml"),
+          )
+      )
+
+  public val icon_15224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15224.xml"),
+          )
+      )
+
+  public val icon_15225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15225.xml"),
+          )
+      )
+
+  public val icon_15226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15226.xml"),
+          )
+      )
+
+  public val icon_15227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15227.xml"),
+          )
+      )
+
+  public val icon_15228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15228.xml"),
+          )
+      )
+
+  public val icon_15229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15229.xml"),
+          )
+      )
+
+  public val icon_1523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1523.xml"),
+          )
+      )
+
+  public val icon_15230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15230.xml"),
+          )
+      )
+
+  public val icon_15231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15231.xml"),
+          )
+      )
+
+  public val icon_15232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15232.xml"),
+          )
+      )
+
+  public val icon_15233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15233.xml"),
+          )
+      )
+
+  public val icon_15234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15234.xml"),
+          )
+      )
+
+  public val icon_15235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15235.xml"),
+          )
+      )
+
+  public val icon_15236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15236.xml"),
+          )
+      )
+
+  public val icon_15237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15237.xml"),
+          )
+      )
+
+  public val icon_15238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15238.xml"),
+          )
+      )
+
+  public val icon_15239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15239.xml"),
+          )
+      )
+
+  public val icon_1524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1524.xml"),
+          )
+      )
+
+  public val icon_15240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15240.xml"),
+          )
+      )
+
+  public val icon_15241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15241.xml"),
+          )
+      )
+
+  public val icon_15242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15242.xml"),
+          )
+      )
+
+  public val icon_15243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15243.xml"),
+          )
+      )
+
+  public val icon_15244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15244.xml"),
+          )
+      )
+
+  public val icon_15245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15245.xml"),
+          )
+      )
+
+  public val icon_15246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15246.xml"),
+          )
+      )
+
+  public val icon_15247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15247.xml"),
+          )
+      )
+
+  public val icon_15248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15248.xml"),
+          )
+      )
+
+  public val icon_15249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15249.xml"),
+          )
+      )
+
+  public val icon_1525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1525.xml"),
+          )
+      )
+
+  public val icon_15250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15250.xml"),
+          )
+      )
+
+  public val icon_15251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15251.xml"),
+          )
+      )
+
+  public val icon_15252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15252.xml"),
+          )
+      )
+
+  public val icon_15253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15253.xml"),
+          )
+      )
+
+  public val icon_15254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15254.xml"),
+          )
+      )
+
+  public val icon_15255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15255.xml"),
+          )
+      )
+
+  public val icon_15256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15256.xml"),
+          )
+      )
+
+  public val icon_15257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15257.xml"),
+          )
+      )
+
+  public val icon_15258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15258.xml"),
+          )
+      )
+
+  public val icon_15259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15259.xml"),
+          )
+      )
+
+  public val icon_1526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1526.xml"),
+          )
+      )
+
+  public val icon_15260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15260.xml"),
+          )
+      )
+
+  public val icon_15261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15261.xml"),
+          )
+      )
+
+  public val icon_15262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15262.xml"),
+          )
+      )
+
+  public val icon_15263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15263.xml"),
+          )
+      )
+
+  public val icon_15264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15264.xml"),
+          )
+      )
+
+  public val icon_15265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15265.xml"),
+          )
+      )
+
+  public val icon_15266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15266.xml"),
+          )
+      )
+
+  public val icon_15267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15267.xml"),
+          )
+      )
+
+  public val icon_15268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15268.xml"),
+          )
+      )
+
+  public val icon_15269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15269.xml"),
+          )
+      )
+
+  public val icon_1527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1527.xml"),
+          )
+      )
+
+  public val icon_15270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15270.xml"),
+          )
+      )
+
+  public val icon_15271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15271.xml"),
+          )
+      )
+
+  public val icon_15272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15272.xml"),
+          )
+      )
+
+  public val icon_15273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15273.xml"),
+          )
+      )
+
+  public val icon_15274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15274.xml"),
+          )
+      )
+
+  public val icon_15275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15275.xml"),
+          )
+      )
+
+  public val icon_15276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15276.xml"),
+          )
+      )
+
+  public val icon_15277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15277.xml"),
+          )
+      )
+
+  public val icon_15278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15278.xml"),
+          )
+      )
+
+  public val icon_15279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15279.xml"),
+          )
+      )
+
+  public val icon_1528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1528.xml"),
+          )
+      )
+
+  public val icon_15280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15280.xml"),
+          )
+      )
+
+  public val icon_15281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15281.xml"),
+          )
+      )
+
+  public val icon_15282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15282.xml"),
+          )
+      )
+
+  public val icon_15283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15283.xml"),
+          )
+      )
+
+  public val icon_15284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15284.xml"),
+          )
+      )
+
+  public val icon_15285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15285.xml"),
+          )
+      )
+
+  public val icon_15286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15286.xml"),
+          )
+      )
+
+  public val icon_15287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15287.xml"),
+          )
+      )
+
+  public val icon_15288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15288.xml"),
+          )
+      )
+
+  public val icon_15289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15289.xml"),
+          )
+      )
+
+  public val icon_1529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1529.xml"),
+          )
+      )
+
+  public val icon_15290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15290.xml"),
+          )
+      )
+
+  public val icon_15291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15291.xml"),
+          )
+      )
+
+  public val icon_15292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15292.xml"),
+          )
+      )
+
+  public val icon_15293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15293.xml"),
+          )
+      )
+
+  public val icon_15294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15294.xml"),
+          )
+      )
+
+  public val icon_15295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15295.xml"),
+          )
+      )
+
+  public val icon_15296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15296.xml"),
+          )
+      )
+
+  public val icon_15297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15297.xml"),
+          )
+      )
+
+  public val icon_15298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15298.xml"),
+          )
+      )
+
+  public val icon_15299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15299.xml"),
+          )
+      )
+
+  public val icon_153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_153.xml"),
+          )
+      )
+
+  public val icon_1530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1530.xml"),
+          )
+      )
+
+  public val icon_15300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15300.xml"),
+          )
+      )
+
+  public val icon_15301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15301.xml"),
+          )
+      )
+
+  public val icon_15302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15302.xml"),
+          )
+      )
+
+  public val icon_15303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15303.xml"),
+          )
+      )
+
+  public val icon_15304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15304.xml"),
+          )
+      )
+
+  public val icon_15305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15305.xml"),
+          )
+      )
+
+  public val icon_15306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15306.xml"),
+          )
+      )
+
+  public val icon_15307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15307.xml"),
+          )
+      )
+
+  public val icon_15308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15308.xml"),
+          )
+      )
+
+  public val icon_15309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15309.xml"),
+          )
+      )
+
+  public val icon_1531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1531.xml"),
+          )
+      )
+
+  public val icon_15310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15310.xml"),
+          )
+      )
+
+  public val icon_15311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15311.xml"),
+          )
+      )
+
+  public val icon_15312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15312.xml"),
+          )
+      )
+
+  public val icon_15313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15313.xml"),
+          )
+      )
+
+  public val icon_15314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15314.xml"),
+          )
+      )
+
+  public val icon_15315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15315.xml"),
+          )
+      )
+
+  public val icon_15316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15316.xml"),
+          )
+      )
+
+  public val icon_15317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15317.xml"),
+          )
+      )
+
+  public val icon_15318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15318.xml"),
+          )
+      )
+
+  public val icon_15319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15319.xml"),
+          )
+      )
+
+  public val icon_1532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1532.xml"),
+          )
+      )
+
+  public val icon_15320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15320.xml"),
+          )
+      )
+
+  public val icon_15321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15321.xml"),
+          )
+      )
+
+  public val icon_15322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15322.xml"),
+          )
+      )
+
+  public val icon_15323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15323.xml"),
+          )
+      )
+
+  public val icon_15324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15324.xml"),
+          )
+      )
+
+  public val icon_15325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15325.xml"),
+          )
+      )
+
+  public val icon_15326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15326.xml"),
+          )
+      )
+
+  public val icon_15327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15327.xml"),
+          )
+      )
+
+  public val icon_15328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15328.xml"),
+          )
+      )
+
+  public val icon_15329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15329.xml"),
+          )
+      )
+
+  public val icon_1533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1533.xml"),
+          )
+      )
+
+  public val icon_15330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15330.xml"),
+          )
+      )
+
+  public val icon_15331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15331.xml"),
+          )
+      )
+
+  public val icon_15332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15332.xml"),
+          )
+      )
+
+  public val icon_15333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15333.xml"),
+          )
+      )
+
+  public val icon_15334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15334.xml"),
+          )
+      )
+
+  public val icon_15335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15335.xml"),
+          )
+      )
+
+  public val icon_15336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15336.xml"),
+          )
+      )
+
+  public val icon_15337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15337.xml"),
+          )
+      )
+
+  public val icon_15338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15338.xml"),
+          )
+      )
+
+  public val icon_15339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15339.xml"),
+          )
+      )
+
+  public val icon_1534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1534.xml"),
+          )
+      )
+
+  public val icon_15340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15340.xml"),
+          )
+      )
+
+  public val icon_15341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15341.xml"),
+          )
+      )
+
+  public val icon_15342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15342.xml"),
+          )
+      )
+
+  public val icon_15343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15343.xml"),
+          )
+      )
+
+  public val icon_15344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15344.xml"),
+          )
+      )
+
+  public val icon_15345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15345.xml"),
+          )
+      )
+
+  public val icon_15346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15346.xml"),
+          )
+      )
+
+  public val icon_15347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15347.xml"),
+          )
+      )
+
+  public val icon_15348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15348.xml"),
+          )
+      )
+
+  public val icon_15349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15349.xml"),
+          )
+      )
+
+  public val icon_1535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1535.xml"),
+          )
+      )
+
+  public val icon_15350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15350.xml"),
+          )
+      )
+
+  public val icon_15351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15351.xml"),
+          )
+      )
+
+  public val icon_15352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15352.xml"),
+          )
+      )
+
+  public val icon_15353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15353.xml"),
+          )
+      )
+
+  public val icon_15354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15354.xml"),
+          )
+      )
+
+  public val icon_15355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15355.xml"),
+          )
+      )
+
+  public val icon_15356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15356.xml"),
+          )
+      )
+
+  public val icon_15357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15357.xml"),
+          )
+      )
+
+  public val icon_15358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15358.xml"),
+          )
+      )
+
+  public val icon_15359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15359.xml"),
+          )
+      )
+
+  public val icon_1536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1536.xml"),
+          )
+      )
+
+  public val icon_15360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15360.xml"),
+          )
+      )
+
+  public val icon_15361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15361.xml"),
+          )
+      )
+
+  public val icon_15362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15362.xml"),
+          )
+      )
+
+  public val icon_15363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15363.xml"),
+          )
+      )
+
+  public val icon_15364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15364.xml"),
+          )
+      )
+
+  public val icon_15365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15365.xml"),
+          )
+      )
+
+  public val icon_15366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15366.xml"),
+          )
+      )
+
+  public val icon_15367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15367.xml"),
+          )
+      )
+
+  public val icon_15368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15368.xml"),
+          )
+      )
+
+  public val icon_15369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15369.xml"),
+          )
+      )
+
+  public val icon_1537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1537.xml"),
+          )
+      )
+
+  public val icon_15370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15370.xml"),
+          )
+      )
+
+  public val icon_15371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15371.xml"),
+          )
+      )
+
+  public val icon_15372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15372.xml"),
+          )
+      )
+
+  public val icon_15373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15373.xml"),
+          )
+      )
+
+  public val icon_15374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15374.xml"),
+          )
+      )
+
+  public val icon_15375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15375.xml"),
+          )
+      )
+
+  public val icon_15376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15376.xml"),
+          )
+      )
+
+  public val icon_15377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15377.xml"),
+          )
+      )
+
+  public val icon_15378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15378.xml"),
+          )
+      )
+
+  public val icon_15379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15379.xml"),
+          )
+      )
+
+  public val icon_1538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1538.xml"),
+          )
+      )
+
+  public val icon_15380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15380.xml"),
+          )
+      )
+
+  public val icon_15381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15381.xml"),
+          )
+      )
+
+  public val icon_15382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15382.xml"),
+          )
+      )
+
+  public val icon_15383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15383.xml"),
+          )
+      )
+
+  public val icon_15384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15384.xml"),
+          )
+      )
+
+  public val icon_15385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15385.xml"),
+          )
+      )
+
+  public val icon_15386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15386.xml"),
+          )
+      )
+
+  public val icon_15387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15387.xml"),
+          )
+      )
+
+  public val icon_15388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15388.xml"),
+          )
+      )
+
+  public val icon_15389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15389.xml"),
+          )
+      )
+
+  public val icon_1539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1539.xml"),
+          )
+      )
+
+  public val icon_15390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15390.xml"),
+          )
+      )
+
+  public val icon_15391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15391.xml"),
+          )
+      )
+
+  public val icon_15392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15392.xml"),
+          )
+      )
+
+  public val icon_15393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15393.xml"),
+          )
+      )
+
+  public val icon_15394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15394.xml"),
+          )
+      )
+
+  public val icon_15395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15395.xml"),
+          )
+      )
+
+  public val icon_15396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15396.xml"),
+          )
+      )
+
+  public val icon_15397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15397.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14948: DrawableResource
+  get() = Drawable11.icon_14948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14949: DrawableResource
+  get() = Drawable11.icon_14949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1495: DrawableResource
+  get() = Drawable11.icon_1495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14950: DrawableResource
+  get() = Drawable11.icon_14950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14951: DrawableResource
+  get() = Drawable11.icon_14951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14952: DrawableResource
+  get() = Drawable11.icon_14952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14953: DrawableResource
+  get() = Drawable11.icon_14953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14954: DrawableResource
+  get() = Drawable11.icon_14954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14955: DrawableResource
+  get() = Drawable11.icon_14955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14956: DrawableResource
+  get() = Drawable11.icon_14956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14957: DrawableResource
+  get() = Drawable11.icon_14957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14958: DrawableResource
+  get() = Drawable11.icon_14958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14959: DrawableResource
+  get() = Drawable11.icon_14959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1496: DrawableResource
+  get() = Drawable11.icon_1496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14960: DrawableResource
+  get() = Drawable11.icon_14960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14961: DrawableResource
+  get() = Drawable11.icon_14961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14962: DrawableResource
+  get() = Drawable11.icon_14962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14963: DrawableResource
+  get() = Drawable11.icon_14963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14964: DrawableResource
+  get() = Drawable11.icon_14964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14965: DrawableResource
+  get() = Drawable11.icon_14965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14966: DrawableResource
+  get() = Drawable11.icon_14966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14967: DrawableResource
+  get() = Drawable11.icon_14967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14968: DrawableResource
+  get() = Drawable11.icon_14968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14969: DrawableResource
+  get() = Drawable11.icon_14969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1497: DrawableResource
+  get() = Drawable11.icon_1497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14970: DrawableResource
+  get() = Drawable11.icon_14970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14971: DrawableResource
+  get() = Drawable11.icon_14971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14972: DrawableResource
+  get() = Drawable11.icon_14972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14973: DrawableResource
+  get() = Drawable11.icon_14973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14974: DrawableResource
+  get() = Drawable11.icon_14974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14975: DrawableResource
+  get() = Drawable11.icon_14975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14976: DrawableResource
+  get() = Drawable11.icon_14976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14977: DrawableResource
+  get() = Drawable11.icon_14977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14978: DrawableResource
+  get() = Drawable11.icon_14978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14979: DrawableResource
+  get() = Drawable11.icon_14979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1498: DrawableResource
+  get() = Drawable11.icon_1498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14980: DrawableResource
+  get() = Drawable11.icon_14980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14981: DrawableResource
+  get() = Drawable11.icon_14981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14982: DrawableResource
+  get() = Drawable11.icon_14982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14983: DrawableResource
+  get() = Drawable11.icon_14983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14984: DrawableResource
+  get() = Drawable11.icon_14984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14985: DrawableResource
+  get() = Drawable11.icon_14985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14986: DrawableResource
+  get() = Drawable11.icon_14986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14987: DrawableResource
+  get() = Drawable11.icon_14987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14988: DrawableResource
+  get() = Drawable11.icon_14988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14989: DrawableResource
+  get() = Drawable11.icon_14989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1499: DrawableResource
+  get() = Drawable11.icon_1499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14990: DrawableResource
+  get() = Drawable11.icon_14990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14991: DrawableResource
+  get() = Drawable11.icon_14991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14992: DrawableResource
+  get() = Drawable11.icon_14992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14993: DrawableResource
+  get() = Drawable11.icon_14993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14994: DrawableResource
+  get() = Drawable11.icon_14994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14995: DrawableResource
+  get() = Drawable11.icon_14995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14996: DrawableResource
+  get() = Drawable11.icon_14996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14997: DrawableResource
+  get() = Drawable11.icon_14997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14998: DrawableResource
+  get() = Drawable11.icon_14998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14999: DrawableResource
+  get() = Drawable11.icon_14999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15: DrawableResource
+  get() = Drawable11.icon_15
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_150: DrawableResource
+  get() = Drawable11.icon_150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1500: DrawableResource
+  get() = Drawable11.icon_1500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15000: DrawableResource
+  get() = Drawable11.icon_15000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15001: DrawableResource
+  get() = Drawable11.icon_15001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15002: DrawableResource
+  get() = Drawable11.icon_15002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15003: DrawableResource
+  get() = Drawable11.icon_15003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15004: DrawableResource
+  get() = Drawable11.icon_15004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15005: DrawableResource
+  get() = Drawable11.icon_15005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15006: DrawableResource
+  get() = Drawable11.icon_15006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15007: DrawableResource
+  get() = Drawable11.icon_15007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15008: DrawableResource
+  get() = Drawable11.icon_15008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15009: DrawableResource
+  get() = Drawable11.icon_15009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1501: DrawableResource
+  get() = Drawable11.icon_1501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15010: DrawableResource
+  get() = Drawable11.icon_15010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15011: DrawableResource
+  get() = Drawable11.icon_15011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15012: DrawableResource
+  get() = Drawable11.icon_15012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15013: DrawableResource
+  get() = Drawable11.icon_15013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15014: DrawableResource
+  get() = Drawable11.icon_15014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15015: DrawableResource
+  get() = Drawable11.icon_15015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15016: DrawableResource
+  get() = Drawable11.icon_15016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15017: DrawableResource
+  get() = Drawable11.icon_15017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15018: DrawableResource
+  get() = Drawable11.icon_15018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15019: DrawableResource
+  get() = Drawable11.icon_15019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1502: DrawableResource
+  get() = Drawable11.icon_1502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15020: DrawableResource
+  get() = Drawable11.icon_15020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15021: DrawableResource
+  get() = Drawable11.icon_15021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15022: DrawableResource
+  get() = Drawable11.icon_15022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15023: DrawableResource
+  get() = Drawable11.icon_15023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15024: DrawableResource
+  get() = Drawable11.icon_15024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15025: DrawableResource
+  get() = Drawable11.icon_15025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15026: DrawableResource
+  get() = Drawable11.icon_15026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15027: DrawableResource
+  get() = Drawable11.icon_15027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15028: DrawableResource
+  get() = Drawable11.icon_15028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15029: DrawableResource
+  get() = Drawable11.icon_15029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1503: DrawableResource
+  get() = Drawable11.icon_1503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15030: DrawableResource
+  get() = Drawable11.icon_15030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15031: DrawableResource
+  get() = Drawable11.icon_15031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15032: DrawableResource
+  get() = Drawable11.icon_15032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15033: DrawableResource
+  get() = Drawable11.icon_15033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15034: DrawableResource
+  get() = Drawable11.icon_15034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15035: DrawableResource
+  get() = Drawable11.icon_15035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15036: DrawableResource
+  get() = Drawable11.icon_15036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15037: DrawableResource
+  get() = Drawable11.icon_15037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15038: DrawableResource
+  get() = Drawable11.icon_15038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15039: DrawableResource
+  get() = Drawable11.icon_15039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1504: DrawableResource
+  get() = Drawable11.icon_1504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15040: DrawableResource
+  get() = Drawable11.icon_15040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15041: DrawableResource
+  get() = Drawable11.icon_15041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15042: DrawableResource
+  get() = Drawable11.icon_15042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15043: DrawableResource
+  get() = Drawable11.icon_15043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15044: DrawableResource
+  get() = Drawable11.icon_15044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15045: DrawableResource
+  get() = Drawable11.icon_15045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15046: DrawableResource
+  get() = Drawable11.icon_15046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15047: DrawableResource
+  get() = Drawable11.icon_15047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15048: DrawableResource
+  get() = Drawable11.icon_15048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15049: DrawableResource
+  get() = Drawable11.icon_15049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1505: DrawableResource
+  get() = Drawable11.icon_1505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15050: DrawableResource
+  get() = Drawable11.icon_15050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15051: DrawableResource
+  get() = Drawable11.icon_15051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15052: DrawableResource
+  get() = Drawable11.icon_15052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15053: DrawableResource
+  get() = Drawable11.icon_15053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15054: DrawableResource
+  get() = Drawable11.icon_15054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15055: DrawableResource
+  get() = Drawable11.icon_15055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15056: DrawableResource
+  get() = Drawable11.icon_15056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15057: DrawableResource
+  get() = Drawable11.icon_15057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15058: DrawableResource
+  get() = Drawable11.icon_15058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15059: DrawableResource
+  get() = Drawable11.icon_15059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1506: DrawableResource
+  get() = Drawable11.icon_1506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15060: DrawableResource
+  get() = Drawable11.icon_15060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15061: DrawableResource
+  get() = Drawable11.icon_15061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15062: DrawableResource
+  get() = Drawable11.icon_15062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15063: DrawableResource
+  get() = Drawable11.icon_15063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15064: DrawableResource
+  get() = Drawable11.icon_15064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15065: DrawableResource
+  get() = Drawable11.icon_15065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15066: DrawableResource
+  get() = Drawable11.icon_15066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15067: DrawableResource
+  get() = Drawable11.icon_15067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15068: DrawableResource
+  get() = Drawable11.icon_15068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15069: DrawableResource
+  get() = Drawable11.icon_15069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1507: DrawableResource
+  get() = Drawable11.icon_1507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15070: DrawableResource
+  get() = Drawable11.icon_15070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15071: DrawableResource
+  get() = Drawable11.icon_15071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15072: DrawableResource
+  get() = Drawable11.icon_15072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15073: DrawableResource
+  get() = Drawable11.icon_15073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15074: DrawableResource
+  get() = Drawable11.icon_15074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15075: DrawableResource
+  get() = Drawable11.icon_15075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15076: DrawableResource
+  get() = Drawable11.icon_15076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15077: DrawableResource
+  get() = Drawable11.icon_15077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15078: DrawableResource
+  get() = Drawable11.icon_15078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15079: DrawableResource
+  get() = Drawable11.icon_15079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1508: DrawableResource
+  get() = Drawable11.icon_1508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15080: DrawableResource
+  get() = Drawable11.icon_15080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15081: DrawableResource
+  get() = Drawable11.icon_15081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15082: DrawableResource
+  get() = Drawable11.icon_15082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15083: DrawableResource
+  get() = Drawable11.icon_15083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15084: DrawableResource
+  get() = Drawable11.icon_15084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15085: DrawableResource
+  get() = Drawable11.icon_15085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15086: DrawableResource
+  get() = Drawable11.icon_15086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15087: DrawableResource
+  get() = Drawable11.icon_15087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15088: DrawableResource
+  get() = Drawable11.icon_15088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15089: DrawableResource
+  get() = Drawable11.icon_15089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1509: DrawableResource
+  get() = Drawable11.icon_1509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15090: DrawableResource
+  get() = Drawable11.icon_15090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15091: DrawableResource
+  get() = Drawable11.icon_15091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15092: DrawableResource
+  get() = Drawable11.icon_15092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15093: DrawableResource
+  get() = Drawable11.icon_15093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15094: DrawableResource
+  get() = Drawable11.icon_15094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15095: DrawableResource
+  get() = Drawable11.icon_15095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15096: DrawableResource
+  get() = Drawable11.icon_15096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15097: DrawableResource
+  get() = Drawable11.icon_15097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15098: DrawableResource
+  get() = Drawable11.icon_15098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15099: DrawableResource
+  get() = Drawable11.icon_15099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_151: DrawableResource
+  get() = Drawable11.icon_151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1510: DrawableResource
+  get() = Drawable11.icon_1510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15100: DrawableResource
+  get() = Drawable11.icon_15100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15101: DrawableResource
+  get() = Drawable11.icon_15101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15102: DrawableResource
+  get() = Drawable11.icon_15102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15103: DrawableResource
+  get() = Drawable11.icon_15103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15104: DrawableResource
+  get() = Drawable11.icon_15104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15105: DrawableResource
+  get() = Drawable11.icon_15105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15106: DrawableResource
+  get() = Drawable11.icon_15106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15107: DrawableResource
+  get() = Drawable11.icon_15107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15108: DrawableResource
+  get() = Drawable11.icon_15108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15109: DrawableResource
+  get() = Drawable11.icon_15109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1511: DrawableResource
+  get() = Drawable11.icon_1511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15110: DrawableResource
+  get() = Drawable11.icon_15110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15111: DrawableResource
+  get() = Drawable11.icon_15111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15112: DrawableResource
+  get() = Drawable11.icon_15112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15113: DrawableResource
+  get() = Drawable11.icon_15113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15114: DrawableResource
+  get() = Drawable11.icon_15114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15115: DrawableResource
+  get() = Drawable11.icon_15115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15116: DrawableResource
+  get() = Drawable11.icon_15116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15117: DrawableResource
+  get() = Drawable11.icon_15117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15118: DrawableResource
+  get() = Drawable11.icon_15118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15119: DrawableResource
+  get() = Drawable11.icon_15119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1512: DrawableResource
+  get() = Drawable11.icon_1512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15120: DrawableResource
+  get() = Drawable11.icon_15120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15121: DrawableResource
+  get() = Drawable11.icon_15121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15122: DrawableResource
+  get() = Drawable11.icon_15122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15123: DrawableResource
+  get() = Drawable11.icon_15123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15124: DrawableResource
+  get() = Drawable11.icon_15124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15125: DrawableResource
+  get() = Drawable11.icon_15125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15126: DrawableResource
+  get() = Drawable11.icon_15126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15127: DrawableResource
+  get() = Drawable11.icon_15127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15128: DrawableResource
+  get() = Drawable11.icon_15128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15129: DrawableResource
+  get() = Drawable11.icon_15129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1513: DrawableResource
+  get() = Drawable11.icon_1513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15130: DrawableResource
+  get() = Drawable11.icon_15130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15131: DrawableResource
+  get() = Drawable11.icon_15131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15132: DrawableResource
+  get() = Drawable11.icon_15132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15133: DrawableResource
+  get() = Drawable11.icon_15133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15134: DrawableResource
+  get() = Drawable11.icon_15134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15135: DrawableResource
+  get() = Drawable11.icon_15135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15136: DrawableResource
+  get() = Drawable11.icon_15136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15137: DrawableResource
+  get() = Drawable11.icon_15137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15138: DrawableResource
+  get() = Drawable11.icon_15138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15139: DrawableResource
+  get() = Drawable11.icon_15139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1514: DrawableResource
+  get() = Drawable11.icon_1514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15140: DrawableResource
+  get() = Drawable11.icon_15140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15141: DrawableResource
+  get() = Drawable11.icon_15141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15142: DrawableResource
+  get() = Drawable11.icon_15142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15143: DrawableResource
+  get() = Drawable11.icon_15143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15144: DrawableResource
+  get() = Drawable11.icon_15144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15145: DrawableResource
+  get() = Drawable11.icon_15145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15146: DrawableResource
+  get() = Drawable11.icon_15146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15147: DrawableResource
+  get() = Drawable11.icon_15147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15148: DrawableResource
+  get() = Drawable11.icon_15148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15149: DrawableResource
+  get() = Drawable11.icon_15149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1515: DrawableResource
+  get() = Drawable11.icon_1515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15150: DrawableResource
+  get() = Drawable11.icon_15150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15151: DrawableResource
+  get() = Drawable11.icon_15151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15152: DrawableResource
+  get() = Drawable11.icon_15152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15153: DrawableResource
+  get() = Drawable11.icon_15153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15154: DrawableResource
+  get() = Drawable11.icon_15154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15155: DrawableResource
+  get() = Drawable11.icon_15155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15156: DrawableResource
+  get() = Drawable11.icon_15156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15157: DrawableResource
+  get() = Drawable11.icon_15157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15158: DrawableResource
+  get() = Drawable11.icon_15158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15159: DrawableResource
+  get() = Drawable11.icon_15159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1516: DrawableResource
+  get() = Drawable11.icon_1516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15160: DrawableResource
+  get() = Drawable11.icon_15160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15161: DrawableResource
+  get() = Drawable11.icon_15161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15162: DrawableResource
+  get() = Drawable11.icon_15162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15163: DrawableResource
+  get() = Drawable11.icon_15163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15164: DrawableResource
+  get() = Drawable11.icon_15164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15165: DrawableResource
+  get() = Drawable11.icon_15165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15166: DrawableResource
+  get() = Drawable11.icon_15166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15167: DrawableResource
+  get() = Drawable11.icon_15167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15168: DrawableResource
+  get() = Drawable11.icon_15168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15169: DrawableResource
+  get() = Drawable11.icon_15169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1517: DrawableResource
+  get() = Drawable11.icon_1517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15170: DrawableResource
+  get() = Drawable11.icon_15170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15171: DrawableResource
+  get() = Drawable11.icon_15171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15172: DrawableResource
+  get() = Drawable11.icon_15172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15173: DrawableResource
+  get() = Drawable11.icon_15173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15174: DrawableResource
+  get() = Drawable11.icon_15174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15175: DrawableResource
+  get() = Drawable11.icon_15175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15176: DrawableResource
+  get() = Drawable11.icon_15176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15177: DrawableResource
+  get() = Drawable11.icon_15177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15178: DrawableResource
+  get() = Drawable11.icon_15178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15179: DrawableResource
+  get() = Drawable11.icon_15179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1518: DrawableResource
+  get() = Drawable11.icon_1518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15180: DrawableResource
+  get() = Drawable11.icon_15180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15181: DrawableResource
+  get() = Drawable11.icon_15181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15182: DrawableResource
+  get() = Drawable11.icon_15182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15183: DrawableResource
+  get() = Drawable11.icon_15183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15184: DrawableResource
+  get() = Drawable11.icon_15184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15185: DrawableResource
+  get() = Drawable11.icon_15185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15186: DrawableResource
+  get() = Drawable11.icon_15186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15187: DrawableResource
+  get() = Drawable11.icon_15187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15188: DrawableResource
+  get() = Drawable11.icon_15188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15189: DrawableResource
+  get() = Drawable11.icon_15189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1519: DrawableResource
+  get() = Drawable11.icon_1519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15190: DrawableResource
+  get() = Drawable11.icon_15190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15191: DrawableResource
+  get() = Drawable11.icon_15191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15192: DrawableResource
+  get() = Drawable11.icon_15192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15193: DrawableResource
+  get() = Drawable11.icon_15193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15194: DrawableResource
+  get() = Drawable11.icon_15194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15195: DrawableResource
+  get() = Drawable11.icon_15195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15196: DrawableResource
+  get() = Drawable11.icon_15196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15197: DrawableResource
+  get() = Drawable11.icon_15197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15198: DrawableResource
+  get() = Drawable11.icon_15198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15199: DrawableResource
+  get() = Drawable11.icon_15199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_152: DrawableResource
+  get() = Drawable11.icon_152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1520: DrawableResource
+  get() = Drawable11.icon_1520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15200: DrawableResource
+  get() = Drawable11.icon_15200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15201: DrawableResource
+  get() = Drawable11.icon_15201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15202: DrawableResource
+  get() = Drawable11.icon_15202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15203: DrawableResource
+  get() = Drawable11.icon_15203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15204: DrawableResource
+  get() = Drawable11.icon_15204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15205: DrawableResource
+  get() = Drawable11.icon_15205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15206: DrawableResource
+  get() = Drawable11.icon_15206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15207: DrawableResource
+  get() = Drawable11.icon_15207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15208: DrawableResource
+  get() = Drawable11.icon_15208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15209: DrawableResource
+  get() = Drawable11.icon_15209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1521: DrawableResource
+  get() = Drawable11.icon_1521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15210: DrawableResource
+  get() = Drawable11.icon_15210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15211: DrawableResource
+  get() = Drawable11.icon_15211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15212: DrawableResource
+  get() = Drawable11.icon_15212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15213: DrawableResource
+  get() = Drawable11.icon_15213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15214: DrawableResource
+  get() = Drawable11.icon_15214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15215: DrawableResource
+  get() = Drawable11.icon_15215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15216: DrawableResource
+  get() = Drawable11.icon_15216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15217: DrawableResource
+  get() = Drawable11.icon_15217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15218: DrawableResource
+  get() = Drawable11.icon_15218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15219: DrawableResource
+  get() = Drawable11.icon_15219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1522: DrawableResource
+  get() = Drawable11.icon_1522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15220: DrawableResource
+  get() = Drawable11.icon_15220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15221: DrawableResource
+  get() = Drawable11.icon_15221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15222: DrawableResource
+  get() = Drawable11.icon_15222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15223: DrawableResource
+  get() = Drawable11.icon_15223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15224: DrawableResource
+  get() = Drawable11.icon_15224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15225: DrawableResource
+  get() = Drawable11.icon_15225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15226: DrawableResource
+  get() = Drawable11.icon_15226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15227: DrawableResource
+  get() = Drawable11.icon_15227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15228: DrawableResource
+  get() = Drawable11.icon_15228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15229: DrawableResource
+  get() = Drawable11.icon_15229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1523: DrawableResource
+  get() = Drawable11.icon_1523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15230: DrawableResource
+  get() = Drawable11.icon_15230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15231: DrawableResource
+  get() = Drawable11.icon_15231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15232: DrawableResource
+  get() = Drawable11.icon_15232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15233: DrawableResource
+  get() = Drawable11.icon_15233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15234: DrawableResource
+  get() = Drawable11.icon_15234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15235: DrawableResource
+  get() = Drawable11.icon_15235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15236: DrawableResource
+  get() = Drawable11.icon_15236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15237: DrawableResource
+  get() = Drawable11.icon_15237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15238: DrawableResource
+  get() = Drawable11.icon_15238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15239: DrawableResource
+  get() = Drawable11.icon_15239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1524: DrawableResource
+  get() = Drawable11.icon_1524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15240: DrawableResource
+  get() = Drawable11.icon_15240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15241: DrawableResource
+  get() = Drawable11.icon_15241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15242: DrawableResource
+  get() = Drawable11.icon_15242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15243: DrawableResource
+  get() = Drawable11.icon_15243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15244: DrawableResource
+  get() = Drawable11.icon_15244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15245: DrawableResource
+  get() = Drawable11.icon_15245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15246: DrawableResource
+  get() = Drawable11.icon_15246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15247: DrawableResource
+  get() = Drawable11.icon_15247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15248: DrawableResource
+  get() = Drawable11.icon_15248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15249: DrawableResource
+  get() = Drawable11.icon_15249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1525: DrawableResource
+  get() = Drawable11.icon_1525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15250: DrawableResource
+  get() = Drawable11.icon_15250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15251: DrawableResource
+  get() = Drawable11.icon_15251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15252: DrawableResource
+  get() = Drawable11.icon_15252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15253: DrawableResource
+  get() = Drawable11.icon_15253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15254: DrawableResource
+  get() = Drawable11.icon_15254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15255: DrawableResource
+  get() = Drawable11.icon_15255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15256: DrawableResource
+  get() = Drawable11.icon_15256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15257: DrawableResource
+  get() = Drawable11.icon_15257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15258: DrawableResource
+  get() = Drawable11.icon_15258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15259: DrawableResource
+  get() = Drawable11.icon_15259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1526: DrawableResource
+  get() = Drawable11.icon_1526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15260: DrawableResource
+  get() = Drawable11.icon_15260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15261: DrawableResource
+  get() = Drawable11.icon_15261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15262: DrawableResource
+  get() = Drawable11.icon_15262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15263: DrawableResource
+  get() = Drawable11.icon_15263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15264: DrawableResource
+  get() = Drawable11.icon_15264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15265: DrawableResource
+  get() = Drawable11.icon_15265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15266: DrawableResource
+  get() = Drawable11.icon_15266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15267: DrawableResource
+  get() = Drawable11.icon_15267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15268: DrawableResource
+  get() = Drawable11.icon_15268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15269: DrawableResource
+  get() = Drawable11.icon_15269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1527: DrawableResource
+  get() = Drawable11.icon_1527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15270: DrawableResource
+  get() = Drawable11.icon_15270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15271: DrawableResource
+  get() = Drawable11.icon_15271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15272: DrawableResource
+  get() = Drawable11.icon_15272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15273: DrawableResource
+  get() = Drawable11.icon_15273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15274: DrawableResource
+  get() = Drawable11.icon_15274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15275: DrawableResource
+  get() = Drawable11.icon_15275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15276: DrawableResource
+  get() = Drawable11.icon_15276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15277: DrawableResource
+  get() = Drawable11.icon_15277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15278: DrawableResource
+  get() = Drawable11.icon_15278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15279: DrawableResource
+  get() = Drawable11.icon_15279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1528: DrawableResource
+  get() = Drawable11.icon_1528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15280: DrawableResource
+  get() = Drawable11.icon_15280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15281: DrawableResource
+  get() = Drawable11.icon_15281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15282: DrawableResource
+  get() = Drawable11.icon_15282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15283: DrawableResource
+  get() = Drawable11.icon_15283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15284: DrawableResource
+  get() = Drawable11.icon_15284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15285: DrawableResource
+  get() = Drawable11.icon_15285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15286: DrawableResource
+  get() = Drawable11.icon_15286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15287: DrawableResource
+  get() = Drawable11.icon_15287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15288: DrawableResource
+  get() = Drawable11.icon_15288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15289: DrawableResource
+  get() = Drawable11.icon_15289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1529: DrawableResource
+  get() = Drawable11.icon_1529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15290: DrawableResource
+  get() = Drawable11.icon_15290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15291: DrawableResource
+  get() = Drawable11.icon_15291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15292: DrawableResource
+  get() = Drawable11.icon_15292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15293: DrawableResource
+  get() = Drawable11.icon_15293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15294: DrawableResource
+  get() = Drawable11.icon_15294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15295: DrawableResource
+  get() = Drawable11.icon_15295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15296: DrawableResource
+  get() = Drawable11.icon_15296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15297: DrawableResource
+  get() = Drawable11.icon_15297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15298: DrawableResource
+  get() = Drawable11.icon_15298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15299: DrawableResource
+  get() = Drawable11.icon_15299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_153: DrawableResource
+  get() = Drawable11.icon_153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1530: DrawableResource
+  get() = Drawable11.icon_1530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15300: DrawableResource
+  get() = Drawable11.icon_15300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15301: DrawableResource
+  get() = Drawable11.icon_15301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15302: DrawableResource
+  get() = Drawable11.icon_15302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15303: DrawableResource
+  get() = Drawable11.icon_15303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15304: DrawableResource
+  get() = Drawable11.icon_15304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15305: DrawableResource
+  get() = Drawable11.icon_15305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15306: DrawableResource
+  get() = Drawable11.icon_15306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15307: DrawableResource
+  get() = Drawable11.icon_15307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15308: DrawableResource
+  get() = Drawable11.icon_15308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15309: DrawableResource
+  get() = Drawable11.icon_15309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1531: DrawableResource
+  get() = Drawable11.icon_1531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15310: DrawableResource
+  get() = Drawable11.icon_15310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15311: DrawableResource
+  get() = Drawable11.icon_15311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15312: DrawableResource
+  get() = Drawable11.icon_15312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15313: DrawableResource
+  get() = Drawable11.icon_15313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15314: DrawableResource
+  get() = Drawable11.icon_15314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15315: DrawableResource
+  get() = Drawable11.icon_15315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15316: DrawableResource
+  get() = Drawable11.icon_15316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15317: DrawableResource
+  get() = Drawable11.icon_15317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15318: DrawableResource
+  get() = Drawable11.icon_15318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15319: DrawableResource
+  get() = Drawable11.icon_15319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1532: DrawableResource
+  get() = Drawable11.icon_1532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15320: DrawableResource
+  get() = Drawable11.icon_15320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15321: DrawableResource
+  get() = Drawable11.icon_15321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15322: DrawableResource
+  get() = Drawable11.icon_15322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15323: DrawableResource
+  get() = Drawable11.icon_15323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15324: DrawableResource
+  get() = Drawable11.icon_15324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15325: DrawableResource
+  get() = Drawable11.icon_15325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15326: DrawableResource
+  get() = Drawable11.icon_15326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15327: DrawableResource
+  get() = Drawable11.icon_15327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15328: DrawableResource
+  get() = Drawable11.icon_15328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15329: DrawableResource
+  get() = Drawable11.icon_15329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1533: DrawableResource
+  get() = Drawable11.icon_1533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15330: DrawableResource
+  get() = Drawable11.icon_15330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15331: DrawableResource
+  get() = Drawable11.icon_15331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15332: DrawableResource
+  get() = Drawable11.icon_15332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15333: DrawableResource
+  get() = Drawable11.icon_15333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15334: DrawableResource
+  get() = Drawable11.icon_15334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15335: DrawableResource
+  get() = Drawable11.icon_15335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15336: DrawableResource
+  get() = Drawable11.icon_15336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15337: DrawableResource
+  get() = Drawable11.icon_15337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15338: DrawableResource
+  get() = Drawable11.icon_15338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15339: DrawableResource
+  get() = Drawable11.icon_15339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1534: DrawableResource
+  get() = Drawable11.icon_1534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15340: DrawableResource
+  get() = Drawable11.icon_15340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15341: DrawableResource
+  get() = Drawable11.icon_15341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15342: DrawableResource
+  get() = Drawable11.icon_15342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15343: DrawableResource
+  get() = Drawable11.icon_15343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15344: DrawableResource
+  get() = Drawable11.icon_15344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15345: DrawableResource
+  get() = Drawable11.icon_15345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15346: DrawableResource
+  get() = Drawable11.icon_15346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15347: DrawableResource
+  get() = Drawable11.icon_15347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15348: DrawableResource
+  get() = Drawable11.icon_15348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15349: DrawableResource
+  get() = Drawable11.icon_15349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1535: DrawableResource
+  get() = Drawable11.icon_1535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15350: DrawableResource
+  get() = Drawable11.icon_15350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15351: DrawableResource
+  get() = Drawable11.icon_15351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15352: DrawableResource
+  get() = Drawable11.icon_15352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15353: DrawableResource
+  get() = Drawable11.icon_15353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15354: DrawableResource
+  get() = Drawable11.icon_15354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15355: DrawableResource
+  get() = Drawable11.icon_15355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15356: DrawableResource
+  get() = Drawable11.icon_15356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15357: DrawableResource
+  get() = Drawable11.icon_15357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15358: DrawableResource
+  get() = Drawable11.icon_15358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15359: DrawableResource
+  get() = Drawable11.icon_15359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1536: DrawableResource
+  get() = Drawable11.icon_1536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15360: DrawableResource
+  get() = Drawable11.icon_15360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15361: DrawableResource
+  get() = Drawable11.icon_15361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15362: DrawableResource
+  get() = Drawable11.icon_15362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15363: DrawableResource
+  get() = Drawable11.icon_15363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15364: DrawableResource
+  get() = Drawable11.icon_15364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15365: DrawableResource
+  get() = Drawable11.icon_15365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15366: DrawableResource
+  get() = Drawable11.icon_15366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15367: DrawableResource
+  get() = Drawable11.icon_15367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15368: DrawableResource
+  get() = Drawable11.icon_15368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15369: DrawableResource
+  get() = Drawable11.icon_15369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1537: DrawableResource
+  get() = Drawable11.icon_1537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15370: DrawableResource
+  get() = Drawable11.icon_15370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15371: DrawableResource
+  get() = Drawable11.icon_15371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15372: DrawableResource
+  get() = Drawable11.icon_15372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15373: DrawableResource
+  get() = Drawable11.icon_15373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15374: DrawableResource
+  get() = Drawable11.icon_15374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15375: DrawableResource
+  get() = Drawable11.icon_15375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15376: DrawableResource
+  get() = Drawable11.icon_15376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15377: DrawableResource
+  get() = Drawable11.icon_15377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15378: DrawableResource
+  get() = Drawable11.icon_15378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15379: DrawableResource
+  get() = Drawable11.icon_15379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1538: DrawableResource
+  get() = Drawable11.icon_1538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15380: DrawableResource
+  get() = Drawable11.icon_15380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15381: DrawableResource
+  get() = Drawable11.icon_15381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15382: DrawableResource
+  get() = Drawable11.icon_15382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15383: DrawableResource
+  get() = Drawable11.icon_15383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15384: DrawableResource
+  get() = Drawable11.icon_15384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15385: DrawableResource
+  get() = Drawable11.icon_15385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15386: DrawableResource
+  get() = Drawable11.icon_15386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15387: DrawableResource
+  get() = Drawable11.icon_15387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15388: DrawableResource
+  get() = Drawable11.icon_15388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15389: DrawableResource
+  get() = Drawable11.icon_15389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1539: DrawableResource
+  get() = Drawable11.icon_1539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15390: DrawableResource
+  get() = Drawable11.icon_15390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15391: DrawableResource
+  get() = Drawable11.icon_15391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15392: DrawableResource
+  get() = Drawable11.icon_15392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15393: DrawableResource
+  get() = Drawable11.icon_15393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15394: DrawableResource
+  get() = Drawable11.icon_15394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15395: DrawableResource
+  get() = Drawable11.icon_15395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15396: DrawableResource
+  get() = Drawable11.icon_15396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15397: DrawableResource
+  get() = Drawable11.icon_15397

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable12.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable12.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable12 {
+  public val icon_15398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15398.xml"),
+          )
+      )
+
+  public val icon_15399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15399.xml"),
+          )
+      )
+
+  public val icon_154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_154.xml"),
+          )
+      )
+
+  public val icon_1540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1540.xml"),
+          )
+      )
+
+  public val icon_15400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15400.xml"),
+          )
+      )
+
+  public val icon_15401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15401.xml"),
+          )
+      )
+
+  public val icon_15402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15402.xml"),
+          )
+      )
+
+  public val icon_15403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15403.xml"),
+          )
+      )
+
+  public val icon_15404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15404.xml"),
+          )
+      )
+
+  public val icon_15405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15405.xml"),
+          )
+      )
+
+  public val icon_15406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15406.xml"),
+          )
+      )
+
+  public val icon_15407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15407.xml"),
+          )
+      )
+
+  public val icon_15408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15408.xml"),
+          )
+      )
+
+  public val icon_15409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15409.xml"),
+          )
+      )
+
+  public val icon_1541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1541.xml"),
+          )
+      )
+
+  public val icon_15410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15410.xml"),
+          )
+      )
+
+  public val icon_15411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15411.xml"),
+          )
+      )
+
+  public val icon_15412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15412.xml"),
+          )
+      )
+
+  public val icon_15413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15413.xml"),
+          )
+      )
+
+  public val icon_15414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15414.xml"),
+          )
+      )
+
+  public val icon_15415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15415.xml"),
+          )
+      )
+
+  public val icon_15416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15416.xml"),
+          )
+      )
+
+  public val icon_15417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15417.xml"),
+          )
+      )
+
+  public val icon_15418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15418.xml"),
+          )
+      )
+
+  public val icon_15419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15419.xml"),
+          )
+      )
+
+  public val icon_1542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1542.xml"),
+          )
+      )
+
+  public val icon_15420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15420.xml"),
+          )
+      )
+
+  public val icon_15421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15421.xml"),
+          )
+      )
+
+  public val icon_15422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15422.xml"),
+          )
+      )
+
+  public val icon_15423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15423.xml"),
+          )
+      )
+
+  public val icon_15424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15424.xml"),
+          )
+      )
+
+  public val icon_15425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15425.xml"),
+          )
+      )
+
+  public val icon_15426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15426.xml"),
+          )
+      )
+
+  public val icon_15427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15427.xml"),
+          )
+      )
+
+  public val icon_15428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15428.xml"),
+          )
+      )
+
+  public val icon_15429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15429.xml"),
+          )
+      )
+
+  public val icon_1543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1543.xml"),
+          )
+      )
+
+  public val icon_15430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15430.xml"),
+          )
+      )
+
+  public val icon_15431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15431.xml"),
+          )
+      )
+
+  public val icon_15432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15432.xml"),
+          )
+      )
+
+  public val icon_15433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15433.xml"),
+          )
+      )
+
+  public val icon_15434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15434.xml"),
+          )
+      )
+
+  public val icon_15435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15435.xml"),
+          )
+      )
+
+  public val icon_15436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15436.xml"),
+          )
+      )
+
+  public val icon_15437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15437.xml"),
+          )
+      )
+
+  public val icon_15438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15438.xml"),
+          )
+      )
+
+  public val icon_15439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15439.xml"),
+          )
+      )
+
+  public val icon_1544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1544.xml"),
+          )
+      )
+
+  public val icon_15440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15440.xml"),
+          )
+      )
+
+  public val icon_15441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15441.xml"),
+          )
+      )
+
+  public val icon_15442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15442.xml"),
+          )
+      )
+
+  public val icon_15443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15443.xml"),
+          )
+      )
+
+  public val icon_15444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15444.xml"),
+          )
+      )
+
+  public val icon_15445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15445.xml"),
+          )
+      )
+
+  public val icon_15446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15446.xml"),
+          )
+      )
+
+  public val icon_15447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15447.xml"),
+          )
+      )
+
+  public val icon_15448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15448.xml"),
+          )
+      )
+
+  public val icon_15449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15449.xml"),
+          )
+      )
+
+  public val icon_1545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1545.xml"),
+          )
+      )
+
+  public val icon_15450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15450.xml"),
+          )
+      )
+
+  public val icon_15451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15451.xml"),
+          )
+      )
+
+  public val icon_15452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15452.xml"),
+          )
+      )
+
+  public val icon_15453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15453.xml"),
+          )
+      )
+
+  public val icon_15454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15454.xml"),
+          )
+      )
+
+  public val icon_15455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15455.xml"),
+          )
+      )
+
+  public val icon_15456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15456.xml"),
+          )
+      )
+
+  public val icon_15457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15457.xml"),
+          )
+      )
+
+  public val icon_15458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15458.xml"),
+          )
+      )
+
+  public val icon_15459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15459.xml"),
+          )
+      )
+
+  public val icon_1546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1546.xml"),
+          )
+      )
+
+  public val icon_15460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15460.xml"),
+          )
+      )
+
+  public val icon_15461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15461.xml"),
+          )
+      )
+
+  public val icon_15462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15462.xml"),
+          )
+      )
+
+  public val icon_15463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15463.xml"),
+          )
+      )
+
+  public val icon_15464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15464.xml"),
+          )
+      )
+
+  public val icon_15465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15465.xml"),
+          )
+      )
+
+  public val icon_15466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15466.xml"),
+          )
+      )
+
+  public val icon_15467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15467.xml"),
+          )
+      )
+
+  public val icon_15468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15468.xml"),
+          )
+      )
+
+  public val icon_15469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15469.xml"),
+          )
+      )
+
+  public val icon_1547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1547.xml"),
+          )
+      )
+
+  public val icon_15470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15470.xml"),
+          )
+      )
+
+  public val icon_15471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15471.xml"),
+          )
+      )
+
+  public val icon_15472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15472.xml"),
+          )
+      )
+
+  public val icon_15473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15473.xml"),
+          )
+      )
+
+  public val icon_15474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15474.xml"),
+          )
+      )
+
+  public val icon_15475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15475.xml"),
+          )
+      )
+
+  public val icon_15476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15476.xml"),
+          )
+      )
+
+  public val icon_15477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15477.xml"),
+          )
+      )
+
+  public val icon_15478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15478.xml"),
+          )
+      )
+
+  public val icon_15479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15479.xml"),
+          )
+      )
+
+  public val icon_1548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1548.xml"),
+          )
+      )
+
+  public val icon_15480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15480.xml"),
+          )
+      )
+
+  public val icon_15481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15481.xml"),
+          )
+      )
+
+  public val icon_15482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15482.xml"),
+          )
+      )
+
+  public val icon_15483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15483.xml"),
+          )
+      )
+
+  public val icon_15484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15484.xml"),
+          )
+      )
+
+  public val icon_15485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15485.xml"),
+          )
+      )
+
+  public val icon_15486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15486.xml"),
+          )
+      )
+
+  public val icon_15487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15487.xml"),
+          )
+      )
+
+  public val icon_15488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15488.xml"),
+          )
+      )
+
+  public val icon_15489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15489.xml"),
+          )
+      )
+
+  public val icon_1549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1549.xml"),
+          )
+      )
+
+  public val icon_15490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15490.xml"),
+          )
+      )
+
+  public val icon_15491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15491.xml"),
+          )
+      )
+
+  public val icon_15492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15492.xml"),
+          )
+      )
+
+  public val icon_15493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15493.xml"),
+          )
+      )
+
+  public val icon_15494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15494.xml"),
+          )
+      )
+
+  public val icon_15495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15495.xml"),
+          )
+      )
+
+  public val icon_15496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15496.xml"),
+          )
+      )
+
+  public val icon_15497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15497.xml"),
+          )
+      )
+
+  public val icon_15498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15498.xml"),
+          )
+      )
+
+  public val icon_15499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15499.xml"),
+          )
+      )
+
+  public val icon_155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_155.xml"),
+          )
+      )
+
+  public val icon_1550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1550.xml"),
+          )
+      )
+
+  public val icon_15500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15500.xml"),
+          )
+      )
+
+  public val icon_15501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15501.xml"),
+          )
+      )
+
+  public val icon_15502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15502.xml"),
+          )
+      )
+
+  public val icon_15503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15503.xml"),
+          )
+      )
+
+  public val icon_15504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15504.xml"),
+          )
+      )
+
+  public val icon_15505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15505.xml"),
+          )
+      )
+
+  public val icon_15506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15506.xml"),
+          )
+      )
+
+  public val icon_15507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15507.xml"),
+          )
+      )
+
+  public val icon_15508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15508.xml"),
+          )
+      )
+
+  public val icon_15509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15509.xml"),
+          )
+      )
+
+  public val icon_1551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1551.xml"),
+          )
+      )
+
+  public val icon_15510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15510.xml"),
+          )
+      )
+
+  public val icon_15511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15511.xml"),
+          )
+      )
+
+  public val icon_15512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15512.xml"),
+          )
+      )
+
+  public val icon_15513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15513.xml"),
+          )
+      )
+
+  public val icon_15514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15514.xml"),
+          )
+      )
+
+  public val icon_15515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15515.xml"),
+          )
+      )
+
+  public val icon_15516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15516.xml"),
+          )
+      )
+
+  public val icon_15517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15517.xml"),
+          )
+      )
+
+  public val icon_15518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15518.xml"),
+          )
+      )
+
+  public val icon_15519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15519.xml"),
+          )
+      )
+
+  public val icon_1552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1552.xml"),
+          )
+      )
+
+  public val icon_15520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15520.xml"),
+          )
+      )
+
+  public val icon_15521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15521.xml"),
+          )
+      )
+
+  public val icon_15522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15522.xml"),
+          )
+      )
+
+  public val icon_15523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15523.xml"),
+          )
+      )
+
+  public val icon_15524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15524.xml"),
+          )
+      )
+
+  public val icon_15525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15525.xml"),
+          )
+      )
+
+  public val icon_15526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15526.xml"),
+          )
+      )
+
+  public val icon_15527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15527.xml"),
+          )
+      )
+
+  public val icon_15528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15528.xml"),
+          )
+      )
+
+  public val icon_15529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15529.xml"),
+          )
+      )
+
+  public val icon_1553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1553.xml"),
+          )
+      )
+
+  public val icon_15530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15530.xml"),
+          )
+      )
+
+  public val icon_15531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15531.xml"),
+          )
+      )
+
+  public val icon_15532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15532.xml"),
+          )
+      )
+
+  public val icon_15533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15533.xml"),
+          )
+      )
+
+  public val icon_15534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15534.xml"),
+          )
+      )
+
+  public val icon_15535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15535.xml"),
+          )
+      )
+
+  public val icon_15536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15536.xml"),
+          )
+      )
+
+  public val icon_15537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15537.xml"),
+          )
+      )
+
+  public val icon_15538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15538.xml"),
+          )
+      )
+
+  public val icon_15539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15539.xml"),
+          )
+      )
+
+  public val icon_1554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1554.xml"),
+          )
+      )
+
+  public val icon_15540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15540.xml"),
+          )
+      )
+
+  public val icon_15541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15541.xml"),
+          )
+      )
+
+  public val icon_15542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15542.xml"),
+          )
+      )
+
+  public val icon_15543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15543.xml"),
+          )
+      )
+
+  public val icon_15544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15544.xml"),
+          )
+      )
+
+  public val icon_15545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15545.xml"),
+          )
+      )
+
+  public val icon_15546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15546.xml"),
+          )
+      )
+
+  public val icon_15547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15547.xml"),
+          )
+      )
+
+  public val icon_15548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15548.xml"),
+          )
+      )
+
+  public val icon_15549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15549.xml"),
+          )
+      )
+
+  public val icon_1555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1555.xml"),
+          )
+      )
+
+  public val icon_15550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15550.xml"),
+          )
+      )
+
+  public val icon_15551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15551.xml"),
+          )
+      )
+
+  public val icon_15552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15552.xml"),
+          )
+      )
+
+  public val icon_15553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15553.xml"),
+          )
+      )
+
+  public val icon_15554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15554.xml"),
+          )
+      )
+
+  public val icon_15555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15555.xml"),
+          )
+      )
+
+  public val icon_15556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15556.xml"),
+          )
+      )
+
+  public val icon_15557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15557.xml"),
+          )
+      )
+
+  public val icon_15558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15558.xml"),
+          )
+      )
+
+  public val icon_15559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15559.xml"),
+          )
+      )
+
+  public val icon_1556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1556.xml"),
+          )
+      )
+
+  public val icon_15560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15560.xml"),
+          )
+      )
+
+  public val icon_15561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15561.xml"),
+          )
+      )
+
+  public val icon_15562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15562.xml"),
+          )
+      )
+
+  public val icon_15563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15563.xml"),
+          )
+      )
+
+  public val icon_15564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15564.xml"),
+          )
+      )
+
+  public val icon_15565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15565.xml"),
+          )
+      )
+
+  public val icon_15566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15566.xml"),
+          )
+      )
+
+  public val icon_15567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15567.xml"),
+          )
+      )
+
+  public val icon_15568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15568.xml"),
+          )
+      )
+
+  public val icon_15569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15569.xml"),
+          )
+      )
+
+  public val icon_1557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1557.xml"),
+          )
+      )
+
+  public val icon_15570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15570.xml"),
+          )
+      )
+
+  public val icon_15571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15571.xml"),
+          )
+      )
+
+  public val icon_15572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15572.xml"),
+          )
+      )
+
+  public val icon_15573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15573.xml"),
+          )
+      )
+
+  public val icon_15574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15574.xml"),
+          )
+      )
+
+  public val icon_15575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15575.xml"),
+          )
+      )
+
+  public val icon_15576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15576.xml"),
+          )
+      )
+
+  public val icon_15577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15577.xml"),
+          )
+      )
+
+  public val icon_15578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15578.xml"),
+          )
+      )
+
+  public val icon_15579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15579.xml"),
+          )
+      )
+
+  public val icon_1558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1558.xml"),
+          )
+      )
+
+  public val icon_15580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15580.xml"),
+          )
+      )
+
+  public val icon_15581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15581.xml"),
+          )
+      )
+
+  public val icon_15582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15582.xml"),
+          )
+      )
+
+  public val icon_15583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15583.xml"),
+          )
+      )
+
+  public val icon_15584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15584.xml"),
+          )
+      )
+
+  public val icon_15585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15585.xml"),
+          )
+      )
+
+  public val icon_15586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15586.xml"),
+          )
+      )
+
+  public val icon_15587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15587.xml"),
+          )
+      )
+
+  public val icon_15588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15588.xml"),
+          )
+      )
+
+  public val icon_15589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15589.xml"),
+          )
+      )
+
+  public val icon_1559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1559.xml"),
+          )
+      )
+
+  public val icon_15590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15590.xml"),
+          )
+      )
+
+  public val icon_15591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15591.xml"),
+          )
+      )
+
+  public val icon_15592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15592.xml"),
+          )
+      )
+
+  public val icon_15593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15593.xml"),
+          )
+      )
+
+  public val icon_15594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15594.xml"),
+          )
+      )
+
+  public val icon_15595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15595.xml"),
+          )
+      )
+
+  public val icon_15596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15596.xml"),
+          )
+      )
+
+  public val icon_15597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15597.xml"),
+          )
+      )
+
+  public val icon_15598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15598.xml"),
+          )
+      )
+
+  public val icon_15599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15599.xml"),
+          )
+      )
+
+  public val icon_156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_156.xml"),
+          )
+      )
+
+  public val icon_1560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1560.xml"),
+          )
+      )
+
+  public val icon_15600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15600.xml"),
+          )
+      )
+
+  public val icon_15601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15601.xml"),
+          )
+      )
+
+  public val icon_15602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15602.xml"),
+          )
+      )
+
+  public val icon_15603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15603.xml"),
+          )
+      )
+
+  public val icon_15604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15604.xml"),
+          )
+      )
+
+  public val icon_15605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15605.xml"),
+          )
+      )
+
+  public val icon_15606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15606.xml"),
+          )
+      )
+
+  public val icon_15607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15607.xml"),
+          )
+      )
+
+  public val icon_15608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15608.xml"),
+          )
+      )
+
+  public val icon_15609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15609.xml"),
+          )
+      )
+
+  public val icon_1561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1561.xml"),
+          )
+      )
+
+  public val icon_15610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15610.xml"),
+          )
+      )
+
+  public val icon_15611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15611.xml"),
+          )
+      )
+
+  public val icon_15612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15612.xml"),
+          )
+      )
+
+  public val icon_15613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15613.xml"),
+          )
+      )
+
+  public val icon_15614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15614.xml"),
+          )
+      )
+
+  public val icon_15615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15615.xml"),
+          )
+      )
+
+  public val icon_15616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15616.xml"),
+          )
+      )
+
+  public val icon_15617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15617.xml"),
+          )
+      )
+
+  public val icon_15618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15618.xml"),
+          )
+      )
+
+  public val icon_15619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15619.xml"),
+          )
+      )
+
+  public val icon_1562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1562.xml"),
+          )
+      )
+
+  public val icon_15620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15620.xml"),
+          )
+      )
+
+  public val icon_15621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15621.xml"),
+          )
+      )
+
+  public val icon_15622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15622.xml"),
+          )
+      )
+
+  public val icon_15623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15623.xml"),
+          )
+      )
+
+  public val icon_15624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15624.xml"),
+          )
+      )
+
+  public val icon_15625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15625.xml"),
+          )
+      )
+
+  public val icon_15626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15626.xml"),
+          )
+      )
+
+  public val icon_15627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15627.xml"),
+          )
+      )
+
+  public val icon_15628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15628.xml"),
+          )
+      )
+
+  public val icon_15629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15629.xml"),
+          )
+      )
+
+  public val icon_1563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1563.xml"),
+          )
+      )
+
+  public val icon_15630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15630.xml"),
+          )
+      )
+
+  public val icon_15631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15631.xml"),
+          )
+      )
+
+  public val icon_15632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15632.xml"),
+          )
+      )
+
+  public val icon_15633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15633.xml"),
+          )
+      )
+
+  public val icon_15634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15634.xml"),
+          )
+      )
+
+  public val icon_15635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15635.xml"),
+          )
+      )
+
+  public val icon_15636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15636.xml"),
+          )
+      )
+
+  public val icon_15637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15637.xml"),
+          )
+      )
+
+  public val icon_15638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15638.xml"),
+          )
+      )
+
+  public val icon_15639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15639.xml"),
+          )
+      )
+
+  public val icon_1564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1564.xml"),
+          )
+      )
+
+  public val icon_15640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15640.xml"),
+          )
+      )
+
+  public val icon_15641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15641.xml"),
+          )
+      )
+
+  public val icon_15642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15642.xml"),
+          )
+      )
+
+  public val icon_15643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15643.xml"),
+          )
+      )
+
+  public val icon_15644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15644.xml"),
+          )
+      )
+
+  public val icon_15645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15645.xml"),
+          )
+      )
+
+  public val icon_15646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15646.xml"),
+          )
+      )
+
+  public val icon_15647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15647.xml"),
+          )
+      )
+
+  public val icon_15648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15648.xml"),
+          )
+      )
+
+  public val icon_15649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15649.xml"),
+          )
+      )
+
+  public val icon_1565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1565.xml"),
+          )
+      )
+
+  public val icon_15650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15650.xml"),
+          )
+      )
+
+  public val icon_15651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15651.xml"),
+          )
+      )
+
+  public val icon_15652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15652.xml"),
+          )
+      )
+
+  public val icon_15653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15653.xml"),
+          )
+      )
+
+  public val icon_15654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15654.xml"),
+          )
+      )
+
+  public val icon_15655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15655.xml"),
+          )
+      )
+
+  public val icon_15656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15656.xml"),
+          )
+      )
+
+  public val icon_15657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15657.xml"),
+          )
+      )
+
+  public val icon_15658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15658.xml"),
+          )
+      )
+
+  public val icon_15659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15659.xml"),
+          )
+      )
+
+  public val icon_1566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1566.xml"),
+          )
+      )
+
+  public val icon_15660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15660.xml"),
+          )
+      )
+
+  public val icon_15661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15661.xml"),
+          )
+      )
+
+  public val icon_15662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15662.xml"),
+          )
+      )
+
+  public val icon_15663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15663.xml"),
+          )
+      )
+
+  public val icon_15664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15664.xml"),
+          )
+      )
+
+  public val icon_15665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15665.xml"),
+          )
+      )
+
+  public val icon_15666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15666.xml"),
+          )
+      )
+
+  public val icon_15667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15667.xml"),
+          )
+      )
+
+  public val icon_15668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15668.xml"),
+          )
+      )
+
+  public val icon_15669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15669.xml"),
+          )
+      )
+
+  public val icon_1567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1567.xml"),
+          )
+      )
+
+  public val icon_15670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15670.xml"),
+          )
+      )
+
+  public val icon_15671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15671.xml"),
+          )
+      )
+
+  public val icon_15672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15672.xml"),
+          )
+      )
+
+  public val icon_15673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15673.xml"),
+          )
+      )
+
+  public val icon_15674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15674.xml"),
+          )
+      )
+
+  public val icon_15675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15675.xml"),
+          )
+      )
+
+  public val icon_15676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15676.xml"),
+          )
+      )
+
+  public val icon_15677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15677.xml"),
+          )
+      )
+
+  public val icon_15678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15678.xml"),
+          )
+      )
+
+  public val icon_15679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15679.xml"),
+          )
+      )
+
+  public val icon_1568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1568.xml"),
+          )
+      )
+
+  public val icon_15680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15680.xml"),
+          )
+      )
+
+  public val icon_15681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15681.xml"),
+          )
+      )
+
+  public val icon_15682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15682.xml"),
+          )
+      )
+
+  public val icon_15683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15683.xml"),
+          )
+      )
+
+  public val icon_15684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15684.xml"),
+          )
+      )
+
+  public val icon_15685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15685.xml"),
+          )
+      )
+
+  public val icon_15686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15686.xml"),
+          )
+      )
+
+  public val icon_15687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15687.xml"),
+          )
+      )
+
+  public val icon_15688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15688.xml"),
+          )
+      )
+
+  public val icon_15689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15689.xml"),
+          )
+      )
+
+  public val icon_1569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1569.xml"),
+          )
+      )
+
+  public val icon_15690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15690.xml"),
+          )
+      )
+
+  public val icon_15691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15691.xml"),
+          )
+      )
+
+  public val icon_15692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15692.xml"),
+          )
+      )
+
+  public val icon_15693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15693.xml"),
+          )
+      )
+
+  public val icon_15694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15694.xml"),
+          )
+      )
+
+  public val icon_15695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15695.xml"),
+          )
+      )
+
+  public val icon_15696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15696.xml"),
+          )
+      )
+
+  public val icon_15697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15697.xml"),
+          )
+      )
+
+  public val icon_15698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15698.xml"),
+          )
+      )
+
+  public val icon_15699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15699.xml"),
+          )
+      )
+
+  public val icon_157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_157.xml"),
+          )
+      )
+
+  public val icon_1570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1570.xml"),
+          )
+      )
+
+  public val icon_15700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15700.xml"),
+          )
+      )
+
+  public val icon_15701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15701.xml"),
+          )
+      )
+
+  public val icon_15702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15702.xml"),
+          )
+      )
+
+  public val icon_15703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15703.xml"),
+          )
+      )
+
+  public val icon_15704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15704.xml"),
+          )
+      )
+
+  public val icon_15705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15705.xml"),
+          )
+      )
+
+  public val icon_15706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15706.xml"),
+          )
+      )
+
+  public val icon_15707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15707.xml"),
+          )
+      )
+
+  public val icon_15708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15708.xml"),
+          )
+      )
+
+  public val icon_15709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15709.xml"),
+          )
+      )
+
+  public val icon_1571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1571.xml"),
+          )
+      )
+
+  public val icon_15710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15710.xml"),
+          )
+      )
+
+  public val icon_15711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15711.xml"),
+          )
+      )
+
+  public val icon_15712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15712.xml"),
+          )
+      )
+
+  public val icon_15713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15713.xml"),
+          )
+      )
+
+  public val icon_15714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15714.xml"),
+          )
+      )
+
+  public val icon_15715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15715.xml"),
+          )
+      )
+
+  public val icon_15716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15716.xml"),
+          )
+      )
+
+  public val icon_15717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15717.xml"),
+          )
+      )
+
+  public val icon_15718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15718.xml"),
+          )
+      )
+
+  public val icon_15719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15719.xml"),
+          )
+      )
+
+  public val icon_1572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1572.xml"),
+          )
+      )
+
+  public val icon_15720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15720.xml"),
+          )
+      )
+
+  public val icon_15721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15721.xml"),
+          )
+      )
+
+  public val icon_15722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15722.xml"),
+          )
+      )
+
+  public val icon_15723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15723.xml"),
+          )
+      )
+
+  public val icon_15724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15724.xml"),
+          )
+      )
+
+  public val icon_15725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15725.xml"),
+          )
+      )
+
+  public val icon_15726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15726.xml"),
+          )
+      )
+
+  public val icon_15727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15727.xml"),
+          )
+      )
+
+  public val icon_15728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15728.xml"),
+          )
+      )
+
+  public val icon_15729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15729.xml"),
+          )
+      )
+
+  public val icon_1573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1573.xml"),
+          )
+      )
+
+  public val icon_15730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15730.xml"),
+          )
+      )
+
+  public val icon_15731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15731.xml"),
+          )
+      )
+
+  public val icon_15732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15732.xml"),
+          )
+      )
+
+  public val icon_15733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15733.xml"),
+          )
+      )
+
+  public val icon_15734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15734.xml"),
+          )
+      )
+
+  public val icon_15735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15735.xml"),
+          )
+      )
+
+  public val icon_15736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15736.xml"),
+          )
+      )
+
+  public val icon_15737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15737.xml"),
+          )
+      )
+
+  public val icon_15738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15738.xml"),
+          )
+      )
+
+  public val icon_15739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15739.xml"),
+          )
+      )
+
+  public val icon_1574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1574.xml"),
+          )
+      )
+
+  public val icon_15740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15740.xml"),
+          )
+      )
+
+  public val icon_15741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15741.xml"),
+          )
+      )
+
+  public val icon_15742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15742.xml"),
+          )
+      )
+
+  public val icon_15743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15743.xml"),
+          )
+      )
+
+  public val icon_15744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15744.xml"),
+          )
+      )
+
+  public val icon_15745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15745.xml"),
+          )
+      )
+
+  public val icon_15746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15746.xml"),
+          )
+      )
+
+  public val icon_15747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15747.xml"),
+          )
+      )
+
+  public val icon_15748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15748.xml"),
+          )
+      )
+
+  public val icon_15749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15749.xml"),
+          )
+      )
+
+  public val icon_1575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1575.xml"),
+          )
+      )
+
+  public val icon_15750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15750.xml"),
+          )
+      )
+
+  public val icon_15751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15751.xml"),
+          )
+      )
+
+  public val icon_15752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15752.xml"),
+          )
+      )
+
+  public val icon_15753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15753.xml"),
+          )
+      )
+
+  public val icon_15754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15754.xml"),
+          )
+      )
+
+  public val icon_15755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15755.xml"),
+          )
+      )
+
+  public val icon_15756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15756.xml"),
+          )
+      )
+
+  public val icon_15757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15757.xml"),
+          )
+      )
+
+  public val icon_15758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15758.xml"),
+          )
+      )
+
+  public val icon_15759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15759.xml"),
+          )
+      )
+
+  public val icon_1576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1576.xml"),
+          )
+      )
+
+  public val icon_15760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15760.xml"),
+          )
+      )
+
+  public val icon_15761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15761.xml"),
+          )
+      )
+
+  public val icon_15762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15762.xml"),
+          )
+      )
+
+  public val icon_15763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15763.xml"),
+          )
+      )
+
+  public val icon_15764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15764.xml"),
+          )
+      )
+
+  public val icon_15765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15765.xml"),
+          )
+      )
+
+  public val icon_15766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15766.xml"),
+          )
+      )
+
+  public val icon_15767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15767.xml"),
+          )
+      )
+
+  public val icon_15768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15768.xml"),
+          )
+      )
+
+  public val icon_15769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15769.xml"),
+          )
+      )
+
+  public val icon_1577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1577.xml"),
+          )
+      )
+
+  public val icon_15770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15770.xml"),
+          )
+      )
+
+  public val icon_15771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15771.xml"),
+          )
+      )
+
+  public val icon_15772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15772.xml"),
+          )
+      )
+
+  public val icon_15773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15773.xml"),
+          )
+      )
+
+  public val icon_15774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15774.xml"),
+          )
+      )
+
+  public val icon_15775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15775.xml"),
+          )
+      )
+
+  public val icon_15776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15776.xml"),
+          )
+      )
+
+  public val icon_15777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15777.xml"),
+          )
+      )
+
+  public val icon_15778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15778.xml"),
+          )
+      )
+
+  public val icon_15779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15779.xml"),
+          )
+      )
+
+  public val icon_1578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1578.xml"),
+          )
+      )
+
+  public val icon_15780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15780.xml"),
+          )
+      )
+
+  public val icon_15781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15781.xml"),
+          )
+      )
+
+  public val icon_15782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15782.xml"),
+          )
+      )
+
+  public val icon_15783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15783.xml"),
+          )
+      )
+
+  public val icon_15784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15784.xml"),
+          )
+      )
+
+  public val icon_15785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15785.xml"),
+          )
+      )
+
+  public val icon_15786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15786.xml"),
+          )
+      )
+
+  public val icon_15787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15787.xml"),
+          )
+      )
+
+  public val icon_15788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15788.xml"),
+          )
+      )
+
+  public val icon_15789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15789.xml"),
+          )
+      )
+
+  public val icon_1579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1579.xml"),
+          )
+      )
+
+  public val icon_15790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15790.xml"),
+          )
+      )
+
+  public val icon_15791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15791.xml"),
+          )
+      )
+
+  public val icon_15792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15792.xml"),
+          )
+      )
+
+  public val icon_15793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15793.xml"),
+          )
+      )
+
+  public val icon_15794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15794.xml"),
+          )
+      )
+
+  public val icon_15795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15795.xml"),
+          )
+      )
+
+  public val icon_15796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15796.xml"),
+          )
+      )
+
+  public val icon_15797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15797.xml"),
+          )
+      )
+
+  public val icon_15798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15798.xml"),
+          )
+      )
+
+  public val icon_15799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15799.xml"),
+          )
+      )
+
+  public val icon_158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_158.xml"),
+          )
+      )
+
+  public val icon_1580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1580.xml"),
+          )
+      )
+
+  public val icon_15800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15800.xml"),
+          )
+      )
+
+  public val icon_15801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15801.xml"),
+          )
+      )
+
+  public val icon_15802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15802.xml"),
+          )
+      )
+
+  public val icon_15803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15803.xml"),
+          )
+      )
+
+  public val icon_15804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15804.xml"),
+          )
+      )
+
+  public val icon_15805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15805.xml"),
+          )
+      )
+
+  public val icon_15806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15806.xml"),
+          )
+      )
+
+  public val icon_15807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15807.xml"),
+          )
+      )
+
+  public val icon_15808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15808.xml"),
+          )
+      )
+
+  public val icon_15809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15809.xml"),
+          )
+      )
+
+  public val icon_1581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1581.xml"),
+          )
+      )
+
+  public val icon_15810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15810.xml"),
+          )
+      )
+
+  public val icon_15811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15811.xml"),
+          )
+      )
+
+  public val icon_15812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15812.xml"),
+          )
+      )
+
+  public val icon_15813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15813.xml"),
+          )
+      )
+
+  public val icon_15814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15814.xml"),
+          )
+      )
+
+  public val icon_15815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15815.xml"),
+          )
+      )
+
+  public val icon_15816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15816.xml"),
+          )
+      )
+
+  public val icon_15817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15817.xml"),
+          )
+      )
+
+  public val icon_15818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15818.xml"),
+          )
+      )
+
+  public val icon_15819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15819.xml"),
+          )
+      )
+
+  public val icon_1582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1582.xml"),
+          )
+      )
+
+  public val icon_15820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15820.xml"),
+          )
+      )
+
+  public val icon_15821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15821.xml"),
+          )
+      )
+
+  public val icon_15822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15822.xml"),
+          )
+      )
+
+  public val icon_15823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15823.xml"),
+          )
+      )
+
+  public val icon_15824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15824.xml"),
+          )
+      )
+
+  public val icon_15825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15825.xml"),
+          )
+      )
+
+  public val icon_15826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15826.xml"),
+          )
+      )
+
+  public val icon_15827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15827.xml"),
+          )
+      )
+
+  public val icon_15828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15828.xml"),
+          )
+      )
+
+  public val icon_15829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15829.xml"),
+          )
+      )
+
+  public val icon_1583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1583.xml"),
+          )
+      )
+
+  public val icon_15830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15830.xml"),
+          )
+      )
+
+  public val icon_15831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15831.xml"),
+          )
+      )
+
+  public val icon_15832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15832.xml"),
+          )
+      )
+
+  public val icon_15833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15833.xml"),
+          )
+      )
+
+  public val icon_15834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15834.xml"),
+          )
+      )
+
+  public val icon_15835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15835.xml"),
+          )
+      )
+
+  public val icon_15836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15836.xml"),
+          )
+      )
+
+  public val icon_15837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15837.xml"),
+          )
+      )
+
+  public val icon_15838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15838.xml"),
+          )
+      )
+
+  public val icon_15839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15839.xml"),
+          )
+      )
+
+  public val icon_1584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1584.xml"),
+          )
+      )
+
+  public val icon_15840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15840.xml"),
+          )
+      )
+
+  public val icon_15841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15841.xml"),
+          )
+      )
+
+  public val icon_15842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15842.xml"),
+          )
+      )
+
+  public val icon_15843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15843.xml"),
+          )
+      )
+
+  public val icon_15844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15844.xml"),
+          )
+      )
+
+  public val icon_15845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15845.xml"),
+          )
+      )
+
+  public val icon_15846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15846.xml"),
+          )
+      )
+
+  public val icon_15847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15847.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15398: DrawableResource
+  get() = Drawable12.icon_15398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15399: DrawableResource
+  get() = Drawable12.icon_15399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_154: DrawableResource
+  get() = Drawable12.icon_154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1540: DrawableResource
+  get() = Drawable12.icon_1540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15400: DrawableResource
+  get() = Drawable12.icon_15400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15401: DrawableResource
+  get() = Drawable12.icon_15401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15402: DrawableResource
+  get() = Drawable12.icon_15402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15403: DrawableResource
+  get() = Drawable12.icon_15403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15404: DrawableResource
+  get() = Drawable12.icon_15404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15405: DrawableResource
+  get() = Drawable12.icon_15405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15406: DrawableResource
+  get() = Drawable12.icon_15406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15407: DrawableResource
+  get() = Drawable12.icon_15407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15408: DrawableResource
+  get() = Drawable12.icon_15408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15409: DrawableResource
+  get() = Drawable12.icon_15409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1541: DrawableResource
+  get() = Drawable12.icon_1541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15410: DrawableResource
+  get() = Drawable12.icon_15410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15411: DrawableResource
+  get() = Drawable12.icon_15411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15412: DrawableResource
+  get() = Drawable12.icon_15412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15413: DrawableResource
+  get() = Drawable12.icon_15413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15414: DrawableResource
+  get() = Drawable12.icon_15414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15415: DrawableResource
+  get() = Drawable12.icon_15415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15416: DrawableResource
+  get() = Drawable12.icon_15416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15417: DrawableResource
+  get() = Drawable12.icon_15417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15418: DrawableResource
+  get() = Drawable12.icon_15418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15419: DrawableResource
+  get() = Drawable12.icon_15419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1542: DrawableResource
+  get() = Drawable12.icon_1542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15420: DrawableResource
+  get() = Drawable12.icon_15420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15421: DrawableResource
+  get() = Drawable12.icon_15421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15422: DrawableResource
+  get() = Drawable12.icon_15422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15423: DrawableResource
+  get() = Drawable12.icon_15423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15424: DrawableResource
+  get() = Drawable12.icon_15424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15425: DrawableResource
+  get() = Drawable12.icon_15425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15426: DrawableResource
+  get() = Drawable12.icon_15426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15427: DrawableResource
+  get() = Drawable12.icon_15427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15428: DrawableResource
+  get() = Drawable12.icon_15428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15429: DrawableResource
+  get() = Drawable12.icon_15429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1543: DrawableResource
+  get() = Drawable12.icon_1543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15430: DrawableResource
+  get() = Drawable12.icon_15430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15431: DrawableResource
+  get() = Drawable12.icon_15431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15432: DrawableResource
+  get() = Drawable12.icon_15432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15433: DrawableResource
+  get() = Drawable12.icon_15433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15434: DrawableResource
+  get() = Drawable12.icon_15434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15435: DrawableResource
+  get() = Drawable12.icon_15435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15436: DrawableResource
+  get() = Drawable12.icon_15436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15437: DrawableResource
+  get() = Drawable12.icon_15437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15438: DrawableResource
+  get() = Drawable12.icon_15438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15439: DrawableResource
+  get() = Drawable12.icon_15439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1544: DrawableResource
+  get() = Drawable12.icon_1544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15440: DrawableResource
+  get() = Drawable12.icon_15440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15441: DrawableResource
+  get() = Drawable12.icon_15441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15442: DrawableResource
+  get() = Drawable12.icon_15442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15443: DrawableResource
+  get() = Drawable12.icon_15443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15444: DrawableResource
+  get() = Drawable12.icon_15444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15445: DrawableResource
+  get() = Drawable12.icon_15445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15446: DrawableResource
+  get() = Drawable12.icon_15446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15447: DrawableResource
+  get() = Drawable12.icon_15447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15448: DrawableResource
+  get() = Drawable12.icon_15448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15449: DrawableResource
+  get() = Drawable12.icon_15449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1545: DrawableResource
+  get() = Drawable12.icon_1545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15450: DrawableResource
+  get() = Drawable12.icon_15450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15451: DrawableResource
+  get() = Drawable12.icon_15451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15452: DrawableResource
+  get() = Drawable12.icon_15452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15453: DrawableResource
+  get() = Drawable12.icon_15453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15454: DrawableResource
+  get() = Drawable12.icon_15454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15455: DrawableResource
+  get() = Drawable12.icon_15455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15456: DrawableResource
+  get() = Drawable12.icon_15456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15457: DrawableResource
+  get() = Drawable12.icon_15457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15458: DrawableResource
+  get() = Drawable12.icon_15458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15459: DrawableResource
+  get() = Drawable12.icon_15459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1546: DrawableResource
+  get() = Drawable12.icon_1546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15460: DrawableResource
+  get() = Drawable12.icon_15460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15461: DrawableResource
+  get() = Drawable12.icon_15461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15462: DrawableResource
+  get() = Drawable12.icon_15462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15463: DrawableResource
+  get() = Drawable12.icon_15463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15464: DrawableResource
+  get() = Drawable12.icon_15464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15465: DrawableResource
+  get() = Drawable12.icon_15465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15466: DrawableResource
+  get() = Drawable12.icon_15466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15467: DrawableResource
+  get() = Drawable12.icon_15467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15468: DrawableResource
+  get() = Drawable12.icon_15468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15469: DrawableResource
+  get() = Drawable12.icon_15469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1547: DrawableResource
+  get() = Drawable12.icon_1547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15470: DrawableResource
+  get() = Drawable12.icon_15470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15471: DrawableResource
+  get() = Drawable12.icon_15471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15472: DrawableResource
+  get() = Drawable12.icon_15472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15473: DrawableResource
+  get() = Drawable12.icon_15473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15474: DrawableResource
+  get() = Drawable12.icon_15474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15475: DrawableResource
+  get() = Drawable12.icon_15475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15476: DrawableResource
+  get() = Drawable12.icon_15476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15477: DrawableResource
+  get() = Drawable12.icon_15477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15478: DrawableResource
+  get() = Drawable12.icon_15478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15479: DrawableResource
+  get() = Drawable12.icon_15479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1548: DrawableResource
+  get() = Drawable12.icon_1548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15480: DrawableResource
+  get() = Drawable12.icon_15480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15481: DrawableResource
+  get() = Drawable12.icon_15481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15482: DrawableResource
+  get() = Drawable12.icon_15482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15483: DrawableResource
+  get() = Drawable12.icon_15483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15484: DrawableResource
+  get() = Drawable12.icon_15484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15485: DrawableResource
+  get() = Drawable12.icon_15485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15486: DrawableResource
+  get() = Drawable12.icon_15486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15487: DrawableResource
+  get() = Drawable12.icon_15487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15488: DrawableResource
+  get() = Drawable12.icon_15488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15489: DrawableResource
+  get() = Drawable12.icon_15489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1549: DrawableResource
+  get() = Drawable12.icon_1549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15490: DrawableResource
+  get() = Drawable12.icon_15490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15491: DrawableResource
+  get() = Drawable12.icon_15491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15492: DrawableResource
+  get() = Drawable12.icon_15492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15493: DrawableResource
+  get() = Drawable12.icon_15493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15494: DrawableResource
+  get() = Drawable12.icon_15494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15495: DrawableResource
+  get() = Drawable12.icon_15495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15496: DrawableResource
+  get() = Drawable12.icon_15496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15497: DrawableResource
+  get() = Drawable12.icon_15497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15498: DrawableResource
+  get() = Drawable12.icon_15498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15499: DrawableResource
+  get() = Drawable12.icon_15499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_155: DrawableResource
+  get() = Drawable12.icon_155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1550: DrawableResource
+  get() = Drawable12.icon_1550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15500: DrawableResource
+  get() = Drawable12.icon_15500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15501: DrawableResource
+  get() = Drawable12.icon_15501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15502: DrawableResource
+  get() = Drawable12.icon_15502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15503: DrawableResource
+  get() = Drawable12.icon_15503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15504: DrawableResource
+  get() = Drawable12.icon_15504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15505: DrawableResource
+  get() = Drawable12.icon_15505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15506: DrawableResource
+  get() = Drawable12.icon_15506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15507: DrawableResource
+  get() = Drawable12.icon_15507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15508: DrawableResource
+  get() = Drawable12.icon_15508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15509: DrawableResource
+  get() = Drawable12.icon_15509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1551: DrawableResource
+  get() = Drawable12.icon_1551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15510: DrawableResource
+  get() = Drawable12.icon_15510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15511: DrawableResource
+  get() = Drawable12.icon_15511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15512: DrawableResource
+  get() = Drawable12.icon_15512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15513: DrawableResource
+  get() = Drawable12.icon_15513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15514: DrawableResource
+  get() = Drawable12.icon_15514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15515: DrawableResource
+  get() = Drawable12.icon_15515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15516: DrawableResource
+  get() = Drawable12.icon_15516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15517: DrawableResource
+  get() = Drawable12.icon_15517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15518: DrawableResource
+  get() = Drawable12.icon_15518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15519: DrawableResource
+  get() = Drawable12.icon_15519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1552: DrawableResource
+  get() = Drawable12.icon_1552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15520: DrawableResource
+  get() = Drawable12.icon_15520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15521: DrawableResource
+  get() = Drawable12.icon_15521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15522: DrawableResource
+  get() = Drawable12.icon_15522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15523: DrawableResource
+  get() = Drawable12.icon_15523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15524: DrawableResource
+  get() = Drawable12.icon_15524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15525: DrawableResource
+  get() = Drawable12.icon_15525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15526: DrawableResource
+  get() = Drawable12.icon_15526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15527: DrawableResource
+  get() = Drawable12.icon_15527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15528: DrawableResource
+  get() = Drawable12.icon_15528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15529: DrawableResource
+  get() = Drawable12.icon_15529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1553: DrawableResource
+  get() = Drawable12.icon_1553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15530: DrawableResource
+  get() = Drawable12.icon_15530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15531: DrawableResource
+  get() = Drawable12.icon_15531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15532: DrawableResource
+  get() = Drawable12.icon_15532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15533: DrawableResource
+  get() = Drawable12.icon_15533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15534: DrawableResource
+  get() = Drawable12.icon_15534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15535: DrawableResource
+  get() = Drawable12.icon_15535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15536: DrawableResource
+  get() = Drawable12.icon_15536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15537: DrawableResource
+  get() = Drawable12.icon_15537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15538: DrawableResource
+  get() = Drawable12.icon_15538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15539: DrawableResource
+  get() = Drawable12.icon_15539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1554: DrawableResource
+  get() = Drawable12.icon_1554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15540: DrawableResource
+  get() = Drawable12.icon_15540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15541: DrawableResource
+  get() = Drawable12.icon_15541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15542: DrawableResource
+  get() = Drawable12.icon_15542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15543: DrawableResource
+  get() = Drawable12.icon_15543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15544: DrawableResource
+  get() = Drawable12.icon_15544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15545: DrawableResource
+  get() = Drawable12.icon_15545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15546: DrawableResource
+  get() = Drawable12.icon_15546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15547: DrawableResource
+  get() = Drawable12.icon_15547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15548: DrawableResource
+  get() = Drawable12.icon_15548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15549: DrawableResource
+  get() = Drawable12.icon_15549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1555: DrawableResource
+  get() = Drawable12.icon_1555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15550: DrawableResource
+  get() = Drawable12.icon_15550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15551: DrawableResource
+  get() = Drawable12.icon_15551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15552: DrawableResource
+  get() = Drawable12.icon_15552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15553: DrawableResource
+  get() = Drawable12.icon_15553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15554: DrawableResource
+  get() = Drawable12.icon_15554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15555: DrawableResource
+  get() = Drawable12.icon_15555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15556: DrawableResource
+  get() = Drawable12.icon_15556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15557: DrawableResource
+  get() = Drawable12.icon_15557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15558: DrawableResource
+  get() = Drawable12.icon_15558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15559: DrawableResource
+  get() = Drawable12.icon_15559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1556: DrawableResource
+  get() = Drawable12.icon_1556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15560: DrawableResource
+  get() = Drawable12.icon_15560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15561: DrawableResource
+  get() = Drawable12.icon_15561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15562: DrawableResource
+  get() = Drawable12.icon_15562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15563: DrawableResource
+  get() = Drawable12.icon_15563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15564: DrawableResource
+  get() = Drawable12.icon_15564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15565: DrawableResource
+  get() = Drawable12.icon_15565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15566: DrawableResource
+  get() = Drawable12.icon_15566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15567: DrawableResource
+  get() = Drawable12.icon_15567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15568: DrawableResource
+  get() = Drawable12.icon_15568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15569: DrawableResource
+  get() = Drawable12.icon_15569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1557: DrawableResource
+  get() = Drawable12.icon_1557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15570: DrawableResource
+  get() = Drawable12.icon_15570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15571: DrawableResource
+  get() = Drawable12.icon_15571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15572: DrawableResource
+  get() = Drawable12.icon_15572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15573: DrawableResource
+  get() = Drawable12.icon_15573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15574: DrawableResource
+  get() = Drawable12.icon_15574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15575: DrawableResource
+  get() = Drawable12.icon_15575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15576: DrawableResource
+  get() = Drawable12.icon_15576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15577: DrawableResource
+  get() = Drawable12.icon_15577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15578: DrawableResource
+  get() = Drawable12.icon_15578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15579: DrawableResource
+  get() = Drawable12.icon_15579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1558: DrawableResource
+  get() = Drawable12.icon_1558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15580: DrawableResource
+  get() = Drawable12.icon_15580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15581: DrawableResource
+  get() = Drawable12.icon_15581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15582: DrawableResource
+  get() = Drawable12.icon_15582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15583: DrawableResource
+  get() = Drawable12.icon_15583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15584: DrawableResource
+  get() = Drawable12.icon_15584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15585: DrawableResource
+  get() = Drawable12.icon_15585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15586: DrawableResource
+  get() = Drawable12.icon_15586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15587: DrawableResource
+  get() = Drawable12.icon_15587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15588: DrawableResource
+  get() = Drawable12.icon_15588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15589: DrawableResource
+  get() = Drawable12.icon_15589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1559: DrawableResource
+  get() = Drawable12.icon_1559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15590: DrawableResource
+  get() = Drawable12.icon_15590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15591: DrawableResource
+  get() = Drawable12.icon_15591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15592: DrawableResource
+  get() = Drawable12.icon_15592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15593: DrawableResource
+  get() = Drawable12.icon_15593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15594: DrawableResource
+  get() = Drawable12.icon_15594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15595: DrawableResource
+  get() = Drawable12.icon_15595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15596: DrawableResource
+  get() = Drawable12.icon_15596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15597: DrawableResource
+  get() = Drawable12.icon_15597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15598: DrawableResource
+  get() = Drawable12.icon_15598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15599: DrawableResource
+  get() = Drawable12.icon_15599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_156: DrawableResource
+  get() = Drawable12.icon_156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1560: DrawableResource
+  get() = Drawable12.icon_1560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15600: DrawableResource
+  get() = Drawable12.icon_15600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15601: DrawableResource
+  get() = Drawable12.icon_15601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15602: DrawableResource
+  get() = Drawable12.icon_15602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15603: DrawableResource
+  get() = Drawable12.icon_15603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15604: DrawableResource
+  get() = Drawable12.icon_15604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15605: DrawableResource
+  get() = Drawable12.icon_15605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15606: DrawableResource
+  get() = Drawable12.icon_15606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15607: DrawableResource
+  get() = Drawable12.icon_15607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15608: DrawableResource
+  get() = Drawable12.icon_15608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15609: DrawableResource
+  get() = Drawable12.icon_15609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1561: DrawableResource
+  get() = Drawable12.icon_1561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15610: DrawableResource
+  get() = Drawable12.icon_15610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15611: DrawableResource
+  get() = Drawable12.icon_15611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15612: DrawableResource
+  get() = Drawable12.icon_15612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15613: DrawableResource
+  get() = Drawable12.icon_15613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15614: DrawableResource
+  get() = Drawable12.icon_15614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15615: DrawableResource
+  get() = Drawable12.icon_15615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15616: DrawableResource
+  get() = Drawable12.icon_15616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15617: DrawableResource
+  get() = Drawable12.icon_15617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15618: DrawableResource
+  get() = Drawable12.icon_15618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15619: DrawableResource
+  get() = Drawable12.icon_15619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1562: DrawableResource
+  get() = Drawable12.icon_1562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15620: DrawableResource
+  get() = Drawable12.icon_15620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15621: DrawableResource
+  get() = Drawable12.icon_15621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15622: DrawableResource
+  get() = Drawable12.icon_15622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15623: DrawableResource
+  get() = Drawable12.icon_15623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15624: DrawableResource
+  get() = Drawable12.icon_15624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15625: DrawableResource
+  get() = Drawable12.icon_15625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15626: DrawableResource
+  get() = Drawable12.icon_15626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15627: DrawableResource
+  get() = Drawable12.icon_15627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15628: DrawableResource
+  get() = Drawable12.icon_15628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15629: DrawableResource
+  get() = Drawable12.icon_15629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1563: DrawableResource
+  get() = Drawable12.icon_1563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15630: DrawableResource
+  get() = Drawable12.icon_15630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15631: DrawableResource
+  get() = Drawable12.icon_15631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15632: DrawableResource
+  get() = Drawable12.icon_15632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15633: DrawableResource
+  get() = Drawable12.icon_15633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15634: DrawableResource
+  get() = Drawable12.icon_15634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15635: DrawableResource
+  get() = Drawable12.icon_15635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15636: DrawableResource
+  get() = Drawable12.icon_15636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15637: DrawableResource
+  get() = Drawable12.icon_15637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15638: DrawableResource
+  get() = Drawable12.icon_15638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15639: DrawableResource
+  get() = Drawable12.icon_15639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1564: DrawableResource
+  get() = Drawable12.icon_1564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15640: DrawableResource
+  get() = Drawable12.icon_15640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15641: DrawableResource
+  get() = Drawable12.icon_15641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15642: DrawableResource
+  get() = Drawable12.icon_15642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15643: DrawableResource
+  get() = Drawable12.icon_15643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15644: DrawableResource
+  get() = Drawable12.icon_15644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15645: DrawableResource
+  get() = Drawable12.icon_15645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15646: DrawableResource
+  get() = Drawable12.icon_15646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15647: DrawableResource
+  get() = Drawable12.icon_15647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15648: DrawableResource
+  get() = Drawable12.icon_15648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15649: DrawableResource
+  get() = Drawable12.icon_15649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1565: DrawableResource
+  get() = Drawable12.icon_1565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15650: DrawableResource
+  get() = Drawable12.icon_15650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15651: DrawableResource
+  get() = Drawable12.icon_15651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15652: DrawableResource
+  get() = Drawable12.icon_15652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15653: DrawableResource
+  get() = Drawable12.icon_15653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15654: DrawableResource
+  get() = Drawable12.icon_15654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15655: DrawableResource
+  get() = Drawable12.icon_15655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15656: DrawableResource
+  get() = Drawable12.icon_15656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15657: DrawableResource
+  get() = Drawable12.icon_15657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15658: DrawableResource
+  get() = Drawable12.icon_15658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15659: DrawableResource
+  get() = Drawable12.icon_15659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1566: DrawableResource
+  get() = Drawable12.icon_1566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15660: DrawableResource
+  get() = Drawable12.icon_15660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15661: DrawableResource
+  get() = Drawable12.icon_15661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15662: DrawableResource
+  get() = Drawable12.icon_15662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15663: DrawableResource
+  get() = Drawable12.icon_15663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15664: DrawableResource
+  get() = Drawable12.icon_15664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15665: DrawableResource
+  get() = Drawable12.icon_15665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15666: DrawableResource
+  get() = Drawable12.icon_15666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15667: DrawableResource
+  get() = Drawable12.icon_15667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15668: DrawableResource
+  get() = Drawable12.icon_15668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15669: DrawableResource
+  get() = Drawable12.icon_15669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1567: DrawableResource
+  get() = Drawable12.icon_1567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15670: DrawableResource
+  get() = Drawable12.icon_15670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15671: DrawableResource
+  get() = Drawable12.icon_15671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15672: DrawableResource
+  get() = Drawable12.icon_15672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15673: DrawableResource
+  get() = Drawable12.icon_15673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15674: DrawableResource
+  get() = Drawable12.icon_15674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15675: DrawableResource
+  get() = Drawable12.icon_15675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15676: DrawableResource
+  get() = Drawable12.icon_15676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15677: DrawableResource
+  get() = Drawable12.icon_15677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15678: DrawableResource
+  get() = Drawable12.icon_15678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15679: DrawableResource
+  get() = Drawable12.icon_15679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1568: DrawableResource
+  get() = Drawable12.icon_1568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15680: DrawableResource
+  get() = Drawable12.icon_15680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15681: DrawableResource
+  get() = Drawable12.icon_15681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15682: DrawableResource
+  get() = Drawable12.icon_15682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15683: DrawableResource
+  get() = Drawable12.icon_15683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15684: DrawableResource
+  get() = Drawable12.icon_15684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15685: DrawableResource
+  get() = Drawable12.icon_15685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15686: DrawableResource
+  get() = Drawable12.icon_15686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15687: DrawableResource
+  get() = Drawable12.icon_15687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15688: DrawableResource
+  get() = Drawable12.icon_15688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15689: DrawableResource
+  get() = Drawable12.icon_15689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1569: DrawableResource
+  get() = Drawable12.icon_1569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15690: DrawableResource
+  get() = Drawable12.icon_15690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15691: DrawableResource
+  get() = Drawable12.icon_15691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15692: DrawableResource
+  get() = Drawable12.icon_15692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15693: DrawableResource
+  get() = Drawable12.icon_15693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15694: DrawableResource
+  get() = Drawable12.icon_15694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15695: DrawableResource
+  get() = Drawable12.icon_15695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15696: DrawableResource
+  get() = Drawable12.icon_15696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15697: DrawableResource
+  get() = Drawable12.icon_15697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15698: DrawableResource
+  get() = Drawable12.icon_15698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15699: DrawableResource
+  get() = Drawable12.icon_15699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_157: DrawableResource
+  get() = Drawable12.icon_157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1570: DrawableResource
+  get() = Drawable12.icon_1570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15700: DrawableResource
+  get() = Drawable12.icon_15700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15701: DrawableResource
+  get() = Drawable12.icon_15701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15702: DrawableResource
+  get() = Drawable12.icon_15702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15703: DrawableResource
+  get() = Drawable12.icon_15703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15704: DrawableResource
+  get() = Drawable12.icon_15704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15705: DrawableResource
+  get() = Drawable12.icon_15705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15706: DrawableResource
+  get() = Drawable12.icon_15706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15707: DrawableResource
+  get() = Drawable12.icon_15707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15708: DrawableResource
+  get() = Drawable12.icon_15708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15709: DrawableResource
+  get() = Drawable12.icon_15709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1571: DrawableResource
+  get() = Drawable12.icon_1571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15710: DrawableResource
+  get() = Drawable12.icon_15710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15711: DrawableResource
+  get() = Drawable12.icon_15711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15712: DrawableResource
+  get() = Drawable12.icon_15712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15713: DrawableResource
+  get() = Drawable12.icon_15713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15714: DrawableResource
+  get() = Drawable12.icon_15714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15715: DrawableResource
+  get() = Drawable12.icon_15715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15716: DrawableResource
+  get() = Drawable12.icon_15716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15717: DrawableResource
+  get() = Drawable12.icon_15717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15718: DrawableResource
+  get() = Drawable12.icon_15718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15719: DrawableResource
+  get() = Drawable12.icon_15719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1572: DrawableResource
+  get() = Drawable12.icon_1572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15720: DrawableResource
+  get() = Drawable12.icon_15720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15721: DrawableResource
+  get() = Drawable12.icon_15721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15722: DrawableResource
+  get() = Drawable12.icon_15722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15723: DrawableResource
+  get() = Drawable12.icon_15723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15724: DrawableResource
+  get() = Drawable12.icon_15724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15725: DrawableResource
+  get() = Drawable12.icon_15725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15726: DrawableResource
+  get() = Drawable12.icon_15726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15727: DrawableResource
+  get() = Drawable12.icon_15727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15728: DrawableResource
+  get() = Drawable12.icon_15728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15729: DrawableResource
+  get() = Drawable12.icon_15729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1573: DrawableResource
+  get() = Drawable12.icon_1573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15730: DrawableResource
+  get() = Drawable12.icon_15730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15731: DrawableResource
+  get() = Drawable12.icon_15731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15732: DrawableResource
+  get() = Drawable12.icon_15732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15733: DrawableResource
+  get() = Drawable12.icon_15733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15734: DrawableResource
+  get() = Drawable12.icon_15734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15735: DrawableResource
+  get() = Drawable12.icon_15735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15736: DrawableResource
+  get() = Drawable12.icon_15736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15737: DrawableResource
+  get() = Drawable12.icon_15737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15738: DrawableResource
+  get() = Drawable12.icon_15738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15739: DrawableResource
+  get() = Drawable12.icon_15739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1574: DrawableResource
+  get() = Drawable12.icon_1574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15740: DrawableResource
+  get() = Drawable12.icon_15740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15741: DrawableResource
+  get() = Drawable12.icon_15741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15742: DrawableResource
+  get() = Drawable12.icon_15742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15743: DrawableResource
+  get() = Drawable12.icon_15743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15744: DrawableResource
+  get() = Drawable12.icon_15744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15745: DrawableResource
+  get() = Drawable12.icon_15745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15746: DrawableResource
+  get() = Drawable12.icon_15746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15747: DrawableResource
+  get() = Drawable12.icon_15747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15748: DrawableResource
+  get() = Drawable12.icon_15748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15749: DrawableResource
+  get() = Drawable12.icon_15749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1575: DrawableResource
+  get() = Drawable12.icon_1575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15750: DrawableResource
+  get() = Drawable12.icon_15750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15751: DrawableResource
+  get() = Drawable12.icon_15751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15752: DrawableResource
+  get() = Drawable12.icon_15752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15753: DrawableResource
+  get() = Drawable12.icon_15753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15754: DrawableResource
+  get() = Drawable12.icon_15754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15755: DrawableResource
+  get() = Drawable12.icon_15755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15756: DrawableResource
+  get() = Drawable12.icon_15756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15757: DrawableResource
+  get() = Drawable12.icon_15757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15758: DrawableResource
+  get() = Drawable12.icon_15758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15759: DrawableResource
+  get() = Drawable12.icon_15759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1576: DrawableResource
+  get() = Drawable12.icon_1576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15760: DrawableResource
+  get() = Drawable12.icon_15760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15761: DrawableResource
+  get() = Drawable12.icon_15761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15762: DrawableResource
+  get() = Drawable12.icon_15762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15763: DrawableResource
+  get() = Drawable12.icon_15763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15764: DrawableResource
+  get() = Drawable12.icon_15764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15765: DrawableResource
+  get() = Drawable12.icon_15765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15766: DrawableResource
+  get() = Drawable12.icon_15766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15767: DrawableResource
+  get() = Drawable12.icon_15767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15768: DrawableResource
+  get() = Drawable12.icon_15768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15769: DrawableResource
+  get() = Drawable12.icon_15769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1577: DrawableResource
+  get() = Drawable12.icon_1577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15770: DrawableResource
+  get() = Drawable12.icon_15770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15771: DrawableResource
+  get() = Drawable12.icon_15771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15772: DrawableResource
+  get() = Drawable12.icon_15772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15773: DrawableResource
+  get() = Drawable12.icon_15773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15774: DrawableResource
+  get() = Drawable12.icon_15774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15775: DrawableResource
+  get() = Drawable12.icon_15775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15776: DrawableResource
+  get() = Drawable12.icon_15776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15777: DrawableResource
+  get() = Drawable12.icon_15777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15778: DrawableResource
+  get() = Drawable12.icon_15778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15779: DrawableResource
+  get() = Drawable12.icon_15779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1578: DrawableResource
+  get() = Drawable12.icon_1578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15780: DrawableResource
+  get() = Drawable12.icon_15780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15781: DrawableResource
+  get() = Drawable12.icon_15781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15782: DrawableResource
+  get() = Drawable12.icon_15782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15783: DrawableResource
+  get() = Drawable12.icon_15783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15784: DrawableResource
+  get() = Drawable12.icon_15784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15785: DrawableResource
+  get() = Drawable12.icon_15785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15786: DrawableResource
+  get() = Drawable12.icon_15786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15787: DrawableResource
+  get() = Drawable12.icon_15787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15788: DrawableResource
+  get() = Drawable12.icon_15788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15789: DrawableResource
+  get() = Drawable12.icon_15789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1579: DrawableResource
+  get() = Drawable12.icon_1579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15790: DrawableResource
+  get() = Drawable12.icon_15790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15791: DrawableResource
+  get() = Drawable12.icon_15791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15792: DrawableResource
+  get() = Drawable12.icon_15792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15793: DrawableResource
+  get() = Drawable12.icon_15793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15794: DrawableResource
+  get() = Drawable12.icon_15794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15795: DrawableResource
+  get() = Drawable12.icon_15795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15796: DrawableResource
+  get() = Drawable12.icon_15796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15797: DrawableResource
+  get() = Drawable12.icon_15797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15798: DrawableResource
+  get() = Drawable12.icon_15798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15799: DrawableResource
+  get() = Drawable12.icon_15799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_158: DrawableResource
+  get() = Drawable12.icon_158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1580: DrawableResource
+  get() = Drawable12.icon_1580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15800: DrawableResource
+  get() = Drawable12.icon_15800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15801: DrawableResource
+  get() = Drawable12.icon_15801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15802: DrawableResource
+  get() = Drawable12.icon_15802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15803: DrawableResource
+  get() = Drawable12.icon_15803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15804: DrawableResource
+  get() = Drawable12.icon_15804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15805: DrawableResource
+  get() = Drawable12.icon_15805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15806: DrawableResource
+  get() = Drawable12.icon_15806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15807: DrawableResource
+  get() = Drawable12.icon_15807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15808: DrawableResource
+  get() = Drawable12.icon_15808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15809: DrawableResource
+  get() = Drawable12.icon_15809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1581: DrawableResource
+  get() = Drawable12.icon_1581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15810: DrawableResource
+  get() = Drawable12.icon_15810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15811: DrawableResource
+  get() = Drawable12.icon_15811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15812: DrawableResource
+  get() = Drawable12.icon_15812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15813: DrawableResource
+  get() = Drawable12.icon_15813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15814: DrawableResource
+  get() = Drawable12.icon_15814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15815: DrawableResource
+  get() = Drawable12.icon_15815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15816: DrawableResource
+  get() = Drawable12.icon_15816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15817: DrawableResource
+  get() = Drawable12.icon_15817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15818: DrawableResource
+  get() = Drawable12.icon_15818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15819: DrawableResource
+  get() = Drawable12.icon_15819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1582: DrawableResource
+  get() = Drawable12.icon_1582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15820: DrawableResource
+  get() = Drawable12.icon_15820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15821: DrawableResource
+  get() = Drawable12.icon_15821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15822: DrawableResource
+  get() = Drawable12.icon_15822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15823: DrawableResource
+  get() = Drawable12.icon_15823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15824: DrawableResource
+  get() = Drawable12.icon_15824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15825: DrawableResource
+  get() = Drawable12.icon_15825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15826: DrawableResource
+  get() = Drawable12.icon_15826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15827: DrawableResource
+  get() = Drawable12.icon_15827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15828: DrawableResource
+  get() = Drawable12.icon_15828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15829: DrawableResource
+  get() = Drawable12.icon_15829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1583: DrawableResource
+  get() = Drawable12.icon_1583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15830: DrawableResource
+  get() = Drawable12.icon_15830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15831: DrawableResource
+  get() = Drawable12.icon_15831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15832: DrawableResource
+  get() = Drawable12.icon_15832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15833: DrawableResource
+  get() = Drawable12.icon_15833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15834: DrawableResource
+  get() = Drawable12.icon_15834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15835: DrawableResource
+  get() = Drawable12.icon_15835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15836: DrawableResource
+  get() = Drawable12.icon_15836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15837: DrawableResource
+  get() = Drawable12.icon_15837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15838: DrawableResource
+  get() = Drawable12.icon_15838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15839: DrawableResource
+  get() = Drawable12.icon_15839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1584: DrawableResource
+  get() = Drawable12.icon_1584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15840: DrawableResource
+  get() = Drawable12.icon_15840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15841: DrawableResource
+  get() = Drawable12.icon_15841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15842: DrawableResource
+  get() = Drawable12.icon_15842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15843: DrawableResource
+  get() = Drawable12.icon_15843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15844: DrawableResource
+  get() = Drawable12.icon_15844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15845: DrawableResource
+  get() = Drawable12.icon_15845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15846: DrawableResource
+  get() = Drawable12.icon_15846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15847: DrawableResource
+  get() = Drawable12.icon_15847

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable13.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable13.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable13 {
+  public val icon_15848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15848.xml"),
+          )
+      )
+
+  public val icon_15849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15849.xml"),
+          )
+      )
+
+  public val icon_1585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1585.xml"),
+          )
+      )
+
+  public val icon_15850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15850.xml"),
+          )
+      )
+
+  public val icon_15851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15851.xml"),
+          )
+      )
+
+  public val icon_15852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15852.xml"),
+          )
+      )
+
+  public val icon_15853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15853.xml"),
+          )
+      )
+
+  public val icon_15854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15854.xml"),
+          )
+      )
+
+  public val icon_15855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15855.xml"),
+          )
+      )
+
+  public val icon_15856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15856.xml"),
+          )
+      )
+
+  public val icon_15857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15857.xml"),
+          )
+      )
+
+  public val icon_15858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15858.xml"),
+          )
+      )
+
+  public val icon_15859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15859.xml"),
+          )
+      )
+
+  public val icon_1586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1586.xml"),
+          )
+      )
+
+  public val icon_15860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15860.xml"),
+          )
+      )
+
+  public val icon_15861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15861.xml"),
+          )
+      )
+
+  public val icon_15862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15862.xml"),
+          )
+      )
+
+  public val icon_15863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15863.xml"),
+          )
+      )
+
+  public val icon_15864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15864.xml"),
+          )
+      )
+
+  public val icon_15865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15865.xml"),
+          )
+      )
+
+  public val icon_15866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15866.xml"),
+          )
+      )
+
+  public val icon_15867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15867.xml"),
+          )
+      )
+
+  public val icon_15868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15868.xml"),
+          )
+      )
+
+  public val icon_15869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15869.xml"),
+          )
+      )
+
+  public val icon_1587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1587.xml"),
+          )
+      )
+
+  public val icon_15870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15870.xml"),
+          )
+      )
+
+  public val icon_15871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15871.xml"),
+          )
+      )
+
+  public val icon_15872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15872.xml"),
+          )
+      )
+
+  public val icon_15873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15873.xml"),
+          )
+      )
+
+  public val icon_15874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15874.xml"),
+          )
+      )
+
+  public val icon_15875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15875.xml"),
+          )
+      )
+
+  public val icon_15876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15876.xml"),
+          )
+      )
+
+  public val icon_15877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15877.xml"),
+          )
+      )
+
+  public val icon_15878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15878.xml"),
+          )
+      )
+
+  public val icon_15879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15879.xml"),
+          )
+      )
+
+  public val icon_1588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1588.xml"),
+          )
+      )
+
+  public val icon_15880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15880.xml"),
+          )
+      )
+
+  public val icon_15881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15881.xml"),
+          )
+      )
+
+  public val icon_15882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15882.xml"),
+          )
+      )
+
+  public val icon_15883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15883.xml"),
+          )
+      )
+
+  public val icon_15884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15884.xml"),
+          )
+      )
+
+  public val icon_15885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15885.xml"),
+          )
+      )
+
+  public val icon_15886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15886.xml"),
+          )
+      )
+
+  public val icon_15887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15887.xml"),
+          )
+      )
+
+  public val icon_15888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15888.xml"),
+          )
+      )
+
+  public val icon_15889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15889.xml"),
+          )
+      )
+
+  public val icon_1589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1589.xml"),
+          )
+      )
+
+  public val icon_15890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15890.xml"),
+          )
+      )
+
+  public val icon_15891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15891.xml"),
+          )
+      )
+
+  public val icon_15892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15892.xml"),
+          )
+      )
+
+  public val icon_15893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15893.xml"),
+          )
+      )
+
+  public val icon_15894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15894.xml"),
+          )
+      )
+
+  public val icon_15895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15895.xml"),
+          )
+      )
+
+  public val icon_15896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15896.xml"),
+          )
+      )
+
+  public val icon_15897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15897.xml"),
+          )
+      )
+
+  public val icon_15898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15898.xml"),
+          )
+      )
+
+  public val icon_15899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15899.xml"),
+          )
+      )
+
+  public val icon_159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_159.xml"),
+          )
+      )
+
+  public val icon_1590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1590.xml"),
+          )
+      )
+
+  public val icon_15900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15900.xml"),
+          )
+      )
+
+  public val icon_15901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15901.xml"),
+          )
+      )
+
+  public val icon_15902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15902.xml"),
+          )
+      )
+
+  public val icon_15903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15903.xml"),
+          )
+      )
+
+  public val icon_15904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15904.xml"),
+          )
+      )
+
+  public val icon_15905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15905.xml"),
+          )
+      )
+
+  public val icon_15906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15906.xml"),
+          )
+      )
+
+  public val icon_15907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15907.xml"),
+          )
+      )
+
+  public val icon_15908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15908.xml"),
+          )
+      )
+
+  public val icon_15909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15909.xml"),
+          )
+      )
+
+  public val icon_1591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1591.xml"),
+          )
+      )
+
+  public val icon_15910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15910.xml"),
+          )
+      )
+
+  public val icon_15911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15911.xml"),
+          )
+      )
+
+  public val icon_15912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15912.xml"),
+          )
+      )
+
+  public val icon_15913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15913.xml"),
+          )
+      )
+
+  public val icon_15914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15914.xml"),
+          )
+      )
+
+  public val icon_15915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15915.xml"),
+          )
+      )
+
+  public val icon_15916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15916.xml"),
+          )
+      )
+
+  public val icon_15917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15917.xml"),
+          )
+      )
+
+  public val icon_15918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15918.xml"),
+          )
+      )
+
+  public val icon_15919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15919.xml"),
+          )
+      )
+
+  public val icon_1592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1592.xml"),
+          )
+      )
+
+  public val icon_15920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15920.xml"),
+          )
+      )
+
+  public val icon_15921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15921.xml"),
+          )
+      )
+
+  public val icon_15922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15922.xml"),
+          )
+      )
+
+  public val icon_15923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15923.xml"),
+          )
+      )
+
+  public val icon_15924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15924.xml"),
+          )
+      )
+
+  public val icon_15925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15925.xml"),
+          )
+      )
+
+  public val icon_15926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15926.xml"),
+          )
+      )
+
+  public val icon_15927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15927.xml"),
+          )
+      )
+
+  public val icon_15928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15928.xml"),
+          )
+      )
+
+  public val icon_15929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15929.xml"),
+          )
+      )
+
+  public val icon_1593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1593.xml"),
+          )
+      )
+
+  public val icon_15930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15930.xml"),
+          )
+      )
+
+  public val icon_15931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15931.xml"),
+          )
+      )
+
+  public val icon_15932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15932.xml"),
+          )
+      )
+
+  public val icon_15933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15933.xml"),
+          )
+      )
+
+  public val icon_15934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15934.xml"),
+          )
+      )
+
+  public val icon_15935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15935.xml"),
+          )
+      )
+
+  public val icon_15936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15936.xml"),
+          )
+      )
+
+  public val icon_15937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15937.xml"),
+          )
+      )
+
+  public val icon_15938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15938.xml"),
+          )
+      )
+
+  public val icon_15939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15939.xml"),
+          )
+      )
+
+  public val icon_1594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1594.xml"),
+          )
+      )
+
+  public val icon_15940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15940.xml"),
+          )
+      )
+
+  public val icon_15941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15941.xml"),
+          )
+      )
+
+  public val icon_15942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15942.xml"),
+          )
+      )
+
+  public val icon_15943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15943.xml"),
+          )
+      )
+
+  public val icon_15944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15944.xml"),
+          )
+      )
+
+  public val icon_15945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15945.xml"),
+          )
+      )
+
+  public val icon_15946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15946.xml"),
+          )
+      )
+
+  public val icon_15947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15947.xml"),
+          )
+      )
+
+  public val icon_15948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15948.xml"),
+          )
+      )
+
+  public val icon_15949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15949.xml"),
+          )
+      )
+
+  public val icon_1595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1595.xml"),
+          )
+      )
+
+  public val icon_15950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15950.xml"),
+          )
+      )
+
+  public val icon_15951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15951.xml"),
+          )
+      )
+
+  public val icon_15952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15952.xml"),
+          )
+      )
+
+  public val icon_15953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15953.xml"),
+          )
+      )
+
+  public val icon_15954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15954.xml"),
+          )
+      )
+
+  public val icon_15955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15955.xml"),
+          )
+      )
+
+  public val icon_15956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15956.xml"),
+          )
+      )
+
+  public val icon_15957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15957.xml"),
+          )
+      )
+
+  public val icon_15958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15958.xml"),
+          )
+      )
+
+  public val icon_15959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15959.xml"),
+          )
+      )
+
+  public val icon_1596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1596.xml"),
+          )
+      )
+
+  public val icon_15960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15960.xml"),
+          )
+      )
+
+  public val icon_15961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15961.xml"),
+          )
+      )
+
+  public val icon_15962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15962.xml"),
+          )
+      )
+
+  public val icon_15963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15963.xml"),
+          )
+      )
+
+  public val icon_15964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15964.xml"),
+          )
+      )
+
+  public val icon_15965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15965.xml"),
+          )
+      )
+
+  public val icon_15966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15966.xml"),
+          )
+      )
+
+  public val icon_15967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15967.xml"),
+          )
+      )
+
+  public val icon_15968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15968.xml"),
+          )
+      )
+
+  public val icon_15969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15969.xml"),
+          )
+      )
+
+  public val icon_1597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1597.xml"),
+          )
+      )
+
+  public val icon_15970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15970.xml"),
+          )
+      )
+
+  public val icon_15971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15971.xml"),
+          )
+      )
+
+  public val icon_15972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15972.xml"),
+          )
+      )
+
+  public val icon_15973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15973.xml"),
+          )
+      )
+
+  public val icon_15974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15974.xml"),
+          )
+      )
+
+  public val icon_15975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15975.xml"),
+          )
+      )
+
+  public val icon_15976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15976.xml"),
+          )
+      )
+
+  public val icon_15977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15977.xml"),
+          )
+      )
+
+  public val icon_15978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15978.xml"),
+          )
+      )
+
+  public val icon_15979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15979.xml"),
+          )
+      )
+
+  public val icon_1598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1598.xml"),
+          )
+      )
+
+  public val icon_15980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15980.xml"),
+          )
+      )
+
+  public val icon_15981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15981.xml"),
+          )
+      )
+
+  public val icon_15982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15982.xml"),
+          )
+      )
+
+  public val icon_15983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15983.xml"),
+          )
+      )
+
+  public val icon_15984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15984.xml"),
+          )
+      )
+
+  public val icon_15985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15985.xml"),
+          )
+      )
+
+  public val icon_15986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15986.xml"),
+          )
+      )
+
+  public val icon_15987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15987.xml"),
+          )
+      )
+
+  public val icon_15988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15988.xml"),
+          )
+      )
+
+  public val icon_15989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15989.xml"),
+          )
+      )
+
+  public val icon_1599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1599.xml"),
+          )
+      )
+
+  public val icon_15990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15990.xml"),
+          )
+      )
+
+  public val icon_15991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15991.xml"),
+          )
+      )
+
+  public val icon_15992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15992.xml"),
+          )
+      )
+
+  public val icon_15993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15993.xml"),
+          )
+      )
+
+  public val icon_15994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15994.xml"),
+          )
+      )
+
+  public val icon_15995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15995.xml"),
+          )
+      )
+
+  public val icon_15996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15996.xml"),
+          )
+      )
+
+  public val icon_15997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15997.xml"),
+          )
+      )
+
+  public val icon_15998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15998.xml"),
+          )
+      )
+
+  public val icon_15999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_15999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_15999.xml"),
+          )
+      )
+
+  public val icon_16: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16.xml"),
+          )
+      )
+
+  public val icon_160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_160.xml"),
+          )
+      )
+
+  public val icon_1600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1600.xml"),
+          )
+      )
+
+  public val icon_16000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16000.xml"),
+          )
+      )
+
+  public val icon_16001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16001.xml"),
+          )
+      )
+
+  public val icon_16002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16002.xml"),
+          )
+      )
+
+  public val icon_16003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16003.xml"),
+          )
+      )
+
+  public val icon_16004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16004.xml"),
+          )
+      )
+
+  public val icon_16005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16005.xml"),
+          )
+      )
+
+  public val icon_16006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16006.xml"),
+          )
+      )
+
+  public val icon_16007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16007.xml"),
+          )
+      )
+
+  public val icon_16008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16008.xml"),
+          )
+      )
+
+  public val icon_16009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16009.xml"),
+          )
+      )
+
+  public val icon_1601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1601.xml"),
+          )
+      )
+
+  public val icon_16010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16010.xml"),
+          )
+      )
+
+  public val icon_16011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16011.xml"),
+          )
+      )
+
+  public val icon_16012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16012.xml"),
+          )
+      )
+
+  public val icon_16013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16013.xml"),
+          )
+      )
+
+  public val icon_16014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16014.xml"),
+          )
+      )
+
+  public val icon_16015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16015.xml"),
+          )
+      )
+
+  public val icon_16016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16016.xml"),
+          )
+      )
+
+  public val icon_16017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16017.xml"),
+          )
+      )
+
+  public val icon_16018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16018.xml"),
+          )
+      )
+
+  public val icon_16019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16019.xml"),
+          )
+      )
+
+  public val icon_1602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1602.xml"),
+          )
+      )
+
+  public val icon_16020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16020.xml"),
+          )
+      )
+
+  public val icon_16021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16021.xml"),
+          )
+      )
+
+  public val icon_16022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16022.xml"),
+          )
+      )
+
+  public val icon_16023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16023.xml"),
+          )
+      )
+
+  public val icon_16024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16024.xml"),
+          )
+      )
+
+  public val icon_16025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16025.xml"),
+          )
+      )
+
+  public val icon_16026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16026.xml"),
+          )
+      )
+
+  public val icon_16027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16027.xml"),
+          )
+      )
+
+  public val icon_16028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16028.xml"),
+          )
+      )
+
+  public val icon_16029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16029.xml"),
+          )
+      )
+
+  public val icon_1603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1603.xml"),
+          )
+      )
+
+  public val icon_16030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16030.xml"),
+          )
+      )
+
+  public val icon_16031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16031.xml"),
+          )
+      )
+
+  public val icon_16032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16032.xml"),
+          )
+      )
+
+  public val icon_16033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16033.xml"),
+          )
+      )
+
+  public val icon_16034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16034.xml"),
+          )
+      )
+
+  public val icon_16035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16035.xml"),
+          )
+      )
+
+  public val icon_16036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16036.xml"),
+          )
+      )
+
+  public val icon_16037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16037.xml"),
+          )
+      )
+
+  public val icon_16038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16038.xml"),
+          )
+      )
+
+  public val icon_16039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16039.xml"),
+          )
+      )
+
+  public val icon_1604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1604.xml"),
+          )
+      )
+
+  public val icon_16040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16040.xml"),
+          )
+      )
+
+  public val icon_16041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16041.xml"),
+          )
+      )
+
+  public val icon_16042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16042.xml"),
+          )
+      )
+
+  public val icon_16043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16043.xml"),
+          )
+      )
+
+  public val icon_16044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16044.xml"),
+          )
+      )
+
+  public val icon_16045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16045.xml"),
+          )
+      )
+
+  public val icon_16046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16046.xml"),
+          )
+      )
+
+  public val icon_16047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16047.xml"),
+          )
+      )
+
+  public val icon_16048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16048.xml"),
+          )
+      )
+
+  public val icon_16049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16049.xml"),
+          )
+      )
+
+  public val icon_1605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1605.xml"),
+          )
+      )
+
+  public val icon_16050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16050.xml"),
+          )
+      )
+
+  public val icon_16051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16051.xml"),
+          )
+      )
+
+  public val icon_16052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16052.xml"),
+          )
+      )
+
+  public val icon_16053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16053.xml"),
+          )
+      )
+
+  public val icon_16054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16054.xml"),
+          )
+      )
+
+  public val icon_16055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16055.xml"),
+          )
+      )
+
+  public val icon_16056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16056.xml"),
+          )
+      )
+
+  public val icon_16057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16057.xml"),
+          )
+      )
+
+  public val icon_16058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16058.xml"),
+          )
+      )
+
+  public val icon_16059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16059.xml"),
+          )
+      )
+
+  public val icon_1606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1606.xml"),
+          )
+      )
+
+  public val icon_16060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16060.xml"),
+          )
+      )
+
+  public val icon_16061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16061.xml"),
+          )
+      )
+
+  public val icon_16062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16062.xml"),
+          )
+      )
+
+  public val icon_16063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16063.xml"),
+          )
+      )
+
+  public val icon_16064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16064.xml"),
+          )
+      )
+
+  public val icon_16065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16065.xml"),
+          )
+      )
+
+  public val icon_16066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16066.xml"),
+          )
+      )
+
+  public val icon_16067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16067.xml"),
+          )
+      )
+
+  public val icon_16068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16068.xml"),
+          )
+      )
+
+  public val icon_16069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16069.xml"),
+          )
+      )
+
+  public val icon_1607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1607.xml"),
+          )
+      )
+
+  public val icon_16070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16070.xml"),
+          )
+      )
+
+  public val icon_16071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16071.xml"),
+          )
+      )
+
+  public val icon_16072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16072.xml"),
+          )
+      )
+
+  public val icon_16073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16073.xml"),
+          )
+      )
+
+  public val icon_16074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16074.xml"),
+          )
+      )
+
+  public val icon_16075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16075.xml"),
+          )
+      )
+
+  public val icon_16076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16076.xml"),
+          )
+      )
+
+  public val icon_16077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16077.xml"),
+          )
+      )
+
+  public val icon_16078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16078.xml"),
+          )
+      )
+
+  public val icon_16079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16079.xml"),
+          )
+      )
+
+  public val icon_1608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1608.xml"),
+          )
+      )
+
+  public val icon_16080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16080.xml"),
+          )
+      )
+
+  public val icon_16081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16081.xml"),
+          )
+      )
+
+  public val icon_16082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16082.xml"),
+          )
+      )
+
+  public val icon_16083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16083.xml"),
+          )
+      )
+
+  public val icon_16084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16084.xml"),
+          )
+      )
+
+  public val icon_16085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16085.xml"),
+          )
+      )
+
+  public val icon_16086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16086.xml"),
+          )
+      )
+
+  public val icon_16087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16087.xml"),
+          )
+      )
+
+  public val icon_16088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16088.xml"),
+          )
+      )
+
+  public val icon_16089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16089.xml"),
+          )
+      )
+
+  public val icon_1609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1609.xml"),
+          )
+      )
+
+  public val icon_16090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16090.xml"),
+          )
+      )
+
+  public val icon_16091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16091.xml"),
+          )
+      )
+
+  public val icon_16092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16092.xml"),
+          )
+      )
+
+  public val icon_16093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16093.xml"),
+          )
+      )
+
+  public val icon_16094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16094.xml"),
+          )
+      )
+
+  public val icon_16095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16095.xml"),
+          )
+      )
+
+  public val icon_16096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16096.xml"),
+          )
+      )
+
+  public val icon_16097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16097.xml"),
+          )
+      )
+
+  public val icon_16098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16098.xml"),
+          )
+      )
+
+  public val icon_16099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16099.xml"),
+          )
+      )
+
+  public val icon_161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_161.xml"),
+          )
+      )
+
+  public val icon_1610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1610.xml"),
+          )
+      )
+
+  public val icon_16100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16100.xml"),
+          )
+      )
+
+  public val icon_16101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16101.xml"),
+          )
+      )
+
+  public val icon_16102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16102.xml"),
+          )
+      )
+
+  public val icon_16103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16103.xml"),
+          )
+      )
+
+  public val icon_16104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16104.xml"),
+          )
+      )
+
+  public val icon_16105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16105.xml"),
+          )
+      )
+
+  public val icon_16106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16106.xml"),
+          )
+      )
+
+  public val icon_16107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16107.xml"),
+          )
+      )
+
+  public val icon_16108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16108.xml"),
+          )
+      )
+
+  public val icon_16109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16109.xml"),
+          )
+      )
+
+  public val icon_1611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1611.xml"),
+          )
+      )
+
+  public val icon_16110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16110.xml"),
+          )
+      )
+
+  public val icon_16111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16111.xml"),
+          )
+      )
+
+  public val icon_16112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16112.xml"),
+          )
+      )
+
+  public val icon_16113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16113.xml"),
+          )
+      )
+
+  public val icon_16114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16114.xml"),
+          )
+      )
+
+  public val icon_16115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16115.xml"),
+          )
+      )
+
+  public val icon_16116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16116.xml"),
+          )
+      )
+
+  public val icon_16117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16117.xml"),
+          )
+      )
+
+  public val icon_16118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16118.xml"),
+          )
+      )
+
+  public val icon_16119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16119.xml"),
+          )
+      )
+
+  public val icon_1612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1612.xml"),
+          )
+      )
+
+  public val icon_16120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16120.xml"),
+          )
+      )
+
+  public val icon_16121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16121.xml"),
+          )
+      )
+
+  public val icon_16122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16122.xml"),
+          )
+      )
+
+  public val icon_16123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16123.xml"),
+          )
+      )
+
+  public val icon_16124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16124.xml"),
+          )
+      )
+
+  public val icon_16125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16125.xml"),
+          )
+      )
+
+  public val icon_16126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16126.xml"),
+          )
+      )
+
+  public val icon_16127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16127.xml"),
+          )
+      )
+
+  public val icon_16128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16128.xml"),
+          )
+      )
+
+  public val icon_16129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16129.xml"),
+          )
+      )
+
+  public val icon_1613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1613.xml"),
+          )
+      )
+
+  public val icon_16130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16130.xml"),
+          )
+      )
+
+  public val icon_16131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16131.xml"),
+          )
+      )
+
+  public val icon_16132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16132.xml"),
+          )
+      )
+
+  public val icon_16133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16133.xml"),
+          )
+      )
+
+  public val icon_16134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16134.xml"),
+          )
+      )
+
+  public val icon_16135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16135.xml"),
+          )
+      )
+
+  public val icon_16136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16136.xml"),
+          )
+      )
+
+  public val icon_16137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16137.xml"),
+          )
+      )
+
+  public val icon_16138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16138.xml"),
+          )
+      )
+
+  public val icon_16139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16139.xml"),
+          )
+      )
+
+  public val icon_1614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1614.xml"),
+          )
+      )
+
+  public val icon_16140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16140.xml"),
+          )
+      )
+
+  public val icon_16141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16141.xml"),
+          )
+      )
+
+  public val icon_16142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16142.xml"),
+          )
+      )
+
+  public val icon_16143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16143.xml"),
+          )
+      )
+
+  public val icon_16144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16144.xml"),
+          )
+      )
+
+  public val icon_16145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16145.xml"),
+          )
+      )
+
+  public val icon_16146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16146.xml"),
+          )
+      )
+
+  public val icon_16147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16147.xml"),
+          )
+      )
+
+  public val icon_16148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16148.xml"),
+          )
+      )
+
+  public val icon_16149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16149.xml"),
+          )
+      )
+
+  public val icon_1615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1615.xml"),
+          )
+      )
+
+  public val icon_16150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16150.xml"),
+          )
+      )
+
+  public val icon_16151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16151.xml"),
+          )
+      )
+
+  public val icon_16152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16152.xml"),
+          )
+      )
+
+  public val icon_16153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16153.xml"),
+          )
+      )
+
+  public val icon_16154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16154.xml"),
+          )
+      )
+
+  public val icon_16155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16155.xml"),
+          )
+      )
+
+  public val icon_16156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16156.xml"),
+          )
+      )
+
+  public val icon_16157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16157.xml"),
+          )
+      )
+
+  public val icon_16158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16158.xml"),
+          )
+      )
+
+  public val icon_16159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16159.xml"),
+          )
+      )
+
+  public val icon_1616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1616.xml"),
+          )
+      )
+
+  public val icon_16160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16160.xml"),
+          )
+      )
+
+  public val icon_16161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16161.xml"),
+          )
+      )
+
+  public val icon_16162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16162.xml"),
+          )
+      )
+
+  public val icon_16163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16163.xml"),
+          )
+      )
+
+  public val icon_16164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16164.xml"),
+          )
+      )
+
+  public val icon_16165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16165.xml"),
+          )
+      )
+
+  public val icon_16166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16166.xml"),
+          )
+      )
+
+  public val icon_16167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16167.xml"),
+          )
+      )
+
+  public val icon_16168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16168.xml"),
+          )
+      )
+
+  public val icon_16169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16169.xml"),
+          )
+      )
+
+  public val icon_1617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1617.xml"),
+          )
+      )
+
+  public val icon_16170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16170.xml"),
+          )
+      )
+
+  public val icon_16171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16171.xml"),
+          )
+      )
+
+  public val icon_16172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16172.xml"),
+          )
+      )
+
+  public val icon_16173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16173.xml"),
+          )
+      )
+
+  public val icon_16174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16174.xml"),
+          )
+      )
+
+  public val icon_16175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16175.xml"),
+          )
+      )
+
+  public val icon_16176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16176.xml"),
+          )
+      )
+
+  public val icon_16177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16177.xml"),
+          )
+      )
+
+  public val icon_16178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16178.xml"),
+          )
+      )
+
+  public val icon_16179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16179.xml"),
+          )
+      )
+
+  public val icon_1618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1618.xml"),
+          )
+      )
+
+  public val icon_16180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16180.xml"),
+          )
+      )
+
+  public val icon_16181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16181.xml"),
+          )
+      )
+
+  public val icon_16182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16182.xml"),
+          )
+      )
+
+  public val icon_16183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16183.xml"),
+          )
+      )
+
+  public val icon_16184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16184.xml"),
+          )
+      )
+
+  public val icon_16185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16185.xml"),
+          )
+      )
+
+  public val icon_16186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16186.xml"),
+          )
+      )
+
+  public val icon_16187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16187.xml"),
+          )
+      )
+
+  public val icon_16188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16188.xml"),
+          )
+      )
+
+  public val icon_16189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16189.xml"),
+          )
+      )
+
+  public val icon_1619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1619.xml"),
+          )
+      )
+
+  public val icon_16190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16190.xml"),
+          )
+      )
+
+  public val icon_16191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16191.xml"),
+          )
+      )
+
+  public val icon_16192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16192.xml"),
+          )
+      )
+
+  public val icon_16193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16193.xml"),
+          )
+      )
+
+  public val icon_16194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16194.xml"),
+          )
+      )
+
+  public val icon_16195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16195.xml"),
+          )
+      )
+
+  public val icon_16196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16196.xml"),
+          )
+      )
+
+  public val icon_16197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16197.xml"),
+          )
+      )
+
+  public val icon_16198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16198.xml"),
+          )
+      )
+
+  public val icon_16199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16199.xml"),
+          )
+      )
+
+  public val icon_162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_162.xml"),
+          )
+      )
+
+  public val icon_1620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1620.xml"),
+          )
+      )
+
+  public val icon_16200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16200.xml"),
+          )
+      )
+
+  public val icon_16201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16201.xml"),
+          )
+      )
+
+  public val icon_16202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16202.xml"),
+          )
+      )
+
+  public val icon_16203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16203.xml"),
+          )
+      )
+
+  public val icon_16204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16204.xml"),
+          )
+      )
+
+  public val icon_16205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16205.xml"),
+          )
+      )
+
+  public val icon_16206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16206.xml"),
+          )
+      )
+
+  public val icon_16207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16207.xml"),
+          )
+      )
+
+  public val icon_16208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16208.xml"),
+          )
+      )
+
+  public val icon_16209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16209.xml"),
+          )
+      )
+
+  public val icon_1621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1621.xml"),
+          )
+      )
+
+  public val icon_16210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16210.xml"),
+          )
+      )
+
+  public val icon_16211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16211.xml"),
+          )
+      )
+
+  public val icon_16212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16212.xml"),
+          )
+      )
+
+  public val icon_16213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16213.xml"),
+          )
+      )
+
+  public val icon_16214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16214.xml"),
+          )
+      )
+
+  public val icon_16215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16215.xml"),
+          )
+      )
+
+  public val icon_16216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16216.xml"),
+          )
+      )
+
+  public val icon_16217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16217.xml"),
+          )
+      )
+
+  public val icon_16218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16218.xml"),
+          )
+      )
+
+  public val icon_16219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16219.xml"),
+          )
+      )
+
+  public val icon_1622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1622.xml"),
+          )
+      )
+
+  public val icon_16220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16220.xml"),
+          )
+      )
+
+  public val icon_16221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16221.xml"),
+          )
+      )
+
+  public val icon_16222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16222.xml"),
+          )
+      )
+
+  public val icon_16223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16223.xml"),
+          )
+      )
+
+  public val icon_16224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16224.xml"),
+          )
+      )
+
+  public val icon_16225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16225.xml"),
+          )
+      )
+
+  public val icon_16226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16226.xml"),
+          )
+      )
+
+  public val icon_16227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16227.xml"),
+          )
+      )
+
+  public val icon_16228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16228.xml"),
+          )
+      )
+
+  public val icon_16229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16229.xml"),
+          )
+      )
+
+  public val icon_1623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1623.xml"),
+          )
+      )
+
+  public val icon_16230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16230.xml"),
+          )
+      )
+
+  public val icon_16231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16231.xml"),
+          )
+      )
+
+  public val icon_16232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16232.xml"),
+          )
+      )
+
+  public val icon_16233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16233.xml"),
+          )
+      )
+
+  public val icon_16234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16234.xml"),
+          )
+      )
+
+  public val icon_16235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16235.xml"),
+          )
+      )
+
+  public val icon_16236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16236.xml"),
+          )
+      )
+
+  public val icon_16237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16237.xml"),
+          )
+      )
+
+  public val icon_16238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16238.xml"),
+          )
+      )
+
+  public val icon_16239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16239.xml"),
+          )
+      )
+
+  public val icon_1624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1624.xml"),
+          )
+      )
+
+  public val icon_16240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16240.xml"),
+          )
+      )
+
+  public val icon_16241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16241.xml"),
+          )
+      )
+
+  public val icon_16242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16242.xml"),
+          )
+      )
+
+  public val icon_16243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16243.xml"),
+          )
+      )
+
+  public val icon_16244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16244.xml"),
+          )
+      )
+
+  public val icon_16245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16245.xml"),
+          )
+      )
+
+  public val icon_16246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16246.xml"),
+          )
+      )
+
+  public val icon_16247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16247.xml"),
+          )
+      )
+
+  public val icon_16248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16248.xml"),
+          )
+      )
+
+  public val icon_16249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16249.xml"),
+          )
+      )
+
+  public val icon_1625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1625.xml"),
+          )
+      )
+
+  public val icon_16250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16250.xml"),
+          )
+      )
+
+  public val icon_16251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16251.xml"),
+          )
+      )
+
+  public val icon_16252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16252.xml"),
+          )
+      )
+
+  public val icon_16253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16253.xml"),
+          )
+      )
+
+  public val icon_16254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16254.xml"),
+          )
+      )
+
+  public val icon_16255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16255.xml"),
+          )
+      )
+
+  public val icon_16256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16256.xml"),
+          )
+      )
+
+  public val icon_16257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16257.xml"),
+          )
+      )
+
+  public val icon_16258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16258.xml"),
+          )
+      )
+
+  public val icon_16259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16259.xml"),
+          )
+      )
+
+  public val icon_1626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1626.xml"),
+          )
+      )
+
+  public val icon_16260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16260.xml"),
+          )
+      )
+
+  public val icon_16261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16261.xml"),
+          )
+      )
+
+  public val icon_16262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16262.xml"),
+          )
+      )
+
+  public val icon_16263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16263.xml"),
+          )
+      )
+
+  public val icon_16264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16264.xml"),
+          )
+      )
+
+  public val icon_16265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16265.xml"),
+          )
+      )
+
+  public val icon_16266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16266.xml"),
+          )
+      )
+
+  public val icon_16267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16267.xml"),
+          )
+      )
+
+  public val icon_16268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16268.xml"),
+          )
+      )
+
+  public val icon_16269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16269.xml"),
+          )
+      )
+
+  public val icon_1627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1627.xml"),
+          )
+      )
+
+  public val icon_16270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16270.xml"),
+          )
+      )
+
+  public val icon_16271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16271.xml"),
+          )
+      )
+
+  public val icon_16272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16272.xml"),
+          )
+      )
+
+  public val icon_16273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16273.xml"),
+          )
+      )
+
+  public val icon_16274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16274.xml"),
+          )
+      )
+
+  public val icon_16275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16275.xml"),
+          )
+      )
+
+  public val icon_16276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16276.xml"),
+          )
+      )
+
+  public val icon_16277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16277.xml"),
+          )
+      )
+
+  public val icon_16278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16278.xml"),
+          )
+      )
+
+  public val icon_16279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16279.xml"),
+          )
+      )
+
+  public val icon_1628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1628.xml"),
+          )
+      )
+
+  public val icon_16280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16280.xml"),
+          )
+      )
+
+  public val icon_16281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16281.xml"),
+          )
+      )
+
+  public val icon_16282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16282.xml"),
+          )
+      )
+
+  public val icon_16283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16283.xml"),
+          )
+      )
+
+  public val icon_16284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16284.xml"),
+          )
+      )
+
+  public val icon_16285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16285.xml"),
+          )
+      )
+
+  public val icon_16286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16286.xml"),
+          )
+      )
+
+  public val icon_16287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16287.xml"),
+          )
+      )
+
+  public val icon_16288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16288.xml"),
+          )
+      )
+
+  public val icon_16289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16289.xml"),
+          )
+      )
+
+  public val icon_1629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1629.xml"),
+          )
+      )
+
+  public val icon_16290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16290.xml"),
+          )
+      )
+
+  public val icon_16291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16291.xml"),
+          )
+      )
+
+  public val icon_16292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16292.xml"),
+          )
+      )
+
+  public val icon_16293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16293.xml"),
+          )
+      )
+
+  public val icon_16294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16294.xml"),
+          )
+      )
+
+  public val icon_16295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16295.xml"),
+          )
+      )
+
+  public val icon_16296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16296.xml"),
+          )
+      )
+
+  public val icon_16297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16297.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15848: DrawableResource
+  get() = Drawable13.icon_15848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15849: DrawableResource
+  get() = Drawable13.icon_15849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1585: DrawableResource
+  get() = Drawable13.icon_1585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15850: DrawableResource
+  get() = Drawable13.icon_15850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15851: DrawableResource
+  get() = Drawable13.icon_15851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15852: DrawableResource
+  get() = Drawable13.icon_15852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15853: DrawableResource
+  get() = Drawable13.icon_15853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15854: DrawableResource
+  get() = Drawable13.icon_15854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15855: DrawableResource
+  get() = Drawable13.icon_15855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15856: DrawableResource
+  get() = Drawable13.icon_15856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15857: DrawableResource
+  get() = Drawable13.icon_15857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15858: DrawableResource
+  get() = Drawable13.icon_15858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15859: DrawableResource
+  get() = Drawable13.icon_15859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1586: DrawableResource
+  get() = Drawable13.icon_1586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15860: DrawableResource
+  get() = Drawable13.icon_15860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15861: DrawableResource
+  get() = Drawable13.icon_15861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15862: DrawableResource
+  get() = Drawable13.icon_15862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15863: DrawableResource
+  get() = Drawable13.icon_15863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15864: DrawableResource
+  get() = Drawable13.icon_15864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15865: DrawableResource
+  get() = Drawable13.icon_15865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15866: DrawableResource
+  get() = Drawable13.icon_15866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15867: DrawableResource
+  get() = Drawable13.icon_15867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15868: DrawableResource
+  get() = Drawable13.icon_15868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15869: DrawableResource
+  get() = Drawable13.icon_15869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1587: DrawableResource
+  get() = Drawable13.icon_1587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15870: DrawableResource
+  get() = Drawable13.icon_15870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15871: DrawableResource
+  get() = Drawable13.icon_15871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15872: DrawableResource
+  get() = Drawable13.icon_15872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15873: DrawableResource
+  get() = Drawable13.icon_15873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15874: DrawableResource
+  get() = Drawable13.icon_15874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15875: DrawableResource
+  get() = Drawable13.icon_15875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15876: DrawableResource
+  get() = Drawable13.icon_15876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15877: DrawableResource
+  get() = Drawable13.icon_15877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15878: DrawableResource
+  get() = Drawable13.icon_15878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15879: DrawableResource
+  get() = Drawable13.icon_15879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1588: DrawableResource
+  get() = Drawable13.icon_1588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15880: DrawableResource
+  get() = Drawable13.icon_15880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15881: DrawableResource
+  get() = Drawable13.icon_15881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15882: DrawableResource
+  get() = Drawable13.icon_15882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15883: DrawableResource
+  get() = Drawable13.icon_15883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15884: DrawableResource
+  get() = Drawable13.icon_15884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15885: DrawableResource
+  get() = Drawable13.icon_15885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15886: DrawableResource
+  get() = Drawable13.icon_15886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15887: DrawableResource
+  get() = Drawable13.icon_15887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15888: DrawableResource
+  get() = Drawable13.icon_15888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15889: DrawableResource
+  get() = Drawable13.icon_15889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1589: DrawableResource
+  get() = Drawable13.icon_1589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15890: DrawableResource
+  get() = Drawable13.icon_15890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15891: DrawableResource
+  get() = Drawable13.icon_15891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15892: DrawableResource
+  get() = Drawable13.icon_15892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15893: DrawableResource
+  get() = Drawable13.icon_15893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15894: DrawableResource
+  get() = Drawable13.icon_15894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15895: DrawableResource
+  get() = Drawable13.icon_15895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15896: DrawableResource
+  get() = Drawable13.icon_15896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15897: DrawableResource
+  get() = Drawable13.icon_15897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15898: DrawableResource
+  get() = Drawable13.icon_15898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15899: DrawableResource
+  get() = Drawable13.icon_15899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_159: DrawableResource
+  get() = Drawable13.icon_159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1590: DrawableResource
+  get() = Drawable13.icon_1590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15900: DrawableResource
+  get() = Drawable13.icon_15900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15901: DrawableResource
+  get() = Drawable13.icon_15901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15902: DrawableResource
+  get() = Drawable13.icon_15902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15903: DrawableResource
+  get() = Drawable13.icon_15903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15904: DrawableResource
+  get() = Drawable13.icon_15904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15905: DrawableResource
+  get() = Drawable13.icon_15905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15906: DrawableResource
+  get() = Drawable13.icon_15906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15907: DrawableResource
+  get() = Drawable13.icon_15907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15908: DrawableResource
+  get() = Drawable13.icon_15908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15909: DrawableResource
+  get() = Drawable13.icon_15909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1591: DrawableResource
+  get() = Drawable13.icon_1591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15910: DrawableResource
+  get() = Drawable13.icon_15910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15911: DrawableResource
+  get() = Drawable13.icon_15911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15912: DrawableResource
+  get() = Drawable13.icon_15912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15913: DrawableResource
+  get() = Drawable13.icon_15913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15914: DrawableResource
+  get() = Drawable13.icon_15914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15915: DrawableResource
+  get() = Drawable13.icon_15915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15916: DrawableResource
+  get() = Drawable13.icon_15916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15917: DrawableResource
+  get() = Drawable13.icon_15917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15918: DrawableResource
+  get() = Drawable13.icon_15918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15919: DrawableResource
+  get() = Drawable13.icon_15919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1592: DrawableResource
+  get() = Drawable13.icon_1592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15920: DrawableResource
+  get() = Drawable13.icon_15920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15921: DrawableResource
+  get() = Drawable13.icon_15921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15922: DrawableResource
+  get() = Drawable13.icon_15922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15923: DrawableResource
+  get() = Drawable13.icon_15923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15924: DrawableResource
+  get() = Drawable13.icon_15924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15925: DrawableResource
+  get() = Drawable13.icon_15925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15926: DrawableResource
+  get() = Drawable13.icon_15926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15927: DrawableResource
+  get() = Drawable13.icon_15927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15928: DrawableResource
+  get() = Drawable13.icon_15928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15929: DrawableResource
+  get() = Drawable13.icon_15929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1593: DrawableResource
+  get() = Drawable13.icon_1593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15930: DrawableResource
+  get() = Drawable13.icon_15930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15931: DrawableResource
+  get() = Drawable13.icon_15931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15932: DrawableResource
+  get() = Drawable13.icon_15932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15933: DrawableResource
+  get() = Drawable13.icon_15933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15934: DrawableResource
+  get() = Drawable13.icon_15934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15935: DrawableResource
+  get() = Drawable13.icon_15935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15936: DrawableResource
+  get() = Drawable13.icon_15936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15937: DrawableResource
+  get() = Drawable13.icon_15937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15938: DrawableResource
+  get() = Drawable13.icon_15938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15939: DrawableResource
+  get() = Drawable13.icon_15939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1594: DrawableResource
+  get() = Drawable13.icon_1594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15940: DrawableResource
+  get() = Drawable13.icon_15940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15941: DrawableResource
+  get() = Drawable13.icon_15941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15942: DrawableResource
+  get() = Drawable13.icon_15942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15943: DrawableResource
+  get() = Drawable13.icon_15943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15944: DrawableResource
+  get() = Drawable13.icon_15944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15945: DrawableResource
+  get() = Drawable13.icon_15945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15946: DrawableResource
+  get() = Drawable13.icon_15946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15947: DrawableResource
+  get() = Drawable13.icon_15947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15948: DrawableResource
+  get() = Drawable13.icon_15948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15949: DrawableResource
+  get() = Drawable13.icon_15949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1595: DrawableResource
+  get() = Drawable13.icon_1595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15950: DrawableResource
+  get() = Drawable13.icon_15950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15951: DrawableResource
+  get() = Drawable13.icon_15951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15952: DrawableResource
+  get() = Drawable13.icon_15952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15953: DrawableResource
+  get() = Drawable13.icon_15953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15954: DrawableResource
+  get() = Drawable13.icon_15954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15955: DrawableResource
+  get() = Drawable13.icon_15955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15956: DrawableResource
+  get() = Drawable13.icon_15956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15957: DrawableResource
+  get() = Drawable13.icon_15957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15958: DrawableResource
+  get() = Drawable13.icon_15958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15959: DrawableResource
+  get() = Drawable13.icon_15959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1596: DrawableResource
+  get() = Drawable13.icon_1596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15960: DrawableResource
+  get() = Drawable13.icon_15960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15961: DrawableResource
+  get() = Drawable13.icon_15961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15962: DrawableResource
+  get() = Drawable13.icon_15962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15963: DrawableResource
+  get() = Drawable13.icon_15963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15964: DrawableResource
+  get() = Drawable13.icon_15964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15965: DrawableResource
+  get() = Drawable13.icon_15965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15966: DrawableResource
+  get() = Drawable13.icon_15966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15967: DrawableResource
+  get() = Drawable13.icon_15967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15968: DrawableResource
+  get() = Drawable13.icon_15968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15969: DrawableResource
+  get() = Drawable13.icon_15969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1597: DrawableResource
+  get() = Drawable13.icon_1597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15970: DrawableResource
+  get() = Drawable13.icon_15970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15971: DrawableResource
+  get() = Drawable13.icon_15971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15972: DrawableResource
+  get() = Drawable13.icon_15972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15973: DrawableResource
+  get() = Drawable13.icon_15973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15974: DrawableResource
+  get() = Drawable13.icon_15974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15975: DrawableResource
+  get() = Drawable13.icon_15975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15976: DrawableResource
+  get() = Drawable13.icon_15976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15977: DrawableResource
+  get() = Drawable13.icon_15977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15978: DrawableResource
+  get() = Drawable13.icon_15978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15979: DrawableResource
+  get() = Drawable13.icon_15979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1598: DrawableResource
+  get() = Drawable13.icon_1598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15980: DrawableResource
+  get() = Drawable13.icon_15980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15981: DrawableResource
+  get() = Drawable13.icon_15981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15982: DrawableResource
+  get() = Drawable13.icon_15982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15983: DrawableResource
+  get() = Drawable13.icon_15983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15984: DrawableResource
+  get() = Drawable13.icon_15984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15985: DrawableResource
+  get() = Drawable13.icon_15985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15986: DrawableResource
+  get() = Drawable13.icon_15986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15987: DrawableResource
+  get() = Drawable13.icon_15987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15988: DrawableResource
+  get() = Drawable13.icon_15988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15989: DrawableResource
+  get() = Drawable13.icon_15989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1599: DrawableResource
+  get() = Drawable13.icon_1599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15990: DrawableResource
+  get() = Drawable13.icon_15990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15991: DrawableResource
+  get() = Drawable13.icon_15991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15992: DrawableResource
+  get() = Drawable13.icon_15992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15993: DrawableResource
+  get() = Drawable13.icon_15993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15994: DrawableResource
+  get() = Drawable13.icon_15994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15995: DrawableResource
+  get() = Drawable13.icon_15995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15996: DrawableResource
+  get() = Drawable13.icon_15996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15997: DrawableResource
+  get() = Drawable13.icon_15997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15998: DrawableResource
+  get() = Drawable13.icon_15998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_15999: DrawableResource
+  get() = Drawable13.icon_15999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16: DrawableResource
+  get() = Drawable13.icon_16
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_160: DrawableResource
+  get() = Drawable13.icon_160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1600: DrawableResource
+  get() = Drawable13.icon_1600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16000: DrawableResource
+  get() = Drawable13.icon_16000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16001: DrawableResource
+  get() = Drawable13.icon_16001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16002: DrawableResource
+  get() = Drawable13.icon_16002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16003: DrawableResource
+  get() = Drawable13.icon_16003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16004: DrawableResource
+  get() = Drawable13.icon_16004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16005: DrawableResource
+  get() = Drawable13.icon_16005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16006: DrawableResource
+  get() = Drawable13.icon_16006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16007: DrawableResource
+  get() = Drawable13.icon_16007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16008: DrawableResource
+  get() = Drawable13.icon_16008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16009: DrawableResource
+  get() = Drawable13.icon_16009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1601: DrawableResource
+  get() = Drawable13.icon_1601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16010: DrawableResource
+  get() = Drawable13.icon_16010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16011: DrawableResource
+  get() = Drawable13.icon_16011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16012: DrawableResource
+  get() = Drawable13.icon_16012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16013: DrawableResource
+  get() = Drawable13.icon_16013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16014: DrawableResource
+  get() = Drawable13.icon_16014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16015: DrawableResource
+  get() = Drawable13.icon_16015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16016: DrawableResource
+  get() = Drawable13.icon_16016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16017: DrawableResource
+  get() = Drawable13.icon_16017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16018: DrawableResource
+  get() = Drawable13.icon_16018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16019: DrawableResource
+  get() = Drawable13.icon_16019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1602: DrawableResource
+  get() = Drawable13.icon_1602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16020: DrawableResource
+  get() = Drawable13.icon_16020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16021: DrawableResource
+  get() = Drawable13.icon_16021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16022: DrawableResource
+  get() = Drawable13.icon_16022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16023: DrawableResource
+  get() = Drawable13.icon_16023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16024: DrawableResource
+  get() = Drawable13.icon_16024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16025: DrawableResource
+  get() = Drawable13.icon_16025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16026: DrawableResource
+  get() = Drawable13.icon_16026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16027: DrawableResource
+  get() = Drawable13.icon_16027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16028: DrawableResource
+  get() = Drawable13.icon_16028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16029: DrawableResource
+  get() = Drawable13.icon_16029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1603: DrawableResource
+  get() = Drawable13.icon_1603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16030: DrawableResource
+  get() = Drawable13.icon_16030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16031: DrawableResource
+  get() = Drawable13.icon_16031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16032: DrawableResource
+  get() = Drawable13.icon_16032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16033: DrawableResource
+  get() = Drawable13.icon_16033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16034: DrawableResource
+  get() = Drawable13.icon_16034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16035: DrawableResource
+  get() = Drawable13.icon_16035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16036: DrawableResource
+  get() = Drawable13.icon_16036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16037: DrawableResource
+  get() = Drawable13.icon_16037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16038: DrawableResource
+  get() = Drawable13.icon_16038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16039: DrawableResource
+  get() = Drawable13.icon_16039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1604: DrawableResource
+  get() = Drawable13.icon_1604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16040: DrawableResource
+  get() = Drawable13.icon_16040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16041: DrawableResource
+  get() = Drawable13.icon_16041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16042: DrawableResource
+  get() = Drawable13.icon_16042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16043: DrawableResource
+  get() = Drawable13.icon_16043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16044: DrawableResource
+  get() = Drawable13.icon_16044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16045: DrawableResource
+  get() = Drawable13.icon_16045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16046: DrawableResource
+  get() = Drawable13.icon_16046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16047: DrawableResource
+  get() = Drawable13.icon_16047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16048: DrawableResource
+  get() = Drawable13.icon_16048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16049: DrawableResource
+  get() = Drawable13.icon_16049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1605: DrawableResource
+  get() = Drawable13.icon_1605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16050: DrawableResource
+  get() = Drawable13.icon_16050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16051: DrawableResource
+  get() = Drawable13.icon_16051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16052: DrawableResource
+  get() = Drawable13.icon_16052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16053: DrawableResource
+  get() = Drawable13.icon_16053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16054: DrawableResource
+  get() = Drawable13.icon_16054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16055: DrawableResource
+  get() = Drawable13.icon_16055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16056: DrawableResource
+  get() = Drawable13.icon_16056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16057: DrawableResource
+  get() = Drawable13.icon_16057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16058: DrawableResource
+  get() = Drawable13.icon_16058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16059: DrawableResource
+  get() = Drawable13.icon_16059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1606: DrawableResource
+  get() = Drawable13.icon_1606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16060: DrawableResource
+  get() = Drawable13.icon_16060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16061: DrawableResource
+  get() = Drawable13.icon_16061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16062: DrawableResource
+  get() = Drawable13.icon_16062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16063: DrawableResource
+  get() = Drawable13.icon_16063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16064: DrawableResource
+  get() = Drawable13.icon_16064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16065: DrawableResource
+  get() = Drawable13.icon_16065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16066: DrawableResource
+  get() = Drawable13.icon_16066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16067: DrawableResource
+  get() = Drawable13.icon_16067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16068: DrawableResource
+  get() = Drawable13.icon_16068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16069: DrawableResource
+  get() = Drawable13.icon_16069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1607: DrawableResource
+  get() = Drawable13.icon_1607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16070: DrawableResource
+  get() = Drawable13.icon_16070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16071: DrawableResource
+  get() = Drawable13.icon_16071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16072: DrawableResource
+  get() = Drawable13.icon_16072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16073: DrawableResource
+  get() = Drawable13.icon_16073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16074: DrawableResource
+  get() = Drawable13.icon_16074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16075: DrawableResource
+  get() = Drawable13.icon_16075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16076: DrawableResource
+  get() = Drawable13.icon_16076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16077: DrawableResource
+  get() = Drawable13.icon_16077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16078: DrawableResource
+  get() = Drawable13.icon_16078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16079: DrawableResource
+  get() = Drawable13.icon_16079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1608: DrawableResource
+  get() = Drawable13.icon_1608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16080: DrawableResource
+  get() = Drawable13.icon_16080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16081: DrawableResource
+  get() = Drawable13.icon_16081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16082: DrawableResource
+  get() = Drawable13.icon_16082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16083: DrawableResource
+  get() = Drawable13.icon_16083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16084: DrawableResource
+  get() = Drawable13.icon_16084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16085: DrawableResource
+  get() = Drawable13.icon_16085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16086: DrawableResource
+  get() = Drawable13.icon_16086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16087: DrawableResource
+  get() = Drawable13.icon_16087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16088: DrawableResource
+  get() = Drawable13.icon_16088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16089: DrawableResource
+  get() = Drawable13.icon_16089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1609: DrawableResource
+  get() = Drawable13.icon_1609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16090: DrawableResource
+  get() = Drawable13.icon_16090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16091: DrawableResource
+  get() = Drawable13.icon_16091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16092: DrawableResource
+  get() = Drawable13.icon_16092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16093: DrawableResource
+  get() = Drawable13.icon_16093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16094: DrawableResource
+  get() = Drawable13.icon_16094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16095: DrawableResource
+  get() = Drawable13.icon_16095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16096: DrawableResource
+  get() = Drawable13.icon_16096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16097: DrawableResource
+  get() = Drawable13.icon_16097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16098: DrawableResource
+  get() = Drawable13.icon_16098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16099: DrawableResource
+  get() = Drawable13.icon_16099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_161: DrawableResource
+  get() = Drawable13.icon_161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1610: DrawableResource
+  get() = Drawable13.icon_1610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16100: DrawableResource
+  get() = Drawable13.icon_16100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16101: DrawableResource
+  get() = Drawable13.icon_16101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16102: DrawableResource
+  get() = Drawable13.icon_16102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16103: DrawableResource
+  get() = Drawable13.icon_16103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16104: DrawableResource
+  get() = Drawable13.icon_16104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16105: DrawableResource
+  get() = Drawable13.icon_16105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16106: DrawableResource
+  get() = Drawable13.icon_16106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16107: DrawableResource
+  get() = Drawable13.icon_16107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16108: DrawableResource
+  get() = Drawable13.icon_16108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16109: DrawableResource
+  get() = Drawable13.icon_16109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1611: DrawableResource
+  get() = Drawable13.icon_1611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16110: DrawableResource
+  get() = Drawable13.icon_16110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16111: DrawableResource
+  get() = Drawable13.icon_16111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16112: DrawableResource
+  get() = Drawable13.icon_16112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16113: DrawableResource
+  get() = Drawable13.icon_16113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16114: DrawableResource
+  get() = Drawable13.icon_16114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16115: DrawableResource
+  get() = Drawable13.icon_16115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16116: DrawableResource
+  get() = Drawable13.icon_16116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16117: DrawableResource
+  get() = Drawable13.icon_16117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16118: DrawableResource
+  get() = Drawable13.icon_16118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16119: DrawableResource
+  get() = Drawable13.icon_16119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1612: DrawableResource
+  get() = Drawable13.icon_1612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16120: DrawableResource
+  get() = Drawable13.icon_16120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16121: DrawableResource
+  get() = Drawable13.icon_16121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16122: DrawableResource
+  get() = Drawable13.icon_16122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16123: DrawableResource
+  get() = Drawable13.icon_16123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16124: DrawableResource
+  get() = Drawable13.icon_16124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16125: DrawableResource
+  get() = Drawable13.icon_16125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16126: DrawableResource
+  get() = Drawable13.icon_16126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16127: DrawableResource
+  get() = Drawable13.icon_16127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16128: DrawableResource
+  get() = Drawable13.icon_16128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16129: DrawableResource
+  get() = Drawable13.icon_16129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1613: DrawableResource
+  get() = Drawable13.icon_1613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16130: DrawableResource
+  get() = Drawable13.icon_16130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16131: DrawableResource
+  get() = Drawable13.icon_16131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16132: DrawableResource
+  get() = Drawable13.icon_16132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16133: DrawableResource
+  get() = Drawable13.icon_16133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16134: DrawableResource
+  get() = Drawable13.icon_16134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16135: DrawableResource
+  get() = Drawable13.icon_16135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16136: DrawableResource
+  get() = Drawable13.icon_16136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16137: DrawableResource
+  get() = Drawable13.icon_16137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16138: DrawableResource
+  get() = Drawable13.icon_16138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16139: DrawableResource
+  get() = Drawable13.icon_16139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1614: DrawableResource
+  get() = Drawable13.icon_1614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16140: DrawableResource
+  get() = Drawable13.icon_16140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16141: DrawableResource
+  get() = Drawable13.icon_16141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16142: DrawableResource
+  get() = Drawable13.icon_16142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16143: DrawableResource
+  get() = Drawable13.icon_16143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16144: DrawableResource
+  get() = Drawable13.icon_16144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16145: DrawableResource
+  get() = Drawable13.icon_16145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16146: DrawableResource
+  get() = Drawable13.icon_16146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16147: DrawableResource
+  get() = Drawable13.icon_16147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16148: DrawableResource
+  get() = Drawable13.icon_16148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16149: DrawableResource
+  get() = Drawable13.icon_16149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1615: DrawableResource
+  get() = Drawable13.icon_1615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16150: DrawableResource
+  get() = Drawable13.icon_16150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16151: DrawableResource
+  get() = Drawable13.icon_16151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16152: DrawableResource
+  get() = Drawable13.icon_16152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16153: DrawableResource
+  get() = Drawable13.icon_16153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16154: DrawableResource
+  get() = Drawable13.icon_16154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16155: DrawableResource
+  get() = Drawable13.icon_16155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16156: DrawableResource
+  get() = Drawable13.icon_16156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16157: DrawableResource
+  get() = Drawable13.icon_16157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16158: DrawableResource
+  get() = Drawable13.icon_16158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16159: DrawableResource
+  get() = Drawable13.icon_16159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1616: DrawableResource
+  get() = Drawable13.icon_1616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16160: DrawableResource
+  get() = Drawable13.icon_16160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16161: DrawableResource
+  get() = Drawable13.icon_16161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16162: DrawableResource
+  get() = Drawable13.icon_16162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16163: DrawableResource
+  get() = Drawable13.icon_16163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16164: DrawableResource
+  get() = Drawable13.icon_16164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16165: DrawableResource
+  get() = Drawable13.icon_16165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16166: DrawableResource
+  get() = Drawable13.icon_16166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16167: DrawableResource
+  get() = Drawable13.icon_16167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16168: DrawableResource
+  get() = Drawable13.icon_16168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16169: DrawableResource
+  get() = Drawable13.icon_16169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1617: DrawableResource
+  get() = Drawable13.icon_1617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16170: DrawableResource
+  get() = Drawable13.icon_16170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16171: DrawableResource
+  get() = Drawable13.icon_16171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16172: DrawableResource
+  get() = Drawable13.icon_16172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16173: DrawableResource
+  get() = Drawable13.icon_16173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16174: DrawableResource
+  get() = Drawable13.icon_16174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16175: DrawableResource
+  get() = Drawable13.icon_16175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16176: DrawableResource
+  get() = Drawable13.icon_16176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16177: DrawableResource
+  get() = Drawable13.icon_16177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16178: DrawableResource
+  get() = Drawable13.icon_16178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16179: DrawableResource
+  get() = Drawable13.icon_16179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1618: DrawableResource
+  get() = Drawable13.icon_1618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16180: DrawableResource
+  get() = Drawable13.icon_16180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16181: DrawableResource
+  get() = Drawable13.icon_16181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16182: DrawableResource
+  get() = Drawable13.icon_16182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16183: DrawableResource
+  get() = Drawable13.icon_16183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16184: DrawableResource
+  get() = Drawable13.icon_16184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16185: DrawableResource
+  get() = Drawable13.icon_16185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16186: DrawableResource
+  get() = Drawable13.icon_16186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16187: DrawableResource
+  get() = Drawable13.icon_16187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16188: DrawableResource
+  get() = Drawable13.icon_16188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16189: DrawableResource
+  get() = Drawable13.icon_16189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1619: DrawableResource
+  get() = Drawable13.icon_1619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16190: DrawableResource
+  get() = Drawable13.icon_16190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16191: DrawableResource
+  get() = Drawable13.icon_16191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16192: DrawableResource
+  get() = Drawable13.icon_16192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16193: DrawableResource
+  get() = Drawable13.icon_16193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16194: DrawableResource
+  get() = Drawable13.icon_16194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16195: DrawableResource
+  get() = Drawable13.icon_16195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16196: DrawableResource
+  get() = Drawable13.icon_16196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16197: DrawableResource
+  get() = Drawable13.icon_16197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16198: DrawableResource
+  get() = Drawable13.icon_16198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16199: DrawableResource
+  get() = Drawable13.icon_16199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_162: DrawableResource
+  get() = Drawable13.icon_162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1620: DrawableResource
+  get() = Drawable13.icon_1620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16200: DrawableResource
+  get() = Drawable13.icon_16200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16201: DrawableResource
+  get() = Drawable13.icon_16201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16202: DrawableResource
+  get() = Drawable13.icon_16202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16203: DrawableResource
+  get() = Drawable13.icon_16203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16204: DrawableResource
+  get() = Drawable13.icon_16204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16205: DrawableResource
+  get() = Drawable13.icon_16205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16206: DrawableResource
+  get() = Drawable13.icon_16206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16207: DrawableResource
+  get() = Drawable13.icon_16207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16208: DrawableResource
+  get() = Drawable13.icon_16208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16209: DrawableResource
+  get() = Drawable13.icon_16209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1621: DrawableResource
+  get() = Drawable13.icon_1621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16210: DrawableResource
+  get() = Drawable13.icon_16210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16211: DrawableResource
+  get() = Drawable13.icon_16211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16212: DrawableResource
+  get() = Drawable13.icon_16212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16213: DrawableResource
+  get() = Drawable13.icon_16213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16214: DrawableResource
+  get() = Drawable13.icon_16214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16215: DrawableResource
+  get() = Drawable13.icon_16215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16216: DrawableResource
+  get() = Drawable13.icon_16216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16217: DrawableResource
+  get() = Drawable13.icon_16217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16218: DrawableResource
+  get() = Drawable13.icon_16218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16219: DrawableResource
+  get() = Drawable13.icon_16219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1622: DrawableResource
+  get() = Drawable13.icon_1622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16220: DrawableResource
+  get() = Drawable13.icon_16220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16221: DrawableResource
+  get() = Drawable13.icon_16221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16222: DrawableResource
+  get() = Drawable13.icon_16222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16223: DrawableResource
+  get() = Drawable13.icon_16223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16224: DrawableResource
+  get() = Drawable13.icon_16224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16225: DrawableResource
+  get() = Drawable13.icon_16225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16226: DrawableResource
+  get() = Drawable13.icon_16226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16227: DrawableResource
+  get() = Drawable13.icon_16227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16228: DrawableResource
+  get() = Drawable13.icon_16228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16229: DrawableResource
+  get() = Drawable13.icon_16229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1623: DrawableResource
+  get() = Drawable13.icon_1623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16230: DrawableResource
+  get() = Drawable13.icon_16230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16231: DrawableResource
+  get() = Drawable13.icon_16231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16232: DrawableResource
+  get() = Drawable13.icon_16232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16233: DrawableResource
+  get() = Drawable13.icon_16233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16234: DrawableResource
+  get() = Drawable13.icon_16234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16235: DrawableResource
+  get() = Drawable13.icon_16235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16236: DrawableResource
+  get() = Drawable13.icon_16236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16237: DrawableResource
+  get() = Drawable13.icon_16237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16238: DrawableResource
+  get() = Drawable13.icon_16238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16239: DrawableResource
+  get() = Drawable13.icon_16239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1624: DrawableResource
+  get() = Drawable13.icon_1624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16240: DrawableResource
+  get() = Drawable13.icon_16240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16241: DrawableResource
+  get() = Drawable13.icon_16241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16242: DrawableResource
+  get() = Drawable13.icon_16242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16243: DrawableResource
+  get() = Drawable13.icon_16243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16244: DrawableResource
+  get() = Drawable13.icon_16244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16245: DrawableResource
+  get() = Drawable13.icon_16245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16246: DrawableResource
+  get() = Drawable13.icon_16246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16247: DrawableResource
+  get() = Drawable13.icon_16247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16248: DrawableResource
+  get() = Drawable13.icon_16248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16249: DrawableResource
+  get() = Drawable13.icon_16249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1625: DrawableResource
+  get() = Drawable13.icon_1625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16250: DrawableResource
+  get() = Drawable13.icon_16250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16251: DrawableResource
+  get() = Drawable13.icon_16251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16252: DrawableResource
+  get() = Drawable13.icon_16252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16253: DrawableResource
+  get() = Drawable13.icon_16253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16254: DrawableResource
+  get() = Drawable13.icon_16254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16255: DrawableResource
+  get() = Drawable13.icon_16255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16256: DrawableResource
+  get() = Drawable13.icon_16256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16257: DrawableResource
+  get() = Drawable13.icon_16257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16258: DrawableResource
+  get() = Drawable13.icon_16258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16259: DrawableResource
+  get() = Drawable13.icon_16259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1626: DrawableResource
+  get() = Drawable13.icon_1626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16260: DrawableResource
+  get() = Drawable13.icon_16260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16261: DrawableResource
+  get() = Drawable13.icon_16261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16262: DrawableResource
+  get() = Drawable13.icon_16262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16263: DrawableResource
+  get() = Drawable13.icon_16263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16264: DrawableResource
+  get() = Drawable13.icon_16264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16265: DrawableResource
+  get() = Drawable13.icon_16265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16266: DrawableResource
+  get() = Drawable13.icon_16266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16267: DrawableResource
+  get() = Drawable13.icon_16267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16268: DrawableResource
+  get() = Drawable13.icon_16268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16269: DrawableResource
+  get() = Drawable13.icon_16269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1627: DrawableResource
+  get() = Drawable13.icon_1627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16270: DrawableResource
+  get() = Drawable13.icon_16270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16271: DrawableResource
+  get() = Drawable13.icon_16271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16272: DrawableResource
+  get() = Drawable13.icon_16272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16273: DrawableResource
+  get() = Drawable13.icon_16273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16274: DrawableResource
+  get() = Drawable13.icon_16274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16275: DrawableResource
+  get() = Drawable13.icon_16275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16276: DrawableResource
+  get() = Drawable13.icon_16276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16277: DrawableResource
+  get() = Drawable13.icon_16277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16278: DrawableResource
+  get() = Drawable13.icon_16278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16279: DrawableResource
+  get() = Drawable13.icon_16279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1628: DrawableResource
+  get() = Drawable13.icon_1628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16280: DrawableResource
+  get() = Drawable13.icon_16280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16281: DrawableResource
+  get() = Drawable13.icon_16281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16282: DrawableResource
+  get() = Drawable13.icon_16282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16283: DrawableResource
+  get() = Drawable13.icon_16283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16284: DrawableResource
+  get() = Drawable13.icon_16284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16285: DrawableResource
+  get() = Drawable13.icon_16285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16286: DrawableResource
+  get() = Drawable13.icon_16286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16287: DrawableResource
+  get() = Drawable13.icon_16287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16288: DrawableResource
+  get() = Drawable13.icon_16288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16289: DrawableResource
+  get() = Drawable13.icon_16289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1629: DrawableResource
+  get() = Drawable13.icon_1629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16290: DrawableResource
+  get() = Drawable13.icon_16290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16291: DrawableResource
+  get() = Drawable13.icon_16291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16292: DrawableResource
+  get() = Drawable13.icon_16292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16293: DrawableResource
+  get() = Drawable13.icon_16293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16294: DrawableResource
+  get() = Drawable13.icon_16294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16295: DrawableResource
+  get() = Drawable13.icon_16295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16296: DrawableResource
+  get() = Drawable13.icon_16296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16297: DrawableResource
+  get() = Drawable13.icon_16297

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable14.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable14.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable14 {
+  public val icon_16298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16298.xml"),
+          )
+      )
+
+  public val icon_16299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16299.xml"),
+          )
+      )
+
+  public val icon_163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_163.xml"),
+          )
+      )
+
+  public val icon_1630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1630.xml"),
+          )
+      )
+
+  public val icon_16300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16300.xml"),
+          )
+      )
+
+  public val icon_16301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16301.xml"),
+          )
+      )
+
+  public val icon_16302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16302.xml"),
+          )
+      )
+
+  public val icon_16303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16303.xml"),
+          )
+      )
+
+  public val icon_16304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16304.xml"),
+          )
+      )
+
+  public val icon_16305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16305.xml"),
+          )
+      )
+
+  public val icon_16306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16306.xml"),
+          )
+      )
+
+  public val icon_16307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16307.xml"),
+          )
+      )
+
+  public val icon_16308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16308.xml"),
+          )
+      )
+
+  public val icon_16309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16309.xml"),
+          )
+      )
+
+  public val icon_1631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1631.xml"),
+          )
+      )
+
+  public val icon_16310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16310.xml"),
+          )
+      )
+
+  public val icon_16311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16311.xml"),
+          )
+      )
+
+  public val icon_16312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16312.xml"),
+          )
+      )
+
+  public val icon_16313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16313.xml"),
+          )
+      )
+
+  public val icon_16314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16314.xml"),
+          )
+      )
+
+  public val icon_16315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16315.xml"),
+          )
+      )
+
+  public val icon_16316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16316.xml"),
+          )
+      )
+
+  public val icon_16317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16317.xml"),
+          )
+      )
+
+  public val icon_16318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16318.xml"),
+          )
+      )
+
+  public val icon_16319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16319.xml"),
+          )
+      )
+
+  public val icon_1632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1632.xml"),
+          )
+      )
+
+  public val icon_16320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16320.xml"),
+          )
+      )
+
+  public val icon_16321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16321.xml"),
+          )
+      )
+
+  public val icon_16322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16322.xml"),
+          )
+      )
+
+  public val icon_16323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16323.xml"),
+          )
+      )
+
+  public val icon_16324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16324.xml"),
+          )
+      )
+
+  public val icon_16325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16325.xml"),
+          )
+      )
+
+  public val icon_16326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16326.xml"),
+          )
+      )
+
+  public val icon_16327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16327.xml"),
+          )
+      )
+
+  public val icon_16328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16328.xml"),
+          )
+      )
+
+  public val icon_16329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16329.xml"),
+          )
+      )
+
+  public val icon_1633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1633.xml"),
+          )
+      )
+
+  public val icon_16330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16330.xml"),
+          )
+      )
+
+  public val icon_16331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16331.xml"),
+          )
+      )
+
+  public val icon_16332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16332.xml"),
+          )
+      )
+
+  public val icon_16333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16333.xml"),
+          )
+      )
+
+  public val icon_16334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16334.xml"),
+          )
+      )
+
+  public val icon_16335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16335.xml"),
+          )
+      )
+
+  public val icon_16336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16336.xml"),
+          )
+      )
+
+  public val icon_16337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16337.xml"),
+          )
+      )
+
+  public val icon_16338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16338.xml"),
+          )
+      )
+
+  public val icon_16339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16339.xml"),
+          )
+      )
+
+  public val icon_1634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1634.xml"),
+          )
+      )
+
+  public val icon_16340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16340.xml"),
+          )
+      )
+
+  public val icon_16341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16341.xml"),
+          )
+      )
+
+  public val icon_16342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16342.xml"),
+          )
+      )
+
+  public val icon_16343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16343.xml"),
+          )
+      )
+
+  public val icon_16344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16344.xml"),
+          )
+      )
+
+  public val icon_16345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16345.xml"),
+          )
+      )
+
+  public val icon_16346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16346.xml"),
+          )
+      )
+
+  public val icon_16347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16347.xml"),
+          )
+      )
+
+  public val icon_16348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16348.xml"),
+          )
+      )
+
+  public val icon_16349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16349.xml"),
+          )
+      )
+
+  public val icon_1635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1635.xml"),
+          )
+      )
+
+  public val icon_16350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16350.xml"),
+          )
+      )
+
+  public val icon_16351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16351.xml"),
+          )
+      )
+
+  public val icon_16352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16352.xml"),
+          )
+      )
+
+  public val icon_16353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16353.xml"),
+          )
+      )
+
+  public val icon_16354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16354.xml"),
+          )
+      )
+
+  public val icon_16355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16355.xml"),
+          )
+      )
+
+  public val icon_16356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16356.xml"),
+          )
+      )
+
+  public val icon_16357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16357.xml"),
+          )
+      )
+
+  public val icon_16358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16358.xml"),
+          )
+      )
+
+  public val icon_16359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16359.xml"),
+          )
+      )
+
+  public val icon_1636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1636.xml"),
+          )
+      )
+
+  public val icon_16360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16360.xml"),
+          )
+      )
+
+  public val icon_16361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16361.xml"),
+          )
+      )
+
+  public val icon_16362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16362.xml"),
+          )
+      )
+
+  public val icon_16363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16363.xml"),
+          )
+      )
+
+  public val icon_16364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16364.xml"),
+          )
+      )
+
+  public val icon_16365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16365.xml"),
+          )
+      )
+
+  public val icon_16366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16366.xml"),
+          )
+      )
+
+  public val icon_16367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16367.xml"),
+          )
+      )
+
+  public val icon_16368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16368.xml"),
+          )
+      )
+
+  public val icon_16369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16369.xml"),
+          )
+      )
+
+  public val icon_1637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1637.xml"),
+          )
+      )
+
+  public val icon_16370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16370.xml"),
+          )
+      )
+
+  public val icon_16371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16371.xml"),
+          )
+      )
+
+  public val icon_16372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16372.xml"),
+          )
+      )
+
+  public val icon_16373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16373.xml"),
+          )
+      )
+
+  public val icon_16374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16374.xml"),
+          )
+      )
+
+  public val icon_16375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16375.xml"),
+          )
+      )
+
+  public val icon_16376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16376.xml"),
+          )
+      )
+
+  public val icon_16377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16377.xml"),
+          )
+      )
+
+  public val icon_16378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16378.xml"),
+          )
+      )
+
+  public val icon_16379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16379.xml"),
+          )
+      )
+
+  public val icon_1638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1638.xml"),
+          )
+      )
+
+  public val icon_16380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16380.xml"),
+          )
+      )
+
+  public val icon_16381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16381.xml"),
+          )
+      )
+
+  public val icon_16382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16382.xml"),
+          )
+      )
+
+  public val icon_16383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16383.xml"),
+          )
+      )
+
+  public val icon_16384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16384.xml"),
+          )
+      )
+
+  public val icon_16385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16385.xml"),
+          )
+      )
+
+  public val icon_16386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16386.xml"),
+          )
+      )
+
+  public val icon_16387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16387.xml"),
+          )
+      )
+
+  public val icon_16388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16388.xml"),
+          )
+      )
+
+  public val icon_16389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16389.xml"),
+          )
+      )
+
+  public val icon_1639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1639.xml"),
+          )
+      )
+
+  public val icon_16390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16390.xml"),
+          )
+      )
+
+  public val icon_16391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16391.xml"),
+          )
+      )
+
+  public val icon_16392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16392.xml"),
+          )
+      )
+
+  public val icon_16393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16393.xml"),
+          )
+      )
+
+  public val icon_16394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16394.xml"),
+          )
+      )
+
+  public val icon_16395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16395.xml"),
+          )
+      )
+
+  public val icon_16396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16396.xml"),
+          )
+      )
+
+  public val icon_16397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16397.xml"),
+          )
+      )
+
+  public val icon_16398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16398.xml"),
+          )
+      )
+
+  public val icon_16399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16399.xml"),
+          )
+      )
+
+  public val icon_164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_164.xml"),
+          )
+      )
+
+  public val icon_1640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1640.xml"),
+          )
+      )
+
+  public val icon_16400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16400.xml"),
+          )
+      )
+
+  public val icon_16401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16401.xml"),
+          )
+      )
+
+  public val icon_16402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16402.xml"),
+          )
+      )
+
+  public val icon_16403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16403.xml"),
+          )
+      )
+
+  public val icon_16404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16404.xml"),
+          )
+      )
+
+  public val icon_16405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16405.xml"),
+          )
+      )
+
+  public val icon_16406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16406.xml"),
+          )
+      )
+
+  public val icon_16407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16407.xml"),
+          )
+      )
+
+  public val icon_16408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16408.xml"),
+          )
+      )
+
+  public val icon_16409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16409.xml"),
+          )
+      )
+
+  public val icon_1641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1641.xml"),
+          )
+      )
+
+  public val icon_16410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16410.xml"),
+          )
+      )
+
+  public val icon_16411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16411.xml"),
+          )
+      )
+
+  public val icon_16412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16412.xml"),
+          )
+      )
+
+  public val icon_16413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16413.xml"),
+          )
+      )
+
+  public val icon_16414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16414.xml"),
+          )
+      )
+
+  public val icon_16415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16415.xml"),
+          )
+      )
+
+  public val icon_16416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16416.xml"),
+          )
+      )
+
+  public val icon_16417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16417.xml"),
+          )
+      )
+
+  public val icon_16418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16418.xml"),
+          )
+      )
+
+  public val icon_16419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16419.xml"),
+          )
+      )
+
+  public val icon_1642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1642.xml"),
+          )
+      )
+
+  public val icon_16420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16420.xml"),
+          )
+      )
+
+  public val icon_16421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16421.xml"),
+          )
+      )
+
+  public val icon_16422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16422.xml"),
+          )
+      )
+
+  public val icon_16423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16423.xml"),
+          )
+      )
+
+  public val icon_16424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16424.xml"),
+          )
+      )
+
+  public val icon_16425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16425.xml"),
+          )
+      )
+
+  public val icon_16426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16426.xml"),
+          )
+      )
+
+  public val icon_16427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16427.xml"),
+          )
+      )
+
+  public val icon_16428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16428.xml"),
+          )
+      )
+
+  public val icon_16429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16429.xml"),
+          )
+      )
+
+  public val icon_1643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1643.xml"),
+          )
+      )
+
+  public val icon_16430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16430.xml"),
+          )
+      )
+
+  public val icon_16431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16431.xml"),
+          )
+      )
+
+  public val icon_16432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16432.xml"),
+          )
+      )
+
+  public val icon_16433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16433.xml"),
+          )
+      )
+
+  public val icon_16434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16434.xml"),
+          )
+      )
+
+  public val icon_16435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16435.xml"),
+          )
+      )
+
+  public val icon_16436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16436.xml"),
+          )
+      )
+
+  public val icon_16437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16437.xml"),
+          )
+      )
+
+  public val icon_16438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16438.xml"),
+          )
+      )
+
+  public val icon_16439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16439.xml"),
+          )
+      )
+
+  public val icon_1644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1644.xml"),
+          )
+      )
+
+  public val icon_16440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16440.xml"),
+          )
+      )
+
+  public val icon_16441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16441.xml"),
+          )
+      )
+
+  public val icon_16442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16442.xml"),
+          )
+      )
+
+  public val icon_16443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16443.xml"),
+          )
+      )
+
+  public val icon_16444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16444.xml"),
+          )
+      )
+
+  public val icon_16445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16445.xml"),
+          )
+      )
+
+  public val icon_16446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16446.xml"),
+          )
+      )
+
+  public val icon_16447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16447.xml"),
+          )
+      )
+
+  public val icon_16448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16448.xml"),
+          )
+      )
+
+  public val icon_16449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16449.xml"),
+          )
+      )
+
+  public val icon_1645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1645.xml"),
+          )
+      )
+
+  public val icon_16450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16450.xml"),
+          )
+      )
+
+  public val icon_16451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16451.xml"),
+          )
+      )
+
+  public val icon_16452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16452.xml"),
+          )
+      )
+
+  public val icon_16453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16453.xml"),
+          )
+      )
+
+  public val icon_16454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16454.xml"),
+          )
+      )
+
+  public val icon_16455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16455.xml"),
+          )
+      )
+
+  public val icon_16456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16456.xml"),
+          )
+      )
+
+  public val icon_16457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16457.xml"),
+          )
+      )
+
+  public val icon_16458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16458.xml"),
+          )
+      )
+
+  public val icon_16459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16459.xml"),
+          )
+      )
+
+  public val icon_1646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1646.xml"),
+          )
+      )
+
+  public val icon_16460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16460.xml"),
+          )
+      )
+
+  public val icon_16461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16461.xml"),
+          )
+      )
+
+  public val icon_16462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16462.xml"),
+          )
+      )
+
+  public val icon_16463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16463.xml"),
+          )
+      )
+
+  public val icon_16464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16464.xml"),
+          )
+      )
+
+  public val icon_16465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16465.xml"),
+          )
+      )
+
+  public val icon_16466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16466.xml"),
+          )
+      )
+
+  public val icon_16467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16467.xml"),
+          )
+      )
+
+  public val icon_16468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16468.xml"),
+          )
+      )
+
+  public val icon_16469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16469.xml"),
+          )
+      )
+
+  public val icon_1647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1647.xml"),
+          )
+      )
+
+  public val icon_16470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16470.xml"),
+          )
+      )
+
+  public val icon_16471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16471.xml"),
+          )
+      )
+
+  public val icon_16472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16472.xml"),
+          )
+      )
+
+  public val icon_16473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16473.xml"),
+          )
+      )
+
+  public val icon_16474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16474.xml"),
+          )
+      )
+
+  public val icon_16475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16475.xml"),
+          )
+      )
+
+  public val icon_16476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16476.xml"),
+          )
+      )
+
+  public val icon_16477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16477.xml"),
+          )
+      )
+
+  public val icon_16478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16478.xml"),
+          )
+      )
+
+  public val icon_16479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16479.xml"),
+          )
+      )
+
+  public val icon_1648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1648.xml"),
+          )
+      )
+
+  public val icon_16480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16480.xml"),
+          )
+      )
+
+  public val icon_16481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16481.xml"),
+          )
+      )
+
+  public val icon_16482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16482.xml"),
+          )
+      )
+
+  public val icon_16483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16483.xml"),
+          )
+      )
+
+  public val icon_16484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16484.xml"),
+          )
+      )
+
+  public val icon_16485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16485.xml"),
+          )
+      )
+
+  public val icon_16486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16486.xml"),
+          )
+      )
+
+  public val icon_16487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16487.xml"),
+          )
+      )
+
+  public val icon_16488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16488.xml"),
+          )
+      )
+
+  public val icon_16489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16489.xml"),
+          )
+      )
+
+  public val icon_1649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1649.xml"),
+          )
+      )
+
+  public val icon_16490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16490.xml"),
+          )
+      )
+
+  public val icon_16491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16491.xml"),
+          )
+      )
+
+  public val icon_16492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16492.xml"),
+          )
+      )
+
+  public val icon_16493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16493.xml"),
+          )
+      )
+
+  public val icon_16494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16494.xml"),
+          )
+      )
+
+  public val icon_16495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16495.xml"),
+          )
+      )
+
+  public val icon_16496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16496.xml"),
+          )
+      )
+
+  public val icon_16497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16497.xml"),
+          )
+      )
+
+  public val icon_16498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16498.xml"),
+          )
+      )
+
+  public val icon_16499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16499.xml"),
+          )
+      )
+
+  public val icon_165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_165.xml"),
+          )
+      )
+
+  public val icon_1650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1650.xml"),
+          )
+      )
+
+  public val icon_16500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16500.xml"),
+          )
+      )
+
+  public val icon_16501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16501.xml"),
+          )
+      )
+
+  public val icon_16502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16502.xml"),
+          )
+      )
+
+  public val icon_16503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16503.xml"),
+          )
+      )
+
+  public val icon_16504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16504.xml"),
+          )
+      )
+
+  public val icon_16505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16505.xml"),
+          )
+      )
+
+  public val icon_16506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16506.xml"),
+          )
+      )
+
+  public val icon_16507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16507.xml"),
+          )
+      )
+
+  public val icon_16508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16508.xml"),
+          )
+      )
+
+  public val icon_16509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16509.xml"),
+          )
+      )
+
+  public val icon_1651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1651.xml"),
+          )
+      )
+
+  public val icon_16510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16510.xml"),
+          )
+      )
+
+  public val icon_16511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16511.xml"),
+          )
+      )
+
+  public val icon_16512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16512.xml"),
+          )
+      )
+
+  public val icon_16513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16513.xml"),
+          )
+      )
+
+  public val icon_16514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16514.xml"),
+          )
+      )
+
+  public val icon_16515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16515.xml"),
+          )
+      )
+
+  public val icon_16516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16516.xml"),
+          )
+      )
+
+  public val icon_16517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16517.xml"),
+          )
+      )
+
+  public val icon_16518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16518.xml"),
+          )
+      )
+
+  public val icon_16519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16519.xml"),
+          )
+      )
+
+  public val icon_1652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1652.xml"),
+          )
+      )
+
+  public val icon_16520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16520.xml"),
+          )
+      )
+
+  public val icon_16521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16521.xml"),
+          )
+      )
+
+  public val icon_16522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16522.xml"),
+          )
+      )
+
+  public val icon_16523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16523.xml"),
+          )
+      )
+
+  public val icon_16524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16524.xml"),
+          )
+      )
+
+  public val icon_16525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16525.xml"),
+          )
+      )
+
+  public val icon_16526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16526.xml"),
+          )
+      )
+
+  public val icon_16527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16527.xml"),
+          )
+      )
+
+  public val icon_16528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16528.xml"),
+          )
+      )
+
+  public val icon_16529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16529.xml"),
+          )
+      )
+
+  public val icon_1653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1653.xml"),
+          )
+      )
+
+  public val icon_16530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16530.xml"),
+          )
+      )
+
+  public val icon_16531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16531.xml"),
+          )
+      )
+
+  public val icon_16532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16532.xml"),
+          )
+      )
+
+  public val icon_16533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16533.xml"),
+          )
+      )
+
+  public val icon_16534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16534.xml"),
+          )
+      )
+
+  public val icon_16535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16535.xml"),
+          )
+      )
+
+  public val icon_16536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16536.xml"),
+          )
+      )
+
+  public val icon_16537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16537.xml"),
+          )
+      )
+
+  public val icon_16538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16538.xml"),
+          )
+      )
+
+  public val icon_16539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16539.xml"),
+          )
+      )
+
+  public val icon_1654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1654.xml"),
+          )
+      )
+
+  public val icon_16540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16540.xml"),
+          )
+      )
+
+  public val icon_16541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16541.xml"),
+          )
+      )
+
+  public val icon_16542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16542.xml"),
+          )
+      )
+
+  public val icon_16543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16543.xml"),
+          )
+      )
+
+  public val icon_16544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16544.xml"),
+          )
+      )
+
+  public val icon_16545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16545.xml"),
+          )
+      )
+
+  public val icon_16546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16546.xml"),
+          )
+      )
+
+  public val icon_16547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16547.xml"),
+          )
+      )
+
+  public val icon_16548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16548.xml"),
+          )
+      )
+
+  public val icon_16549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16549.xml"),
+          )
+      )
+
+  public val icon_1655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1655.xml"),
+          )
+      )
+
+  public val icon_16550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16550.xml"),
+          )
+      )
+
+  public val icon_16551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16551.xml"),
+          )
+      )
+
+  public val icon_16552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16552.xml"),
+          )
+      )
+
+  public val icon_16553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16553.xml"),
+          )
+      )
+
+  public val icon_16554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16554.xml"),
+          )
+      )
+
+  public val icon_16555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16555.xml"),
+          )
+      )
+
+  public val icon_16556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16556.xml"),
+          )
+      )
+
+  public val icon_16557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16557.xml"),
+          )
+      )
+
+  public val icon_16558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16558.xml"),
+          )
+      )
+
+  public val icon_16559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16559.xml"),
+          )
+      )
+
+  public val icon_1656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1656.xml"),
+          )
+      )
+
+  public val icon_16560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16560.xml"),
+          )
+      )
+
+  public val icon_16561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16561.xml"),
+          )
+      )
+
+  public val icon_16562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16562.xml"),
+          )
+      )
+
+  public val icon_16563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16563.xml"),
+          )
+      )
+
+  public val icon_16564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16564.xml"),
+          )
+      )
+
+  public val icon_16565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16565.xml"),
+          )
+      )
+
+  public val icon_16566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16566.xml"),
+          )
+      )
+
+  public val icon_16567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16567.xml"),
+          )
+      )
+
+  public val icon_16568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16568.xml"),
+          )
+      )
+
+  public val icon_16569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16569.xml"),
+          )
+      )
+
+  public val icon_1657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1657.xml"),
+          )
+      )
+
+  public val icon_16570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16570.xml"),
+          )
+      )
+
+  public val icon_16571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16571.xml"),
+          )
+      )
+
+  public val icon_16572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16572.xml"),
+          )
+      )
+
+  public val icon_16573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16573.xml"),
+          )
+      )
+
+  public val icon_16574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16574.xml"),
+          )
+      )
+
+  public val icon_16575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16575.xml"),
+          )
+      )
+
+  public val icon_16576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16576.xml"),
+          )
+      )
+
+  public val icon_16577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16577.xml"),
+          )
+      )
+
+  public val icon_16578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16578.xml"),
+          )
+      )
+
+  public val icon_16579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16579.xml"),
+          )
+      )
+
+  public val icon_1658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1658.xml"),
+          )
+      )
+
+  public val icon_16580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16580.xml"),
+          )
+      )
+
+  public val icon_16581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16581.xml"),
+          )
+      )
+
+  public val icon_16582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16582.xml"),
+          )
+      )
+
+  public val icon_16583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16583.xml"),
+          )
+      )
+
+  public val icon_16584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16584.xml"),
+          )
+      )
+
+  public val icon_16585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16585.xml"),
+          )
+      )
+
+  public val icon_16586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16586.xml"),
+          )
+      )
+
+  public val icon_16587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16587.xml"),
+          )
+      )
+
+  public val icon_16588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16588.xml"),
+          )
+      )
+
+  public val icon_16589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16589.xml"),
+          )
+      )
+
+  public val icon_1659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1659.xml"),
+          )
+      )
+
+  public val icon_16590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16590.xml"),
+          )
+      )
+
+  public val icon_16591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16591.xml"),
+          )
+      )
+
+  public val icon_16592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16592.xml"),
+          )
+      )
+
+  public val icon_16593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16593.xml"),
+          )
+      )
+
+  public val icon_16594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16594.xml"),
+          )
+      )
+
+  public val icon_16595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16595.xml"),
+          )
+      )
+
+  public val icon_16596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16596.xml"),
+          )
+      )
+
+  public val icon_16597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16597.xml"),
+          )
+      )
+
+  public val icon_16598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16598.xml"),
+          )
+      )
+
+  public val icon_16599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16599.xml"),
+          )
+      )
+
+  public val icon_166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_166.xml"),
+          )
+      )
+
+  public val icon_1660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1660.xml"),
+          )
+      )
+
+  public val icon_16600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16600.xml"),
+          )
+      )
+
+  public val icon_16601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16601.xml"),
+          )
+      )
+
+  public val icon_16602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16602.xml"),
+          )
+      )
+
+  public val icon_16603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16603.xml"),
+          )
+      )
+
+  public val icon_16604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16604.xml"),
+          )
+      )
+
+  public val icon_16605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16605.xml"),
+          )
+      )
+
+  public val icon_16606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16606.xml"),
+          )
+      )
+
+  public val icon_16607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16607.xml"),
+          )
+      )
+
+  public val icon_16608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16608.xml"),
+          )
+      )
+
+  public val icon_16609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16609.xml"),
+          )
+      )
+
+  public val icon_1661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1661.xml"),
+          )
+      )
+
+  public val icon_16610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16610.xml"),
+          )
+      )
+
+  public val icon_16611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16611.xml"),
+          )
+      )
+
+  public val icon_16612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16612.xml"),
+          )
+      )
+
+  public val icon_16613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16613.xml"),
+          )
+      )
+
+  public val icon_16614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16614.xml"),
+          )
+      )
+
+  public val icon_16615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16615.xml"),
+          )
+      )
+
+  public val icon_16616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16616.xml"),
+          )
+      )
+
+  public val icon_16617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16617.xml"),
+          )
+      )
+
+  public val icon_16618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16618.xml"),
+          )
+      )
+
+  public val icon_16619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16619.xml"),
+          )
+      )
+
+  public val icon_1662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1662.xml"),
+          )
+      )
+
+  public val icon_16620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16620.xml"),
+          )
+      )
+
+  public val icon_16621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16621.xml"),
+          )
+      )
+
+  public val icon_16622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16622.xml"),
+          )
+      )
+
+  public val icon_16623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16623.xml"),
+          )
+      )
+
+  public val icon_16624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16624.xml"),
+          )
+      )
+
+  public val icon_16625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16625.xml"),
+          )
+      )
+
+  public val icon_16626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16626.xml"),
+          )
+      )
+
+  public val icon_16627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16627.xml"),
+          )
+      )
+
+  public val icon_16628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16628.xml"),
+          )
+      )
+
+  public val icon_16629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16629.xml"),
+          )
+      )
+
+  public val icon_1663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1663.xml"),
+          )
+      )
+
+  public val icon_16630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16630.xml"),
+          )
+      )
+
+  public val icon_16631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16631.xml"),
+          )
+      )
+
+  public val icon_16632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16632.xml"),
+          )
+      )
+
+  public val icon_16633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16633.xml"),
+          )
+      )
+
+  public val icon_16634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16634.xml"),
+          )
+      )
+
+  public val icon_16635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16635.xml"),
+          )
+      )
+
+  public val icon_16636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16636.xml"),
+          )
+      )
+
+  public val icon_16637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16637.xml"),
+          )
+      )
+
+  public val icon_16638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16638.xml"),
+          )
+      )
+
+  public val icon_16639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16639.xml"),
+          )
+      )
+
+  public val icon_1664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1664.xml"),
+          )
+      )
+
+  public val icon_16640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16640.xml"),
+          )
+      )
+
+  public val icon_16641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16641.xml"),
+          )
+      )
+
+  public val icon_16642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16642.xml"),
+          )
+      )
+
+  public val icon_16643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16643.xml"),
+          )
+      )
+
+  public val icon_16644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16644.xml"),
+          )
+      )
+
+  public val icon_16645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16645.xml"),
+          )
+      )
+
+  public val icon_16646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16646.xml"),
+          )
+      )
+
+  public val icon_16647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16647.xml"),
+          )
+      )
+
+  public val icon_16648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16648.xml"),
+          )
+      )
+
+  public val icon_16649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16649.xml"),
+          )
+      )
+
+  public val icon_1665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1665.xml"),
+          )
+      )
+
+  public val icon_16650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16650.xml"),
+          )
+      )
+
+  public val icon_16651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16651.xml"),
+          )
+      )
+
+  public val icon_16652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16652.xml"),
+          )
+      )
+
+  public val icon_16653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16653.xml"),
+          )
+      )
+
+  public val icon_16654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16654.xml"),
+          )
+      )
+
+  public val icon_16655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16655.xml"),
+          )
+      )
+
+  public val icon_16656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16656.xml"),
+          )
+      )
+
+  public val icon_16657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16657.xml"),
+          )
+      )
+
+  public val icon_16658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16658.xml"),
+          )
+      )
+
+  public val icon_16659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16659.xml"),
+          )
+      )
+
+  public val icon_1666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1666.xml"),
+          )
+      )
+
+  public val icon_16660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16660.xml"),
+          )
+      )
+
+  public val icon_16661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16661.xml"),
+          )
+      )
+
+  public val icon_16662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16662.xml"),
+          )
+      )
+
+  public val icon_16663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16663.xml"),
+          )
+      )
+
+  public val icon_16664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16664.xml"),
+          )
+      )
+
+  public val icon_16665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16665.xml"),
+          )
+      )
+
+  public val icon_16666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16666.xml"),
+          )
+      )
+
+  public val icon_16667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16667.xml"),
+          )
+      )
+
+  public val icon_16668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16668.xml"),
+          )
+      )
+
+  public val icon_16669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16669.xml"),
+          )
+      )
+
+  public val icon_1667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1667.xml"),
+          )
+      )
+
+  public val icon_16670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16670.xml"),
+          )
+      )
+
+  public val icon_16671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16671.xml"),
+          )
+      )
+
+  public val icon_16672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16672.xml"),
+          )
+      )
+
+  public val icon_16673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16673.xml"),
+          )
+      )
+
+  public val icon_16674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16674.xml"),
+          )
+      )
+
+  public val icon_16675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16675.xml"),
+          )
+      )
+
+  public val icon_16676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16676.xml"),
+          )
+      )
+
+  public val icon_16677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16677.xml"),
+          )
+      )
+
+  public val icon_16678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16678.xml"),
+          )
+      )
+
+  public val icon_16679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16679.xml"),
+          )
+      )
+
+  public val icon_1668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1668.xml"),
+          )
+      )
+
+  public val icon_16680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16680.xml"),
+          )
+      )
+
+  public val icon_16681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16681.xml"),
+          )
+      )
+
+  public val icon_16682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16682.xml"),
+          )
+      )
+
+  public val icon_16683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16683.xml"),
+          )
+      )
+
+  public val icon_16684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16684.xml"),
+          )
+      )
+
+  public val icon_16685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16685.xml"),
+          )
+      )
+
+  public val icon_16686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16686.xml"),
+          )
+      )
+
+  public val icon_16687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16687.xml"),
+          )
+      )
+
+  public val icon_16688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16688.xml"),
+          )
+      )
+
+  public val icon_16689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16689.xml"),
+          )
+      )
+
+  public val icon_1669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1669.xml"),
+          )
+      )
+
+  public val icon_16690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16690.xml"),
+          )
+      )
+
+  public val icon_16691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16691.xml"),
+          )
+      )
+
+  public val icon_16692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16692.xml"),
+          )
+      )
+
+  public val icon_16693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16693.xml"),
+          )
+      )
+
+  public val icon_16694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16694.xml"),
+          )
+      )
+
+  public val icon_16695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16695.xml"),
+          )
+      )
+
+  public val icon_16696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16696.xml"),
+          )
+      )
+
+  public val icon_16697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16697.xml"),
+          )
+      )
+
+  public val icon_16698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16698.xml"),
+          )
+      )
+
+  public val icon_16699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16699.xml"),
+          )
+      )
+
+  public val icon_167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_167.xml"),
+          )
+      )
+
+  public val icon_1670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1670.xml"),
+          )
+      )
+
+  public val icon_16700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16700.xml"),
+          )
+      )
+
+  public val icon_16701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16701.xml"),
+          )
+      )
+
+  public val icon_16702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16702.xml"),
+          )
+      )
+
+  public val icon_16703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16703.xml"),
+          )
+      )
+
+  public val icon_16704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16704.xml"),
+          )
+      )
+
+  public val icon_16705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16705.xml"),
+          )
+      )
+
+  public val icon_16706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16706.xml"),
+          )
+      )
+
+  public val icon_16707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16707.xml"),
+          )
+      )
+
+  public val icon_16708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16708.xml"),
+          )
+      )
+
+  public val icon_16709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16709.xml"),
+          )
+      )
+
+  public val icon_1671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1671.xml"),
+          )
+      )
+
+  public val icon_16710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16710.xml"),
+          )
+      )
+
+  public val icon_16711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16711.xml"),
+          )
+      )
+
+  public val icon_16712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16712.xml"),
+          )
+      )
+
+  public val icon_16713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16713.xml"),
+          )
+      )
+
+  public val icon_16714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16714.xml"),
+          )
+      )
+
+  public val icon_16715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16715.xml"),
+          )
+      )
+
+  public val icon_16716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16716.xml"),
+          )
+      )
+
+  public val icon_16717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16717.xml"),
+          )
+      )
+
+  public val icon_16718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16718.xml"),
+          )
+      )
+
+  public val icon_16719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16719.xml"),
+          )
+      )
+
+  public val icon_1672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1672.xml"),
+          )
+      )
+
+  public val icon_16720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16720.xml"),
+          )
+      )
+
+  public val icon_16721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16721.xml"),
+          )
+      )
+
+  public val icon_16722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16722.xml"),
+          )
+      )
+
+  public val icon_16723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16723.xml"),
+          )
+      )
+
+  public val icon_16724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16724.xml"),
+          )
+      )
+
+  public val icon_16725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16725.xml"),
+          )
+      )
+
+  public val icon_16726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16726.xml"),
+          )
+      )
+
+  public val icon_16727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16727.xml"),
+          )
+      )
+
+  public val icon_16728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16728.xml"),
+          )
+      )
+
+  public val icon_16729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16729.xml"),
+          )
+      )
+
+  public val icon_1673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1673.xml"),
+          )
+      )
+
+  public val icon_16730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16730.xml"),
+          )
+      )
+
+  public val icon_16731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16731.xml"),
+          )
+      )
+
+  public val icon_16732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16732.xml"),
+          )
+      )
+
+  public val icon_16733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16733.xml"),
+          )
+      )
+
+  public val icon_16734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16734.xml"),
+          )
+      )
+
+  public val icon_16735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16735.xml"),
+          )
+      )
+
+  public val icon_16736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16736.xml"),
+          )
+      )
+
+  public val icon_16737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16737.xml"),
+          )
+      )
+
+  public val icon_16738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16738.xml"),
+          )
+      )
+
+  public val icon_16739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16739.xml"),
+          )
+      )
+
+  public val icon_1674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1674.xml"),
+          )
+      )
+
+  public val icon_16740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16740.xml"),
+          )
+      )
+
+  public val icon_16741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16741.xml"),
+          )
+      )
+
+  public val icon_16742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16742.xml"),
+          )
+      )
+
+  public val icon_16743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16743.xml"),
+          )
+      )
+
+  public val icon_16744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16744.xml"),
+          )
+      )
+
+  public val icon_16745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16745.xml"),
+          )
+      )
+
+  public val icon_16746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16746.xml"),
+          )
+      )
+
+  public val icon_16747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16747.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16298: DrawableResource
+  get() = Drawable14.icon_16298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16299: DrawableResource
+  get() = Drawable14.icon_16299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_163: DrawableResource
+  get() = Drawable14.icon_163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1630: DrawableResource
+  get() = Drawable14.icon_1630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16300: DrawableResource
+  get() = Drawable14.icon_16300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16301: DrawableResource
+  get() = Drawable14.icon_16301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16302: DrawableResource
+  get() = Drawable14.icon_16302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16303: DrawableResource
+  get() = Drawable14.icon_16303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16304: DrawableResource
+  get() = Drawable14.icon_16304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16305: DrawableResource
+  get() = Drawable14.icon_16305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16306: DrawableResource
+  get() = Drawable14.icon_16306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16307: DrawableResource
+  get() = Drawable14.icon_16307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16308: DrawableResource
+  get() = Drawable14.icon_16308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16309: DrawableResource
+  get() = Drawable14.icon_16309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1631: DrawableResource
+  get() = Drawable14.icon_1631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16310: DrawableResource
+  get() = Drawable14.icon_16310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16311: DrawableResource
+  get() = Drawable14.icon_16311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16312: DrawableResource
+  get() = Drawable14.icon_16312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16313: DrawableResource
+  get() = Drawable14.icon_16313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16314: DrawableResource
+  get() = Drawable14.icon_16314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16315: DrawableResource
+  get() = Drawable14.icon_16315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16316: DrawableResource
+  get() = Drawable14.icon_16316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16317: DrawableResource
+  get() = Drawable14.icon_16317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16318: DrawableResource
+  get() = Drawable14.icon_16318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16319: DrawableResource
+  get() = Drawable14.icon_16319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1632: DrawableResource
+  get() = Drawable14.icon_1632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16320: DrawableResource
+  get() = Drawable14.icon_16320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16321: DrawableResource
+  get() = Drawable14.icon_16321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16322: DrawableResource
+  get() = Drawable14.icon_16322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16323: DrawableResource
+  get() = Drawable14.icon_16323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16324: DrawableResource
+  get() = Drawable14.icon_16324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16325: DrawableResource
+  get() = Drawable14.icon_16325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16326: DrawableResource
+  get() = Drawable14.icon_16326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16327: DrawableResource
+  get() = Drawable14.icon_16327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16328: DrawableResource
+  get() = Drawable14.icon_16328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16329: DrawableResource
+  get() = Drawable14.icon_16329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1633: DrawableResource
+  get() = Drawable14.icon_1633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16330: DrawableResource
+  get() = Drawable14.icon_16330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16331: DrawableResource
+  get() = Drawable14.icon_16331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16332: DrawableResource
+  get() = Drawable14.icon_16332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16333: DrawableResource
+  get() = Drawable14.icon_16333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16334: DrawableResource
+  get() = Drawable14.icon_16334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16335: DrawableResource
+  get() = Drawable14.icon_16335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16336: DrawableResource
+  get() = Drawable14.icon_16336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16337: DrawableResource
+  get() = Drawable14.icon_16337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16338: DrawableResource
+  get() = Drawable14.icon_16338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16339: DrawableResource
+  get() = Drawable14.icon_16339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1634: DrawableResource
+  get() = Drawable14.icon_1634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16340: DrawableResource
+  get() = Drawable14.icon_16340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16341: DrawableResource
+  get() = Drawable14.icon_16341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16342: DrawableResource
+  get() = Drawable14.icon_16342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16343: DrawableResource
+  get() = Drawable14.icon_16343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16344: DrawableResource
+  get() = Drawable14.icon_16344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16345: DrawableResource
+  get() = Drawable14.icon_16345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16346: DrawableResource
+  get() = Drawable14.icon_16346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16347: DrawableResource
+  get() = Drawable14.icon_16347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16348: DrawableResource
+  get() = Drawable14.icon_16348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16349: DrawableResource
+  get() = Drawable14.icon_16349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1635: DrawableResource
+  get() = Drawable14.icon_1635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16350: DrawableResource
+  get() = Drawable14.icon_16350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16351: DrawableResource
+  get() = Drawable14.icon_16351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16352: DrawableResource
+  get() = Drawable14.icon_16352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16353: DrawableResource
+  get() = Drawable14.icon_16353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16354: DrawableResource
+  get() = Drawable14.icon_16354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16355: DrawableResource
+  get() = Drawable14.icon_16355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16356: DrawableResource
+  get() = Drawable14.icon_16356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16357: DrawableResource
+  get() = Drawable14.icon_16357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16358: DrawableResource
+  get() = Drawable14.icon_16358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16359: DrawableResource
+  get() = Drawable14.icon_16359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1636: DrawableResource
+  get() = Drawable14.icon_1636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16360: DrawableResource
+  get() = Drawable14.icon_16360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16361: DrawableResource
+  get() = Drawable14.icon_16361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16362: DrawableResource
+  get() = Drawable14.icon_16362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16363: DrawableResource
+  get() = Drawable14.icon_16363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16364: DrawableResource
+  get() = Drawable14.icon_16364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16365: DrawableResource
+  get() = Drawable14.icon_16365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16366: DrawableResource
+  get() = Drawable14.icon_16366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16367: DrawableResource
+  get() = Drawable14.icon_16367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16368: DrawableResource
+  get() = Drawable14.icon_16368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16369: DrawableResource
+  get() = Drawable14.icon_16369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1637: DrawableResource
+  get() = Drawable14.icon_1637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16370: DrawableResource
+  get() = Drawable14.icon_16370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16371: DrawableResource
+  get() = Drawable14.icon_16371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16372: DrawableResource
+  get() = Drawable14.icon_16372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16373: DrawableResource
+  get() = Drawable14.icon_16373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16374: DrawableResource
+  get() = Drawable14.icon_16374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16375: DrawableResource
+  get() = Drawable14.icon_16375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16376: DrawableResource
+  get() = Drawable14.icon_16376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16377: DrawableResource
+  get() = Drawable14.icon_16377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16378: DrawableResource
+  get() = Drawable14.icon_16378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16379: DrawableResource
+  get() = Drawable14.icon_16379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1638: DrawableResource
+  get() = Drawable14.icon_1638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16380: DrawableResource
+  get() = Drawable14.icon_16380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16381: DrawableResource
+  get() = Drawable14.icon_16381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16382: DrawableResource
+  get() = Drawable14.icon_16382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16383: DrawableResource
+  get() = Drawable14.icon_16383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16384: DrawableResource
+  get() = Drawable14.icon_16384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16385: DrawableResource
+  get() = Drawable14.icon_16385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16386: DrawableResource
+  get() = Drawable14.icon_16386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16387: DrawableResource
+  get() = Drawable14.icon_16387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16388: DrawableResource
+  get() = Drawable14.icon_16388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16389: DrawableResource
+  get() = Drawable14.icon_16389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1639: DrawableResource
+  get() = Drawable14.icon_1639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16390: DrawableResource
+  get() = Drawable14.icon_16390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16391: DrawableResource
+  get() = Drawable14.icon_16391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16392: DrawableResource
+  get() = Drawable14.icon_16392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16393: DrawableResource
+  get() = Drawable14.icon_16393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16394: DrawableResource
+  get() = Drawable14.icon_16394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16395: DrawableResource
+  get() = Drawable14.icon_16395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16396: DrawableResource
+  get() = Drawable14.icon_16396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16397: DrawableResource
+  get() = Drawable14.icon_16397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16398: DrawableResource
+  get() = Drawable14.icon_16398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16399: DrawableResource
+  get() = Drawable14.icon_16399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_164: DrawableResource
+  get() = Drawable14.icon_164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1640: DrawableResource
+  get() = Drawable14.icon_1640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16400: DrawableResource
+  get() = Drawable14.icon_16400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16401: DrawableResource
+  get() = Drawable14.icon_16401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16402: DrawableResource
+  get() = Drawable14.icon_16402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16403: DrawableResource
+  get() = Drawable14.icon_16403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16404: DrawableResource
+  get() = Drawable14.icon_16404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16405: DrawableResource
+  get() = Drawable14.icon_16405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16406: DrawableResource
+  get() = Drawable14.icon_16406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16407: DrawableResource
+  get() = Drawable14.icon_16407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16408: DrawableResource
+  get() = Drawable14.icon_16408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16409: DrawableResource
+  get() = Drawable14.icon_16409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1641: DrawableResource
+  get() = Drawable14.icon_1641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16410: DrawableResource
+  get() = Drawable14.icon_16410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16411: DrawableResource
+  get() = Drawable14.icon_16411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16412: DrawableResource
+  get() = Drawable14.icon_16412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16413: DrawableResource
+  get() = Drawable14.icon_16413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16414: DrawableResource
+  get() = Drawable14.icon_16414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16415: DrawableResource
+  get() = Drawable14.icon_16415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16416: DrawableResource
+  get() = Drawable14.icon_16416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16417: DrawableResource
+  get() = Drawable14.icon_16417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16418: DrawableResource
+  get() = Drawable14.icon_16418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16419: DrawableResource
+  get() = Drawable14.icon_16419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1642: DrawableResource
+  get() = Drawable14.icon_1642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16420: DrawableResource
+  get() = Drawable14.icon_16420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16421: DrawableResource
+  get() = Drawable14.icon_16421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16422: DrawableResource
+  get() = Drawable14.icon_16422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16423: DrawableResource
+  get() = Drawable14.icon_16423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16424: DrawableResource
+  get() = Drawable14.icon_16424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16425: DrawableResource
+  get() = Drawable14.icon_16425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16426: DrawableResource
+  get() = Drawable14.icon_16426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16427: DrawableResource
+  get() = Drawable14.icon_16427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16428: DrawableResource
+  get() = Drawable14.icon_16428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16429: DrawableResource
+  get() = Drawable14.icon_16429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1643: DrawableResource
+  get() = Drawable14.icon_1643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16430: DrawableResource
+  get() = Drawable14.icon_16430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16431: DrawableResource
+  get() = Drawable14.icon_16431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16432: DrawableResource
+  get() = Drawable14.icon_16432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16433: DrawableResource
+  get() = Drawable14.icon_16433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16434: DrawableResource
+  get() = Drawable14.icon_16434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16435: DrawableResource
+  get() = Drawable14.icon_16435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16436: DrawableResource
+  get() = Drawable14.icon_16436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16437: DrawableResource
+  get() = Drawable14.icon_16437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16438: DrawableResource
+  get() = Drawable14.icon_16438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16439: DrawableResource
+  get() = Drawable14.icon_16439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1644: DrawableResource
+  get() = Drawable14.icon_1644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16440: DrawableResource
+  get() = Drawable14.icon_16440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16441: DrawableResource
+  get() = Drawable14.icon_16441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16442: DrawableResource
+  get() = Drawable14.icon_16442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16443: DrawableResource
+  get() = Drawable14.icon_16443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16444: DrawableResource
+  get() = Drawable14.icon_16444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16445: DrawableResource
+  get() = Drawable14.icon_16445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16446: DrawableResource
+  get() = Drawable14.icon_16446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16447: DrawableResource
+  get() = Drawable14.icon_16447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16448: DrawableResource
+  get() = Drawable14.icon_16448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16449: DrawableResource
+  get() = Drawable14.icon_16449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1645: DrawableResource
+  get() = Drawable14.icon_1645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16450: DrawableResource
+  get() = Drawable14.icon_16450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16451: DrawableResource
+  get() = Drawable14.icon_16451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16452: DrawableResource
+  get() = Drawable14.icon_16452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16453: DrawableResource
+  get() = Drawable14.icon_16453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16454: DrawableResource
+  get() = Drawable14.icon_16454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16455: DrawableResource
+  get() = Drawable14.icon_16455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16456: DrawableResource
+  get() = Drawable14.icon_16456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16457: DrawableResource
+  get() = Drawable14.icon_16457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16458: DrawableResource
+  get() = Drawable14.icon_16458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16459: DrawableResource
+  get() = Drawable14.icon_16459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1646: DrawableResource
+  get() = Drawable14.icon_1646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16460: DrawableResource
+  get() = Drawable14.icon_16460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16461: DrawableResource
+  get() = Drawable14.icon_16461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16462: DrawableResource
+  get() = Drawable14.icon_16462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16463: DrawableResource
+  get() = Drawable14.icon_16463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16464: DrawableResource
+  get() = Drawable14.icon_16464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16465: DrawableResource
+  get() = Drawable14.icon_16465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16466: DrawableResource
+  get() = Drawable14.icon_16466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16467: DrawableResource
+  get() = Drawable14.icon_16467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16468: DrawableResource
+  get() = Drawable14.icon_16468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16469: DrawableResource
+  get() = Drawable14.icon_16469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1647: DrawableResource
+  get() = Drawable14.icon_1647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16470: DrawableResource
+  get() = Drawable14.icon_16470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16471: DrawableResource
+  get() = Drawable14.icon_16471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16472: DrawableResource
+  get() = Drawable14.icon_16472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16473: DrawableResource
+  get() = Drawable14.icon_16473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16474: DrawableResource
+  get() = Drawable14.icon_16474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16475: DrawableResource
+  get() = Drawable14.icon_16475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16476: DrawableResource
+  get() = Drawable14.icon_16476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16477: DrawableResource
+  get() = Drawable14.icon_16477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16478: DrawableResource
+  get() = Drawable14.icon_16478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16479: DrawableResource
+  get() = Drawable14.icon_16479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1648: DrawableResource
+  get() = Drawable14.icon_1648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16480: DrawableResource
+  get() = Drawable14.icon_16480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16481: DrawableResource
+  get() = Drawable14.icon_16481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16482: DrawableResource
+  get() = Drawable14.icon_16482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16483: DrawableResource
+  get() = Drawable14.icon_16483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16484: DrawableResource
+  get() = Drawable14.icon_16484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16485: DrawableResource
+  get() = Drawable14.icon_16485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16486: DrawableResource
+  get() = Drawable14.icon_16486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16487: DrawableResource
+  get() = Drawable14.icon_16487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16488: DrawableResource
+  get() = Drawable14.icon_16488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16489: DrawableResource
+  get() = Drawable14.icon_16489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1649: DrawableResource
+  get() = Drawable14.icon_1649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16490: DrawableResource
+  get() = Drawable14.icon_16490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16491: DrawableResource
+  get() = Drawable14.icon_16491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16492: DrawableResource
+  get() = Drawable14.icon_16492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16493: DrawableResource
+  get() = Drawable14.icon_16493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16494: DrawableResource
+  get() = Drawable14.icon_16494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16495: DrawableResource
+  get() = Drawable14.icon_16495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16496: DrawableResource
+  get() = Drawable14.icon_16496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16497: DrawableResource
+  get() = Drawable14.icon_16497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16498: DrawableResource
+  get() = Drawable14.icon_16498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16499: DrawableResource
+  get() = Drawable14.icon_16499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_165: DrawableResource
+  get() = Drawable14.icon_165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1650: DrawableResource
+  get() = Drawable14.icon_1650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16500: DrawableResource
+  get() = Drawable14.icon_16500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16501: DrawableResource
+  get() = Drawable14.icon_16501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16502: DrawableResource
+  get() = Drawable14.icon_16502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16503: DrawableResource
+  get() = Drawable14.icon_16503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16504: DrawableResource
+  get() = Drawable14.icon_16504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16505: DrawableResource
+  get() = Drawable14.icon_16505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16506: DrawableResource
+  get() = Drawable14.icon_16506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16507: DrawableResource
+  get() = Drawable14.icon_16507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16508: DrawableResource
+  get() = Drawable14.icon_16508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16509: DrawableResource
+  get() = Drawable14.icon_16509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1651: DrawableResource
+  get() = Drawable14.icon_1651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16510: DrawableResource
+  get() = Drawable14.icon_16510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16511: DrawableResource
+  get() = Drawable14.icon_16511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16512: DrawableResource
+  get() = Drawable14.icon_16512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16513: DrawableResource
+  get() = Drawable14.icon_16513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16514: DrawableResource
+  get() = Drawable14.icon_16514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16515: DrawableResource
+  get() = Drawable14.icon_16515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16516: DrawableResource
+  get() = Drawable14.icon_16516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16517: DrawableResource
+  get() = Drawable14.icon_16517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16518: DrawableResource
+  get() = Drawable14.icon_16518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16519: DrawableResource
+  get() = Drawable14.icon_16519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1652: DrawableResource
+  get() = Drawable14.icon_1652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16520: DrawableResource
+  get() = Drawable14.icon_16520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16521: DrawableResource
+  get() = Drawable14.icon_16521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16522: DrawableResource
+  get() = Drawable14.icon_16522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16523: DrawableResource
+  get() = Drawable14.icon_16523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16524: DrawableResource
+  get() = Drawable14.icon_16524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16525: DrawableResource
+  get() = Drawable14.icon_16525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16526: DrawableResource
+  get() = Drawable14.icon_16526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16527: DrawableResource
+  get() = Drawable14.icon_16527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16528: DrawableResource
+  get() = Drawable14.icon_16528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16529: DrawableResource
+  get() = Drawable14.icon_16529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1653: DrawableResource
+  get() = Drawable14.icon_1653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16530: DrawableResource
+  get() = Drawable14.icon_16530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16531: DrawableResource
+  get() = Drawable14.icon_16531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16532: DrawableResource
+  get() = Drawable14.icon_16532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16533: DrawableResource
+  get() = Drawable14.icon_16533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16534: DrawableResource
+  get() = Drawable14.icon_16534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16535: DrawableResource
+  get() = Drawable14.icon_16535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16536: DrawableResource
+  get() = Drawable14.icon_16536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16537: DrawableResource
+  get() = Drawable14.icon_16537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16538: DrawableResource
+  get() = Drawable14.icon_16538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16539: DrawableResource
+  get() = Drawable14.icon_16539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1654: DrawableResource
+  get() = Drawable14.icon_1654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16540: DrawableResource
+  get() = Drawable14.icon_16540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16541: DrawableResource
+  get() = Drawable14.icon_16541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16542: DrawableResource
+  get() = Drawable14.icon_16542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16543: DrawableResource
+  get() = Drawable14.icon_16543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16544: DrawableResource
+  get() = Drawable14.icon_16544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16545: DrawableResource
+  get() = Drawable14.icon_16545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16546: DrawableResource
+  get() = Drawable14.icon_16546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16547: DrawableResource
+  get() = Drawable14.icon_16547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16548: DrawableResource
+  get() = Drawable14.icon_16548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16549: DrawableResource
+  get() = Drawable14.icon_16549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1655: DrawableResource
+  get() = Drawable14.icon_1655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16550: DrawableResource
+  get() = Drawable14.icon_16550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16551: DrawableResource
+  get() = Drawable14.icon_16551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16552: DrawableResource
+  get() = Drawable14.icon_16552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16553: DrawableResource
+  get() = Drawable14.icon_16553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16554: DrawableResource
+  get() = Drawable14.icon_16554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16555: DrawableResource
+  get() = Drawable14.icon_16555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16556: DrawableResource
+  get() = Drawable14.icon_16556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16557: DrawableResource
+  get() = Drawable14.icon_16557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16558: DrawableResource
+  get() = Drawable14.icon_16558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16559: DrawableResource
+  get() = Drawable14.icon_16559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1656: DrawableResource
+  get() = Drawable14.icon_1656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16560: DrawableResource
+  get() = Drawable14.icon_16560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16561: DrawableResource
+  get() = Drawable14.icon_16561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16562: DrawableResource
+  get() = Drawable14.icon_16562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16563: DrawableResource
+  get() = Drawable14.icon_16563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16564: DrawableResource
+  get() = Drawable14.icon_16564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16565: DrawableResource
+  get() = Drawable14.icon_16565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16566: DrawableResource
+  get() = Drawable14.icon_16566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16567: DrawableResource
+  get() = Drawable14.icon_16567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16568: DrawableResource
+  get() = Drawable14.icon_16568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16569: DrawableResource
+  get() = Drawable14.icon_16569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1657: DrawableResource
+  get() = Drawable14.icon_1657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16570: DrawableResource
+  get() = Drawable14.icon_16570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16571: DrawableResource
+  get() = Drawable14.icon_16571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16572: DrawableResource
+  get() = Drawable14.icon_16572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16573: DrawableResource
+  get() = Drawable14.icon_16573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16574: DrawableResource
+  get() = Drawable14.icon_16574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16575: DrawableResource
+  get() = Drawable14.icon_16575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16576: DrawableResource
+  get() = Drawable14.icon_16576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16577: DrawableResource
+  get() = Drawable14.icon_16577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16578: DrawableResource
+  get() = Drawable14.icon_16578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16579: DrawableResource
+  get() = Drawable14.icon_16579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1658: DrawableResource
+  get() = Drawable14.icon_1658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16580: DrawableResource
+  get() = Drawable14.icon_16580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16581: DrawableResource
+  get() = Drawable14.icon_16581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16582: DrawableResource
+  get() = Drawable14.icon_16582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16583: DrawableResource
+  get() = Drawable14.icon_16583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16584: DrawableResource
+  get() = Drawable14.icon_16584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16585: DrawableResource
+  get() = Drawable14.icon_16585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16586: DrawableResource
+  get() = Drawable14.icon_16586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16587: DrawableResource
+  get() = Drawable14.icon_16587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16588: DrawableResource
+  get() = Drawable14.icon_16588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16589: DrawableResource
+  get() = Drawable14.icon_16589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1659: DrawableResource
+  get() = Drawable14.icon_1659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16590: DrawableResource
+  get() = Drawable14.icon_16590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16591: DrawableResource
+  get() = Drawable14.icon_16591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16592: DrawableResource
+  get() = Drawable14.icon_16592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16593: DrawableResource
+  get() = Drawable14.icon_16593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16594: DrawableResource
+  get() = Drawable14.icon_16594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16595: DrawableResource
+  get() = Drawable14.icon_16595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16596: DrawableResource
+  get() = Drawable14.icon_16596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16597: DrawableResource
+  get() = Drawable14.icon_16597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16598: DrawableResource
+  get() = Drawable14.icon_16598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16599: DrawableResource
+  get() = Drawable14.icon_16599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_166: DrawableResource
+  get() = Drawable14.icon_166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1660: DrawableResource
+  get() = Drawable14.icon_1660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16600: DrawableResource
+  get() = Drawable14.icon_16600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16601: DrawableResource
+  get() = Drawable14.icon_16601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16602: DrawableResource
+  get() = Drawable14.icon_16602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16603: DrawableResource
+  get() = Drawable14.icon_16603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16604: DrawableResource
+  get() = Drawable14.icon_16604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16605: DrawableResource
+  get() = Drawable14.icon_16605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16606: DrawableResource
+  get() = Drawable14.icon_16606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16607: DrawableResource
+  get() = Drawable14.icon_16607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16608: DrawableResource
+  get() = Drawable14.icon_16608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16609: DrawableResource
+  get() = Drawable14.icon_16609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1661: DrawableResource
+  get() = Drawable14.icon_1661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16610: DrawableResource
+  get() = Drawable14.icon_16610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16611: DrawableResource
+  get() = Drawable14.icon_16611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16612: DrawableResource
+  get() = Drawable14.icon_16612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16613: DrawableResource
+  get() = Drawable14.icon_16613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16614: DrawableResource
+  get() = Drawable14.icon_16614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16615: DrawableResource
+  get() = Drawable14.icon_16615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16616: DrawableResource
+  get() = Drawable14.icon_16616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16617: DrawableResource
+  get() = Drawable14.icon_16617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16618: DrawableResource
+  get() = Drawable14.icon_16618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16619: DrawableResource
+  get() = Drawable14.icon_16619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1662: DrawableResource
+  get() = Drawable14.icon_1662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16620: DrawableResource
+  get() = Drawable14.icon_16620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16621: DrawableResource
+  get() = Drawable14.icon_16621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16622: DrawableResource
+  get() = Drawable14.icon_16622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16623: DrawableResource
+  get() = Drawable14.icon_16623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16624: DrawableResource
+  get() = Drawable14.icon_16624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16625: DrawableResource
+  get() = Drawable14.icon_16625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16626: DrawableResource
+  get() = Drawable14.icon_16626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16627: DrawableResource
+  get() = Drawable14.icon_16627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16628: DrawableResource
+  get() = Drawable14.icon_16628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16629: DrawableResource
+  get() = Drawable14.icon_16629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1663: DrawableResource
+  get() = Drawable14.icon_1663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16630: DrawableResource
+  get() = Drawable14.icon_16630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16631: DrawableResource
+  get() = Drawable14.icon_16631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16632: DrawableResource
+  get() = Drawable14.icon_16632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16633: DrawableResource
+  get() = Drawable14.icon_16633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16634: DrawableResource
+  get() = Drawable14.icon_16634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16635: DrawableResource
+  get() = Drawable14.icon_16635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16636: DrawableResource
+  get() = Drawable14.icon_16636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16637: DrawableResource
+  get() = Drawable14.icon_16637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16638: DrawableResource
+  get() = Drawable14.icon_16638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16639: DrawableResource
+  get() = Drawable14.icon_16639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1664: DrawableResource
+  get() = Drawable14.icon_1664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16640: DrawableResource
+  get() = Drawable14.icon_16640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16641: DrawableResource
+  get() = Drawable14.icon_16641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16642: DrawableResource
+  get() = Drawable14.icon_16642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16643: DrawableResource
+  get() = Drawable14.icon_16643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16644: DrawableResource
+  get() = Drawable14.icon_16644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16645: DrawableResource
+  get() = Drawable14.icon_16645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16646: DrawableResource
+  get() = Drawable14.icon_16646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16647: DrawableResource
+  get() = Drawable14.icon_16647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16648: DrawableResource
+  get() = Drawable14.icon_16648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16649: DrawableResource
+  get() = Drawable14.icon_16649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1665: DrawableResource
+  get() = Drawable14.icon_1665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16650: DrawableResource
+  get() = Drawable14.icon_16650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16651: DrawableResource
+  get() = Drawable14.icon_16651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16652: DrawableResource
+  get() = Drawable14.icon_16652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16653: DrawableResource
+  get() = Drawable14.icon_16653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16654: DrawableResource
+  get() = Drawable14.icon_16654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16655: DrawableResource
+  get() = Drawable14.icon_16655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16656: DrawableResource
+  get() = Drawable14.icon_16656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16657: DrawableResource
+  get() = Drawable14.icon_16657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16658: DrawableResource
+  get() = Drawable14.icon_16658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16659: DrawableResource
+  get() = Drawable14.icon_16659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1666: DrawableResource
+  get() = Drawable14.icon_1666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16660: DrawableResource
+  get() = Drawable14.icon_16660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16661: DrawableResource
+  get() = Drawable14.icon_16661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16662: DrawableResource
+  get() = Drawable14.icon_16662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16663: DrawableResource
+  get() = Drawable14.icon_16663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16664: DrawableResource
+  get() = Drawable14.icon_16664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16665: DrawableResource
+  get() = Drawable14.icon_16665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16666: DrawableResource
+  get() = Drawable14.icon_16666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16667: DrawableResource
+  get() = Drawable14.icon_16667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16668: DrawableResource
+  get() = Drawable14.icon_16668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16669: DrawableResource
+  get() = Drawable14.icon_16669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1667: DrawableResource
+  get() = Drawable14.icon_1667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16670: DrawableResource
+  get() = Drawable14.icon_16670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16671: DrawableResource
+  get() = Drawable14.icon_16671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16672: DrawableResource
+  get() = Drawable14.icon_16672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16673: DrawableResource
+  get() = Drawable14.icon_16673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16674: DrawableResource
+  get() = Drawable14.icon_16674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16675: DrawableResource
+  get() = Drawable14.icon_16675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16676: DrawableResource
+  get() = Drawable14.icon_16676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16677: DrawableResource
+  get() = Drawable14.icon_16677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16678: DrawableResource
+  get() = Drawable14.icon_16678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16679: DrawableResource
+  get() = Drawable14.icon_16679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1668: DrawableResource
+  get() = Drawable14.icon_1668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16680: DrawableResource
+  get() = Drawable14.icon_16680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16681: DrawableResource
+  get() = Drawable14.icon_16681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16682: DrawableResource
+  get() = Drawable14.icon_16682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16683: DrawableResource
+  get() = Drawable14.icon_16683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16684: DrawableResource
+  get() = Drawable14.icon_16684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16685: DrawableResource
+  get() = Drawable14.icon_16685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16686: DrawableResource
+  get() = Drawable14.icon_16686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16687: DrawableResource
+  get() = Drawable14.icon_16687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16688: DrawableResource
+  get() = Drawable14.icon_16688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16689: DrawableResource
+  get() = Drawable14.icon_16689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1669: DrawableResource
+  get() = Drawable14.icon_1669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16690: DrawableResource
+  get() = Drawable14.icon_16690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16691: DrawableResource
+  get() = Drawable14.icon_16691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16692: DrawableResource
+  get() = Drawable14.icon_16692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16693: DrawableResource
+  get() = Drawable14.icon_16693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16694: DrawableResource
+  get() = Drawable14.icon_16694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16695: DrawableResource
+  get() = Drawable14.icon_16695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16696: DrawableResource
+  get() = Drawable14.icon_16696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16697: DrawableResource
+  get() = Drawable14.icon_16697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16698: DrawableResource
+  get() = Drawable14.icon_16698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16699: DrawableResource
+  get() = Drawable14.icon_16699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_167: DrawableResource
+  get() = Drawable14.icon_167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1670: DrawableResource
+  get() = Drawable14.icon_1670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16700: DrawableResource
+  get() = Drawable14.icon_16700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16701: DrawableResource
+  get() = Drawable14.icon_16701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16702: DrawableResource
+  get() = Drawable14.icon_16702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16703: DrawableResource
+  get() = Drawable14.icon_16703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16704: DrawableResource
+  get() = Drawable14.icon_16704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16705: DrawableResource
+  get() = Drawable14.icon_16705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16706: DrawableResource
+  get() = Drawable14.icon_16706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16707: DrawableResource
+  get() = Drawable14.icon_16707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16708: DrawableResource
+  get() = Drawable14.icon_16708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16709: DrawableResource
+  get() = Drawable14.icon_16709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1671: DrawableResource
+  get() = Drawable14.icon_1671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16710: DrawableResource
+  get() = Drawable14.icon_16710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16711: DrawableResource
+  get() = Drawable14.icon_16711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16712: DrawableResource
+  get() = Drawable14.icon_16712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16713: DrawableResource
+  get() = Drawable14.icon_16713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16714: DrawableResource
+  get() = Drawable14.icon_16714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16715: DrawableResource
+  get() = Drawable14.icon_16715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16716: DrawableResource
+  get() = Drawable14.icon_16716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16717: DrawableResource
+  get() = Drawable14.icon_16717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16718: DrawableResource
+  get() = Drawable14.icon_16718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16719: DrawableResource
+  get() = Drawable14.icon_16719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1672: DrawableResource
+  get() = Drawable14.icon_1672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16720: DrawableResource
+  get() = Drawable14.icon_16720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16721: DrawableResource
+  get() = Drawable14.icon_16721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16722: DrawableResource
+  get() = Drawable14.icon_16722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16723: DrawableResource
+  get() = Drawable14.icon_16723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16724: DrawableResource
+  get() = Drawable14.icon_16724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16725: DrawableResource
+  get() = Drawable14.icon_16725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16726: DrawableResource
+  get() = Drawable14.icon_16726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16727: DrawableResource
+  get() = Drawable14.icon_16727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16728: DrawableResource
+  get() = Drawable14.icon_16728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16729: DrawableResource
+  get() = Drawable14.icon_16729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1673: DrawableResource
+  get() = Drawable14.icon_1673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16730: DrawableResource
+  get() = Drawable14.icon_16730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16731: DrawableResource
+  get() = Drawable14.icon_16731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16732: DrawableResource
+  get() = Drawable14.icon_16732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16733: DrawableResource
+  get() = Drawable14.icon_16733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16734: DrawableResource
+  get() = Drawable14.icon_16734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16735: DrawableResource
+  get() = Drawable14.icon_16735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16736: DrawableResource
+  get() = Drawable14.icon_16736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16737: DrawableResource
+  get() = Drawable14.icon_16737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16738: DrawableResource
+  get() = Drawable14.icon_16738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16739: DrawableResource
+  get() = Drawable14.icon_16739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1674: DrawableResource
+  get() = Drawable14.icon_1674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16740: DrawableResource
+  get() = Drawable14.icon_16740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16741: DrawableResource
+  get() = Drawable14.icon_16741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16742: DrawableResource
+  get() = Drawable14.icon_16742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16743: DrawableResource
+  get() = Drawable14.icon_16743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16744: DrawableResource
+  get() = Drawable14.icon_16744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16745: DrawableResource
+  get() = Drawable14.icon_16745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16746: DrawableResource
+  get() = Drawable14.icon_16746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16747: DrawableResource
+  get() = Drawable14.icon_16747

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable15.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable15.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable15 {
+  public val icon_16748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16748.xml"),
+          )
+      )
+
+  public val icon_16749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16749.xml"),
+          )
+      )
+
+  public val icon_1675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1675.xml"),
+          )
+      )
+
+  public val icon_16750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16750.xml"),
+          )
+      )
+
+  public val icon_16751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16751.xml"),
+          )
+      )
+
+  public val icon_16752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16752.xml"),
+          )
+      )
+
+  public val icon_16753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16753.xml"),
+          )
+      )
+
+  public val icon_16754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16754.xml"),
+          )
+      )
+
+  public val icon_16755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16755.xml"),
+          )
+      )
+
+  public val icon_16756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16756.xml"),
+          )
+      )
+
+  public val icon_16757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16757.xml"),
+          )
+      )
+
+  public val icon_16758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16758.xml"),
+          )
+      )
+
+  public val icon_16759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16759.xml"),
+          )
+      )
+
+  public val icon_1676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1676.xml"),
+          )
+      )
+
+  public val icon_16760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16760.xml"),
+          )
+      )
+
+  public val icon_16761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16761.xml"),
+          )
+      )
+
+  public val icon_16762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16762.xml"),
+          )
+      )
+
+  public val icon_16763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16763.xml"),
+          )
+      )
+
+  public val icon_16764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16764.xml"),
+          )
+      )
+
+  public val icon_16765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16765.xml"),
+          )
+      )
+
+  public val icon_16766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16766.xml"),
+          )
+      )
+
+  public val icon_16767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16767.xml"),
+          )
+      )
+
+  public val icon_16768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16768.xml"),
+          )
+      )
+
+  public val icon_16769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16769.xml"),
+          )
+      )
+
+  public val icon_1677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1677.xml"),
+          )
+      )
+
+  public val icon_16770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16770.xml"),
+          )
+      )
+
+  public val icon_16771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16771.xml"),
+          )
+      )
+
+  public val icon_16772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16772.xml"),
+          )
+      )
+
+  public val icon_16773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16773.xml"),
+          )
+      )
+
+  public val icon_16774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16774.xml"),
+          )
+      )
+
+  public val icon_16775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16775.xml"),
+          )
+      )
+
+  public val icon_16776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16776.xml"),
+          )
+      )
+
+  public val icon_16777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16777.xml"),
+          )
+      )
+
+  public val icon_16778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16778.xml"),
+          )
+      )
+
+  public val icon_16779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16779.xml"),
+          )
+      )
+
+  public val icon_1678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1678.xml"),
+          )
+      )
+
+  public val icon_16780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16780.xml"),
+          )
+      )
+
+  public val icon_16781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16781.xml"),
+          )
+      )
+
+  public val icon_16782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16782.xml"),
+          )
+      )
+
+  public val icon_16783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16783.xml"),
+          )
+      )
+
+  public val icon_16784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16784.xml"),
+          )
+      )
+
+  public val icon_16785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16785.xml"),
+          )
+      )
+
+  public val icon_16786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16786.xml"),
+          )
+      )
+
+  public val icon_16787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16787.xml"),
+          )
+      )
+
+  public val icon_16788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16788.xml"),
+          )
+      )
+
+  public val icon_16789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16789.xml"),
+          )
+      )
+
+  public val icon_1679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1679.xml"),
+          )
+      )
+
+  public val icon_16790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16790.xml"),
+          )
+      )
+
+  public val icon_16791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16791.xml"),
+          )
+      )
+
+  public val icon_16792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16792.xml"),
+          )
+      )
+
+  public val icon_16793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16793.xml"),
+          )
+      )
+
+  public val icon_16794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16794.xml"),
+          )
+      )
+
+  public val icon_16795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16795.xml"),
+          )
+      )
+
+  public val icon_16796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16796.xml"),
+          )
+      )
+
+  public val icon_16797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16797.xml"),
+          )
+      )
+
+  public val icon_16798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16798.xml"),
+          )
+      )
+
+  public val icon_16799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16799.xml"),
+          )
+      )
+
+  public val icon_168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_168.xml"),
+          )
+      )
+
+  public val icon_1680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1680.xml"),
+          )
+      )
+
+  public val icon_16800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16800.xml"),
+          )
+      )
+
+  public val icon_16801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16801.xml"),
+          )
+      )
+
+  public val icon_16802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16802.xml"),
+          )
+      )
+
+  public val icon_16803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16803.xml"),
+          )
+      )
+
+  public val icon_16804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16804.xml"),
+          )
+      )
+
+  public val icon_16805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16805.xml"),
+          )
+      )
+
+  public val icon_16806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16806.xml"),
+          )
+      )
+
+  public val icon_16807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16807.xml"),
+          )
+      )
+
+  public val icon_16808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16808.xml"),
+          )
+      )
+
+  public val icon_16809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16809.xml"),
+          )
+      )
+
+  public val icon_1681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1681.xml"),
+          )
+      )
+
+  public val icon_16810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16810.xml"),
+          )
+      )
+
+  public val icon_16811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16811.xml"),
+          )
+      )
+
+  public val icon_16812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16812.xml"),
+          )
+      )
+
+  public val icon_16813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16813.xml"),
+          )
+      )
+
+  public val icon_16814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16814.xml"),
+          )
+      )
+
+  public val icon_16815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16815.xml"),
+          )
+      )
+
+  public val icon_16816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16816.xml"),
+          )
+      )
+
+  public val icon_16817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16817.xml"),
+          )
+      )
+
+  public val icon_16818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16818.xml"),
+          )
+      )
+
+  public val icon_16819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16819.xml"),
+          )
+      )
+
+  public val icon_1682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1682.xml"),
+          )
+      )
+
+  public val icon_16820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16820.xml"),
+          )
+      )
+
+  public val icon_16821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16821.xml"),
+          )
+      )
+
+  public val icon_16822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16822.xml"),
+          )
+      )
+
+  public val icon_16823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16823.xml"),
+          )
+      )
+
+  public val icon_16824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16824.xml"),
+          )
+      )
+
+  public val icon_16825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16825.xml"),
+          )
+      )
+
+  public val icon_16826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16826.xml"),
+          )
+      )
+
+  public val icon_16827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16827.xml"),
+          )
+      )
+
+  public val icon_16828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16828.xml"),
+          )
+      )
+
+  public val icon_16829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16829.xml"),
+          )
+      )
+
+  public val icon_1683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1683.xml"),
+          )
+      )
+
+  public val icon_16830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16830.xml"),
+          )
+      )
+
+  public val icon_16831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16831.xml"),
+          )
+      )
+
+  public val icon_16832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16832.xml"),
+          )
+      )
+
+  public val icon_16833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16833.xml"),
+          )
+      )
+
+  public val icon_16834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16834.xml"),
+          )
+      )
+
+  public val icon_16835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16835.xml"),
+          )
+      )
+
+  public val icon_16836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16836.xml"),
+          )
+      )
+
+  public val icon_16837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16837.xml"),
+          )
+      )
+
+  public val icon_16838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16838.xml"),
+          )
+      )
+
+  public val icon_16839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16839.xml"),
+          )
+      )
+
+  public val icon_1684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1684.xml"),
+          )
+      )
+
+  public val icon_16840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16840.xml"),
+          )
+      )
+
+  public val icon_16841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16841.xml"),
+          )
+      )
+
+  public val icon_16842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16842.xml"),
+          )
+      )
+
+  public val icon_16843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16843.xml"),
+          )
+      )
+
+  public val icon_16844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16844.xml"),
+          )
+      )
+
+  public val icon_16845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16845.xml"),
+          )
+      )
+
+  public val icon_16846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16846.xml"),
+          )
+      )
+
+  public val icon_16847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16847.xml"),
+          )
+      )
+
+  public val icon_16848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16848.xml"),
+          )
+      )
+
+  public val icon_16849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16849.xml"),
+          )
+      )
+
+  public val icon_1685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1685.xml"),
+          )
+      )
+
+  public val icon_16850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16850.xml"),
+          )
+      )
+
+  public val icon_16851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16851.xml"),
+          )
+      )
+
+  public val icon_16852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16852.xml"),
+          )
+      )
+
+  public val icon_16853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16853.xml"),
+          )
+      )
+
+  public val icon_16854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16854.xml"),
+          )
+      )
+
+  public val icon_16855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16855.xml"),
+          )
+      )
+
+  public val icon_16856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16856.xml"),
+          )
+      )
+
+  public val icon_16857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16857.xml"),
+          )
+      )
+
+  public val icon_16858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16858.xml"),
+          )
+      )
+
+  public val icon_16859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16859.xml"),
+          )
+      )
+
+  public val icon_1686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1686.xml"),
+          )
+      )
+
+  public val icon_16860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16860.xml"),
+          )
+      )
+
+  public val icon_16861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16861.xml"),
+          )
+      )
+
+  public val icon_16862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16862.xml"),
+          )
+      )
+
+  public val icon_16863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16863.xml"),
+          )
+      )
+
+  public val icon_16864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16864.xml"),
+          )
+      )
+
+  public val icon_16865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16865.xml"),
+          )
+      )
+
+  public val icon_16866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16866.xml"),
+          )
+      )
+
+  public val icon_16867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16867.xml"),
+          )
+      )
+
+  public val icon_16868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16868.xml"),
+          )
+      )
+
+  public val icon_16869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16869.xml"),
+          )
+      )
+
+  public val icon_1687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1687.xml"),
+          )
+      )
+
+  public val icon_16870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16870.xml"),
+          )
+      )
+
+  public val icon_16871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16871.xml"),
+          )
+      )
+
+  public val icon_16872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16872.xml"),
+          )
+      )
+
+  public val icon_16873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16873.xml"),
+          )
+      )
+
+  public val icon_16874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16874.xml"),
+          )
+      )
+
+  public val icon_16875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16875.xml"),
+          )
+      )
+
+  public val icon_16876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16876.xml"),
+          )
+      )
+
+  public val icon_16877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16877.xml"),
+          )
+      )
+
+  public val icon_16878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16878.xml"),
+          )
+      )
+
+  public val icon_16879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16879.xml"),
+          )
+      )
+
+  public val icon_1688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1688.xml"),
+          )
+      )
+
+  public val icon_16880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16880.xml"),
+          )
+      )
+
+  public val icon_16881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16881.xml"),
+          )
+      )
+
+  public val icon_16882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16882.xml"),
+          )
+      )
+
+  public val icon_16883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16883.xml"),
+          )
+      )
+
+  public val icon_16884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16884.xml"),
+          )
+      )
+
+  public val icon_16885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16885.xml"),
+          )
+      )
+
+  public val icon_16886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16886.xml"),
+          )
+      )
+
+  public val icon_16887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16887.xml"),
+          )
+      )
+
+  public val icon_16888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16888.xml"),
+          )
+      )
+
+  public val icon_16889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16889.xml"),
+          )
+      )
+
+  public val icon_1689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1689.xml"),
+          )
+      )
+
+  public val icon_16890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16890.xml"),
+          )
+      )
+
+  public val icon_16891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16891.xml"),
+          )
+      )
+
+  public val icon_16892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16892.xml"),
+          )
+      )
+
+  public val icon_16893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16893.xml"),
+          )
+      )
+
+  public val icon_16894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16894.xml"),
+          )
+      )
+
+  public val icon_16895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16895.xml"),
+          )
+      )
+
+  public val icon_16896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16896.xml"),
+          )
+      )
+
+  public val icon_16897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16897.xml"),
+          )
+      )
+
+  public val icon_16898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16898.xml"),
+          )
+      )
+
+  public val icon_16899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16899.xml"),
+          )
+      )
+
+  public val icon_169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_169.xml"),
+          )
+      )
+
+  public val icon_1690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1690.xml"),
+          )
+      )
+
+  public val icon_16900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16900.xml"),
+          )
+      )
+
+  public val icon_16901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16901.xml"),
+          )
+      )
+
+  public val icon_16902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16902.xml"),
+          )
+      )
+
+  public val icon_16903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16903.xml"),
+          )
+      )
+
+  public val icon_16904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16904.xml"),
+          )
+      )
+
+  public val icon_16905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16905.xml"),
+          )
+      )
+
+  public val icon_16906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16906.xml"),
+          )
+      )
+
+  public val icon_16907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16907.xml"),
+          )
+      )
+
+  public val icon_16908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16908.xml"),
+          )
+      )
+
+  public val icon_16909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16909.xml"),
+          )
+      )
+
+  public val icon_1691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1691.xml"),
+          )
+      )
+
+  public val icon_16910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16910.xml"),
+          )
+      )
+
+  public val icon_16911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16911.xml"),
+          )
+      )
+
+  public val icon_16912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16912.xml"),
+          )
+      )
+
+  public val icon_16913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16913.xml"),
+          )
+      )
+
+  public val icon_16914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16914.xml"),
+          )
+      )
+
+  public val icon_16915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16915.xml"),
+          )
+      )
+
+  public val icon_16916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16916.xml"),
+          )
+      )
+
+  public val icon_16917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16917.xml"),
+          )
+      )
+
+  public val icon_16918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16918.xml"),
+          )
+      )
+
+  public val icon_16919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16919.xml"),
+          )
+      )
+
+  public val icon_1692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1692.xml"),
+          )
+      )
+
+  public val icon_16920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16920.xml"),
+          )
+      )
+
+  public val icon_16921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16921.xml"),
+          )
+      )
+
+  public val icon_16922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16922.xml"),
+          )
+      )
+
+  public val icon_16923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16923.xml"),
+          )
+      )
+
+  public val icon_16924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16924.xml"),
+          )
+      )
+
+  public val icon_16925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16925.xml"),
+          )
+      )
+
+  public val icon_16926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16926.xml"),
+          )
+      )
+
+  public val icon_16927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16927.xml"),
+          )
+      )
+
+  public val icon_16928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16928.xml"),
+          )
+      )
+
+  public val icon_16929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16929.xml"),
+          )
+      )
+
+  public val icon_1693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1693.xml"),
+          )
+      )
+
+  public val icon_16930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16930.xml"),
+          )
+      )
+
+  public val icon_16931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16931.xml"),
+          )
+      )
+
+  public val icon_16932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16932.xml"),
+          )
+      )
+
+  public val icon_16933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16933.xml"),
+          )
+      )
+
+  public val icon_16934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16934.xml"),
+          )
+      )
+
+  public val icon_16935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16935.xml"),
+          )
+      )
+
+  public val icon_16936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16936.xml"),
+          )
+      )
+
+  public val icon_16937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16937.xml"),
+          )
+      )
+
+  public val icon_16938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16938.xml"),
+          )
+      )
+
+  public val icon_16939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16939.xml"),
+          )
+      )
+
+  public val icon_1694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1694.xml"),
+          )
+      )
+
+  public val icon_16940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16940.xml"),
+          )
+      )
+
+  public val icon_16941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16941.xml"),
+          )
+      )
+
+  public val icon_16942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16942.xml"),
+          )
+      )
+
+  public val icon_16943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16943.xml"),
+          )
+      )
+
+  public val icon_16944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16944.xml"),
+          )
+      )
+
+  public val icon_16945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16945.xml"),
+          )
+      )
+
+  public val icon_16946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16946.xml"),
+          )
+      )
+
+  public val icon_16947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16947.xml"),
+          )
+      )
+
+  public val icon_16948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16948.xml"),
+          )
+      )
+
+  public val icon_16949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16949.xml"),
+          )
+      )
+
+  public val icon_1695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1695.xml"),
+          )
+      )
+
+  public val icon_16950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16950.xml"),
+          )
+      )
+
+  public val icon_16951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16951.xml"),
+          )
+      )
+
+  public val icon_16952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16952.xml"),
+          )
+      )
+
+  public val icon_16953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16953.xml"),
+          )
+      )
+
+  public val icon_16954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16954.xml"),
+          )
+      )
+
+  public val icon_16955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16955.xml"),
+          )
+      )
+
+  public val icon_16956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16956.xml"),
+          )
+      )
+
+  public val icon_16957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16957.xml"),
+          )
+      )
+
+  public val icon_16958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16958.xml"),
+          )
+      )
+
+  public val icon_16959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16959.xml"),
+          )
+      )
+
+  public val icon_1696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1696.xml"),
+          )
+      )
+
+  public val icon_16960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16960.xml"),
+          )
+      )
+
+  public val icon_16961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16961.xml"),
+          )
+      )
+
+  public val icon_16962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16962.xml"),
+          )
+      )
+
+  public val icon_16963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16963.xml"),
+          )
+      )
+
+  public val icon_16964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16964.xml"),
+          )
+      )
+
+  public val icon_16965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16965.xml"),
+          )
+      )
+
+  public val icon_16966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16966.xml"),
+          )
+      )
+
+  public val icon_16967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16967.xml"),
+          )
+      )
+
+  public val icon_16968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16968.xml"),
+          )
+      )
+
+  public val icon_16969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16969.xml"),
+          )
+      )
+
+  public val icon_1697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1697.xml"),
+          )
+      )
+
+  public val icon_16970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16970.xml"),
+          )
+      )
+
+  public val icon_16971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16971.xml"),
+          )
+      )
+
+  public val icon_16972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16972.xml"),
+          )
+      )
+
+  public val icon_16973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16973.xml"),
+          )
+      )
+
+  public val icon_16974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16974.xml"),
+          )
+      )
+
+  public val icon_16975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16975.xml"),
+          )
+      )
+
+  public val icon_16976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16976.xml"),
+          )
+      )
+
+  public val icon_16977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16977.xml"),
+          )
+      )
+
+  public val icon_16978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16978.xml"),
+          )
+      )
+
+  public val icon_16979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16979.xml"),
+          )
+      )
+
+  public val icon_1698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1698.xml"),
+          )
+      )
+
+  public val icon_16980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16980.xml"),
+          )
+      )
+
+  public val icon_16981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16981.xml"),
+          )
+      )
+
+  public val icon_16982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16982.xml"),
+          )
+      )
+
+  public val icon_16983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16983.xml"),
+          )
+      )
+
+  public val icon_16984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16984.xml"),
+          )
+      )
+
+  public val icon_16985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16985.xml"),
+          )
+      )
+
+  public val icon_16986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16986.xml"),
+          )
+      )
+
+  public val icon_16987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16987.xml"),
+          )
+      )
+
+  public val icon_16988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16988.xml"),
+          )
+      )
+
+  public val icon_16989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16989.xml"),
+          )
+      )
+
+  public val icon_1699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1699.xml"),
+          )
+      )
+
+  public val icon_16990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16990.xml"),
+          )
+      )
+
+  public val icon_16991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16991.xml"),
+          )
+      )
+
+  public val icon_16992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16992.xml"),
+          )
+      )
+
+  public val icon_16993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16993.xml"),
+          )
+      )
+
+  public val icon_16994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16994.xml"),
+          )
+      )
+
+  public val icon_16995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16995.xml"),
+          )
+      )
+
+  public val icon_16996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16996.xml"),
+          )
+      )
+
+  public val icon_16997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16997.xml"),
+          )
+      )
+
+  public val icon_16998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16998.xml"),
+          )
+      )
+
+  public val icon_16999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_16999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_16999.xml"),
+          )
+      )
+
+  public val icon_17: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17.xml"),
+          )
+      )
+
+  public val icon_170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_170.xml"),
+          )
+      )
+
+  public val icon_1700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1700.xml"),
+          )
+      )
+
+  public val icon_17000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17000.xml"),
+          )
+      )
+
+  public val icon_17001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17001.xml"),
+          )
+      )
+
+  public val icon_17002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17002.xml"),
+          )
+      )
+
+  public val icon_17003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17003.xml"),
+          )
+      )
+
+  public val icon_17004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17004.xml"),
+          )
+      )
+
+  public val icon_17005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17005.xml"),
+          )
+      )
+
+  public val icon_17006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17006.xml"),
+          )
+      )
+
+  public val icon_17007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17007.xml"),
+          )
+      )
+
+  public val icon_17008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17008.xml"),
+          )
+      )
+
+  public val icon_17009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17009.xml"),
+          )
+      )
+
+  public val icon_1701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1701.xml"),
+          )
+      )
+
+  public val icon_17010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17010.xml"),
+          )
+      )
+
+  public val icon_17011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17011.xml"),
+          )
+      )
+
+  public val icon_17012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17012.xml"),
+          )
+      )
+
+  public val icon_17013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17013.xml"),
+          )
+      )
+
+  public val icon_17014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17014.xml"),
+          )
+      )
+
+  public val icon_17015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17015.xml"),
+          )
+      )
+
+  public val icon_17016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17016.xml"),
+          )
+      )
+
+  public val icon_17017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17017.xml"),
+          )
+      )
+
+  public val icon_17018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17018.xml"),
+          )
+      )
+
+  public val icon_17019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17019.xml"),
+          )
+      )
+
+  public val icon_1702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1702.xml"),
+          )
+      )
+
+  public val icon_17020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17020.xml"),
+          )
+      )
+
+  public val icon_17021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17021.xml"),
+          )
+      )
+
+  public val icon_17022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17022.xml"),
+          )
+      )
+
+  public val icon_17023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17023.xml"),
+          )
+      )
+
+  public val icon_17024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17024.xml"),
+          )
+      )
+
+  public val icon_17025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17025.xml"),
+          )
+      )
+
+  public val icon_17026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17026.xml"),
+          )
+      )
+
+  public val icon_17027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17027.xml"),
+          )
+      )
+
+  public val icon_17028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17028.xml"),
+          )
+      )
+
+  public val icon_17029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17029.xml"),
+          )
+      )
+
+  public val icon_1703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1703.xml"),
+          )
+      )
+
+  public val icon_17030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17030.xml"),
+          )
+      )
+
+  public val icon_17031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17031.xml"),
+          )
+      )
+
+  public val icon_17032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17032.xml"),
+          )
+      )
+
+  public val icon_17033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17033.xml"),
+          )
+      )
+
+  public val icon_17034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17034.xml"),
+          )
+      )
+
+  public val icon_17035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17035.xml"),
+          )
+      )
+
+  public val icon_17036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17036.xml"),
+          )
+      )
+
+  public val icon_17037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17037.xml"),
+          )
+      )
+
+  public val icon_17038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17038.xml"),
+          )
+      )
+
+  public val icon_17039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17039.xml"),
+          )
+      )
+
+  public val icon_1704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1704.xml"),
+          )
+      )
+
+  public val icon_17040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17040.xml"),
+          )
+      )
+
+  public val icon_17041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17041.xml"),
+          )
+      )
+
+  public val icon_17042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17042.xml"),
+          )
+      )
+
+  public val icon_17043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17043.xml"),
+          )
+      )
+
+  public val icon_17044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17044.xml"),
+          )
+      )
+
+  public val icon_17045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17045.xml"),
+          )
+      )
+
+  public val icon_17046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17046.xml"),
+          )
+      )
+
+  public val icon_17047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17047.xml"),
+          )
+      )
+
+  public val icon_17048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17048.xml"),
+          )
+      )
+
+  public val icon_17049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17049.xml"),
+          )
+      )
+
+  public val icon_1705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1705.xml"),
+          )
+      )
+
+  public val icon_17050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17050.xml"),
+          )
+      )
+
+  public val icon_17051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17051.xml"),
+          )
+      )
+
+  public val icon_17052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17052.xml"),
+          )
+      )
+
+  public val icon_17053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17053.xml"),
+          )
+      )
+
+  public val icon_17054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17054.xml"),
+          )
+      )
+
+  public val icon_17055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17055.xml"),
+          )
+      )
+
+  public val icon_17056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17056.xml"),
+          )
+      )
+
+  public val icon_17057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17057.xml"),
+          )
+      )
+
+  public val icon_17058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17058.xml"),
+          )
+      )
+
+  public val icon_17059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17059.xml"),
+          )
+      )
+
+  public val icon_1706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1706.xml"),
+          )
+      )
+
+  public val icon_17060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17060.xml"),
+          )
+      )
+
+  public val icon_17061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17061.xml"),
+          )
+      )
+
+  public val icon_17062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17062.xml"),
+          )
+      )
+
+  public val icon_17063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17063.xml"),
+          )
+      )
+
+  public val icon_17064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17064.xml"),
+          )
+      )
+
+  public val icon_17065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17065.xml"),
+          )
+      )
+
+  public val icon_17066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17066.xml"),
+          )
+      )
+
+  public val icon_17067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17067.xml"),
+          )
+      )
+
+  public val icon_17068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17068.xml"),
+          )
+      )
+
+  public val icon_17069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17069.xml"),
+          )
+      )
+
+  public val icon_1707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1707.xml"),
+          )
+      )
+
+  public val icon_17070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17070.xml"),
+          )
+      )
+
+  public val icon_17071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17071.xml"),
+          )
+      )
+
+  public val icon_17072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17072.xml"),
+          )
+      )
+
+  public val icon_17073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17073.xml"),
+          )
+      )
+
+  public val icon_17074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17074.xml"),
+          )
+      )
+
+  public val icon_17075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17075.xml"),
+          )
+      )
+
+  public val icon_17076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17076.xml"),
+          )
+      )
+
+  public val icon_17077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17077.xml"),
+          )
+      )
+
+  public val icon_17078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17078.xml"),
+          )
+      )
+
+  public val icon_17079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17079.xml"),
+          )
+      )
+
+  public val icon_1708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1708.xml"),
+          )
+      )
+
+  public val icon_17080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17080.xml"),
+          )
+      )
+
+  public val icon_17081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17081.xml"),
+          )
+      )
+
+  public val icon_17082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17082.xml"),
+          )
+      )
+
+  public val icon_17083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17083.xml"),
+          )
+      )
+
+  public val icon_17084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17084.xml"),
+          )
+      )
+
+  public val icon_17085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17085.xml"),
+          )
+      )
+
+  public val icon_17086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17086.xml"),
+          )
+      )
+
+  public val icon_17087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17087.xml"),
+          )
+      )
+
+  public val icon_17088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17088.xml"),
+          )
+      )
+
+  public val icon_17089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17089.xml"),
+          )
+      )
+
+  public val icon_1709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1709.xml"),
+          )
+      )
+
+  public val icon_17090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17090.xml"),
+          )
+      )
+
+  public val icon_17091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17091.xml"),
+          )
+      )
+
+  public val icon_17092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17092.xml"),
+          )
+      )
+
+  public val icon_17093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17093.xml"),
+          )
+      )
+
+  public val icon_17094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17094.xml"),
+          )
+      )
+
+  public val icon_17095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17095.xml"),
+          )
+      )
+
+  public val icon_17096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17096.xml"),
+          )
+      )
+
+  public val icon_17097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17097.xml"),
+          )
+      )
+
+  public val icon_17098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17098.xml"),
+          )
+      )
+
+  public val icon_17099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17099.xml"),
+          )
+      )
+
+  public val icon_171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_171.xml"),
+          )
+      )
+
+  public val icon_1710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1710.xml"),
+          )
+      )
+
+  public val icon_17100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17100.xml"),
+          )
+      )
+
+  public val icon_17101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17101.xml"),
+          )
+      )
+
+  public val icon_17102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17102.xml"),
+          )
+      )
+
+  public val icon_17103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17103.xml"),
+          )
+      )
+
+  public val icon_17104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17104.xml"),
+          )
+      )
+
+  public val icon_17105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17105.xml"),
+          )
+      )
+
+  public val icon_17106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17106.xml"),
+          )
+      )
+
+  public val icon_17107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17107.xml"),
+          )
+      )
+
+  public val icon_17108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17108.xml"),
+          )
+      )
+
+  public val icon_17109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17109.xml"),
+          )
+      )
+
+  public val icon_1711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1711.xml"),
+          )
+      )
+
+  public val icon_17110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17110.xml"),
+          )
+      )
+
+  public val icon_17111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17111.xml"),
+          )
+      )
+
+  public val icon_17112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17112.xml"),
+          )
+      )
+
+  public val icon_17113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17113.xml"),
+          )
+      )
+
+  public val icon_17114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17114.xml"),
+          )
+      )
+
+  public val icon_17115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17115.xml"),
+          )
+      )
+
+  public val icon_17116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17116.xml"),
+          )
+      )
+
+  public val icon_17117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17117.xml"),
+          )
+      )
+
+  public val icon_17118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17118.xml"),
+          )
+      )
+
+  public val icon_17119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17119.xml"),
+          )
+      )
+
+  public val icon_1712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1712.xml"),
+          )
+      )
+
+  public val icon_17120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17120.xml"),
+          )
+      )
+
+  public val icon_17121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17121.xml"),
+          )
+      )
+
+  public val icon_17122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17122.xml"),
+          )
+      )
+
+  public val icon_17123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17123.xml"),
+          )
+      )
+
+  public val icon_17124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17124.xml"),
+          )
+      )
+
+  public val icon_17125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17125.xml"),
+          )
+      )
+
+  public val icon_17126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17126.xml"),
+          )
+      )
+
+  public val icon_17127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17127.xml"),
+          )
+      )
+
+  public val icon_17128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17128.xml"),
+          )
+      )
+
+  public val icon_17129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17129.xml"),
+          )
+      )
+
+  public val icon_1713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1713.xml"),
+          )
+      )
+
+  public val icon_17130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17130.xml"),
+          )
+      )
+
+  public val icon_17131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17131.xml"),
+          )
+      )
+
+  public val icon_17132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17132.xml"),
+          )
+      )
+
+  public val icon_17133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17133.xml"),
+          )
+      )
+
+  public val icon_17134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17134.xml"),
+          )
+      )
+
+  public val icon_17135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17135.xml"),
+          )
+      )
+
+  public val icon_17136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17136.xml"),
+          )
+      )
+
+  public val icon_17137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17137.xml"),
+          )
+      )
+
+  public val icon_17138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17138.xml"),
+          )
+      )
+
+  public val icon_17139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17139.xml"),
+          )
+      )
+
+  public val icon_1714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1714.xml"),
+          )
+      )
+
+  public val icon_17140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17140.xml"),
+          )
+      )
+
+  public val icon_17141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17141.xml"),
+          )
+      )
+
+  public val icon_17142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17142.xml"),
+          )
+      )
+
+  public val icon_17143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17143.xml"),
+          )
+      )
+
+  public val icon_17144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17144.xml"),
+          )
+      )
+
+  public val icon_17145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17145.xml"),
+          )
+      )
+
+  public val icon_17146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17146.xml"),
+          )
+      )
+
+  public val icon_17147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17147.xml"),
+          )
+      )
+
+  public val icon_17148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17148.xml"),
+          )
+      )
+
+  public val icon_17149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17149.xml"),
+          )
+      )
+
+  public val icon_1715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1715.xml"),
+          )
+      )
+
+  public val icon_17150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17150.xml"),
+          )
+      )
+
+  public val icon_17151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17151.xml"),
+          )
+      )
+
+  public val icon_17152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17152.xml"),
+          )
+      )
+
+  public val icon_17153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17153.xml"),
+          )
+      )
+
+  public val icon_17154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17154.xml"),
+          )
+      )
+
+  public val icon_17155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17155.xml"),
+          )
+      )
+
+  public val icon_17156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17156.xml"),
+          )
+      )
+
+  public val icon_17157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17157.xml"),
+          )
+      )
+
+  public val icon_17158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17158.xml"),
+          )
+      )
+
+  public val icon_17159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17159.xml"),
+          )
+      )
+
+  public val icon_1716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1716.xml"),
+          )
+      )
+
+  public val icon_17160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17160.xml"),
+          )
+      )
+
+  public val icon_17161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17161.xml"),
+          )
+      )
+
+  public val icon_17162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17162.xml"),
+          )
+      )
+
+  public val icon_17163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17163.xml"),
+          )
+      )
+
+  public val icon_17164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17164.xml"),
+          )
+      )
+
+  public val icon_17165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17165.xml"),
+          )
+      )
+
+  public val icon_17166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17166.xml"),
+          )
+      )
+
+  public val icon_17167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17167.xml"),
+          )
+      )
+
+  public val icon_17168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17168.xml"),
+          )
+      )
+
+  public val icon_17169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17169.xml"),
+          )
+      )
+
+  public val icon_1717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1717.xml"),
+          )
+      )
+
+  public val icon_17170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17170.xml"),
+          )
+      )
+
+  public val icon_17171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17171.xml"),
+          )
+      )
+
+  public val icon_17172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17172.xml"),
+          )
+      )
+
+  public val icon_17173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17173.xml"),
+          )
+      )
+
+  public val icon_17174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17174.xml"),
+          )
+      )
+
+  public val icon_17175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17175.xml"),
+          )
+      )
+
+  public val icon_17176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17176.xml"),
+          )
+      )
+
+  public val icon_17177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17177.xml"),
+          )
+      )
+
+  public val icon_17178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17178.xml"),
+          )
+      )
+
+  public val icon_17179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17179.xml"),
+          )
+      )
+
+  public val icon_1718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1718.xml"),
+          )
+      )
+
+  public val icon_17180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17180.xml"),
+          )
+      )
+
+  public val icon_17181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17181.xml"),
+          )
+      )
+
+  public val icon_17182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17182.xml"),
+          )
+      )
+
+  public val icon_17183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17183.xml"),
+          )
+      )
+
+  public val icon_17184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17184.xml"),
+          )
+      )
+
+  public val icon_17185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17185.xml"),
+          )
+      )
+
+  public val icon_17186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17186.xml"),
+          )
+      )
+
+  public val icon_17187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17187.xml"),
+          )
+      )
+
+  public val icon_17188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17188.xml"),
+          )
+      )
+
+  public val icon_17189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17189.xml"),
+          )
+      )
+
+  public val icon_1719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1719.xml"),
+          )
+      )
+
+  public val icon_17190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17190.xml"),
+          )
+      )
+
+  public val icon_17191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17191.xml"),
+          )
+      )
+
+  public val icon_17192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17192.xml"),
+          )
+      )
+
+  public val icon_17193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17193.xml"),
+          )
+      )
+
+  public val icon_17194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17194.xml"),
+          )
+      )
+
+  public val icon_17195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17195.xml"),
+          )
+      )
+
+  public val icon_17196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17196.xml"),
+          )
+      )
+
+  public val icon_17197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17197.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16748: DrawableResource
+  get() = Drawable15.icon_16748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16749: DrawableResource
+  get() = Drawable15.icon_16749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1675: DrawableResource
+  get() = Drawable15.icon_1675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16750: DrawableResource
+  get() = Drawable15.icon_16750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16751: DrawableResource
+  get() = Drawable15.icon_16751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16752: DrawableResource
+  get() = Drawable15.icon_16752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16753: DrawableResource
+  get() = Drawable15.icon_16753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16754: DrawableResource
+  get() = Drawable15.icon_16754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16755: DrawableResource
+  get() = Drawable15.icon_16755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16756: DrawableResource
+  get() = Drawable15.icon_16756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16757: DrawableResource
+  get() = Drawable15.icon_16757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16758: DrawableResource
+  get() = Drawable15.icon_16758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16759: DrawableResource
+  get() = Drawable15.icon_16759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1676: DrawableResource
+  get() = Drawable15.icon_1676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16760: DrawableResource
+  get() = Drawable15.icon_16760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16761: DrawableResource
+  get() = Drawable15.icon_16761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16762: DrawableResource
+  get() = Drawable15.icon_16762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16763: DrawableResource
+  get() = Drawable15.icon_16763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16764: DrawableResource
+  get() = Drawable15.icon_16764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16765: DrawableResource
+  get() = Drawable15.icon_16765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16766: DrawableResource
+  get() = Drawable15.icon_16766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16767: DrawableResource
+  get() = Drawable15.icon_16767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16768: DrawableResource
+  get() = Drawable15.icon_16768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16769: DrawableResource
+  get() = Drawable15.icon_16769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1677: DrawableResource
+  get() = Drawable15.icon_1677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16770: DrawableResource
+  get() = Drawable15.icon_16770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16771: DrawableResource
+  get() = Drawable15.icon_16771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16772: DrawableResource
+  get() = Drawable15.icon_16772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16773: DrawableResource
+  get() = Drawable15.icon_16773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16774: DrawableResource
+  get() = Drawable15.icon_16774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16775: DrawableResource
+  get() = Drawable15.icon_16775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16776: DrawableResource
+  get() = Drawable15.icon_16776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16777: DrawableResource
+  get() = Drawable15.icon_16777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16778: DrawableResource
+  get() = Drawable15.icon_16778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16779: DrawableResource
+  get() = Drawable15.icon_16779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1678: DrawableResource
+  get() = Drawable15.icon_1678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16780: DrawableResource
+  get() = Drawable15.icon_16780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16781: DrawableResource
+  get() = Drawable15.icon_16781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16782: DrawableResource
+  get() = Drawable15.icon_16782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16783: DrawableResource
+  get() = Drawable15.icon_16783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16784: DrawableResource
+  get() = Drawable15.icon_16784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16785: DrawableResource
+  get() = Drawable15.icon_16785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16786: DrawableResource
+  get() = Drawable15.icon_16786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16787: DrawableResource
+  get() = Drawable15.icon_16787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16788: DrawableResource
+  get() = Drawable15.icon_16788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16789: DrawableResource
+  get() = Drawable15.icon_16789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1679: DrawableResource
+  get() = Drawable15.icon_1679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16790: DrawableResource
+  get() = Drawable15.icon_16790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16791: DrawableResource
+  get() = Drawable15.icon_16791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16792: DrawableResource
+  get() = Drawable15.icon_16792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16793: DrawableResource
+  get() = Drawable15.icon_16793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16794: DrawableResource
+  get() = Drawable15.icon_16794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16795: DrawableResource
+  get() = Drawable15.icon_16795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16796: DrawableResource
+  get() = Drawable15.icon_16796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16797: DrawableResource
+  get() = Drawable15.icon_16797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16798: DrawableResource
+  get() = Drawable15.icon_16798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16799: DrawableResource
+  get() = Drawable15.icon_16799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_168: DrawableResource
+  get() = Drawable15.icon_168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1680: DrawableResource
+  get() = Drawable15.icon_1680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16800: DrawableResource
+  get() = Drawable15.icon_16800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16801: DrawableResource
+  get() = Drawable15.icon_16801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16802: DrawableResource
+  get() = Drawable15.icon_16802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16803: DrawableResource
+  get() = Drawable15.icon_16803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16804: DrawableResource
+  get() = Drawable15.icon_16804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16805: DrawableResource
+  get() = Drawable15.icon_16805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16806: DrawableResource
+  get() = Drawable15.icon_16806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16807: DrawableResource
+  get() = Drawable15.icon_16807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16808: DrawableResource
+  get() = Drawable15.icon_16808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16809: DrawableResource
+  get() = Drawable15.icon_16809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1681: DrawableResource
+  get() = Drawable15.icon_1681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16810: DrawableResource
+  get() = Drawable15.icon_16810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16811: DrawableResource
+  get() = Drawable15.icon_16811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16812: DrawableResource
+  get() = Drawable15.icon_16812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16813: DrawableResource
+  get() = Drawable15.icon_16813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16814: DrawableResource
+  get() = Drawable15.icon_16814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16815: DrawableResource
+  get() = Drawable15.icon_16815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16816: DrawableResource
+  get() = Drawable15.icon_16816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16817: DrawableResource
+  get() = Drawable15.icon_16817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16818: DrawableResource
+  get() = Drawable15.icon_16818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16819: DrawableResource
+  get() = Drawable15.icon_16819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1682: DrawableResource
+  get() = Drawable15.icon_1682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16820: DrawableResource
+  get() = Drawable15.icon_16820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16821: DrawableResource
+  get() = Drawable15.icon_16821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16822: DrawableResource
+  get() = Drawable15.icon_16822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16823: DrawableResource
+  get() = Drawable15.icon_16823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16824: DrawableResource
+  get() = Drawable15.icon_16824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16825: DrawableResource
+  get() = Drawable15.icon_16825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16826: DrawableResource
+  get() = Drawable15.icon_16826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16827: DrawableResource
+  get() = Drawable15.icon_16827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16828: DrawableResource
+  get() = Drawable15.icon_16828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16829: DrawableResource
+  get() = Drawable15.icon_16829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1683: DrawableResource
+  get() = Drawable15.icon_1683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16830: DrawableResource
+  get() = Drawable15.icon_16830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16831: DrawableResource
+  get() = Drawable15.icon_16831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16832: DrawableResource
+  get() = Drawable15.icon_16832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16833: DrawableResource
+  get() = Drawable15.icon_16833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16834: DrawableResource
+  get() = Drawable15.icon_16834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16835: DrawableResource
+  get() = Drawable15.icon_16835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16836: DrawableResource
+  get() = Drawable15.icon_16836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16837: DrawableResource
+  get() = Drawable15.icon_16837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16838: DrawableResource
+  get() = Drawable15.icon_16838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16839: DrawableResource
+  get() = Drawable15.icon_16839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1684: DrawableResource
+  get() = Drawable15.icon_1684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16840: DrawableResource
+  get() = Drawable15.icon_16840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16841: DrawableResource
+  get() = Drawable15.icon_16841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16842: DrawableResource
+  get() = Drawable15.icon_16842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16843: DrawableResource
+  get() = Drawable15.icon_16843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16844: DrawableResource
+  get() = Drawable15.icon_16844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16845: DrawableResource
+  get() = Drawable15.icon_16845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16846: DrawableResource
+  get() = Drawable15.icon_16846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16847: DrawableResource
+  get() = Drawable15.icon_16847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16848: DrawableResource
+  get() = Drawable15.icon_16848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16849: DrawableResource
+  get() = Drawable15.icon_16849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1685: DrawableResource
+  get() = Drawable15.icon_1685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16850: DrawableResource
+  get() = Drawable15.icon_16850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16851: DrawableResource
+  get() = Drawable15.icon_16851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16852: DrawableResource
+  get() = Drawable15.icon_16852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16853: DrawableResource
+  get() = Drawable15.icon_16853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16854: DrawableResource
+  get() = Drawable15.icon_16854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16855: DrawableResource
+  get() = Drawable15.icon_16855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16856: DrawableResource
+  get() = Drawable15.icon_16856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16857: DrawableResource
+  get() = Drawable15.icon_16857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16858: DrawableResource
+  get() = Drawable15.icon_16858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16859: DrawableResource
+  get() = Drawable15.icon_16859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1686: DrawableResource
+  get() = Drawable15.icon_1686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16860: DrawableResource
+  get() = Drawable15.icon_16860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16861: DrawableResource
+  get() = Drawable15.icon_16861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16862: DrawableResource
+  get() = Drawable15.icon_16862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16863: DrawableResource
+  get() = Drawable15.icon_16863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16864: DrawableResource
+  get() = Drawable15.icon_16864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16865: DrawableResource
+  get() = Drawable15.icon_16865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16866: DrawableResource
+  get() = Drawable15.icon_16866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16867: DrawableResource
+  get() = Drawable15.icon_16867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16868: DrawableResource
+  get() = Drawable15.icon_16868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16869: DrawableResource
+  get() = Drawable15.icon_16869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1687: DrawableResource
+  get() = Drawable15.icon_1687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16870: DrawableResource
+  get() = Drawable15.icon_16870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16871: DrawableResource
+  get() = Drawable15.icon_16871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16872: DrawableResource
+  get() = Drawable15.icon_16872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16873: DrawableResource
+  get() = Drawable15.icon_16873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16874: DrawableResource
+  get() = Drawable15.icon_16874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16875: DrawableResource
+  get() = Drawable15.icon_16875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16876: DrawableResource
+  get() = Drawable15.icon_16876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16877: DrawableResource
+  get() = Drawable15.icon_16877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16878: DrawableResource
+  get() = Drawable15.icon_16878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16879: DrawableResource
+  get() = Drawable15.icon_16879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1688: DrawableResource
+  get() = Drawable15.icon_1688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16880: DrawableResource
+  get() = Drawable15.icon_16880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16881: DrawableResource
+  get() = Drawable15.icon_16881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16882: DrawableResource
+  get() = Drawable15.icon_16882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16883: DrawableResource
+  get() = Drawable15.icon_16883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16884: DrawableResource
+  get() = Drawable15.icon_16884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16885: DrawableResource
+  get() = Drawable15.icon_16885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16886: DrawableResource
+  get() = Drawable15.icon_16886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16887: DrawableResource
+  get() = Drawable15.icon_16887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16888: DrawableResource
+  get() = Drawable15.icon_16888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16889: DrawableResource
+  get() = Drawable15.icon_16889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1689: DrawableResource
+  get() = Drawable15.icon_1689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16890: DrawableResource
+  get() = Drawable15.icon_16890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16891: DrawableResource
+  get() = Drawable15.icon_16891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16892: DrawableResource
+  get() = Drawable15.icon_16892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16893: DrawableResource
+  get() = Drawable15.icon_16893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16894: DrawableResource
+  get() = Drawable15.icon_16894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16895: DrawableResource
+  get() = Drawable15.icon_16895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16896: DrawableResource
+  get() = Drawable15.icon_16896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16897: DrawableResource
+  get() = Drawable15.icon_16897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16898: DrawableResource
+  get() = Drawable15.icon_16898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16899: DrawableResource
+  get() = Drawable15.icon_16899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_169: DrawableResource
+  get() = Drawable15.icon_169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1690: DrawableResource
+  get() = Drawable15.icon_1690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16900: DrawableResource
+  get() = Drawable15.icon_16900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16901: DrawableResource
+  get() = Drawable15.icon_16901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16902: DrawableResource
+  get() = Drawable15.icon_16902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16903: DrawableResource
+  get() = Drawable15.icon_16903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16904: DrawableResource
+  get() = Drawable15.icon_16904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16905: DrawableResource
+  get() = Drawable15.icon_16905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16906: DrawableResource
+  get() = Drawable15.icon_16906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16907: DrawableResource
+  get() = Drawable15.icon_16907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16908: DrawableResource
+  get() = Drawable15.icon_16908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16909: DrawableResource
+  get() = Drawable15.icon_16909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1691: DrawableResource
+  get() = Drawable15.icon_1691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16910: DrawableResource
+  get() = Drawable15.icon_16910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16911: DrawableResource
+  get() = Drawable15.icon_16911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16912: DrawableResource
+  get() = Drawable15.icon_16912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16913: DrawableResource
+  get() = Drawable15.icon_16913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16914: DrawableResource
+  get() = Drawable15.icon_16914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16915: DrawableResource
+  get() = Drawable15.icon_16915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16916: DrawableResource
+  get() = Drawable15.icon_16916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16917: DrawableResource
+  get() = Drawable15.icon_16917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16918: DrawableResource
+  get() = Drawable15.icon_16918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16919: DrawableResource
+  get() = Drawable15.icon_16919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1692: DrawableResource
+  get() = Drawable15.icon_1692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16920: DrawableResource
+  get() = Drawable15.icon_16920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16921: DrawableResource
+  get() = Drawable15.icon_16921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16922: DrawableResource
+  get() = Drawable15.icon_16922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16923: DrawableResource
+  get() = Drawable15.icon_16923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16924: DrawableResource
+  get() = Drawable15.icon_16924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16925: DrawableResource
+  get() = Drawable15.icon_16925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16926: DrawableResource
+  get() = Drawable15.icon_16926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16927: DrawableResource
+  get() = Drawable15.icon_16927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16928: DrawableResource
+  get() = Drawable15.icon_16928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16929: DrawableResource
+  get() = Drawable15.icon_16929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1693: DrawableResource
+  get() = Drawable15.icon_1693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16930: DrawableResource
+  get() = Drawable15.icon_16930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16931: DrawableResource
+  get() = Drawable15.icon_16931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16932: DrawableResource
+  get() = Drawable15.icon_16932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16933: DrawableResource
+  get() = Drawable15.icon_16933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16934: DrawableResource
+  get() = Drawable15.icon_16934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16935: DrawableResource
+  get() = Drawable15.icon_16935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16936: DrawableResource
+  get() = Drawable15.icon_16936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16937: DrawableResource
+  get() = Drawable15.icon_16937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16938: DrawableResource
+  get() = Drawable15.icon_16938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16939: DrawableResource
+  get() = Drawable15.icon_16939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1694: DrawableResource
+  get() = Drawable15.icon_1694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16940: DrawableResource
+  get() = Drawable15.icon_16940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16941: DrawableResource
+  get() = Drawable15.icon_16941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16942: DrawableResource
+  get() = Drawable15.icon_16942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16943: DrawableResource
+  get() = Drawable15.icon_16943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16944: DrawableResource
+  get() = Drawable15.icon_16944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16945: DrawableResource
+  get() = Drawable15.icon_16945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16946: DrawableResource
+  get() = Drawable15.icon_16946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16947: DrawableResource
+  get() = Drawable15.icon_16947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16948: DrawableResource
+  get() = Drawable15.icon_16948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16949: DrawableResource
+  get() = Drawable15.icon_16949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1695: DrawableResource
+  get() = Drawable15.icon_1695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16950: DrawableResource
+  get() = Drawable15.icon_16950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16951: DrawableResource
+  get() = Drawable15.icon_16951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16952: DrawableResource
+  get() = Drawable15.icon_16952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16953: DrawableResource
+  get() = Drawable15.icon_16953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16954: DrawableResource
+  get() = Drawable15.icon_16954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16955: DrawableResource
+  get() = Drawable15.icon_16955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16956: DrawableResource
+  get() = Drawable15.icon_16956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16957: DrawableResource
+  get() = Drawable15.icon_16957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16958: DrawableResource
+  get() = Drawable15.icon_16958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16959: DrawableResource
+  get() = Drawable15.icon_16959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1696: DrawableResource
+  get() = Drawable15.icon_1696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16960: DrawableResource
+  get() = Drawable15.icon_16960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16961: DrawableResource
+  get() = Drawable15.icon_16961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16962: DrawableResource
+  get() = Drawable15.icon_16962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16963: DrawableResource
+  get() = Drawable15.icon_16963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16964: DrawableResource
+  get() = Drawable15.icon_16964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16965: DrawableResource
+  get() = Drawable15.icon_16965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16966: DrawableResource
+  get() = Drawable15.icon_16966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16967: DrawableResource
+  get() = Drawable15.icon_16967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16968: DrawableResource
+  get() = Drawable15.icon_16968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16969: DrawableResource
+  get() = Drawable15.icon_16969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1697: DrawableResource
+  get() = Drawable15.icon_1697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16970: DrawableResource
+  get() = Drawable15.icon_16970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16971: DrawableResource
+  get() = Drawable15.icon_16971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16972: DrawableResource
+  get() = Drawable15.icon_16972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16973: DrawableResource
+  get() = Drawable15.icon_16973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16974: DrawableResource
+  get() = Drawable15.icon_16974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16975: DrawableResource
+  get() = Drawable15.icon_16975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16976: DrawableResource
+  get() = Drawable15.icon_16976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16977: DrawableResource
+  get() = Drawable15.icon_16977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16978: DrawableResource
+  get() = Drawable15.icon_16978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16979: DrawableResource
+  get() = Drawable15.icon_16979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1698: DrawableResource
+  get() = Drawable15.icon_1698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16980: DrawableResource
+  get() = Drawable15.icon_16980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16981: DrawableResource
+  get() = Drawable15.icon_16981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16982: DrawableResource
+  get() = Drawable15.icon_16982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16983: DrawableResource
+  get() = Drawable15.icon_16983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16984: DrawableResource
+  get() = Drawable15.icon_16984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16985: DrawableResource
+  get() = Drawable15.icon_16985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16986: DrawableResource
+  get() = Drawable15.icon_16986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16987: DrawableResource
+  get() = Drawable15.icon_16987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16988: DrawableResource
+  get() = Drawable15.icon_16988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16989: DrawableResource
+  get() = Drawable15.icon_16989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1699: DrawableResource
+  get() = Drawable15.icon_1699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16990: DrawableResource
+  get() = Drawable15.icon_16990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16991: DrawableResource
+  get() = Drawable15.icon_16991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16992: DrawableResource
+  get() = Drawable15.icon_16992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16993: DrawableResource
+  get() = Drawable15.icon_16993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16994: DrawableResource
+  get() = Drawable15.icon_16994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16995: DrawableResource
+  get() = Drawable15.icon_16995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16996: DrawableResource
+  get() = Drawable15.icon_16996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16997: DrawableResource
+  get() = Drawable15.icon_16997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16998: DrawableResource
+  get() = Drawable15.icon_16998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_16999: DrawableResource
+  get() = Drawable15.icon_16999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17: DrawableResource
+  get() = Drawable15.icon_17
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_170: DrawableResource
+  get() = Drawable15.icon_170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1700: DrawableResource
+  get() = Drawable15.icon_1700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17000: DrawableResource
+  get() = Drawable15.icon_17000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17001: DrawableResource
+  get() = Drawable15.icon_17001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17002: DrawableResource
+  get() = Drawable15.icon_17002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17003: DrawableResource
+  get() = Drawable15.icon_17003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17004: DrawableResource
+  get() = Drawable15.icon_17004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17005: DrawableResource
+  get() = Drawable15.icon_17005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17006: DrawableResource
+  get() = Drawable15.icon_17006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17007: DrawableResource
+  get() = Drawable15.icon_17007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17008: DrawableResource
+  get() = Drawable15.icon_17008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17009: DrawableResource
+  get() = Drawable15.icon_17009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1701: DrawableResource
+  get() = Drawable15.icon_1701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17010: DrawableResource
+  get() = Drawable15.icon_17010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17011: DrawableResource
+  get() = Drawable15.icon_17011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17012: DrawableResource
+  get() = Drawable15.icon_17012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17013: DrawableResource
+  get() = Drawable15.icon_17013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17014: DrawableResource
+  get() = Drawable15.icon_17014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17015: DrawableResource
+  get() = Drawable15.icon_17015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17016: DrawableResource
+  get() = Drawable15.icon_17016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17017: DrawableResource
+  get() = Drawable15.icon_17017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17018: DrawableResource
+  get() = Drawable15.icon_17018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17019: DrawableResource
+  get() = Drawable15.icon_17019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1702: DrawableResource
+  get() = Drawable15.icon_1702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17020: DrawableResource
+  get() = Drawable15.icon_17020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17021: DrawableResource
+  get() = Drawable15.icon_17021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17022: DrawableResource
+  get() = Drawable15.icon_17022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17023: DrawableResource
+  get() = Drawable15.icon_17023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17024: DrawableResource
+  get() = Drawable15.icon_17024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17025: DrawableResource
+  get() = Drawable15.icon_17025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17026: DrawableResource
+  get() = Drawable15.icon_17026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17027: DrawableResource
+  get() = Drawable15.icon_17027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17028: DrawableResource
+  get() = Drawable15.icon_17028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17029: DrawableResource
+  get() = Drawable15.icon_17029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1703: DrawableResource
+  get() = Drawable15.icon_1703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17030: DrawableResource
+  get() = Drawable15.icon_17030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17031: DrawableResource
+  get() = Drawable15.icon_17031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17032: DrawableResource
+  get() = Drawable15.icon_17032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17033: DrawableResource
+  get() = Drawable15.icon_17033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17034: DrawableResource
+  get() = Drawable15.icon_17034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17035: DrawableResource
+  get() = Drawable15.icon_17035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17036: DrawableResource
+  get() = Drawable15.icon_17036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17037: DrawableResource
+  get() = Drawable15.icon_17037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17038: DrawableResource
+  get() = Drawable15.icon_17038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17039: DrawableResource
+  get() = Drawable15.icon_17039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1704: DrawableResource
+  get() = Drawable15.icon_1704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17040: DrawableResource
+  get() = Drawable15.icon_17040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17041: DrawableResource
+  get() = Drawable15.icon_17041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17042: DrawableResource
+  get() = Drawable15.icon_17042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17043: DrawableResource
+  get() = Drawable15.icon_17043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17044: DrawableResource
+  get() = Drawable15.icon_17044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17045: DrawableResource
+  get() = Drawable15.icon_17045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17046: DrawableResource
+  get() = Drawable15.icon_17046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17047: DrawableResource
+  get() = Drawable15.icon_17047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17048: DrawableResource
+  get() = Drawable15.icon_17048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17049: DrawableResource
+  get() = Drawable15.icon_17049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1705: DrawableResource
+  get() = Drawable15.icon_1705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17050: DrawableResource
+  get() = Drawable15.icon_17050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17051: DrawableResource
+  get() = Drawable15.icon_17051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17052: DrawableResource
+  get() = Drawable15.icon_17052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17053: DrawableResource
+  get() = Drawable15.icon_17053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17054: DrawableResource
+  get() = Drawable15.icon_17054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17055: DrawableResource
+  get() = Drawable15.icon_17055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17056: DrawableResource
+  get() = Drawable15.icon_17056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17057: DrawableResource
+  get() = Drawable15.icon_17057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17058: DrawableResource
+  get() = Drawable15.icon_17058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17059: DrawableResource
+  get() = Drawable15.icon_17059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1706: DrawableResource
+  get() = Drawable15.icon_1706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17060: DrawableResource
+  get() = Drawable15.icon_17060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17061: DrawableResource
+  get() = Drawable15.icon_17061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17062: DrawableResource
+  get() = Drawable15.icon_17062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17063: DrawableResource
+  get() = Drawable15.icon_17063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17064: DrawableResource
+  get() = Drawable15.icon_17064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17065: DrawableResource
+  get() = Drawable15.icon_17065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17066: DrawableResource
+  get() = Drawable15.icon_17066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17067: DrawableResource
+  get() = Drawable15.icon_17067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17068: DrawableResource
+  get() = Drawable15.icon_17068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17069: DrawableResource
+  get() = Drawable15.icon_17069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1707: DrawableResource
+  get() = Drawable15.icon_1707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17070: DrawableResource
+  get() = Drawable15.icon_17070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17071: DrawableResource
+  get() = Drawable15.icon_17071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17072: DrawableResource
+  get() = Drawable15.icon_17072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17073: DrawableResource
+  get() = Drawable15.icon_17073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17074: DrawableResource
+  get() = Drawable15.icon_17074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17075: DrawableResource
+  get() = Drawable15.icon_17075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17076: DrawableResource
+  get() = Drawable15.icon_17076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17077: DrawableResource
+  get() = Drawable15.icon_17077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17078: DrawableResource
+  get() = Drawable15.icon_17078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17079: DrawableResource
+  get() = Drawable15.icon_17079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1708: DrawableResource
+  get() = Drawable15.icon_1708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17080: DrawableResource
+  get() = Drawable15.icon_17080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17081: DrawableResource
+  get() = Drawable15.icon_17081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17082: DrawableResource
+  get() = Drawable15.icon_17082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17083: DrawableResource
+  get() = Drawable15.icon_17083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17084: DrawableResource
+  get() = Drawable15.icon_17084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17085: DrawableResource
+  get() = Drawable15.icon_17085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17086: DrawableResource
+  get() = Drawable15.icon_17086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17087: DrawableResource
+  get() = Drawable15.icon_17087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17088: DrawableResource
+  get() = Drawable15.icon_17088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17089: DrawableResource
+  get() = Drawable15.icon_17089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1709: DrawableResource
+  get() = Drawable15.icon_1709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17090: DrawableResource
+  get() = Drawable15.icon_17090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17091: DrawableResource
+  get() = Drawable15.icon_17091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17092: DrawableResource
+  get() = Drawable15.icon_17092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17093: DrawableResource
+  get() = Drawable15.icon_17093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17094: DrawableResource
+  get() = Drawable15.icon_17094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17095: DrawableResource
+  get() = Drawable15.icon_17095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17096: DrawableResource
+  get() = Drawable15.icon_17096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17097: DrawableResource
+  get() = Drawable15.icon_17097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17098: DrawableResource
+  get() = Drawable15.icon_17098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17099: DrawableResource
+  get() = Drawable15.icon_17099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_171: DrawableResource
+  get() = Drawable15.icon_171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1710: DrawableResource
+  get() = Drawable15.icon_1710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17100: DrawableResource
+  get() = Drawable15.icon_17100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17101: DrawableResource
+  get() = Drawable15.icon_17101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17102: DrawableResource
+  get() = Drawable15.icon_17102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17103: DrawableResource
+  get() = Drawable15.icon_17103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17104: DrawableResource
+  get() = Drawable15.icon_17104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17105: DrawableResource
+  get() = Drawable15.icon_17105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17106: DrawableResource
+  get() = Drawable15.icon_17106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17107: DrawableResource
+  get() = Drawable15.icon_17107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17108: DrawableResource
+  get() = Drawable15.icon_17108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17109: DrawableResource
+  get() = Drawable15.icon_17109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1711: DrawableResource
+  get() = Drawable15.icon_1711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17110: DrawableResource
+  get() = Drawable15.icon_17110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17111: DrawableResource
+  get() = Drawable15.icon_17111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17112: DrawableResource
+  get() = Drawable15.icon_17112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17113: DrawableResource
+  get() = Drawable15.icon_17113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17114: DrawableResource
+  get() = Drawable15.icon_17114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17115: DrawableResource
+  get() = Drawable15.icon_17115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17116: DrawableResource
+  get() = Drawable15.icon_17116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17117: DrawableResource
+  get() = Drawable15.icon_17117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17118: DrawableResource
+  get() = Drawable15.icon_17118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17119: DrawableResource
+  get() = Drawable15.icon_17119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1712: DrawableResource
+  get() = Drawable15.icon_1712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17120: DrawableResource
+  get() = Drawable15.icon_17120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17121: DrawableResource
+  get() = Drawable15.icon_17121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17122: DrawableResource
+  get() = Drawable15.icon_17122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17123: DrawableResource
+  get() = Drawable15.icon_17123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17124: DrawableResource
+  get() = Drawable15.icon_17124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17125: DrawableResource
+  get() = Drawable15.icon_17125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17126: DrawableResource
+  get() = Drawable15.icon_17126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17127: DrawableResource
+  get() = Drawable15.icon_17127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17128: DrawableResource
+  get() = Drawable15.icon_17128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17129: DrawableResource
+  get() = Drawable15.icon_17129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1713: DrawableResource
+  get() = Drawable15.icon_1713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17130: DrawableResource
+  get() = Drawable15.icon_17130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17131: DrawableResource
+  get() = Drawable15.icon_17131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17132: DrawableResource
+  get() = Drawable15.icon_17132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17133: DrawableResource
+  get() = Drawable15.icon_17133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17134: DrawableResource
+  get() = Drawable15.icon_17134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17135: DrawableResource
+  get() = Drawable15.icon_17135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17136: DrawableResource
+  get() = Drawable15.icon_17136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17137: DrawableResource
+  get() = Drawable15.icon_17137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17138: DrawableResource
+  get() = Drawable15.icon_17138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17139: DrawableResource
+  get() = Drawable15.icon_17139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1714: DrawableResource
+  get() = Drawable15.icon_1714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17140: DrawableResource
+  get() = Drawable15.icon_17140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17141: DrawableResource
+  get() = Drawable15.icon_17141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17142: DrawableResource
+  get() = Drawable15.icon_17142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17143: DrawableResource
+  get() = Drawable15.icon_17143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17144: DrawableResource
+  get() = Drawable15.icon_17144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17145: DrawableResource
+  get() = Drawable15.icon_17145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17146: DrawableResource
+  get() = Drawable15.icon_17146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17147: DrawableResource
+  get() = Drawable15.icon_17147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17148: DrawableResource
+  get() = Drawable15.icon_17148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17149: DrawableResource
+  get() = Drawable15.icon_17149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1715: DrawableResource
+  get() = Drawable15.icon_1715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17150: DrawableResource
+  get() = Drawable15.icon_17150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17151: DrawableResource
+  get() = Drawable15.icon_17151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17152: DrawableResource
+  get() = Drawable15.icon_17152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17153: DrawableResource
+  get() = Drawable15.icon_17153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17154: DrawableResource
+  get() = Drawable15.icon_17154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17155: DrawableResource
+  get() = Drawable15.icon_17155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17156: DrawableResource
+  get() = Drawable15.icon_17156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17157: DrawableResource
+  get() = Drawable15.icon_17157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17158: DrawableResource
+  get() = Drawable15.icon_17158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17159: DrawableResource
+  get() = Drawable15.icon_17159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1716: DrawableResource
+  get() = Drawable15.icon_1716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17160: DrawableResource
+  get() = Drawable15.icon_17160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17161: DrawableResource
+  get() = Drawable15.icon_17161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17162: DrawableResource
+  get() = Drawable15.icon_17162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17163: DrawableResource
+  get() = Drawable15.icon_17163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17164: DrawableResource
+  get() = Drawable15.icon_17164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17165: DrawableResource
+  get() = Drawable15.icon_17165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17166: DrawableResource
+  get() = Drawable15.icon_17166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17167: DrawableResource
+  get() = Drawable15.icon_17167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17168: DrawableResource
+  get() = Drawable15.icon_17168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17169: DrawableResource
+  get() = Drawable15.icon_17169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1717: DrawableResource
+  get() = Drawable15.icon_1717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17170: DrawableResource
+  get() = Drawable15.icon_17170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17171: DrawableResource
+  get() = Drawable15.icon_17171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17172: DrawableResource
+  get() = Drawable15.icon_17172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17173: DrawableResource
+  get() = Drawable15.icon_17173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17174: DrawableResource
+  get() = Drawable15.icon_17174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17175: DrawableResource
+  get() = Drawable15.icon_17175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17176: DrawableResource
+  get() = Drawable15.icon_17176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17177: DrawableResource
+  get() = Drawable15.icon_17177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17178: DrawableResource
+  get() = Drawable15.icon_17178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17179: DrawableResource
+  get() = Drawable15.icon_17179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1718: DrawableResource
+  get() = Drawable15.icon_1718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17180: DrawableResource
+  get() = Drawable15.icon_17180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17181: DrawableResource
+  get() = Drawable15.icon_17181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17182: DrawableResource
+  get() = Drawable15.icon_17182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17183: DrawableResource
+  get() = Drawable15.icon_17183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17184: DrawableResource
+  get() = Drawable15.icon_17184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17185: DrawableResource
+  get() = Drawable15.icon_17185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17186: DrawableResource
+  get() = Drawable15.icon_17186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17187: DrawableResource
+  get() = Drawable15.icon_17187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17188: DrawableResource
+  get() = Drawable15.icon_17188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17189: DrawableResource
+  get() = Drawable15.icon_17189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1719: DrawableResource
+  get() = Drawable15.icon_1719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17190: DrawableResource
+  get() = Drawable15.icon_17190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17191: DrawableResource
+  get() = Drawable15.icon_17191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17192: DrawableResource
+  get() = Drawable15.icon_17192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17193: DrawableResource
+  get() = Drawable15.icon_17193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17194: DrawableResource
+  get() = Drawable15.icon_17194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17195: DrawableResource
+  get() = Drawable15.icon_17195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17196: DrawableResource
+  get() = Drawable15.icon_17196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17197: DrawableResource
+  get() = Drawable15.icon_17197

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable16.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable16.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable16 {
+  public val icon_17198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17198.xml"),
+          )
+      )
+
+  public val icon_17199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17199.xml"),
+          )
+      )
+
+  public val icon_172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_172.xml"),
+          )
+      )
+
+  public val icon_1720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1720.xml"),
+          )
+      )
+
+  public val icon_17200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17200.xml"),
+          )
+      )
+
+  public val icon_17201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17201.xml"),
+          )
+      )
+
+  public val icon_17202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17202.xml"),
+          )
+      )
+
+  public val icon_17203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17203.xml"),
+          )
+      )
+
+  public val icon_17204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17204.xml"),
+          )
+      )
+
+  public val icon_17205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17205.xml"),
+          )
+      )
+
+  public val icon_17206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17206.xml"),
+          )
+      )
+
+  public val icon_17207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17207.xml"),
+          )
+      )
+
+  public val icon_17208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17208.xml"),
+          )
+      )
+
+  public val icon_17209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17209.xml"),
+          )
+      )
+
+  public val icon_1721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1721.xml"),
+          )
+      )
+
+  public val icon_17210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17210.xml"),
+          )
+      )
+
+  public val icon_17211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17211.xml"),
+          )
+      )
+
+  public val icon_17212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17212.xml"),
+          )
+      )
+
+  public val icon_17213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17213.xml"),
+          )
+      )
+
+  public val icon_17214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17214.xml"),
+          )
+      )
+
+  public val icon_17215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17215.xml"),
+          )
+      )
+
+  public val icon_17216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17216.xml"),
+          )
+      )
+
+  public val icon_17217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17217.xml"),
+          )
+      )
+
+  public val icon_17218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17218.xml"),
+          )
+      )
+
+  public val icon_17219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17219.xml"),
+          )
+      )
+
+  public val icon_1722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1722.xml"),
+          )
+      )
+
+  public val icon_17220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17220.xml"),
+          )
+      )
+
+  public val icon_17221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17221.xml"),
+          )
+      )
+
+  public val icon_17222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17222.xml"),
+          )
+      )
+
+  public val icon_17223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17223.xml"),
+          )
+      )
+
+  public val icon_17224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17224.xml"),
+          )
+      )
+
+  public val icon_17225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17225.xml"),
+          )
+      )
+
+  public val icon_17226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17226.xml"),
+          )
+      )
+
+  public val icon_17227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17227.xml"),
+          )
+      )
+
+  public val icon_17228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17228.xml"),
+          )
+      )
+
+  public val icon_17229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17229.xml"),
+          )
+      )
+
+  public val icon_1723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1723.xml"),
+          )
+      )
+
+  public val icon_17230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17230.xml"),
+          )
+      )
+
+  public val icon_17231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17231.xml"),
+          )
+      )
+
+  public val icon_17232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17232.xml"),
+          )
+      )
+
+  public val icon_17233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17233.xml"),
+          )
+      )
+
+  public val icon_17234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17234.xml"),
+          )
+      )
+
+  public val icon_17235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17235.xml"),
+          )
+      )
+
+  public val icon_17236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17236.xml"),
+          )
+      )
+
+  public val icon_17237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17237.xml"),
+          )
+      )
+
+  public val icon_17238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17238.xml"),
+          )
+      )
+
+  public val icon_17239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17239.xml"),
+          )
+      )
+
+  public val icon_1724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1724.xml"),
+          )
+      )
+
+  public val icon_17240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17240.xml"),
+          )
+      )
+
+  public val icon_17241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17241.xml"),
+          )
+      )
+
+  public val icon_17242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17242.xml"),
+          )
+      )
+
+  public val icon_17243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17243.xml"),
+          )
+      )
+
+  public val icon_17244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17244.xml"),
+          )
+      )
+
+  public val icon_17245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17245.xml"),
+          )
+      )
+
+  public val icon_17246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17246.xml"),
+          )
+      )
+
+  public val icon_17247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17247.xml"),
+          )
+      )
+
+  public val icon_17248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17248.xml"),
+          )
+      )
+
+  public val icon_17249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17249.xml"),
+          )
+      )
+
+  public val icon_1725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1725.xml"),
+          )
+      )
+
+  public val icon_17250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17250.xml"),
+          )
+      )
+
+  public val icon_17251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17251.xml"),
+          )
+      )
+
+  public val icon_17252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17252.xml"),
+          )
+      )
+
+  public val icon_17253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17253.xml"),
+          )
+      )
+
+  public val icon_17254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17254.xml"),
+          )
+      )
+
+  public val icon_17255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17255.xml"),
+          )
+      )
+
+  public val icon_17256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17256.xml"),
+          )
+      )
+
+  public val icon_17257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17257.xml"),
+          )
+      )
+
+  public val icon_17258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17258.xml"),
+          )
+      )
+
+  public val icon_17259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17259.xml"),
+          )
+      )
+
+  public val icon_1726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1726.xml"),
+          )
+      )
+
+  public val icon_17260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17260.xml"),
+          )
+      )
+
+  public val icon_17261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17261.xml"),
+          )
+      )
+
+  public val icon_17262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17262.xml"),
+          )
+      )
+
+  public val icon_17263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17263.xml"),
+          )
+      )
+
+  public val icon_17264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17264.xml"),
+          )
+      )
+
+  public val icon_17265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17265.xml"),
+          )
+      )
+
+  public val icon_17266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17266.xml"),
+          )
+      )
+
+  public val icon_17267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17267.xml"),
+          )
+      )
+
+  public val icon_17268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17268.xml"),
+          )
+      )
+
+  public val icon_17269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17269.xml"),
+          )
+      )
+
+  public val icon_1727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1727.xml"),
+          )
+      )
+
+  public val icon_17270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17270.xml"),
+          )
+      )
+
+  public val icon_17271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17271.xml"),
+          )
+      )
+
+  public val icon_17272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17272.xml"),
+          )
+      )
+
+  public val icon_17273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17273.xml"),
+          )
+      )
+
+  public val icon_17274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17274.xml"),
+          )
+      )
+
+  public val icon_17275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17275.xml"),
+          )
+      )
+
+  public val icon_17276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17276.xml"),
+          )
+      )
+
+  public val icon_17277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17277.xml"),
+          )
+      )
+
+  public val icon_17278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17278.xml"),
+          )
+      )
+
+  public val icon_17279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17279.xml"),
+          )
+      )
+
+  public val icon_1728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1728.xml"),
+          )
+      )
+
+  public val icon_17280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17280.xml"),
+          )
+      )
+
+  public val icon_17281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17281.xml"),
+          )
+      )
+
+  public val icon_17282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17282.xml"),
+          )
+      )
+
+  public val icon_17283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17283.xml"),
+          )
+      )
+
+  public val icon_17284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17284.xml"),
+          )
+      )
+
+  public val icon_17285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17285.xml"),
+          )
+      )
+
+  public val icon_17286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17286.xml"),
+          )
+      )
+
+  public val icon_17287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17287.xml"),
+          )
+      )
+
+  public val icon_17288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17288.xml"),
+          )
+      )
+
+  public val icon_17289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17289.xml"),
+          )
+      )
+
+  public val icon_1729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1729.xml"),
+          )
+      )
+
+  public val icon_17290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17290.xml"),
+          )
+      )
+
+  public val icon_17291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17291.xml"),
+          )
+      )
+
+  public val icon_17292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17292.xml"),
+          )
+      )
+
+  public val icon_17293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17293.xml"),
+          )
+      )
+
+  public val icon_17294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17294.xml"),
+          )
+      )
+
+  public val icon_17295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17295.xml"),
+          )
+      )
+
+  public val icon_17296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17296.xml"),
+          )
+      )
+
+  public val icon_17297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17297.xml"),
+          )
+      )
+
+  public val icon_17298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17298.xml"),
+          )
+      )
+
+  public val icon_17299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17299.xml"),
+          )
+      )
+
+  public val icon_173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_173.xml"),
+          )
+      )
+
+  public val icon_1730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1730.xml"),
+          )
+      )
+
+  public val icon_17300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17300.xml"),
+          )
+      )
+
+  public val icon_17301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17301.xml"),
+          )
+      )
+
+  public val icon_17302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17302.xml"),
+          )
+      )
+
+  public val icon_17303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17303.xml"),
+          )
+      )
+
+  public val icon_17304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17304.xml"),
+          )
+      )
+
+  public val icon_17305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17305.xml"),
+          )
+      )
+
+  public val icon_17306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17306.xml"),
+          )
+      )
+
+  public val icon_17307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17307.xml"),
+          )
+      )
+
+  public val icon_17308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17308.xml"),
+          )
+      )
+
+  public val icon_17309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17309.xml"),
+          )
+      )
+
+  public val icon_1731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1731.xml"),
+          )
+      )
+
+  public val icon_17310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17310.xml"),
+          )
+      )
+
+  public val icon_17311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17311.xml"),
+          )
+      )
+
+  public val icon_17312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17312.xml"),
+          )
+      )
+
+  public val icon_17313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17313.xml"),
+          )
+      )
+
+  public val icon_17314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17314.xml"),
+          )
+      )
+
+  public val icon_17315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17315.xml"),
+          )
+      )
+
+  public val icon_17316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17316.xml"),
+          )
+      )
+
+  public val icon_17317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17317.xml"),
+          )
+      )
+
+  public val icon_17318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17318.xml"),
+          )
+      )
+
+  public val icon_17319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17319.xml"),
+          )
+      )
+
+  public val icon_1732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1732.xml"),
+          )
+      )
+
+  public val icon_17320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17320.xml"),
+          )
+      )
+
+  public val icon_17321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17321.xml"),
+          )
+      )
+
+  public val icon_17322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17322.xml"),
+          )
+      )
+
+  public val icon_17323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17323.xml"),
+          )
+      )
+
+  public val icon_17324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17324.xml"),
+          )
+      )
+
+  public val icon_17325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17325.xml"),
+          )
+      )
+
+  public val icon_17326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17326.xml"),
+          )
+      )
+
+  public val icon_17327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17327.xml"),
+          )
+      )
+
+  public val icon_17328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17328.xml"),
+          )
+      )
+
+  public val icon_17329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17329.xml"),
+          )
+      )
+
+  public val icon_1733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1733.xml"),
+          )
+      )
+
+  public val icon_17330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17330.xml"),
+          )
+      )
+
+  public val icon_17331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17331.xml"),
+          )
+      )
+
+  public val icon_17332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17332.xml"),
+          )
+      )
+
+  public val icon_17333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17333.xml"),
+          )
+      )
+
+  public val icon_17334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17334.xml"),
+          )
+      )
+
+  public val icon_17335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17335.xml"),
+          )
+      )
+
+  public val icon_17336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17336.xml"),
+          )
+      )
+
+  public val icon_17337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17337.xml"),
+          )
+      )
+
+  public val icon_17338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17338.xml"),
+          )
+      )
+
+  public val icon_17339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17339.xml"),
+          )
+      )
+
+  public val icon_1734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1734.xml"),
+          )
+      )
+
+  public val icon_17340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17340.xml"),
+          )
+      )
+
+  public val icon_17341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17341.xml"),
+          )
+      )
+
+  public val icon_17342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17342.xml"),
+          )
+      )
+
+  public val icon_17343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17343.xml"),
+          )
+      )
+
+  public val icon_17344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17344.xml"),
+          )
+      )
+
+  public val icon_17345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17345.xml"),
+          )
+      )
+
+  public val icon_17346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17346.xml"),
+          )
+      )
+
+  public val icon_17347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17347.xml"),
+          )
+      )
+
+  public val icon_17348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17348.xml"),
+          )
+      )
+
+  public val icon_17349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17349.xml"),
+          )
+      )
+
+  public val icon_1735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1735.xml"),
+          )
+      )
+
+  public val icon_17350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17350.xml"),
+          )
+      )
+
+  public val icon_17351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17351.xml"),
+          )
+      )
+
+  public val icon_17352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17352.xml"),
+          )
+      )
+
+  public val icon_17353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17353.xml"),
+          )
+      )
+
+  public val icon_17354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17354.xml"),
+          )
+      )
+
+  public val icon_17355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17355.xml"),
+          )
+      )
+
+  public val icon_17356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17356.xml"),
+          )
+      )
+
+  public val icon_17357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17357.xml"),
+          )
+      )
+
+  public val icon_17358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17358.xml"),
+          )
+      )
+
+  public val icon_17359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17359.xml"),
+          )
+      )
+
+  public val icon_1736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1736.xml"),
+          )
+      )
+
+  public val icon_17360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17360.xml"),
+          )
+      )
+
+  public val icon_17361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17361.xml"),
+          )
+      )
+
+  public val icon_17362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17362.xml"),
+          )
+      )
+
+  public val icon_17363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17363.xml"),
+          )
+      )
+
+  public val icon_17364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17364.xml"),
+          )
+      )
+
+  public val icon_17365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17365.xml"),
+          )
+      )
+
+  public val icon_17366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17366.xml"),
+          )
+      )
+
+  public val icon_17367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17367.xml"),
+          )
+      )
+
+  public val icon_17368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17368.xml"),
+          )
+      )
+
+  public val icon_17369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17369.xml"),
+          )
+      )
+
+  public val icon_1737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1737.xml"),
+          )
+      )
+
+  public val icon_17370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17370.xml"),
+          )
+      )
+
+  public val icon_17371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17371.xml"),
+          )
+      )
+
+  public val icon_17372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17372.xml"),
+          )
+      )
+
+  public val icon_17373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17373.xml"),
+          )
+      )
+
+  public val icon_17374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17374.xml"),
+          )
+      )
+
+  public val icon_17375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17375.xml"),
+          )
+      )
+
+  public val icon_17376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17376.xml"),
+          )
+      )
+
+  public val icon_17377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17377.xml"),
+          )
+      )
+
+  public val icon_17378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17378.xml"),
+          )
+      )
+
+  public val icon_17379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17379.xml"),
+          )
+      )
+
+  public val icon_1738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1738.xml"),
+          )
+      )
+
+  public val icon_17380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17380.xml"),
+          )
+      )
+
+  public val icon_17381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17381.xml"),
+          )
+      )
+
+  public val icon_17382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17382.xml"),
+          )
+      )
+
+  public val icon_17383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17383.xml"),
+          )
+      )
+
+  public val icon_17384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17384.xml"),
+          )
+      )
+
+  public val icon_17385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17385.xml"),
+          )
+      )
+
+  public val icon_17386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17386.xml"),
+          )
+      )
+
+  public val icon_17387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17387.xml"),
+          )
+      )
+
+  public val icon_17388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17388.xml"),
+          )
+      )
+
+  public val icon_17389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17389.xml"),
+          )
+      )
+
+  public val icon_1739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1739.xml"),
+          )
+      )
+
+  public val icon_17390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17390.xml"),
+          )
+      )
+
+  public val icon_17391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17391.xml"),
+          )
+      )
+
+  public val icon_17392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17392.xml"),
+          )
+      )
+
+  public val icon_17393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17393.xml"),
+          )
+      )
+
+  public val icon_17394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17394.xml"),
+          )
+      )
+
+  public val icon_17395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17395.xml"),
+          )
+      )
+
+  public val icon_17396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17396.xml"),
+          )
+      )
+
+  public val icon_17397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17397.xml"),
+          )
+      )
+
+  public val icon_17398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17398.xml"),
+          )
+      )
+
+  public val icon_17399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17399.xml"),
+          )
+      )
+
+  public val icon_174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_174.xml"),
+          )
+      )
+
+  public val icon_1740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1740.xml"),
+          )
+      )
+
+  public val icon_17400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17400.xml"),
+          )
+      )
+
+  public val icon_17401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17401.xml"),
+          )
+      )
+
+  public val icon_17402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17402.xml"),
+          )
+      )
+
+  public val icon_17403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17403.xml"),
+          )
+      )
+
+  public val icon_17404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17404.xml"),
+          )
+      )
+
+  public val icon_17405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17405.xml"),
+          )
+      )
+
+  public val icon_17406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17406.xml"),
+          )
+      )
+
+  public val icon_17407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17407.xml"),
+          )
+      )
+
+  public val icon_17408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17408.xml"),
+          )
+      )
+
+  public val icon_17409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17409.xml"),
+          )
+      )
+
+  public val icon_1741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1741.xml"),
+          )
+      )
+
+  public val icon_17410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17410.xml"),
+          )
+      )
+
+  public val icon_17411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17411.xml"),
+          )
+      )
+
+  public val icon_17412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17412.xml"),
+          )
+      )
+
+  public val icon_17413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17413.xml"),
+          )
+      )
+
+  public val icon_17414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17414.xml"),
+          )
+      )
+
+  public val icon_17415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17415.xml"),
+          )
+      )
+
+  public val icon_17416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17416.xml"),
+          )
+      )
+
+  public val icon_17417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17417.xml"),
+          )
+      )
+
+  public val icon_17418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17418.xml"),
+          )
+      )
+
+  public val icon_17419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17419.xml"),
+          )
+      )
+
+  public val icon_1742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1742.xml"),
+          )
+      )
+
+  public val icon_17420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17420.xml"),
+          )
+      )
+
+  public val icon_17421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17421.xml"),
+          )
+      )
+
+  public val icon_17422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17422.xml"),
+          )
+      )
+
+  public val icon_17423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17423.xml"),
+          )
+      )
+
+  public val icon_17424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17424.xml"),
+          )
+      )
+
+  public val icon_17425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17425.xml"),
+          )
+      )
+
+  public val icon_17426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17426.xml"),
+          )
+      )
+
+  public val icon_17427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17427.xml"),
+          )
+      )
+
+  public val icon_17428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17428.xml"),
+          )
+      )
+
+  public val icon_17429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17429.xml"),
+          )
+      )
+
+  public val icon_1743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1743.xml"),
+          )
+      )
+
+  public val icon_17430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17430.xml"),
+          )
+      )
+
+  public val icon_17431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17431.xml"),
+          )
+      )
+
+  public val icon_17432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17432.xml"),
+          )
+      )
+
+  public val icon_17433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17433.xml"),
+          )
+      )
+
+  public val icon_17434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17434.xml"),
+          )
+      )
+
+  public val icon_17435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17435.xml"),
+          )
+      )
+
+  public val icon_17436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17436.xml"),
+          )
+      )
+
+  public val icon_17437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17437.xml"),
+          )
+      )
+
+  public val icon_17438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17438.xml"),
+          )
+      )
+
+  public val icon_17439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17439.xml"),
+          )
+      )
+
+  public val icon_1744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1744.xml"),
+          )
+      )
+
+  public val icon_17440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17440.xml"),
+          )
+      )
+
+  public val icon_17441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17441.xml"),
+          )
+      )
+
+  public val icon_17442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17442.xml"),
+          )
+      )
+
+  public val icon_17443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17443.xml"),
+          )
+      )
+
+  public val icon_17444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17444.xml"),
+          )
+      )
+
+  public val icon_17445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17445.xml"),
+          )
+      )
+
+  public val icon_17446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17446.xml"),
+          )
+      )
+
+  public val icon_17447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17447.xml"),
+          )
+      )
+
+  public val icon_17448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17448.xml"),
+          )
+      )
+
+  public val icon_17449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17449.xml"),
+          )
+      )
+
+  public val icon_1745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1745.xml"),
+          )
+      )
+
+  public val icon_17450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17450.xml"),
+          )
+      )
+
+  public val icon_17451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17451.xml"),
+          )
+      )
+
+  public val icon_17452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17452.xml"),
+          )
+      )
+
+  public val icon_17453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17453.xml"),
+          )
+      )
+
+  public val icon_17454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17454.xml"),
+          )
+      )
+
+  public val icon_17455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17455.xml"),
+          )
+      )
+
+  public val icon_17456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17456.xml"),
+          )
+      )
+
+  public val icon_17457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17457.xml"),
+          )
+      )
+
+  public val icon_17458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17458.xml"),
+          )
+      )
+
+  public val icon_17459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17459.xml"),
+          )
+      )
+
+  public val icon_1746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1746.xml"),
+          )
+      )
+
+  public val icon_17460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17460.xml"),
+          )
+      )
+
+  public val icon_17461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17461.xml"),
+          )
+      )
+
+  public val icon_17462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17462.xml"),
+          )
+      )
+
+  public val icon_17463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17463.xml"),
+          )
+      )
+
+  public val icon_17464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17464.xml"),
+          )
+      )
+
+  public val icon_17465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17465.xml"),
+          )
+      )
+
+  public val icon_17466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17466.xml"),
+          )
+      )
+
+  public val icon_17467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17467.xml"),
+          )
+      )
+
+  public val icon_17468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17468.xml"),
+          )
+      )
+
+  public val icon_17469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17469.xml"),
+          )
+      )
+
+  public val icon_1747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1747.xml"),
+          )
+      )
+
+  public val icon_17470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17470.xml"),
+          )
+      )
+
+  public val icon_17471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17471.xml"),
+          )
+      )
+
+  public val icon_17472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17472.xml"),
+          )
+      )
+
+  public val icon_17473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17473.xml"),
+          )
+      )
+
+  public val icon_17474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17474.xml"),
+          )
+      )
+
+  public val icon_17475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17475.xml"),
+          )
+      )
+
+  public val icon_17476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17476.xml"),
+          )
+      )
+
+  public val icon_17477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17477.xml"),
+          )
+      )
+
+  public val icon_17478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17478.xml"),
+          )
+      )
+
+  public val icon_17479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17479.xml"),
+          )
+      )
+
+  public val icon_1748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1748.xml"),
+          )
+      )
+
+  public val icon_17480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17480.xml"),
+          )
+      )
+
+  public val icon_17481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17481.xml"),
+          )
+      )
+
+  public val icon_17482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17482.xml"),
+          )
+      )
+
+  public val icon_17483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17483.xml"),
+          )
+      )
+
+  public val icon_17484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17484.xml"),
+          )
+      )
+
+  public val icon_17485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17485.xml"),
+          )
+      )
+
+  public val icon_17486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17486.xml"),
+          )
+      )
+
+  public val icon_17487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17487.xml"),
+          )
+      )
+
+  public val icon_17488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17488.xml"),
+          )
+      )
+
+  public val icon_17489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17489.xml"),
+          )
+      )
+
+  public val icon_1749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1749.xml"),
+          )
+      )
+
+  public val icon_17490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17490.xml"),
+          )
+      )
+
+  public val icon_17491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17491.xml"),
+          )
+      )
+
+  public val icon_17492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17492.xml"),
+          )
+      )
+
+  public val icon_17493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17493.xml"),
+          )
+      )
+
+  public val icon_17494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17494.xml"),
+          )
+      )
+
+  public val icon_17495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17495.xml"),
+          )
+      )
+
+  public val icon_17496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17496.xml"),
+          )
+      )
+
+  public val icon_17497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17497.xml"),
+          )
+      )
+
+  public val icon_17498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17498.xml"),
+          )
+      )
+
+  public val icon_17499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17499.xml"),
+          )
+      )
+
+  public val icon_175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_175.xml"),
+          )
+      )
+
+  public val icon_1750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1750.xml"),
+          )
+      )
+
+  public val icon_17500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17500.xml"),
+          )
+      )
+
+  public val icon_17501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17501.xml"),
+          )
+      )
+
+  public val icon_17502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17502.xml"),
+          )
+      )
+
+  public val icon_17503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17503.xml"),
+          )
+      )
+
+  public val icon_17504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17504.xml"),
+          )
+      )
+
+  public val icon_17505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17505.xml"),
+          )
+      )
+
+  public val icon_17506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17506.xml"),
+          )
+      )
+
+  public val icon_17507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17507.xml"),
+          )
+      )
+
+  public val icon_17508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17508.xml"),
+          )
+      )
+
+  public val icon_17509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17509.xml"),
+          )
+      )
+
+  public val icon_1751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1751.xml"),
+          )
+      )
+
+  public val icon_17510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17510.xml"),
+          )
+      )
+
+  public val icon_17511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17511.xml"),
+          )
+      )
+
+  public val icon_17512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17512.xml"),
+          )
+      )
+
+  public val icon_17513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17513.xml"),
+          )
+      )
+
+  public val icon_17514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17514.xml"),
+          )
+      )
+
+  public val icon_17515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17515.xml"),
+          )
+      )
+
+  public val icon_17516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17516.xml"),
+          )
+      )
+
+  public val icon_17517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17517.xml"),
+          )
+      )
+
+  public val icon_17518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17518.xml"),
+          )
+      )
+
+  public val icon_17519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17519.xml"),
+          )
+      )
+
+  public val icon_1752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1752.xml"),
+          )
+      )
+
+  public val icon_17520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17520.xml"),
+          )
+      )
+
+  public val icon_17521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17521.xml"),
+          )
+      )
+
+  public val icon_17522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17522.xml"),
+          )
+      )
+
+  public val icon_17523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17523.xml"),
+          )
+      )
+
+  public val icon_17524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17524.xml"),
+          )
+      )
+
+  public val icon_17525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17525.xml"),
+          )
+      )
+
+  public val icon_17526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17526.xml"),
+          )
+      )
+
+  public val icon_17527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17527.xml"),
+          )
+      )
+
+  public val icon_17528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17528.xml"),
+          )
+      )
+
+  public val icon_17529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17529.xml"),
+          )
+      )
+
+  public val icon_1753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1753.xml"),
+          )
+      )
+
+  public val icon_17530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17530.xml"),
+          )
+      )
+
+  public val icon_17531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17531.xml"),
+          )
+      )
+
+  public val icon_17532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17532.xml"),
+          )
+      )
+
+  public val icon_17533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17533.xml"),
+          )
+      )
+
+  public val icon_17534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17534.xml"),
+          )
+      )
+
+  public val icon_17535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17535.xml"),
+          )
+      )
+
+  public val icon_17536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17536.xml"),
+          )
+      )
+
+  public val icon_17537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17537.xml"),
+          )
+      )
+
+  public val icon_17538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17538.xml"),
+          )
+      )
+
+  public val icon_17539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17539.xml"),
+          )
+      )
+
+  public val icon_1754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1754.xml"),
+          )
+      )
+
+  public val icon_17540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17540.xml"),
+          )
+      )
+
+  public val icon_17541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17541.xml"),
+          )
+      )
+
+  public val icon_17542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17542.xml"),
+          )
+      )
+
+  public val icon_17543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17543.xml"),
+          )
+      )
+
+  public val icon_17544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17544.xml"),
+          )
+      )
+
+  public val icon_17545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17545.xml"),
+          )
+      )
+
+  public val icon_17546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17546.xml"),
+          )
+      )
+
+  public val icon_17547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17547.xml"),
+          )
+      )
+
+  public val icon_17548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17548.xml"),
+          )
+      )
+
+  public val icon_17549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17549.xml"),
+          )
+      )
+
+  public val icon_1755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1755.xml"),
+          )
+      )
+
+  public val icon_17550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17550.xml"),
+          )
+      )
+
+  public val icon_17551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17551.xml"),
+          )
+      )
+
+  public val icon_17552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17552.xml"),
+          )
+      )
+
+  public val icon_17553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17553.xml"),
+          )
+      )
+
+  public val icon_17554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17554.xml"),
+          )
+      )
+
+  public val icon_17555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17555.xml"),
+          )
+      )
+
+  public val icon_17556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17556.xml"),
+          )
+      )
+
+  public val icon_17557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17557.xml"),
+          )
+      )
+
+  public val icon_17558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17558.xml"),
+          )
+      )
+
+  public val icon_17559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17559.xml"),
+          )
+      )
+
+  public val icon_1756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1756.xml"),
+          )
+      )
+
+  public val icon_17560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17560.xml"),
+          )
+      )
+
+  public val icon_17561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17561.xml"),
+          )
+      )
+
+  public val icon_17562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17562.xml"),
+          )
+      )
+
+  public val icon_17563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17563.xml"),
+          )
+      )
+
+  public val icon_17564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17564.xml"),
+          )
+      )
+
+  public val icon_17565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17565.xml"),
+          )
+      )
+
+  public val icon_17566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17566.xml"),
+          )
+      )
+
+  public val icon_17567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17567.xml"),
+          )
+      )
+
+  public val icon_17568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17568.xml"),
+          )
+      )
+
+  public val icon_17569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17569.xml"),
+          )
+      )
+
+  public val icon_1757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1757.xml"),
+          )
+      )
+
+  public val icon_17570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17570.xml"),
+          )
+      )
+
+  public val icon_17571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17571.xml"),
+          )
+      )
+
+  public val icon_17572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17572.xml"),
+          )
+      )
+
+  public val icon_17573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17573.xml"),
+          )
+      )
+
+  public val icon_17574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17574.xml"),
+          )
+      )
+
+  public val icon_17575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17575.xml"),
+          )
+      )
+
+  public val icon_17576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17576.xml"),
+          )
+      )
+
+  public val icon_17577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17577.xml"),
+          )
+      )
+
+  public val icon_17578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17578.xml"),
+          )
+      )
+
+  public val icon_17579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17579.xml"),
+          )
+      )
+
+  public val icon_1758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1758.xml"),
+          )
+      )
+
+  public val icon_17580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17580.xml"),
+          )
+      )
+
+  public val icon_17581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17581.xml"),
+          )
+      )
+
+  public val icon_17582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17582.xml"),
+          )
+      )
+
+  public val icon_17583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17583.xml"),
+          )
+      )
+
+  public val icon_17584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17584.xml"),
+          )
+      )
+
+  public val icon_17585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17585.xml"),
+          )
+      )
+
+  public val icon_17586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17586.xml"),
+          )
+      )
+
+  public val icon_17587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17587.xml"),
+          )
+      )
+
+  public val icon_17588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17588.xml"),
+          )
+      )
+
+  public val icon_17589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17589.xml"),
+          )
+      )
+
+  public val icon_1759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1759.xml"),
+          )
+      )
+
+  public val icon_17590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17590.xml"),
+          )
+      )
+
+  public val icon_17591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17591.xml"),
+          )
+      )
+
+  public val icon_17592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17592.xml"),
+          )
+      )
+
+  public val icon_17593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17593.xml"),
+          )
+      )
+
+  public val icon_17594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17594.xml"),
+          )
+      )
+
+  public val icon_17595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17595.xml"),
+          )
+      )
+
+  public val icon_17596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17596.xml"),
+          )
+      )
+
+  public val icon_17597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17597.xml"),
+          )
+      )
+
+  public val icon_17598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17598.xml"),
+          )
+      )
+
+  public val icon_17599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17599.xml"),
+          )
+      )
+
+  public val icon_176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_176.xml"),
+          )
+      )
+
+  public val icon_1760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1760.xml"),
+          )
+      )
+
+  public val icon_17600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17600.xml"),
+          )
+      )
+
+  public val icon_17601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17601.xml"),
+          )
+      )
+
+  public val icon_17602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17602.xml"),
+          )
+      )
+
+  public val icon_17603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17603.xml"),
+          )
+      )
+
+  public val icon_17604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17604.xml"),
+          )
+      )
+
+  public val icon_17605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17605.xml"),
+          )
+      )
+
+  public val icon_17606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17606.xml"),
+          )
+      )
+
+  public val icon_17607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17607.xml"),
+          )
+      )
+
+  public val icon_17608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17608.xml"),
+          )
+      )
+
+  public val icon_17609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17609.xml"),
+          )
+      )
+
+  public val icon_1761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1761.xml"),
+          )
+      )
+
+  public val icon_17610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17610.xml"),
+          )
+      )
+
+  public val icon_17611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17611.xml"),
+          )
+      )
+
+  public val icon_17612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17612.xml"),
+          )
+      )
+
+  public val icon_17613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17613.xml"),
+          )
+      )
+
+  public val icon_17614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17614.xml"),
+          )
+      )
+
+  public val icon_17615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17615.xml"),
+          )
+      )
+
+  public val icon_17616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17616.xml"),
+          )
+      )
+
+  public val icon_17617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17617.xml"),
+          )
+      )
+
+  public val icon_17618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17618.xml"),
+          )
+      )
+
+  public val icon_17619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17619.xml"),
+          )
+      )
+
+  public val icon_1762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1762.xml"),
+          )
+      )
+
+  public val icon_17620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17620.xml"),
+          )
+      )
+
+  public val icon_17621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17621.xml"),
+          )
+      )
+
+  public val icon_17622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17622.xml"),
+          )
+      )
+
+  public val icon_17623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17623.xml"),
+          )
+      )
+
+  public val icon_17624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17624.xml"),
+          )
+      )
+
+  public val icon_17625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17625.xml"),
+          )
+      )
+
+  public val icon_17626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17626.xml"),
+          )
+      )
+
+  public val icon_17627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17627.xml"),
+          )
+      )
+
+  public val icon_17628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17628.xml"),
+          )
+      )
+
+  public val icon_17629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17629.xml"),
+          )
+      )
+
+  public val icon_1763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1763.xml"),
+          )
+      )
+
+  public val icon_17630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17630.xml"),
+          )
+      )
+
+  public val icon_17631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17631.xml"),
+          )
+      )
+
+  public val icon_17632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17632.xml"),
+          )
+      )
+
+  public val icon_17633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17633.xml"),
+          )
+      )
+
+  public val icon_17634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17634.xml"),
+          )
+      )
+
+  public val icon_17635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17635.xml"),
+          )
+      )
+
+  public val icon_17636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17636.xml"),
+          )
+      )
+
+  public val icon_17637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17637.xml"),
+          )
+      )
+
+  public val icon_17638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17638.xml"),
+          )
+      )
+
+  public val icon_17639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17639.xml"),
+          )
+      )
+
+  public val icon_1764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1764.xml"),
+          )
+      )
+
+  public val icon_17640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17640.xml"),
+          )
+      )
+
+  public val icon_17641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17641.xml"),
+          )
+      )
+
+  public val icon_17642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17642.xml"),
+          )
+      )
+
+  public val icon_17643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17643.xml"),
+          )
+      )
+
+  public val icon_17644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17644.xml"),
+          )
+      )
+
+  public val icon_17645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17645.xml"),
+          )
+      )
+
+  public val icon_17646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17646.xml"),
+          )
+      )
+
+  public val icon_17647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17647.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17198: DrawableResource
+  get() = Drawable16.icon_17198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17199: DrawableResource
+  get() = Drawable16.icon_17199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_172: DrawableResource
+  get() = Drawable16.icon_172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1720: DrawableResource
+  get() = Drawable16.icon_1720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17200: DrawableResource
+  get() = Drawable16.icon_17200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17201: DrawableResource
+  get() = Drawable16.icon_17201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17202: DrawableResource
+  get() = Drawable16.icon_17202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17203: DrawableResource
+  get() = Drawable16.icon_17203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17204: DrawableResource
+  get() = Drawable16.icon_17204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17205: DrawableResource
+  get() = Drawable16.icon_17205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17206: DrawableResource
+  get() = Drawable16.icon_17206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17207: DrawableResource
+  get() = Drawable16.icon_17207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17208: DrawableResource
+  get() = Drawable16.icon_17208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17209: DrawableResource
+  get() = Drawable16.icon_17209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1721: DrawableResource
+  get() = Drawable16.icon_1721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17210: DrawableResource
+  get() = Drawable16.icon_17210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17211: DrawableResource
+  get() = Drawable16.icon_17211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17212: DrawableResource
+  get() = Drawable16.icon_17212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17213: DrawableResource
+  get() = Drawable16.icon_17213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17214: DrawableResource
+  get() = Drawable16.icon_17214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17215: DrawableResource
+  get() = Drawable16.icon_17215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17216: DrawableResource
+  get() = Drawable16.icon_17216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17217: DrawableResource
+  get() = Drawable16.icon_17217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17218: DrawableResource
+  get() = Drawable16.icon_17218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17219: DrawableResource
+  get() = Drawable16.icon_17219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1722: DrawableResource
+  get() = Drawable16.icon_1722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17220: DrawableResource
+  get() = Drawable16.icon_17220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17221: DrawableResource
+  get() = Drawable16.icon_17221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17222: DrawableResource
+  get() = Drawable16.icon_17222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17223: DrawableResource
+  get() = Drawable16.icon_17223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17224: DrawableResource
+  get() = Drawable16.icon_17224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17225: DrawableResource
+  get() = Drawable16.icon_17225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17226: DrawableResource
+  get() = Drawable16.icon_17226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17227: DrawableResource
+  get() = Drawable16.icon_17227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17228: DrawableResource
+  get() = Drawable16.icon_17228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17229: DrawableResource
+  get() = Drawable16.icon_17229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1723: DrawableResource
+  get() = Drawable16.icon_1723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17230: DrawableResource
+  get() = Drawable16.icon_17230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17231: DrawableResource
+  get() = Drawable16.icon_17231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17232: DrawableResource
+  get() = Drawable16.icon_17232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17233: DrawableResource
+  get() = Drawable16.icon_17233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17234: DrawableResource
+  get() = Drawable16.icon_17234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17235: DrawableResource
+  get() = Drawable16.icon_17235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17236: DrawableResource
+  get() = Drawable16.icon_17236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17237: DrawableResource
+  get() = Drawable16.icon_17237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17238: DrawableResource
+  get() = Drawable16.icon_17238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17239: DrawableResource
+  get() = Drawable16.icon_17239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1724: DrawableResource
+  get() = Drawable16.icon_1724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17240: DrawableResource
+  get() = Drawable16.icon_17240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17241: DrawableResource
+  get() = Drawable16.icon_17241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17242: DrawableResource
+  get() = Drawable16.icon_17242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17243: DrawableResource
+  get() = Drawable16.icon_17243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17244: DrawableResource
+  get() = Drawable16.icon_17244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17245: DrawableResource
+  get() = Drawable16.icon_17245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17246: DrawableResource
+  get() = Drawable16.icon_17246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17247: DrawableResource
+  get() = Drawable16.icon_17247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17248: DrawableResource
+  get() = Drawable16.icon_17248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17249: DrawableResource
+  get() = Drawable16.icon_17249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1725: DrawableResource
+  get() = Drawable16.icon_1725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17250: DrawableResource
+  get() = Drawable16.icon_17250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17251: DrawableResource
+  get() = Drawable16.icon_17251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17252: DrawableResource
+  get() = Drawable16.icon_17252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17253: DrawableResource
+  get() = Drawable16.icon_17253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17254: DrawableResource
+  get() = Drawable16.icon_17254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17255: DrawableResource
+  get() = Drawable16.icon_17255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17256: DrawableResource
+  get() = Drawable16.icon_17256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17257: DrawableResource
+  get() = Drawable16.icon_17257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17258: DrawableResource
+  get() = Drawable16.icon_17258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17259: DrawableResource
+  get() = Drawable16.icon_17259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1726: DrawableResource
+  get() = Drawable16.icon_1726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17260: DrawableResource
+  get() = Drawable16.icon_17260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17261: DrawableResource
+  get() = Drawable16.icon_17261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17262: DrawableResource
+  get() = Drawable16.icon_17262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17263: DrawableResource
+  get() = Drawable16.icon_17263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17264: DrawableResource
+  get() = Drawable16.icon_17264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17265: DrawableResource
+  get() = Drawable16.icon_17265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17266: DrawableResource
+  get() = Drawable16.icon_17266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17267: DrawableResource
+  get() = Drawable16.icon_17267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17268: DrawableResource
+  get() = Drawable16.icon_17268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17269: DrawableResource
+  get() = Drawable16.icon_17269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1727: DrawableResource
+  get() = Drawable16.icon_1727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17270: DrawableResource
+  get() = Drawable16.icon_17270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17271: DrawableResource
+  get() = Drawable16.icon_17271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17272: DrawableResource
+  get() = Drawable16.icon_17272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17273: DrawableResource
+  get() = Drawable16.icon_17273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17274: DrawableResource
+  get() = Drawable16.icon_17274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17275: DrawableResource
+  get() = Drawable16.icon_17275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17276: DrawableResource
+  get() = Drawable16.icon_17276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17277: DrawableResource
+  get() = Drawable16.icon_17277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17278: DrawableResource
+  get() = Drawable16.icon_17278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17279: DrawableResource
+  get() = Drawable16.icon_17279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1728: DrawableResource
+  get() = Drawable16.icon_1728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17280: DrawableResource
+  get() = Drawable16.icon_17280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17281: DrawableResource
+  get() = Drawable16.icon_17281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17282: DrawableResource
+  get() = Drawable16.icon_17282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17283: DrawableResource
+  get() = Drawable16.icon_17283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17284: DrawableResource
+  get() = Drawable16.icon_17284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17285: DrawableResource
+  get() = Drawable16.icon_17285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17286: DrawableResource
+  get() = Drawable16.icon_17286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17287: DrawableResource
+  get() = Drawable16.icon_17287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17288: DrawableResource
+  get() = Drawable16.icon_17288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17289: DrawableResource
+  get() = Drawable16.icon_17289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1729: DrawableResource
+  get() = Drawable16.icon_1729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17290: DrawableResource
+  get() = Drawable16.icon_17290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17291: DrawableResource
+  get() = Drawable16.icon_17291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17292: DrawableResource
+  get() = Drawable16.icon_17292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17293: DrawableResource
+  get() = Drawable16.icon_17293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17294: DrawableResource
+  get() = Drawable16.icon_17294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17295: DrawableResource
+  get() = Drawable16.icon_17295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17296: DrawableResource
+  get() = Drawable16.icon_17296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17297: DrawableResource
+  get() = Drawable16.icon_17297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17298: DrawableResource
+  get() = Drawable16.icon_17298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17299: DrawableResource
+  get() = Drawable16.icon_17299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_173: DrawableResource
+  get() = Drawable16.icon_173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1730: DrawableResource
+  get() = Drawable16.icon_1730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17300: DrawableResource
+  get() = Drawable16.icon_17300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17301: DrawableResource
+  get() = Drawable16.icon_17301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17302: DrawableResource
+  get() = Drawable16.icon_17302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17303: DrawableResource
+  get() = Drawable16.icon_17303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17304: DrawableResource
+  get() = Drawable16.icon_17304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17305: DrawableResource
+  get() = Drawable16.icon_17305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17306: DrawableResource
+  get() = Drawable16.icon_17306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17307: DrawableResource
+  get() = Drawable16.icon_17307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17308: DrawableResource
+  get() = Drawable16.icon_17308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17309: DrawableResource
+  get() = Drawable16.icon_17309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1731: DrawableResource
+  get() = Drawable16.icon_1731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17310: DrawableResource
+  get() = Drawable16.icon_17310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17311: DrawableResource
+  get() = Drawable16.icon_17311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17312: DrawableResource
+  get() = Drawable16.icon_17312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17313: DrawableResource
+  get() = Drawable16.icon_17313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17314: DrawableResource
+  get() = Drawable16.icon_17314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17315: DrawableResource
+  get() = Drawable16.icon_17315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17316: DrawableResource
+  get() = Drawable16.icon_17316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17317: DrawableResource
+  get() = Drawable16.icon_17317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17318: DrawableResource
+  get() = Drawable16.icon_17318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17319: DrawableResource
+  get() = Drawable16.icon_17319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1732: DrawableResource
+  get() = Drawable16.icon_1732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17320: DrawableResource
+  get() = Drawable16.icon_17320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17321: DrawableResource
+  get() = Drawable16.icon_17321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17322: DrawableResource
+  get() = Drawable16.icon_17322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17323: DrawableResource
+  get() = Drawable16.icon_17323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17324: DrawableResource
+  get() = Drawable16.icon_17324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17325: DrawableResource
+  get() = Drawable16.icon_17325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17326: DrawableResource
+  get() = Drawable16.icon_17326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17327: DrawableResource
+  get() = Drawable16.icon_17327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17328: DrawableResource
+  get() = Drawable16.icon_17328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17329: DrawableResource
+  get() = Drawable16.icon_17329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1733: DrawableResource
+  get() = Drawable16.icon_1733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17330: DrawableResource
+  get() = Drawable16.icon_17330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17331: DrawableResource
+  get() = Drawable16.icon_17331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17332: DrawableResource
+  get() = Drawable16.icon_17332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17333: DrawableResource
+  get() = Drawable16.icon_17333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17334: DrawableResource
+  get() = Drawable16.icon_17334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17335: DrawableResource
+  get() = Drawable16.icon_17335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17336: DrawableResource
+  get() = Drawable16.icon_17336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17337: DrawableResource
+  get() = Drawable16.icon_17337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17338: DrawableResource
+  get() = Drawable16.icon_17338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17339: DrawableResource
+  get() = Drawable16.icon_17339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1734: DrawableResource
+  get() = Drawable16.icon_1734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17340: DrawableResource
+  get() = Drawable16.icon_17340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17341: DrawableResource
+  get() = Drawable16.icon_17341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17342: DrawableResource
+  get() = Drawable16.icon_17342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17343: DrawableResource
+  get() = Drawable16.icon_17343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17344: DrawableResource
+  get() = Drawable16.icon_17344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17345: DrawableResource
+  get() = Drawable16.icon_17345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17346: DrawableResource
+  get() = Drawable16.icon_17346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17347: DrawableResource
+  get() = Drawable16.icon_17347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17348: DrawableResource
+  get() = Drawable16.icon_17348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17349: DrawableResource
+  get() = Drawable16.icon_17349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1735: DrawableResource
+  get() = Drawable16.icon_1735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17350: DrawableResource
+  get() = Drawable16.icon_17350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17351: DrawableResource
+  get() = Drawable16.icon_17351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17352: DrawableResource
+  get() = Drawable16.icon_17352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17353: DrawableResource
+  get() = Drawable16.icon_17353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17354: DrawableResource
+  get() = Drawable16.icon_17354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17355: DrawableResource
+  get() = Drawable16.icon_17355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17356: DrawableResource
+  get() = Drawable16.icon_17356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17357: DrawableResource
+  get() = Drawable16.icon_17357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17358: DrawableResource
+  get() = Drawable16.icon_17358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17359: DrawableResource
+  get() = Drawable16.icon_17359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1736: DrawableResource
+  get() = Drawable16.icon_1736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17360: DrawableResource
+  get() = Drawable16.icon_17360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17361: DrawableResource
+  get() = Drawable16.icon_17361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17362: DrawableResource
+  get() = Drawable16.icon_17362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17363: DrawableResource
+  get() = Drawable16.icon_17363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17364: DrawableResource
+  get() = Drawable16.icon_17364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17365: DrawableResource
+  get() = Drawable16.icon_17365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17366: DrawableResource
+  get() = Drawable16.icon_17366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17367: DrawableResource
+  get() = Drawable16.icon_17367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17368: DrawableResource
+  get() = Drawable16.icon_17368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17369: DrawableResource
+  get() = Drawable16.icon_17369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1737: DrawableResource
+  get() = Drawable16.icon_1737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17370: DrawableResource
+  get() = Drawable16.icon_17370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17371: DrawableResource
+  get() = Drawable16.icon_17371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17372: DrawableResource
+  get() = Drawable16.icon_17372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17373: DrawableResource
+  get() = Drawable16.icon_17373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17374: DrawableResource
+  get() = Drawable16.icon_17374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17375: DrawableResource
+  get() = Drawable16.icon_17375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17376: DrawableResource
+  get() = Drawable16.icon_17376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17377: DrawableResource
+  get() = Drawable16.icon_17377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17378: DrawableResource
+  get() = Drawable16.icon_17378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17379: DrawableResource
+  get() = Drawable16.icon_17379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1738: DrawableResource
+  get() = Drawable16.icon_1738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17380: DrawableResource
+  get() = Drawable16.icon_17380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17381: DrawableResource
+  get() = Drawable16.icon_17381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17382: DrawableResource
+  get() = Drawable16.icon_17382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17383: DrawableResource
+  get() = Drawable16.icon_17383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17384: DrawableResource
+  get() = Drawable16.icon_17384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17385: DrawableResource
+  get() = Drawable16.icon_17385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17386: DrawableResource
+  get() = Drawable16.icon_17386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17387: DrawableResource
+  get() = Drawable16.icon_17387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17388: DrawableResource
+  get() = Drawable16.icon_17388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17389: DrawableResource
+  get() = Drawable16.icon_17389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1739: DrawableResource
+  get() = Drawable16.icon_1739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17390: DrawableResource
+  get() = Drawable16.icon_17390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17391: DrawableResource
+  get() = Drawable16.icon_17391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17392: DrawableResource
+  get() = Drawable16.icon_17392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17393: DrawableResource
+  get() = Drawable16.icon_17393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17394: DrawableResource
+  get() = Drawable16.icon_17394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17395: DrawableResource
+  get() = Drawable16.icon_17395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17396: DrawableResource
+  get() = Drawable16.icon_17396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17397: DrawableResource
+  get() = Drawable16.icon_17397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17398: DrawableResource
+  get() = Drawable16.icon_17398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17399: DrawableResource
+  get() = Drawable16.icon_17399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_174: DrawableResource
+  get() = Drawable16.icon_174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1740: DrawableResource
+  get() = Drawable16.icon_1740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17400: DrawableResource
+  get() = Drawable16.icon_17400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17401: DrawableResource
+  get() = Drawable16.icon_17401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17402: DrawableResource
+  get() = Drawable16.icon_17402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17403: DrawableResource
+  get() = Drawable16.icon_17403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17404: DrawableResource
+  get() = Drawable16.icon_17404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17405: DrawableResource
+  get() = Drawable16.icon_17405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17406: DrawableResource
+  get() = Drawable16.icon_17406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17407: DrawableResource
+  get() = Drawable16.icon_17407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17408: DrawableResource
+  get() = Drawable16.icon_17408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17409: DrawableResource
+  get() = Drawable16.icon_17409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1741: DrawableResource
+  get() = Drawable16.icon_1741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17410: DrawableResource
+  get() = Drawable16.icon_17410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17411: DrawableResource
+  get() = Drawable16.icon_17411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17412: DrawableResource
+  get() = Drawable16.icon_17412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17413: DrawableResource
+  get() = Drawable16.icon_17413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17414: DrawableResource
+  get() = Drawable16.icon_17414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17415: DrawableResource
+  get() = Drawable16.icon_17415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17416: DrawableResource
+  get() = Drawable16.icon_17416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17417: DrawableResource
+  get() = Drawable16.icon_17417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17418: DrawableResource
+  get() = Drawable16.icon_17418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17419: DrawableResource
+  get() = Drawable16.icon_17419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1742: DrawableResource
+  get() = Drawable16.icon_1742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17420: DrawableResource
+  get() = Drawable16.icon_17420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17421: DrawableResource
+  get() = Drawable16.icon_17421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17422: DrawableResource
+  get() = Drawable16.icon_17422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17423: DrawableResource
+  get() = Drawable16.icon_17423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17424: DrawableResource
+  get() = Drawable16.icon_17424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17425: DrawableResource
+  get() = Drawable16.icon_17425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17426: DrawableResource
+  get() = Drawable16.icon_17426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17427: DrawableResource
+  get() = Drawable16.icon_17427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17428: DrawableResource
+  get() = Drawable16.icon_17428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17429: DrawableResource
+  get() = Drawable16.icon_17429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1743: DrawableResource
+  get() = Drawable16.icon_1743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17430: DrawableResource
+  get() = Drawable16.icon_17430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17431: DrawableResource
+  get() = Drawable16.icon_17431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17432: DrawableResource
+  get() = Drawable16.icon_17432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17433: DrawableResource
+  get() = Drawable16.icon_17433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17434: DrawableResource
+  get() = Drawable16.icon_17434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17435: DrawableResource
+  get() = Drawable16.icon_17435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17436: DrawableResource
+  get() = Drawable16.icon_17436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17437: DrawableResource
+  get() = Drawable16.icon_17437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17438: DrawableResource
+  get() = Drawable16.icon_17438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17439: DrawableResource
+  get() = Drawable16.icon_17439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1744: DrawableResource
+  get() = Drawable16.icon_1744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17440: DrawableResource
+  get() = Drawable16.icon_17440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17441: DrawableResource
+  get() = Drawable16.icon_17441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17442: DrawableResource
+  get() = Drawable16.icon_17442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17443: DrawableResource
+  get() = Drawable16.icon_17443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17444: DrawableResource
+  get() = Drawable16.icon_17444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17445: DrawableResource
+  get() = Drawable16.icon_17445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17446: DrawableResource
+  get() = Drawable16.icon_17446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17447: DrawableResource
+  get() = Drawable16.icon_17447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17448: DrawableResource
+  get() = Drawable16.icon_17448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17449: DrawableResource
+  get() = Drawable16.icon_17449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1745: DrawableResource
+  get() = Drawable16.icon_1745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17450: DrawableResource
+  get() = Drawable16.icon_17450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17451: DrawableResource
+  get() = Drawable16.icon_17451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17452: DrawableResource
+  get() = Drawable16.icon_17452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17453: DrawableResource
+  get() = Drawable16.icon_17453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17454: DrawableResource
+  get() = Drawable16.icon_17454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17455: DrawableResource
+  get() = Drawable16.icon_17455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17456: DrawableResource
+  get() = Drawable16.icon_17456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17457: DrawableResource
+  get() = Drawable16.icon_17457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17458: DrawableResource
+  get() = Drawable16.icon_17458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17459: DrawableResource
+  get() = Drawable16.icon_17459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1746: DrawableResource
+  get() = Drawable16.icon_1746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17460: DrawableResource
+  get() = Drawable16.icon_17460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17461: DrawableResource
+  get() = Drawable16.icon_17461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17462: DrawableResource
+  get() = Drawable16.icon_17462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17463: DrawableResource
+  get() = Drawable16.icon_17463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17464: DrawableResource
+  get() = Drawable16.icon_17464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17465: DrawableResource
+  get() = Drawable16.icon_17465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17466: DrawableResource
+  get() = Drawable16.icon_17466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17467: DrawableResource
+  get() = Drawable16.icon_17467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17468: DrawableResource
+  get() = Drawable16.icon_17468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17469: DrawableResource
+  get() = Drawable16.icon_17469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1747: DrawableResource
+  get() = Drawable16.icon_1747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17470: DrawableResource
+  get() = Drawable16.icon_17470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17471: DrawableResource
+  get() = Drawable16.icon_17471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17472: DrawableResource
+  get() = Drawable16.icon_17472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17473: DrawableResource
+  get() = Drawable16.icon_17473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17474: DrawableResource
+  get() = Drawable16.icon_17474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17475: DrawableResource
+  get() = Drawable16.icon_17475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17476: DrawableResource
+  get() = Drawable16.icon_17476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17477: DrawableResource
+  get() = Drawable16.icon_17477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17478: DrawableResource
+  get() = Drawable16.icon_17478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17479: DrawableResource
+  get() = Drawable16.icon_17479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1748: DrawableResource
+  get() = Drawable16.icon_1748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17480: DrawableResource
+  get() = Drawable16.icon_17480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17481: DrawableResource
+  get() = Drawable16.icon_17481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17482: DrawableResource
+  get() = Drawable16.icon_17482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17483: DrawableResource
+  get() = Drawable16.icon_17483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17484: DrawableResource
+  get() = Drawable16.icon_17484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17485: DrawableResource
+  get() = Drawable16.icon_17485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17486: DrawableResource
+  get() = Drawable16.icon_17486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17487: DrawableResource
+  get() = Drawable16.icon_17487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17488: DrawableResource
+  get() = Drawable16.icon_17488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17489: DrawableResource
+  get() = Drawable16.icon_17489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1749: DrawableResource
+  get() = Drawable16.icon_1749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17490: DrawableResource
+  get() = Drawable16.icon_17490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17491: DrawableResource
+  get() = Drawable16.icon_17491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17492: DrawableResource
+  get() = Drawable16.icon_17492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17493: DrawableResource
+  get() = Drawable16.icon_17493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17494: DrawableResource
+  get() = Drawable16.icon_17494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17495: DrawableResource
+  get() = Drawable16.icon_17495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17496: DrawableResource
+  get() = Drawable16.icon_17496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17497: DrawableResource
+  get() = Drawable16.icon_17497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17498: DrawableResource
+  get() = Drawable16.icon_17498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17499: DrawableResource
+  get() = Drawable16.icon_17499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_175: DrawableResource
+  get() = Drawable16.icon_175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1750: DrawableResource
+  get() = Drawable16.icon_1750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17500: DrawableResource
+  get() = Drawable16.icon_17500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17501: DrawableResource
+  get() = Drawable16.icon_17501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17502: DrawableResource
+  get() = Drawable16.icon_17502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17503: DrawableResource
+  get() = Drawable16.icon_17503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17504: DrawableResource
+  get() = Drawable16.icon_17504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17505: DrawableResource
+  get() = Drawable16.icon_17505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17506: DrawableResource
+  get() = Drawable16.icon_17506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17507: DrawableResource
+  get() = Drawable16.icon_17507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17508: DrawableResource
+  get() = Drawable16.icon_17508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17509: DrawableResource
+  get() = Drawable16.icon_17509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1751: DrawableResource
+  get() = Drawable16.icon_1751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17510: DrawableResource
+  get() = Drawable16.icon_17510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17511: DrawableResource
+  get() = Drawable16.icon_17511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17512: DrawableResource
+  get() = Drawable16.icon_17512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17513: DrawableResource
+  get() = Drawable16.icon_17513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17514: DrawableResource
+  get() = Drawable16.icon_17514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17515: DrawableResource
+  get() = Drawable16.icon_17515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17516: DrawableResource
+  get() = Drawable16.icon_17516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17517: DrawableResource
+  get() = Drawable16.icon_17517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17518: DrawableResource
+  get() = Drawable16.icon_17518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17519: DrawableResource
+  get() = Drawable16.icon_17519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1752: DrawableResource
+  get() = Drawable16.icon_1752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17520: DrawableResource
+  get() = Drawable16.icon_17520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17521: DrawableResource
+  get() = Drawable16.icon_17521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17522: DrawableResource
+  get() = Drawable16.icon_17522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17523: DrawableResource
+  get() = Drawable16.icon_17523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17524: DrawableResource
+  get() = Drawable16.icon_17524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17525: DrawableResource
+  get() = Drawable16.icon_17525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17526: DrawableResource
+  get() = Drawable16.icon_17526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17527: DrawableResource
+  get() = Drawable16.icon_17527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17528: DrawableResource
+  get() = Drawable16.icon_17528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17529: DrawableResource
+  get() = Drawable16.icon_17529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1753: DrawableResource
+  get() = Drawable16.icon_1753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17530: DrawableResource
+  get() = Drawable16.icon_17530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17531: DrawableResource
+  get() = Drawable16.icon_17531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17532: DrawableResource
+  get() = Drawable16.icon_17532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17533: DrawableResource
+  get() = Drawable16.icon_17533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17534: DrawableResource
+  get() = Drawable16.icon_17534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17535: DrawableResource
+  get() = Drawable16.icon_17535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17536: DrawableResource
+  get() = Drawable16.icon_17536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17537: DrawableResource
+  get() = Drawable16.icon_17537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17538: DrawableResource
+  get() = Drawable16.icon_17538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17539: DrawableResource
+  get() = Drawable16.icon_17539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1754: DrawableResource
+  get() = Drawable16.icon_1754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17540: DrawableResource
+  get() = Drawable16.icon_17540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17541: DrawableResource
+  get() = Drawable16.icon_17541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17542: DrawableResource
+  get() = Drawable16.icon_17542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17543: DrawableResource
+  get() = Drawable16.icon_17543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17544: DrawableResource
+  get() = Drawable16.icon_17544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17545: DrawableResource
+  get() = Drawable16.icon_17545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17546: DrawableResource
+  get() = Drawable16.icon_17546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17547: DrawableResource
+  get() = Drawable16.icon_17547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17548: DrawableResource
+  get() = Drawable16.icon_17548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17549: DrawableResource
+  get() = Drawable16.icon_17549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1755: DrawableResource
+  get() = Drawable16.icon_1755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17550: DrawableResource
+  get() = Drawable16.icon_17550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17551: DrawableResource
+  get() = Drawable16.icon_17551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17552: DrawableResource
+  get() = Drawable16.icon_17552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17553: DrawableResource
+  get() = Drawable16.icon_17553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17554: DrawableResource
+  get() = Drawable16.icon_17554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17555: DrawableResource
+  get() = Drawable16.icon_17555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17556: DrawableResource
+  get() = Drawable16.icon_17556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17557: DrawableResource
+  get() = Drawable16.icon_17557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17558: DrawableResource
+  get() = Drawable16.icon_17558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17559: DrawableResource
+  get() = Drawable16.icon_17559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1756: DrawableResource
+  get() = Drawable16.icon_1756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17560: DrawableResource
+  get() = Drawable16.icon_17560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17561: DrawableResource
+  get() = Drawable16.icon_17561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17562: DrawableResource
+  get() = Drawable16.icon_17562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17563: DrawableResource
+  get() = Drawable16.icon_17563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17564: DrawableResource
+  get() = Drawable16.icon_17564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17565: DrawableResource
+  get() = Drawable16.icon_17565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17566: DrawableResource
+  get() = Drawable16.icon_17566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17567: DrawableResource
+  get() = Drawable16.icon_17567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17568: DrawableResource
+  get() = Drawable16.icon_17568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17569: DrawableResource
+  get() = Drawable16.icon_17569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1757: DrawableResource
+  get() = Drawable16.icon_1757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17570: DrawableResource
+  get() = Drawable16.icon_17570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17571: DrawableResource
+  get() = Drawable16.icon_17571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17572: DrawableResource
+  get() = Drawable16.icon_17572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17573: DrawableResource
+  get() = Drawable16.icon_17573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17574: DrawableResource
+  get() = Drawable16.icon_17574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17575: DrawableResource
+  get() = Drawable16.icon_17575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17576: DrawableResource
+  get() = Drawable16.icon_17576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17577: DrawableResource
+  get() = Drawable16.icon_17577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17578: DrawableResource
+  get() = Drawable16.icon_17578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17579: DrawableResource
+  get() = Drawable16.icon_17579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1758: DrawableResource
+  get() = Drawable16.icon_1758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17580: DrawableResource
+  get() = Drawable16.icon_17580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17581: DrawableResource
+  get() = Drawable16.icon_17581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17582: DrawableResource
+  get() = Drawable16.icon_17582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17583: DrawableResource
+  get() = Drawable16.icon_17583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17584: DrawableResource
+  get() = Drawable16.icon_17584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17585: DrawableResource
+  get() = Drawable16.icon_17585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17586: DrawableResource
+  get() = Drawable16.icon_17586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17587: DrawableResource
+  get() = Drawable16.icon_17587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17588: DrawableResource
+  get() = Drawable16.icon_17588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17589: DrawableResource
+  get() = Drawable16.icon_17589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1759: DrawableResource
+  get() = Drawable16.icon_1759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17590: DrawableResource
+  get() = Drawable16.icon_17590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17591: DrawableResource
+  get() = Drawable16.icon_17591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17592: DrawableResource
+  get() = Drawable16.icon_17592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17593: DrawableResource
+  get() = Drawable16.icon_17593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17594: DrawableResource
+  get() = Drawable16.icon_17594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17595: DrawableResource
+  get() = Drawable16.icon_17595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17596: DrawableResource
+  get() = Drawable16.icon_17596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17597: DrawableResource
+  get() = Drawable16.icon_17597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17598: DrawableResource
+  get() = Drawable16.icon_17598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17599: DrawableResource
+  get() = Drawable16.icon_17599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_176: DrawableResource
+  get() = Drawable16.icon_176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1760: DrawableResource
+  get() = Drawable16.icon_1760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17600: DrawableResource
+  get() = Drawable16.icon_17600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17601: DrawableResource
+  get() = Drawable16.icon_17601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17602: DrawableResource
+  get() = Drawable16.icon_17602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17603: DrawableResource
+  get() = Drawable16.icon_17603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17604: DrawableResource
+  get() = Drawable16.icon_17604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17605: DrawableResource
+  get() = Drawable16.icon_17605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17606: DrawableResource
+  get() = Drawable16.icon_17606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17607: DrawableResource
+  get() = Drawable16.icon_17607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17608: DrawableResource
+  get() = Drawable16.icon_17608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17609: DrawableResource
+  get() = Drawable16.icon_17609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1761: DrawableResource
+  get() = Drawable16.icon_1761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17610: DrawableResource
+  get() = Drawable16.icon_17610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17611: DrawableResource
+  get() = Drawable16.icon_17611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17612: DrawableResource
+  get() = Drawable16.icon_17612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17613: DrawableResource
+  get() = Drawable16.icon_17613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17614: DrawableResource
+  get() = Drawable16.icon_17614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17615: DrawableResource
+  get() = Drawable16.icon_17615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17616: DrawableResource
+  get() = Drawable16.icon_17616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17617: DrawableResource
+  get() = Drawable16.icon_17617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17618: DrawableResource
+  get() = Drawable16.icon_17618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17619: DrawableResource
+  get() = Drawable16.icon_17619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1762: DrawableResource
+  get() = Drawable16.icon_1762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17620: DrawableResource
+  get() = Drawable16.icon_17620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17621: DrawableResource
+  get() = Drawable16.icon_17621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17622: DrawableResource
+  get() = Drawable16.icon_17622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17623: DrawableResource
+  get() = Drawable16.icon_17623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17624: DrawableResource
+  get() = Drawable16.icon_17624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17625: DrawableResource
+  get() = Drawable16.icon_17625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17626: DrawableResource
+  get() = Drawable16.icon_17626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17627: DrawableResource
+  get() = Drawable16.icon_17627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17628: DrawableResource
+  get() = Drawable16.icon_17628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17629: DrawableResource
+  get() = Drawable16.icon_17629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1763: DrawableResource
+  get() = Drawable16.icon_1763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17630: DrawableResource
+  get() = Drawable16.icon_17630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17631: DrawableResource
+  get() = Drawable16.icon_17631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17632: DrawableResource
+  get() = Drawable16.icon_17632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17633: DrawableResource
+  get() = Drawable16.icon_17633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17634: DrawableResource
+  get() = Drawable16.icon_17634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17635: DrawableResource
+  get() = Drawable16.icon_17635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17636: DrawableResource
+  get() = Drawable16.icon_17636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17637: DrawableResource
+  get() = Drawable16.icon_17637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17638: DrawableResource
+  get() = Drawable16.icon_17638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17639: DrawableResource
+  get() = Drawable16.icon_17639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1764: DrawableResource
+  get() = Drawable16.icon_1764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17640: DrawableResource
+  get() = Drawable16.icon_17640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17641: DrawableResource
+  get() = Drawable16.icon_17641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17642: DrawableResource
+  get() = Drawable16.icon_17642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17643: DrawableResource
+  get() = Drawable16.icon_17643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17644: DrawableResource
+  get() = Drawable16.icon_17644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17645: DrawableResource
+  get() = Drawable16.icon_17645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17646: DrawableResource
+  get() = Drawable16.icon_17646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17647: DrawableResource
+  get() = Drawable16.icon_17647

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable17.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable17.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable17 {
+  public val icon_17648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17648.xml"),
+          )
+      )
+
+  public val icon_17649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17649.xml"),
+          )
+      )
+
+  public val icon_1765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1765.xml"),
+          )
+      )
+
+  public val icon_17650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17650.xml"),
+          )
+      )
+
+  public val icon_17651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17651.xml"),
+          )
+      )
+
+  public val icon_17652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17652.xml"),
+          )
+      )
+
+  public val icon_17653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17653.xml"),
+          )
+      )
+
+  public val icon_17654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17654.xml"),
+          )
+      )
+
+  public val icon_17655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17655.xml"),
+          )
+      )
+
+  public val icon_17656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17656.xml"),
+          )
+      )
+
+  public val icon_17657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17657.xml"),
+          )
+      )
+
+  public val icon_17658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17658.xml"),
+          )
+      )
+
+  public val icon_17659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17659.xml"),
+          )
+      )
+
+  public val icon_1766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1766.xml"),
+          )
+      )
+
+  public val icon_17660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17660.xml"),
+          )
+      )
+
+  public val icon_17661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17661.xml"),
+          )
+      )
+
+  public val icon_17662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17662.xml"),
+          )
+      )
+
+  public val icon_17663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17663.xml"),
+          )
+      )
+
+  public val icon_17664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17664.xml"),
+          )
+      )
+
+  public val icon_17665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17665.xml"),
+          )
+      )
+
+  public val icon_17666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17666.xml"),
+          )
+      )
+
+  public val icon_17667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17667.xml"),
+          )
+      )
+
+  public val icon_17668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17668.xml"),
+          )
+      )
+
+  public val icon_17669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17669.xml"),
+          )
+      )
+
+  public val icon_1767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1767.xml"),
+          )
+      )
+
+  public val icon_17670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17670.xml"),
+          )
+      )
+
+  public val icon_17671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17671.xml"),
+          )
+      )
+
+  public val icon_17672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17672.xml"),
+          )
+      )
+
+  public val icon_17673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17673.xml"),
+          )
+      )
+
+  public val icon_17674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17674.xml"),
+          )
+      )
+
+  public val icon_17675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17675.xml"),
+          )
+      )
+
+  public val icon_17676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17676.xml"),
+          )
+      )
+
+  public val icon_17677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17677.xml"),
+          )
+      )
+
+  public val icon_17678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17678.xml"),
+          )
+      )
+
+  public val icon_17679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17679.xml"),
+          )
+      )
+
+  public val icon_1768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1768.xml"),
+          )
+      )
+
+  public val icon_17680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17680.xml"),
+          )
+      )
+
+  public val icon_17681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17681.xml"),
+          )
+      )
+
+  public val icon_17682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17682.xml"),
+          )
+      )
+
+  public val icon_17683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17683.xml"),
+          )
+      )
+
+  public val icon_17684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17684.xml"),
+          )
+      )
+
+  public val icon_17685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17685.xml"),
+          )
+      )
+
+  public val icon_17686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17686.xml"),
+          )
+      )
+
+  public val icon_17687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17687.xml"),
+          )
+      )
+
+  public val icon_17688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17688.xml"),
+          )
+      )
+
+  public val icon_17689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17689.xml"),
+          )
+      )
+
+  public val icon_1769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1769.xml"),
+          )
+      )
+
+  public val icon_17690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17690.xml"),
+          )
+      )
+
+  public val icon_17691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17691.xml"),
+          )
+      )
+
+  public val icon_17692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17692.xml"),
+          )
+      )
+
+  public val icon_17693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17693.xml"),
+          )
+      )
+
+  public val icon_17694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17694.xml"),
+          )
+      )
+
+  public val icon_17695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17695.xml"),
+          )
+      )
+
+  public val icon_17696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17696.xml"),
+          )
+      )
+
+  public val icon_17697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17697.xml"),
+          )
+      )
+
+  public val icon_17698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17698.xml"),
+          )
+      )
+
+  public val icon_17699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17699.xml"),
+          )
+      )
+
+  public val icon_177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_177.xml"),
+          )
+      )
+
+  public val icon_1770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1770.xml"),
+          )
+      )
+
+  public val icon_17700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17700.xml"),
+          )
+      )
+
+  public val icon_17701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17701.xml"),
+          )
+      )
+
+  public val icon_17702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17702.xml"),
+          )
+      )
+
+  public val icon_17703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17703.xml"),
+          )
+      )
+
+  public val icon_17704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17704.xml"),
+          )
+      )
+
+  public val icon_17705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17705.xml"),
+          )
+      )
+
+  public val icon_17706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17706.xml"),
+          )
+      )
+
+  public val icon_17707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17707.xml"),
+          )
+      )
+
+  public val icon_17708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17708.xml"),
+          )
+      )
+
+  public val icon_17709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17709.xml"),
+          )
+      )
+
+  public val icon_1771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1771.xml"),
+          )
+      )
+
+  public val icon_17710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17710.xml"),
+          )
+      )
+
+  public val icon_17711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17711.xml"),
+          )
+      )
+
+  public val icon_17712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17712.xml"),
+          )
+      )
+
+  public val icon_17713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17713.xml"),
+          )
+      )
+
+  public val icon_17714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17714.xml"),
+          )
+      )
+
+  public val icon_17715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17715.xml"),
+          )
+      )
+
+  public val icon_17716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17716.xml"),
+          )
+      )
+
+  public val icon_17717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17717.xml"),
+          )
+      )
+
+  public val icon_17718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17718.xml"),
+          )
+      )
+
+  public val icon_17719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17719.xml"),
+          )
+      )
+
+  public val icon_1772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1772.xml"),
+          )
+      )
+
+  public val icon_17720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17720.xml"),
+          )
+      )
+
+  public val icon_17721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17721.xml"),
+          )
+      )
+
+  public val icon_17722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17722.xml"),
+          )
+      )
+
+  public val icon_17723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17723.xml"),
+          )
+      )
+
+  public val icon_17724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17724.xml"),
+          )
+      )
+
+  public val icon_17725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17725.xml"),
+          )
+      )
+
+  public val icon_17726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17726.xml"),
+          )
+      )
+
+  public val icon_17727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17727.xml"),
+          )
+      )
+
+  public val icon_17728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17728.xml"),
+          )
+      )
+
+  public val icon_17729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17729.xml"),
+          )
+      )
+
+  public val icon_1773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1773.xml"),
+          )
+      )
+
+  public val icon_17730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17730.xml"),
+          )
+      )
+
+  public val icon_17731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17731.xml"),
+          )
+      )
+
+  public val icon_17732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17732.xml"),
+          )
+      )
+
+  public val icon_17733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17733.xml"),
+          )
+      )
+
+  public val icon_17734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17734.xml"),
+          )
+      )
+
+  public val icon_17735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17735.xml"),
+          )
+      )
+
+  public val icon_17736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17736.xml"),
+          )
+      )
+
+  public val icon_17737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17737.xml"),
+          )
+      )
+
+  public val icon_17738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17738.xml"),
+          )
+      )
+
+  public val icon_17739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17739.xml"),
+          )
+      )
+
+  public val icon_1774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1774.xml"),
+          )
+      )
+
+  public val icon_17740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17740.xml"),
+          )
+      )
+
+  public val icon_17741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17741.xml"),
+          )
+      )
+
+  public val icon_17742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17742.xml"),
+          )
+      )
+
+  public val icon_17743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17743.xml"),
+          )
+      )
+
+  public val icon_17744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17744.xml"),
+          )
+      )
+
+  public val icon_17745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17745.xml"),
+          )
+      )
+
+  public val icon_17746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17746.xml"),
+          )
+      )
+
+  public val icon_17747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17747.xml"),
+          )
+      )
+
+  public val icon_17748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17748.xml"),
+          )
+      )
+
+  public val icon_17749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17749.xml"),
+          )
+      )
+
+  public val icon_1775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1775.xml"),
+          )
+      )
+
+  public val icon_17750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17750.xml"),
+          )
+      )
+
+  public val icon_17751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17751.xml"),
+          )
+      )
+
+  public val icon_17752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17752.xml"),
+          )
+      )
+
+  public val icon_17753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17753.xml"),
+          )
+      )
+
+  public val icon_17754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17754.xml"),
+          )
+      )
+
+  public val icon_17755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17755.xml"),
+          )
+      )
+
+  public val icon_17756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17756.xml"),
+          )
+      )
+
+  public val icon_17757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17757.xml"),
+          )
+      )
+
+  public val icon_17758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17758.xml"),
+          )
+      )
+
+  public val icon_17759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17759.xml"),
+          )
+      )
+
+  public val icon_1776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1776.xml"),
+          )
+      )
+
+  public val icon_17760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17760.xml"),
+          )
+      )
+
+  public val icon_17761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17761.xml"),
+          )
+      )
+
+  public val icon_17762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17762.xml"),
+          )
+      )
+
+  public val icon_17763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17763.xml"),
+          )
+      )
+
+  public val icon_17764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17764.xml"),
+          )
+      )
+
+  public val icon_17765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17765.xml"),
+          )
+      )
+
+  public val icon_17766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17766.xml"),
+          )
+      )
+
+  public val icon_17767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17767.xml"),
+          )
+      )
+
+  public val icon_17768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17768.xml"),
+          )
+      )
+
+  public val icon_17769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17769.xml"),
+          )
+      )
+
+  public val icon_1777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1777.xml"),
+          )
+      )
+
+  public val icon_17770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17770.xml"),
+          )
+      )
+
+  public val icon_17771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17771.xml"),
+          )
+      )
+
+  public val icon_17772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17772.xml"),
+          )
+      )
+
+  public val icon_17773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17773.xml"),
+          )
+      )
+
+  public val icon_17774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17774.xml"),
+          )
+      )
+
+  public val icon_17775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17775.xml"),
+          )
+      )
+
+  public val icon_17776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17776.xml"),
+          )
+      )
+
+  public val icon_17777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17777.xml"),
+          )
+      )
+
+  public val icon_17778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17778.xml"),
+          )
+      )
+
+  public val icon_17779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17779.xml"),
+          )
+      )
+
+  public val icon_1778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1778.xml"),
+          )
+      )
+
+  public val icon_17780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17780.xml"),
+          )
+      )
+
+  public val icon_17781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17781.xml"),
+          )
+      )
+
+  public val icon_17782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17782.xml"),
+          )
+      )
+
+  public val icon_17783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17783.xml"),
+          )
+      )
+
+  public val icon_17784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17784.xml"),
+          )
+      )
+
+  public val icon_17785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17785.xml"),
+          )
+      )
+
+  public val icon_17786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17786.xml"),
+          )
+      )
+
+  public val icon_17787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17787.xml"),
+          )
+      )
+
+  public val icon_17788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17788.xml"),
+          )
+      )
+
+  public val icon_17789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17789.xml"),
+          )
+      )
+
+  public val icon_1779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1779.xml"),
+          )
+      )
+
+  public val icon_17790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17790.xml"),
+          )
+      )
+
+  public val icon_17791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17791.xml"),
+          )
+      )
+
+  public val icon_17792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17792.xml"),
+          )
+      )
+
+  public val icon_17793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17793.xml"),
+          )
+      )
+
+  public val icon_17794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17794.xml"),
+          )
+      )
+
+  public val icon_17795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17795.xml"),
+          )
+      )
+
+  public val icon_17796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17796.xml"),
+          )
+      )
+
+  public val icon_17797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17797.xml"),
+          )
+      )
+
+  public val icon_17798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17798.xml"),
+          )
+      )
+
+  public val icon_17799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17799.xml"),
+          )
+      )
+
+  public val icon_178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_178.xml"),
+          )
+      )
+
+  public val icon_1780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1780.xml"),
+          )
+      )
+
+  public val icon_17800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17800.xml"),
+          )
+      )
+
+  public val icon_17801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17801.xml"),
+          )
+      )
+
+  public val icon_17802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17802.xml"),
+          )
+      )
+
+  public val icon_17803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17803.xml"),
+          )
+      )
+
+  public val icon_17804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17804.xml"),
+          )
+      )
+
+  public val icon_17805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17805.xml"),
+          )
+      )
+
+  public val icon_17806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17806.xml"),
+          )
+      )
+
+  public val icon_17807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17807.xml"),
+          )
+      )
+
+  public val icon_17808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17808.xml"),
+          )
+      )
+
+  public val icon_17809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17809.xml"),
+          )
+      )
+
+  public val icon_1781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1781.xml"),
+          )
+      )
+
+  public val icon_17810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17810.xml"),
+          )
+      )
+
+  public val icon_17811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17811.xml"),
+          )
+      )
+
+  public val icon_17812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17812.xml"),
+          )
+      )
+
+  public val icon_17813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17813.xml"),
+          )
+      )
+
+  public val icon_17814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17814.xml"),
+          )
+      )
+
+  public val icon_17815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17815.xml"),
+          )
+      )
+
+  public val icon_17816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17816.xml"),
+          )
+      )
+
+  public val icon_17817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17817.xml"),
+          )
+      )
+
+  public val icon_17818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17818.xml"),
+          )
+      )
+
+  public val icon_17819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17819.xml"),
+          )
+      )
+
+  public val icon_1782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1782.xml"),
+          )
+      )
+
+  public val icon_17820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17820.xml"),
+          )
+      )
+
+  public val icon_17821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17821.xml"),
+          )
+      )
+
+  public val icon_17822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17822.xml"),
+          )
+      )
+
+  public val icon_17823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17823.xml"),
+          )
+      )
+
+  public val icon_17824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17824.xml"),
+          )
+      )
+
+  public val icon_17825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17825.xml"),
+          )
+      )
+
+  public val icon_17826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17826.xml"),
+          )
+      )
+
+  public val icon_17827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17827.xml"),
+          )
+      )
+
+  public val icon_17828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17828.xml"),
+          )
+      )
+
+  public val icon_17829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17829.xml"),
+          )
+      )
+
+  public val icon_1783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1783.xml"),
+          )
+      )
+
+  public val icon_17830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17830.xml"),
+          )
+      )
+
+  public val icon_17831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17831.xml"),
+          )
+      )
+
+  public val icon_17832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17832.xml"),
+          )
+      )
+
+  public val icon_17833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17833.xml"),
+          )
+      )
+
+  public val icon_17834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17834.xml"),
+          )
+      )
+
+  public val icon_17835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17835.xml"),
+          )
+      )
+
+  public val icon_17836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17836.xml"),
+          )
+      )
+
+  public val icon_17837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17837.xml"),
+          )
+      )
+
+  public val icon_17838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17838.xml"),
+          )
+      )
+
+  public val icon_17839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17839.xml"),
+          )
+      )
+
+  public val icon_1784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1784.xml"),
+          )
+      )
+
+  public val icon_17840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17840.xml"),
+          )
+      )
+
+  public val icon_17841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17841.xml"),
+          )
+      )
+
+  public val icon_17842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17842.xml"),
+          )
+      )
+
+  public val icon_17843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17843.xml"),
+          )
+      )
+
+  public val icon_17844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17844.xml"),
+          )
+      )
+
+  public val icon_17845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17845.xml"),
+          )
+      )
+
+  public val icon_17846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17846.xml"),
+          )
+      )
+
+  public val icon_17847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17847.xml"),
+          )
+      )
+
+  public val icon_17848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17848.xml"),
+          )
+      )
+
+  public val icon_17849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17849.xml"),
+          )
+      )
+
+  public val icon_1785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1785.xml"),
+          )
+      )
+
+  public val icon_17850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17850.xml"),
+          )
+      )
+
+  public val icon_17851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17851.xml"),
+          )
+      )
+
+  public val icon_17852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17852.xml"),
+          )
+      )
+
+  public val icon_17853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17853.xml"),
+          )
+      )
+
+  public val icon_17854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17854.xml"),
+          )
+      )
+
+  public val icon_17855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17855.xml"),
+          )
+      )
+
+  public val icon_17856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17856.xml"),
+          )
+      )
+
+  public val icon_17857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17857.xml"),
+          )
+      )
+
+  public val icon_17858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17858.xml"),
+          )
+      )
+
+  public val icon_17859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17859.xml"),
+          )
+      )
+
+  public val icon_1786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1786.xml"),
+          )
+      )
+
+  public val icon_17860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17860.xml"),
+          )
+      )
+
+  public val icon_17861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17861.xml"),
+          )
+      )
+
+  public val icon_17862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17862.xml"),
+          )
+      )
+
+  public val icon_17863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17863.xml"),
+          )
+      )
+
+  public val icon_17864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17864.xml"),
+          )
+      )
+
+  public val icon_17865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17865.xml"),
+          )
+      )
+
+  public val icon_17866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17866.xml"),
+          )
+      )
+
+  public val icon_17867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17867.xml"),
+          )
+      )
+
+  public val icon_17868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17868.xml"),
+          )
+      )
+
+  public val icon_17869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17869.xml"),
+          )
+      )
+
+  public val icon_1787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1787.xml"),
+          )
+      )
+
+  public val icon_17870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17870.xml"),
+          )
+      )
+
+  public val icon_17871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17871.xml"),
+          )
+      )
+
+  public val icon_17872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17872.xml"),
+          )
+      )
+
+  public val icon_17873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17873.xml"),
+          )
+      )
+
+  public val icon_17874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17874.xml"),
+          )
+      )
+
+  public val icon_17875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17875.xml"),
+          )
+      )
+
+  public val icon_17876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17876.xml"),
+          )
+      )
+
+  public val icon_17877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17877.xml"),
+          )
+      )
+
+  public val icon_17878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17878.xml"),
+          )
+      )
+
+  public val icon_17879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17879.xml"),
+          )
+      )
+
+  public val icon_1788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1788.xml"),
+          )
+      )
+
+  public val icon_17880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17880.xml"),
+          )
+      )
+
+  public val icon_17881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17881.xml"),
+          )
+      )
+
+  public val icon_17882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17882.xml"),
+          )
+      )
+
+  public val icon_17883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17883.xml"),
+          )
+      )
+
+  public val icon_17884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17884.xml"),
+          )
+      )
+
+  public val icon_17885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17885.xml"),
+          )
+      )
+
+  public val icon_17886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17886.xml"),
+          )
+      )
+
+  public val icon_17887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17887.xml"),
+          )
+      )
+
+  public val icon_17888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17888.xml"),
+          )
+      )
+
+  public val icon_17889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17889.xml"),
+          )
+      )
+
+  public val icon_1789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1789.xml"),
+          )
+      )
+
+  public val icon_17890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17890.xml"),
+          )
+      )
+
+  public val icon_17891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17891.xml"),
+          )
+      )
+
+  public val icon_17892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17892.xml"),
+          )
+      )
+
+  public val icon_17893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17893.xml"),
+          )
+      )
+
+  public val icon_17894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17894.xml"),
+          )
+      )
+
+  public val icon_17895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17895.xml"),
+          )
+      )
+
+  public val icon_17896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17896.xml"),
+          )
+      )
+
+  public val icon_17897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17897.xml"),
+          )
+      )
+
+  public val icon_17898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17898.xml"),
+          )
+      )
+
+  public val icon_17899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17899.xml"),
+          )
+      )
+
+  public val icon_179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_179.xml"),
+          )
+      )
+
+  public val icon_1790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1790.xml"),
+          )
+      )
+
+  public val icon_17900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17900.xml"),
+          )
+      )
+
+  public val icon_17901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17901.xml"),
+          )
+      )
+
+  public val icon_17902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17902.xml"),
+          )
+      )
+
+  public val icon_17903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17903.xml"),
+          )
+      )
+
+  public val icon_17904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17904.xml"),
+          )
+      )
+
+  public val icon_17905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17905.xml"),
+          )
+      )
+
+  public val icon_17906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17906.xml"),
+          )
+      )
+
+  public val icon_17907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17907.xml"),
+          )
+      )
+
+  public val icon_17908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17908.xml"),
+          )
+      )
+
+  public val icon_17909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17909.xml"),
+          )
+      )
+
+  public val icon_1791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1791.xml"),
+          )
+      )
+
+  public val icon_17910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17910.xml"),
+          )
+      )
+
+  public val icon_17911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17911.xml"),
+          )
+      )
+
+  public val icon_17912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17912.xml"),
+          )
+      )
+
+  public val icon_17913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17913.xml"),
+          )
+      )
+
+  public val icon_17914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17914.xml"),
+          )
+      )
+
+  public val icon_17915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17915.xml"),
+          )
+      )
+
+  public val icon_17916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17916.xml"),
+          )
+      )
+
+  public val icon_17917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17917.xml"),
+          )
+      )
+
+  public val icon_17918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17918.xml"),
+          )
+      )
+
+  public val icon_17919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17919.xml"),
+          )
+      )
+
+  public val icon_1792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1792.xml"),
+          )
+      )
+
+  public val icon_17920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17920.xml"),
+          )
+      )
+
+  public val icon_17921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17921.xml"),
+          )
+      )
+
+  public val icon_17922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17922.xml"),
+          )
+      )
+
+  public val icon_17923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17923.xml"),
+          )
+      )
+
+  public val icon_17924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17924.xml"),
+          )
+      )
+
+  public val icon_17925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17925.xml"),
+          )
+      )
+
+  public val icon_17926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17926.xml"),
+          )
+      )
+
+  public val icon_17927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17927.xml"),
+          )
+      )
+
+  public val icon_17928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17928.xml"),
+          )
+      )
+
+  public val icon_17929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17929.xml"),
+          )
+      )
+
+  public val icon_1793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1793.xml"),
+          )
+      )
+
+  public val icon_17930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17930.xml"),
+          )
+      )
+
+  public val icon_17931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17931.xml"),
+          )
+      )
+
+  public val icon_17932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17932.xml"),
+          )
+      )
+
+  public val icon_17933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17933.xml"),
+          )
+      )
+
+  public val icon_17934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17934.xml"),
+          )
+      )
+
+  public val icon_17935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17935.xml"),
+          )
+      )
+
+  public val icon_17936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17936.xml"),
+          )
+      )
+
+  public val icon_17937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17937.xml"),
+          )
+      )
+
+  public val icon_17938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17938.xml"),
+          )
+      )
+
+  public val icon_17939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17939.xml"),
+          )
+      )
+
+  public val icon_1794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1794.xml"),
+          )
+      )
+
+  public val icon_17940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17940.xml"),
+          )
+      )
+
+  public val icon_17941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17941.xml"),
+          )
+      )
+
+  public val icon_17942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17942.xml"),
+          )
+      )
+
+  public val icon_17943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17943.xml"),
+          )
+      )
+
+  public val icon_17944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17944.xml"),
+          )
+      )
+
+  public val icon_17945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17945.xml"),
+          )
+      )
+
+  public val icon_17946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17946.xml"),
+          )
+      )
+
+  public val icon_17947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17947.xml"),
+          )
+      )
+
+  public val icon_17948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17948.xml"),
+          )
+      )
+
+  public val icon_17949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17949.xml"),
+          )
+      )
+
+  public val icon_1795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1795.xml"),
+          )
+      )
+
+  public val icon_17950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17950.xml"),
+          )
+      )
+
+  public val icon_17951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17951.xml"),
+          )
+      )
+
+  public val icon_17952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17952.xml"),
+          )
+      )
+
+  public val icon_17953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17953.xml"),
+          )
+      )
+
+  public val icon_17954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17954.xml"),
+          )
+      )
+
+  public val icon_17955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17955.xml"),
+          )
+      )
+
+  public val icon_17956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17956.xml"),
+          )
+      )
+
+  public val icon_17957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17957.xml"),
+          )
+      )
+
+  public val icon_17958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17958.xml"),
+          )
+      )
+
+  public val icon_17959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17959.xml"),
+          )
+      )
+
+  public val icon_1796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1796.xml"),
+          )
+      )
+
+  public val icon_17960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17960.xml"),
+          )
+      )
+
+  public val icon_17961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17961.xml"),
+          )
+      )
+
+  public val icon_17962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17962.xml"),
+          )
+      )
+
+  public val icon_17963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17963.xml"),
+          )
+      )
+
+  public val icon_17964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17964.xml"),
+          )
+      )
+
+  public val icon_17965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17965.xml"),
+          )
+      )
+
+  public val icon_17966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17966.xml"),
+          )
+      )
+
+  public val icon_17967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17967.xml"),
+          )
+      )
+
+  public val icon_17968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17968.xml"),
+          )
+      )
+
+  public val icon_17969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17969.xml"),
+          )
+      )
+
+  public val icon_1797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1797.xml"),
+          )
+      )
+
+  public val icon_17970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17970.xml"),
+          )
+      )
+
+  public val icon_17971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17971.xml"),
+          )
+      )
+
+  public val icon_17972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17972.xml"),
+          )
+      )
+
+  public val icon_17973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17973.xml"),
+          )
+      )
+
+  public val icon_17974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17974.xml"),
+          )
+      )
+
+  public val icon_17975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17975.xml"),
+          )
+      )
+
+  public val icon_17976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17976.xml"),
+          )
+      )
+
+  public val icon_17977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17977.xml"),
+          )
+      )
+
+  public val icon_17978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17978.xml"),
+          )
+      )
+
+  public val icon_17979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17979.xml"),
+          )
+      )
+
+  public val icon_1798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1798.xml"),
+          )
+      )
+
+  public val icon_17980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17980.xml"),
+          )
+      )
+
+  public val icon_17981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17981.xml"),
+          )
+      )
+
+  public val icon_17982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17982.xml"),
+          )
+      )
+
+  public val icon_17983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17983.xml"),
+          )
+      )
+
+  public val icon_17984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17984.xml"),
+          )
+      )
+
+  public val icon_17985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17985.xml"),
+          )
+      )
+
+  public val icon_17986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17986.xml"),
+          )
+      )
+
+  public val icon_17987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17987.xml"),
+          )
+      )
+
+  public val icon_17988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17988.xml"),
+          )
+      )
+
+  public val icon_17989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17989.xml"),
+          )
+      )
+
+  public val icon_1799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1799.xml"),
+          )
+      )
+
+  public val icon_17990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17990.xml"),
+          )
+      )
+
+  public val icon_17991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17991.xml"),
+          )
+      )
+
+  public val icon_17992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17992.xml"),
+          )
+      )
+
+  public val icon_17993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17993.xml"),
+          )
+      )
+
+  public val icon_17994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17994.xml"),
+          )
+      )
+
+  public val icon_17995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17995.xml"),
+          )
+      )
+
+  public val icon_17996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17996.xml"),
+          )
+      )
+
+  public val icon_17997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17997.xml"),
+          )
+      )
+
+  public val icon_17998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17998.xml"),
+          )
+      )
+
+  public val icon_17999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_17999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_17999.xml"),
+          )
+      )
+
+  public val icon_18: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18.xml"),
+          )
+      )
+
+  public val icon_180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_180.xml"),
+          )
+      )
+
+  public val icon_1800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1800.xml"),
+          )
+      )
+
+  public val icon_18000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18000.xml"),
+          )
+      )
+
+  public val icon_18001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18001.xml"),
+          )
+      )
+
+  public val icon_18002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18002.xml"),
+          )
+      )
+
+  public val icon_18003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18003.xml"),
+          )
+      )
+
+  public val icon_18004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18004.xml"),
+          )
+      )
+
+  public val icon_18005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18005.xml"),
+          )
+      )
+
+  public val icon_18006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18006.xml"),
+          )
+      )
+
+  public val icon_18007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18007.xml"),
+          )
+      )
+
+  public val icon_18008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18008.xml"),
+          )
+      )
+
+  public val icon_18009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18009.xml"),
+          )
+      )
+
+  public val icon_1801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1801.xml"),
+          )
+      )
+
+  public val icon_18010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18010.xml"),
+          )
+      )
+
+  public val icon_18011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18011.xml"),
+          )
+      )
+
+  public val icon_18012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18012.xml"),
+          )
+      )
+
+  public val icon_18013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18013.xml"),
+          )
+      )
+
+  public val icon_18014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18014.xml"),
+          )
+      )
+
+  public val icon_18015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18015.xml"),
+          )
+      )
+
+  public val icon_18016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18016.xml"),
+          )
+      )
+
+  public val icon_18017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18017.xml"),
+          )
+      )
+
+  public val icon_18018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18018.xml"),
+          )
+      )
+
+  public val icon_18019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18019.xml"),
+          )
+      )
+
+  public val icon_1802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1802.xml"),
+          )
+      )
+
+  public val icon_18020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18020.xml"),
+          )
+      )
+
+  public val icon_18021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18021.xml"),
+          )
+      )
+
+  public val icon_18022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18022.xml"),
+          )
+      )
+
+  public val icon_18023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18023.xml"),
+          )
+      )
+
+  public val icon_18024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18024.xml"),
+          )
+      )
+
+  public val icon_18025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18025.xml"),
+          )
+      )
+
+  public val icon_18026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18026.xml"),
+          )
+      )
+
+  public val icon_18027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18027.xml"),
+          )
+      )
+
+  public val icon_18028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18028.xml"),
+          )
+      )
+
+  public val icon_18029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18029.xml"),
+          )
+      )
+
+  public val icon_1803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1803.xml"),
+          )
+      )
+
+  public val icon_18030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18030.xml"),
+          )
+      )
+
+  public val icon_18031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18031.xml"),
+          )
+      )
+
+  public val icon_18032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18032.xml"),
+          )
+      )
+
+  public val icon_18033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18033.xml"),
+          )
+      )
+
+  public val icon_18034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18034.xml"),
+          )
+      )
+
+  public val icon_18035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18035.xml"),
+          )
+      )
+
+  public val icon_18036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18036.xml"),
+          )
+      )
+
+  public val icon_18037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18037.xml"),
+          )
+      )
+
+  public val icon_18038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18038.xml"),
+          )
+      )
+
+  public val icon_18039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18039.xml"),
+          )
+      )
+
+  public val icon_1804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1804.xml"),
+          )
+      )
+
+  public val icon_18040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18040.xml"),
+          )
+      )
+
+  public val icon_18041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18041.xml"),
+          )
+      )
+
+  public val icon_18042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18042.xml"),
+          )
+      )
+
+  public val icon_18043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18043.xml"),
+          )
+      )
+
+  public val icon_18044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18044.xml"),
+          )
+      )
+
+  public val icon_18045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18045.xml"),
+          )
+      )
+
+  public val icon_18046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18046.xml"),
+          )
+      )
+
+  public val icon_18047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18047.xml"),
+          )
+      )
+
+  public val icon_18048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18048.xml"),
+          )
+      )
+
+  public val icon_18049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18049.xml"),
+          )
+      )
+
+  public val icon_1805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1805.xml"),
+          )
+      )
+
+  public val icon_18050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18050.xml"),
+          )
+      )
+
+  public val icon_18051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18051.xml"),
+          )
+      )
+
+  public val icon_18052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18052.xml"),
+          )
+      )
+
+  public val icon_18053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18053.xml"),
+          )
+      )
+
+  public val icon_18054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18054.xml"),
+          )
+      )
+
+  public val icon_18055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18055.xml"),
+          )
+      )
+
+  public val icon_18056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18056.xml"),
+          )
+      )
+
+  public val icon_18057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18057.xml"),
+          )
+      )
+
+  public val icon_18058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18058.xml"),
+          )
+      )
+
+  public val icon_18059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18059.xml"),
+          )
+      )
+
+  public val icon_1806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1806.xml"),
+          )
+      )
+
+  public val icon_18060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18060.xml"),
+          )
+      )
+
+  public val icon_18061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18061.xml"),
+          )
+      )
+
+  public val icon_18062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18062.xml"),
+          )
+      )
+
+  public val icon_18063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18063.xml"),
+          )
+      )
+
+  public val icon_18064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18064.xml"),
+          )
+      )
+
+  public val icon_18065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18065.xml"),
+          )
+      )
+
+  public val icon_18066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18066.xml"),
+          )
+      )
+
+  public val icon_18067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18067.xml"),
+          )
+      )
+
+  public val icon_18068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18068.xml"),
+          )
+      )
+
+  public val icon_18069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18069.xml"),
+          )
+      )
+
+  public val icon_1807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1807.xml"),
+          )
+      )
+
+  public val icon_18070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18070.xml"),
+          )
+      )
+
+  public val icon_18071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18071.xml"),
+          )
+      )
+
+  public val icon_18072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18072.xml"),
+          )
+      )
+
+  public val icon_18073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18073.xml"),
+          )
+      )
+
+  public val icon_18074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18074.xml"),
+          )
+      )
+
+  public val icon_18075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18075.xml"),
+          )
+      )
+
+  public val icon_18076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18076.xml"),
+          )
+      )
+
+  public val icon_18077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18077.xml"),
+          )
+      )
+
+  public val icon_18078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18078.xml"),
+          )
+      )
+
+  public val icon_18079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18079.xml"),
+          )
+      )
+
+  public val icon_1808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1808.xml"),
+          )
+      )
+
+  public val icon_18080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18080.xml"),
+          )
+      )
+
+  public val icon_18081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18081.xml"),
+          )
+      )
+
+  public val icon_18082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18082.xml"),
+          )
+      )
+
+  public val icon_18083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18083.xml"),
+          )
+      )
+
+  public val icon_18084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18084.xml"),
+          )
+      )
+
+  public val icon_18085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18085.xml"),
+          )
+      )
+
+  public val icon_18086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18086.xml"),
+          )
+      )
+
+  public val icon_18087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18087.xml"),
+          )
+      )
+
+  public val icon_18088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18088.xml"),
+          )
+      )
+
+  public val icon_18089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18089.xml"),
+          )
+      )
+
+  public val icon_1809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1809.xml"),
+          )
+      )
+
+  public val icon_18090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18090.xml"),
+          )
+      )
+
+  public val icon_18091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18091.xml"),
+          )
+      )
+
+  public val icon_18092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18092.xml"),
+          )
+      )
+
+  public val icon_18093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18093.xml"),
+          )
+      )
+
+  public val icon_18094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18094.xml"),
+          )
+      )
+
+  public val icon_18095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18095.xml"),
+          )
+      )
+
+  public val icon_18096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18096.xml"),
+          )
+      )
+
+  public val icon_18097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18097.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17648: DrawableResource
+  get() = Drawable17.icon_17648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17649: DrawableResource
+  get() = Drawable17.icon_17649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1765: DrawableResource
+  get() = Drawable17.icon_1765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17650: DrawableResource
+  get() = Drawable17.icon_17650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17651: DrawableResource
+  get() = Drawable17.icon_17651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17652: DrawableResource
+  get() = Drawable17.icon_17652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17653: DrawableResource
+  get() = Drawable17.icon_17653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17654: DrawableResource
+  get() = Drawable17.icon_17654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17655: DrawableResource
+  get() = Drawable17.icon_17655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17656: DrawableResource
+  get() = Drawable17.icon_17656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17657: DrawableResource
+  get() = Drawable17.icon_17657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17658: DrawableResource
+  get() = Drawable17.icon_17658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17659: DrawableResource
+  get() = Drawable17.icon_17659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1766: DrawableResource
+  get() = Drawable17.icon_1766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17660: DrawableResource
+  get() = Drawable17.icon_17660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17661: DrawableResource
+  get() = Drawable17.icon_17661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17662: DrawableResource
+  get() = Drawable17.icon_17662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17663: DrawableResource
+  get() = Drawable17.icon_17663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17664: DrawableResource
+  get() = Drawable17.icon_17664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17665: DrawableResource
+  get() = Drawable17.icon_17665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17666: DrawableResource
+  get() = Drawable17.icon_17666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17667: DrawableResource
+  get() = Drawable17.icon_17667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17668: DrawableResource
+  get() = Drawable17.icon_17668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17669: DrawableResource
+  get() = Drawable17.icon_17669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1767: DrawableResource
+  get() = Drawable17.icon_1767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17670: DrawableResource
+  get() = Drawable17.icon_17670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17671: DrawableResource
+  get() = Drawable17.icon_17671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17672: DrawableResource
+  get() = Drawable17.icon_17672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17673: DrawableResource
+  get() = Drawable17.icon_17673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17674: DrawableResource
+  get() = Drawable17.icon_17674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17675: DrawableResource
+  get() = Drawable17.icon_17675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17676: DrawableResource
+  get() = Drawable17.icon_17676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17677: DrawableResource
+  get() = Drawable17.icon_17677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17678: DrawableResource
+  get() = Drawable17.icon_17678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17679: DrawableResource
+  get() = Drawable17.icon_17679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1768: DrawableResource
+  get() = Drawable17.icon_1768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17680: DrawableResource
+  get() = Drawable17.icon_17680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17681: DrawableResource
+  get() = Drawable17.icon_17681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17682: DrawableResource
+  get() = Drawable17.icon_17682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17683: DrawableResource
+  get() = Drawable17.icon_17683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17684: DrawableResource
+  get() = Drawable17.icon_17684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17685: DrawableResource
+  get() = Drawable17.icon_17685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17686: DrawableResource
+  get() = Drawable17.icon_17686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17687: DrawableResource
+  get() = Drawable17.icon_17687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17688: DrawableResource
+  get() = Drawable17.icon_17688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17689: DrawableResource
+  get() = Drawable17.icon_17689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1769: DrawableResource
+  get() = Drawable17.icon_1769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17690: DrawableResource
+  get() = Drawable17.icon_17690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17691: DrawableResource
+  get() = Drawable17.icon_17691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17692: DrawableResource
+  get() = Drawable17.icon_17692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17693: DrawableResource
+  get() = Drawable17.icon_17693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17694: DrawableResource
+  get() = Drawable17.icon_17694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17695: DrawableResource
+  get() = Drawable17.icon_17695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17696: DrawableResource
+  get() = Drawable17.icon_17696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17697: DrawableResource
+  get() = Drawable17.icon_17697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17698: DrawableResource
+  get() = Drawable17.icon_17698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17699: DrawableResource
+  get() = Drawable17.icon_17699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_177: DrawableResource
+  get() = Drawable17.icon_177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1770: DrawableResource
+  get() = Drawable17.icon_1770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17700: DrawableResource
+  get() = Drawable17.icon_17700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17701: DrawableResource
+  get() = Drawable17.icon_17701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17702: DrawableResource
+  get() = Drawable17.icon_17702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17703: DrawableResource
+  get() = Drawable17.icon_17703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17704: DrawableResource
+  get() = Drawable17.icon_17704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17705: DrawableResource
+  get() = Drawable17.icon_17705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17706: DrawableResource
+  get() = Drawable17.icon_17706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17707: DrawableResource
+  get() = Drawable17.icon_17707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17708: DrawableResource
+  get() = Drawable17.icon_17708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17709: DrawableResource
+  get() = Drawable17.icon_17709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1771: DrawableResource
+  get() = Drawable17.icon_1771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17710: DrawableResource
+  get() = Drawable17.icon_17710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17711: DrawableResource
+  get() = Drawable17.icon_17711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17712: DrawableResource
+  get() = Drawable17.icon_17712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17713: DrawableResource
+  get() = Drawable17.icon_17713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17714: DrawableResource
+  get() = Drawable17.icon_17714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17715: DrawableResource
+  get() = Drawable17.icon_17715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17716: DrawableResource
+  get() = Drawable17.icon_17716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17717: DrawableResource
+  get() = Drawable17.icon_17717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17718: DrawableResource
+  get() = Drawable17.icon_17718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17719: DrawableResource
+  get() = Drawable17.icon_17719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1772: DrawableResource
+  get() = Drawable17.icon_1772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17720: DrawableResource
+  get() = Drawable17.icon_17720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17721: DrawableResource
+  get() = Drawable17.icon_17721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17722: DrawableResource
+  get() = Drawable17.icon_17722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17723: DrawableResource
+  get() = Drawable17.icon_17723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17724: DrawableResource
+  get() = Drawable17.icon_17724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17725: DrawableResource
+  get() = Drawable17.icon_17725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17726: DrawableResource
+  get() = Drawable17.icon_17726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17727: DrawableResource
+  get() = Drawable17.icon_17727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17728: DrawableResource
+  get() = Drawable17.icon_17728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17729: DrawableResource
+  get() = Drawable17.icon_17729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1773: DrawableResource
+  get() = Drawable17.icon_1773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17730: DrawableResource
+  get() = Drawable17.icon_17730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17731: DrawableResource
+  get() = Drawable17.icon_17731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17732: DrawableResource
+  get() = Drawable17.icon_17732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17733: DrawableResource
+  get() = Drawable17.icon_17733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17734: DrawableResource
+  get() = Drawable17.icon_17734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17735: DrawableResource
+  get() = Drawable17.icon_17735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17736: DrawableResource
+  get() = Drawable17.icon_17736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17737: DrawableResource
+  get() = Drawable17.icon_17737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17738: DrawableResource
+  get() = Drawable17.icon_17738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17739: DrawableResource
+  get() = Drawable17.icon_17739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1774: DrawableResource
+  get() = Drawable17.icon_1774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17740: DrawableResource
+  get() = Drawable17.icon_17740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17741: DrawableResource
+  get() = Drawable17.icon_17741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17742: DrawableResource
+  get() = Drawable17.icon_17742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17743: DrawableResource
+  get() = Drawable17.icon_17743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17744: DrawableResource
+  get() = Drawable17.icon_17744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17745: DrawableResource
+  get() = Drawable17.icon_17745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17746: DrawableResource
+  get() = Drawable17.icon_17746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17747: DrawableResource
+  get() = Drawable17.icon_17747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17748: DrawableResource
+  get() = Drawable17.icon_17748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17749: DrawableResource
+  get() = Drawable17.icon_17749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1775: DrawableResource
+  get() = Drawable17.icon_1775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17750: DrawableResource
+  get() = Drawable17.icon_17750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17751: DrawableResource
+  get() = Drawable17.icon_17751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17752: DrawableResource
+  get() = Drawable17.icon_17752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17753: DrawableResource
+  get() = Drawable17.icon_17753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17754: DrawableResource
+  get() = Drawable17.icon_17754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17755: DrawableResource
+  get() = Drawable17.icon_17755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17756: DrawableResource
+  get() = Drawable17.icon_17756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17757: DrawableResource
+  get() = Drawable17.icon_17757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17758: DrawableResource
+  get() = Drawable17.icon_17758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17759: DrawableResource
+  get() = Drawable17.icon_17759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1776: DrawableResource
+  get() = Drawable17.icon_1776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17760: DrawableResource
+  get() = Drawable17.icon_17760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17761: DrawableResource
+  get() = Drawable17.icon_17761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17762: DrawableResource
+  get() = Drawable17.icon_17762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17763: DrawableResource
+  get() = Drawable17.icon_17763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17764: DrawableResource
+  get() = Drawable17.icon_17764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17765: DrawableResource
+  get() = Drawable17.icon_17765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17766: DrawableResource
+  get() = Drawable17.icon_17766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17767: DrawableResource
+  get() = Drawable17.icon_17767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17768: DrawableResource
+  get() = Drawable17.icon_17768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17769: DrawableResource
+  get() = Drawable17.icon_17769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1777: DrawableResource
+  get() = Drawable17.icon_1777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17770: DrawableResource
+  get() = Drawable17.icon_17770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17771: DrawableResource
+  get() = Drawable17.icon_17771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17772: DrawableResource
+  get() = Drawable17.icon_17772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17773: DrawableResource
+  get() = Drawable17.icon_17773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17774: DrawableResource
+  get() = Drawable17.icon_17774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17775: DrawableResource
+  get() = Drawable17.icon_17775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17776: DrawableResource
+  get() = Drawable17.icon_17776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17777: DrawableResource
+  get() = Drawable17.icon_17777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17778: DrawableResource
+  get() = Drawable17.icon_17778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17779: DrawableResource
+  get() = Drawable17.icon_17779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1778: DrawableResource
+  get() = Drawable17.icon_1778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17780: DrawableResource
+  get() = Drawable17.icon_17780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17781: DrawableResource
+  get() = Drawable17.icon_17781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17782: DrawableResource
+  get() = Drawable17.icon_17782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17783: DrawableResource
+  get() = Drawable17.icon_17783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17784: DrawableResource
+  get() = Drawable17.icon_17784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17785: DrawableResource
+  get() = Drawable17.icon_17785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17786: DrawableResource
+  get() = Drawable17.icon_17786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17787: DrawableResource
+  get() = Drawable17.icon_17787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17788: DrawableResource
+  get() = Drawable17.icon_17788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17789: DrawableResource
+  get() = Drawable17.icon_17789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1779: DrawableResource
+  get() = Drawable17.icon_1779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17790: DrawableResource
+  get() = Drawable17.icon_17790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17791: DrawableResource
+  get() = Drawable17.icon_17791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17792: DrawableResource
+  get() = Drawable17.icon_17792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17793: DrawableResource
+  get() = Drawable17.icon_17793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17794: DrawableResource
+  get() = Drawable17.icon_17794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17795: DrawableResource
+  get() = Drawable17.icon_17795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17796: DrawableResource
+  get() = Drawable17.icon_17796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17797: DrawableResource
+  get() = Drawable17.icon_17797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17798: DrawableResource
+  get() = Drawable17.icon_17798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17799: DrawableResource
+  get() = Drawable17.icon_17799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_178: DrawableResource
+  get() = Drawable17.icon_178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1780: DrawableResource
+  get() = Drawable17.icon_1780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17800: DrawableResource
+  get() = Drawable17.icon_17800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17801: DrawableResource
+  get() = Drawable17.icon_17801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17802: DrawableResource
+  get() = Drawable17.icon_17802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17803: DrawableResource
+  get() = Drawable17.icon_17803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17804: DrawableResource
+  get() = Drawable17.icon_17804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17805: DrawableResource
+  get() = Drawable17.icon_17805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17806: DrawableResource
+  get() = Drawable17.icon_17806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17807: DrawableResource
+  get() = Drawable17.icon_17807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17808: DrawableResource
+  get() = Drawable17.icon_17808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17809: DrawableResource
+  get() = Drawable17.icon_17809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1781: DrawableResource
+  get() = Drawable17.icon_1781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17810: DrawableResource
+  get() = Drawable17.icon_17810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17811: DrawableResource
+  get() = Drawable17.icon_17811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17812: DrawableResource
+  get() = Drawable17.icon_17812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17813: DrawableResource
+  get() = Drawable17.icon_17813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17814: DrawableResource
+  get() = Drawable17.icon_17814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17815: DrawableResource
+  get() = Drawable17.icon_17815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17816: DrawableResource
+  get() = Drawable17.icon_17816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17817: DrawableResource
+  get() = Drawable17.icon_17817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17818: DrawableResource
+  get() = Drawable17.icon_17818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17819: DrawableResource
+  get() = Drawable17.icon_17819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1782: DrawableResource
+  get() = Drawable17.icon_1782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17820: DrawableResource
+  get() = Drawable17.icon_17820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17821: DrawableResource
+  get() = Drawable17.icon_17821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17822: DrawableResource
+  get() = Drawable17.icon_17822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17823: DrawableResource
+  get() = Drawable17.icon_17823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17824: DrawableResource
+  get() = Drawable17.icon_17824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17825: DrawableResource
+  get() = Drawable17.icon_17825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17826: DrawableResource
+  get() = Drawable17.icon_17826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17827: DrawableResource
+  get() = Drawable17.icon_17827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17828: DrawableResource
+  get() = Drawable17.icon_17828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17829: DrawableResource
+  get() = Drawable17.icon_17829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1783: DrawableResource
+  get() = Drawable17.icon_1783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17830: DrawableResource
+  get() = Drawable17.icon_17830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17831: DrawableResource
+  get() = Drawable17.icon_17831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17832: DrawableResource
+  get() = Drawable17.icon_17832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17833: DrawableResource
+  get() = Drawable17.icon_17833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17834: DrawableResource
+  get() = Drawable17.icon_17834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17835: DrawableResource
+  get() = Drawable17.icon_17835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17836: DrawableResource
+  get() = Drawable17.icon_17836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17837: DrawableResource
+  get() = Drawable17.icon_17837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17838: DrawableResource
+  get() = Drawable17.icon_17838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17839: DrawableResource
+  get() = Drawable17.icon_17839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1784: DrawableResource
+  get() = Drawable17.icon_1784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17840: DrawableResource
+  get() = Drawable17.icon_17840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17841: DrawableResource
+  get() = Drawable17.icon_17841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17842: DrawableResource
+  get() = Drawable17.icon_17842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17843: DrawableResource
+  get() = Drawable17.icon_17843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17844: DrawableResource
+  get() = Drawable17.icon_17844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17845: DrawableResource
+  get() = Drawable17.icon_17845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17846: DrawableResource
+  get() = Drawable17.icon_17846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17847: DrawableResource
+  get() = Drawable17.icon_17847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17848: DrawableResource
+  get() = Drawable17.icon_17848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17849: DrawableResource
+  get() = Drawable17.icon_17849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1785: DrawableResource
+  get() = Drawable17.icon_1785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17850: DrawableResource
+  get() = Drawable17.icon_17850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17851: DrawableResource
+  get() = Drawable17.icon_17851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17852: DrawableResource
+  get() = Drawable17.icon_17852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17853: DrawableResource
+  get() = Drawable17.icon_17853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17854: DrawableResource
+  get() = Drawable17.icon_17854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17855: DrawableResource
+  get() = Drawable17.icon_17855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17856: DrawableResource
+  get() = Drawable17.icon_17856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17857: DrawableResource
+  get() = Drawable17.icon_17857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17858: DrawableResource
+  get() = Drawable17.icon_17858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17859: DrawableResource
+  get() = Drawable17.icon_17859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1786: DrawableResource
+  get() = Drawable17.icon_1786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17860: DrawableResource
+  get() = Drawable17.icon_17860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17861: DrawableResource
+  get() = Drawable17.icon_17861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17862: DrawableResource
+  get() = Drawable17.icon_17862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17863: DrawableResource
+  get() = Drawable17.icon_17863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17864: DrawableResource
+  get() = Drawable17.icon_17864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17865: DrawableResource
+  get() = Drawable17.icon_17865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17866: DrawableResource
+  get() = Drawable17.icon_17866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17867: DrawableResource
+  get() = Drawable17.icon_17867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17868: DrawableResource
+  get() = Drawable17.icon_17868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17869: DrawableResource
+  get() = Drawable17.icon_17869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1787: DrawableResource
+  get() = Drawable17.icon_1787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17870: DrawableResource
+  get() = Drawable17.icon_17870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17871: DrawableResource
+  get() = Drawable17.icon_17871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17872: DrawableResource
+  get() = Drawable17.icon_17872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17873: DrawableResource
+  get() = Drawable17.icon_17873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17874: DrawableResource
+  get() = Drawable17.icon_17874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17875: DrawableResource
+  get() = Drawable17.icon_17875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17876: DrawableResource
+  get() = Drawable17.icon_17876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17877: DrawableResource
+  get() = Drawable17.icon_17877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17878: DrawableResource
+  get() = Drawable17.icon_17878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17879: DrawableResource
+  get() = Drawable17.icon_17879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1788: DrawableResource
+  get() = Drawable17.icon_1788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17880: DrawableResource
+  get() = Drawable17.icon_17880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17881: DrawableResource
+  get() = Drawable17.icon_17881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17882: DrawableResource
+  get() = Drawable17.icon_17882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17883: DrawableResource
+  get() = Drawable17.icon_17883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17884: DrawableResource
+  get() = Drawable17.icon_17884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17885: DrawableResource
+  get() = Drawable17.icon_17885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17886: DrawableResource
+  get() = Drawable17.icon_17886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17887: DrawableResource
+  get() = Drawable17.icon_17887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17888: DrawableResource
+  get() = Drawable17.icon_17888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17889: DrawableResource
+  get() = Drawable17.icon_17889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1789: DrawableResource
+  get() = Drawable17.icon_1789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17890: DrawableResource
+  get() = Drawable17.icon_17890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17891: DrawableResource
+  get() = Drawable17.icon_17891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17892: DrawableResource
+  get() = Drawable17.icon_17892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17893: DrawableResource
+  get() = Drawable17.icon_17893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17894: DrawableResource
+  get() = Drawable17.icon_17894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17895: DrawableResource
+  get() = Drawable17.icon_17895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17896: DrawableResource
+  get() = Drawable17.icon_17896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17897: DrawableResource
+  get() = Drawable17.icon_17897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17898: DrawableResource
+  get() = Drawable17.icon_17898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17899: DrawableResource
+  get() = Drawable17.icon_17899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_179: DrawableResource
+  get() = Drawable17.icon_179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1790: DrawableResource
+  get() = Drawable17.icon_1790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17900: DrawableResource
+  get() = Drawable17.icon_17900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17901: DrawableResource
+  get() = Drawable17.icon_17901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17902: DrawableResource
+  get() = Drawable17.icon_17902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17903: DrawableResource
+  get() = Drawable17.icon_17903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17904: DrawableResource
+  get() = Drawable17.icon_17904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17905: DrawableResource
+  get() = Drawable17.icon_17905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17906: DrawableResource
+  get() = Drawable17.icon_17906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17907: DrawableResource
+  get() = Drawable17.icon_17907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17908: DrawableResource
+  get() = Drawable17.icon_17908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17909: DrawableResource
+  get() = Drawable17.icon_17909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1791: DrawableResource
+  get() = Drawable17.icon_1791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17910: DrawableResource
+  get() = Drawable17.icon_17910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17911: DrawableResource
+  get() = Drawable17.icon_17911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17912: DrawableResource
+  get() = Drawable17.icon_17912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17913: DrawableResource
+  get() = Drawable17.icon_17913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17914: DrawableResource
+  get() = Drawable17.icon_17914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17915: DrawableResource
+  get() = Drawable17.icon_17915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17916: DrawableResource
+  get() = Drawable17.icon_17916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17917: DrawableResource
+  get() = Drawable17.icon_17917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17918: DrawableResource
+  get() = Drawable17.icon_17918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17919: DrawableResource
+  get() = Drawable17.icon_17919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1792: DrawableResource
+  get() = Drawable17.icon_1792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17920: DrawableResource
+  get() = Drawable17.icon_17920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17921: DrawableResource
+  get() = Drawable17.icon_17921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17922: DrawableResource
+  get() = Drawable17.icon_17922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17923: DrawableResource
+  get() = Drawable17.icon_17923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17924: DrawableResource
+  get() = Drawable17.icon_17924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17925: DrawableResource
+  get() = Drawable17.icon_17925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17926: DrawableResource
+  get() = Drawable17.icon_17926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17927: DrawableResource
+  get() = Drawable17.icon_17927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17928: DrawableResource
+  get() = Drawable17.icon_17928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17929: DrawableResource
+  get() = Drawable17.icon_17929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1793: DrawableResource
+  get() = Drawable17.icon_1793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17930: DrawableResource
+  get() = Drawable17.icon_17930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17931: DrawableResource
+  get() = Drawable17.icon_17931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17932: DrawableResource
+  get() = Drawable17.icon_17932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17933: DrawableResource
+  get() = Drawable17.icon_17933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17934: DrawableResource
+  get() = Drawable17.icon_17934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17935: DrawableResource
+  get() = Drawable17.icon_17935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17936: DrawableResource
+  get() = Drawable17.icon_17936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17937: DrawableResource
+  get() = Drawable17.icon_17937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17938: DrawableResource
+  get() = Drawable17.icon_17938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17939: DrawableResource
+  get() = Drawable17.icon_17939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1794: DrawableResource
+  get() = Drawable17.icon_1794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17940: DrawableResource
+  get() = Drawable17.icon_17940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17941: DrawableResource
+  get() = Drawable17.icon_17941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17942: DrawableResource
+  get() = Drawable17.icon_17942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17943: DrawableResource
+  get() = Drawable17.icon_17943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17944: DrawableResource
+  get() = Drawable17.icon_17944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17945: DrawableResource
+  get() = Drawable17.icon_17945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17946: DrawableResource
+  get() = Drawable17.icon_17946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17947: DrawableResource
+  get() = Drawable17.icon_17947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17948: DrawableResource
+  get() = Drawable17.icon_17948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17949: DrawableResource
+  get() = Drawable17.icon_17949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1795: DrawableResource
+  get() = Drawable17.icon_1795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17950: DrawableResource
+  get() = Drawable17.icon_17950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17951: DrawableResource
+  get() = Drawable17.icon_17951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17952: DrawableResource
+  get() = Drawable17.icon_17952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17953: DrawableResource
+  get() = Drawable17.icon_17953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17954: DrawableResource
+  get() = Drawable17.icon_17954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17955: DrawableResource
+  get() = Drawable17.icon_17955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17956: DrawableResource
+  get() = Drawable17.icon_17956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17957: DrawableResource
+  get() = Drawable17.icon_17957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17958: DrawableResource
+  get() = Drawable17.icon_17958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17959: DrawableResource
+  get() = Drawable17.icon_17959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1796: DrawableResource
+  get() = Drawable17.icon_1796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17960: DrawableResource
+  get() = Drawable17.icon_17960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17961: DrawableResource
+  get() = Drawable17.icon_17961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17962: DrawableResource
+  get() = Drawable17.icon_17962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17963: DrawableResource
+  get() = Drawable17.icon_17963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17964: DrawableResource
+  get() = Drawable17.icon_17964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17965: DrawableResource
+  get() = Drawable17.icon_17965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17966: DrawableResource
+  get() = Drawable17.icon_17966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17967: DrawableResource
+  get() = Drawable17.icon_17967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17968: DrawableResource
+  get() = Drawable17.icon_17968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17969: DrawableResource
+  get() = Drawable17.icon_17969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1797: DrawableResource
+  get() = Drawable17.icon_1797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17970: DrawableResource
+  get() = Drawable17.icon_17970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17971: DrawableResource
+  get() = Drawable17.icon_17971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17972: DrawableResource
+  get() = Drawable17.icon_17972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17973: DrawableResource
+  get() = Drawable17.icon_17973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17974: DrawableResource
+  get() = Drawable17.icon_17974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17975: DrawableResource
+  get() = Drawable17.icon_17975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17976: DrawableResource
+  get() = Drawable17.icon_17976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17977: DrawableResource
+  get() = Drawable17.icon_17977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17978: DrawableResource
+  get() = Drawable17.icon_17978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17979: DrawableResource
+  get() = Drawable17.icon_17979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1798: DrawableResource
+  get() = Drawable17.icon_1798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17980: DrawableResource
+  get() = Drawable17.icon_17980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17981: DrawableResource
+  get() = Drawable17.icon_17981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17982: DrawableResource
+  get() = Drawable17.icon_17982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17983: DrawableResource
+  get() = Drawable17.icon_17983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17984: DrawableResource
+  get() = Drawable17.icon_17984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17985: DrawableResource
+  get() = Drawable17.icon_17985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17986: DrawableResource
+  get() = Drawable17.icon_17986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17987: DrawableResource
+  get() = Drawable17.icon_17987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17988: DrawableResource
+  get() = Drawable17.icon_17988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17989: DrawableResource
+  get() = Drawable17.icon_17989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1799: DrawableResource
+  get() = Drawable17.icon_1799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17990: DrawableResource
+  get() = Drawable17.icon_17990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17991: DrawableResource
+  get() = Drawable17.icon_17991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17992: DrawableResource
+  get() = Drawable17.icon_17992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17993: DrawableResource
+  get() = Drawable17.icon_17993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17994: DrawableResource
+  get() = Drawable17.icon_17994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17995: DrawableResource
+  get() = Drawable17.icon_17995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17996: DrawableResource
+  get() = Drawable17.icon_17996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17997: DrawableResource
+  get() = Drawable17.icon_17997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17998: DrawableResource
+  get() = Drawable17.icon_17998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_17999: DrawableResource
+  get() = Drawable17.icon_17999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18: DrawableResource
+  get() = Drawable17.icon_18
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_180: DrawableResource
+  get() = Drawable17.icon_180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1800: DrawableResource
+  get() = Drawable17.icon_1800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18000: DrawableResource
+  get() = Drawable17.icon_18000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18001: DrawableResource
+  get() = Drawable17.icon_18001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18002: DrawableResource
+  get() = Drawable17.icon_18002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18003: DrawableResource
+  get() = Drawable17.icon_18003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18004: DrawableResource
+  get() = Drawable17.icon_18004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18005: DrawableResource
+  get() = Drawable17.icon_18005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18006: DrawableResource
+  get() = Drawable17.icon_18006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18007: DrawableResource
+  get() = Drawable17.icon_18007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18008: DrawableResource
+  get() = Drawable17.icon_18008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18009: DrawableResource
+  get() = Drawable17.icon_18009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1801: DrawableResource
+  get() = Drawable17.icon_1801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18010: DrawableResource
+  get() = Drawable17.icon_18010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18011: DrawableResource
+  get() = Drawable17.icon_18011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18012: DrawableResource
+  get() = Drawable17.icon_18012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18013: DrawableResource
+  get() = Drawable17.icon_18013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18014: DrawableResource
+  get() = Drawable17.icon_18014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18015: DrawableResource
+  get() = Drawable17.icon_18015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18016: DrawableResource
+  get() = Drawable17.icon_18016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18017: DrawableResource
+  get() = Drawable17.icon_18017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18018: DrawableResource
+  get() = Drawable17.icon_18018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18019: DrawableResource
+  get() = Drawable17.icon_18019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1802: DrawableResource
+  get() = Drawable17.icon_1802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18020: DrawableResource
+  get() = Drawable17.icon_18020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18021: DrawableResource
+  get() = Drawable17.icon_18021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18022: DrawableResource
+  get() = Drawable17.icon_18022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18023: DrawableResource
+  get() = Drawable17.icon_18023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18024: DrawableResource
+  get() = Drawable17.icon_18024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18025: DrawableResource
+  get() = Drawable17.icon_18025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18026: DrawableResource
+  get() = Drawable17.icon_18026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18027: DrawableResource
+  get() = Drawable17.icon_18027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18028: DrawableResource
+  get() = Drawable17.icon_18028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18029: DrawableResource
+  get() = Drawable17.icon_18029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1803: DrawableResource
+  get() = Drawable17.icon_1803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18030: DrawableResource
+  get() = Drawable17.icon_18030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18031: DrawableResource
+  get() = Drawable17.icon_18031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18032: DrawableResource
+  get() = Drawable17.icon_18032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18033: DrawableResource
+  get() = Drawable17.icon_18033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18034: DrawableResource
+  get() = Drawable17.icon_18034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18035: DrawableResource
+  get() = Drawable17.icon_18035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18036: DrawableResource
+  get() = Drawable17.icon_18036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18037: DrawableResource
+  get() = Drawable17.icon_18037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18038: DrawableResource
+  get() = Drawable17.icon_18038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18039: DrawableResource
+  get() = Drawable17.icon_18039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1804: DrawableResource
+  get() = Drawable17.icon_1804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18040: DrawableResource
+  get() = Drawable17.icon_18040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18041: DrawableResource
+  get() = Drawable17.icon_18041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18042: DrawableResource
+  get() = Drawable17.icon_18042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18043: DrawableResource
+  get() = Drawable17.icon_18043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18044: DrawableResource
+  get() = Drawable17.icon_18044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18045: DrawableResource
+  get() = Drawable17.icon_18045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18046: DrawableResource
+  get() = Drawable17.icon_18046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18047: DrawableResource
+  get() = Drawable17.icon_18047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18048: DrawableResource
+  get() = Drawable17.icon_18048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18049: DrawableResource
+  get() = Drawable17.icon_18049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1805: DrawableResource
+  get() = Drawable17.icon_1805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18050: DrawableResource
+  get() = Drawable17.icon_18050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18051: DrawableResource
+  get() = Drawable17.icon_18051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18052: DrawableResource
+  get() = Drawable17.icon_18052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18053: DrawableResource
+  get() = Drawable17.icon_18053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18054: DrawableResource
+  get() = Drawable17.icon_18054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18055: DrawableResource
+  get() = Drawable17.icon_18055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18056: DrawableResource
+  get() = Drawable17.icon_18056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18057: DrawableResource
+  get() = Drawable17.icon_18057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18058: DrawableResource
+  get() = Drawable17.icon_18058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18059: DrawableResource
+  get() = Drawable17.icon_18059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1806: DrawableResource
+  get() = Drawable17.icon_1806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18060: DrawableResource
+  get() = Drawable17.icon_18060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18061: DrawableResource
+  get() = Drawable17.icon_18061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18062: DrawableResource
+  get() = Drawable17.icon_18062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18063: DrawableResource
+  get() = Drawable17.icon_18063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18064: DrawableResource
+  get() = Drawable17.icon_18064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18065: DrawableResource
+  get() = Drawable17.icon_18065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18066: DrawableResource
+  get() = Drawable17.icon_18066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18067: DrawableResource
+  get() = Drawable17.icon_18067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18068: DrawableResource
+  get() = Drawable17.icon_18068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18069: DrawableResource
+  get() = Drawable17.icon_18069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1807: DrawableResource
+  get() = Drawable17.icon_1807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18070: DrawableResource
+  get() = Drawable17.icon_18070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18071: DrawableResource
+  get() = Drawable17.icon_18071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18072: DrawableResource
+  get() = Drawable17.icon_18072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18073: DrawableResource
+  get() = Drawable17.icon_18073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18074: DrawableResource
+  get() = Drawable17.icon_18074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18075: DrawableResource
+  get() = Drawable17.icon_18075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18076: DrawableResource
+  get() = Drawable17.icon_18076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18077: DrawableResource
+  get() = Drawable17.icon_18077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18078: DrawableResource
+  get() = Drawable17.icon_18078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18079: DrawableResource
+  get() = Drawable17.icon_18079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1808: DrawableResource
+  get() = Drawable17.icon_1808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18080: DrawableResource
+  get() = Drawable17.icon_18080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18081: DrawableResource
+  get() = Drawable17.icon_18081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18082: DrawableResource
+  get() = Drawable17.icon_18082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18083: DrawableResource
+  get() = Drawable17.icon_18083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18084: DrawableResource
+  get() = Drawable17.icon_18084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18085: DrawableResource
+  get() = Drawable17.icon_18085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18086: DrawableResource
+  get() = Drawable17.icon_18086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18087: DrawableResource
+  get() = Drawable17.icon_18087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18088: DrawableResource
+  get() = Drawable17.icon_18088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18089: DrawableResource
+  get() = Drawable17.icon_18089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1809: DrawableResource
+  get() = Drawable17.icon_1809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18090: DrawableResource
+  get() = Drawable17.icon_18090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18091: DrawableResource
+  get() = Drawable17.icon_18091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18092: DrawableResource
+  get() = Drawable17.icon_18092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18093: DrawableResource
+  get() = Drawable17.icon_18093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18094: DrawableResource
+  get() = Drawable17.icon_18094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18095: DrawableResource
+  get() = Drawable17.icon_18095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18096: DrawableResource
+  get() = Drawable17.icon_18096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18097: DrawableResource
+  get() = Drawable17.icon_18097

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable18.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable18.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable18 {
+  public val icon_18098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18098.xml"),
+          )
+      )
+
+  public val icon_18099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18099.xml"),
+          )
+      )
+
+  public val icon_181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_181.xml"),
+          )
+      )
+
+  public val icon_1810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1810.xml"),
+          )
+      )
+
+  public val icon_18100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18100.xml"),
+          )
+      )
+
+  public val icon_18101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18101.xml"),
+          )
+      )
+
+  public val icon_18102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18102.xml"),
+          )
+      )
+
+  public val icon_18103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18103.xml"),
+          )
+      )
+
+  public val icon_18104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18104.xml"),
+          )
+      )
+
+  public val icon_18105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18105.xml"),
+          )
+      )
+
+  public val icon_18106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18106.xml"),
+          )
+      )
+
+  public val icon_18107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18107.xml"),
+          )
+      )
+
+  public val icon_18108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18108.xml"),
+          )
+      )
+
+  public val icon_18109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18109.xml"),
+          )
+      )
+
+  public val icon_1811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1811.xml"),
+          )
+      )
+
+  public val icon_18110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18110.xml"),
+          )
+      )
+
+  public val icon_18111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18111.xml"),
+          )
+      )
+
+  public val icon_18112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18112.xml"),
+          )
+      )
+
+  public val icon_18113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18113.xml"),
+          )
+      )
+
+  public val icon_18114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18114.xml"),
+          )
+      )
+
+  public val icon_18115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18115.xml"),
+          )
+      )
+
+  public val icon_18116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18116.xml"),
+          )
+      )
+
+  public val icon_18117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18117.xml"),
+          )
+      )
+
+  public val icon_18118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18118.xml"),
+          )
+      )
+
+  public val icon_18119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18119.xml"),
+          )
+      )
+
+  public val icon_1812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1812.xml"),
+          )
+      )
+
+  public val icon_18120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18120.xml"),
+          )
+      )
+
+  public val icon_18121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18121.xml"),
+          )
+      )
+
+  public val icon_18122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18122.xml"),
+          )
+      )
+
+  public val icon_18123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18123.xml"),
+          )
+      )
+
+  public val icon_18124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18124.xml"),
+          )
+      )
+
+  public val icon_18125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18125.xml"),
+          )
+      )
+
+  public val icon_18126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18126.xml"),
+          )
+      )
+
+  public val icon_18127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18127.xml"),
+          )
+      )
+
+  public val icon_18128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18128.xml"),
+          )
+      )
+
+  public val icon_18129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18129.xml"),
+          )
+      )
+
+  public val icon_1813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1813.xml"),
+          )
+      )
+
+  public val icon_18130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18130.xml"),
+          )
+      )
+
+  public val icon_18131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18131.xml"),
+          )
+      )
+
+  public val icon_18132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18132.xml"),
+          )
+      )
+
+  public val icon_18133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18133.xml"),
+          )
+      )
+
+  public val icon_18134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18134.xml"),
+          )
+      )
+
+  public val icon_18135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18135.xml"),
+          )
+      )
+
+  public val icon_18136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18136.xml"),
+          )
+      )
+
+  public val icon_18137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18137.xml"),
+          )
+      )
+
+  public val icon_18138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18138.xml"),
+          )
+      )
+
+  public val icon_18139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18139.xml"),
+          )
+      )
+
+  public val icon_1814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1814.xml"),
+          )
+      )
+
+  public val icon_18140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18140.xml"),
+          )
+      )
+
+  public val icon_18141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18141.xml"),
+          )
+      )
+
+  public val icon_18142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18142.xml"),
+          )
+      )
+
+  public val icon_18143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18143.xml"),
+          )
+      )
+
+  public val icon_18144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18144.xml"),
+          )
+      )
+
+  public val icon_18145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18145.xml"),
+          )
+      )
+
+  public val icon_18146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18146.xml"),
+          )
+      )
+
+  public val icon_18147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18147.xml"),
+          )
+      )
+
+  public val icon_18148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18148.xml"),
+          )
+      )
+
+  public val icon_18149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18149.xml"),
+          )
+      )
+
+  public val icon_1815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1815.xml"),
+          )
+      )
+
+  public val icon_18150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18150.xml"),
+          )
+      )
+
+  public val icon_18151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18151.xml"),
+          )
+      )
+
+  public val icon_18152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18152.xml"),
+          )
+      )
+
+  public val icon_18153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18153.xml"),
+          )
+      )
+
+  public val icon_18154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18154.xml"),
+          )
+      )
+
+  public val icon_18155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18155.xml"),
+          )
+      )
+
+  public val icon_18156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18156.xml"),
+          )
+      )
+
+  public val icon_18157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18157.xml"),
+          )
+      )
+
+  public val icon_18158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18158.xml"),
+          )
+      )
+
+  public val icon_18159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18159.xml"),
+          )
+      )
+
+  public val icon_1816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1816.xml"),
+          )
+      )
+
+  public val icon_18160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18160.xml"),
+          )
+      )
+
+  public val icon_18161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18161.xml"),
+          )
+      )
+
+  public val icon_18162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18162.xml"),
+          )
+      )
+
+  public val icon_18163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18163.xml"),
+          )
+      )
+
+  public val icon_18164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18164.xml"),
+          )
+      )
+
+  public val icon_18165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18165.xml"),
+          )
+      )
+
+  public val icon_18166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18166.xml"),
+          )
+      )
+
+  public val icon_18167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18167.xml"),
+          )
+      )
+
+  public val icon_18168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18168.xml"),
+          )
+      )
+
+  public val icon_18169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18169.xml"),
+          )
+      )
+
+  public val icon_1817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1817.xml"),
+          )
+      )
+
+  public val icon_18170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18170.xml"),
+          )
+      )
+
+  public val icon_18171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18171.xml"),
+          )
+      )
+
+  public val icon_18172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18172.xml"),
+          )
+      )
+
+  public val icon_18173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18173.xml"),
+          )
+      )
+
+  public val icon_18174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18174.xml"),
+          )
+      )
+
+  public val icon_18175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18175.xml"),
+          )
+      )
+
+  public val icon_18176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18176.xml"),
+          )
+      )
+
+  public val icon_18177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18177.xml"),
+          )
+      )
+
+  public val icon_18178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18178.xml"),
+          )
+      )
+
+  public val icon_18179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18179.xml"),
+          )
+      )
+
+  public val icon_1818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1818.xml"),
+          )
+      )
+
+  public val icon_18180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18180.xml"),
+          )
+      )
+
+  public val icon_18181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18181.xml"),
+          )
+      )
+
+  public val icon_18182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18182.xml"),
+          )
+      )
+
+  public val icon_18183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18183.xml"),
+          )
+      )
+
+  public val icon_18184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18184.xml"),
+          )
+      )
+
+  public val icon_18185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18185.xml"),
+          )
+      )
+
+  public val icon_18186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18186.xml"),
+          )
+      )
+
+  public val icon_18187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18187.xml"),
+          )
+      )
+
+  public val icon_18188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18188.xml"),
+          )
+      )
+
+  public val icon_18189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18189.xml"),
+          )
+      )
+
+  public val icon_1819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1819.xml"),
+          )
+      )
+
+  public val icon_18190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18190.xml"),
+          )
+      )
+
+  public val icon_18191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18191.xml"),
+          )
+      )
+
+  public val icon_18192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18192.xml"),
+          )
+      )
+
+  public val icon_18193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18193.xml"),
+          )
+      )
+
+  public val icon_18194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18194.xml"),
+          )
+      )
+
+  public val icon_18195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18195.xml"),
+          )
+      )
+
+  public val icon_18196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18196.xml"),
+          )
+      )
+
+  public val icon_18197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18197.xml"),
+          )
+      )
+
+  public val icon_18198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18198.xml"),
+          )
+      )
+
+  public val icon_18199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18199.xml"),
+          )
+      )
+
+  public val icon_182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_182.xml"),
+          )
+      )
+
+  public val icon_1820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1820.xml"),
+          )
+      )
+
+  public val icon_18200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18200.xml"),
+          )
+      )
+
+  public val icon_18201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18201.xml"),
+          )
+      )
+
+  public val icon_18202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18202.xml"),
+          )
+      )
+
+  public val icon_18203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18203.xml"),
+          )
+      )
+
+  public val icon_18204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18204.xml"),
+          )
+      )
+
+  public val icon_18205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18205.xml"),
+          )
+      )
+
+  public val icon_18206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18206.xml"),
+          )
+      )
+
+  public val icon_18207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18207.xml"),
+          )
+      )
+
+  public val icon_18208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18208.xml"),
+          )
+      )
+
+  public val icon_18209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18209.xml"),
+          )
+      )
+
+  public val icon_1821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1821.xml"),
+          )
+      )
+
+  public val icon_18210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18210.xml"),
+          )
+      )
+
+  public val icon_18211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18211.xml"),
+          )
+      )
+
+  public val icon_18212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18212.xml"),
+          )
+      )
+
+  public val icon_18213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18213.xml"),
+          )
+      )
+
+  public val icon_18214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18214.xml"),
+          )
+      )
+
+  public val icon_18215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18215.xml"),
+          )
+      )
+
+  public val icon_18216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18216.xml"),
+          )
+      )
+
+  public val icon_18217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18217.xml"),
+          )
+      )
+
+  public val icon_18218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18218.xml"),
+          )
+      )
+
+  public val icon_18219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18219.xml"),
+          )
+      )
+
+  public val icon_1822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1822.xml"),
+          )
+      )
+
+  public val icon_18220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18220.xml"),
+          )
+      )
+
+  public val icon_18221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18221.xml"),
+          )
+      )
+
+  public val icon_18222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18222.xml"),
+          )
+      )
+
+  public val icon_18223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18223.xml"),
+          )
+      )
+
+  public val icon_18224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18224.xml"),
+          )
+      )
+
+  public val icon_18225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18225.xml"),
+          )
+      )
+
+  public val icon_18226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18226.xml"),
+          )
+      )
+
+  public val icon_18227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18227.xml"),
+          )
+      )
+
+  public val icon_18228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18228.xml"),
+          )
+      )
+
+  public val icon_18229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18229.xml"),
+          )
+      )
+
+  public val icon_1823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1823.xml"),
+          )
+      )
+
+  public val icon_18230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18230.xml"),
+          )
+      )
+
+  public val icon_18231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18231.xml"),
+          )
+      )
+
+  public val icon_18232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18232.xml"),
+          )
+      )
+
+  public val icon_18233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18233.xml"),
+          )
+      )
+
+  public val icon_18234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18234.xml"),
+          )
+      )
+
+  public val icon_18235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18235.xml"),
+          )
+      )
+
+  public val icon_18236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18236.xml"),
+          )
+      )
+
+  public val icon_18237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18237.xml"),
+          )
+      )
+
+  public val icon_18238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18238.xml"),
+          )
+      )
+
+  public val icon_18239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18239.xml"),
+          )
+      )
+
+  public val icon_1824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1824.xml"),
+          )
+      )
+
+  public val icon_18240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18240.xml"),
+          )
+      )
+
+  public val icon_18241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18241.xml"),
+          )
+      )
+
+  public val icon_18242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18242.xml"),
+          )
+      )
+
+  public val icon_18243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18243.xml"),
+          )
+      )
+
+  public val icon_18244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18244.xml"),
+          )
+      )
+
+  public val icon_18245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18245.xml"),
+          )
+      )
+
+  public val icon_18246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18246.xml"),
+          )
+      )
+
+  public val icon_18247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18247.xml"),
+          )
+      )
+
+  public val icon_18248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18248.xml"),
+          )
+      )
+
+  public val icon_18249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18249.xml"),
+          )
+      )
+
+  public val icon_1825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1825.xml"),
+          )
+      )
+
+  public val icon_18250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18250.xml"),
+          )
+      )
+
+  public val icon_18251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18251.xml"),
+          )
+      )
+
+  public val icon_18252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18252.xml"),
+          )
+      )
+
+  public val icon_18253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18253.xml"),
+          )
+      )
+
+  public val icon_18254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18254.xml"),
+          )
+      )
+
+  public val icon_18255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18255.xml"),
+          )
+      )
+
+  public val icon_18256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18256.xml"),
+          )
+      )
+
+  public val icon_18257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18257.xml"),
+          )
+      )
+
+  public val icon_18258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18258.xml"),
+          )
+      )
+
+  public val icon_18259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18259.xml"),
+          )
+      )
+
+  public val icon_1826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1826.xml"),
+          )
+      )
+
+  public val icon_18260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18260.xml"),
+          )
+      )
+
+  public val icon_18261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18261.xml"),
+          )
+      )
+
+  public val icon_18262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18262.xml"),
+          )
+      )
+
+  public val icon_18263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18263.xml"),
+          )
+      )
+
+  public val icon_18264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18264.xml"),
+          )
+      )
+
+  public val icon_18265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18265.xml"),
+          )
+      )
+
+  public val icon_18266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18266.xml"),
+          )
+      )
+
+  public val icon_18267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18267.xml"),
+          )
+      )
+
+  public val icon_18268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18268.xml"),
+          )
+      )
+
+  public val icon_18269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18269.xml"),
+          )
+      )
+
+  public val icon_1827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1827.xml"),
+          )
+      )
+
+  public val icon_18270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18270.xml"),
+          )
+      )
+
+  public val icon_18271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18271.xml"),
+          )
+      )
+
+  public val icon_18272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18272.xml"),
+          )
+      )
+
+  public val icon_18273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18273.xml"),
+          )
+      )
+
+  public val icon_18274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18274.xml"),
+          )
+      )
+
+  public val icon_18275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18275.xml"),
+          )
+      )
+
+  public val icon_18276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18276.xml"),
+          )
+      )
+
+  public val icon_18277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18277.xml"),
+          )
+      )
+
+  public val icon_18278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18278.xml"),
+          )
+      )
+
+  public val icon_18279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18279.xml"),
+          )
+      )
+
+  public val icon_1828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1828.xml"),
+          )
+      )
+
+  public val icon_18280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18280.xml"),
+          )
+      )
+
+  public val icon_18281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18281.xml"),
+          )
+      )
+
+  public val icon_18282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18282.xml"),
+          )
+      )
+
+  public val icon_18283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18283.xml"),
+          )
+      )
+
+  public val icon_18284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18284.xml"),
+          )
+      )
+
+  public val icon_18285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18285.xml"),
+          )
+      )
+
+  public val icon_18286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18286.xml"),
+          )
+      )
+
+  public val icon_18287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18287.xml"),
+          )
+      )
+
+  public val icon_18288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18288.xml"),
+          )
+      )
+
+  public val icon_18289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18289.xml"),
+          )
+      )
+
+  public val icon_1829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1829.xml"),
+          )
+      )
+
+  public val icon_18290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18290.xml"),
+          )
+      )
+
+  public val icon_18291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18291.xml"),
+          )
+      )
+
+  public val icon_18292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18292.xml"),
+          )
+      )
+
+  public val icon_18293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18293.xml"),
+          )
+      )
+
+  public val icon_18294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18294.xml"),
+          )
+      )
+
+  public val icon_18295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18295.xml"),
+          )
+      )
+
+  public val icon_18296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18296.xml"),
+          )
+      )
+
+  public val icon_18297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18297.xml"),
+          )
+      )
+
+  public val icon_18298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18298.xml"),
+          )
+      )
+
+  public val icon_18299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18299.xml"),
+          )
+      )
+
+  public val icon_183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_183.xml"),
+          )
+      )
+
+  public val icon_1830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1830.xml"),
+          )
+      )
+
+  public val icon_18300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18300.xml"),
+          )
+      )
+
+  public val icon_18301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18301.xml"),
+          )
+      )
+
+  public val icon_18302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18302.xml"),
+          )
+      )
+
+  public val icon_18303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18303.xml"),
+          )
+      )
+
+  public val icon_18304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18304.xml"),
+          )
+      )
+
+  public val icon_18305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18305.xml"),
+          )
+      )
+
+  public val icon_18306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18306.xml"),
+          )
+      )
+
+  public val icon_18307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18307.xml"),
+          )
+      )
+
+  public val icon_18308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18308.xml"),
+          )
+      )
+
+  public val icon_18309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18309.xml"),
+          )
+      )
+
+  public val icon_1831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1831.xml"),
+          )
+      )
+
+  public val icon_18310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18310.xml"),
+          )
+      )
+
+  public val icon_18311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18311.xml"),
+          )
+      )
+
+  public val icon_18312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18312.xml"),
+          )
+      )
+
+  public val icon_18313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18313.xml"),
+          )
+      )
+
+  public val icon_18314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18314.xml"),
+          )
+      )
+
+  public val icon_18315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18315.xml"),
+          )
+      )
+
+  public val icon_18316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18316.xml"),
+          )
+      )
+
+  public val icon_18317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18317.xml"),
+          )
+      )
+
+  public val icon_18318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18318.xml"),
+          )
+      )
+
+  public val icon_18319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18319.xml"),
+          )
+      )
+
+  public val icon_1832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1832.xml"),
+          )
+      )
+
+  public val icon_18320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18320.xml"),
+          )
+      )
+
+  public val icon_18321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18321.xml"),
+          )
+      )
+
+  public val icon_18322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18322.xml"),
+          )
+      )
+
+  public val icon_18323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18323.xml"),
+          )
+      )
+
+  public val icon_18324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18324.xml"),
+          )
+      )
+
+  public val icon_18325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18325.xml"),
+          )
+      )
+
+  public val icon_18326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18326.xml"),
+          )
+      )
+
+  public val icon_18327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18327.xml"),
+          )
+      )
+
+  public val icon_18328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18328.xml"),
+          )
+      )
+
+  public val icon_18329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18329.xml"),
+          )
+      )
+
+  public val icon_1833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1833.xml"),
+          )
+      )
+
+  public val icon_18330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18330.xml"),
+          )
+      )
+
+  public val icon_18331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18331.xml"),
+          )
+      )
+
+  public val icon_18332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18332.xml"),
+          )
+      )
+
+  public val icon_18333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18333.xml"),
+          )
+      )
+
+  public val icon_18334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18334.xml"),
+          )
+      )
+
+  public val icon_18335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18335.xml"),
+          )
+      )
+
+  public val icon_18336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18336.xml"),
+          )
+      )
+
+  public val icon_18337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18337.xml"),
+          )
+      )
+
+  public val icon_18338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18338.xml"),
+          )
+      )
+
+  public val icon_18339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18339.xml"),
+          )
+      )
+
+  public val icon_1834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1834.xml"),
+          )
+      )
+
+  public val icon_18340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18340.xml"),
+          )
+      )
+
+  public val icon_18341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18341.xml"),
+          )
+      )
+
+  public val icon_18342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18342.xml"),
+          )
+      )
+
+  public val icon_18343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18343.xml"),
+          )
+      )
+
+  public val icon_18344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18344.xml"),
+          )
+      )
+
+  public val icon_18345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18345.xml"),
+          )
+      )
+
+  public val icon_18346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18346.xml"),
+          )
+      )
+
+  public val icon_18347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18347.xml"),
+          )
+      )
+
+  public val icon_18348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18348.xml"),
+          )
+      )
+
+  public val icon_18349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18349.xml"),
+          )
+      )
+
+  public val icon_1835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1835.xml"),
+          )
+      )
+
+  public val icon_18350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18350.xml"),
+          )
+      )
+
+  public val icon_18351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18351.xml"),
+          )
+      )
+
+  public val icon_18352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18352.xml"),
+          )
+      )
+
+  public val icon_18353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18353.xml"),
+          )
+      )
+
+  public val icon_18354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18354.xml"),
+          )
+      )
+
+  public val icon_18355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18355.xml"),
+          )
+      )
+
+  public val icon_18356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18356.xml"),
+          )
+      )
+
+  public val icon_18357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18357.xml"),
+          )
+      )
+
+  public val icon_18358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18358.xml"),
+          )
+      )
+
+  public val icon_18359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18359.xml"),
+          )
+      )
+
+  public val icon_1836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1836.xml"),
+          )
+      )
+
+  public val icon_18360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18360.xml"),
+          )
+      )
+
+  public val icon_18361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18361.xml"),
+          )
+      )
+
+  public val icon_18362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18362.xml"),
+          )
+      )
+
+  public val icon_18363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18363.xml"),
+          )
+      )
+
+  public val icon_18364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18364.xml"),
+          )
+      )
+
+  public val icon_18365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18365.xml"),
+          )
+      )
+
+  public val icon_18366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18366.xml"),
+          )
+      )
+
+  public val icon_18367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18367.xml"),
+          )
+      )
+
+  public val icon_18368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18368.xml"),
+          )
+      )
+
+  public val icon_18369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18369.xml"),
+          )
+      )
+
+  public val icon_1837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1837.xml"),
+          )
+      )
+
+  public val icon_18370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18370.xml"),
+          )
+      )
+
+  public val icon_18371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18371.xml"),
+          )
+      )
+
+  public val icon_18372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18372.xml"),
+          )
+      )
+
+  public val icon_18373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18373.xml"),
+          )
+      )
+
+  public val icon_18374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18374.xml"),
+          )
+      )
+
+  public val icon_18375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18375.xml"),
+          )
+      )
+
+  public val icon_18376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18376.xml"),
+          )
+      )
+
+  public val icon_18377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18377.xml"),
+          )
+      )
+
+  public val icon_18378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18378.xml"),
+          )
+      )
+
+  public val icon_18379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18379.xml"),
+          )
+      )
+
+  public val icon_1838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1838.xml"),
+          )
+      )
+
+  public val icon_18380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18380.xml"),
+          )
+      )
+
+  public val icon_18381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18381.xml"),
+          )
+      )
+
+  public val icon_18382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18382.xml"),
+          )
+      )
+
+  public val icon_18383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18383.xml"),
+          )
+      )
+
+  public val icon_18384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18384.xml"),
+          )
+      )
+
+  public val icon_18385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18385.xml"),
+          )
+      )
+
+  public val icon_18386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18386.xml"),
+          )
+      )
+
+  public val icon_18387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18387.xml"),
+          )
+      )
+
+  public val icon_18388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18388.xml"),
+          )
+      )
+
+  public val icon_18389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18389.xml"),
+          )
+      )
+
+  public val icon_1839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1839.xml"),
+          )
+      )
+
+  public val icon_18390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18390.xml"),
+          )
+      )
+
+  public val icon_18391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18391.xml"),
+          )
+      )
+
+  public val icon_18392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18392.xml"),
+          )
+      )
+
+  public val icon_18393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18393.xml"),
+          )
+      )
+
+  public val icon_18394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18394.xml"),
+          )
+      )
+
+  public val icon_18395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18395.xml"),
+          )
+      )
+
+  public val icon_18396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18396.xml"),
+          )
+      )
+
+  public val icon_18397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18397.xml"),
+          )
+      )
+
+  public val icon_18398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18398.xml"),
+          )
+      )
+
+  public val icon_18399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18399.xml"),
+          )
+      )
+
+  public val icon_184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_184.xml"),
+          )
+      )
+
+  public val icon_1840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1840.xml"),
+          )
+      )
+
+  public val icon_18400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18400.xml"),
+          )
+      )
+
+  public val icon_18401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18401.xml"),
+          )
+      )
+
+  public val icon_18402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18402.xml"),
+          )
+      )
+
+  public val icon_18403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18403.xml"),
+          )
+      )
+
+  public val icon_18404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18404.xml"),
+          )
+      )
+
+  public val icon_18405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18405.xml"),
+          )
+      )
+
+  public val icon_18406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18406.xml"),
+          )
+      )
+
+  public val icon_18407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18407.xml"),
+          )
+      )
+
+  public val icon_18408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18408.xml"),
+          )
+      )
+
+  public val icon_18409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18409.xml"),
+          )
+      )
+
+  public val icon_1841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1841.xml"),
+          )
+      )
+
+  public val icon_18410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18410.xml"),
+          )
+      )
+
+  public val icon_18411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18411.xml"),
+          )
+      )
+
+  public val icon_18412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18412.xml"),
+          )
+      )
+
+  public val icon_18413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18413.xml"),
+          )
+      )
+
+  public val icon_18414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18414.xml"),
+          )
+      )
+
+  public val icon_18415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18415.xml"),
+          )
+      )
+
+  public val icon_18416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18416.xml"),
+          )
+      )
+
+  public val icon_18417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18417.xml"),
+          )
+      )
+
+  public val icon_18418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18418.xml"),
+          )
+      )
+
+  public val icon_18419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18419.xml"),
+          )
+      )
+
+  public val icon_1842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1842.xml"),
+          )
+      )
+
+  public val icon_18420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18420.xml"),
+          )
+      )
+
+  public val icon_18421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18421.xml"),
+          )
+      )
+
+  public val icon_18422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18422.xml"),
+          )
+      )
+
+  public val icon_18423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18423.xml"),
+          )
+      )
+
+  public val icon_18424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18424.xml"),
+          )
+      )
+
+  public val icon_18425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18425.xml"),
+          )
+      )
+
+  public val icon_18426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18426.xml"),
+          )
+      )
+
+  public val icon_18427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18427.xml"),
+          )
+      )
+
+  public val icon_18428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18428.xml"),
+          )
+      )
+
+  public val icon_18429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18429.xml"),
+          )
+      )
+
+  public val icon_1843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1843.xml"),
+          )
+      )
+
+  public val icon_18430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18430.xml"),
+          )
+      )
+
+  public val icon_18431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18431.xml"),
+          )
+      )
+
+  public val icon_18432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18432.xml"),
+          )
+      )
+
+  public val icon_18433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18433.xml"),
+          )
+      )
+
+  public val icon_18434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18434.xml"),
+          )
+      )
+
+  public val icon_18435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18435.xml"),
+          )
+      )
+
+  public val icon_18436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18436.xml"),
+          )
+      )
+
+  public val icon_18437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18437.xml"),
+          )
+      )
+
+  public val icon_18438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18438.xml"),
+          )
+      )
+
+  public val icon_18439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18439.xml"),
+          )
+      )
+
+  public val icon_1844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1844.xml"),
+          )
+      )
+
+  public val icon_18440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18440.xml"),
+          )
+      )
+
+  public val icon_18441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18441.xml"),
+          )
+      )
+
+  public val icon_18442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18442.xml"),
+          )
+      )
+
+  public val icon_18443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18443.xml"),
+          )
+      )
+
+  public val icon_18444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18444.xml"),
+          )
+      )
+
+  public val icon_18445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18445.xml"),
+          )
+      )
+
+  public val icon_18446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18446.xml"),
+          )
+      )
+
+  public val icon_18447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18447.xml"),
+          )
+      )
+
+  public val icon_18448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18448.xml"),
+          )
+      )
+
+  public val icon_18449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18449.xml"),
+          )
+      )
+
+  public val icon_1845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1845.xml"),
+          )
+      )
+
+  public val icon_18450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18450.xml"),
+          )
+      )
+
+  public val icon_18451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18451.xml"),
+          )
+      )
+
+  public val icon_18452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18452.xml"),
+          )
+      )
+
+  public val icon_18453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18453.xml"),
+          )
+      )
+
+  public val icon_18454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18454.xml"),
+          )
+      )
+
+  public val icon_18455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18455.xml"),
+          )
+      )
+
+  public val icon_18456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18456.xml"),
+          )
+      )
+
+  public val icon_18457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18457.xml"),
+          )
+      )
+
+  public val icon_18458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18458.xml"),
+          )
+      )
+
+  public val icon_18459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18459.xml"),
+          )
+      )
+
+  public val icon_1846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1846.xml"),
+          )
+      )
+
+  public val icon_18460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18460.xml"),
+          )
+      )
+
+  public val icon_18461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18461.xml"),
+          )
+      )
+
+  public val icon_18462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18462.xml"),
+          )
+      )
+
+  public val icon_18463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18463.xml"),
+          )
+      )
+
+  public val icon_18464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18464.xml"),
+          )
+      )
+
+  public val icon_18465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18465.xml"),
+          )
+      )
+
+  public val icon_18466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18466.xml"),
+          )
+      )
+
+  public val icon_18467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18467.xml"),
+          )
+      )
+
+  public val icon_18468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18468.xml"),
+          )
+      )
+
+  public val icon_18469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18469.xml"),
+          )
+      )
+
+  public val icon_1847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1847.xml"),
+          )
+      )
+
+  public val icon_18470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18470.xml"),
+          )
+      )
+
+  public val icon_18471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18471.xml"),
+          )
+      )
+
+  public val icon_18472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18472.xml"),
+          )
+      )
+
+  public val icon_18473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18473.xml"),
+          )
+      )
+
+  public val icon_18474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18474.xml"),
+          )
+      )
+
+  public val icon_18475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18475.xml"),
+          )
+      )
+
+  public val icon_18476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18476.xml"),
+          )
+      )
+
+  public val icon_18477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18477.xml"),
+          )
+      )
+
+  public val icon_18478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18478.xml"),
+          )
+      )
+
+  public val icon_18479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18479.xml"),
+          )
+      )
+
+  public val icon_1848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1848.xml"),
+          )
+      )
+
+  public val icon_18480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18480.xml"),
+          )
+      )
+
+  public val icon_18481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18481.xml"),
+          )
+      )
+
+  public val icon_18482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18482.xml"),
+          )
+      )
+
+  public val icon_18483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18483.xml"),
+          )
+      )
+
+  public val icon_18484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18484.xml"),
+          )
+      )
+
+  public val icon_18485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18485.xml"),
+          )
+      )
+
+  public val icon_18486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18486.xml"),
+          )
+      )
+
+  public val icon_18487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18487.xml"),
+          )
+      )
+
+  public val icon_18488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18488.xml"),
+          )
+      )
+
+  public val icon_18489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18489.xml"),
+          )
+      )
+
+  public val icon_1849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1849.xml"),
+          )
+      )
+
+  public val icon_18490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18490.xml"),
+          )
+      )
+
+  public val icon_18491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18491.xml"),
+          )
+      )
+
+  public val icon_18492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18492.xml"),
+          )
+      )
+
+  public val icon_18493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18493.xml"),
+          )
+      )
+
+  public val icon_18494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18494.xml"),
+          )
+      )
+
+  public val icon_18495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18495.xml"),
+          )
+      )
+
+  public val icon_18496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18496.xml"),
+          )
+      )
+
+  public val icon_18497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18497.xml"),
+          )
+      )
+
+  public val icon_18498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18498.xml"),
+          )
+      )
+
+  public val icon_18499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18499.xml"),
+          )
+      )
+
+  public val icon_185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_185.xml"),
+          )
+      )
+
+  public val icon_1850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1850.xml"),
+          )
+      )
+
+  public val icon_18500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18500.xml"),
+          )
+      )
+
+  public val icon_18501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18501.xml"),
+          )
+      )
+
+  public val icon_18502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18502.xml"),
+          )
+      )
+
+  public val icon_18503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18503.xml"),
+          )
+      )
+
+  public val icon_18504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18504.xml"),
+          )
+      )
+
+  public val icon_18505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18505.xml"),
+          )
+      )
+
+  public val icon_18506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18506.xml"),
+          )
+      )
+
+  public val icon_18507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18507.xml"),
+          )
+      )
+
+  public val icon_18508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18508.xml"),
+          )
+      )
+
+  public val icon_18509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18509.xml"),
+          )
+      )
+
+  public val icon_1851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1851.xml"),
+          )
+      )
+
+  public val icon_18510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18510.xml"),
+          )
+      )
+
+  public val icon_18511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18511.xml"),
+          )
+      )
+
+  public val icon_18512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18512.xml"),
+          )
+      )
+
+  public val icon_18513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18513.xml"),
+          )
+      )
+
+  public val icon_18514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18514.xml"),
+          )
+      )
+
+  public val icon_18515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18515.xml"),
+          )
+      )
+
+  public val icon_18516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18516.xml"),
+          )
+      )
+
+  public val icon_18517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18517.xml"),
+          )
+      )
+
+  public val icon_18518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18518.xml"),
+          )
+      )
+
+  public val icon_18519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18519.xml"),
+          )
+      )
+
+  public val icon_1852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1852.xml"),
+          )
+      )
+
+  public val icon_18520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18520.xml"),
+          )
+      )
+
+  public val icon_18521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18521.xml"),
+          )
+      )
+
+  public val icon_18522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18522.xml"),
+          )
+      )
+
+  public val icon_18523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18523.xml"),
+          )
+      )
+
+  public val icon_18524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18524.xml"),
+          )
+      )
+
+  public val icon_18525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18525.xml"),
+          )
+      )
+
+  public val icon_18526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18526.xml"),
+          )
+      )
+
+  public val icon_18527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18527.xml"),
+          )
+      )
+
+  public val icon_18528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18528.xml"),
+          )
+      )
+
+  public val icon_18529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18529.xml"),
+          )
+      )
+
+  public val icon_1853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1853.xml"),
+          )
+      )
+
+  public val icon_18530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18530.xml"),
+          )
+      )
+
+  public val icon_18531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18531.xml"),
+          )
+      )
+
+  public val icon_18532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18532.xml"),
+          )
+      )
+
+  public val icon_18533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18533.xml"),
+          )
+      )
+
+  public val icon_18534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18534.xml"),
+          )
+      )
+
+  public val icon_18535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18535.xml"),
+          )
+      )
+
+  public val icon_18536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18536.xml"),
+          )
+      )
+
+  public val icon_18537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18537.xml"),
+          )
+      )
+
+  public val icon_18538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18538.xml"),
+          )
+      )
+
+  public val icon_18539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18539.xml"),
+          )
+      )
+
+  public val icon_1854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1854.xml"),
+          )
+      )
+
+  public val icon_18540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18540.xml"),
+          )
+      )
+
+  public val icon_18541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18541.xml"),
+          )
+      )
+
+  public val icon_18542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18542.xml"),
+          )
+      )
+
+  public val icon_18543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18543.xml"),
+          )
+      )
+
+  public val icon_18544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18544.xml"),
+          )
+      )
+
+  public val icon_18545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18545.xml"),
+          )
+      )
+
+  public val icon_18546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18546.xml"),
+          )
+      )
+
+  public val icon_18547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18547.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18098: DrawableResource
+  get() = Drawable18.icon_18098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18099: DrawableResource
+  get() = Drawable18.icon_18099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_181: DrawableResource
+  get() = Drawable18.icon_181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1810: DrawableResource
+  get() = Drawable18.icon_1810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18100: DrawableResource
+  get() = Drawable18.icon_18100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18101: DrawableResource
+  get() = Drawable18.icon_18101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18102: DrawableResource
+  get() = Drawable18.icon_18102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18103: DrawableResource
+  get() = Drawable18.icon_18103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18104: DrawableResource
+  get() = Drawable18.icon_18104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18105: DrawableResource
+  get() = Drawable18.icon_18105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18106: DrawableResource
+  get() = Drawable18.icon_18106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18107: DrawableResource
+  get() = Drawable18.icon_18107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18108: DrawableResource
+  get() = Drawable18.icon_18108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18109: DrawableResource
+  get() = Drawable18.icon_18109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1811: DrawableResource
+  get() = Drawable18.icon_1811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18110: DrawableResource
+  get() = Drawable18.icon_18110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18111: DrawableResource
+  get() = Drawable18.icon_18111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18112: DrawableResource
+  get() = Drawable18.icon_18112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18113: DrawableResource
+  get() = Drawable18.icon_18113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18114: DrawableResource
+  get() = Drawable18.icon_18114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18115: DrawableResource
+  get() = Drawable18.icon_18115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18116: DrawableResource
+  get() = Drawable18.icon_18116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18117: DrawableResource
+  get() = Drawable18.icon_18117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18118: DrawableResource
+  get() = Drawable18.icon_18118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18119: DrawableResource
+  get() = Drawable18.icon_18119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1812: DrawableResource
+  get() = Drawable18.icon_1812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18120: DrawableResource
+  get() = Drawable18.icon_18120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18121: DrawableResource
+  get() = Drawable18.icon_18121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18122: DrawableResource
+  get() = Drawable18.icon_18122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18123: DrawableResource
+  get() = Drawable18.icon_18123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18124: DrawableResource
+  get() = Drawable18.icon_18124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18125: DrawableResource
+  get() = Drawable18.icon_18125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18126: DrawableResource
+  get() = Drawable18.icon_18126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18127: DrawableResource
+  get() = Drawable18.icon_18127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18128: DrawableResource
+  get() = Drawable18.icon_18128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18129: DrawableResource
+  get() = Drawable18.icon_18129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1813: DrawableResource
+  get() = Drawable18.icon_1813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18130: DrawableResource
+  get() = Drawable18.icon_18130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18131: DrawableResource
+  get() = Drawable18.icon_18131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18132: DrawableResource
+  get() = Drawable18.icon_18132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18133: DrawableResource
+  get() = Drawable18.icon_18133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18134: DrawableResource
+  get() = Drawable18.icon_18134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18135: DrawableResource
+  get() = Drawable18.icon_18135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18136: DrawableResource
+  get() = Drawable18.icon_18136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18137: DrawableResource
+  get() = Drawable18.icon_18137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18138: DrawableResource
+  get() = Drawable18.icon_18138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18139: DrawableResource
+  get() = Drawable18.icon_18139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1814: DrawableResource
+  get() = Drawable18.icon_1814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18140: DrawableResource
+  get() = Drawable18.icon_18140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18141: DrawableResource
+  get() = Drawable18.icon_18141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18142: DrawableResource
+  get() = Drawable18.icon_18142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18143: DrawableResource
+  get() = Drawable18.icon_18143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18144: DrawableResource
+  get() = Drawable18.icon_18144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18145: DrawableResource
+  get() = Drawable18.icon_18145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18146: DrawableResource
+  get() = Drawable18.icon_18146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18147: DrawableResource
+  get() = Drawable18.icon_18147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18148: DrawableResource
+  get() = Drawable18.icon_18148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18149: DrawableResource
+  get() = Drawable18.icon_18149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1815: DrawableResource
+  get() = Drawable18.icon_1815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18150: DrawableResource
+  get() = Drawable18.icon_18150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18151: DrawableResource
+  get() = Drawable18.icon_18151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18152: DrawableResource
+  get() = Drawable18.icon_18152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18153: DrawableResource
+  get() = Drawable18.icon_18153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18154: DrawableResource
+  get() = Drawable18.icon_18154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18155: DrawableResource
+  get() = Drawable18.icon_18155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18156: DrawableResource
+  get() = Drawable18.icon_18156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18157: DrawableResource
+  get() = Drawable18.icon_18157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18158: DrawableResource
+  get() = Drawable18.icon_18158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18159: DrawableResource
+  get() = Drawable18.icon_18159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1816: DrawableResource
+  get() = Drawable18.icon_1816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18160: DrawableResource
+  get() = Drawable18.icon_18160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18161: DrawableResource
+  get() = Drawable18.icon_18161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18162: DrawableResource
+  get() = Drawable18.icon_18162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18163: DrawableResource
+  get() = Drawable18.icon_18163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18164: DrawableResource
+  get() = Drawable18.icon_18164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18165: DrawableResource
+  get() = Drawable18.icon_18165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18166: DrawableResource
+  get() = Drawable18.icon_18166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18167: DrawableResource
+  get() = Drawable18.icon_18167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18168: DrawableResource
+  get() = Drawable18.icon_18168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18169: DrawableResource
+  get() = Drawable18.icon_18169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1817: DrawableResource
+  get() = Drawable18.icon_1817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18170: DrawableResource
+  get() = Drawable18.icon_18170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18171: DrawableResource
+  get() = Drawable18.icon_18171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18172: DrawableResource
+  get() = Drawable18.icon_18172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18173: DrawableResource
+  get() = Drawable18.icon_18173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18174: DrawableResource
+  get() = Drawable18.icon_18174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18175: DrawableResource
+  get() = Drawable18.icon_18175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18176: DrawableResource
+  get() = Drawable18.icon_18176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18177: DrawableResource
+  get() = Drawable18.icon_18177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18178: DrawableResource
+  get() = Drawable18.icon_18178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18179: DrawableResource
+  get() = Drawable18.icon_18179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1818: DrawableResource
+  get() = Drawable18.icon_1818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18180: DrawableResource
+  get() = Drawable18.icon_18180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18181: DrawableResource
+  get() = Drawable18.icon_18181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18182: DrawableResource
+  get() = Drawable18.icon_18182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18183: DrawableResource
+  get() = Drawable18.icon_18183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18184: DrawableResource
+  get() = Drawable18.icon_18184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18185: DrawableResource
+  get() = Drawable18.icon_18185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18186: DrawableResource
+  get() = Drawable18.icon_18186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18187: DrawableResource
+  get() = Drawable18.icon_18187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18188: DrawableResource
+  get() = Drawable18.icon_18188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18189: DrawableResource
+  get() = Drawable18.icon_18189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1819: DrawableResource
+  get() = Drawable18.icon_1819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18190: DrawableResource
+  get() = Drawable18.icon_18190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18191: DrawableResource
+  get() = Drawable18.icon_18191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18192: DrawableResource
+  get() = Drawable18.icon_18192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18193: DrawableResource
+  get() = Drawable18.icon_18193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18194: DrawableResource
+  get() = Drawable18.icon_18194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18195: DrawableResource
+  get() = Drawable18.icon_18195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18196: DrawableResource
+  get() = Drawable18.icon_18196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18197: DrawableResource
+  get() = Drawable18.icon_18197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18198: DrawableResource
+  get() = Drawable18.icon_18198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18199: DrawableResource
+  get() = Drawable18.icon_18199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_182: DrawableResource
+  get() = Drawable18.icon_182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1820: DrawableResource
+  get() = Drawable18.icon_1820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18200: DrawableResource
+  get() = Drawable18.icon_18200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18201: DrawableResource
+  get() = Drawable18.icon_18201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18202: DrawableResource
+  get() = Drawable18.icon_18202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18203: DrawableResource
+  get() = Drawable18.icon_18203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18204: DrawableResource
+  get() = Drawable18.icon_18204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18205: DrawableResource
+  get() = Drawable18.icon_18205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18206: DrawableResource
+  get() = Drawable18.icon_18206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18207: DrawableResource
+  get() = Drawable18.icon_18207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18208: DrawableResource
+  get() = Drawable18.icon_18208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18209: DrawableResource
+  get() = Drawable18.icon_18209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1821: DrawableResource
+  get() = Drawable18.icon_1821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18210: DrawableResource
+  get() = Drawable18.icon_18210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18211: DrawableResource
+  get() = Drawable18.icon_18211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18212: DrawableResource
+  get() = Drawable18.icon_18212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18213: DrawableResource
+  get() = Drawable18.icon_18213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18214: DrawableResource
+  get() = Drawable18.icon_18214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18215: DrawableResource
+  get() = Drawable18.icon_18215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18216: DrawableResource
+  get() = Drawable18.icon_18216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18217: DrawableResource
+  get() = Drawable18.icon_18217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18218: DrawableResource
+  get() = Drawable18.icon_18218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18219: DrawableResource
+  get() = Drawable18.icon_18219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1822: DrawableResource
+  get() = Drawable18.icon_1822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18220: DrawableResource
+  get() = Drawable18.icon_18220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18221: DrawableResource
+  get() = Drawable18.icon_18221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18222: DrawableResource
+  get() = Drawable18.icon_18222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18223: DrawableResource
+  get() = Drawable18.icon_18223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18224: DrawableResource
+  get() = Drawable18.icon_18224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18225: DrawableResource
+  get() = Drawable18.icon_18225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18226: DrawableResource
+  get() = Drawable18.icon_18226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18227: DrawableResource
+  get() = Drawable18.icon_18227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18228: DrawableResource
+  get() = Drawable18.icon_18228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18229: DrawableResource
+  get() = Drawable18.icon_18229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1823: DrawableResource
+  get() = Drawable18.icon_1823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18230: DrawableResource
+  get() = Drawable18.icon_18230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18231: DrawableResource
+  get() = Drawable18.icon_18231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18232: DrawableResource
+  get() = Drawable18.icon_18232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18233: DrawableResource
+  get() = Drawable18.icon_18233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18234: DrawableResource
+  get() = Drawable18.icon_18234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18235: DrawableResource
+  get() = Drawable18.icon_18235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18236: DrawableResource
+  get() = Drawable18.icon_18236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18237: DrawableResource
+  get() = Drawable18.icon_18237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18238: DrawableResource
+  get() = Drawable18.icon_18238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18239: DrawableResource
+  get() = Drawable18.icon_18239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1824: DrawableResource
+  get() = Drawable18.icon_1824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18240: DrawableResource
+  get() = Drawable18.icon_18240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18241: DrawableResource
+  get() = Drawable18.icon_18241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18242: DrawableResource
+  get() = Drawable18.icon_18242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18243: DrawableResource
+  get() = Drawable18.icon_18243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18244: DrawableResource
+  get() = Drawable18.icon_18244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18245: DrawableResource
+  get() = Drawable18.icon_18245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18246: DrawableResource
+  get() = Drawable18.icon_18246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18247: DrawableResource
+  get() = Drawable18.icon_18247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18248: DrawableResource
+  get() = Drawable18.icon_18248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18249: DrawableResource
+  get() = Drawable18.icon_18249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1825: DrawableResource
+  get() = Drawable18.icon_1825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18250: DrawableResource
+  get() = Drawable18.icon_18250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18251: DrawableResource
+  get() = Drawable18.icon_18251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18252: DrawableResource
+  get() = Drawable18.icon_18252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18253: DrawableResource
+  get() = Drawable18.icon_18253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18254: DrawableResource
+  get() = Drawable18.icon_18254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18255: DrawableResource
+  get() = Drawable18.icon_18255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18256: DrawableResource
+  get() = Drawable18.icon_18256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18257: DrawableResource
+  get() = Drawable18.icon_18257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18258: DrawableResource
+  get() = Drawable18.icon_18258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18259: DrawableResource
+  get() = Drawable18.icon_18259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1826: DrawableResource
+  get() = Drawable18.icon_1826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18260: DrawableResource
+  get() = Drawable18.icon_18260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18261: DrawableResource
+  get() = Drawable18.icon_18261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18262: DrawableResource
+  get() = Drawable18.icon_18262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18263: DrawableResource
+  get() = Drawable18.icon_18263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18264: DrawableResource
+  get() = Drawable18.icon_18264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18265: DrawableResource
+  get() = Drawable18.icon_18265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18266: DrawableResource
+  get() = Drawable18.icon_18266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18267: DrawableResource
+  get() = Drawable18.icon_18267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18268: DrawableResource
+  get() = Drawable18.icon_18268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18269: DrawableResource
+  get() = Drawable18.icon_18269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1827: DrawableResource
+  get() = Drawable18.icon_1827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18270: DrawableResource
+  get() = Drawable18.icon_18270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18271: DrawableResource
+  get() = Drawable18.icon_18271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18272: DrawableResource
+  get() = Drawable18.icon_18272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18273: DrawableResource
+  get() = Drawable18.icon_18273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18274: DrawableResource
+  get() = Drawable18.icon_18274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18275: DrawableResource
+  get() = Drawable18.icon_18275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18276: DrawableResource
+  get() = Drawable18.icon_18276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18277: DrawableResource
+  get() = Drawable18.icon_18277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18278: DrawableResource
+  get() = Drawable18.icon_18278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18279: DrawableResource
+  get() = Drawable18.icon_18279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1828: DrawableResource
+  get() = Drawable18.icon_1828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18280: DrawableResource
+  get() = Drawable18.icon_18280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18281: DrawableResource
+  get() = Drawable18.icon_18281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18282: DrawableResource
+  get() = Drawable18.icon_18282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18283: DrawableResource
+  get() = Drawable18.icon_18283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18284: DrawableResource
+  get() = Drawable18.icon_18284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18285: DrawableResource
+  get() = Drawable18.icon_18285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18286: DrawableResource
+  get() = Drawable18.icon_18286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18287: DrawableResource
+  get() = Drawable18.icon_18287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18288: DrawableResource
+  get() = Drawable18.icon_18288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18289: DrawableResource
+  get() = Drawable18.icon_18289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1829: DrawableResource
+  get() = Drawable18.icon_1829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18290: DrawableResource
+  get() = Drawable18.icon_18290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18291: DrawableResource
+  get() = Drawable18.icon_18291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18292: DrawableResource
+  get() = Drawable18.icon_18292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18293: DrawableResource
+  get() = Drawable18.icon_18293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18294: DrawableResource
+  get() = Drawable18.icon_18294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18295: DrawableResource
+  get() = Drawable18.icon_18295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18296: DrawableResource
+  get() = Drawable18.icon_18296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18297: DrawableResource
+  get() = Drawable18.icon_18297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18298: DrawableResource
+  get() = Drawable18.icon_18298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18299: DrawableResource
+  get() = Drawable18.icon_18299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_183: DrawableResource
+  get() = Drawable18.icon_183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1830: DrawableResource
+  get() = Drawable18.icon_1830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18300: DrawableResource
+  get() = Drawable18.icon_18300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18301: DrawableResource
+  get() = Drawable18.icon_18301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18302: DrawableResource
+  get() = Drawable18.icon_18302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18303: DrawableResource
+  get() = Drawable18.icon_18303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18304: DrawableResource
+  get() = Drawable18.icon_18304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18305: DrawableResource
+  get() = Drawable18.icon_18305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18306: DrawableResource
+  get() = Drawable18.icon_18306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18307: DrawableResource
+  get() = Drawable18.icon_18307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18308: DrawableResource
+  get() = Drawable18.icon_18308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18309: DrawableResource
+  get() = Drawable18.icon_18309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1831: DrawableResource
+  get() = Drawable18.icon_1831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18310: DrawableResource
+  get() = Drawable18.icon_18310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18311: DrawableResource
+  get() = Drawable18.icon_18311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18312: DrawableResource
+  get() = Drawable18.icon_18312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18313: DrawableResource
+  get() = Drawable18.icon_18313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18314: DrawableResource
+  get() = Drawable18.icon_18314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18315: DrawableResource
+  get() = Drawable18.icon_18315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18316: DrawableResource
+  get() = Drawable18.icon_18316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18317: DrawableResource
+  get() = Drawable18.icon_18317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18318: DrawableResource
+  get() = Drawable18.icon_18318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18319: DrawableResource
+  get() = Drawable18.icon_18319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1832: DrawableResource
+  get() = Drawable18.icon_1832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18320: DrawableResource
+  get() = Drawable18.icon_18320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18321: DrawableResource
+  get() = Drawable18.icon_18321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18322: DrawableResource
+  get() = Drawable18.icon_18322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18323: DrawableResource
+  get() = Drawable18.icon_18323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18324: DrawableResource
+  get() = Drawable18.icon_18324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18325: DrawableResource
+  get() = Drawable18.icon_18325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18326: DrawableResource
+  get() = Drawable18.icon_18326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18327: DrawableResource
+  get() = Drawable18.icon_18327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18328: DrawableResource
+  get() = Drawable18.icon_18328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18329: DrawableResource
+  get() = Drawable18.icon_18329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1833: DrawableResource
+  get() = Drawable18.icon_1833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18330: DrawableResource
+  get() = Drawable18.icon_18330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18331: DrawableResource
+  get() = Drawable18.icon_18331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18332: DrawableResource
+  get() = Drawable18.icon_18332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18333: DrawableResource
+  get() = Drawable18.icon_18333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18334: DrawableResource
+  get() = Drawable18.icon_18334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18335: DrawableResource
+  get() = Drawable18.icon_18335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18336: DrawableResource
+  get() = Drawable18.icon_18336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18337: DrawableResource
+  get() = Drawable18.icon_18337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18338: DrawableResource
+  get() = Drawable18.icon_18338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18339: DrawableResource
+  get() = Drawable18.icon_18339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1834: DrawableResource
+  get() = Drawable18.icon_1834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18340: DrawableResource
+  get() = Drawable18.icon_18340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18341: DrawableResource
+  get() = Drawable18.icon_18341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18342: DrawableResource
+  get() = Drawable18.icon_18342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18343: DrawableResource
+  get() = Drawable18.icon_18343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18344: DrawableResource
+  get() = Drawable18.icon_18344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18345: DrawableResource
+  get() = Drawable18.icon_18345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18346: DrawableResource
+  get() = Drawable18.icon_18346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18347: DrawableResource
+  get() = Drawable18.icon_18347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18348: DrawableResource
+  get() = Drawable18.icon_18348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18349: DrawableResource
+  get() = Drawable18.icon_18349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1835: DrawableResource
+  get() = Drawable18.icon_1835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18350: DrawableResource
+  get() = Drawable18.icon_18350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18351: DrawableResource
+  get() = Drawable18.icon_18351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18352: DrawableResource
+  get() = Drawable18.icon_18352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18353: DrawableResource
+  get() = Drawable18.icon_18353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18354: DrawableResource
+  get() = Drawable18.icon_18354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18355: DrawableResource
+  get() = Drawable18.icon_18355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18356: DrawableResource
+  get() = Drawable18.icon_18356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18357: DrawableResource
+  get() = Drawable18.icon_18357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18358: DrawableResource
+  get() = Drawable18.icon_18358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18359: DrawableResource
+  get() = Drawable18.icon_18359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1836: DrawableResource
+  get() = Drawable18.icon_1836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18360: DrawableResource
+  get() = Drawable18.icon_18360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18361: DrawableResource
+  get() = Drawable18.icon_18361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18362: DrawableResource
+  get() = Drawable18.icon_18362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18363: DrawableResource
+  get() = Drawable18.icon_18363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18364: DrawableResource
+  get() = Drawable18.icon_18364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18365: DrawableResource
+  get() = Drawable18.icon_18365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18366: DrawableResource
+  get() = Drawable18.icon_18366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18367: DrawableResource
+  get() = Drawable18.icon_18367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18368: DrawableResource
+  get() = Drawable18.icon_18368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18369: DrawableResource
+  get() = Drawable18.icon_18369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1837: DrawableResource
+  get() = Drawable18.icon_1837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18370: DrawableResource
+  get() = Drawable18.icon_18370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18371: DrawableResource
+  get() = Drawable18.icon_18371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18372: DrawableResource
+  get() = Drawable18.icon_18372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18373: DrawableResource
+  get() = Drawable18.icon_18373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18374: DrawableResource
+  get() = Drawable18.icon_18374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18375: DrawableResource
+  get() = Drawable18.icon_18375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18376: DrawableResource
+  get() = Drawable18.icon_18376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18377: DrawableResource
+  get() = Drawable18.icon_18377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18378: DrawableResource
+  get() = Drawable18.icon_18378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18379: DrawableResource
+  get() = Drawable18.icon_18379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1838: DrawableResource
+  get() = Drawable18.icon_1838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18380: DrawableResource
+  get() = Drawable18.icon_18380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18381: DrawableResource
+  get() = Drawable18.icon_18381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18382: DrawableResource
+  get() = Drawable18.icon_18382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18383: DrawableResource
+  get() = Drawable18.icon_18383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18384: DrawableResource
+  get() = Drawable18.icon_18384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18385: DrawableResource
+  get() = Drawable18.icon_18385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18386: DrawableResource
+  get() = Drawable18.icon_18386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18387: DrawableResource
+  get() = Drawable18.icon_18387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18388: DrawableResource
+  get() = Drawable18.icon_18388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18389: DrawableResource
+  get() = Drawable18.icon_18389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1839: DrawableResource
+  get() = Drawable18.icon_1839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18390: DrawableResource
+  get() = Drawable18.icon_18390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18391: DrawableResource
+  get() = Drawable18.icon_18391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18392: DrawableResource
+  get() = Drawable18.icon_18392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18393: DrawableResource
+  get() = Drawable18.icon_18393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18394: DrawableResource
+  get() = Drawable18.icon_18394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18395: DrawableResource
+  get() = Drawable18.icon_18395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18396: DrawableResource
+  get() = Drawable18.icon_18396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18397: DrawableResource
+  get() = Drawable18.icon_18397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18398: DrawableResource
+  get() = Drawable18.icon_18398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18399: DrawableResource
+  get() = Drawable18.icon_18399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_184: DrawableResource
+  get() = Drawable18.icon_184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1840: DrawableResource
+  get() = Drawable18.icon_1840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18400: DrawableResource
+  get() = Drawable18.icon_18400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18401: DrawableResource
+  get() = Drawable18.icon_18401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18402: DrawableResource
+  get() = Drawable18.icon_18402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18403: DrawableResource
+  get() = Drawable18.icon_18403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18404: DrawableResource
+  get() = Drawable18.icon_18404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18405: DrawableResource
+  get() = Drawable18.icon_18405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18406: DrawableResource
+  get() = Drawable18.icon_18406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18407: DrawableResource
+  get() = Drawable18.icon_18407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18408: DrawableResource
+  get() = Drawable18.icon_18408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18409: DrawableResource
+  get() = Drawable18.icon_18409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1841: DrawableResource
+  get() = Drawable18.icon_1841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18410: DrawableResource
+  get() = Drawable18.icon_18410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18411: DrawableResource
+  get() = Drawable18.icon_18411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18412: DrawableResource
+  get() = Drawable18.icon_18412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18413: DrawableResource
+  get() = Drawable18.icon_18413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18414: DrawableResource
+  get() = Drawable18.icon_18414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18415: DrawableResource
+  get() = Drawable18.icon_18415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18416: DrawableResource
+  get() = Drawable18.icon_18416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18417: DrawableResource
+  get() = Drawable18.icon_18417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18418: DrawableResource
+  get() = Drawable18.icon_18418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18419: DrawableResource
+  get() = Drawable18.icon_18419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1842: DrawableResource
+  get() = Drawable18.icon_1842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18420: DrawableResource
+  get() = Drawable18.icon_18420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18421: DrawableResource
+  get() = Drawable18.icon_18421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18422: DrawableResource
+  get() = Drawable18.icon_18422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18423: DrawableResource
+  get() = Drawable18.icon_18423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18424: DrawableResource
+  get() = Drawable18.icon_18424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18425: DrawableResource
+  get() = Drawable18.icon_18425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18426: DrawableResource
+  get() = Drawable18.icon_18426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18427: DrawableResource
+  get() = Drawable18.icon_18427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18428: DrawableResource
+  get() = Drawable18.icon_18428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18429: DrawableResource
+  get() = Drawable18.icon_18429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1843: DrawableResource
+  get() = Drawable18.icon_1843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18430: DrawableResource
+  get() = Drawable18.icon_18430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18431: DrawableResource
+  get() = Drawable18.icon_18431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18432: DrawableResource
+  get() = Drawable18.icon_18432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18433: DrawableResource
+  get() = Drawable18.icon_18433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18434: DrawableResource
+  get() = Drawable18.icon_18434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18435: DrawableResource
+  get() = Drawable18.icon_18435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18436: DrawableResource
+  get() = Drawable18.icon_18436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18437: DrawableResource
+  get() = Drawable18.icon_18437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18438: DrawableResource
+  get() = Drawable18.icon_18438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18439: DrawableResource
+  get() = Drawable18.icon_18439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1844: DrawableResource
+  get() = Drawable18.icon_1844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18440: DrawableResource
+  get() = Drawable18.icon_18440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18441: DrawableResource
+  get() = Drawable18.icon_18441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18442: DrawableResource
+  get() = Drawable18.icon_18442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18443: DrawableResource
+  get() = Drawable18.icon_18443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18444: DrawableResource
+  get() = Drawable18.icon_18444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18445: DrawableResource
+  get() = Drawable18.icon_18445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18446: DrawableResource
+  get() = Drawable18.icon_18446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18447: DrawableResource
+  get() = Drawable18.icon_18447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18448: DrawableResource
+  get() = Drawable18.icon_18448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18449: DrawableResource
+  get() = Drawable18.icon_18449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1845: DrawableResource
+  get() = Drawable18.icon_1845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18450: DrawableResource
+  get() = Drawable18.icon_18450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18451: DrawableResource
+  get() = Drawable18.icon_18451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18452: DrawableResource
+  get() = Drawable18.icon_18452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18453: DrawableResource
+  get() = Drawable18.icon_18453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18454: DrawableResource
+  get() = Drawable18.icon_18454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18455: DrawableResource
+  get() = Drawable18.icon_18455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18456: DrawableResource
+  get() = Drawable18.icon_18456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18457: DrawableResource
+  get() = Drawable18.icon_18457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18458: DrawableResource
+  get() = Drawable18.icon_18458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18459: DrawableResource
+  get() = Drawable18.icon_18459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1846: DrawableResource
+  get() = Drawable18.icon_1846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18460: DrawableResource
+  get() = Drawable18.icon_18460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18461: DrawableResource
+  get() = Drawable18.icon_18461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18462: DrawableResource
+  get() = Drawable18.icon_18462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18463: DrawableResource
+  get() = Drawable18.icon_18463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18464: DrawableResource
+  get() = Drawable18.icon_18464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18465: DrawableResource
+  get() = Drawable18.icon_18465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18466: DrawableResource
+  get() = Drawable18.icon_18466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18467: DrawableResource
+  get() = Drawable18.icon_18467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18468: DrawableResource
+  get() = Drawable18.icon_18468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18469: DrawableResource
+  get() = Drawable18.icon_18469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1847: DrawableResource
+  get() = Drawable18.icon_1847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18470: DrawableResource
+  get() = Drawable18.icon_18470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18471: DrawableResource
+  get() = Drawable18.icon_18471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18472: DrawableResource
+  get() = Drawable18.icon_18472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18473: DrawableResource
+  get() = Drawable18.icon_18473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18474: DrawableResource
+  get() = Drawable18.icon_18474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18475: DrawableResource
+  get() = Drawable18.icon_18475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18476: DrawableResource
+  get() = Drawable18.icon_18476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18477: DrawableResource
+  get() = Drawable18.icon_18477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18478: DrawableResource
+  get() = Drawable18.icon_18478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18479: DrawableResource
+  get() = Drawable18.icon_18479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1848: DrawableResource
+  get() = Drawable18.icon_1848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18480: DrawableResource
+  get() = Drawable18.icon_18480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18481: DrawableResource
+  get() = Drawable18.icon_18481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18482: DrawableResource
+  get() = Drawable18.icon_18482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18483: DrawableResource
+  get() = Drawable18.icon_18483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18484: DrawableResource
+  get() = Drawable18.icon_18484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18485: DrawableResource
+  get() = Drawable18.icon_18485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18486: DrawableResource
+  get() = Drawable18.icon_18486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18487: DrawableResource
+  get() = Drawable18.icon_18487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18488: DrawableResource
+  get() = Drawable18.icon_18488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18489: DrawableResource
+  get() = Drawable18.icon_18489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1849: DrawableResource
+  get() = Drawable18.icon_1849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18490: DrawableResource
+  get() = Drawable18.icon_18490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18491: DrawableResource
+  get() = Drawable18.icon_18491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18492: DrawableResource
+  get() = Drawable18.icon_18492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18493: DrawableResource
+  get() = Drawable18.icon_18493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18494: DrawableResource
+  get() = Drawable18.icon_18494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18495: DrawableResource
+  get() = Drawable18.icon_18495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18496: DrawableResource
+  get() = Drawable18.icon_18496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18497: DrawableResource
+  get() = Drawable18.icon_18497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18498: DrawableResource
+  get() = Drawable18.icon_18498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18499: DrawableResource
+  get() = Drawable18.icon_18499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_185: DrawableResource
+  get() = Drawable18.icon_185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1850: DrawableResource
+  get() = Drawable18.icon_1850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18500: DrawableResource
+  get() = Drawable18.icon_18500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18501: DrawableResource
+  get() = Drawable18.icon_18501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18502: DrawableResource
+  get() = Drawable18.icon_18502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18503: DrawableResource
+  get() = Drawable18.icon_18503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18504: DrawableResource
+  get() = Drawable18.icon_18504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18505: DrawableResource
+  get() = Drawable18.icon_18505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18506: DrawableResource
+  get() = Drawable18.icon_18506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18507: DrawableResource
+  get() = Drawable18.icon_18507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18508: DrawableResource
+  get() = Drawable18.icon_18508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18509: DrawableResource
+  get() = Drawable18.icon_18509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1851: DrawableResource
+  get() = Drawable18.icon_1851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18510: DrawableResource
+  get() = Drawable18.icon_18510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18511: DrawableResource
+  get() = Drawable18.icon_18511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18512: DrawableResource
+  get() = Drawable18.icon_18512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18513: DrawableResource
+  get() = Drawable18.icon_18513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18514: DrawableResource
+  get() = Drawable18.icon_18514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18515: DrawableResource
+  get() = Drawable18.icon_18515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18516: DrawableResource
+  get() = Drawable18.icon_18516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18517: DrawableResource
+  get() = Drawable18.icon_18517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18518: DrawableResource
+  get() = Drawable18.icon_18518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18519: DrawableResource
+  get() = Drawable18.icon_18519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1852: DrawableResource
+  get() = Drawable18.icon_1852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18520: DrawableResource
+  get() = Drawable18.icon_18520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18521: DrawableResource
+  get() = Drawable18.icon_18521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18522: DrawableResource
+  get() = Drawable18.icon_18522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18523: DrawableResource
+  get() = Drawable18.icon_18523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18524: DrawableResource
+  get() = Drawable18.icon_18524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18525: DrawableResource
+  get() = Drawable18.icon_18525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18526: DrawableResource
+  get() = Drawable18.icon_18526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18527: DrawableResource
+  get() = Drawable18.icon_18527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18528: DrawableResource
+  get() = Drawable18.icon_18528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18529: DrawableResource
+  get() = Drawable18.icon_18529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1853: DrawableResource
+  get() = Drawable18.icon_1853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18530: DrawableResource
+  get() = Drawable18.icon_18530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18531: DrawableResource
+  get() = Drawable18.icon_18531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18532: DrawableResource
+  get() = Drawable18.icon_18532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18533: DrawableResource
+  get() = Drawable18.icon_18533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18534: DrawableResource
+  get() = Drawable18.icon_18534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18535: DrawableResource
+  get() = Drawable18.icon_18535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18536: DrawableResource
+  get() = Drawable18.icon_18536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18537: DrawableResource
+  get() = Drawable18.icon_18537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18538: DrawableResource
+  get() = Drawable18.icon_18538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18539: DrawableResource
+  get() = Drawable18.icon_18539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1854: DrawableResource
+  get() = Drawable18.icon_1854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18540: DrawableResource
+  get() = Drawable18.icon_18540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18541: DrawableResource
+  get() = Drawable18.icon_18541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18542: DrawableResource
+  get() = Drawable18.icon_18542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18543: DrawableResource
+  get() = Drawable18.icon_18543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18544: DrawableResource
+  get() = Drawable18.icon_18544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18545: DrawableResource
+  get() = Drawable18.icon_18545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18546: DrawableResource
+  get() = Drawable18.icon_18546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18547: DrawableResource
+  get() = Drawable18.icon_18547

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable19.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable19.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable19 {
+  public val icon_18548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18548.xml"),
+          )
+      )
+
+  public val icon_18549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18549.xml"),
+          )
+      )
+
+  public val icon_1855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1855.xml"),
+          )
+      )
+
+  public val icon_18550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18550.xml"),
+          )
+      )
+
+  public val icon_18551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18551.xml"),
+          )
+      )
+
+  public val icon_18552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18552.xml"),
+          )
+      )
+
+  public val icon_18553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18553.xml"),
+          )
+      )
+
+  public val icon_18554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18554.xml"),
+          )
+      )
+
+  public val icon_18555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18555.xml"),
+          )
+      )
+
+  public val icon_18556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18556.xml"),
+          )
+      )
+
+  public val icon_18557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18557.xml"),
+          )
+      )
+
+  public val icon_18558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18558.xml"),
+          )
+      )
+
+  public val icon_18559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18559.xml"),
+          )
+      )
+
+  public val icon_1856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1856.xml"),
+          )
+      )
+
+  public val icon_18560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18560.xml"),
+          )
+      )
+
+  public val icon_18561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18561.xml"),
+          )
+      )
+
+  public val icon_18562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18562.xml"),
+          )
+      )
+
+  public val icon_18563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18563.xml"),
+          )
+      )
+
+  public val icon_18564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18564.xml"),
+          )
+      )
+
+  public val icon_18565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18565.xml"),
+          )
+      )
+
+  public val icon_18566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18566.xml"),
+          )
+      )
+
+  public val icon_18567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18567.xml"),
+          )
+      )
+
+  public val icon_18568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18568.xml"),
+          )
+      )
+
+  public val icon_18569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18569.xml"),
+          )
+      )
+
+  public val icon_1857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1857.xml"),
+          )
+      )
+
+  public val icon_18570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18570.xml"),
+          )
+      )
+
+  public val icon_18571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18571.xml"),
+          )
+      )
+
+  public val icon_18572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18572.xml"),
+          )
+      )
+
+  public val icon_18573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18573.xml"),
+          )
+      )
+
+  public val icon_18574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18574.xml"),
+          )
+      )
+
+  public val icon_18575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18575.xml"),
+          )
+      )
+
+  public val icon_18576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18576.xml"),
+          )
+      )
+
+  public val icon_18577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18577.xml"),
+          )
+      )
+
+  public val icon_18578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18578.xml"),
+          )
+      )
+
+  public val icon_18579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18579.xml"),
+          )
+      )
+
+  public val icon_1858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1858.xml"),
+          )
+      )
+
+  public val icon_18580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18580.xml"),
+          )
+      )
+
+  public val icon_18581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18581.xml"),
+          )
+      )
+
+  public val icon_18582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18582.xml"),
+          )
+      )
+
+  public val icon_18583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18583.xml"),
+          )
+      )
+
+  public val icon_18584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18584.xml"),
+          )
+      )
+
+  public val icon_18585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18585.xml"),
+          )
+      )
+
+  public val icon_18586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18586.xml"),
+          )
+      )
+
+  public val icon_18587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18587.xml"),
+          )
+      )
+
+  public val icon_18588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18588.xml"),
+          )
+      )
+
+  public val icon_18589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18589.xml"),
+          )
+      )
+
+  public val icon_1859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1859.xml"),
+          )
+      )
+
+  public val icon_18590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18590.xml"),
+          )
+      )
+
+  public val icon_18591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18591.xml"),
+          )
+      )
+
+  public val icon_18592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18592.xml"),
+          )
+      )
+
+  public val icon_18593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18593.xml"),
+          )
+      )
+
+  public val icon_18594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18594.xml"),
+          )
+      )
+
+  public val icon_18595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18595.xml"),
+          )
+      )
+
+  public val icon_18596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18596.xml"),
+          )
+      )
+
+  public val icon_18597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18597.xml"),
+          )
+      )
+
+  public val icon_18598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18598.xml"),
+          )
+      )
+
+  public val icon_18599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18599.xml"),
+          )
+      )
+
+  public val icon_186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_186.xml"),
+          )
+      )
+
+  public val icon_1860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1860.xml"),
+          )
+      )
+
+  public val icon_18600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18600.xml"),
+          )
+      )
+
+  public val icon_18601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18601.xml"),
+          )
+      )
+
+  public val icon_18602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18602.xml"),
+          )
+      )
+
+  public val icon_18603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18603.xml"),
+          )
+      )
+
+  public val icon_18604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18604.xml"),
+          )
+      )
+
+  public val icon_18605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18605.xml"),
+          )
+      )
+
+  public val icon_18606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18606.xml"),
+          )
+      )
+
+  public val icon_18607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18607.xml"),
+          )
+      )
+
+  public val icon_18608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18608.xml"),
+          )
+      )
+
+  public val icon_18609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18609.xml"),
+          )
+      )
+
+  public val icon_1861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1861.xml"),
+          )
+      )
+
+  public val icon_18610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18610.xml"),
+          )
+      )
+
+  public val icon_18611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18611.xml"),
+          )
+      )
+
+  public val icon_18612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18612.xml"),
+          )
+      )
+
+  public val icon_18613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18613.xml"),
+          )
+      )
+
+  public val icon_18614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18614.xml"),
+          )
+      )
+
+  public val icon_18615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18615.xml"),
+          )
+      )
+
+  public val icon_18616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18616.xml"),
+          )
+      )
+
+  public val icon_18617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18617.xml"),
+          )
+      )
+
+  public val icon_18618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18618.xml"),
+          )
+      )
+
+  public val icon_18619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18619.xml"),
+          )
+      )
+
+  public val icon_1862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1862.xml"),
+          )
+      )
+
+  public val icon_18620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18620.xml"),
+          )
+      )
+
+  public val icon_18621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18621.xml"),
+          )
+      )
+
+  public val icon_18622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18622.xml"),
+          )
+      )
+
+  public val icon_18623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18623.xml"),
+          )
+      )
+
+  public val icon_18624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18624.xml"),
+          )
+      )
+
+  public val icon_18625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18625.xml"),
+          )
+      )
+
+  public val icon_18626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18626.xml"),
+          )
+      )
+
+  public val icon_18627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18627.xml"),
+          )
+      )
+
+  public val icon_18628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18628.xml"),
+          )
+      )
+
+  public val icon_18629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18629.xml"),
+          )
+      )
+
+  public val icon_1863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1863.xml"),
+          )
+      )
+
+  public val icon_18630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18630.xml"),
+          )
+      )
+
+  public val icon_18631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18631.xml"),
+          )
+      )
+
+  public val icon_18632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18632.xml"),
+          )
+      )
+
+  public val icon_18633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18633.xml"),
+          )
+      )
+
+  public val icon_18634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18634.xml"),
+          )
+      )
+
+  public val icon_18635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18635.xml"),
+          )
+      )
+
+  public val icon_18636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18636.xml"),
+          )
+      )
+
+  public val icon_18637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18637.xml"),
+          )
+      )
+
+  public val icon_18638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18638.xml"),
+          )
+      )
+
+  public val icon_18639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18639.xml"),
+          )
+      )
+
+  public val icon_1864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1864.xml"),
+          )
+      )
+
+  public val icon_18640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18640.xml"),
+          )
+      )
+
+  public val icon_18641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18641.xml"),
+          )
+      )
+
+  public val icon_18642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18642.xml"),
+          )
+      )
+
+  public val icon_18643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18643.xml"),
+          )
+      )
+
+  public val icon_18644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18644.xml"),
+          )
+      )
+
+  public val icon_18645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18645.xml"),
+          )
+      )
+
+  public val icon_18646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18646.xml"),
+          )
+      )
+
+  public val icon_18647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18647.xml"),
+          )
+      )
+
+  public val icon_18648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18648.xml"),
+          )
+      )
+
+  public val icon_18649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18649.xml"),
+          )
+      )
+
+  public val icon_1865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1865.xml"),
+          )
+      )
+
+  public val icon_18650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18650.xml"),
+          )
+      )
+
+  public val icon_18651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18651.xml"),
+          )
+      )
+
+  public val icon_18652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18652.xml"),
+          )
+      )
+
+  public val icon_18653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18653.xml"),
+          )
+      )
+
+  public val icon_18654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18654.xml"),
+          )
+      )
+
+  public val icon_18655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18655.xml"),
+          )
+      )
+
+  public val icon_18656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18656.xml"),
+          )
+      )
+
+  public val icon_18657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18657.xml"),
+          )
+      )
+
+  public val icon_18658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18658.xml"),
+          )
+      )
+
+  public val icon_18659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18659.xml"),
+          )
+      )
+
+  public val icon_1866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1866.xml"),
+          )
+      )
+
+  public val icon_18660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18660.xml"),
+          )
+      )
+
+  public val icon_18661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18661.xml"),
+          )
+      )
+
+  public val icon_18662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18662.xml"),
+          )
+      )
+
+  public val icon_18663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18663.xml"),
+          )
+      )
+
+  public val icon_18664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18664.xml"),
+          )
+      )
+
+  public val icon_18665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18665.xml"),
+          )
+      )
+
+  public val icon_18666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18666.xml"),
+          )
+      )
+
+  public val icon_18667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18667.xml"),
+          )
+      )
+
+  public val icon_18668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18668.xml"),
+          )
+      )
+
+  public val icon_18669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18669.xml"),
+          )
+      )
+
+  public val icon_1867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1867.xml"),
+          )
+      )
+
+  public val icon_18670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18670.xml"),
+          )
+      )
+
+  public val icon_18671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18671.xml"),
+          )
+      )
+
+  public val icon_18672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18672.xml"),
+          )
+      )
+
+  public val icon_18673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18673.xml"),
+          )
+      )
+
+  public val icon_18674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18674.xml"),
+          )
+      )
+
+  public val icon_18675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18675.xml"),
+          )
+      )
+
+  public val icon_18676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18676.xml"),
+          )
+      )
+
+  public val icon_18677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18677.xml"),
+          )
+      )
+
+  public val icon_18678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18678.xml"),
+          )
+      )
+
+  public val icon_18679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18679.xml"),
+          )
+      )
+
+  public val icon_1868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1868.xml"),
+          )
+      )
+
+  public val icon_18680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18680.xml"),
+          )
+      )
+
+  public val icon_18681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18681.xml"),
+          )
+      )
+
+  public val icon_18682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18682.xml"),
+          )
+      )
+
+  public val icon_18683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18683.xml"),
+          )
+      )
+
+  public val icon_18684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18684.xml"),
+          )
+      )
+
+  public val icon_18685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18685.xml"),
+          )
+      )
+
+  public val icon_18686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18686.xml"),
+          )
+      )
+
+  public val icon_18687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18687.xml"),
+          )
+      )
+
+  public val icon_18688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18688.xml"),
+          )
+      )
+
+  public val icon_18689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18689.xml"),
+          )
+      )
+
+  public val icon_1869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1869.xml"),
+          )
+      )
+
+  public val icon_18690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18690.xml"),
+          )
+      )
+
+  public val icon_18691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18691.xml"),
+          )
+      )
+
+  public val icon_18692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18692.xml"),
+          )
+      )
+
+  public val icon_18693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18693.xml"),
+          )
+      )
+
+  public val icon_18694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18694.xml"),
+          )
+      )
+
+  public val icon_18695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18695.xml"),
+          )
+      )
+
+  public val icon_18696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18696.xml"),
+          )
+      )
+
+  public val icon_18697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18697.xml"),
+          )
+      )
+
+  public val icon_18698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18698.xml"),
+          )
+      )
+
+  public val icon_18699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18699.xml"),
+          )
+      )
+
+  public val icon_187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_187.xml"),
+          )
+      )
+
+  public val icon_1870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1870.xml"),
+          )
+      )
+
+  public val icon_18700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18700.xml"),
+          )
+      )
+
+  public val icon_18701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18701.xml"),
+          )
+      )
+
+  public val icon_18702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18702.xml"),
+          )
+      )
+
+  public val icon_18703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18703.xml"),
+          )
+      )
+
+  public val icon_18704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18704.xml"),
+          )
+      )
+
+  public val icon_18705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18705.xml"),
+          )
+      )
+
+  public val icon_18706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18706.xml"),
+          )
+      )
+
+  public val icon_18707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18707.xml"),
+          )
+      )
+
+  public val icon_18708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18708.xml"),
+          )
+      )
+
+  public val icon_18709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18709.xml"),
+          )
+      )
+
+  public val icon_1871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1871.xml"),
+          )
+      )
+
+  public val icon_18710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18710.xml"),
+          )
+      )
+
+  public val icon_18711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18711.xml"),
+          )
+      )
+
+  public val icon_18712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18712.xml"),
+          )
+      )
+
+  public val icon_18713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18713.xml"),
+          )
+      )
+
+  public val icon_18714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18714.xml"),
+          )
+      )
+
+  public val icon_18715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18715.xml"),
+          )
+      )
+
+  public val icon_18716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18716.xml"),
+          )
+      )
+
+  public val icon_18717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18717.xml"),
+          )
+      )
+
+  public val icon_18718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18718.xml"),
+          )
+      )
+
+  public val icon_18719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18719.xml"),
+          )
+      )
+
+  public val icon_1872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1872.xml"),
+          )
+      )
+
+  public val icon_18720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18720.xml"),
+          )
+      )
+
+  public val icon_18721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18721.xml"),
+          )
+      )
+
+  public val icon_18722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18722.xml"),
+          )
+      )
+
+  public val icon_18723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18723.xml"),
+          )
+      )
+
+  public val icon_18724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18724.xml"),
+          )
+      )
+
+  public val icon_18725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18725.xml"),
+          )
+      )
+
+  public val icon_18726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18726.xml"),
+          )
+      )
+
+  public val icon_18727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18727.xml"),
+          )
+      )
+
+  public val icon_18728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18728.xml"),
+          )
+      )
+
+  public val icon_18729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18729.xml"),
+          )
+      )
+
+  public val icon_1873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1873.xml"),
+          )
+      )
+
+  public val icon_18730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18730.xml"),
+          )
+      )
+
+  public val icon_18731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18731.xml"),
+          )
+      )
+
+  public val icon_18732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18732.xml"),
+          )
+      )
+
+  public val icon_18733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18733.xml"),
+          )
+      )
+
+  public val icon_18734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18734.xml"),
+          )
+      )
+
+  public val icon_18735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18735.xml"),
+          )
+      )
+
+  public val icon_18736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18736.xml"),
+          )
+      )
+
+  public val icon_18737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18737.xml"),
+          )
+      )
+
+  public val icon_18738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18738.xml"),
+          )
+      )
+
+  public val icon_18739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18739.xml"),
+          )
+      )
+
+  public val icon_1874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1874.xml"),
+          )
+      )
+
+  public val icon_18740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18740.xml"),
+          )
+      )
+
+  public val icon_18741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18741.xml"),
+          )
+      )
+
+  public val icon_18742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18742.xml"),
+          )
+      )
+
+  public val icon_18743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18743.xml"),
+          )
+      )
+
+  public val icon_18744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18744.xml"),
+          )
+      )
+
+  public val icon_18745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18745.xml"),
+          )
+      )
+
+  public val icon_18746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18746.xml"),
+          )
+      )
+
+  public val icon_18747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18747.xml"),
+          )
+      )
+
+  public val icon_18748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18748.xml"),
+          )
+      )
+
+  public val icon_18749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18749.xml"),
+          )
+      )
+
+  public val icon_1875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1875.xml"),
+          )
+      )
+
+  public val icon_18750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18750.xml"),
+          )
+      )
+
+  public val icon_18751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18751.xml"),
+          )
+      )
+
+  public val icon_18752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18752.xml"),
+          )
+      )
+
+  public val icon_18753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18753.xml"),
+          )
+      )
+
+  public val icon_18754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18754.xml"),
+          )
+      )
+
+  public val icon_18755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18755.xml"),
+          )
+      )
+
+  public val icon_18756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18756.xml"),
+          )
+      )
+
+  public val icon_18757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18757.xml"),
+          )
+      )
+
+  public val icon_18758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18758.xml"),
+          )
+      )
+
+  public val icon_18759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18759.xml"),
+          )
+      )
+
+  public val icon_1876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1876.xml"),
+          )
+      )
+
+  public val icon_18760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18760.xml"),
+          )
+      )
+
+  public val icon_18761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18761.xml"),
+          )
+      )
+
+  public val icon_18762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18762.xml"),
+          )
+      )
+
+  public val icon_18763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18763.xml"),
+          )
+      )
+
+  public val icon_18764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18764.xml"),
+          )
+      )
+
+  public val icon_18765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18765.xml"),
+          )
+      )
+
+  public val icon_18766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18766.xml"),
+          )
+      )
+
+  public val icon_18767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18767.xml"),
+          )
+      )
+
+  public val icon_18768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18768.xml"),
+          )
+      )
+
+  public val icon_18769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18769.xml"),
+          )
+      )
+
+  public val icon_1877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1877.xml"),
+          )
+      )
+
+  public val icon_18770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18770.xml"),
+          )
+      )
+
+  public val icon_18771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18771.xml"),
+          )
+      )
+
+  public val icon_18772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18772.xml"),
+          )
+      )
+
+  public val icon_18773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18773.xml"),
+          )
+      )
+
+  public val icon_18774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18774.xml"),
+          )
+      )
+
+  public val icon_18775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18775.xml"),
+          )
+      )
+
+  public val icon_18776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18776.xml"),
+          )
+      )
+
+  public val icon_18777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18777.xml"),
+          )
+      )
+
+  public val icon_18778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18778.xml"),
+          )
+      )
+
+  public val icon_18779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18779.xml"),
+          )
+      )
+
+  public val icon_1878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1878.xml"),
+          )
+      )
+
+  public val icon_18780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18780.xml"),
+          )
+      )
+
+  public val icon_18781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18781.xml"),
+          )
+      )
+
+  public val icon_18782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18782.xml"),
+          )
+      )
+
+  public val icon_18783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18783.xml"),
+          )
+      )
+
+  public val icon_18784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18784.xml"),
+          )
+      )
+
+  public val icon_18785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18785.xml"),
+          )
+      )
+
+  public val icon_18786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18786.xml"),
+          )
+      )
+
+  public val icon_18787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18787.xml"),
+          )
+      )
+
+  public val icon_18788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18788.xml"),
+          )
+      )
+
+  public val icon_18789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18789.xml"),
+          )
+      )
+
+  public val icon_1879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1879.xml"),
+          )
+      )
+
+  public val icon_18790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18790.xml"),
+          )
+      )
+
+  public val icon_18791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18791.xml"),
+          )
+      )
+
+  public val icon_18792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18792.xml"),
+          )
+      )
+
+  public val icon_18793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18793.xml"),
+          )
+      )
+
+  public val icon_18794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18794.xml"),
+          )
+      )
+
+  public val icon_18795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18795.xml"),
+          )
+      )
+
+  public val icon_18796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18796.xml"),
+          )
+      )
+
+  public val icon_18797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18797.xml"),
+          )
+      )
+
+  public val icon_18798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18798.xml"),
+          )
+      )
+
+  public val icon_18799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18799.xml"),
+          )
+      )
+
+  public val icon_188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_188.xml"),
+          )
+      )
+
+  public val icon_1880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1880.xml"),
+          )
+      )
+
+  public val icon_18800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18800.xml"),
+          )
+      )
+
+  public val icon_18801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18801.xml"),
+          )
+      )
+
+  public val icon_18802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18802.xml"),
+          )
+      )
+
+  public val icon_18803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18803.xml"),
+          )
+      )
+
+  public val icon_18804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18804.xml"),
+          )
+      )
+
+  public val icon_18805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18805.xml"),
+          )
+      )
+
+  public val icon_18806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18806.xml"),
+          )
+      )
+
+  public val icon_18807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18807.xml"),
+          )
+      )
+
+  public val icon_18808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18808.xml"),
+          )
+      )
+
+  public val icon_18809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18809.xml"),
+          )
+      )
+
+  public val icon_1881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1881.xml"),
+          )
+      )
+
+  public val icon_18810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18810.xml"),
+          )
+      )
+
+  public val icon_18811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18811.xml"),
+          )
+      )
+
+  public val icon_18812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18812.xml"),
+          )
+      )
+
+  public val icon_18813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18813.xml"),
+          )
+      )
+
+  public val icon_18814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18814.xml"),
+          )
+      )
+
+  public val icon_18815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18815.xml"),
+          )
+      )
+
+  public val icon_18816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18816.xml"),
+          )
+      )
+
+  public val icon_18817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18817.xml"),
+          )
+      )
+
+  public val icon_18818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18818.xml"),
+          )
+      )
+
+  public val icon_18819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18819.xml"),
+          )
+      )
+
+  public val icon_1882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1882.xml"),
+          )
+      )
+
+  public val icon_18820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18820.xml"),
+          )
+      )
+
+  public val icon_18821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18821.xml"),
+          )
+      )
+
+  public val icon_18822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18822.xml"),
+          )
+      )
+
+  public val icon_18823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18823.xml"),
+          )
+      )
+
+  public val icon_18824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18824.xml"),
+          )
+      )
+
+  public val icon_18825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18825.xml"),
+          )
+      )
+
+  public val icon_18826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18826.xml"),
+          )
+      )
+
+  public val icon_18827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18827.xml"),
+          )
+      )
+
+  public val icon_18828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18828.xml"),
+          )
+      )
+
+  public val icon_18829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18829.xml"),
+          )
+      )
+
+  public val icon_1883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1883.xml"),
+          )
+      )
+
+  public val icon_18830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18830.xml"),
+          )
+      )
+
+  public val icon_18831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18831.xml"),
+          )
+      )
+
+  public val icon_18832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18832.xml"),
+          )
+      )
+
+  public val icon_18833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18833.xml"),
+          )
+      )
+
+  public val icon_18834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18834.xml"),
+          )
+      )
+
+  public val icon_18835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18835.xml"),
+          )
+      )
+
+  public val icon_18836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18836.xml"),
+          )
+      )
+
+  public val icon_18837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18837.xml"),
+          )
+      )
+
+  public val icon_18838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18838.xml"),
+          )
+      )
+
+  public val icon_18839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18839.xml"),
+          )
+      )
+
+  public val icon_1884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1884.xml"),
+          )
+      )
+
+  public val icon_18840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18840.xml"),
+          )
+      )
+
+  public val icon_18841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18841.xml"),
+          )
+      )
+
+  public val icon_18842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18842.xml"),
+          )
+      )
+
+  public val icon_18843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18843.xml"),
+          )
+      )
+
+  public val icon_18844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18844.xml"),
+          )
+      )
+
+  public val icon_18845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18845.xml"),
+          )
+      )
+
+  public val icon_18846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18846.xml"),
+          )
+      )
+
+  public val icon_18847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18847.xml"),
+          )
+      )
+
+  public val icon_18848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18848.xml"),
+          )
+      )
+
+  public val icon_18849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18849.xml"),
+          )
+      )
+
+  public val icon_1885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1885.xml"),
+          )
+      )
+
+  public val icon_18850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18850.xml"),
+          )
+      )
+
+  public val icon_18851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18851.xml"),
+          )
+      )
+
+  public val icon_18852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18852.xml"),
+          )
+      )
+
+  public val icon_18853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18853.xml"),
+          )
+      )
+
+  public val icon_18854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18854.xml"),
+          )
+      )
+
+  public val icon_18855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18855.xml"),
+          )
+      )
+
+  public val icon_18856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18856.xml"),
+          )
+      )
+
+  public val icon_18857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18857.xml"),
+          )
+      )
+
+  public val icon_18858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18858.xml"),
+          )
+      )
+
+  public val icon_18859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18859.xml"),
+          )
+      )
+
+  public val icon_1886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1886.xml"),
+          )
+      )
+
+  public val icon_18860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18860.xml"),
+          )
+      )
+
+  public val icon_18861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18861.xml"),
+          )
+      )
+
+  public val icon_18862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18862.xml"),
+          )
+      )
+
+  public val icon_18863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18863.xml"),
+          )
+      )
+
+  public val icon_18864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18864.xml"),
+          )
+      )
+
+  public val icon_18865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18865.xml"),
+          )
+      )
+
+  public val icon_18866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18866.xml"),
+          )
+      )
+
+  public val icon_18867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18867.xml"),
+          )
+      )
+
+  public val icon_18868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18868.xml"),
+          )
+      )
+
+  public val icon_18869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18869.xml"),
+          )
+      )
+
+  public val icon_1887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1887.xml"),
+          )
+      )
+
+  public val icon_18870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18870.xml"),
+          )
+      )
+
+  public val icon_18871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18871.xml"),
+          )
+      )
+
+  public val icon_18872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18872.xml"),
+          )
+      )
+
+  public val icon_18873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18873.xml"),
+          )
+      )
+
+  public val icon_18874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18874.xml"),
+          )
+      )
+
+  public val icon_18875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18875.xml"),
+          )
+      )
+
+  public val icon_18876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18876.xml"),
+          )
+      )
+
+  public val icon_18877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18877.xml"),
+          )
+      )
+
+  public val icon_18878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18878.xml"),
+          )
+      )
+
+  public val icon_18879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18879.xml"),
+          )
+      )
+
+  public val icon_1888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1888.xml"),
+          )
+      )
+
+  public val icon_18880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18880.xml"),
+          )
+      )
+
+  public val icon_18881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18881.xml"),
+          )
+      )
+
+  public val icon_18882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18882.xml"),
+          )
+      )
+
+  public val icon_18883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18883.xml"),
+          )
+      )
+
+  public val icon_18884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18884.xml"),
+          )
+      )
+
+  public val icon_18885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18885.xml"),
+          )
+      )
+
+  public val icon_18886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18886.xml"),
+          )
+      )
+
+  public val icon_18887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18887.xml"),
+          )
+      )
+
+  public val icon_18888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18888.xml"),
+          )
+      )
+
+  public val icon_18889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18889.xml"),
+          )
+      )
+
+  public val icon_1889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1889.xml"),
+          )
+      )
+
+  public val icon_18890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18890.xml"),
+          )
+      )
+
+  public val icon_18891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18891.xml"),
+          )
+      )
+
+  public val icon_18892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18892.xml"),
+          )
+      )
+
+  public val icon_18893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18893.xml"),
+          )
+      )
+
+  public val icon_18894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18894.xml"),
+          )
+      )
+
+  public val icon_18895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18895.xml"),
+          )
+      )
+
+  public val icon_18896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18896.xml"),
+          )
+      )
+
+  public val icon_18897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18897.xml"),
+          )
+      )
+
+  public val icon_18898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18898.xml"),
+          )
+      )
+
+  public val icon_18899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18899.xml"),
+          )
+      )
+
+  public val icon_189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_189.xml"),
+          )
+      )
+
+  public val icon_1890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1890.xml"),
+          )
+      )
+
+  public val icon_18900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18900.xml"),
+          )
+      )
+
+  public val icon_18901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18901.xml"),
+          )
+      )
+
+  public val icon_18902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18902.xml"),
+          )
+      )
+
+  public val icon_18903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18903.xml"),
+          )
+      )
+
+  public val icon_18904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18904.xml"),
+          )
+      )
+
+  public val icon_18905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18905.xml"),
+          )
+      )
+
+  public val icon_18906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18906.xml"),
+          )
+      )
+
+  public val icon_18907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18907.xml"),
+          )
+      )
+
+  public val icon_18908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18908.xml"),
+          )
+      )
+
+  public val icon_18909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18909.xml"),
+          )
+      )
+
+  public val icon_1891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1891.xml"),
+          )
+      )
+
+  public val icon_18910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18910.xml"),
+          )
+      )
+
+  public val icon_18911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18911.xml"),
+          )
+      )
+
+  public val icon_18912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18912.xml"),
+          )
+      )
+
+  public val icon_18913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18913.xml"),
+          )
+      )
+
+  public val icon_18914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18914.xml"),
+          )
+      )
+
+  public val icon_18915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18915.xml"),
+          )
+      )
+
+  public val icon_18916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18916.xml"),
+          )
+      )
+
+  public val icon_18917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18917.xml"),
+          )
+      )
+
+  public val icon_18918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18918.xml"),
+          )
+      )
+
+  public val icon_18919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18919.xml"),
+          )
+      )
+
+  public val icon_1892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1892.xml"),
+          )
+      )
+
+  public val icon_18920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18920.xml"),
+          )
+      )
+
+  public val icon_18921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18921.xml"),
+          )
+      )
+
+  public val icon_18922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18922.xml"),
+          )
+      )
+
+  public val icon_18923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18923.xml"),
+          )
+      )
+
+  public val icon_18924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18924.xml"),
+          )
+      )
+
+  public val icon_18925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18925.xml"),
+          )
+      )
+
+  public val icon_18926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18926.xml"),
+          )
+      )
+
+  public val icon_18927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18927.xml"),
+          )
+      )
+
+  public val icon_18928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18928.xml"),
+          )
+      )
+
+  public val icon_18929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18929.xml"),
+          )
+      )
+
+  public val icon_1893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1893.xml"),
+          )
+      )
+
+  public val icon_18930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18930.xml"),
+          )
+      )
+
+  public val icon_18931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18931.xml"),
+          )
+      )
+
+  public val icon_18932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18932.xml"),
+          )
+      )
+
+  public val icon_18933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18933.xml"),
+          )
+      )
+
+  public val icon_18934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18934.xml"),
+          )
+      )
+
+  public val icon_18935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18935.xml"),
+          )
+      )
+
+  public val icon_18936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18936.xml"),
+          )
+      )
+
+  public val icon_18937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18937.xml"),
+          )
+      )
+
+  public val icon_18938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18938.xml"),
+          )
+      )
+
+  public val icon_18939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18939.xml"),
+          )
+      )
+
+  public val icon_1894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1894.xml"),
+          )
+      )
+
+  public val icon_18940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18940.xml"),
+          )
+      )
+
+  public val icon_18941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18941.xml"),
+          )
+      )
+
+  public val icon_18942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18942.xml"),
+          )
+      )
+
+  public val icon_18943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18943.xml"),
+          )
+      )
+
+  public val icon_18944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18944.xml"),
+          )
+      )
+
+  public val icon_18945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18945.xml"),
+          )
+      )
+
+  public val icon_18946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18946.xml"),
+          )
+      )
+
+  public val icon_18947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18947.xml"),
+          )
+      )
+
+  public val icon_18948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18948.xml"),
+          )
+      )
+
+  public val icon_18949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18949.xml"),
+          )
+      )
+
+  public val icon_1895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1895.xml"),
+          )
+      )
+
+  public val icon_18950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18950.xml"),
+          )
+      )
+
+  public val icon_18951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18951.xml"),
+          )
+      )
+
+  public val icon_18952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18952.xml"),
+          )
+      )
+
+  public val icon_18953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18953.xml"),
+          )
+      )
+
+  public val icon_18954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18954.xml"),
+          )
+      )
+
+  public val icon_18955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18955.xml"),
+          )
+      )
+
+  public val icon_18956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18956.xml"),
+          )
+      )
+
+  public val icon_18957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18957.xml"),
+          )
+      )
+
+  public val icon_18958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18958.xml"),
+          )
+      )
+
+  public val icon_18959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18959.xml"),
+          )
+      )
+
+  public val icon_1896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1896.xml"),
+          )
+      )
+
+  public val icon_18960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18960.xml"),
+          )
+      )
+
+  public val icon_18961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18961.xml"),
+          )
+      )
+
+  public val icon_18962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18962.xml"),
+          )
+      )
+
+  public val icon_18963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18963.xml"),
+          )
+      )
+
+  public val icon_18964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18964.xml"),
+          )
+      )
+
+  public val icon_18965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18965.xml"),
+          )
+      )
+
+  public val icon_18966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18966.xml"),
+          )
+      )
+
+  public val icon_18967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18967.xml"),
+          )
+      )
+
+  public val icon_18968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18968.xml"),
+          )
+      )
+
+  public val icon_18969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18969.xml"),
+          )
+      )
+
+  public val icon_1897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1897.xml"),
+          )
+      )
+
+  public val icon_18970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18970.xml"),
+          )
+      )
+
+  public val icon_18971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18971.xml"),
+          )
+      )
+
+  public val icon_18972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18972.xml"),
+          )
+      )
+
+  public val icon_18973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18973.xml"),
+          )
+      )
+
+  public val icon_18974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18974.xml"),
+          )
+      )
+
+  public val icon_18975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18975.xml"),
+          )
+      )
+
+  public val icon_18976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18976.xml"),
+          )
+      )
+
+  public val icon_18977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18977.xml"),
+          )
+      )
+
+  public val icon_18978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18978.xml"),
+          )
+      )
+
+  public val icon_18979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18979.xml"),
+          )
+      )
+
+  public val icon_1898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1898.xml"),
+          )
+      )
+
+  public val icon_18980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18980.xml"),
+          )
+      )
+
+  public val icon_18981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18981.xml"),
+          )
+      )
+
+  public val icon_18982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18982.xml"),
+          )
+      )
+
+  public val icon_18983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18983.xml"),
+          )
+      )
+
+  public val icon_18984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18984.xml"),
+          )
+      )
+
+  public val icon_18985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18985.xml"),
+          )
+      )
+
+  public val icon_18986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18986.xml"),
+          )
+      )
+
+  public val icon_18987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18987.xml"),
+          )
+      )
+
+  public val icon_18988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18988.xml"),
+          )
+      )
+
+  public val icon_18989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18989.xml"),
+          )
+      )
+
+  public val icon_1899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1899.xml"),
+          )
+      )
+
+  public val icon_18990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18990.xml"),
+          )
+      )
+
+  public val icon_18991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18991.xml"),
+          )
+      )
+
+  public val icon_18992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18992.xml"),
+          )
+      )
+
+  public val icon_18993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18993.xml"),
+          )
+      )
+
+  public val icon_18994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18994.xml"),
+          )
+      )
+
+  public val icon_18995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18995.xml"),
+          )
+      )
+
+  public val icon_18996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18996.xml"),
+          )
+      )
+
+  public val icon_18997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18997.xml"),
+          )
+      )
+
+  public val icon_18998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18998.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18548: DrawableResource
+  get() = Drawable19.icon_18548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18549: DrawableResource
+  get() = Drawable19.icon_18549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1855: DrawableResource
+  get() = Drawable19.icon_1855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18550: DrawableResource
+  get() = Drawable19.icon_18550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18551: DrawableResource
+  get() = Drawable19.icon_18551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18552: DrawableResource
+  get() = Drawable19.icon_18552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18553: DrawableResource
+  get() = Drawable19.icon_18553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18554: DrawableResource
+  get() = Drawable19.icon_18554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18555: DrawableResource
+  get() = Drawable19.icon_18555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18556: DrawableResource
+  get() = Drawable19.icon_18556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18557: DrawableResource
+  get() = Drawable19.icon_18557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18558: DrawableResource
+  get() = Drawable19.icon_18558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18559: DrawableResource
+  get() = Drawable19.icon_18559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1856: DrawableResource
+  get() = Drawable19.icon_1856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18560: DrawableResource
+  get() = Drawable19.icon_18560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18561: DrawableResource
+  get() = Drawable19.icon_18561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18562: DrawableResource
+  get() = Drawable19.icon_18562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18563: DrawableResource
+  get() = Drawable19.icon_18563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18564: DrawableResource
+  get() = Drawable19.icon_18564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18565: DrawableResource
+  get() = Drawable19.icon_18565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18566: DrawableResource
+  get() = Drawable19.icon_18566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18567: DrawableResource
+  get() = Drawable19.icon_18567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18568: DrawableResource
+  get() = Drawable19.icon_18568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18569: DrawableResource
+  get() = Drawable19.icon_18569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1857: DrawableResource
+  get() = Drawable19.icon_1857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18570: DrawableResource
+  get() = Drawable19.icon_18570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18571: DrawableResource
+  get() = Drawable19.icon_18571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18572: DrawableResource
+  get() = Drawable19.icon_18572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18573: DrawableResource
+  get() = Drawable19.icon_18573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18574: DrawableResource
+  get() = Drawable19.icon_18574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18575: DrawableResource
+  get() = Drawable19.icon_18575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18576: DrawableResource
+  get() = Drawable19.icon_18576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18577: DrawableResource
+  get() = Drawable19.icon_18577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18578: DrawableResource
+  get() = Drawable19.icon_18578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18579: DrawableResource
+  get() = Drawable19.icon_18579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1858: DrawableResource
+  get() = Drawable19.icon_1858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18580: DrawableResource
+  get() = Drawable19.icon_18580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18581: DrawableResource
+  get() = Drawable19.icon_18581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18582: DrawableResource
+  get() = Drawable19.icon_18582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18583: DrawableResource
+  get() = Drawable19.icon_18583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18584: DrawableResource
+  get() = Drawable19.icon_18584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18585: DrawableResource
+  get() = Drawable19.icon_18585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18586: DrawableResource
+  get() = Drawable19.icon_18586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18587: DrawableResource
+  get() = Drawable19.icon_18587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18588: DrawableResource
+  get() = Drawable19.icon_18588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18589: DrawableResource
+  get() = Drawable19.icon_18589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1859: DrawableResource
+  get() = Drawable19.icon_1859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18590: DrawableResource
+  get() = Drawable19.icon_18590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18591: DrawableResource
+  get() = Drawable19.icon_18591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18592: DrawableResource
+  get() = Drawable19.icon_18592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18593: DrawableResource
+  get() = Drawable19.icon_18593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18594: DrawableResource
+  get() = Drawable19.icon_18594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18595: DrawableResource
+  get() = Drawable19.icon_18595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18596: DrawableResource
+  get() = Drawable19.icon_18596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18597: DrawableResource
+  get() = Drawable19.icon_18597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18598: DrawableResource
+  get() = Drawable19.icon_18598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18599: DrawableResource
+  get() = Drawable19.icon_18599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_186: DrawableResource
+  get() = Drawable19.icon_186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1860: DrawableResource
+  get() = Drawable19.icon_1860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18600: DrawableResource
+  get() = Drawable19.icon_18600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18601: DrawableResource
+  get() = Drawable19.icon_18601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18602: DrawableResource
+  get() = Drawable19.icon_18602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18603: DrawableResource
+  get() = Drawable19.icon_18603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18604: DrawableResource
+  get() = Drawable19.icon_18604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18605: DrawableResource
+  get() = Drawable19.icon_18605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18606: DrawableResource
+  get() = Drawable19.icon_18606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18607: DrawableResource
+  get() = Drawable19.icon_18607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18608: DrawableResource
+  get() = Drawable19.icon_18608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18609: DrawableResource
+  get() = Drawable19.icon_18609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1861: DrawableResource
+  get() = Drawable19.icon_1861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18610: DrawableResource
+  get() = Drawable19.icon_18610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18611: DrawableResource
+  get() = Drawable19.icon_18611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18612: DrawableResource
+  get() = Drawable19.icon_18612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18613: DrawableResource
+  get() = Drawable19.icon_18613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18614: DrawableResource
+  get() = Drawable19.icon_18614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18615: DrawableResource
+  get() = Drawable19.icon_18615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18616: DrawableResource
+  get() = Drawable19.icon_18616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18617: DrawableResource
+  get() = Drawable19.icon_18617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18618: DrawableResource
+  get() = Drawable19.icon_18618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18619: DrawableResource
+  get() = Drawable19.icon_18619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1862: DrawableResource
+  get() = Drawable19.icon_1862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18620: DrawableResource
+  get() = Drawable19.icon_18620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18621: DrawableResource
+  get() = Drawable19.icon_18621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18622: DrawableResource
+  get() = Drawable19.icon_18622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18623: DrawableResource
+  get() = Drawable19.icon_18623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18624: DrawableResource
+  get() = Drawable19.icon_18624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18625: DrawableResource
+  get() = Drawable19.icon_18625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18626: DrawableResource
+  get() = Drawable19.icon_18626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18627: DrawableResource
+  get() = Drawable19.icon_18627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18628: DrawableResource
+  get() = Drawable19.icon_18628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18629: DrawableResource
+  get() = Drawable19.icon_18629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1863: DrawableResource
+  get() = Drawable19.icon_1863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18630: DrawableResource
+  get() = Drawable19.icon_18630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18631: DrawableResource
+  get() = Drawable19.icon_18631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18632: DrawableResource
+  get() = Drawable19.icon_18632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18633: DrawableResource
+  get() = Drawable19.icon_18633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18634: DrawableResource
+  get() = Drawable19.icon_18634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18635: DrawableResource
+  get() = Drawable19.icon_18635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18636: DrawableResource
+  get() = Drawable19.icon_18636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18637: DrawableResource
+  get() = Drawable19.icon_18637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18638: DrawableResource
+  get() = Drawable19.icon_18638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18639: DrawableResource
+  get() = Drawable19.icon_18639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1864: DrawableResource
+  get() = Drawable19.icon_1864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18640: DrawableResource
+  get() = Drawable19.icon_18640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18641: DrawableResource
+  get() = Drawable19.icon_18641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18642: DrawableResource
+  get() = Drawable19.icon_18642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18643: DrawableResource
+  get() = Drawable19.icon_18643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18644: DrawableResource
+  get() = Drawable19.icon_18644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18645: DrawableResource
+  get() = Drawable19.icon_18645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18646: DrawableResource
+  get() = Drawable19.icon_18646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18647: DrawableResource
+  get() = Drawable19.icon_18647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18648: DrawableResource
+  get() = Drawable19.icon_18648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18649: DrawableResource
+  get() = Drawable19.icon_18649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1865: DrawableResource
+  get() = Drawable19.icon_1865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18650: DrawableResource
+  get() = Drawable19.icon_18650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18651: DrawableResource
+  get() = Drawable19.icon_18651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18652: DrawableResource
+  get() = Drawable19.icon_18652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18653: DrawableResource
+  get() = Drawable19.icon_18653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18654: DrawableResource
+  get() = Drawable19.icon_18654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18655: DrawableResource
+  get() = Drawable19.icon_18655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18656: DrawableResource
+  get() = Drawable19.icon_18656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18657: DrawableResource
+  get() = Drawable19.icon_18657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18658: DrawableResource
+  get() = Drawable19.icon_18658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18659: DrawableResource
+  get() = Drawable19.icon_18659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1866: DrawableResource
+  get() = Drawable19.icon_1866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18660: DrawableResource
+  get() = Drawable19.icon_18660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18661: DrawableResource
+  get() = Drawable19.icon_18661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18662: DrawableResource
+  get() = Drawable19.icon_18662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18663: DrawableResource
+  get() = Drawable19.icon_18663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18664: DrawableResource
+  get() = Drawable19.icon_18664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18665: DrawableResource
+  get() = Drawable19.icon_18665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18666: DrawableResource
+  get() = Drawable19.icon_18666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18667: DrawableResource
+  get() = Drawable19.icon_18667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18668: DrawableResource
+  get() = Drawable19.icon_18668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18669: DrawableResource
+  get() = Drawable19.icon_18669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1867: DrawableResource
+  get() = Drawable19.icon_1867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18670: DrawableResource
+  get() = Drawable19.icon_18670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18671: DrawableResource
+  get() = Drawable19.icon_18671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18672: DrawableResource
+  get() = Drawable19.icon_18672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18673: DrawableResource
+  get() = Drawable19.icon_18673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18674: DrawableResource
+  get() = Drawable19.icon_18674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18675: DrawableResource
+  get() = Drawable19.icon_18675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18676: DrawableResource
+  get() = Drawable19.icon_18676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18677: DrawableResource
+  get() = Drawable19.icon_18677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18678: DrawableResource
+  get() = Drawable19.icon_18678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18679: DrawableResource
+  get() = Drawable19.icon_18679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1868: DrawableResource
+  get() = Drawable19.icon_1868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18680: DrawableResource
+  get() = Drawable19.icon_18680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18681: DrawableResource
+  get() = Drawable19.icon_18681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18682: DrawableResource
+  get() = Drawable19.icon_18682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18683: DrawableResource
+  get() = Drawable19.icon_18683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18684: DrawableResource
+  get() = Drawable19.icon_18684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18685: DrawableResource
+  get() = Drawable19.icon_18685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18686: DrawableResource
+  get() = Drawable19.icon_18686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18687: DrawableResource
+  get() = Drawable19.icon_18687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18688: DrawableResource
+  get() = Drawable19.icon_18688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18689: DrawableResource
+  get() = Drawable19.icon_18689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1869: DrawableResource
+  get() = Drawable19.icon_1869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18690: DrawableResource
+  get() = Drawable19.icon_18690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18691: DrawableResource
+  get() = Drawable19.icon_18691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18692: DrawableResource
+  get() = Drawable19.icon_18692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18693: DrawableResource
+  get() = Drawable19.icon_18693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18694: DrawableResource
+  get() = Drawable19.icon_18694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18695: DrawableResource
+  get() = Drawable19.icon_18695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18696: DrawableResource
+  get() = Drawable19.icon_18696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18697: DrawableResource
+  get() = Drawable19.icon_18697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18698: DrawableResource
+  get() = Drawable19.icon_18698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18699: DrawableResource
+  get() = Drawable19.icon_18699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_187: DrawableResource
+  get() = Drawable19.icon_187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1870: DrawableResource
+  get() = Drawable19.icon_1870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18700: DrawableResource
+  get() = Drawable19.icon_18700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18701: DrawableResource
+  get() = Drawable19.icon_18701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18702: DrawableResource
+  get() = Drawable19.icon_18702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18703: DrawableResource
+  get() = Drawable19.icon_18703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18704: DrawableResource
+  get() = Drawable19.icon_18704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18705: DrawableResource
+  get() = Drawable19.icon_18705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18706: DrawableResource
+  get() = Drawable19.icon_18706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18707: DrawableResource
+  get() = Drawable19.icon_18707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18708: DrawableResource
+  get() = Drawable19.icon_18708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18709: DrawableResource
+  get() = Drawable19.icon_18709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1871: DrawableResource
+  get() = Drawable19.icon_1871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18710: DrawableResource
+  get() = Drawable19.icon_18710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18711: DrawableResource
+  get() = Drawable19.icon_18711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18712: DrawableResource
+  get() = Drawable19.icon_18712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18713: DrawableResource
+  get() = Drawable19.icon_18713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18714: DrawableResource
+  get() = Drawable19.icon_18714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18715: DrawableResource
+  get() = Drawable19.icon_18715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18716: DrawableResource
+  get() = Drawable19.icon_18716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18717: DrawableResource
+  get() = Drawable19.icon_18717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18718: DrawableResource
+  get() = Drawable19.icon_18718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18719: DrawableResource
+  get() = Drawable19.icon_18719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1872: DrawableResource
+  get() = Drawable19.icon_1872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18720: DrawableResource
+  get() = Drawable19.icon_18720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18721: DrawableResource
+  get() = Drawable19.icon_18721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18722: DrawableResource
+  get() = Drawable19.icon_18722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18723: DrawableResource
+  get() = Drawable19.icon_18723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18724: DrawableResource
+  get() = Drawable19.icon_18724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18725: DrawableResource
+  get() = Drawable19.icon_18725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18726: DrawableResource
+  get() = Drawable19.icon_18726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18727: DrawableResource
+  get() = Drawable19.icon_18727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18728: DrawableResource
+  get() = Drawable19.icon_18728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18729: DrawableResource
+  get() = Drawable19.icon_18729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1873: DrawableResource
+  get() = Drawable19.icon_1873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18730: DrawableResource
+  get() = Drawable19.icon_18730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18731: DrawableResource
+  get() = Drawable19.icon_18731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18732: DrawableResource
+  get() = Drawable19.icon_18732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18733: DrawableResource
+  get() = Drawable19.icon_18733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18734: DrawableResource
+  get() = Drawable19.icon_18734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18735: DrawableResource
+  get() = Drawable19.icon_18735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18736: DrawableResource
+  get() = Drawable19.icon_18736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18737: DrawableResource
+  get() = Drawable19.icon_18737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18738: DrawableResource
+  get() = Drawable19.icon_18738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18739: DrawableResource
+  get() = Drawable19.icon_18739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1874: DrawableResource
+  get() = Drawable19.icon_1874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18740: DrawableResource
+  get() = Drawable19.icon_18740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18741: DrawableResource
+  get() = Drawable19.icon_18741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18742: DrawableResource
+  get() = Drawable19.icon_18742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18743: DrawableResource
+  get() = Drawable19.icon_18743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18744: DrawableResource
+  get() = Drawable19.icon_18744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18745: DrawableResource
+  get() = Drawable19.icon_18745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18746: DrawableResource
+  get() = Drawable19.icon_18746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18747: DrawableResource
+  get() = Drawable19.icon_18747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18748: DrawableResource
+  get() = Drawable19.icon_18748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18749: DrawableResource
+  get() = Drawable19.icon_18749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1875: DrawableResource
+  get() = Drawable19.icon_1875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18750: DrawableResource
+  get() = Drawable19.icon_18750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18751: DrawableResource
+  get() = Drawable19.icon_18751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18752: DrawableResource
+  get() = Drawable19.icon_18752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18753: DrawableResource
+  get() = Drawable19.icon_18753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18754: DrawableResource
+  get() = Drawable19.icon_18754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18755: DrawableResource
+  get() = Drawable19.icon_18755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18756: DrawableResource
+  get() = Drawable19.icon_18756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18757: DrawableResource
+  get() = Drawable19.icon_18757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18758: DrawableResource
+  get() = Drawable19.icon_18758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18759: DrawableResource
+  get() = Drawable19.icon_18759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1876: DrawableResource
+  get() = Drawable19.icon_1876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18760: DrawableResource
+  get() = Drawable19.icon_18760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18761: DrawableResource
+  get() = Drawable19.icon_18761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18762: DrawableResource
+  get() = Drawable19.icon_18762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18763: DrawableResource
+  get() = Drawable19.icon_18763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18764: DrawableResource
+  get() = Drawable19.icon_18764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18765: DrawableResource
+  get() = Drawable19.icon_18765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18766: DrawableResource
+  get() = Drawable19.icon_18766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18767: DrawableResource
+  get() = Drawable19.icon_18767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18768: DrawableResource
+  get() = Drawable19.icon_18768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18769: DrawableResource
+  get() = Drawable19.icon_18769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1877: DrawableResource
+  get() = Drawable19.icon_1877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18770: DrawableResource
+  get() = Drawable19.icon_18770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18771: DrawableResource
+  get() = Drawable19.icon_18771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18772: DrawableResource
+  get() = Drawable19.icon_18772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18773: DrawableResource
+  get() = Drawable19.icon_18773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18774: DrawableResource
+  get() = Drawable19.icon_18774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18775: DrawableResource
+  get() = Drawable19.icon_18775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18776: DrawableResource
+  get() = Drawable19.icon_18776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18777: DrawableResource
+  get() = Drawable19.icon_18777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18778: DrawableResource
+  get() = Drawable19.icon_18778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18779: DrawableResource
+  get() = Drawable19.icon_18779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1878: DrawableResource
+  get() = Drawable19.icon_1878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18780: DrawableResource
+  get() = Drawable19.icon_18780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18781: DrawableResource
+  get() = Drawable19.icon_18781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18782: DrawableResource
+  get() = Drawable19.icon_18782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18783: DrawableResource
+  get() = Drawable19.icon_18783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18784: DrawableResource
+  get() = Drawable19.icon_18784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18785: DrawableResource
+  get() = Drawable19.icon_18785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18786: DrawableResource
+  get() = Drawable19.icon_18786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18787: DrawableResource
+  get() = Drawable19.icon_18787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18788: DrawableResource
+  get() = Drawable19.icon_18788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18789: DrawableResource
+  get() = Drawable19.icon_18789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1879: DrawableResource
+  get() = Drawable19.icon_1879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18790: DrawableResource
+  get() = Drawable19.icon_18790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18791: DrawableResource
+  get() = Drawable19.icon_18791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18792: DrawableResource
+  get() = Drawable19.icon_18792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18793: DrawableResource
+  get() = Drawable19.icon_18793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18794: DrawableResource
+  get() = Drawable19.icon_18794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18795: DrawableResource
+  get() = Drawable19.icon_18795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18796: DrawableResource
+  get() = Drawable19.icon_18796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18797: DrawableResource
+  get() = Drawable19.icon_18797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18798: DrawableResource
+  get() = Drawable19.icon_18798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18799: DrawableResource
+  get() = Drawable19.icon_18799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_188: DrawableResource
+  get() = Drawable19.icon_188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1880: DrawableResource
+  get() = Drawable19.icon_1880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18800: DrawableResource
+  get() = Drawable19.icon_18800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18801: DrawableResource
+  get() = Drawable19.icon_18801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18802: DrawableResource
+  get() = Drawable19.icon_18802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18803: DrawableResource
+  get() = Drawable19.icon_18803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18804: DrawableResource
+  get() = Drawable19.icon_18804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18805: DrawableResource
+  get() = Drawable19.icon_18805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18806: DrawableResource
+  get() = Drawable19.icon_18806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18807: DrawableResource
+  get() = Drawable19.icon_18807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18808: DrawableResource
+  get() = Drawable19.icon_18808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18809: DrawableResource
+  get() = Drawable19.icon_18809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1881: DrawableResource
+  get() = Drawable19.icon_1881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18810: DrawableResource
+  get() = Drawable19.icon_18810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18811: DrawableResource
+  get() = Drawable19.icon_18811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18812: DrawableResource
+  get() = Drawable19.icon_18812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18813: DrawableResource
+  get() = Drawable19.icon_18813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18814: DrawableResource
+  get() = Drawable19.icon_18814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18815: DrawableResource
+  get() = Drawable19.icon_18815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18816: DrawableResource
+  get() = Drawable19.icon_18816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18817: DrawableResource
+  get() = Drawable19.icon_18817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18818: DrawableResource
+  get() = Drawable19.icon_18818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18819: DrawableResource
+  get() = Drawable19.icon_18819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1882: DrawableResource
+  get() = Drawable19.icon_1882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18820: DrawableResource
+  get() = Drawable19.icon_18820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18821: DrawableResource
+  get() = Drawable19.icon_18821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18822: DrawableResource
+  get() = Drawable19.icon_18822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18823: DrawableResource
+  get() = Drawable19.icon_18823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18824: DrawableResource
+  get() = Drawable19.icon_18824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18825: DrawableResource
+  get() = Drawable19.icon_18825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18826: DrawableResource
+  get() = Drawable19.icon_18826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18827: DrawableResource
+  get() = Drawable19.icon_18827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18828: DrawableResource
+  get() = Drawable19.icon_18828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18829: DrawableResource
+  get() = Drawable19.icon_18829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1883: DrawableResource
+  get() = Drawable19.icon_1883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18830: DrawableResource
+  get() = Drawable19.icon_18830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18831: DrawableResource
+  get() = Drawable19.icon_18831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18832: DrawableResource
+  get() = Drawable19.icon_18832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18833: DrawableResource
+  get() = Drawable19.icon_18833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18834: DrawableResource
+  get() = Drawable19.icon_18834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18835: DrawableResource
+  get() = Drawable19.icon_18835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18836: DrawableResource
+  get() = Drawable19.icon_18836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18837: DrawableResource
+  get() = Drawable19.icon_18837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18838: DrawableResource
+  get() = Drawable19.icon_18838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18839: DrawableResource
+  get() = Drawable19.icon_18839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1884: DrawableResource
+  get() = Drawable19.icon_1884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18840: DrawableResource
+  get() = Drawable19.icon_18840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18841: DrawableResource
+  get() = Drawable19.icon_18841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18842: DrawableResource
+  get() = Drawable19.icon_18842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18843: DrawableResource
+  get() = Drawable19.icon_18843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18844: DrawableResource
+  get() = Drawable19.icon_18844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18845: DrawableResource
+  get() = Drawable19.icon_18845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18846: DrawableResource
+  get() = Drawable19.icon_18846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18847: DrawableResource
+  get() = Drawable19.icon_18847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18848: DrawableResource
+  get() = Drawable19.icon_18848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18849: DrawableResource
+  get() = Drawable19.icon_18849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1885: DrawableResource
+  get() = Drawable19.icon_1885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18850: DrawableResource
+  get() = Drawable19.icon_18850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18851: DrawableResource
+  get() = Drawable19.icon_18851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18852: DrawableResource
+  get() = Drawable19.icon_18852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18853: DrawableResource
+  get() = Drawable19.icon_18853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18854: DrawableResource
+  get() = Drawable19.icon_18854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18855: DrawableResource
+  get() = Drawable19.icon_18855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18856: DrawableResource
+  get() = Drawable19.icon_18856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18857: DrawableResource
+  get() = Drawable19.icon_18857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18858: DrawableResource
+  get() = Drawable19.icon_18858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18859: DrawableResource
+  get() = Drawable19.icon_18859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1886: DrawableResource
+  get() = Drawable19.icon_1886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18860: DrawableResource
+  get() = Drawable19.icon_18860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18861: DrawableResource
+  get() = Drawable19.icon_18861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18862: DrawableResource
+  get() = Drawable19.icon_18862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18863: DrawableResource
+  get() = Drawable19.icon_18863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18864: DrawableResource
+  get() = Drawable19.icon_18864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18865: DrawableResource
+  get() = Drawable19.icon_18865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18866: DrawableResource
+  get() = Drawable19.icon_18866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18867: DrawableResource
+  get() = Drawable19.icon_18867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18868: DrawableResource
+  get() = Drawable19.icon_18868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18869: DrawableResource
+  get() = Drawable19.icon_18869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1887: DrawableResource
+  get() = Drawable19.icon_1887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18870: DrawableResource
+  get() = Drawable19.icon_18870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18871: DrawableResource
+  get() = Drawable19.icon_18871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18872: DrawableResource
+  get() = Drawable19.icon_18872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18873: DrawableResource
+  get() = Drawable19.icon_18873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18874: DrawableResource
+  get() = Drawable19.icon_18874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18875: DrawableResource
+  get() = Drawable19.icon_18875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18876: DrawableResource
+  get() = Drawable19.icon_18876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18877: DrawableResource
+  get() = Drawable19.icon_18877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18878: DrawableResource
+  get() = Drawable19.icon_18878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18879: DrawableResource
+  get() = Drawable19.icon_18879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1888: DrawableResource
+  get() = Drawable19.icon_1888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18880: DrawableResource
+  get() = Drawable19.icon_18880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18881: DrawableResource
+  get() = Drawable19.icon_18881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18882: DrawableResource
+  get() = Drawable19.icon_18882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18883: DrawableResource
+  get() = Drawable19.icon_18883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18884: DrawableResource
+  get() = Drawable19.icon_18884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18885: DrawableResource
+  get() = Drawable19.icon_18885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18886: DrawableResource
+  get() = Drawable19.icon_18886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18887: DrawableResource
+  get() = Drawable19.icon_18887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18888: DrawableResource
+  get() = Drawable19.icon_18888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18889: DrawableResource
+  get() = Drawable19.icon_18889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1889: DrawableResource
+  get() = Drawable19.icon_1889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18890: DrawableResource
+  get() = Drawable19.icon_18890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18891: DrawableResource
+  get() = Drawable19.icon_18891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18892: DrawableResource
+  get() = Drawable19.icon_18892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18893: DrawableResource
+  get() = Drawable19.icon_18893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18894: DrawableResource
+  get() = Drawable19.icon_18894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18895: DrawableResource
+  get() = Drawable19.icon_18895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18896: DrawableResource
+  get() = Drawable19.icon_18896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18897: DrawableResource
+  get() = Drawable19.icon_18897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18898: DrawableResource
+  get() = Drawable19.icon_18898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18899: DrawableResource
+  get() = Drawable19.icon_18899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_189: DrawableResource
+  get() = Drawable19.icon_189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1890: DrawableResource
+  get() = Drawable19.icon_1890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18900: DrawableResource
+  get() = Drawable19.icon_18900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18901: DrawableResource
+  get() = Drawable19.icon_18901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18902: DrawableResource
+  get() = Drawable19.icon_18902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18903: DrawableResource
+  get() = Drawable19.icon_18903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18904: DrawableResource
+  get() = Drawable19.icon_18904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18905: DrawableResource
+  get() = Drawable19.icon_18905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18906: DrawableResource
+  get() = Drawable19.icon_18906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18907: DrawableResource
+  get() = Drawable19.icon_18907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18908: DrawableResource
+  get() = Drawable19.icon_18908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18909: DrawableResource
+  get() = Drawable19.icon_18909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1891: DrawableResource
+  get() = Drawable19.icon_1891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18910: DrawableResource
+  get() = Drawable19.icon_18910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18911: DrawableResource
+  get() = Drawable19.icon_18911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18912: DrawableResource
+  get() = Drawable19.icon_18912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18913: DrawableResource
+  get() = Drawable19.icon_18913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18914: DrawableResource
+  get() = Drawable19.icon_18914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18915: DrawableResource
+  get() = Drawable19.icon_18915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18916: DrawableResource
+  get() = Drawable19.icon_18916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18917: DrawableResource
+  get() = Drawable19.icon_18917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18918: DrawableResource
+  get() = Drawable19.icon_18918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18919: DrawableResource
+  get() = Drawable19.icon_18919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1892: DrawableResource
+  get() = Drawable19.icon_1892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18920: DrawableResource
+  get() = Drawable19.icon_18920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18921: DrawableResource
+  get() = Drawable19.icon_18921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18922: DrawableResource
+  get() = Drawable19.icon_18922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18923: DrawableResource
+  get() = Drawable19.icon_18923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18924: DrawableResource
+  get() = Drawable19.icon_18924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18925: DrawableResource
+  get() = Drawable19.icon_18925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18926: DrawableResource
+  get() = Drawable19.icon_18926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18927: DrawableResource
+  get() = Drawable19.icon_18927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18928: DrawableResource
+  get() = Drawable19.icon_18928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18929: DrawableResource
+  get() = Drawable19.icon_18929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1893: DrawableResource
+  get() = Drawable19.icon_1893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18930: DrawableResource
+  get() = Drawable19.icon_18930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18931: DrawableResource
+  get() = Drawable19.icon_18931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18932: DrawableResource
+  get() = Drawable19.icon_18932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18933: DrawableResource
+  get() = Drawable19.icon_18933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18934: DrawableResource
+  get() = Drawable19.icon_18934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18935: DrawableResource
+  get() = Drawable19.icon_18935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18936: DrawableResource
+  get() = Drawable19.icon_18936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18937: DrawableResource
+  get() = Drawable19.icon_18937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18938: DrawableResource
+  get() = Drawable19.icon_18938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18939: DrawableResource
+  get() = Drawable19.icon_18939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1894: DrawableResource
+  get() = Drawable19.icon_1894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18940: DrawableResource
+  get() = Drawable19.icon_18940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18941: DrawableResource
+  get() = Drawable19.icon_18941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18942: DrawableResource
+  get() = Drawable19.icon_18942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18943: DrawableResource
+  get() = Drawable19.icon_18943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18944: DrawableResource
+  get() = Drawable19.icon_18944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18945: DrawableResource
+  get() = Drawable19.icon_18945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18946: DrawableResource
+  get() = Drawable19.icon_18946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18947: DrawableResource
+  get() = Drawable19.icon_18947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18948: DrawableResource
+  get() = Drawable19.icon_18948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18949: DrawableResource
+  get() = Drawable19.icon_18949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1895: DrawableResource
+  get() = Drawable19.icon_1895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18950: DrawableResource
+  get() = Drawable19.icon_18950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18951: DrawableResource
+  get() = Drawable19.icon_18951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18952: DrawableResource
+  get() = Drawable19.icon_18952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18953: DrawableResource
+  get() = Drawable19.icon_18953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18954: DrawableResource
+  get() = Drawable19.icon_18954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18955: DrawableResource
+  get() = Drawable19.icon_18955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18956: DrawableResource
+  get() = Drawable19.icon_18956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18957: DrawableResource
+  get() = Drawable19.icon_18957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18958: DrawableResource
+  get() = Drawable19.icon_18958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18959: DrawableResource
+  get() = Drawable19.icon_18959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1896: DrawableResource
+  get() = Drawable19.icon_1896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18960: DrawableResource
+  get() = Drawable19.icon_18960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18961: DrawableResource
+  get() = Drawable19.icon_18961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18962: DrawableResource
+  get() = Drawable19.icon_18962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18963: DrawableResource
+  get() = Drawable19.icon_18963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18964: DrawableResource
+  get() = Drawable19.icon_18964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18965: DrawableResource
+  get() = Drawable19.icon_18965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18966: DrawableResource
+  get() = Drawable19.icon_18966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18967: DrawableResource
+  get() = Drawable19.icon_18967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18968: DrawableResource
+  get() = Drawable19.icon_18968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18969: DrawableResource
+  get() = Drawable19.icon_18969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1897: DrawableResource
+  get() = Drawable19.icon_1897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18970: DrawableResource
+  get() = Drawable19.icon_18970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18971: DrawableResource
+  get() = Drawable19.icon_18971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18972: DrawableResource
+  get() = Drawable19.icon_18972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18973: DrawableResource
+  get() = Drawable19.icon_18973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18974: DrawableResource
+  get() = Drawable19.icon_18974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18975: DrawableResource
+  get() = Drawable19.icon_18975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18976: DrawableResource
+  get() = Drawable19.icon_18976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18977: DrawableResource
+  get() = Drawable19.icon_18977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18978: DrawableResource
+  get() = Drawable19.icon_18978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18979: DrawableResource
+  get() = Drawable19.icon_18979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1898: DrawableResource
+  get() = Drawable19.icon_1898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18980: DrawableResource
+  get() = Drawable19.icon_18980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18981: DrawableResource
+  get() = Drawable19.icon_18981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18982: DrawableResource
+  get() = Drawable19.icon_18982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18983: DrawableResource
+  get() = Drawable19.icon_18983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18984: DrawableResource
+  get() = Drawable19.icon_18984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18985: DrawableResource
+  get() = Drawable19.icon_18985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18986: DrawableResource
+  get() = Drawable19.icon_18986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18987: DrawableResource
+  get() = Drawable19.icon_18987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18988: DrawableResource
+  get() = Drawable19.icon_18988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18989: DrawableResource
+  get() = Drawable19.icon_18989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1899: DrawableResource
+  get() = Drawable19.icon_1899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18990: DrawableResource
+  get() = Drawable19.icon_18990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18991: DrawableResource
+  get() = Drawable19.icon_18991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18992: DrawableResource
+  get() = Drawable19.icon_18992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18993: DrawableResource
+  get() = Drawable19.icon_18993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18994: DrawableResource
+  get() = Drawable19.icon_18994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18995: DrawableResource
+  get() = Drawable19.icon_18995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18996: DrawableResource
+  get() = Drawable19.icon_18996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18997: DrawableResource
+  get() = Drawable19.icon_18997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18998: DrawableResource
+  get() = Drawable19.icon_18998

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable2.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable2.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable2 {
+  public val icon_10898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10898.xml"),
+          )
+      )
+
+  public val icon_10899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10899.xml"),
+          )
+      )
+
+  public val icon_109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_109.xml"),
+          )
+      )
+
+  public val icon_1090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1090.xml"),
+          )
+      )
+
+  public val icon_10900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10900.xml"),
+          )
+      )
+
+  public val icon_10901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10901.xml"),
+          )
+      )
+
+  public val icon_10902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10902.xml"),
+          )
+      )
+
+  public val icon_10903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10903.xml"),
+          )
+      )
+
+  public val icon_10904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10904.xml"),
+          )
+      )
+
+  public val icon_10905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10905.xml"),
+          )
+      )
+
+  public val icon_10906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10906.xml"),
+          )
+      )
+
+  public val icon_10907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10907.xml"),
+          )
+      )
+
+  public val icon_10908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10908.xml"),
+          )
+      )
+
+  public val icon_10909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10909.xml"),
+          )
+      )
+
+  public val icon_1091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1091.xml"),
+          )
+      )
+
+  public val icon_10910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10910.xml"),
+          )
+      )
+
+  public val icon_10911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10911.xml"),
+          )
+      )
+
+  public val icon_10912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10912.xml"),
+          )
+      )
+
+  public val icon_10913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10913.xml"),
+          )
+      )
+
+  public val icon_10914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10914.xml"),
+          )
+      )
+
+  public val icon_10915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10915.xml"),
+          )
+      )
+
+  public val icon_10916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10916.xml"),
+          )
+      )
+
+  public val icon_10917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10917.xml"),
+          )
+      )
+
+  public val icon_10918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10918.xml"),
+          )
+      )
+
+  public val icon_10919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10919.xml"),
+          )
+      )
+
+  public val icon_1092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1092.xml"),
+          )
+      )
+
+  public val icon_10920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10920.xml"),
+          )
+      )
+
+  public val icon_10921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10921.xml"),
+          )
+      )
+
+  public val icon_10922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10922.xml"),
+          )
+      )
+
+  public val icon_10923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10923.xml"),
+          )
+      )
+
+  public val icon_10924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10924.xml"),
+          )
+      )
+
+  public val icon_10925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10925.xml"),
+          )
+      )
+
+  public val icon_10926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10926.xml"),
+          )
+      )
+
+  public val icon_10927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10927.xml"),
+          )
+      )
+
+  public val icon_10928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10928.xml"),
+          )
+      )
+
+  public val icon_10929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10929.xml"),
+          )
+      )
+
+  public val icon_1093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1093.xml"),
+          )
+      )
+
+  public val icon_10930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10930.xml"),
+          )
+      )
+
+  public val icon_10931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10931.xml"),
+          )
+      )
+
+  public val icon_10932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10932.xml"),
+          )
+      )
+
+  public val icon_10933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10933.xml"),
+          )
+      )
+
+  public val icon_10934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10934.xml"),
+          )
+      )
+
+  public val icon_10935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10935.xml"),
+          )
+      )
+
+  public val icon_10936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10936.xml"),
+          )
+      )
+
+  public val icon_10937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10937.xml"),
+          )
+      )
+
+  public val icon_10938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10938.xml"),
+          )
+      )
+
+  public val icon_10939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10939.xml"),
+          )
+      )
+
+  public val icon_1094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1094.xml"),
+          )
+      )
+
+  public val icon_10940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10940.xml"),
+          )
+      )
+
+  public val icon_10941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10941.xml"),
+          )
+      )
+
+  public val icon_10942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10942.xml"),
+          )
+      )
+
+  public val icon_10943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10943.xml"),
+          )
+      )
+
+  public val icon_10944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10944.xml"),
+          )
+      )
+
+  public val icon_10945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10945.xml"),
+          )
+      )
+
+  public val icon_10946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10946.xml"),
+          )
+      )
+
+  public val icon_10947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10947.xml"),
+          )
+      )
+
+  public val icon_10948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10948.xml"),
+          )
+      )
+
+  public val icon_10949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10949.xml"),
+          )
+      )
+
+  public val icon_1095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1095.xml"),
+          )
+      )
+
+  public val icon_10950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10950.xml"),
+          )
+      )
+
+  public val icon_10951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10951.xml"),
+          )
+      )
+
+  public val icon_10952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10952.xml"),
+          )
+      )
+
+  public val icon_10953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10953.xml"),
+          )
+      )
+
+  public val icon_10954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10954.xml"),
+          )
+      )
+
+  public val icon_10955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10955.xml"),
+          )
+      )
+
+  public val icon_10956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10956.xml"),
+          )
+      )
+
+  public val icon_10957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10957.xml"),
+          )
+      )
+
+  public val icon_10958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10958.xml"),
+          )
+      )
+
+  public val icon_10959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10959.xml"),
+          )
+      )
+
+  public val icon_1096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1096.xml"),
+          )
+      )
+
+  public val icon_10960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10960.xml"),
+          )
+      )
+
+  public val icon_10961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10961.xml"),
+          )
+      )
+
+  public val icon_10962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10962.xml"),
+          )
+      )
+
+  public val icon_10963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10963.xml"),
+          )
+      )
+
+  public val icon_10964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10964.xml"),
+          )
+      )
+
+  public val icon_10965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10965.xml"),
+          )
+      )
+
+  public val icon_10966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10966.xml"),
+          )
+      )
+
+  public val icon_10967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10967.xml"),
+          )
+      )
+
+  public val icon_10968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10968.xml"),
+          )
+      )
+
+  public val icon_10969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10969.xml"),
+          )
+      )
+
+  public val icon_1097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1097.xml"),
+          )
+      )
+
+  public val icon_10970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10970.xml"),
+          )
+      )
+
+  public val icon_10971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10971.xml"),
+          )
+      )
+
+  public val icon_10972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10972.xml"),
+          )
+      )
+
+  public val icon_10973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10973.xml"),
+          )
+      )
+
+  public val icon_10974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10974.xml"),
+          )
+      )
+
+  public val icon_10975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10975.xml"),
+          )
+      )
+
+  public val icon_10976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10976.xml"),
+          )
+      )
+
+  public val icon_10977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10977.xml"),
+          )
+      )
+
+  public val icon_10978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10978.xml"),
+          )
+      )
+
+  public val icon_10979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10979.xml"),
+          )
+      )
+
+  public val icon_1098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1098.xml"),
+          )
+      )
+
+  public val icon_10980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10980.xml"),
+          )
+      )
+
+  public val icon_10981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10981.xml"),
+          )
+      )
+
+  public val icon_10982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10982.xml"),
+          )
+      )
+
+  public val icon_10983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10983.xml"),
+          )
+      )
+
+  public val icon_10984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10984.xml"),
+          )
+      )
+
+  public val icon_10985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10985.xml"),
+          )
+      )
+
+  public val icon_10986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10986.xml"),
+          )
+      )
+
+  public val icon_10987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10987.xml"),
+          )
+      )
+
+  public val icon_10988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10988.xml"),
+          )
+      )
+
+  public val icon_10989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10989.xml"),
+          )
+      )
+
+  public val icon_1099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1099.xml"),
+          )
+      )
+
+  public val icon_10990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10990.xml"),
+          )
+      )
+
+  public val icon_10991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10991.xml"),
+          )
+      )
+
+  public val icon_10992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10992.xml"),
+          )
+      )
+
+  public val icon_10993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10993.xml"),
+          )
+      )
+
+  public val icon_10994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10994.xml"),
+          )
+      )
+
+  public val icon_10995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10995.xml"),
+          )
+      )
+
+  public val icon_10996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10996.xml"),
+          )
+      )
+
+  public val icon_10997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10997.xml"),
+          )
+      )
+
+  public val icon_10998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10998.xml"),
+          )
+      )
+
+  public val icon_10999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_10999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_10999.xml"),
+          )
+      )
+
+  public val icon_11: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11.xml"),
+          )
+      )
+
+  public val icon_110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_110.xml"),
+          )
+      )
+
+  public val icon_1100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1100.xml"),
+          )
+      )
+
+  public val icon_11000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11000.xml"),
+          )
+      )
+
+  public val icon_11001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11001.xml"),
+          )
+      )
+
+  public val icon_11002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11002.xml"),
+          )
+      )
+
+  public val icon_11003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11003.xml"),
+          )
+      )
+
+  public val icon_11004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11004.xml"),
+          )
+      )
+
+  public val icon_11005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11005.xml"),
+          )
+      )
+
+  public val icon_11006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11006.xml"),
+          )
+      )
+
+  public val icon_11007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11007.xml"),
+          )
+      )
+
+  public val icon_11008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11008.xml"),
+          )
+      )
+
+  public val icon_11009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11009.xml"),
+          )
+      )
+
+  public val icon_1101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1101.xml"),
+          )
+      )
+
+  public val icon_11010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11010.xml"),
+          )
+      )
+
+  public val icon_11011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11011.xml"),
+          )
+      )
+
+  public val icon_11012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11012.xml"),
+          )
+      )
+
+  public val icon_11013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11013.xml"),
+          )
+      )
+
+  public val icon_11014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11014.xml"),
+          )
+      )
+
+  public val icon_11015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11015.xml"),
+          )
+      )
+
+  public val icon_11016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11016.xml"),
+          )
+      )
+
+  public val icon_11017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11017.xml"),
+          )
+      )
+
+  public val icon_11018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11018.xml"),
+          )
+      )
+
+  public val icon_11019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11019.xml"),
+          )
+      )
+
+  public val icon_1102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1102.xml"),
+          )
+      )
+
+  public val icon_11020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11020.xml"),
+          )
+      )
+
+  public val icon_11021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11021.xml"),
+          )
+      )
+
+  public val icon_11022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11022.xml"),
+          )
+      )
+
+  public val icon_11023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11023.xml"),
+          )
+      )
+
+  public val icon_11024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11024.xml"),
+          )
+      )
+
+  public val icon_11025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11025.xml"),
+          )
+      )
+
+  public val icon_11026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11026.xml"),
+          )
+      )
+
+  public val icon_11027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11027.xml"),
+          )
+      )
+
+  public val icon_11028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11028.xml"),
+          )
+      )
+
+  public val icon_11029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11029.xml"),
+          )
+      )
+
+  public val icon_1103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1103.xml"),
+          )
+      )
+
+  public val icon_11030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11030.xml"),
+          )
+      )
+
+  public val icon_11031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11031.xml"),
+          )
+      )
+
+  public val icon_11032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11032.xml"),
+          )
+      )
+
+  public val icon_11033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11033.xml"),
+          )
+      )
+
+  public val icon_11034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11034.xml"),
+          )
+      )
+
+  public val icon_11035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11035.xml"),
+          )
+      )
+
+  public val icon_11036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11036.xml"),
+          )
+      )
+
+  public val icon_11037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11037.xml"),
+          )
+      )
+
+  public val icon_11038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11038.xml"),
+          )
+      )
+
+  public val icon_11039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11039.xml"),
+          )
+      )
+
+  public val icon_1104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1104.xml"),
+          )
+      )
+
+  public val icon_11040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11040.xml"),
+          )
+      )
+
+  public val icon_11041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11041.xml"),
+          )
+      )
+
+  public val icon_11042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11042.xml"),
+          )
+      )
+
+  public val icon_11043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11043.xml"),
+          )
+      )
+
+  public val icon_11044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11044.xml"),
+          )
+      )
+
+  public val icon_11045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11045.xml"),
+          )
+      )
+
+  public val icon_11046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11046.xml"),
+          )
+      )
+
+  public val icon_11047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11047.xml"),
+          )
+      )
+
+  public val icon_11048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11048.xml"),
+          )
+      )
+
+  public val icon_11049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11049.xml"),
+          )
+      )
+
+  public val icon_1105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1105.xml"),
+          )
+      )
+
+  public val icon_11050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11050.xml"),
+          )
+      )
+
+  public val icon_11051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11051.xml"),
+          )
+      )
+
+  public val icon_11052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11052.xml"),
+          )
+      )
+
+  public val icon_11053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11053.xml"),
+          )
+      )
+
+  public val icon_11054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11054.xml"),
+          )
+      )
+
+  public val icon_11055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11055.xml"),
+          )
+      )
+
+  public val icon_11056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11056.xml"),
+          )
+      )
+
+  public val icon_11057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11057.xml"),
+          )
+      )
+
+  public val icon_11058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11058.xml"),
+          )
+      )
+
+  public val icon_11059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11059.xml"),
+          )
+      )
+
+  public val icon_1106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1106.xml"),
+          )
+      )
+
+  public val icon_11060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11060.xml"),
+          )
+      )
+
+  public val icon_11061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11061.xml"),
+          )
+      )
+
+  public val icon_11062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11062.xml"),
+          )
+      )
+
+  public val icon_11063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11063.xml"),
+          )
+      )
+
+  public val icon_11064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11064.xml"),
+          )
+      )
+
+  public val icon_11065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11065.xml"),
+          )
+      )
+
+  public val icon_11066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11066.xml"),
+          )
+      )
+
+  public val icon_11067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11067.xml"),
+          )
+      )
+
+  public val icon_11068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11068.xml"),
+          )
+      )
+
+  public val icon_11069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11069.xml"),
+          )
+      )
+
+  public val icon_1107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1107.xml"),
+          )
+      )
+
+  public val icon_11070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11070.xml"),
+          )
+      )
+
+  public val icon_11071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11071.xml"),
+          )
+      )
+
+  public val icon_11072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11072.xml"),
+          )
+      )
+
+  public val icon_11073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11073.xml"),
+          )
+      )
+
+  public val icon_11074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11074.xml"),
+          )
+      )
+
+  public val icon_11075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11075.xml"),
+          )
+      )
+
+  public val icon_11076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11076.xml"),
+          )
+      )
+
+  public val icon_11077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11077.xml"),
+          )
+      )
+
+  public val icon_11078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11078.xml"),
+          )
+      )
+
+  public val icon_11079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11079.xml"),
+          )
+      )
+
+  public val icon_1108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1108.xml"),
+          )
+      )
+
+  public val icon_11080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11080.xml"),
+          )
+      )
+
+  public val icon_11081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11081.xml"),
+          )
+      )
+
+  public val icon_11082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11082.xml"),
+          )
+      )
+
+  public val icon_11083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11083.xml"),
+          )
+      )
+
+  public val icon_11084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11084.xml"),
+          )
+      )
+
+  public val icon_11085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11085.xml"),
+          )
+      )
+
+  public val icon_11086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11086.xml"),
+          )
+      )
+
+  public val icon_11087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11087.xml"),
+          )
+      )
+
+  public val icon_11088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11088.xml"),
+          )
+      )
+
+  public val icon_11089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11089.xml"),
+          )
+      )
+
+  public val icon_1109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1109.xml"),
+          )
+      )
+
+  public val icon_11090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11090.xml"),
+          )
+      )
+
+  public val icon_11091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11091.xml"),
+          )
+      )
+
+  public val icon_11092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11092.xml"),
+          )
+      )
+
+  public val icon_11093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11093.xml"),
+          )
+      )
+
+  public val icon_11094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11094.xml"),
+          )
+      )
+
+  public val icon_11095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11095.xml"),
+          )
+      )
+
+  public val icon_11096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11096.xml"),
+          )
+      )
+
+  public val icon_11097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11097.xml"),
+          )
+      )
+
+  public val icon_11098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11098.xml"),
+          )
+      )
+
+  public val icon_11099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11099.xml"),
+          )
+      )
+
+  public val icon_111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_111.xml"),
+          )
+      )
+
+  public val icon_1110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1110.xml"),
+          )
+      )
+
+  public val icon_11100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11100.xml"),
+          )
+      )
+
+  public val icon_11101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11101.xml"),
+          )
+      )
+
+  public val icon_11102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11102.xml"),
+          )
+      )
+
+  public val icon_11103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11103.xml"),
+          )
+      )
+
+  public val icon_11104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11104.xml"),
+          )
+      )
+
+  public val icon_11105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11105.xml"),
+          )
+      )
+
+  public val icon_11106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11106.xml"),
+          )
+      )
+
+  public val icon_11107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11107.xml"),
+          )
+      )
+
+  public val icon_11108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11108.xml"),
+          )
+      )
+
+  public val icon_11109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11109.xml"),
+          )
+      )
+
+  public val icon_1111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1111.xml"),
+          )
+      )
+
+  public val icon_11110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11110.xml"),
+          )
+      )
+
+  public val icon_11111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11111.xml"),
+          )
+      )
+
+  public val icon_11112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11112.xml"),
+          )
+      )
+
+  public val icon_11113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11113.xml"),
+          )
+      )
+
+  public val icon_11114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11114.xml"),
+          )
+      )
+
+  public val icon_11115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11115.xml"),
+          )
+      )
+
+  public val icon_11116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11116.xml"),
+          )
+      )
+
+  public val icon_11117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11117.xml"),
+          )
+      )
+
+  public val icon_11118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11118.xml"),
+          )
+      )
+
+  public val icon_11119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11119.xml"),
+          )
+      )
+
+  public val icon_1112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1112.xml"),
+          )
+      )
+
+  public val icon_11120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11120.xml"),
+          )
+      )
+
+  public val icon_11121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11121.xml"),
+          )
+      )
+
+  public val icon_11122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11122.xml"),
+          )
+      )
+
+  public val icon_11123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11123.xml"),
+          )
+      )
+
+  public val icon_11124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11124.xml"),
+          )
+      )
+
+  public val icon_11125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11125.xml"),
+          )
+      )
+
+  public val icon_11126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11126.xml"),
+          )
+      )
+
+  public val icon_11127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11127.xml"),
+          )
+      )
+
+  public val icon_11128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11128.xml"),
+          )
+      )
+
+  public val icon_11129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11129.xml"),
+          )
+      )
+
+  public val icon_1113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1113.xml"),
+          )
+      )
+
+  public val icon_11130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11130.xml"),
+          )
+      )
+
+  public val icon_11131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11131.xml"),
+          )
+      )
+
+  public val icon_11132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11132.xml"),
+          )
+      )
+
+  public val icon_11133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11133.xml"),
+          )
+      )
+
+  public val icon_11134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11134.xml"),
+          )
+      )
+
+  public val icon_11135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11135.xml"),
+          )
+      )
+
+  public val icon_11136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11136.xml"),
+          )
+      )
+
+  public val icon_11137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11137.xml"),
+          )
+      )
+
+  public val icon_11138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11138.xml"),
+          )
+      )
+
+  public val icon_11139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11139.xml"),
+          )
+      )
+
+  public val icon_1114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1114.xml"),
+          )
+      )
+
+  public val icon_11140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11140.xml"),
+          )
+      )
+
+  public val icon_11141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11141.xml"),
+          )
+      )
+
+  public val icon_11142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11142.xml"),
+          )
+      )
+
+  public val icon_11143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11143.xml"),
+          )
+      )
+
+  public val icon_11144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11144.xml"),
+          )
+      )
+
+  public val icon_11145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11145.xml"),
+          )
+      )
+
+  public val icon_11146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11146.xml"),
+          )
+      )
+
+  public val icon_11147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11147.xml"),
+          )
+      )
+
+  public val icon_11148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11148.xml"),
+          )
+      )
+
+  public val icon_11149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11149.xml"),
+          )
+      )
+
+  public val icon_1115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1115.xml"),
+          )
+      )
+
+  public val icon_11150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11150.xml"),
+          )
+      )
+
+  public val icon_11151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11151.xml"),
+          )
+      )
+
+  public val icon_11152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11152.xml"),
+          )
+      )
+
+  public val icon_11153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11153.xml"),
+          )
+      )
+
+  public val icon_11154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11154.xml"),
+          )
+      )
+
+  public val icon_11155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11155.xml"),
+          )
+      )
+
+  public val icon_11156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11156.xml"),
+          )
+      )
+
+  public val icon_11157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11157.xml"),
+          )
+      )
+
+  public val icon_11158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11158.xml"),
+          )
+      )
+
+  public val icon_11159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11159.xml"),
+          )
+      )
+
+  public val icon_1116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1116.xml"),
+          )
+      )
+
+  public val icon_11160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11160.xml"),
+          )
+      )
+
+  public val icon_11161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11161.xml"),
+          )
+      )
+
+  public val icon_11162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11162.xml"),
+          )
+      )
+
+  public val icon_11163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11163.xml"),
+          )
+      )
+
+  public val icon_11164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11164.xml"),
+          )
+      )
+
+  public val icon_11165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11165.xml"),
+          )
+      )
+
+  public val icon_11166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11166.xml"),
+          )
+      )
+
+  public val icon_11167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11167.xml"),
+          )
+      )
+
+  public val icon_11168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11168.xml"),
+          )
+      )
+
+  public val icon_11169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11169.xml"),
+          )
+      )
+
+  public val icon_1117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1117.xml"),
+          )
+      )
+
+  public val icon_11170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11170.xml"),
+          )
+      )
+
+  public val icon_11171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11171.xml"),
+          )
+      )
+
+  public val icon_11172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11172.xml"),
+          )
+      )
+
+  public val icon_11173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11173.xml"),
+          )
+      )
+
+  public val icon_11174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11174.xml"),
+          )
+      )
+
+  public val icon_11175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11175.xml"),
+          )
+      )
+
+  public val icon_11176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11176.xml"),
+          )
+      )
+
+  public val icon_11177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11177.xml"),
+          )
+      )
+
+  public val icon_11178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11178.xml"),
+          )
+      )
+
+  public val icon_11179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11179.xml"),
+          )
+      )
+
+  public val icon_1118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1118.xml"),
+          )
+      )
+
+  public val icon_11180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11180.xml"),
+          )
+      )
+
+  public val icon_11181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11181.xml"),
+          )
+      )
+
+  public val icon_11182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11182.xml"),
+          )
+      )
+
+  public val icon_11183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11183.xml"),
+          )
+      )
+
+  public val icon_11184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11184.xml"),
+          )
+      )
+
+  public val icon_11185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11185.xml"),
+          )
+      )
+
+  public val icon_11186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11186.xml"),
+          )
+      )
+
+  public val icon_11187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11187.xml"),
+          )
+      )
+
+  public val icon_11188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11188.xml"),
+          )
+      )
+
+  public val icon_11189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11189.xml"),
+          )
+      )
+
+  public val icon_1119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1119.xml"),
+          )
+      )
+
+  public val icon_11190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11190.xml"),
+          )
+      )
+
+  public val icon_11191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11191.xml"),
+          )
+      )
+
+  public val icon_11192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11192.xml"),
+          )
+      )
+
+  public val icon_11193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11193.xml"),
+          )
+      )
+
+  public val icon_11194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11194.xml"),
+          )
+      )
+
+  public val icon_11195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11195.xml"),
+          )
+      )
+
+  public val icon_11196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11196.xml"),
+          )
+      )
+
+  public val icon_11197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11197.xml"),
+          )
+      )
+
+  public val icon_11198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11198.xml"),
+          )
+      )
+
+  public val icon_11199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11199.xml"),
+          )
+      )
+
+  public val icon_112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_112.xml"),
+          )
+      )
+
+  public val icon_1120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1120.xml"),
+          )
+      )
+
+  public val icon_11200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11200.xml"),
+          )
+      )
+
+  public val icon_11201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11201.xml"),
+          )
+      )
+
+  public val icon_11202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11202.xml"),
+          )
+      )
+
+  public val icon_11203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11203.xml"),
+          )
+      )
+
+  public val icon_11204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11204.xml"),
+          )
+      )
+
+  public val icon_11205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11205.xml"),
+          )
+      )
+
+  public val icon_11206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11206.xml"),
+          )
+      )
+
+  public val icon_11207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11207.xml"),
+          )
+      )
+
+  public val icon_11208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11208.xml"),
+          )
+      )
+
+  public val icon_11209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11209.xml"),
+          )
+      )
+
+  public val icon_1121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1121.xml"),
+          )
+      )
+
+  public val icon_11210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11210.xml"),
+          )
+      )
+
+  public val icon_11211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11211.xml"),
+          )
+      )
+
+  public val icon_11212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11212.xml"),
+          )
+      )
+
+  public val icon_11213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11213.xml"),
+          )
+      )
+
+  public val icon_11214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11214.xml"),
+          )
+      )
+
+  public val icon_11215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11215.xml"),
+          )
+      )
+
+  public val icon_11216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11216.xml"),
+          )
+      )
+
+  public val icon_11217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11217.xml"),
+          )
+      )
+
+  public val icon_11218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11218.xml"),
+          )
+      )
+
+  public val icon_11219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11219.xml"),
+          )
+      )
+
+  public val icon_1122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1122.xml"),
+          )
+      )
+
+  public val icon_11220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11220.xml"),
+          )
+      )
+
+  public val icon_11221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11221.xml"),
+          )
+      )
+
+  public val icon_11222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11222.xml"),
+          )
+      )
+
+  public val icon_11223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11223.xml"),
+          )
+      )
+
+  public val icon_11224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11224.xml"),
+          )
+      )
+
+  public val icon_11225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11225.xml"),
+          )
+      )
+
+  public val icon_11226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11226.xml"),
+          )
+      )
+
+  public val icon_11227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11227.xml"),
+          )
+      )
+
+  public val icon_11228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11228.xml"),
+          )
+      )
+
+  public val icon_11229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11229.xml"),
+          )
+      )
+
+  public val icon_1123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1123.xml"),
+          )
+      )
+
+  public val icon_11230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11230.xml"),
+          )
+      )
+
+  public val icon_11231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11231.xml"),
+          )
+      )
+
+  public val icon_11232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11232.xml"),
+          )
+      )
+
+  public val icon_11233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11233.xml"),
+          )
+      )
+
+  public val icon_11234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11234.xml"),
+          )
+      )
+
+  public val icon_11235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11235.xml"),
+          )
+      )
+
+  public val icon_11236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11236.xml"),
+          )
+      )
+
+  public val icon_11237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11237.xml"),
+          )
+      )
+
+  public val icon_11238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11238.xml"),
+          )
+      )
+
+  public val icon_11239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11239.xml"),
+          )
+      )
+
+  public val icon_1124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1124.xml"),
+          )
+      )
+
+  public val icon_11240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11240.xml"),
+          )
+      )
+
+  public val icon_11241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11241.xml"),
+          )
+      )
+
+  public val icon_11242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11242.xml"),
+          )
+      )
+
+  public val icon_11243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11243.xml"),
+          )
+      )
+
+  public val icon_11244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11244.xml"),
+          )
+      )
+
+  public val icon_11245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11245.xml"),
+          )
+      )
+
+  public val icon_11246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11246.xml"),
+          )
+      )
+
+  public val icon_11247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11247.xml"),
+          )
+      )
+
+  public val icon_11248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11248.xml"),
+          )
+      )
+
+  public val icon_11249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11249.xml"),
+          )
+      )
+
+  public val icon_1125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1125.xml"),
+          )
+      )
+
+  public val icon_11250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11250.xml"),
+          )
+      )
+
+  public val icon_11251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11251.xml"),
+          )
+      )
+
+  public val icon_11252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11252.xml"),
+          )
+      )
+
+  public val icon_11253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11253.xml"),
+          )
+      )
+
+  public val icon_11254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11254.xml"),
+          )
+      )
+
+  public val icon_11255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11255.xml"),
+          )
+      )
+
+  public val icon_11256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11256.xml"),
+          )
+      )
+
+  public val icon_11257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11257.xml"),
+          )
+      )
+
+  public val icon_11258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11258.xml"),
+          )
+      )
+
+  public val icon_11259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11259.xml"),
+          )
+      )
+
+  public val icon_1126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1126.xml"),
+          )
+      )
+
+  public val icon_11260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11260.xml"),
+          )
+      )
+
+  public val icon_11261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11261.xml"),
+          )
+      )
+
+  public val icon_11262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11262.xml"),
+          )
+      )
+
+  public val icon_11263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11263.xml"),
+          )
+      )
+
+  public val icon_11264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11264.xml"),
+          )
+      )
+
+  public val icon_11265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11265.xml"),
+          )
+      )
+
+  public val icon_11266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11266.xml"),
+          )
+      )
+
+  public val icon_11267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11267.xml"),
+          )
+      )
+
+  public val icon_11268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11268.xml"),
+          )
+      )
+
+  public val icon_11269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11269.xml"),
+          )
+      )
+
+  public val icon_1127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1127.xml"),
+          )
+      )
+
+  public val icon_11270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11270.xml"),
+          )
+      )
+
+  public val icon_11271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11271.xml"),
+          )
+      )
+
+  public val icon_11272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11272.xml"),
+          )
+      )
+
+  public val icon_11273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11273.xml"),
+          )
+      )
+
+  public val icon_11274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11274.xml"),
+          )
+      )
+
+  public val icon_11275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11275.xml"),
+          )
+      )
+
+  public val icon_11276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11276.xml"),
+          )
+      )
+
+  public val icon_11277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11277.xml"),
+          )
+      )
+
+  public val icon_11278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11278.xml"),
+          )
+      )
+
+  public val icon_11279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11279.xml"),
+          )
+      )
+
+  public val icon_1128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1128.xml"),
+          )
+      )
+
+  public val icon_11280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11280.xml"),
+          )
+      )
+
+  public val icon_11281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11281.xml"),
+          )
+      )
+
+  public val icon_11282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11282.xml"),
+          )
+      )
+
+  public val icon_11283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11283.xml"),
+          )
+      )
+
+  public val icon_11284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11284.xml"),
+          )
+      )
+
+  public val icon_11285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11285.xml"),
+          )
+      )
+
+  public val icon_11286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11286.xml"),
+          )
+      )
+
+  public val icon_11287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11287.xml"),
+          )
+      )
+
+  public val icon_11288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11288.xml"),
+          )
+      )
+
+  public val icon_11289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11289.xml"),
+          )
+      )
+
+  public val icon_1129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1129.xml"),
+          )
+      )
+
+  public val icon_11290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11290.xml"),
+          )
+      )
+
+  public val icon_11291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11291.xml"),
+          )
+      )
+
+  public val icon_11292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11292.xml"),
+          )
+      )
+
+  public val icon_11293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11293.xml"),
+          )
+      )
+
+  public val icon_11294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11294.xml"),
+          )
+      )
+
+  public val icon_11295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11295.xml"),
+          )
+      )
+
+  public val icon_11296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11296.xml"),
+          )
+      )
+
+  public val icon_11297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11297.xml"),
+          )
+      )
+
+  public val icon_11298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11298.xml"),
+          )
+      )
+
+  public val icon_11299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11299.xml"),
+          )
+      )
+
+  public val icon_113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_113.xml"),
+          )
+      )
+
+  public val icon_1130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1130.xml"),
+          )
+      )
+
+  public val icon_11300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11300.xml"),
+          )
+      )
+
+  public val icon_11301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11301.xml"),
+          )
+      )
+
+  public val icon_11302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11302.xml"),
+          )
+      )
+
+  public val icon_11303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11303.xml"),
+          )
+      )
+
+  public val icon_11304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11304.xml"),
+          )
+      )
+
+  public val icon_11305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11305.xml"),
+          )
+      )
+
+  public val icon_11306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11306.xml"),
+          )
+      )
+
+  public val icon_11307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11307.xml"),
+          )
+      )
+
+  public val icon_11308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11308.xml"),
+          )
+      )
+
+  public val icon_11309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11309.xml"),
+          )
+      )
+
+  public val icon_1131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1131.xml"),
+          )
+      )
+
+  public val icon_11310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11310.xml"),
+          )
+      )
+
+  public val icon_11311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11311.xml"),
+          )
+      )
+
+  public val icon_11312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11312.xml"),
+          )
+      )
+
+  public val icon_11313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11313.xml"),
+          )
+      )
+
+  public val icon_11314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11314.xml"),
+          )
+      )
+
+  public val icon_11315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11315.xml"),
+          )
+      )
+
+  public val icon_11316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11316.xml"),
+          )
+      )
+
+  public val icon_11317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11317.xml"),
+          )
+      )
+
+  public val icon_11318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11318.xml"),
+          )
+      )
+
+  public val icon_11319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11319.xml"),
+          )
+      )
+
+  public val icon_1132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1132.xml"),
+          )
+      )
+
+  public val icon_11320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11320.xml"),
+          )
+      )
+
+  public val icon_11321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11321.xml"),
+          )
+      )
+
+  public val icon_11322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11322.xml"),
+          )
+      )
+
+  public val icon_11323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11323.xml"),
+          )
+      )
+
+  public val icon_11324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11324.xml"),
+          )
+      )
+
+  public val icon_11325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11325.xml"),
+          )
+      )
+
+  public val icon_11326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11326.xml"),
+          )
+      )
+
+  public val icon_11327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11327.xml"),
+          )
+      )
+
+  public val icon_11328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11328.xml"),
+          )
+      )
+
+  public val icon_11329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11329.xml"),
+          )
+      )
+
+  public val icon_1133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1133.xml"),
+          )
+      )
+
+  public val icon_11330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11330.xml"),
+          )
+      )
+
+  public val icon_11331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11331.xml"),
+          )
+      )
+
+  public val icon_11332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11332.xml"),
+          )
+      )
+
+  public val icon_11333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11333.xml"),
+          )
+      )
+
+  public val icon_11334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11334.xml"),
+          )
+      )
+
+  public val icon_11335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11335.xml"),
+          )
+      )
+
+  public val icon_11336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11336.xml"),
+          )
+      )
+
+  public val icon_11337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11337.xml"),
+          )
+      )
+
+  public val icon_11338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11338.xml"),
+          )
+      )
+
+  public val icon_11339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11339.xml"),
+          )
+      )
+
+  public val icon_1134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1134.xml"),
+          )
+      )
+
+  public val icon_11340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11340.xml"),
+          )
+      )
+
+  public val icon_11341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11341.xml"),
+          )
+      )
+
+  public val icon_11342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11342.xml"),
+          )
+      )
+
+  public val icon_11343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11343.xml"),
+          )
+      )
+
+  public val icon_11344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11344.xml"),
+          )
+      )
+
+  public val icon_11345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11345.xml"),
+          )
+      )
+
+  public val icon_11346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11346.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10898: DrawableResource
+  get() = Drawable2.icon_10898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10899: DrawableResource
+  get() = Drawable2.icon_10899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_109: DrawableResource
+  get() = Drawable2.icon_109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1090: DrawableResource
+  get() = Drawable2.icon_1090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10900: DrawableResource
+  get() = Drawable2.icon_10900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10901: DrawableResource
+  get() = Drawable2.icon_10901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10902: DrawableResource
+  get() = Drawable2.icon_10902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10903: DrawableResource
+  get() = Drawable2.icon_10903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10904: DrawableResource
+  get() = Drawable2.icon_10904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10905: DrawableResource
+  get() = Drawable2.icon_10905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10906: DrawableResource
+  get() = Drawable2.icon_10906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10907: DrawableResource
+  get() = Drawable2.icon_10907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10908: DrawableResource
+  get() = Drawable2.icon_10908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10909: DrawableResource
+  get() = Drawable2.icon_10909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1091: DrawableResource
+  get() = Drawable2.icon_1091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10910: DrawableResource
+  get() = Drawable2.icon_10910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10911: DrawableResource
+  get() = Drawable2.icon_10911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10912: DrawableResource
+  get() = Drawable2.icon_10912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10913: DrawableResource
+  get() = Drawable2.icon_10913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10914: DrawableResource
+  get() = Drawable2.icon_10914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10915: DrawableResource
+  get() = Drawable2.icon_10915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10916: DrawableResource
+  get() = Drawable2.icon_10916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10917: DrawableResource
+  get() = Drawable2.icon_10917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10918: DrawableResource
+  get() = Drawable2.icon_10918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10919: DrawableResource
+  get() = Drawable2.icon_10919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1092: DrawableResource
+  get() = Drawable2.icon_1092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10920: DrawableResource
+  get() = Drawable2.icon_10920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10921: DrawableResource
+  get() = Drawable2.icon_10921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10922: DrawableResource
+  get() = Drawable2.icon_10922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10923: DrawableResource
+  get() = Drawable2.icon_10923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10924: DrawableResource
+  get() = Drawable2.icon_10924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10925: DrawableResource
+  get() = Drawable2.icon_10925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10926: DrawableResource
+  get() = Drawable2.icon_10926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10927: DrawableResource
+  get() = Drawable2.icon_10927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10928: DrawableResource
+  get() = Drawable2.icon_10928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10929: DrawableResource
+  get() = Drawable2.icon_10929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1093: DrawableResource
+  get() = Drawable2.icon_1093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10930: DrawableResource
+  get() = Drawable2.icon_10930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10931: DrawableResource
+  get() = Drawable2.icon_10931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10932: DrawableResource
+  get() = Drawable2.icon_10932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10933: DrawableResource
+  get() = Drawable2.icon_10933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10934: DrawableResource
+  get() = Drawable2.icon_10934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10935: DrawableResource
+  get() = Drawable2.icon_10935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10936: DrawableResource
+  get() = Drawable2.icon_10936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10937: DrawableResource
+  get() = Drawable2.icon_10937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10938: DrawableResource
+  get() = Drawable2.icon_10938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10939: DrawableResource
+  get() = Drawable2.icon_10939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1094: DrawableResource
+  get() = Drawable2.icon_1094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10940: DrawableResource
+  get() = Drawable2.icon_10940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10941: DrawableResource
+  get() = Drawable2.icon_10941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10942: DrawableResource
+  get() = Drawable2.icon_10942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10943: DrawableResource
+  get() = Drawable2.icon_10943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10944: DrawableResource
+  get() = Drawable2.icon_10944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10945: DrawableResource
+  get() = Drawable2.icon_10945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10946: DrawableResource
+  get() = Drawable2.icon_10946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10947: DrawableResource
+  get() = Drawable2.icon_10947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10948: DrawableResource
+  get() = Drawable2.icon_10948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10949: DrawableResource
+  get() = Drawable2.icon_10949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1095: DrawableResource
+  get() = Drawable2.icon_1095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10950: DrawableResource
+  get() = Drawable2.icon_10950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10951: DrawableResource
+  get() = Drawable2.icon_10951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10952: DrawableResource
+  get() = Drawable2.icon_10952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10953: DrawableResource
+  get() = Drawable2.icon_10953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10954: DrawableResource
+  get() = Drawable2.icon_10954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10955: DrawableResource
+  get() = Drawable2.icon_10955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10956: DrawableResource
+  get() = Drawable2.icon_10956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10957: DrawableResource
+  get() = Drawable2.icon_10957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10958: DrawableResource
+  get() = Drawable2.icon_10958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10959: DrawableResource
+  get() = Drawable2.icon_10959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1096: DrawableResource
+  get() = Drawable2.icon_1096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10960: DrawableResource
+  get() = Drawable2.icon_10960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10961: DrawableResource
+  get() = Drawable2.icon_10961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10962: DrawableResource
+  get() = Drawable2.icon_10962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10963: DrawableResource
+  get() = Drawable2.icon_10963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10964: DrawableResource
+  get() = Drawable2.icon_10964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10965: DrawableResource
+  get() = Drawable2.icon_10965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10966: DrawableResource
+  get() = Drawable2.icon_10966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10967: DrawableResource
+  get() = Drawable2.icon_10967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10968: DrawableResource
+  get() = Drawable2.icon_10968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10969: DrawableResource
+  get() = Drawable2.icon_10969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1097: DrawableResource
+  get() = Drawable2.icon_1097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10970: DrawableResource
+  get() = Drawable2.icon_10970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10971: DrawableResource
+  get() = Drawable2.icon_10971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10972: DrawableResource
+  get() = Drawable2.icon_10972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10973: DrawableResource
+  get() = Drawable2.icon_10973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10974: DrawableResource
+  get() = Drawable2.icon_10974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10975: DrawableResource
+  get() = Drawable2.icon_10975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10976: DrawableResource
+  get() = Drawable2.icon_10976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10977: DrawableResource
+  get() = Drawable2.icon_10977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10978: DrawableResource
+  get() = Drawable2.icon_10978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10979: DrawableResource
+  get() = Drawable2.icon_10979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1098: DrawableResource
+  get() = Drawable2.icon_1098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10980: DrawableResource
+  get() = Drawable2.icon_10980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10981: DrawableResource
+  get() = Drawable2.icon_10981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10982: DrawableResource
+  get() = Drawable2.icon_10982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10983: DrawableResource
+  get() = Drawable2.icon_10983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10984: DrawableResource
+  get() = Drawable2.icon_10984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10985: DrawableResource
+  get() = Drawable2.icon_10985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10986: DrawableResource
+  get() = Drawable2.icon_10986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10987: DrawableResource
+  get() = Drawable2.icon_10987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10988: DrawableResource
+  get() = Drawable2.icon_10988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10989: DrawableResource
+  get() = Drawable2.icon_10989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1099: DrawableResource
+  get() = Drawable2.icon_1099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10990: DrawableResource
+  get() = Drawable2.icon_10990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10991: DrawableResource
+  get() = Drawable2.icon_10991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10992: DrawableResource
+  get() = Drawable2.icon_10992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10993: DrawableResource
+  get() = Drawable2.icon_10993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10994: DrawableResource
+  get() = Drawable2.icon_10994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10995: DrawableResource
+  get() = Drawable2.icon_10995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10996: DrawableResource
+  get() = Drawable2.icon_10996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10997: DrawableResource
+  get() = Drawable2.icon_10997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10998: DrawableResource
+  get() = Drawable2.icon_10998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_10999: DrawableResource
+  get() = Drawable2.icon_10999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11: DrawableResource
+  get() = Drawable2.icon_11
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_110: DrawableResource
+  get() = Drawable2.icon_110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1100: DrawableResource
+  get() = Drawable2.icon_1100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11000: DrawableResource
+  get() = Drawable2.icon_11000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11001: DrawableResource
+  get() = Drawable2.icon_11001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11002: DrawableResource
+  get() = Drawable2.icon_11002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11003: DrawableResource
+  get() = Drawable2.icon_11003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11004: DrawableResource
+  get() = Drawable2.icon_11004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11005: DrawableResource
+  get() = Drawable2.icon_11005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11006: DrawableResource
+  get() = Drawable2.icon_11006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11007: DrawableResource
+  get() = Drawable2.icon_11007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11008: DrawableResource
+  get() = Drawable2.icon_11008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11009: DrawableResource
+  get() = Drawable2.icon_11009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1101: DrawableResource
+  get() = Drawable2.icon_1101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11010: DrawableResource
+  get() = Drawable2.icon_11010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11011: DrawableResource
+  get() = Drawable2.icon_11011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11012: DrawableResource
+  get() = Drawable2.icon_11012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11013: DrawableResource
+  get() = Drawable2.icon_11013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11014: DrawableResource
+  get() = Drawable2.icon_11014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11015: DrawableResource
+  get() = Drawable2.icon_11015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11016: DrawableResource
+  get() = Drawable2.icon_11016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11017: DrawableResource
+  get() = Drawable2.icon_11017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11018: DrawableResource
+  get() = Drawable2.icon_11018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11019: DrawableResource
+  get() = Drawable2.icon_11019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1102: DrawableResource
+  get() = Drawable2.icon_1102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11020: DrawableResource
+  get() = Drawable2.icon_11020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11021: DrawableResource
+  get() = Drawable2.icon_11021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11022: DrawableResource
+  get() = Drawable2.icon_11022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11023: DrawableResource
+  get() = Drawable2.icon_11023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11024: DrawableResource
+  get() = Drawable2.icon_11024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11025: DrawableResource
+  get() = Drawable2.icon_11025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11026: DrawableResource
+  get() = Drawable2.icon_11026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11027: DrawableResource
+  get() = Drawable2.icon_11027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11028: DrawableResource
+  get() = Drawable2.icon_11028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11029: DrawableResource
+  get() = Drawable2.icon_11029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1103: DrawableResource
+  get() = Drawable2.icon_1103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11030: DrawableResource
+  get() = Drawable2.icon_11030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11031: DrawableResource
+  get() = Drawable2.icon_11031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11032: DrawableResource
+  get() = Drawable2.icon_11032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11033: DrawableResource
+  get() = Drawable2.icon_11033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11034: DrawableResource
+  get() = Drawable2.icon_11034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11035: DrawableResource
+  get() = Drawable2.icon_11035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11036: DrawableResource
+  get() = Drawable2.icon_11036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11037: DrawableResource
+  get() = Drawable2.icon_11037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11038: DrawableResource
+  get() = Drawable2.icon_11038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11039: DrawableResource
+  get() = Drawable2.icon_11039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1104: DrawableResource
+  get() = Drawable2.icon_1104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11040: DrawableResource
+  get() = Drawable2.icon_11040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11041: DrawableResource
+  get() = Drawable2.icon_11041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11042: DrawableResource
+  get() = Drawable2.icon_11042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11043: DrawableResource
+  get() = Drawable2.icon_11043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11044: DrawableResource
+  get() = Drawable2.icon_11044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11045: DrawableResource
+  get() = Drawable2.icon_11045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11046: DrawableResource
+  get() = Drawable2.icon_11046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11047: DrawableResource
+  get() = Drawable2.icon_11047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11048: DrawableResource
+  get() = Drawable2.icon_11048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11049: DrawableResource
+  get() = Drawable2.icon_11049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1105: DrawableResource
+  get() = Drawable2.icon_1105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11050: DrawableResource
+  get() = Drawable2.icon_11050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11051: DrawableResource
+  get() = Drawable2.icon_11051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11052: DrawableResource
+  get() = Drawable2.icon_11052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11053: DrawableResource
+  get() = Drawable2.icon_11053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11054: DrawableResource
+  get() = Drawable2.icon_11054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11055: DrawableResource
+  get() = Drawable2.icon_11055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11056: DrawableResource
+  get() = Drawable2.icon_11056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11057: DrawableResource
+  get() = Drawable2.icon_11057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11058: DrawableResource
+  get() = Drawable2.icon_11058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11059: DrawableResource
+  get() = Drawable2.icon_11059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1106: DrawableResource
+  get() = Drawable2.icon_1106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11060: DrawableResource
+  get() = Drawable2.icon_11060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11061: DrawableResource
+  get() = Drawable2.icon_11061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11062: DrawableResource
+  get() = Drawable2.icon_11062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11063: DrawableResource
+  get() = Drawable2.icon_11063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11064: DrawableResource
+  get() = Drawable2.icon_11064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11065: DrawableResource
+  get() = Drawable2.icon_11065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11066: DrawableResource
+  get() = Drawable2.icon_11066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11067: DrawableResource
+  get() = Drawable2.icon_11067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11068: DrawableResource
+  get() = Drawable2.icon_11068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11069: DrawableResource
+  get() = Drawable2.icon_11069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1107: DrawableResource
+  get() = Drawable2.icon_1107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11070: DrawableResource
+  get() = Drawable2.icon_11070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11071: DrawableResource
+  get() = Drawable2.icon_11071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11072: DrawableResource
+  get() = Drawable2.icon_11072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11073: DrawableResource
+  get() = Drawable2.icon_11073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11074: DrawableResource
+  get() = Drawable2.icon_11074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11075: DrawableResource
+  get() = Drawable2.icon_11075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11076: DrawableResource
+  get() = Drawable2.icon_11076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11077: DrawableResource
+  get() = Drawable2.icon_11077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11078: DrawableResource
+  get() = Drawable2.icon_11078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11079: DrawableResource
+  get() = Drawable2.icon_11079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1108: DrawableResource
+  get() = Drawable2.icon_1108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11080: DrawableResource
+  get() = Drawable2.icon_11080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11081: DrawableResource
+  get() = Drawable2.icon_11081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11082: DrawableResource
+  get() = Drawable2.icon_11082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11083: DrawableResource
+  get() = Drawable2.icon_11083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11084: DrawableResource
+  get() = Drawable2.icon_11084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11085: DrawableResource
+  get() = Drawable2.icon_11085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11086: DrawableResource
+  get() = Drawable2.icon_11086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11087: DrawableResource
+  get() = Drawable2.icon_11087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11088: DrawableResource
+  get() = Drawable2.icon_11088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11089: DrawableResource
+  get() = Drawable2.icon_11089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1109: DrawableResource
+  get() = Drawable2.icon_1109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11090: DrawableResource
+  get() = Drawable2.icon_11090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11091: DrawableResource
+  get() = Drawable2.icon_11091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11092: DrawableResource
+  get() = Drawable2.icon_11092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11093: DrawableResource
+  get() = Drawable2.icon_11093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11094: DrawableResource
+  get() = Drawable2.icon_11094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11095: DrawableResource
+  get() = Drawable2.icon_11095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11096: DrawableResource
+  get() = Drawable2.icon_11096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11097: DrawableResource
+  get() = Drawable2.icon_11097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11098: DrawableResource
+  get() = Drawable2.icon_11098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11099: DrawableResource
+  get() = Drawable2.icon_11099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_111: DrawableResource
+  get() = Drawable2.icon_111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1110: DrawableResource
+  get() = Drawable2.icon_1110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11100: DrawableResource
+  get() = Drawable2.icon_11100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11101: DrawableResource
+  get() = Drawable2.icon_11101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11102: DrawableResource
+  get() = Drawable2.icon_11102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11103: DrawableResource
+  get() = Drawable2.icon_11103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11104: DrawableResource
+  get() = Drawable2.icon_11104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11105: DrawableResource
+  get() = Drawable2.icon_11105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11106: DrawableResource
+  get() = Drawable2.icon_11106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11107: DrawableResource
+  get() = Drawable2.icon_11107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11108: DrawableResource
+  get() = Drawable2.icon_11108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11109: DrawableResource
+  get() = Drawable2.icon_11109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1111: DrawableResource
+  get() = Drawable2.icon_1111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11110: DrawableResource
+  get() = Drawable2.icon_11110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11111: DrawableResource
+  get() = Drawable2.icon_11111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11112: DrawableResource
+  get() = Drawable2.icon_11112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11113: DrawableResource
+  get() = Drawable2.icon_11113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11114: DrawableResource
+  get() = Drawable2.icon_11114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11115: DrawableResource
+  get() = Drawable2.icon_11115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11116: DrawableResource
+  get() = Drawable2.icon_11116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11117: DrawableResource
+  get() = Drawable2.icon_11117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11118: DrawableResource
+  get() = Drawable2.icon_11118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11119: DrawableResource
+  get() = Drawable2.icon_11119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1112: DrawableResource
+  get() = Drawable2.icon_1112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11120: DrawableResource
+  get() = Drawable2.icon_11120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11121: DrawableResource
+  get() = Drawable2.icon_11121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11122: DrawableResource
+  get() = Drawable2.icon_11122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11123: DrawableResource
+  get() = Drawable2.icon_11123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11124: DrawableResource
+  get() = Drawable2.icon_11124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11125: DrawableResource
+  get() = Drawable2.icon_11125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11126: DrawableResource
+  get() = Drawable2.icon_11126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11127: DrawableResource
+  get() = Drawable2.icon_11127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11128: DrawableResource
+  get() = Drawable2.icon_11128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11129: DrawableResource
+  get() = Drawable2.icon_11129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1113: DrawableResource
+  get() = Drawable2.icon_1113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11130: DrawableResource
+  get() = Drawable2.icon_11130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11131: DrawableResource
+  get() = Drawable2.icon_11131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11132: DrawableResource
+  get() = Drawable2.icon_11132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11133: DrawableResource
+  get() = Drawable2.icon_11133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11134: DrawableResource
+  get() = Drawable2.icon_11134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11135: DrawableResource
+  get() = Drawable2.icon_11135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11136: DrawableResource
+  get() = Drawable2.icon_11136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11137: DrawableResource
+  get() = Drawable2.icon_11137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11138: DrawableResource
+  get() = Drawable2.icon_11138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11139: DrawableResource
+  get() = Drawable2.icon_11139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1114: DrawableResource
+  get() = Drawable2.icon_1114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11140: DrawableResource
+  get() = Drawable2.icon_11140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11141: DrawableResource
+  get() = Drawable2.icon_11141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11142: DrawableResource
+  get() = Drawable2.icon_11142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11143: DrawableResource
+  get() = Drawable2.icon_11143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11144: DrawableResource
+  get() = Drawable2.icon_11144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11145: DrawableResource
+  get() = Drawable2.icon_11145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11146: DrawableResource
+  get() = Drawable2.icon_11146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11147: DrawableResource
+  get() = Drawable2.icon_11147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11148: DrawableResource
+  get() = Drawable2.icon_11148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11149: DrawableResource
+  get() = Drawable2.icon_11149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1115: DrawableResource
+  get() = Drawable2.icon_1115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11150: DrawableResource
+  get() = Drawable2.icon_11150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11151: DrawableResource
+  get() = Drawable2.icon_11151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11152: DrawableResource
+  get() = Drawable2.icon_11152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11153: DrawableResource
+  get() = Drawable2.icon_11153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11154: DrawableResource
+  get() = Drawable2.icon_11154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11155: DrawableResource
+  get() = Drawable2.icon_11155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11156: DrawableResource
+  get() = Drawable2.icon_11156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11157: DrawableResource
+  get() = Drawable2.icon_11157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11158: DrawableResource
+  get() = Drawable2.icon_11158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11159: DrawableResource
+  get() = Drawable2.icon_11159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1116: DrawableResource
+  get() = Drawable2.icon_1116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11160: DrawableResource
+  get() = Drawable2.icon_11160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11161: DrawableResource
+  get() = Drawable2.icon_11161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11162: DrawableResource
+  get() = Drawable2.icon_11162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11163: DrawableResource
+  get() = Drawable2.icon_11163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11164: DrawableResource
+  get() = Drawable2.icon_11164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11165: DrawableResource
+  get() = Drawable2.icon_11165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11166: DrawableResource
+  get() = Drawable2.icon_11166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11167: DrawableResource
+  get() = Drawable2.icon_11167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11168: DrawableResource
+  get() = Drawable2.icon_11168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11169: DrawableResource
+  get() = Drawable2.icon_11169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1117: DrawableResource
+  get() = Drawable2.icon_1117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11170: DrawableResource
+  get() = Drawable2.icon_11170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11171: DrawableResource
+  get() = Drawable2.icon_11171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11172: DrawableResource
+  get() = Drawable2.icon_11172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11173: DrawableResource
+  get() = Drawable2.icon_11173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11174: DrawableResource
+  get() = Drawable2.icon_11174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11175: DrawableResource
+  get() = Drawable2.icon_11175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11176: DrawableResource
+  get() = Drawable2.icon_11176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11177: DrawableResource
+  get() = Drawable2.icon_11177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11178: DrawableResource
+  get() = Drawable2.icon_11178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11179: DrawableResource
+  get() = Drawable2.icon_11179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1118: DrawableResource
+  get() = Drawable2.icon_1118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11180: DrawableResource
+  get() = Drawable2.icon_11180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11181: DrawableResource
+  get() = Drawable2.icon_11181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11182: DrawableResource
+  get() = Drawable2.icon_11182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11183: DrawableResource
+  get() = Drawable2.icon_11183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11184: DrawableResource
+  get() = Drawable2.icon_11184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11185: DrawableResource
+  get() = Drawable2.icon_11185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11186: DrawableResource
+  get() = Drawable2.icon_11186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11187: DrawableResource
+  get() = Drawable2.icon_11187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11188: DrawableResource
+  get() = Drawable2.icon_11188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11189: DrawableResource
+  get() = Drawable2.icon_11189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1119: DrawableResource
+  get() = Drawable2.icon_1119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11190: DrawableResource
+  get() = Drawable2.icon_11190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11191: DrawableResource
+  get() = Drawable2.icon_11191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11192: DrawableResource
+  get() = Drawable2.icon_11192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11193: DrawableResource
+  get() = Drawable2.icon_11193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11194: DrawableResource
+  get() = Drawable2.icon_11194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11195: DrawableResource
+  get() = Drawable2.icon_11195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11196: DrawableResource
+  get() = Drawable2.icon_11196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11197: DrawableResource
+  get() = Drawable2.icon_11197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11198: DrawableResource
+  get() = Drawable2.icon_11198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11199: DrawableResource
+  get() = Drawable2.icon_11199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_112: DrawableResource
+  get() = Drawable2.icon_112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1120: DrawableResource
+  get() = Drawable2.icon_1120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11200: DrawableResource
+  get() = Drawable2.icon_11200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11201: DrawableResource
+  get() = Drawable2.icon_11201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11202: DrawableResource
+  get() = Drawable2.icon_11202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11203: DrawableResource
+  get() = Drawable2.icon_11203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11204: DrawableResource
+  get() = Drawable2.icon_11204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11205: DrawableResource
+  get() = Drawable2.icon_11205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11206: DrawableResource
+  get() = Drawable2.icon_11206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11207: DrawableResource
+  get() = Drawable2.icon_11207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11208: DrawableResource
+  get() = Drawable2.icon_11208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11209: DrawableResource
+  get() = Drawable2.icon_11209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1121: DrawableResource
+  get() = Drawable2.icon_1121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11210: DrawableResource
+  get() = Drawable2.icon_11210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11211: DrawableResource
+  get() = Drawable2.icon_11211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11212: DrawableResource
+  get() = Drawable2.icon_11212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11213: DrawableResource
+  get() = Drawable2.icon_11213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11214: DrawableResource
+  get() = Drawable2.icon_11214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11215: DrawableResource
+  get() = Drawable2.icon_11215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11216: DrawableResource
+  get() = Drawable2.icon_11216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11217: DrawableResource
+  get() = Drawable2.icon_11217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11218: DrawableResource
+  get() = Drawable2.icon_11218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11219: DrawableResource
+  get() = Drawable2.icon_11219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1122: DrawableResource
+  get() = Drawable2.icon_1122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11220: DrawableResource
+  get() = Drawable2.icon_11220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11221: DrawableResource
+  get() = Drawable2.icon_11221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11222: DrawableResource
+  get() = Drawable2.icon_11222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11223: DrawableResource
+  get() = Drawable2.icon_11223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11224: DrawableResource
+  get() = Drawable2.icon_11224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11225: DrawableResource
+  get() = Drawable2.icon_11225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11226: DrawableResource
+  get() = Drawable2.icon_11226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11227: DrawableResource
+  get() = Drawable2.icon_11227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11228: DrawableResource
+  get() = Drawable2.icon_11228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11229: DrawableResource
+  get() = Drawable2.icon_11229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1123: DrawableResource
+  get() = Drawable2.icon_1123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11230: DrawableResource
+  get() = Drawable2.icon_11230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11231: DrawableResource
+  get() = Drawable2.icon_11231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11232: DrawableResource
+  get() = Drawable2.icon_11232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11233: DrawableResource
+  get() = Drawable2.icon_11233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11234: DrawableResource
+  get() = Drawable2.icon_11234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11235: DrawableResource
+  get() = Drawable2.icon_11235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11236: DrawableResource
+  get() = Drawable2.icon_11236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11237: DrawableResource
+  get() = Drawable2.icon_11237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11238: DrawableResource
+  get() = Drawable2.icon_11238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11239: DrawableResource
+  get() = Drawable2.icon_11239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1124: DrawableResource
+  get() = Drawable2.icon_1124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11240: DrawableResource
+  get() = Drawable2.icon_11240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11241: DrawableResource
+  get() = Drawable2.icon_11241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11242: DrawableResource
+  get() = Drawable2.icon_11242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11243: DrawableResource
+  get() = Drawable2.icon_11243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11244: DrawableResource
+  get() = Drawable2.icon_11244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11245: DrawableResource
+  get() = Drawable2.icon_11245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11246: DrawableResource
+  get() = Drawable2.icon_11246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11247: DrawableResource
+  get() = Drawable2.icon_11247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11248: DrawableResource
+  get() = Drawable2.icon_11248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11249: DrawableResource
+  get() = Drawable2.icon_11249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1125: DrawableResource
+  get() = Drawable2.icon_1125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11250: DrawableResource
+  get() = Drawable2.icon_11250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11251: DrawableResource
+  get() = Drawable2.icon_11251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11252: DrawableResource
+  get() = Drawable2.icon_11252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11253: DrawableResource
+  get() = Drawable2.icon_11253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11254: DrawableResource
+  get() = Drawable2.icon_11254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11255: DrawableResource
+  get() = Drawable2.icon_11255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11256: DrawableResource
+  get() = Drawable2.icon_11256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11257: DrawableResource
+  get() = Drawable2.icon_11257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11258: DrawableResource
+  get() = Drawable2.icon_11258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11259: DrawableResource
+  get() = Drawable2.icon_11259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1126: DrawableResource
+  get() = Drawable2.icon_1126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11260: DrawableResource
+  get() = Drawable2.icon_11260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11261: DrawableResource
+  get() = Drawable2.icon_11261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11262: DrawableResource
+  get() = Drawable2.icon_11262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11263: DrawableResource
+  get() = Drawable2.icon_11263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11264: DrawableResource
+  get() = Drawable2.icon_11264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11265: DrawableResource
+  get() = Drawable2.icon_11265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11266: DrawableResource
+  get() = Drawable2.icon_11266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11267: DrawableResource
+  get() = Drawable2.icon_11267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11268: DrawableResource
+  get() = Drawable2.icon_11268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11269: DrawableResource
+  get() = Drawable2.icon_11269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1127: DrawableResource
+  get() = Drawable2.icon_1127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11270: DrawableResource
+  get() = Drawable2.icon_11270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11271: DrawableResource
+  get() = Drawable2.icon_11271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11272: DrawableResource
+  get() = Drawable2.icon_11272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11273: DrawableResource
+  get() = Drawable2.icon_11273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11274: DrawableResource
+  get() = Drawable2.icon_11274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11275: DrawableResource
+  get() = Drawable2.icon_11275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11276: DrawableResource
+  get() = Drawable2.icon_11276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11277: DrawableResource
+  get() = Drawable2.icon_11277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11278: DrawableResource
+  get() = Drawable2.icon_11278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11279: DrawableResource
+  get() = Drawable2.icon_11279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1128: DrawableResource
+  get() = Drawable2.icon_1128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11280: DrawableResource
+  get() = Drawable2.icon_11280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11281: DrawableResource
+  get() = Drawable2.icon_11281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11282: DrawableResource
+  get() = Drawable2.icon_11282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11283: DrawableResource
+  get() = Drawable2.icon_11283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11284: DrawableResource
+  get() = Drawable2.icon_11284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11285: DrawableResource
+  get() = Drawable2.icon_11285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11286: DrawableResource
+  get() = Drawable2.icon_11286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11287: DrawableResource
+  get() = Drawable2.icon_11287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11288: DrawableResource
+  get() = Drawable2.icon_11288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11289: DrawableResource
+  get() = Drawable2.icon_11289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1129: DrawableResource
+  get() = Drawable2.icon_1129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11290: DrawableResource
+  get() = Drawable2.icon_11290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11291: DrawableResource
+  get() = Drawable2.icon_11291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11292: DrawableResource
+  get() = Drawable2.icon_11292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11293: DrawableResource
+  get() = Drawable2.icon_11293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11294: DrawableResource
+  get() = Drawable2.icon_11294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11295: DrawableResource
+  get() = Drawable2.icon_11295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11296: DrawableResource
+  get() = Drawable2.icon_11296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11297: DrawableResource
+  get() = Drawable2.icon_11297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11298: DrawableResource
+  get() = Drawable2.icon_11298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11299: DrawableResource
+  get() = Drawable2.icon_11299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_113: DrawableResource
+  get() = Drawable2.icon_113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1130: DrawableResource
+  get() = Drawable2.icon_1130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11300: DrawableResource
+  get() = Drawable2.icon_11300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11301: DrawableResource
+  get() = Drawable2.icon_11301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11302: DrawableResource
+  get() = Drawable2.icon_11302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11303: DrawableResource
+  get() = Drawable2.icon_11303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11304: DrawableResource
+  get() = Drawable2.icon_11304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11305: DrawableResource
+  get() = Drawable2.icon_11305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11306: DrawableResource
+  get() = Drawable2.icon_11306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11307: DrawableResource
+  get() = Drawable2.icon_11307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11308: DrawableResource
+  get() = Drawable2.icon_11308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11309: DrawableResource
+  get() = Drawable2.icon_11309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1131: DrawableResource
+  get() = Drawable2.icon_1131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11310: DrawableResource
+  get() = Drawable2.icon_11310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11311: DrawableResource
+  get() = Drawable2.icon_11311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11312: DrawableResource
+  get() = Drawable2.icon_11312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11313: DrawableResource
+  get() = Drawable2.icon_11313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11314: DrawableResource
+  get() = Drawable2.icon_11314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11315: DrawableResource
+  get() = Drawable2.icon_11315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11316: DrawableResource
+  get() = Drawable2.icon_11316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11317: DrawableResource
+  get() = Drawable2.icon_11317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11318: DrawableResource
+  get() = Drawable2.icon_11318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11319: DrawableResource
+  get() = Drawable2.icon_11319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1132: DrawableResource
+  get() = Drawable2.icon_1132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11320: DrawableResource
+  get() = Drawable2.icon_11320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11321: DrawableResource
+  get() = Drawable2.icon_11321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11322: DrawableResource
+  get() = Drawable2.icon_11322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11323: DrawableResource
+  get() = Drawable2.icon_11323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11324: DrawableResource
+  get() = Drawable2.icon_11324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11325: DrawableResource
+  get() = Drawable2.icon_11325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11326: DrawableResource
+  get() = Drawable2.icon_11326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11327: DrawableResource
+  get() = Drawable2.icon_11327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11328: DrawableResource
+  get() = Drawable2.icon_11328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11329: DrawableResource
+  get() = Drawable2.icon_11329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1133: DrawableResource
+  get() = Drawable2.icon_1133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11330: DrawableResource
+  get() = Drawable2.icon_11330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11331: DrawableResource
+  get() = Drawable2.icon_11331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11332: DrawableResource
+  get() = Drawable2.icon_11332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11333: DrawableResource
+  get() = Drawable2.icon_11333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11334: DrawableResource
+  get() = Drawable2.icon_11334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11335: DrawableResource
+  get() = Drawable2.icon_11335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11336: DrawableResource
+  get() = Drawable2.icon_11336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11337: DrawableResource
+  get() = Drawable2.icon_11337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11338: DrawableResource
+  get() = Drawable2.icon_11338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11339: DrawableResource
+  get() = Drawable2.icon_11339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1134: DrawableResource
+  get() = Drawable2.icon_1134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11340: DrawableResource
+  get() = Drawable2.icon_11340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11341: DrawableResource
+  get() = Drawable2.icon_11341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11342: DrawableResource
+  get() = Drawable2.icon_11342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11343: DrawableResource
+  get() = Drawable2.icon_11343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11344: DrawableResource
+  get() = Drawable2.icon_11344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11345: DrawableResource
+  get() = Drawable2.icon_11345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11346: DrawableResource
+  get() = Drawable2.icon_11346

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable20.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable20.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable20 {
+  public val icon_18999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_18999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_18999.xml"),
+          )
+      )
+
+  public val icon_19: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19.xml"),
+          )
+      )
+
+  public val icon_190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_190.xml"),
+          )
+      )
+
+  public val icon_1900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1900.xml"),
+          )
+      )
+
+  public val icon_19000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19000.xml"),
+          )
+      )
+
+  public val icon_19001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19001.xml"),
+          )
+      )
+
+  public val icon_19002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19002.xml"),
+          )
+      )
+
+  public val icon_19003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19003.xml"),
+          )
+      )
+
+  public val icon_19004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19004.xml"),
+          )
+      )
+
+  public val icon_19005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19005.xml"),
+          )
+      )
+
+  public val icon_19006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19006.xml"),
+          )
+      )
+
+  public val icon_19007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19007.xml"),
+          )
+      )
+
+  public val icon_19008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19008.xml"),
+          )
+      )
+
+  public val icon_19009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19009.xml"),
+          )
+      )
+
+  public val icon_1901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1901.xml"),
+          )
+      )
+
+  public val icon_19010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19010.xml"),
+          )
+      )
+
+  public val icon_19011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19011.xml"),
+          )
+      )
+
+  public val icon_19012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19012.xml"),
+          )
+      )
+
+  public val icon_19013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19013.xml"),
+          )
+      )
+
+  public val icon_19014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19014.xml"),
+          )
+      )
+
+  public val icon_19015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19015.xml"),
+          )
+      )
+
+  public val icon_19016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19016.xml"),
+          )
+      )
+
+  public val icon_19017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19017.xml"),
+          )
+      )
+
+  public val icon_19018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19018.xml"),
+          )
+      )
+
+  public val icon_19019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19019.xml"),
+          )
+      )
+
+  public val icon_1902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1902.xml"),
+          )
+      )
+
+  public val icon_19020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19020.xml"),
+          )
+      )
+
+  public val icon_19021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19021.xml"),
+          )
+      )
+
+  public val icon_19022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19022.xml"),
+          )
+      )
+
+  public val icon_19023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19023.xml"),
+          )
+      )
+
+  public val icon_19024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19024.xml"),
+          )
+      )
+
+  public val icon_19025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19025.xml"),
+          )
+      )
+
+  public val icon_19026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19026.xml"),
+          )
+      )
+
+  public val icon_19027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19027.xml"),
+          )
+      )
+
+  public val icon_19028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19028.xml"),
+          )
+      )
+
+  public val icon_19029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19029.xml"),
+          )
+      )
+
+  public val icon_1903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1903.xml"),
+          )
+      )
+
+  public val icon_19030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19030.xml"),
+          )
+      )
+
+  public val icon_19031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19031.xml"),
+          )
+      )
+
+  public val icon_19032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19032.xml"),
+          )
+      )
+
+  public val icon_19033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19033.xml"),
+          )
+      )
+
+  public val icon_19034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19034.xml"),
+          )
+      )
+
+  public val icon_19035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19035.xml"),
+          )
+      )
+
+  public val icon_19036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19036.xml"),
+          )
+      )
+
+  public val icon_19037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19037.xml"),
+          )
+      )
+
+  public val icon_19038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19038.xml"),
+          )
+      )
+
+  public val icon_19039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19039.xml"),
+          )
+      )
+
+  public val icon_1904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1904.xml"),
+          )
+      )
+
+  public val icon_19040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19040.xml"),
+          )
+      )
+
+  public val icon_19041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19041.xml"),
+          )
+      )
+
+  public val icon_19042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19042.xml"),
+          )
+      )
+
+  public val icon_19043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19043.xml"),
+          )
+      )
+
+  public val icon_19044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19044.xml"),
+          )
+      )
+
+  public val icon_19045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19045.xml"),
+          )
+      )
+
+  public val icon_19046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19046.xml"),
+          )
+      )
+
+  public val icon_19047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19047.xml"),
+          )
+      )
+
+  public val icon_19048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19048.xml"),
+          )
+      )
+
+  public val icon_19049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19049.xml"),
+          )
+      )
+
+  public val icon_1905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1905.xml"),
+          )
+      )
+
+  public val icon_19050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19050.xml"),
+          )
+      )
+
+  public val icon_19051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19051.xml"),
+          )
+      )
+
+  public val icon_19052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19052.xml"),
+          )
+      )
+
+  public val icon_19053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19053.xml"),
+          )
+      )
+
+  public val icon_19054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19054.xml"),
+          )
+      )
+
+  public val icon_19055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19055.xml"),
+          )
+      )
+
+  public val icon_19056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19056.xml"),
+          )
+      )
+
+  public val icon_19057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19057.xml"),
+          )
+      )
+
+  public val icon_19058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19058.xml"),
+          )
+      )
+
+  public val icon_19059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19059.xml"),
+          )
+      )
+
+  public val icon_1906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1906.xml"),
+          )
+      )
+
+  public val icon_19060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19060.xml"),
+          )
+      )
+
+  public val icon_19061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19061.xml"),
+          )
+      )
+
+  public val icon_19062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19062.xml"),
+          )
+      )
+
+  public val icon_19063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19063.xml"),
+          )
+      )
+
+  public val icon_19064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19064.xml"),
+          )
+      )
+
+  public val icon_19065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19065.xml"),
+          )
+      )
+
+  public val icon_19066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19066.xml"),
+          )
+      )
+
+  public val icon_19067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19067.xml"),
+          )
+      )
+
+  public val icon_19068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19068.xml"),
+          )
+      )
+
+  public val icon_19069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19069.xml"),
+          )
+      )
+
+  public val icon_1907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1907.xml"),
+          )
+      )
+
+  public val icon_19070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19070.xml"),
+          )
+      )
+
+  public val icon_19071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19071.xml"),
+          )
+      )
+
+  public val icon_19072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19072.xml"),
+          )
+      )
+
+  public val icon_19073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19073.xml"),
+          )
+      )
+
+  public val icon_19074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19074.xml"),
+          )
+      )
+
+  public val icon_19075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19075.xml"),
+          )
+      )
+
+  public val icon_19076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19076.xml"),
+          )
+      )
+
+  public val icon_19077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19077.xml"),
+          )
+      )
+
+  public val icon_19078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19078.xml"),
+          )
+      )
+
+  public val icon_19079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19079.xml"),
+          )
+      )
+
+  public val icon_1908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1908.xml"),
+          )
+      )
+
+  public val icon_19080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19080.xml"),
+          )
+      )
+
+  public val icon_19081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19081.xml"),
+          )
+      )
+
+  public val icon_19082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19082.xml"),
+          )
+      )
+
+  public val icon_19083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19083.xml"),
+          )
+      )
+
+  public val icon_19084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19084.xml"),
+          )
+      )
+
+  public val icon_19085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19085.xml"),
+          )
+      )
+
+  public val icon_19086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19086.xml"),
+          )
+      )
+
+  public val icon_19087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19087.xml"),
+          )
+      )
+
+  public val icon_19088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19088.xml"),
+          )
+      )
+
+  public val icon_19089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19089.xml"),
+          )
+      )
+
+  public val icon_1909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1909.xml"),
+          )
+      )
+
+  public val icon_19090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19090.xml"),
+          )
+      )
+
+  public val icon_19091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19091.xml"),
+          )
+      )
+
+  public val icon_19092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19092.xml"),
+          )
+      )
+
+  public val icon_19093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19093.xml"),
+          )
+      )
+
+  public val icon_19094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19094.xml"),
+          )
+      )
+
+  public val icon_19095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19095.xml"),
+          )
+      )
+
+  public val icon_19096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19096.xml"),
+          )
+      )
+
+  public val icon_19097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19097.xml"),
+          )
+      )
+
+  public val icon_19098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19098.xml"),
+          )
+      )
+
+  public val icon_19099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19099.xml"),
+          )
+      )
+
+  public val icon_191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_191.xml"),
+          )
+      )
+
+  public val icon_1910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1910.xml"),
+          )
+      )
+
+  public val icon_19100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19100.xml"),
+          )
+      )
+
+  public val icon_19101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19101.xml"),
+          )
+      )
+
+  public val icon_19102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19102.xml"),
+          )
+      )
+
+  public val icon_19103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19103.xml"),
+          )
+      )
+
+  public val icon_19104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19104.xml"),
+          )
+      )
+
+  public val icon_19105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19105.xml"),
+          )
+      )
+
+  public val icon_19106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19106.xml"),
+          )
+      )
+
+  public val icon_19107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19107.xml"),
+          )
+      )
+
+  public val icon_19108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19108.xml"),
+          )
+      )
+
+  public val icon_19109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19109.xml"),
+          )
+      )
+
+  public val icon_1911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1911.xml"),
+          )
+      )
+
+  public val icon_19110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19110.xml"),
+          )
+      )
+
+  public val icon_19111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19111.xml"),
+          )
+      )
+
+  public val icon_19112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19112.xml"),
+          )
+      )
+
+  public val icon_19113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19113.xml"),
+          )
+      )
+
+  public val icon_19114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19114.xml"),
+          )
+      )
+
+  public val icon_19115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19115.xml"),
+          )
+      )
+
+  public val icon_19116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19116.xml"),
+          )
+      )
+
+  public val icon_19117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19117.xml"),
+          )
+      )
+
+  public val icon_19118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19118.xml"),
+          )
+      )
+
+  public val icon_19119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19119.xml"),
+          )
+      )
+
+  public val icon_1912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1912.xml"),
+          )
+      )
+
+  public val icon_19120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19120.xml"),
+          )
+      )
+
+  public val icon_19121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19121.xml"),
+          )
+      )
+
+  public val icon_19122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19122.xml"),
+          )
+      )
+
+  public val icon_19123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19123.xml"),
+          )
+      )
+
+  public val icon_19124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19124.xml"),
+          )
+      )
+
+  public val icon_19125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19125.xml"),
+          )
+      )
+
+  public val icon_19126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19126.xml"),
+          )
+      )
+
+  public val icon_19127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19127.xml"),
+          )
+      )
+
+  public val icon_19128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19128.xml"),
+          )
+      )
+
+  public val icon_19129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19129.xml"),
+          )
+      )
+
+  public val icon_1913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1913.xml"),
+          )
+      )
+
+  public val icon_19130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19130.xml"),
+          )
+      )
+
+  public val icon_19131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19131.xml"),
+          )
+      )
+
+  public val icon_19132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19132.xml"),
+          )
+      )
+
+  public val icon_19133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19133.xml"),
+          )
+      )
+
+  public val icon_19134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19134.xml"),
+          )
+      )
+
+  public val icon_19135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19135.xml"),
+          )
+      )
+
+  public val icon_19136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19136.xml"),
+          )
+      )
+
+  public val icon_19137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19137.xml"),
+          )
+      )
+
+  public val icon_19138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19138.xml"),
+          )
+      )
+
+  public val icon_19139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19139.xml"),
+          )
+      )
+
+  public val icon_1914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1914.xml"),
+          )
+      )
+
+  public val icon_19140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19140.xml"),
+          )
+      )
+
+  public val icon_19141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19141.xml"),
+          )
+      )
+
+  public val icon_19142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19142.xml"),
+          )
+      )
+
+  public val icon_19143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19143.xml"),
+          )
+      )
+
+  public val icon_19144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19144.xml"),
+          )
+      )
+
+  public val icon_19145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19145.xml"),
+          )
+      )
+
+  public val icon_19146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19146.xml"),
+          )
+      )
+
+  public val icon_19147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19147.xml"),
+          )
+      )
+
+  public val icon_19148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19148.xml"),
+          )
+      )
+
+  public val icon_19149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19149.xml"),
+          )
+      )
+
+  public val icon_1915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1915.xml"),
+          )
+      )
+
+  public val icon_19150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19150.xml"),
+          )
+      )
+
+  public val icon_19151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19151.xml"),
+          )
+      )
+
+  public val icon_19152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19152.xml"),
+          )
+      )
+
+  public val icon_19153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19153.xml"),
+          )
+      )
+
+  public val icon_19154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19154.xml"),
+          )
+      )
+
+  public val icon_19155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19155.xml"),
+          )
+      )
+
+  public val icon_19156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19156.xml"),
+          )
+      )
+
+  public val icon_19157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19157.xml"),
+          )
+      )
+
+  public val icon_19158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19158.xml"),
+          )
+      )
+
+  public val icon_19159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19159.xml"),
+          )
+      )
+
+  public val icon_1916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1916.xml"),
+          )
+      )
+
+  public val icon_19160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19160.xml"),
+          )
+      )
+
+  public val icon_19161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19161.xml"),
+          )
+      )
+
+  public val icon_19162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19162.xml"),
+          )
+      )
+
+  public val icon_19163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19163.xml"),
+          )
+      )
+
+  public val icon_19164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19164.xml"),
+          )
+      )
+
+  public val icon_19165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19165.xml"),
+          )
+      )
+
+  public val icon_19166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19166.xml"),
+          )
+      )
+
+  public val icon_19167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19167.xml"),
+          )
+      )
+
+  public val icon_19168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19168.xml"),
+          )
+      )
+
+  public val icon_19169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19169.xml"),
+          )
+      )
+
+  public val icon_1917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1917.xml"),
+          )
+      )
+
+  public val icon_19170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19170.xml"),
+          )
+      )
+
+  public val icon_19171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19171.xml"),
+          )
+      )
+
+  public val icon_19172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19172.xml"),
+          )
+      )
+
+  public val icon_19173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19173.xml"),
+          )
+      )
+
+  public val icon_19174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19174.xml"),
+          )
+      )
+
+  public val icon_19175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19175.xml"),
+          )
+      )
+
+  public val icon_19176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19176.xml"),
+          )
+      )
+
+  public val icon_19177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19177.xml"),
+          )
+      )
+
+  public val icon_19178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19178.xml"),
+          )
+      )
+
+  public val icon_19179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19179.xml"),
+          )
+      )
+
+  public val icon_1918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1918.xml"),
+          )
+      )
+
+  public val icon_19180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19180.xml"),
+          )
+      )
+
+  public val icon_19181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19181.xml"),
+          )
+      )
+
+  public val icon_19182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19182.xml"),
+          )
+      )
+
+  public val icon_19183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19183.xml"),
+          )
+      )
+
+  public val icon_19184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19184.xml"),
+          )
+      )
+
+  public val icon_19185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19185.xml"),
+          )
+      )
+
+  public val icon_19186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19186.xml"),
+          )
+      )
+
+  public val icon_19187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19187.xml"),
+          )
+      )
+
+  public val icon_19188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19188.xml"),
+          )
+      )
+
+  public val icon_19189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19189.xml"),
+          )
+      )
+
+  public val icon_1919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1919.xml"),
+          )
+      )
+
+  public val icon_19190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19190.xml"),
+          )
+      )
+
+  public val icon_19191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19191.xml"),
+          )
+      )
+
+  public val icon_19192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19192.xml"),
+          )
+      )
+
+  public val icon_19193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19193.xml"),
+          )
+      )
+
+  public val icon_19194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19194.xml"),
+          )
+      )
+
+  public val icon_19195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19195.xml"),
+          )
+      )
+
+  public val icon_19196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19196.xml"),
+          )
+      )
+
+  public val icon_19197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19197.xml"),
+          )
+      )
+
+  public val icon_19198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19198.xml"),
+          )
+      )
+
+  public val icon_19199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19199.xml"),
+          )
+      )
+
+  public val icon_192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_192.xml"),
+          )
+      )
+
+  public val icon_1920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1920.xml"),
+          )
+      )
+
+  public val icon_19200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19200.xml"),
+          )
+      )
+
+  public val icon_19201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19201.xml"),
+          )
+      )
+
+  public val icon_19202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19202.xml"),
+          )
+      )
+
+  public val icon_19203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19203.xml"),
+          )
+      )
+
+  public val icon_19204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19204.xml"),
+          )
+      )
+
+  public val icon_19205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19205.xml"),
+          )
+      )
+
+  public val icon_19206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19206.xml"),
+          )
+      )
+
+  public val icon_19207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19207.xml"),
+          )
+      )
+
+  public val icon_19208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19208.xml"),
+          )
+      )
+
+  public val icon_19209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19209.xml"),
+          )
+      )
+
+  public val icon_1921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1921.xml"),
+          )
+      )
+
+  public val icon_19210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19210.xml"),
+          )
+      )
+
+  public val icon_19211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19211.xml"),
+          )
+      )
+
+  public val icon_19212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19212.xml"),
+          )
+      )
+
+  public val icon_19213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19213.xml"),
+          )
+      )
+
+  public val icon_19214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19214.xml"),
+          )
+      )
+
+  public val icon_19215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19215.xml"),
+          )
+      )
+
+  public val icon_19216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19216.xml"),
+          )
+      )
+
+  public val icon_19217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19217.xml"),
+          )
+      )
+
+  public val icon_19218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19218.xml"),
+          )
+      )
+
+  public val icon_19219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19219.xml"),
+          )
+      )
+
+  public val icon_1922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1922.xml"),
+          )
+      )
+
+  public val icon_19220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19220.xml"),
+          )
+      )
+
+  public val icon_19221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19221.xml"),
+          )
+      )
+
+  public val icon_19222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19222.xml"),
+          )
+      )
+
+  public val icon_19223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19223.xml"),
+          )
+      )
+
+  public val icon_19224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19224.xml"),
+          )
+      )
+
+  public val icon_19225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19225.xml"),
+          )
+      )
+
+  public val icon_19226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19226.xml"),
+          )
+      )
+
+  public val icon_19227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19227.xml"),
+          )
+      )
+
+  public val icon_19228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19228.xml"),
+          )
+      )
+
+  public val icon_19229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19229.xml"),
+          )
+      )
+
+  public val icon_1923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1923.xml"),
+          )
+      )
+
+  public val icon_19230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19230.xml"),
+          )
+      )
+
+  public val icon_19231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19231.xml"),
+          )
+      )
+
+  public val icon_19232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19232.xml"),
+          )
+      )
+
+  public val icon_19233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19233.xml"),
+          )
+      )
+
+  public val icon_19234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19234.xml"),
+          )
+      )
+
+  public val icon_19235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19235.xml"),
+          )
+      )
+
+  public val icon_19236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19236.xml"),
+          )
+      )
+
+  public val icon_19237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19237.xml"),
+          )
+      )
+
+  public val icon_19238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19238.xml"),
+          )
+      )
+
+  public val icon_19239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19239.xml"),
+          )
+      )
+
+  public val icon_1924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1924.xml"),
+          )
+      )
+
+  public val icon_19240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19240.xml"),
+          )
+      )
+
+  public val icon_19241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19241.xml"),
+          )
+      )
+
+  public val icon_19242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19242.xml"),
+          )
+      )
+
+  public val icon_19243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19243.xml"),
+          )
+      )
+
+  public val icon_19244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19244.xml"),
+          )
+      )
+
+  public val icon_19245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19245.xml"),
+          )
+      )
+
+  public val icon_19246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19246.xml"),
+          )
+      )
+
+  public val icon_19247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19247.xml"),
+          )
+      )
+
+  public val icon_19248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19248.xml"),
+          )
+      )
+
+  public val icon_19249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19249.xml"),
+          )
+      )
+
+  public val icon_1925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1925.xml"),
+          )
+      )
+
+  public val icon_19250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19250.xml"),
+          )
+      )
+
+  public val icon_19251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19251.xml"),
+          )
+      )
+
+  public val icon_19252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19252.xml"),
+          )
+      )
+
+  public val icon_19253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19253.xml"),
+          )
+      )
+
+  public val icon_19254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19254.xml"),
+          )
+      )
+
+  public val icon_19255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19255.xml"),
+          )
+      )
+
+  public val icon_19256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19256.xml"),
+          )
+      )
+
+  public val icon_19257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19257.xml"),
+          )
+      )
+
+  public val icon_19258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19258.xml"),
+          )
+      )
+
+  public val icon_19259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19259.xml"),
+          )
+      )
+
+  public val icon_1926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1926.xml"),
+          )
+      )
+
+  public val icon_19260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19260.xml"),
+          )
+      )
+
+  public val icon_19261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19261.xml"),
+          )
+      )
+
+  public val icon_19262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19262.xml"),
+          )
+      )
+
+  public val icon_19263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19263.xml"),
+          )
+      )
+
+  public val icon_19264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19264.xml"),
+          )
+      )
+
+  public val icon_19265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19265.xml"),
+          )
+      )
+
+  public val icon_19266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19266.xml"),
+          )
+      )
+
+  public val icon_19267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19267.xml"),
+          )
+      )
+
+  public val icon_19268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19268.xml"),
+          )
+      )
+
+  public val icon_19269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19269.xml"),
+          )
+      )
+
+  public val icon_1927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1927.xml"),
+          )
+      )
+
+  public val icon_19270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19270.xml"),
+          )
+      )
+
+  public val icon_19271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19271.xml"),
+          )
+      )
+
+  public val icon_19272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19272.xml"),
+          )
+      )
+
+  public val icon_19273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19273.xml"),
+          )
+      )
+
+  public val icon_19274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19274.xml"),
+          )
+      )
+
+  public val icon_19275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19275.xml"),
+          )
+      )
+
+  public val icon_19276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19276.xml"),
+          )
+      )
+
+  public val icon_19277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19277.xml"),
+          )
+      )
+
+  public val icon_19278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19278.xml"),
+          )
+      )
+
+  public val icon_19279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19279.xml"),
+          )
+      )
+
+  public val icon_1928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1928.xml"),
+          )
+      )
+
+  public val icon_19280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19280.xml"),
+          )
+      )
+
+  public val icon_19281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19281.xml"),
+          )
+      )
+
+  public val icon_19282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19282.xml"),
+          )
+      )
+
+  public val icon_19283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19283.xml"),
+          )
+      )
+
+  public val icon_19284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19284.xml"),
+          )
+      )
+
+  public val icon_19285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19285.xml"),
+          )
+      )
+
+  public val icon_19286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19286.xml"),
+          )
+      )
+
+  public val icon_19287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19287.xml"),
+          )
+      )
+
+  public val icon_19288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19288.xml"),
+          )
+      )
+
+  public val icon_19289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19289.xml"),
+          )
+      )
+
+  public val icon_1929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1929.xml"),
+          )
+      )
+
+  public val icon_19290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19290.xml"),
+          )
+      )
+
+  public val icon_19291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19291.xml"),
+          )
+      )
+
+  public val icon_19292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19292.xml"),
+          )
+      )
+
+  public val icon_19293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19293.xml"),
+          )
+      )
+
+  public val icon_19294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19294.xml"),
+          )
+      )
+
+  public val icon_19295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19295.xml"),
+          )
+      )
+
+  public val icon_19296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19296.xml"),
+          )
+      )
+
+  public val icon_19297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19297.xml"),
+          )
+      )
+
+  public val icon_19298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19298.xml"),
+          )
+      )
+
+  public val icon_19299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19299.xml"),
+          )
+      )
+
+  public val icon_193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_193.xml"),
+          )
+      )
+
+  public val icon_1930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1930.xml"),
+          )
+      )
+
+  public val icon_19300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19300.xml"),
+          )
+      )
+
+  public val icon_19301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19301.xml"),
+          )
+      )
+
+  public val icon_19302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19302.xml"),
+          )
+      )
+
+  public val icon_19303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19303.xml"),
+          )
+      )
+
+  public val icon_19304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19304.xml"),
+          )
+      )
+
+  public val icon_19305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19305.xml"),
+          )
+      )
+
+  public val icon_19306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19306.xml"),
+          )
+      )
+
+  public val icon_19307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19307.xml"),
+          )
+      )
+
+  public val icon_19308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19308.xml"),
+          )
+      )
+
+  public val icon_19309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19309.xml"),
+          )
+      )
+
+  public val icon_1931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1931.xml"),
+          )
+      )
+
+  public val icon_19310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19310.xml"),
+          )
+      )
+
+  public val icon_19311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19311.xml"),
+          )
+      )
+
+  public val icon_19312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19312.xml"),
+          )
+      )
+
+  public val icon_19313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19313.xml"),
+          )
+      )
+
+  public val icon_19314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19314.xml"),
+          )
+      )
+
+  public val icon_19315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19315.xml"),
+          )
+      )
+
+  public val icon_19316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19316.xml"),
+          )
+      )
+
+  public val icon_19317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19317.xml"),
+          )
+      )
+
+  public val icon_19318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19318.xml"),
+          )
+      )
+
+  public val icon_19319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19319.xml"),
+          )
+      )
+
+  public val icon_1932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1932.xml"),
+          )
+      )
+
+  public val icon_19320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19320.xml"),
+          )
+      )
+
+  public val icon_19321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19321.xml"),
+          )
+      )
+
+  public val icon_19322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19322.xml"),
+          )
+      )
+
+  public val icon_19323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19323.xml"),
+          )
+      )
+
+  public val icon_19324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19324.xml"),
+          )
+      )
+
+  public val icon_19325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19325.xml"),
+          )
+      )
+
+  public val icon_19326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19326.xml"),
+          )
+      )
+
+  public val icon_19327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19327.xml"),
+          )
+      )
+
+  public val icon_19328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19328.xml"),
+          )
+      )
+
+  public val icon_19329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19329.xml"),
+          )
+      )
+
+  public val icon_1933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1933.xml"),
+          )
+      )
+
+  public val icon_19330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19330.xml"),
+          )
+      )
+
+  public val icon_19331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19331.xml"),
+          )
+      )
+
+  public val icon_19332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19332.xml"),
+          )
+      )
+
+  public val icon_19333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19333.xml"),
+          )
+      )
+
+  public val icon_19334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19334.xml"),
+          )
+      )
+
+  public val icon_19335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19335.xml"),
+          )
+      )
+
+  public val icon_19336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19336.xml"),
+          )
+      )
+
+  public val icon_19337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19337.xml"),
+          )
+      )
+
+  public val icon_19338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19338.xml"),
+          )
+      )
+
+  public val icon_19339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19339.xml"),
+          )
+      )
+
+  public val icon_1934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1934.xml"),
+          )
+      )
+
+  public val icon_19340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19340.xml"),
+          )
+      )
+
+  public val icon_19341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19341.xml"),
+          )
+      )
+
+  public val icon_19342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19342.xml"),
+          )
+      )
+
+  public val icon_19343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19343.xml"),
+          )
+      )
+
+  public val icon_19344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19344.xml"),
+          )
+      )
+
+  public val icon_19345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19345.xml"),
+          )
+      )
+
+  public val icon_19346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19346.xml"),
+          )
+      )
+
+  public val icon_19347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19347.xml"),
+          )
+      )
+
+  public val icon_19348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19348.xml"),
+          )
+      )
+
+  public val icon_19349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19349.xml"),
+          )
+      )
+
+  public val icon_1935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1935.xml"),
+          )
+      )
+
+  public val icon_19350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19350.xml"),
+          )
+      )
+
+  public val icon_19351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19351.xml"),
+          )
+      )
+
+  public val icon_19352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19352.xml"),
+          )
+      )
+
+  public val icon_19353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19353.xml"),
+          )
+      )
+
+  public val icon_19354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19354.xml"),
+          )
+      )
+
+  public val icon_19355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19355.xml"),
+          )
+      )
+
+  public val icon_19356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19356.xml"),
+          )
+      )
+
+  public val icon_19357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19357.xml"),
+          )
+      )
+
+  public val icon_19358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19358.xml"),
+          )
+      )
+
+  public val icon_19359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19359.xml"),
+          )
+      )
+
+  public val icon_1936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1936.xml"),
+          )
+      )
+
+  public val icon_19360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19360.xml"),
+          )
+      )
+
+  public val icon_19361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19361.xml"),
+          )
+      )
+
+  public val icon_19362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19362.xml"),
+          )
+      )
+
+  public val icon_19363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19363.xml"),
+          )
+      )
+
+  public val icon_19364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19364.xml"),
+          )
+      )
+
+  public val icon_19365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19365.xml"),
+          )
+      )
+
+  public val icon_19366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19366.xml"),
+          )
+      )
+
+  public val icon_19367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19367.xml"),
+          )
+      )
+
+  public val icon_19368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19368.xml"),
+          )
+      )
+
+  public val icon_19369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19369.xml"),
+          )
+      )
+
+  public val icon_1937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1937.xml"),
+          )
+      )
+
+  public val icon_19370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19370.xml"),
+          )
+      )
+
+  public val icon_19371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19371.xml"),
+          )
+      )
+
+  public val icon_19372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19372.xml"),
+          )
+      )
+
+  public val icon_19373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19373.xml"),
+          )
+      )
+
+  public val icon_19374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19374.xml"),
+          )
+      )
+
+  public val icon_19375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19375.xml"),
+          )
+      )
+
+  public val icon_19376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19376.xml"),
+          )
+      )
+
+  public val icon_19377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19377.xml"),
+          )
+      )
+
+  public val icon_19378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19378.xml"),
+          )
+      )
+
+  public val icon_19379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19379.xml"),
+          )
+      )
+
+  public val icon_1938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1938.xml"),
+          )
+      )
+
+  public val icon_19380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19380.xml"),
+          )
+      )
+
+  public val icon_19381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19381.xml"),
+          )
+      )
+
+  public val icon_19382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19382.xml"),
+          )
+      )
+
+  public val icon_19383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19383.xml"),
+          )
+      )
+
+  public val icon_19384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19384.xml"),
+          )
+      )
+
+  public val icon_19385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19385.xml"),
+          )
+      )
+
+  public val icon_19386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19386.xml"),
+          )
+      )
+
+  public val icon_19387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19387.xml"),
+          )
+      )
+
+  public val icon_19388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19388.xml"),
+          )
+      )
+
+  public val icon_19389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19389.xml"),
+          )
+      )
+
+  public val icon_1939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1939.xml"),
+          )
+      )
+
+  public val icon_19390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19390.xml"),
+          )
+      )
+
+  public val icon_19391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19391.xml"),
+          )
+      )
+
+  public val icon_19392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19392.xml"),
+          )
+      )
+
+  public val icon_19393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19393.xml"),
+          )
+      )
+
+  public val icon_19394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19394.xml"),
+          )
+      )
+
+  public val icon_19395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19395.xml"),
+          )
+      )
+
+  public val icon_19396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19396.xml"),
+          )
+      )
+
+  public val icon_19397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19397.xml"),
+          )
+      )
+
+  public val icon_19398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19398.xml"),
+          )
+      )
+
+  public val icon_19399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19399.xml"),
+          )
+      )
+
+  public val icon_194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_194.xml"),
+          )
+      )
+
+  public val icon_1940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1940.xml"),
+          )
+      )
+
+  public val icon_19400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19400.xml"),
+          )
+      )
+
+  public val icon_19401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19401.xml"),
+          )
+      )
+
+  public val icon_19402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19402.xml"),
+          )
+      )
+
+  public val icon_19403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19403.xml"),
+          )
+      )
+
+  public val icon_19404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19404.xml"),
+          )
+      )
+
+  public val icon_19405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19405.xml"),
+          )
+      )
+
+  public val icon_19406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19406.xml"),
+          )
+      )
+
+  public val icon_19407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19407.xml"),
+          )
+      )
+
+  public val icon_19408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19408.xml"),
+          )
+      )
+
+  public val icon_19409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19409.xml"),
+          )
+      )
+
+  public val icon_1941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1941.xml"),
+          )
+      )
+
+  public val icon_19410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19410.xml"),
+          )
+      )
+
+  public val icon_19411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19411.xml"),
+          )
+      )
+
+  public val icon_19412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19412.xml"),
+          )
+      )
+
+  public val icon_19413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19413.xml"),
+          )
+      )
+
+  public val icon_19414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19414.xml"),
+          )
+      )
+
+  public val icon_19415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19415.xml"),
+          )
+      )
+
+  public val icon_19416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19416.xml"),
+          )
+      )
+
+  public val icon_19417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19417.xml"),
+          )
+      )
+
+  public val icon_19418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19418.xml"),
+          )
+      )
+
+  public val icon_19419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19419.xml"),
+          )
+      )
+
+  public val icon_1942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1942.xml"),
+          )
+      )
+
+  public val icon_19420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19420.xml"),
+          )
+      )
+
+  public val icon_19421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19421.xml"),
+          )
+      )
+
+  public val icon_19422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19422.xml"),
+          )
+      )
+
+  public val icon_19423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19423.xml"),
+          )
+      )
+
+  public val icon_19424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19424.xml"),
+          )
+      )
+
+  public val icon_19425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19425.xml"),
+          )
+      )
+
+  public val icon_19426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19426.xml"),
+          )
+      )
+
+  public val icon_19427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19427.xml"),
+          )
+      )
+
+  public val icon_19428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19428.xml"),
+          )
+      )
+
+  public val icon_19429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19429.xml"),
+          )
+      )
+
+  public val icon_1943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1943.xml"),
+          )
+      )
+
+  public val icon_19430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19430.xml"),
+          )
+      )
+
+  public val icon_19431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19431.xml"),
+          )
+      )
+
+  public val icon_19432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19432.xml"),
+          )
+      )
+
+  public val icon_19433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19433.xml"),
+          )
+      )
+
+  public val icon_19434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19434.xml"),
+          )
+      )
+
+  public val icon_19435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19435.xml"),
+          )
+      )
+
+  public val icon_19436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19436.xml"),
+          )
+      )
+
+  public val icon_19437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19437.xml"),
+          )
+      )
+
+  public val icon_19438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19438.xml"),
+          )
+      )
+
+  public val icon_19439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19439.xml"),
+          )
+      )
+
+  public val icon_1944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1944.xml"),
+          )
+      )
+
+  public val icon_19440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19440.xml"),
+          )
+      )
+
+  public val icon_19441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19441.xml"),
+          )
+      )
+
+  public val icon_19442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19442.xml"),
+          )
+      )
+
+  public val icon_19443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19443.xml"),
+          )
+      )
+
+  public val icon_19444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19444.xml"),
+          )
+      )
+
+  public val icon_19445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19445.xml"),
+          )
+      )
+
+  public val icon_19446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19446.xml"),
+          )
+      )
+
+  public val icon_19447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19447.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_18999: DrawableResource
+  get() = Drawable20.icon_18999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19: DrawableResource
+  get() = Drawable20.icon_19
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_190: DrawableResource
+  get() = Drawable20.icon_190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1900: DrawableResource
+  get() = Drawable20.icon_1900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19000: DrawableResource
+  get() = Drawable20.icon_19000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19001: DrawableResource
+  get() = Drawable20.icon_19001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19002: DrawableResource
+  get() = Drawable20.icon_19002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19003: DrawableResource
+  get() = Drawable20.icon_19003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19004: DrawableResource
+  get() = Drawable20.icon_19004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19005: DrawableResource
+  get() = Drawable20.icon_19005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19006: DrawableResource
+  get() = Drawable20.icon_19006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19007: DrawableResource
+  get() = Drawable20.icon_19007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19008: DrawableResource
+  get() = Drawable20.icon_19008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19009: DrawableResource
+  get() = Drawable20.icon_19009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1901: DrawableResource
+  get() = Drawable20.icon_1901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19010: DrawableResource
+  get() = Drawable20.icon_19010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19011: DrawableResource
+  get() = Drawable20.icon_19011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19012: DrawableResource
+  get() = Drawable20.icon_19012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19013: DrawableResource
+  get() = Drawable20.icon_19013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19014: DrawableResource
+  get() = Drawable20.icon_19014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19015: DrawableResource
+  get() = Drawable20.icon_19015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19016: DrawableResource
+  get() = Drawable20.icon_19016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19017: DrawableResource
+  get() = Drawable20.icon_19017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19018: DrawableResource
+  get() = Drawable20.icon_19018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19019: DrawableResource
+  get() = Drawable20.icon_19019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1902: DrawableResource
+  get() = Drawable20.icon_1902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19020: DrawableResource
+  get() = Drawable20.icon_19020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19021: DrawableResource
+  get() = Drawable20.icon_19021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19022: DrawableResource
+  get() = Drawable20.icon_19022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19023: DrawableResource
+  get() = Drawable20.icon_19023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19024: DrawableResource
+  get() = Drawable20.icon_19024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19025: DrawableResource
+  get() = Drawable20.icon_19025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19026: DrawableResource
+  get() = Drawable20.icon_19026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19027: DrawableResource
+  get() = Drawable20.icon_19027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19028: DrawableResource
+  get() = Drawable20.icon_19028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19029: DrawableResource
+  get() = Drawable20.icon_19029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1903: DrawableResource
+  get() = Drawable20.icon_1903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19030: DrawableResource
+  get() = Drawable20.icon_19030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19031: DrawableResource
+  get() = Drawable20.icon_19031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19032: DrawableResource
+  get() = Drawable20.icon_19032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19033: DrawableResource
+  get() = Drawable20.icon_19033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19034: DrawableResource
+  get() = Drawable20.icon_19034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19035: DrawableResource
+  get() = Drawable20.icon_19035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19036: DrawableResource
+  get() = Drawable20.icon_19036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19037: DrawableResource
+  get() = Drawable20.icon_19037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19038: DrawableResource
+  get() = Drawable20.icon_19038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19039: DrawableResource
+  get() = Drawable20.icon_19039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1904: DrawableResource
+  get() = Drawable20.icon_1904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19040: DrawableResource
+  get() = Drawable20.icon_19040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19041: DrawableResource
+  get() = Drawable20.icon_19041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19042: DrawableResource
+  get() = Drawable20.icon_19042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19043: DrawableResource
+  get() = Drawable20.icon_19043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19044: DrawableResource
+  get() = Drawable20.icon_19044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19045: DrawableResource
+  get() = Drawable20.icon_19045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19046: DrawableResource
+  get() = Drawable20.icon_19046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19047: DrawableResource
+  get() = Drawable20.icon_19047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19048: DrawableResource
+  get() = Drawable20.icon_19048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19049: DrawableResource
+  get() = Drawable20.icon_19049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1905: DrawableResource
+  get() = Drawable20.icon_1905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19050: DrawableResource
+  get() = Drawable20.icon_19050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19051: DrawableResource
+  get() = Drawable20.icon_19051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19052: DrawableResource
+  get() = Drawable20.icon_19052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19053: DrawableResource
+  get() = Drawable20.icon_19053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19054: DrawableResource
+  get() = Drawable20.icon_19054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19055: DrawableResource
+  get() = Drawable20.icon_19055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19056: DrawableResource
+  get() = Drawable20.icon_19056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19057: DrawableResource
+  get() = Drawable20.icon_19057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19058: DrawableResource
+  get() = Drawable20.icon_19058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19059: DrawableResource
+  get() = Drawable20.icon_19059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1906: DrawableResource
+  get() = Drawable20.icon_1906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19060: DrawableResource
+  get() = Drawable20.icon_19060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19061: DrawableResource
+  get() = Drawable20.icon_19061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19062: DrawableResource
+  get() = Drawable20.icon_19062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19063: DrawableResource
+  get() = Drawable20.icon_19063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19064: DrawableResource
+  get() = Drawable20.icon_19064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19065: DrawableResource
+  get() = Drawable20.icon_19065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19066: DrawableResource
+  get() = Drawable20.icon_19066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19067: DrawableResource
+  get() = Drawable20.icon_19067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19068: DrawableResource
+  get() = Drawable20.icon_19068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19069: DrawableResource
+  get() = Drawable20.icon_19069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1907: DrawableResource
+  get() = Drawable20.icon_1907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19070: DrawableResource
+  get() = Drawable20.icon_19070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19071: DrawableResource
+  get() = Drawable20.icon_19071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19072: DrawableResource
+  get() = Drawable20.icon_19072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19073: DrawableResource
+  get() = Drawable20.icon_19073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19074: DrawableResource
+  get() = Drawable20.icon_19074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19075: DrawableResource
+  get() = Drawable20.icon_19075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19076: DrawableResource
+  get() = Drawable20.icon_19076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19077: DrawableResource
+  get() = Drawable20.icon_19077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19078: DrawableResource
+  get() = Drawable20.icon_19078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19079: DrawableResource
+  get() = Drawable20.icon_19079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1908: DrawableResource
+  get() = Drawable20.icon_1908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19080: DrawableResource
+  get() = Drawable20.icon_19080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19081: DrawableResource
+  get() = Drawable20.icon_19081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19082: DrawableResource
+  get() = Drawable20.icon_19082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19083: DrawableResource
+  get() = Drawable20.icon_19083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19084: DrawableResource
+  get() = Drawable20.icon_19084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19085: DrawableResource
+  get() = Drawable20.icon_19085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19086: DrawableResource
+  get() = Drawable20.icon_19086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19087: DrawableResource
+  get() = Drawable20.icon_19087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19088: DrawableResource
+  get() = Drawable20.icon_19088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19089: DrawableResource
+  get() = Drawable20.icon_19089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1909: DrawableResource
+  get() = Drawable20.icon_1909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19090: DrawableResource
+  get() = Drawable20.icon_19090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19091: DrawableResource
+  get() = Drawable20.icon_19091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19092: DrawableResource
+  get() = Drawable20.icon_19092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19093: DrawableResource
+  get() = Drawable20.icon_19093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19094: DrawableResource
+  get() = Drawable20.icon_19094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19095: DrawableResource
+  get() = Drawable20.icon_19095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19096: DrawableResource
+  get() = Drawable20.icon_19096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19097: DrawableResource
+  get() = Drawable20.icon_19097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19098: DrawableResource
+  get() = Drawable20.icon_19098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19099: DrawableResource
+  get() = Drawable20.icon_19099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_191: DrawableResource
+  get() = Drawable20.icon_191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1910: DrawableResource
+  get() = Drawable20.icon_1910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19100: DrawableResource
+  get() = Drawable20.icon_19100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19101: DrawableResource
+  get() = Drawable20.icon_19101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19102: DrawableResource
+  get() = Drawable20.icon_19102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19103: DrawableResource
+  get() = Drawable20.icon_19103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19104: DrawableResource
+  get() = Drawable20.icon_19104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19105: DrawableResource
+  get() = Drawable20.icon_19105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19106: DrawableResource
+  get() = Drawable20.icon_19106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19107: DrawableResource
+  get() = Drawable20.icon_19107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19108: DrawableResource
+  get() = Drawable20.icon_19108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19109: DrawableResource
+  get() = Drawable20.icon_19109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1911: DrawableResource
+  get() = Drawable20.icon_1911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19110: DrawableResource
+  get() = Drawable20.icon_19110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19111: DrawableResource
+  get() = Drawable20.icon_19111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19112: DrawableResource
+  get() = Drawable20.icon_19112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19113: DrawableResource
+  get() = Drawable20.icon_19113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19114: DrawableResource
+  get() = Drawable20.icon_19114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19115: DrawableResource
+  get() = Drawable20.icon_19115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19116: DrawableResource
+  get() = Drawable20.icon_19116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19117: DrawableResource
+  get() = Drawable20.icon_19117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19118: DrawableResource
+  get() = Drawable20.icon_19118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19119: DrawableResource
+  get() = Drawable20.icon_19119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1912: DrawableResource
+  get() = Drawable20.icon_1912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19120: DrawableResource
+  get() = Drawable20.icon_19120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19121: DrawableResource
+  get() = Drawable20.icon_19121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19122: DrawableResource
+  get() = Drawable20.icon_19122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19123: DrawableResource
+  get() = Drawable20.icon_19123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19124: DrawableResource
+  get() = Drawable20.icon_19124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19125: DrawableResource
+  get() = Drawable20.icon_19125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19126: DrawableResource
+  get() = Drawable20.icon_19126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19127: DrawableResource
+  get() = Drawable20.icon_19127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19128: DrawableResource
+  get() = Drawable20.icon_19128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19129: DrawableResource
+  get() = Drawable20.icon_19129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1913: DrawableResource
+  get() = Drawable20.icon_1913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19130: DrawableResource
+  get() = Drawable20.icon_19130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19131: DrawableResource
+  get() = Drawable20.icon_19131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19132: DrawableResource
+  get() = Drawable20.icon_19132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19133: DrawableResource
+  get() = Drawable20.icon_19133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19134: DrawableResource
+  get() = Drawable20.icon_19134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19135: DrawableResource
+  get() = Drawable20.icon_19135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19136: DrawableResource
+  get() = Drawable20.icon_19136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19137: DrawableResource
+  get() = Drawable20.icon_19137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19138: DrawableResource
+  get() = Drawable20.icon_19138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19139: DrawableResource
+  get() = Drawable20.icon_19139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1914: DrawableResource
+  get() = Drawable20.icon_1914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19140: DrawableResource
+  get() = Drawable20.icon_19140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19141: DrawableResource
+  get() = Drawable20.icon_19141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19142: DrawableResource
+  get() = Drawable20.icon_19142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19143: DrawableResource
+  get() = Drawable20.icon_19143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19144: DrawableResource
+  get() = Drawable20.icon_19144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19145: DrawableResource
+  get() = Drawable20.icon_19145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19146: DrawableResource
+  get() = Drawable20.icon_19146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19147: DrawableResource
+  get() = Drawable20.icon_19147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19148: DrawableResource
+  get() = Drawable20.icon_19148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19149: DrawableResource
+  get() = Drawable20.icon_19149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1915: DrawableResource
+  get() = Drawable20.icon_1915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19150: DrawableResource
+  get() = Drawable20.icon_19150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19151: DrawableResource
+  get() = Drawable20.icon_19151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19152: DrawableResource
+  get() = Drawable20.icon_19152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19153: DrawableResource
+  get() = Drawable20.icon_19153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19154: DrawableResource
+  get() = Drawable20.icon_19154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19155: DrawableResource
+  get() = Drawable20.icon_19155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19156: DrawableResource
+  get() = Drawable20.icon_19156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19157: DrawableResource
+  get() = Drawable20.icon_19157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19158: DrawableResource
+  get() = Drawable20.icon_19158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19159: DrawableResource
+  get() = Drawable20.icon_19159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1916: DrawableResource
+  get() = Drawable20.icon_1916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19160: DrawableResource
+  get() = Drawable20.icon_19160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19161: DrawableResource
+  get() = Drawable20.icon_19161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19162: DrawableResource
+  get() = Drawable20.icon_19162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19163: DrawableResource
+  get() = Drawable20.icon_19163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19164: DrawableResource
+  get() = Drawable20.icon_19164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19165: DrawableResource
+  get() = Drawable20.icon_19165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19166: DrawableResource
+  get() = Drawable20.icon_19166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19167: DrawableResource
+  get() = Drawable20.icon_19167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19168: DrawableResource
+  get() = Drawable20.icon_19168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19169: DrawableResource
+  get() = Drawable20.icon_19169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1917: DrawableResource
+  get() = Drawable20.icon_1917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19170: DrawableResource
+  get() = Drawable20.icon_19170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19171: DrawableResource
+  get() = Drawable20.icon_19171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19172: DrawableResource
+  get() = Drawable20.icon_19172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19173: DrawableResource
+  get() = Drawable20.icon_19173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19174: DrawableResource
+  get() = Drawable20.icon_19174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19175: DrawableResource
+  get() = Drawable20.icon_19175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19176: DrawableResource
+  get() = Drawable20.icon_19176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19177: DrawableResource
+  get() = Drawable20.icon_19177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19178: DrawableResource
+  get() = Drawable20.icon_19178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19179: DrawableResource
+  get() = Drawable20.icon_19179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1918: DrawableResource
+  get() = Drawable20.icon_1918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19180: DrawableResource
+  get() = Drawable20.icon_19180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19181: DrawableResource
+  get() = Drawable20.icon_19181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19182: DrawableResource
+  get() = Drawable20.icon_19182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19183: DrawableResource
+  get() = Drawable20.icon_19183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19184: DrawableResource
+  get() = Drawable20.icon_19184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19185: DrawableResource
+  get() = Drawable20.icon_19185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19186: DrawableResource
+  get() = Drawable20.icon_19186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19187: DrawableResource
+  get() = Drawable20.icon_19187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19188: DrawableResource
+  get() = Drawable20.icon_19188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19189: DrawableResource
+  get() = Drawable20.icon_19189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1919: DrawableResource
+  get() = Drawable20.icon_1919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19190: DrawableResource
+  get() = Drawable20.icon_19190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19191: DrawableResource
+  get() = Drawable20.icon_19191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19192: DrawableResource
+  get() = Drawable20.icon_19192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19193: DrawableResource
+  get() = Drawable20.icon_19193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19194: DrawableResource
+  get() = Drawable20.icon_19194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19195: DrawableResource
+  get() = Drawable20.icon_19195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19196: DrawableResource
+  get() = Drawable20.icon_19196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19197: DrawableResource
+  get() = Drawable20.icon_19197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19198: DrawableResource
+  get() = Drawable20.icon_19198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19199: DrawableResource
+  get() = Drawable20.icon_19199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_192: DrawableResource
+  get() = Drawable20.icon_192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1920: DrawableResource
+  get() = Drawable20.icon_1920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19200: DrawableResource
+  get() = Drawable20.icon_19200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19201: DrawableResource
+  get() = Drawable20.icon_19201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19202: DrawableResource
+  get() = Drawable20.icon_19202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19203: DrawableResource
+  get() = Drawable20.icon_19203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19204: DrawableResource
+  get() = Drawable20.icon_19204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19205: DrawableResource
+  get() = Drawable20.icon_19205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19206: DrawableResource
+  get() = Drawable20.icon_19206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19207: DrawableResource
+  get() = Drawable20.icon_19207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19208: DrawableResource
+  get() = Drawable20.icon_19208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19209: DrawableResource
+  get() = Drawable20.icon_19209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1921: DrawableResource
+  get() = Drawable20.icon_1921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19210: DrawableResource
+  get() = Drawable20.icon_19210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19211: DrawableResource
+  get() = Drawable20.icon_19211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19212: DrawableResource
+  get() = Drawable20.icon_19212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19213: DrawableResource
+  get() = Drawable20.icon_19213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19214: DrawableResource
+  get() = Drawable20.icon_19214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19215: DrawableResource
+  get() = Drawable20.icon_19215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19216: DrawableResource
+  get() = Drawable20.icon_19216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19217: DrawableResource
+  get() = Drawable20.icon_19217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19218: DrawableResource
+  get() = Drawable20.icon_19218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19219: DrawableResource
+  get() = Drawable20.icon_19219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1922: DrawableResource
+  get() = Drawable20.icon_1922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19220: DrawableResource
+  get() = Drawable20.icon_19220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19221: DrawableResource
+  get() = Drawable20.icon_19221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19222: DrawableResource
+  get() = Drawable20.icon_19222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19223: DrawableResource
+  get() = Drawable20.icon_19223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19224: DrawableResource
+  get() = Drawable20.icon_19224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19225: DrawableResource
+  get() = Drawable20.icon_19225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19226: DrawableResource
+  get() = Drawable20.icon_19226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19227: DrawableResource
+  get() = Drawable20.icon_19227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19228: DrawableResource
+  get() = Drawable20.icon_19228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19229: DrawableResource
+  get() = Drawable20.icon_19229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1923: DrawableResource
+  get() = Drawable20.icon_1923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19230: DrawableResource
+  get() = Drawable20.icon_19230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19231: DrawableResource
+  get() = Drawable20.icon_19231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19232: DrawableResource
+  get() = Drawable20.icon_19232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19233: DrawableResource
+  get() = Drawable20.icon_19233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19234: DrawableResource
+  get() = Drawable20.icon_19234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19235: DrawableResource
+  get() = Drawable20.icon_19235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19236: DrawableResource
+  get() = Drawable20.icon_19236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19237: DrawableResource
+  get() = Drawable20.icon_19237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19238: DrawableResource
+  get() = Drawable20.icon_19238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19239: DrawableResource
+  get() = Drawable20.icon_19239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1924: DrawableResource
+  get() = Drawable20.icon_1924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19240: DrawableResource
+  get() = Drawable20.icon_19240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19241: DrawableResource
+  get() = Drawable20.icon_19241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19242: DrawableResource
+  get() = Drawable20.icon_19242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19243: DrawableResource
+  get() = Drawable20.icon_19243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19244: DrawableResource
+  get() = Drawable20.icon_19244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19245: DrawableResource
+  get() = Drawable20.icon_19245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19246: DrawableResource
+  get() = Drawable20.icon_19246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19247: DrawableResource
+  get() = Drawable20.icon_19247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19248: DrawableResource
+  get() = Drawable20.icon_19248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19249: DrawableResource
+  get() = Drawable20.icon_19249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1925: DrawableResource
+  get() = Drawable20.icon_1925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19250: DrawableResource
+  get() = Drawable20.icon_19250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19251: DrawableResource
+  get() = Drawable20.icon_19251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19252: DrawableResource
+  get() = Drawable20.icon_19252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19253: DrawableResource
+  get() = Drawable20.icon_19253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19254: DrawableResource
+  get() = Drawable20.icon_19254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19255: DrawableResource
+  get() = Drawable20.icon_19255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19256: DrawableResource
+  get() = Drawable20.icon_19256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19257: DrawableResource
+  get() = Drawable20.icon_19257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19258: DrawableResource
+  get() = Drawable20.icon_19258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19259: DrawableResource
+  get() = Drawable20.icon_19259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1926: DrawableResource
+  get() = Drawable20.icon_1926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19260: DrawableResource
+  get() = Drawable20.icon_19260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19261: DrawableResource
+  get() = Drawable20.icon_19261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19262: DrawableResource
+  get() = Drawable20.icon_19262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19263: DrawableResource
+  get() = Drawable20.icon_19263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19264: DrawableResource
+  get() = Drawable20.icon_19264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19265: DrawableResource
+  get() = Drawable20.icon_19265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19266: DrawableResource
+  get() = Drawable20.icon_19266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19267: DrawableResource
+  get() = Drawable20.icon_19267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19268: DrawableResource
+  get() = Drawable20.icon_19268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19269: DrawableResource
+  get() = Drawable20.icon_19269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1927: DrawableResource
+  get() = Drawable20.icon_1927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19270: DrawableResource
+  get() = Drawable20.icon_19270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19271: DrawableResource
+  get() = Drawable20.icon_19271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19272: DrawableResource
+  get() = Drawable20.icon_19272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19273: DrawableResource
+  get() = Drawable20.icon_19273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19274: DrawableResource
+  get() = Drawable20.icon_19274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19275: DrawableResource
+  get() = Drawable20.icon_19275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19276: DrawableResource
+  get() = Drawable20.icon_19276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19277: DrawableResource
+  get() = Drawable20.icon_19277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19278: DrawableResource
+  get() = Drawable20.icon_19278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19279: DrawableResource
+  get() = Drawable20.icon_19279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1928: DrawableResource
+  get() = Drawable20.icon_1928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19280: DrawableResource
+  get() = Drawable20.icon_19280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19281: DrawableResource
+  get() = Drawable20.icon_19281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19282: DrawableResource
+  get() = Drawable20.icon_19282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19283: DrawableResource
+  get() = Drawable20.icon_19283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19284: DrawableResource
+  get() = Drawable20.icon_19284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19285: DrawableResource
+  get() = Drawable20.icon_19285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19286: DrawableResource
+  get() = Drawable20.icon_19286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19287: DrawableResource
+  get() = Drawable20.icon_19287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19288: DrawableResource
+  get() = Drawable20.icon_19288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19289: DrawableResource
+  get() = Drawable20.icon_19289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1929: DrawableResource
+  get() = Drawable20.icon_1929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19290: DrawableResource
+  get() = Drawable20.icon_19290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19291: DrawableResource
+  get() = Drawable20.icon_19291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19292: DrawableResource
+  get() = Drawable20.icon_19292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19293: DrawableResource
+  get() = Drawable20.icon_19293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19294: DrawableResource
+  get() = Drawable20.icon_19294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19295: DrawableResource
+  get() = Drawable20.icon_19295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19296: DrawableResource
+  get() = Drawable20.icon_19296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19297: DrawableResource
+  get() = Drawable20.icon_19297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19298: DrawableResource
+  get() = Drawable20.icon_19298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19299: DrawableResource
+  get() = Drawable20.icon_19299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_193: DrawableResource
+  get() = Drawable20.icon_193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1930: DrawableResource
+  get() = Drawable20.icon_1930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19300: DrawableResource
+  get() = Drawable20.icon_19300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19301: DrawableResource
+  get() = Drawable20.icon_19301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19302: DrawableResource
+  get() = Drawable20.icon_19302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19303: DrawableResource
+  get() = Drawable20.icon_19303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19304: DrawableResource
+  get() = Drawable20.icon_19304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19305: DrawableResource
+  get() = Drawable20.icon_19305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19306: DrawableResource
+  get() = Drawable20.icon_19306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19307: DrawableResource
+  get() = Drawable20.icon_19307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19308: DrawableResource
+  get() = Drawable20.icon_19308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19309: DrawableResource
+  get() = Drawable20.icon_19309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1931: DrawableResource
+  get() = Drawable20.icon_1931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19310: DrawableResource
+  get() = Drawable20.icon_19310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19311: DrawableResource
+  get() = Drawable20.icon_19311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19312: DrawableResource
+  get() = Drawable20.icon_19312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19313: DrawableResource
+  get() = Drawable20.icon_19313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19314: DrawableResource
+  get() = Drawable20.icon_19314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19315: DrawableResource
+  get() = Drawable20.icon_19315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19316: DrawableResource
+  get() = Drawable20.icon_19316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19317: DrawableResource
+  get() = Drawable20.icon_19317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19318: DrawableResource
+  get() = Drawable20.icon_19318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19319: DrawableResource
+  get() = Drawable20.icon_19319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1932: DrawableResource
+  get() = Drawable20.icon_1932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19320: DrawableResource
+  get() = Drawable20.icon_19320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19321: DrawableResource
+  get() = Drawable20.icon_19321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19322: DrawableResource
+  get() = Drawable20.icon_19322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19323: DrawableResource
+  get() = Drawable20.icon_19323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19324: DrawableResource
+  get() = Drawable20.icon_19324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19325: DrawableResource
+  get() = Drawable20.icon_19325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19326: DrawableResource
+  get() = Drawable20.icon_19326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19327: DrawableResource
+  get() = Drawable20.icon_19327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19328: DrawableResource
+  get() = Drawable20.icon_19328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19329: DrawableResource
+  get() = Drawable20.icon_19329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1933: DrawableResource
+  get() = Drawable20.icon_1933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19330: DrawableResource
+  get() = Drawable20.icon_19330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19331: DrawableResource
+  get() = Drawable20.icon_19331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19332: DrawableResource
+  get() = Drawable20.icon_19332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19333: DrawableResource
+  get() = Drawable20.icon_19333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19334: DrawableResource
+  get() = Drawable20.icon_19334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19335: DrawableResource
+  get() = Drawable20.icon_19335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19336: DrawableResource
+  get() = Drawable20.icon_19336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19337: DrawableResource
+  get() = Drawable20.icon_19337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19338: DrawableResource
+  get() = Drawable20.icon_19338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19339: DrawableResource
+  get() = Drawable20.icon_19339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1934: DrawableResource
+  get() = Drawable20.icon_1934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19340: DrawableResource
+  get() = Drawable20.icon_19340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19341: DrawableResource
+  get() = Drawable20.icon_19341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19342: DrawableResource
+  get() = Drawable20.icon_19342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19343: DrawableResource
+  get() = Drawable20.icon_19343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19344: DrawableResource
+  get() = Drawable20.icon_19344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19345: DrawableResource
+  get() = Drawable20.icon_19345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19346: DrawableResource
+  get() = Drawable20.icon_19346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19347: DrawableResource
+  get() = Drawable20.icon_19347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19348: DrawableResource
+  get() = Drawable20.icon_19348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19349: DrawableResource
+  get() = Drawable20.icon_19349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1935: DrawableResource
+  get() = Drawable20.icon_1935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19350: DrawableResource
+  get() = Drawable20.icon_19350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19351: DrawableResource
+  get() = Drawable20.icon_19351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19352: DrawableResource
+  get() = Drawable20.icon_19352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19353: DrawableResource
+  get() = Drawable20.icon_19353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19354: DrawableResource
+  get() = Drawable20.icon_19354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19355: DrawableResource
+  get() = Drawable20.icon_19355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19356: DrawableResource
+  get() = Drawable20.icon_19356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19357: DrawableResource
+  get() = Drawable20.icon_19357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19358: DrawableResource
+  get() = Drawable20.icon_19358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19359: DrawableResource
+  get() = Drawable20.icon_19359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1936: DrawableResource
+  get() = Drawable20.icon_1936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19360: DrawableResource
+  get() = Drawable20.icon_19360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19361: DrawableResource
+  get() = Drawable20.icon_19361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19362: DrawableResource
+  get() = Drawable20.icon_19362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19363: DrawableResource
+  get() = Drawable20.icon_19363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19364: DrawableResource
+  get() = Drawable20.icon_19364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19365: DrawableResource
+  get() = Drawable20.icon_19365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19366: DrawableResource
+  get() = Drawable20.icon_19366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19367: DrawableResource
+  get() = Drawable20.icon_19367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19368: DrawableResource
+  get() = Drawable20.icon_19368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19369: DrawableResource
+  get() = Drawable20.icon_19369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1937: DrawableResource
+  get() = Drawable20.icon_1937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19370: DrawableResource
+  get() = Drawable20.icon_19370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19371: DrawableResource
+  get() = Drawable20.icon_19371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19372: DrawableResource
+  get() = Drawable20.icon_19372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19373: DrawableResource
+  get() = Drawable20.icon_19373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19374: DrawableResource
+  get() = Drawable20.icon_19374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19375: DrawableResource
+  get() = Drawable20.icon_19375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19376: DrawableResource
+  get() = Drawable20.icon_19376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19377: DrawableResource
+  get() = Drawable20.icon_19377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19378: DrawableResource
+  get() = Drawable20.icon_19378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19379: DrawableResource
+  get() = Drawable20.icon_19379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1938: DrawableResource
+  get() = Drawable20.icon_1938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19380: DrawableResource
+  get() = Drawable20.icon_19380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19381: DrawableResource
+  get() = Drawable20.icon_19381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19382: DrawableResource
+  get() = Drawable20.icon_19382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19383: DrawableResource
+  get() = Drawable20.icon_19383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19384: DrawableResource
+  get() = Drawable20.icon_19384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19385: DrawableResource
+  get() = Drawable20.icon_19385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19386: DrawableResource
+  get() = Drawable20.icon_19386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19387: DrawableResource
+  get() = Drawable20.icon_19387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19388: DrawableResource
+  get() = Drawable20.icon_19388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19389: DrawableResource
+  get() = Drawable20.icon_19389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1939: DrawableResource
+  get() = Drawable20.icon_1939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19390: DrawableResource
+  get() = Drawable20.icon_19390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19391: DrawableResource
+  get() = Drawable20.icon_19391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19392: DrawableResource
+  get() = Drawable20.icon_19392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19393: DrawableResource
+  get() = Drawable20.icon_19393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19394: DrawableResource
+  get() = Drawable20.icon_19394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19395: DrawableResource
+  get() = Drawable20.icon_19395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19396: DrawableResource
+  get() = Drawable20.icon_19396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19397: DrawableResource
+  get() = Drawable20.icon_19397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19398: DrawableResource
+  get() = Drawable20.icon_19398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19399: DrawableResource
+  get() = Drawable20.icon_19399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_194: DrawableResource
+  get() = Drawable20.icon_194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1940: DrawableResource
+  get() = Drawable20.icon_1940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19400: DrawableResource
+  get() = Drawable20.icon_19400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19401: DrawableResource
+  get() = Drawable20.icon_19401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19402: DrawableResource
+  get() = Drawable20.icon_19402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19403: DrawableResource
+  get() = Drawable20.icon_19403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19404: DrawableResource
+  get() = Drawable20.icon_19404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19405: DrawableResource
+  get() = Drawable20.icon_19405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19406: DrawableResource
+  get() = Drawable20.icon_19406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19407: DrawableResource
+  get() = Drawable20.icon_19407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19408: DrawableResource
+  get() = Drawable20.icon_19408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19409: DrawableResource
+  get() = Drawable20.icon_19409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1941: DrawableResource
+  get() = Drawable20.icon_1941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19410: DrawableResource
+  get() = Drawable20.icon_19410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19411: DrawableResource
+  get() = Drawable20.icon_19411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19412: DrawableResource
+  get() = Drawable20.icon_19412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19413: DrawableResource
+  get() = Drawable20.icon_19413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19414: DrawableResource
+  get() = Drawable20.icon_19414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19415: DrawableResource
+  get() = Drawable20.icon_19415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19416: DrawableResource
+  get() = Drawable20.icon_19416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19417: DrawableResource
+  get() = Drawable20.icon_19417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19418: DrawableResource
+  get() = Drawable20.icon_19418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19419: DrawableResource
+  get() = Drawable20.icon_19419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1942: DrawableResource
+  get() = Drawable20.icon_1942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19420: DrawableResource
+  get() = Drawable20.icon_19420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19421: DrawableResource
+  get() = Drawable20.icon_19421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19422: DrawableResource
+  get() = Drawable20.icon_19422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19423: DrawableResource
+  get() = Drawable20.icon_19423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19424: DrawableResource
+  get() = Drawable20.icon_19424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19425: DrawableResource
+  get() = Drawable20.icon_19425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19426: DrawableResource
+  get() = Drawable20.icon_19426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19427: DrawableResource
+  get() = Drawable20.icon_19427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19428: DrawableResource
+  get() = Drawable20.icon_19428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19429: DrawableResource
+  get() = Drawable20.icon_19429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1943: DrawableResource
+  get() = Drawable20.icon_1943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19430: DrawableResource
+  get() = Drawable20.icon_19430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19431: DrawableResource
+  get() = Drawable20.icon_19431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19432: DrawableResource
+  get() = Drawable20.icon_19432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19433: DrawableResource
+  get() = Drawable20.icon_19433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19434: DrawableResource
+  get() = Drawable20.icon_19434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19435: DrawableResource
+  get() = Drawable20.icon_19435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19436: DrawableResource
+  get() = Drawable20.icon_19436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19437: DrawableResource
+  get() = Drawable20.icon_19437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19438: DrawableResource
+  get() = Drawable20.icon_19438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19439: DrawableResource
+  get() = Drawable20.icon_19439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1944: DrawableResource
+  get() = Drawable20.icon_1944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19440: DrawableResource
+  get() = Drawable20.icon_19440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19441: DrawableResource
+  get() = Drawable20.icon_19441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19442: DrawableResource
+  get() = Drawable20.icon_19442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19443: DrawableResource
+  get() = Drawable20.icon_19443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19444: DrawableResource
+  get() = Drawable20.icon_19444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19445: DrawableResource
+  get() = Drawable20.icon_19445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19446: DrawableResource
+  get() = Drawable20.icon_19446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19447: DrawableResource
+  get() = Drawable20.icon_19447

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable21.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable21.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable21 {
+  public val icon_19448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19448.xml"),
+          )
+      )
+
+  public val icon_19449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19449.xml"),
+          )
+      )
+
+  public val icon_1945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1945.xml"),
+          )
+      )
+
+  public val icon_19450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19450.xml"),
+          )
+      )
+
+  public val icon_19451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19451.xml"),
+          )
+      )
+
+  public val icon_19452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19452.xml"),
+          )
+      )
+
+  public val icon_19453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19453.xml"),
+          )
+      )
+
+  public val icon_19454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19454.xml"),
+          )
+      )
+
+  public val icon_19455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19455.xml"),
+          )
+      )
+
+  public val icon_19456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19456.xml"),
+          )
+      )
+
+  public val icon_19457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19457.xml"),
+          )
+      )
+
+  public val icon_19458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19458.xml"),
+          )
+      )
+
+  public val icon_19459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19459.xml"),
+          )
+      )
+
+  public val icon_1946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1946.xml"),
+          )
+      )
+
+  public val icon_19460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19460.xml"),
+          )
+      )
+
+  public val icon_19461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19461.xml"),
+          )
+      )
+
+  public val icon_19462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19462.xml"),
+          )
+      )
+
+  public val icon_19463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19463.xml"),
+          )
+      )
+
+  public val icon_19464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19464.xml"),
+          )
+      )
+
+  public val icon_19465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19465.xml"),
+          )
+      )
+
+  public val icon_19466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19466.xml"),
+          )
+      )
+
+  public val icon_19467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19467.xml"),
+          )
+      )
+
+  public val icon_19468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19468.xml"),
+          )
+      )
+
+  public val icon_19469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19469.xml"),
+          )
+      )
+
+  public val icon_1947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1947.xml"),
+          )
+      )
+
+  public val icon_19470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19470.xml"),
+          )
+      )
+
+  public val icon_19471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19471.xml"),
+          )
+      )
+
+  public val icon_19472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19472.xml"),
+          )
+      )
+
+  public val icon_19473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19473.xml"),
+          )
+      )
+
+  public val icon_19474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19474.xml"),
+          )
+      )
+
+  public val icon_19475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19475.xml"),
+          )
+      )
+
+  public val icon_19476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19476.xml"),
+          )
+      )
+
+  public val icon_19477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19477.xml"),
+          )
+      )
+
+  public val icon_19478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19478.xml"),
+          )
+      )
+
+  public val icon_19479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19479.xml"),
+          )
+      )
+
+  public val icon_1948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1948.xml"),
+          )
+      )
+
+  public val icon_19480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19480.xml"),
+          )
+      )
+
+  public val icon_19481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19481.xml"),
+          )
+      )
+
+  public val icon_19482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19482.xml"),
+          )
+      )
+
+  public val icon_19483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19483.xml"),
+          )
+      )
+
+  public val icon_19484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19484.xml"),
+          )
+      )
+
+  public val icon_19485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19485.xml"),
+          )
+      )
+
+  public val icon_19486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19486.xml"),
+          )
+      )
+
+  public val icon_19487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19487.xml"),
+          )
+      )
+
+  public val icon_19488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19488.xml"),
+          )
+      )
+
+  public val icon_19489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19489.xml"),
+          )
+      )
+
+  public val icon_1949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1949.xml"),
+          )
+      )
+
+  public val icon_19490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19490.xml"),
+          )
+      )
+
+  public val icon_19491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19491.xml"),
+          )
+      )
+
+  public val icon_19492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19492.xml"),
+          )
+      )
+
+  public val icon_19493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19493.xml"),
+          )
+      )
+
+  public val icon_19494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19494.xml"),
+          )
+      )
+
+  public val icon_19495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19495.xml"),
+          )
+      )
+
+  public val icon_19496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19496.xml"),
+          )
+      )
+
+  public val icon_19497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19497.xml"),
+          )
+      )
+
+  public val icon_19498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19498.xml"),
+          )
+      )
+
+  public val icon_19499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19499.xml"),
+          )
+      )
+
+  public val icon_195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_195.xml"),
+          )
+      )
+
+  public val icon_1950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1950.xml"),
+          )
+      )
+
+  public val icon_19500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19500.xml"),
+          )
+      )
+
+  public val icon_19501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19501.xml"),
+          )
+      )
+
+  public val icon_19502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19502.xml"),
+          )
+      )
+
+  public val icon_19503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19503.xml"),
+          )
+      )
+
+  public val icon_19504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19504.xml"),
+          )
+      )
+
+  public val icon_19505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19505.xml"),
+          )
+      )
+
+  public val icon_19506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19506.xml"),
+          )
+      )
+
+  public val icon_19507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19507.xml"),
+          )
+      )
+
+  public val icon_19508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19508.xml"),
+          )
+      )
+
+  public val icon_19509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19509.xml"),
+          )
+      )
+
+  public val icon_1951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1951.xml"),
+          )
+      )
+
+  public val icon_19510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19510.xml"),
+          )
+      )
+
+  public val icon_19511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19511.xml"),
+          )
+      )
+
+  public val icon_19512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19512.xml"),
+          )
+      )
+
+  public val icon_19513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19513.xml"),
+          )
+      )
+
+  public val icon_19514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19514.xml"),
+          )
+      )
+
+  public val icon_19515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19515.xml"),
+          )
+      )
+
+  public val icon_19516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19516.xml"),
+          )
+      )
+
+  public val icon_19517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19517.xml"),
+          )
+      )
+
+  public val icon_19518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19518.xml"),
+          )
+      )
+
+  public val icon_19519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19519.xml"),
+          )
+      )
+
+  public val icon_1952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1952.xml"),
+          )
+      )
+
+  public val icon_19520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19520.xml"),
+          )
+      )
+
+  public val icon_19521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19521.xml"),
+          )
+      )
+
+  public val icon_19522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19522.xml"),
+          )
+      )
+
+  public val icon_19523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19523.xml"),
+          )
+      )
+
+  public val icon_19524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19524.xml"),
+          )
+      )
+
+  public val icon_19525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19525.xml"),
+          )
+      )
+
+  public val icon_19526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19526.xml"),
+          )
+      )
+
+  public val icon_19527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19527.xml"),
+          )
+      )
+
+  public val icon_19528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19528.xml"),
+          )
+      )
+
+  public val icon_19529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19529.xml"),
+          )
+      )
+
+  public val icon_1953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1953.xml"),
+          )
+      )
+
+  public val icon_19530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19530.xml"),
+          )
+      )
+
+  public val icon_19531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19531.xml"),
+          )
+      )
+
+  public val icon_19532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19532.xml"),
+          )
+      )
+
+  public val icon_19533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19533.xml"),
+          )
+      )
+
+  public val icon_19534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19534.xml"),
+          )
+      )
+
+  public val icon_19535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19535.xml"),
+          )
+      )
+
+  public val icon_19536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19536.xml"),
+          )
+      )
+
+  public val icon_19537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19537.xml"),
+          )
+      )
+
+  public val icon_19538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19538.xml"),
+          )
+      )
+
+  public val icon_19539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19539.xml"),
+          )
+      )
+
+  public val icon_1954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1954.xml"),
+          )
+      )
+
+  public val icon_19540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19540.xml"),
+          )
+      )
+
+  public val icon_19541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19541.xml"),
+          )
+      )
+
+  public val icon_19542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19542.xml"),
+          )
+      )
+
+  public val icon_19543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19543.xml"),
+          )
+      )
+
+  public val icon_19544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19544.xml"),
+          )
+      )
+
+  public val icon_19545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19545.xml"),
+          )
+      )
+
+  public val icon_19546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19546.xml"),
+          )
+      )
+
+  public val icon_19547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19547.xml"),
+          )
+      )
+
+  public val icon_19548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19548.xml"),
+          )
+      )
+
+  public val icon_19549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19549.xml"),
+          )
+      )
+
+  public val icon_1955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1955.xml"),
+          )
+      )
+
+  public val icon_19550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19550.xml"),
+          )
+      )
+
+  public val icon_19551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19551.xml"),
+          )
+      )
+
+  public val icon_19552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19552.xml"),
+          )
+      )
+
+  public val icon_19553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19553.xml"),
+          )
+      )
+
+  public val icon_19554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19554.xml"),
+          )
+      )
+
+  public val icon_19555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19555.xml"),
+          )
+      )
+
+  public val icon_19556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19556.xml"),
+          )
+      )
+
+  public val icon_19557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19557.xml"),
+          )
+      )
+
+  public val icon_19558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19558.xml"),
+          )
+      )
+
+  public val icon_19559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19559.xml"),
+          )
+      )
+
+  public val icon_1956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1956.xml"),
+          )
+      )
+
+  public val icon_19560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19560.xml"),
+          )
+      )
+
+  public val icon_19561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19561.xml"),
+          )
+      )
+
+  public val icon_19562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19562.xml"),
+          )
+      )
+
+  public val icon_19563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19563.xml"),
+          )
+      )
+
+  public val icon_19564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19564.xml"),
+          )
+      )
+
+  public val icon_19565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19565.xml"),
+          )
+      )
+
+  public val icon_19566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19566.xml"),
+          )
+      )
+
+  public val icon_19567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19567.xml"),
+          )
+      )
+
+  public val icon_19568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19568.xml"),
+          )
+      )
+
+  public val icon_19569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19569.xml"),
+          )
+      )
+
+  public val icon_1957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1957.xml"),
+          )
+      )
+
+  public val icon_19570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19570.xml"),
+          )
+      )
+
+  public val icon_19571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19571.xml"),
+          )
+      )
+
+  public val icon_19572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19572.xml"),
+          )
+      )
+
+  public val icon_19573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19573.xml"),
+          )
+      )
+
+  public val icon_19574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19574.xml"),
+          )
+      )
+
+  public val icon_19575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19575.xml"),
+          )
+      )
+
+  public val icon_19576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19576.xml"),
+          )
+      )
+
+  public val icon_19577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19577.xml"),
+          )
+      )
+
+  public val icon_19578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19578.xml"),
+          )
+      )
+
+  public val icon_19579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19579.xml"),
+          )
+      )
+
+  public val icon_1958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1958.xml"),
+          )
+      )
+
+  public val icon_19580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19580.xml"),
+          )
+      )
+
+  public val icon_19581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19581.xml"),
+          )
+      )
+
+  public val icon_19582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19582.xml"),
+          )
+      )
+
+  public val icon_19583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19583.xml"),
+          )
+      )
+
+  public val icon_19584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19584.xml"),
+          )
+      )
+
+  public val icon_19585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19585.xml"),
+          )
+      )
+
+  public val icon_19586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19586.xml"),
+          )
+      )
+
+  public val icon_19587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19587.xml"),
+          )
+      )
+
+  public val icon_19588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19588.xml"),
+          )
+      )
+
+  public val icon_19589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19589.xml"),
+          )
+      )
+
+  public val icon_1959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1959.xml"),
+          )
+      )
+
+  public val icon_19590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19590.xml"),
+          )
+      )
+
+  public val icon_19591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19591.xml"),
+          )
+      )
+
+  public val icon_19592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19592.xml"),
+          )
+      )
+
+  public val icon_19593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19593.xml"),
+          )
+      )
+
+  public val icon_19594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19594.xml"),
+          )
+      )
+
+  public val icon_19595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19595.xml"),
+          )
+      )
+
+  public val icon_19596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19596.xml"),
+          )
+      )
+
+  public val icon_19597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19597.xml"),
+          )
+      )
+
+  public val icon_19598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19598.xml"),
+          )
+      )
+
+  public val icon_19599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19599.xml"),
+          )
+      )
+
+  public val icon_196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_196.xml"),
+          )
+      )
+
+  public val icon_1960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1960.xml"),
+          )
+      )
+
+  public val icon_19600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19600.xml"),
+          )
+      )
+
+  public val icon_19601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19601.xml"),
+          )
+      )
+
+  public val icon_19602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19602.xml"),
+          )
+      )
+
+  public val icon_19603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19603.xml"),
+          )
+      )
+
+  public val icon_19604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19604.xml"),
+          )
+      )
+
+  public val icon_19605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19605.xml"),
+          )
+      )
+
+  public val icon_19606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19606.xml"),
+          )
+      )
+
+  public val icon_19607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19607.xml"),
+          )
+      )
+
+  public val icon_19608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19608.xml"),
+          )
+      )
+
+  public val icon_19609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19609.xml"),
+          )
+      )
+
+  public val icon_1961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1961.xml"),
+          )
+      )
+
+  public val icon_19610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19610.xml"),
+          )
+      )
+
+  public val icon_19611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19611.xml"),
+          )
+      )
+
+  public val icon_19612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19612.xml"),
+          )
+      )
+
+  public val icon_19613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19613.xml"),
+          )
+      )
+
+  public val icon_19614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19614.xml"),
+          )
+      )
+
+  public val icon_19615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19615.xml"),
+          )
+      )
+
+  public val icon_19616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19616.xml"),
+          )
+      )
+
+  public val icon_19617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19617.xml"),
+          )
+      )
+
+  public val icon_19618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19618.xml"),
+          )
+      )
+
+  public val icon_19619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19619.xml"),
+          )
+      )
+
+  public val icon_1962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1962.xml"),
+          )
+      )
+
+  public val icon_19620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19620.xml"),
+          )
+      )
+
+  public val icon_19621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19621.xml"),
+          )
+      )
+
+  public val icon_19622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19622.xml"),
+          )
+      )
+
+  public val icon_19623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19623.xml"),
+          )
+      )
+
+  public val icon_19624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19624.xml"),
+          )
+      )
+
+  public val icon_19625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19625.xml"),
+          )
+      )
+
+  public val icon_19626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19626.xml"),
+          )
+      )
+
+  public val icon_19627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19627.xml"),
+          )
+      )
+
+  public val icon_19628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19628.xml"),
+          )
+      )
+
+  public val icon_19629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19629.xml"),
+          )
+      )
+
+  public val icon_1963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1963.xml"),
+          )
+      )
+
+  public val icon_19630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19630.xml"),
+          )
+      )
+
+  public val icon_19631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19631.xml"),
+          )
+      )
+
+  public val icon_19632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19632.xml"),
+          )
+      )
+
+  public val icon_19633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19633.xml"),
+          )
+      )
+
+  public val icon_19634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19634.xml"),
+          )
+      )
+
+  public val icon_19635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19635.xml"),
+          )
+      )
+
+  public val icon_19636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19636.xml"),
+          )
+      )
+
+  public val icon_19637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19637.xml"),
+          )
+      )
+
+  public val icon_19638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19638.xml"),
+          )
+      )
+
+  public val icon_19639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19639.xml"),
+          )
+      )
+
+  public val icon_1964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1964.xml"),
+          )
+      )
+
+  public val icon_19640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19640.xml"),
+          )
+      )
+
+  public val icon_19641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19641.xml"),
+          )
+      )
+
+  public val icon_19642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19642.xml"),
+          )
+      )
+
+  public val icon_19643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19643.xml"),
+          )
+      )
+
+  public val icon_19644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19644.xml"),
+          )
+      )
+
+  public val icon_19645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19645.xml"),
+          )
+      )
+
+  public val icon_19646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19646.xml"),
+          )
+      )
+
+  public val icon_19647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19647.xml"),
+          )
+      )
+
+  public val icon_19648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19648.xml"),
+          )
+      )
+
+  public val icon_19649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19649.xml"),
+          )
+      )
+
+  public val icon_1965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1965.xml"),
+          )
+      )
+
+  public val icon_19650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19650.xml"),
+          )
+      )
+
+  public val icon_19651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19651.xml"),
+          )
+      )
+
+  public val icon_19652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19652.xml"),
+          )
+      )
+
+  public val icon_19653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19653.xml"),
+          )
+      )
+
+  public val icon_19654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19654.xml"),
+          )
+      )
+
+  public val icon_19655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19655.xml"),
+          )
+      )
+
+  public val icon_19656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19656.xml"),
+          )
+      )
+
+  public val icon_19657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19657.xml"),
+          )
+      )
+
+  public val icon_19658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19658.xml"),
+          )
+      )
+
+  public val icon_19659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19659.xml"),
+          )
+      )
+
+  public val icon_1966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1966.xml"),
+          )
+      )
+
+  public val icon_19660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19660.xml"),
+          )
+      )
+
+  public val icon_19661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19661.xml"),
+          )
+      )
+
+  public val icon_19662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19662.xml"),
+          )
+      )
+
+  public val icon_19663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19663.xml"),
+          )
+      )
+
+  public val icon_19664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19664.xml"),
+          )
+      )
+
+  public val icon_19665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19665.xml"),
+          )
+      )
+
+  public val icon_19666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19666.xml"),
+          )
+      )
+
+  public val icon_19667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19667.xml"),
+          )
+      )
+
+  public val icon_19668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19668.xml"),
+          )
+      )
+
+  public val icon_19669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19669.xml"),
+          )
+      )
+
+  public val icon_1967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1967.xml"),
+          )
+      )
+
+  public val icon_19670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19670.xml"),
+          )
+      )
+
+  public val icon_19671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19671.xml"),
+          )
+      )
+
+  public val icon_19672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19672.xml"),
+          )
+      )
+
+  public val icon_19673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19673.xml"),
+          )
+      )
+
+  public val icon_19674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19674.xml"),
+          )
+      )
+
+  public val icon_19675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19675.xml"),
+          )
+      )
+
+  public val icon_19676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19676.xml"),
+          )
+      )
+
+  public val icon_19677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19677.xml"),
+          )
+      )
+
+  public val icon_19678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19678.xml"),
+          )
+      )
+
+  public val icon_19679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19679.xml"),
+          )
+      )
+
+  public val icon_1968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1968.xml"),
+          )
+      )
+
+  public val icon_19680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19680.xml"),
+          )
+      )
+
+  public val icon_19681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19681.xml"),
+          )
+      )
+
+  public val icon_19682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19682.xml"),
+          )
+      )
+
+  public val icon_19683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19683.xml"),
+          )
+      )
+
+  public val icon_19684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19684.xml"),
+          )
+      )
+
+  public val icon_19685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19685.xml"),
+          )
+      )
+
+  public val icon_19686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19686.xml"),
+          )
+      )
+
+  public val icon_19687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19687.xml"),
+          )
+      )
+
+  public val icon_19688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19688.xml"),
+          )
+      )
+
+  public val icon_19689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19689.xml"),
+          )
+      )
+
+  public val icon_1969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1969.xml"),
+          )
+      )
+
+  public val icon_19690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19690.xml"),
+          )
+      )
+
+  public val icon_19691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19691.xml"),
+          )
+      )
+
+  public val icon_19692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19692.xml"),
+          )
+      )
+
+  public val icon_19693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19693.xml"),
+          )
+      )
+
+  public val icon_19694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19694.xml"),
+          )
+      )
+
+  public val icon_19695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19695.xml"),
+          )
+      )
+
+  public val icon_19696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19696.xml"),
+          )
+      )
+
+  public val icon_19697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19697.xml"),
+          )
+      )
+
+  public val icon_19698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19698.xml"),
+          )
+      )
+
+  public val icon_19699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19699.xml"),
+          )
+      )
+
+  public val icon_197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_197.xml"),
+          )
+      )
+
+  public val icon_1970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1970.xml"),
+          )
+      )
+
+  public val icon_19700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19700.xml"),
+          )
+      )
+
+  public val icon_19701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19701.xml"),
+          )
+      )
+
+  public val icon_19702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19702.xml"),
+          )
+      )
+
+  public val icon_19703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19703.xml"),
+          )
+      )
+
+  public val icon_19704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19704.xml"),
+          )
+      )
+
+  public val icon_19705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19705.xml"),
+          )
+      )
+
+  public val icon_19706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19706.xml"),
+          )
+      )
+
+  public val icon_19707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19707.xml"),
+          )
+      )
+
+  public val icon_19708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19708.xml"),
+          )
+      )
+
+  public val icon_19709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19709.xml"),
+          )
+      )
+
+  public val icon_1971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1971.xml"),
+          )
+      )
+
+  public val icon_19710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19710.xml"),
+          )
+      )
+
+  public val icon_19711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19711.xml"),
+          )
+      )
+
+  public val icon_19712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19712.xml"),
+          )
+      )
+
+  public val icon_19713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19713.xml"),
+          )
+      )
+
+  public val icon_19714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19714.xml"),
+          )
+      )
+
+  public val icon_19715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19715.xml"),
+          )
+      )
+
+  public val icon_19716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19716.xml"),
+          )
+      )
+
+  public val icon_19717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19717.xml"),
+          )
+      )
+
+  public val icon_19718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19718.xml"),
+          )
+      )
+
+  public val icon_19719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19719.xml"),
+          )
+      )
+
+  public val icon_1972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1972.xml"),
+          )
+      )
+
+  public val icon_19720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19720.xml"),
+          )
+      )
+
+  public val icon_19721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19721.xml"),
+          )
+      )
+
+  public val icon_19722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19722.xml"),
+          )
+      )
+
+  public val icon_19723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19723.xml"),
+          )
+      )
+
+  public val icon_19724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19724.xml"),
+          )
+      )
+
+  public val icon_19725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19725.xml"),
+          )
+      )
+
+  public val icon_19726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19726.xml"),
+          )
+      )
+
+  public val icon_19727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19727.xml"),
+          )
+      )
+
+  public val icon_19728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19728.xml"),
+          )
+      )
+
+  public val icon_19729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19729.xml"),
+          )
+      )
+
+  public val icon_1973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1973.xml"),
+          )
+      )
+
+  public val icon_19730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19730.xml"),
+          )
+      )
+
+  public val icon_19731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19731.xml"),
+          )
+      )
+
+  public val icon_19732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19732.xml"),
+          )
+      )
+
+  public val icon_19733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19733.xml"),
+          )
+      )
+
+  public val icon_19734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19734.xml"),
+          )
+      )
+
+  public val icon_19735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19735.xml"),
+          )
+      )
+
+  public val icon_19736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19736.xml"),
+          )
+      )
+
+  public val icon_19737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19737.xml"),
+          )
+      )
+
+  public val icon_19738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19738.xml"),
+          )
+      )
+
+  public val icon_19739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19739.xml"),
+          )
+      )
+
+  public val icon_1974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1974.xml"),
+          )
+      )
+
+  public val icon_19740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19740.xml"),
+          )
+      )
+
+  public val icon_19741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19741.xml"),
+          )
+      )
+
+  public val icon_19742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19742.xml"),
+          )
+      )
+
+  public val icon_19743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19743.xml"),
+          )
+      )
+
+  public val icon_19744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19744.xml"),
+          )
+      )
+
+  public val icon_19745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19745.xml"),
+          )
+      )
+
+  public val icon_19746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19746.xml"),
+          )
+      )
+
+  public val icon_19747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19747.xml"),
+          )
+      )
+
+  public val icon_19748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19748.xml"),
+          )
+      )
+
+  public val icon_19749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19749.xml"),
+          )
+      )
+
+  public val icon_1975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1975.xml"),
+          )
+      )
+
+  public val icon_19750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19750.xml"),
+          )
+      )
+
+  public val icon_19751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19751.xml"),
+          )
+      )
+
+  public val icon_19752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19752.xml"),
+          )
+      )
+
+  public val icon_19753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19753.xml"),
+          )
+      )
+
+  public val icon_19754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19754.xml"),
+          )
+      )
+
+  public val icon_19755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19755.xml"),
+          )
+      )
+
+  public val icon_19756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19756.xml"),
+          )
+      )
+
+  public val icon_19757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19757.xml"),
+          )
+      )
+
+  public val icon_19758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19758.xml"),
+          )
+      )
+
+  public val icon_19759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19759.xml"),
+          )
+      )
+
+  public val icon_1976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1976.xml"),
+          )
+      )
+
+  public val icon_19760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19760.xml"),
+          )
+      )
+
+  public val icon_19761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19761.xml"),
+          )
+      )
+
+  public val icon_19762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19762.xml"),
+          )
+      )
+
+  public val icon_19763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19763.xml"),
+          )
+      )
+
+  public val icon_19764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19764.xml"),
+          )
+      )
+
+  public val icon_19765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19765.xml"),
+          )
+      )
+
+  public val icon_19766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19766.xml"),
+          )
+      )
+
+  public val icon_19767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19767.xml"),
+          )
+      )
+
+  public val icon_19768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19768.xml"),
+          )
+      )
+
+  public val icon_19769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19769.xml"),
+          )
+      )
+
+  public val icon_1977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1977.xml"),
+          )
+      )
+
+  public val icon_19770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19770.xml"),
+          )
+      )
+
+  public val icon_19771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19771.xml"),
+          )
+      )
+
+  public val icon_19772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19772.xml"),
+          )
+      )
+
+  public val icon_19773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19773.xml"),
+          )
+      )
+
+  public val icon_19774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19774.xml"),
+          )
+      )
+
+  public val icon_19775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19775.xml"),
+          )
+      )
+
+  public val icon_19776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19776.xml"),
+          )
+      )
+
+  public val icon_19777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19777.xml"),
+          )
+      )
+
+  public val icon_19778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19778.xml"),
+          )
+      )
+
+  public val icon_19779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19779.xml"),
+          )
+      )
+
+  public val icon_1978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1978.xml"),
+          )
+      )
+
+  public val icon_19780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19780.xml"),
+          )
+      )
+
+  public val icon_19781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19781.xml"),
+          )
+      )
+
+  public val icon_19782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19782.xml"),
+          )
+      )
+
+  public val icon_19783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19783.xml"),
+          )
+      )
+
+  public val icon_19784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19784.xml"),
+          )
+      )
+
+  public val icon_19785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19785.xml"),
+          )
+      )
+
+  public val icon_19786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19786.xml"),
+          )
+      )
+
+  public val icon_19787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19787.xml"),
+          )
+      )
+
+  public val icon_19788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19788.xml"),
+          )
+      )
+
+  public val icon_19789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19789.xml"),
+          )
+      )
+
+  public val icon_1979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1979.xml"),
+          )
+      )
+
+  public val icon_19790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19790.xml"),
+          )
+      )
+
+  public val icon_19791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19791.xml"),
+          )
+      )
+
+  public val icon_19792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19792.xml"),
+          )
+      )
+
+  public val icon_19793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19793.xml"),
+          )
+      )
+
+  public val icon_19794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19794.xml"),
+          )
+      )
+
+  public val icon_19795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19795.xml"),
+          )
+      )
+
+  public val icon_19796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19796.xml"),
+          )
+      )
+
+  public val icon_19797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19797.xml"),
+          )
+      )
+
+  public val icon_19798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19798.xml"),
+          )
+      )
+
+  public val icon_19799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19799.xml"),
+          )
+      )
+
+  public val icon_198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_198.xml"),
+          )
+      )
+
+  public val icon_1980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1980.xml"),
+          )
+      )
+
+  public val icon_19800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19800.xml"),
+          )
+      )
+
+  public val icon_19801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19801.xml"),
+          )
+      )
+
+  public val icon_19802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19802.xml"),
+          )
+      )
+
+  public val icon_19803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19803.xml"),
+          )
+      )
+
+  public val icon_19804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19804.xml"),
+          )
+      )
+
+  public val icon_19805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19805.xml"),
+          )
+      )
+
+  public val icon_19806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19806.xml"),
+          )
+      )
+
+  public val icon_19807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19807.xml"),
+          )
+      )
+
+  public val icon_19808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19808.xml"),
+          )
+      )
+
+  public val icon_19809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19809.xml"),
+          )
+      )
+
+  public val icon_1981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1981.xml"),
+          )
+      )
+
+  public val icon_19810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19810.xml"),
+          )
+      )
+
+  public val icon_19811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19811.xml"),
+          )
+      )
+
+  public val icon_19812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19812.xml"),
+          )
+      )
+
+  public val icon_19813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19813.xml"),
+          )
+      )
+
+  public val icon_19814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19814.xml"),
+          )
+      )
+
+  public val icon_19815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19815.xml"),
+          )
+      )
+
+  public val icon_19816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19816.xml"),
+          )
+      )
+
+  public val icon_19817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19817.xml"),
+          )
+      )
+
+  public val icon_19818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19818.xml"),
+          )
+      )
+
+  public val icon_19819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19819.xml"),
+          )
+      )
+
+  public val icon_1982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1982.xml"),
+          )
+      )
+
+  public val icon_19820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19820.xml"),
+          )
+      )
+
+  public val icon_19821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19821.xml"),
+          )
+      )
+
+  public val icon_19822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19822.xml"),
+          )
+      )
+
+  public val icon_19823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19823.xml"),
+          )
+      )
+
+  public val icon_19824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19824.xml"),
+          )
+      )
+
+  public val icon_19825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19825.xml"),
+          )
+      )
+
+  public val icon_19826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19826.xml"),
+          )
+      )
+
+  public val icon_19827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19827.xml"),
+          )
+      )
+
+  public val icon_19828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19828.xml"),
+          )
+      )
+
+  public val icon_19829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19829.xml"),
+          )
+      )
+
+  public val icon_1983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1983.xml"),
+          )
+      )
+
+  public val icon_19830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19830.xml"),
+          )
+      )
+
+  public val icon_19831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19831.xml"),
+          )
+      )
+
+  public val icon_19832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19832.xml"),
+          )
+      )
+
+  public val icon_19833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19833.xml"),
+          )
+      )
+
+  public val icon_19834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19834.xml"),
+          )
+      )
+
+  public val icon_19835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19835.xml"),
+          )
+      )
+
+  public val icon_19836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19836.xml"),
+          )
+      )
+
+  public val icon_19837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19837.xml"),
+          )
+      )
+
+  public val icon_19838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19838.xml"),
+          )
+      )
+
+  public val icon_19839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19839.xml"),
+          )
+      )
+
+  public val icon_1984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1984.xml"),
+          )
+      )
+
+  public val icon_19840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19840.xml"),
+          )
+      )
+
+  public val icon_19841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19841.xml"),
+          )
+      )
+
+  public val icon_19842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19842.xml"),
+          )
+      )
+
+  public val icon_19843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19843.xml"),
+          )
+      )
+
+  public val icon_19844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19844.xml"),
+          )
+      )
+
+  public val icon_19845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19845.xml"),
+          )
+      )
+
+  public val icon_19846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19846.xml"),
+          )
+      )
+
+  public val icon_19847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19847.xml"),
+          )
+      )
+
+  public val icon_19848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19848.xml"),
+          )
+      )
+
+  public val icon_19849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19849.xml"),
+          )
+      )
+
+  public val icon_1985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1985.xml"),
+          )
+      )
+
+  public val icon_19850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19850.xml"),
+          )
+      )
+
+  public val icon_19851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19851.xml"),
+          )
+      )
+
+  public val icon_19852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19852.xml"),
+          )
+      )
+
+  public val icon_19853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19853.xml"),
+          )
+      )
+
+  public val icon_19854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19854.xml"),
+          )
+      )
+
+  public val icon_19855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19855.xml"),
+          )
+      )
+
+  public val icon_19856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19856.xml"),
+          )
+      )
+
+  public val icon_19857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19857.xml"),
+          )
+      )
+
+  public val icon_19858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19858.xml"),
+          )
+      )
+
+  public val icon_19859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19859.xml"),
+          )
+      )
+
+  public val icon_1986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1986.xml"),
+          )
+      )
+
+  public val icon_19860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19860.xml"),
+          )
+      )
+
+  public val icon_19861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19861.xml"),
+          )
+      )
+
+  public val icon_19862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19862.xml"),
+          )
+      )
+
+  public val icon_19863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19863.xml"),
+          )
+      )
+
+  public val icon_19864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19864.xml"),
+          )
+      )
+
+  public val icon_19865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19865.xml"),
+          )
+      )
+
+  public val icon_19866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19866.xml"),
+          )
+      )
+
+  public val icon_19867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19867.xml"),
+          )
+      )
+
+  public val icon_19868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19868.xml"),
+          )
+      )
+
+  public val icon_19869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19869.xml"),
+          )
+      )
+
+  public val icon_1987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1987.xml"),
+          )
+      )
+
+  public val icon_19870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19870.xml"),
+          )
+      )
+
+  public val icon_19871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19871.xml"),
+          )
+      )
+
+  public val icon_19872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19872.xml"),
+          )
+      )
+
+  public val icon_19873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19873.xml"),
+          )
+      )
+
+  public val icon_19874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19874.xml"),
+          )
+      )
+
+  public val icon_19875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19875.xml"),
+          )
+      )
+
+  public val icon_19876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19876.xml"),
+          )
+      )
+
+  public val icon_19877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19877.xml"),
+          )
+      )
+
+  public val icon_19878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19878.xml"),
+          )
+      )
+
+  public val icon_19879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19879.xml"),
+          )
+      )
+
+  public val icon_1988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1988.xml"),
+          )
+      )
+
+  public val icon_19880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19880.xml"),
+          )
+      )
+
+  public val icon_19881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19881.xml"),
+          )
+      )
+
+  public val icon_19882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19882.xml"),
+          )
+      )
+
+  public val icon_19883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19883.xml"),
+          )
+      )
+
+  public val icon_19884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19884.xml"),
+          )
+      )
+
+  public val icon_19885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19885.xml"),
+          )
+      )
+
+  public val icon_19886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19886.xml"),
+          )
+      )
+
+  public val icon_19887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19887.xml"),
+          )
+      )
+
+  public val icon_19888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19888.xml"),
+          )
+      )
+
+  public val icon_19889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19889.xml"),
+          )
+      )
+
+  public val icon_1989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1989.xml"),
+          )
+      )
+
+  public val icon_19890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19890.xml"),
+          )
+      )
+
+  public val icon_19891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19891.xml"),
+          )
+      )
+
+  public val icon_19892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19892.xml"),
+          )
+      )
+
+  public val icon_19893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19893.xml"),
+          )
+      )
+
+  public val icon_19894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19894.xml"),
+          )
+      )
+
+  public val icon_19895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19895.xml"),
+          )
+      )
+
+  public val icon_19896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19896.xml"),
+          )
+      )
+
+  public val icon_19897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19897.xml"),
+          )
+      )
+
+  public val icon_19898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19898.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19448: DrawableResource
+  get() = Drawable21.icon_19448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19449: DrawableResource
+  get() = Drawable21.icon_19449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1945: DrawableResource
+  get() = Drawable21.icon_1945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19450: DrawableResource
+  get() = Drawable21.icon_19450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19451: DrawableResource
+  get() = Drawable21.icon_19451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19452: DrawableResource
+  get() = Drawable21.icon_19452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19453: DrawableResource
+  get() = Drawable21.icon_19453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19454: DrawableResource
+  get() = Drawable21.icon_19454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19455: DrawableResource
+  get() = Drawable21.icon_19455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19456: DrawableResource
+  get() = Drawable21.icon_19456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19457: DrawableResource
+  get() = Drawable21.icon_19457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19458: DrawableResource
+  get() = Drawable21.icon_19458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19459: DrawableResource
+  get() = Drawable21.icon_19459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1946: DrawableResource
+  get() = Drawable21.icon_1946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19460: DrawableResource
+  get() = Drawable21.icon_19460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19461: DrawableResource
+  get() = Drawable21.icon_19461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19462: DrawableResource
+  get() = Drawable21.icon_19462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19463: DrawableResource
+  get() = Drawable21.icon_19463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19464: DrawableResource
+  get() = Drawable21.icon_19464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19465: DrawableResource
+  get() = Drawable21.icon_19465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19466: DrawableResource
+  get() = Drawable21.icon_19466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19467: DrawableResource
+  get() = Drawable21.icon_19467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19468: DrawableResource
+  get() = Drawable21.icon_19468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19469: DrawableResource
+  get() = Drawable21.icon_19469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1947: DrawableResource
+  get() = Drawable21.icon_1947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19470: DrawableResource
+  get() = Drawable21.icon_19470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19471: DrawableResource
+  get() = Drawable21.icon_19471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19472: DrawableResource
+  get() = Drawable21.icon_19472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19473: DrawableResource
+  get() = Drawable21.icon_19473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19474: DrawableResource
+  get() = Drawable21.icon_19474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19475: DrawableResource
+  get() = Drawable21.icon_19475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19476: DrawableResource
+  get() = Drawable21.icon_19476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19477: DrawableResource
+  get() = Drawable21.icon_19477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19478: DrawableResource
+  get() = Drawable21.icon_19478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19479: DrawableResource
+  get() = Drawable21.icon_19479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1948: DrawableResource
+  get() = Drawable21.icon_1948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19480: DrawableResource
+  get() = Drawable21.icon_19480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19481: DrawableResource
+  get() = Drawable21.icon_19481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19482: DrawableResource
+  get() = Drawable21.icon_19482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19483: DrawableResource
+  get() = Drawable21.icon_19483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19484: DrawableResource
+  get() = Drawable21.icon_19484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19485: DrawableResource
+  get() = Drawable21.icon_19485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19486: DrawableResource
+  get() = Drawable21.icon_19486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19487: DrawableResource
+  get() = Drawable21.icon_19487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19488: DrawableResource
+  get() = Drawable21.icon_19488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19489: DrawableResource
+  get() = Drawable21.icon_19489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1949: DrawableResource
+  get() = Drawable21.icon_1949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19490: DrawableResource
+  get() = Drawable21.icon_19490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19491: DrawableResource
+  get() = Drawable21.icon_19491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19492: DrawableResource
+  get() = Drawable21.icon_19492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19493: DrawableResource
+  get() = Drawable21.icon_19493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19494: DrawableResource
+  get() = Drawable21.icon_19494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19495: DrawableResource
+  get() = Drawable21.icon_19495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19496: DrawableResource
+  get() = Drawable21.icon_19496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19497: DrawableResource
+  get() = Drawable21.icon_19497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19498: DrawableResource
+  get() = Drawable21.icon_19498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19499: DrawableResource
+  get() = Drawable21.icon_19499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_195: DrawableResource
+  get() = Drawable21.icon_195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1950: DrawableResource
+  get() = Drawable21.icon_1950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19500: DrawableResource
+  get() = Drawable21.icon_19500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19501: DrawableResource
+  get() = Drawable21.icon_19501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19502: DrawableResource
+  get() = Drawable21.icon_19502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19503: DrawableResource
+  get() = Drawable21.icon_19503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19504: DrawableResource
+  get() = Drawable21.icon_19504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19505: DrawableResource
+  get() = Drawable21.icon_19505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19506: DrawableResource
+  get() = Drawable21.icon_19506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19507: DrawableResource
+  get() = Drawable21.icon_19507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19508: DrawableResource
+  get() = Drawable21.icon_19508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19509: DrawableResource
+  get() = Drawable21.icon_19509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1951: DrawableResource
+  get() = Drawable21.icon_1951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19510: DrawableResource
+  get() = Drawable21.icon_19510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19511: DrawableResource
+  get() = Drawable21.icon_19511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19512: DrawableResource
+  get() = Drawable21.icon_19512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19513: DrawableResource
+  get() = Drawable21.icon_19513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19514: DrawableResource
+  get() = Drawable21.icon_19514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19515: DrawableResource
+  get() = Drawable21.icon_19515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19516: DrawableResource
+  get() = Drawable21.icon_19516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19517: DrawableResource
+  get() = Drawable21.icon_19517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19518: DrawableResource
+  get() = Drawable21.icon_19518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19519: DrawableResource
+  get() = Drawable21.icon_19519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1952: DrawableResource
+  get() = Drawable21.icon_1952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19520: DrawableResource
+  get() = Drawable21.icon_19520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19521: DrawableResource
+  get() = Drawable21.icon_19521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19522: DrawableResource
+  get() = Drawable21.icon_19522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19523: DrawableResource
+  get() = Drawable21.icon_19523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19524: DrawableResource
+  get() = Drawable21.icon_19524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19525: DrawableResource
+  get() = Drawable21.icon_19525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19526: DrawableResource
+  get() = Drawable21.icon_19526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19527: DrawableResource
+  get() = Drawable21.icon_19527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19528: DrawableResource
+  get() = Drawable21.icon_19528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19529: DrawableResource
+  get() = Drawable21.icon_19529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1953: DrawableResource
+  get() = Drawable21.icon_1953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19530: DrawableResource
+  get() = Drawable21.icon_19530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19531: DrawableResource
+  get() = Drawable21.icon_19531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19532: DrawableResource
+  get() = Drawable21.icon_19532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19533: DrawableResource
+  get() = Drawable21.icon_19533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19534: DrawableResource
+  get() = Drawable21.icon_19534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19535: DrawableResource
+  get() = Drawable21.icon_19535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19536: DrawableResource
+  get() = Drawable21.icon_19536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19537: DrawableResource
+  get() = Drawable21.icon_19537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19538: DrawableResource
+  get() = Drawable21.icon_19538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19539: DrawableResource
+  get() = Drawable21.icon_19539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1954: DrawableResource
+  get() = Drawable21.icon_1954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19540: DrawableResource
+  get() = Drawable21.icon_19540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19541: DrawableResource
+  get() = Drawable21.icon_19541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19542: DrawableResource
+  get() = Drawable21.icon_19542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19543: DrawableResource
+  get() = Drawable21.icon_19543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19544: DrawableResource
+  get() = Drawable21.icon_19544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19545: DrawableResource
+  get() = Drawable21.icon_19545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19546: DrawableResource
+  get() = Drawable21.icon_19546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19547: DrawableResource
+  get() = Drawable21.icon_19547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19548: DrawableResource
+  get() = Drawable21.icon_19548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19549: DrawableResource
+  get() = Drawable21.icon_19549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1955: DrawableResource
+  get() = Drawable21.icon_1955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19550: DrawableResource
+  get() = Drawable21.icon_19550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19551: DrawableResource
+  get() = Drawable21.icon_19551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19552: DrawableResource
+  get() = Drawable21.icon_19552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19553: DrawableResource
+  get() = Drawable21.icon_19553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19554: DrawableResource
+  get() = Drawable21.icon_19554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19555: DrawableResource
+  get() = Drawable21.icon_19555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19556: DrawableResource
+  get() = Drawable21.icon_19556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19557: DrawableResource
+  get() = Drawable21.icon_19557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19558: DrawableResource
+  get() = Drawable21.icon_19558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19559: DrawableResource
+  get() = Drawable21.icon_19559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1956: DrawableResource
+  get() = Drawable21.icon_1956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19560: DrawableResource
+  get() = Drawable21.icon_19560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19561: DrawableResource
+  get() = Drawable21.icon_19561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19562: DrawableResource
+  get() = Drawable21.icon_19562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19563: DrawableResource
+  get() = Drawable21.icon_19563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19564: DrawableResource
+  get() = Drawable21.icon_19564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19565: DrawableResource
+  get() = Drawable21.icon_19565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19566: DrawableResource
+  get() = Drawable21.icon_19566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19567: DrawableResource
+  get() = Drawable21.icon_19567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19568: DrawableResource
+  get() = Drawable21.icon_19568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19569: DrawableResource
+  get() = Drawable21.icon_19569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1957: DrawableResource
+  get() = Drawable21.icon_1957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19570: DrawableResource
+  get() = Drawable21.icon_19570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19571: DrawableResource
+  get() = Drawable21.icon_19571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19572: DrawableResource
+  get() = Drawable21.icon_19572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19573: DrawableResource
+  get() = Drawable21.icon_19573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19574: DrawableResource
+  get() = Drawable21.icon_19574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19575: DrawableResource
+  get() = Drawable21.icon_19575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19576: DrawableResource
+  get() = Drawable21.icon_19576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19577: DrawableResource
+  get() = Drawable21.icon_19577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19578: DrawableResource
+  get() = Drawable21.icon_19578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19579: DrawableResource
+  get() = Drawable21.icon_19579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1958: DrawableResource
+  get() = Drawable21.icon_1958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19580: DrawableResource
+  get() = Drawable21.icon_19580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19581: DrawableResource
+  get() = Drawable21.icon_19581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19582: DrawableResource
+  get() = Drawable21.icon_19582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19583: DrawableResource
+  get() = Drawable21.icon_19583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19584: DrawableResource
+  get() = Drawable21.icon_19584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19585: DrawableResource
+  get() = Drawable21.icon_19585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19586: DrawableResource
+  get() = Drawable21.icon_19586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19587: DrawableResource
+  get() = Drawable21.icon_19587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19588: DrawableResource
+  get() = Drawable21.icon_19588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19589: DrawableResource
+  get() = Drawable21.icon_19589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1959: DrawableResource
+  get() = Drawable21.icon_1959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19590: DrawableResource
+  get() = Drawable21.icon_19590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19591: DrawableResource
+  get() = Drawable21.icon_19591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19592: DrawableResource
+  get() = Drawable21.icon_19592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19593: DrawableResource
+  get() = Drawable21.icon_19593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19594: DrawableResource
+  get() = Drawable21.icon_19594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19595: DrawableResource
+  get() = Drawable21.icon_19595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19596: DrawableResource
+  get() = Drawable21.icon_19596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19597: DrawableResource
+  get() = Drawable21.icon_19597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19598: DrawableResource
+  get() = Drawable21.icon_19598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19599: DrawableResource
+  get() = Drawable21.icon_19599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_196: DrawableResource
+  get() = Drawable21.icon_196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1960: DrawableResource
+  get() = Drawable21.icon_1960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19600: DrawableResource
+  get() = Drawable21.icon_19600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19601: DrawableResource
+  get() = Drawable21.icon_19601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19602: DrawableResource
+  get() = Drawable21.icon_19602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19603: DrawableResource
+  get() = Drawable21.icon_19603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19604: DrawableResource
+  get() = Drawable21.icon_19604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19605: DrawableResource
+  get() = Drawable21.icon_19605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19606: DrawableResource
+  get() = Drawable21.icon_19606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19607: DrawableResource
+  get() = Drawable21.icon_19607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19608: DrawableResource
+  get() = Drawable21.icon_19608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19609: DrawableResource
+  get() = Drawable21.icon_19609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1961: DrawableResource
+  get() = Drawable21.icon_1961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19610: DrawableResource
+  get() = Drawable21.icon_19610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19611: DrawableResource
+  get() = Drawable21.icon_19611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19612: DrawableResource
+  get() = Drawable21.icon_19612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19613: DrawableResource
+  get() = Drawable21.icon_19613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19614: DrawableResource
+  get() = Drawable21.icon_19614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19615: DrawableResource
+  get() = Drawable21.icon_19615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19616: DrawableResource
+  get() = Drawable21.icon_19616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19617: DrawableResource
+  get() = Drawable21.icon_19617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19618: DrawableResource
+  get() = Drawable21.icon_19618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19619: DrawableResource
+  get() = Drawable21.icon_19619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1962: DrawableResource
+  get() = Drawable21.icon_1962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19620: DrawableResource
+  get() = Drawable21.icon_19620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19621: DrawableResource
+  get() = Drawable21.icon_19621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19622: DrawableResource
+  get() = Drawable21.icon_19622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19623: DrawableResource
+  get() = Drawable21.icon_19623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19624: DrawableResource
+  get() = Drawable21.icon_19624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19625: DrawableResource
+  get() = Drawable21.icon_19625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19626: DrawableResource
+  get() = Drawable21.icon_19626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19627: DrawableResource
+  get() = Drawable21.icon_19627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19628: DrawableResource
+  get() = Drawable21.icon_19628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19629: DrawableResource
+  get() = Drawable21.icon_19629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1963: DrawableResource
+  get() = Drawable21.icon_1963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19630: DrawableResource
+  get() = Drawable21.icon_19630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19631: DrawableResource
+  get() = Drawable21.icon_19631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19632: DrawableResource
+  get() = Drawable21.icon_19632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19633: DrawableResource
+  get() = Drawable21.icon_19633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19634: DrawableResource
+  get() = Drawable21.icon_19634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19635: DrawableResource
+  get() = Drawable21.icon_19635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19636: DrawableResource
+  get() = Drawable21.icon_19636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19637: DrawableResource
+  get() = Drawable21.icon_19637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19638: DrawableResource
+  get() = Drawable21.icon_19638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19639: DrawableResource
+  get() = Drawable21.icon_19639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1964: DrawableResource
+  get() = Drawable21.icon_1964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19640: DrawableResource
+  get() = Drawable21.icon_19640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19641: DrawableResource
+  get() = Drawable21.icon_19641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19642: DrawableResource
+  get() = Drawable21.icon_19642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19643: DrawableResource
+  get() = Drawable21.icon_19643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19644: DrawableResource
+  get() = Drawable21.icon_19644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19645: DrawableResource
+  get() = Drawable21.icon_19645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19646: DrawableResource
+  get() = Drawable21.icon_19646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19647: DrawableResource
+  get() = Drawable21.icon_19647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19648: DrawableResource
+  get() = Drawable21.icon_19648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19649: DrawableResource
+  get() = Drawable21.icon_19649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1965: DrawableResource
+  get() = Drawable21.icon_1965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19650: DrawableResource
+  get() = Drawable21.icon_19650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19651: DrawableResource
+  get() = Drawable21.icon_19651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19652: DrawableResource
+  get() = Drawable21.icon_19652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19653: DrawableResource
+  get() = Drawable21.icon_19653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19654: DrawableResource
+  get() = Drawable21.icon_19654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19655: DrawableResource
+  get() = Drawable21.icon_19655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19656: DrawableResource
+  get() = Drawable21.icon_19656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19657: DrawableResource
+  get() = Drawable21.icon_19657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19658: DrawableResource
+  get() = Drawable21.icon_19658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19659: DrawableResource
+  get() = Drawable21.icon_19659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1966: DrawableResource
+  get() = Drawable21.icon_1966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19660: DrawableResource
+  get() = Drawable21.icon_19660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19661: DrawableResource
+  get() = Drawable21.icon_19661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19662: DrawableResource
+  get() = Drawable21.icon_19662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19663: DrawableResource
+  get() = Drawable21.icon_19663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19664: DrawableResource
+  get() = Drawable21.icon_19664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19665: DrawableResource
+  get() = Drawable21.icon_19665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19666: DrawableResource
+  get() = Drawable21.icon_19666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19667: DrawableResource
+  get() = Drawable21.icon_19667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19668: DrawableResource
+  get() = Drawable21.icon_19668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19669: DrawableResource
+  get() = Drawable21.icon_19669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1967: DrawableResource
+  get() = Drawable21.icon_1967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19670: DrawableResource
+  get() = Drawable21.icon_19670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19671: DrawableResource
+  get() = Drawable21.icon_19671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19672: DrawableResource
+  get() = Drawable21.icon_19672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19673: DrawableResource
+  get() = Drawable21.icon_19673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19674: DrawableResource
+  get() = Drawable21.icon_19674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19675: DrawableResource
+  get() = Drawable21.icon_19675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19676: DrawableResource
+  get() = Drawable21.icon_19676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19677: DrawableResource
+  get() = Drawable21.icon_19677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19678: DrawableResource
+  get() = Drawable21.icon_19678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19679: DrawableResource
+  get() = Drawable21.icon_19679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1968: DrawableResource
+  get() = Drawable21.icon_1968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19680: DrawableResource
+  get() = Drawable21.icon_19680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19681: DrawableResource
+  get() = Drawable21.icon_19681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19682: DrawableResource
+  get() = Drawable21.icon_19682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19683: DrawableResource
+  get() = Drawable21.icon_19683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19684: DrawableResource
+  get() = Drawable21.icon_19684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19685: DrawableResource
+  get() = Drawable21.icon_19685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19686: DrawableResource
+  get() = Drawable21.icon_19686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19687: DrawableResource
+  get() = Drawable21.icon_19687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19688: DrawableResource
+  get() = Drawable21.icon_19688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19689: DrawableResource
+  get() = Drawable21.icon_19689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1969: DrawableResource
+  get() = Drawable21.icon_1969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19690: DrawableResource
+  get() = Drawable21.icon_19690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19691: DrawableResource
+  get() = Drawable21.icon_19691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19692: DrawableResource
+  get() = Drawable21.icon_19692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19693: DrawableResource
+  get() = Drawable21.icon_19693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19694: DrawableResource
+  get() = Drawable21.icon_19694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19695: DrawableResource
+  get() = Drawable21.icon_19695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19696: DrawableResource
+  get() = Drawable21.icon_19696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19697: DrawableResource
+  get() = Drawable21.icon_19697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19698: DrawableResource
+  get() = Drawable21.icon_19698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19699: DrawableResource
+  get() = Drawable21.icon_19699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_197: DrawableResource
+  get() = Drawable21.icon_197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1970: DrawableResource
+  get() = Drawable21.icon_1970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19700: DrawableResource
+  get() = Drawable21.icon_19700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19701: DrawableResource
+  get() = Drawable21.icon_19701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19702: DrawableResource
+  get() = Drawable21.icon_19702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19703: DrawableResource
+  get() = Drawable21.icon_19703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19704: DrawableResource
+  get() = Drawable21.icon_19704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19705: DrawableResource
+  get() = Drawable21.icon_19705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19706: DrawableResource
+  get() = Drawable21.icon_19706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19707: DrawableResource
+  get() = Drawable21.icon_19707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19708: DrawableResource
+  get() = Drawable21.icon_19708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19709: DrawableResource
+  get() = Drawable21.icon_19709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1971: DrawableResource
+  get() = Drawable21.icon_1971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19710: DrawableResource
+  get() = Drawable21.icon_19710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19711: DrawableResource
+  get() = Drawable21.icon_19711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19712: DrawableResource
+  get() = Drawable21.icon_19712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19713: DrawableResource
+  get() = Drawable21.icon_19713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19714: DrawableResource
+  get() = Drawable21.icon_19714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19715: DrawableResource
+  get() = Drawable21.icon_19715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19716: DrawableResource
+  get() = Drawable21.icon_19716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19717: DrawableResource
+  get() = Drawable21.icon_19717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19718: DrawableResource
+  get() = Drawable21.icon_19718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19719: DrawableResource
+  get() = Drawable21.icon_19719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1972: DrawableResource
+  get() = Drawable21.icon_1972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19720: DrawableResource
+  get() = Drawable21.icon_19720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19721: DrawableResource
+  get() = Drawable21.icon_19721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19722: DrawableResource
+  get() = Drawable21.icon_19722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19723: DrawableResource
+  get() = Drawable21.icon_19723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19724: DrawableResource
+  get() = Drawable21.icon_19724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19725: DrawableResource
+  get() = Drawable21.icon_19725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19726: DrawableResource
+  get() = Drawable21.icon_19726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19727: DrawableResource
+  get() = Drawable21.icon_19727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19728: DrawableResource
+  get() = Drawable21.icon_19728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19729: DrawableResource
+  get() = Drawable21.icon_19729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1973: DrawableResource
+  get() = Drawable21.icon_1973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19730: DrawableResource
+  get() = Drawable21.icon_19730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19731: DrawableResource
+  get() = Drawable21.icon_19731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19732: DrawableResource
+  get() = Drawable21.icon_19732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19733: DrawableResource
+  get() = Drawable21.icon_19733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19734: DrawableResource
+  get() = Drawable21.icon_19734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19735: DrawableResource
+  get() = Drawable21.icon_19735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19736: DrawableResource
+  get() = Drawable21.icon_19736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19737: DrawableResource
+  get() = Drawable21.icon_19737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19738: DrawableResource
+  get() = Drawable21.icon_19738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19739: DrawableResource
+  get() = Drawable21.icon_19739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1974: DrawableResource
+  get() = Drawable21.icon_1974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19740: DrawableResource
+  get() = Drawable21.icon_19740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19741: DrawableResource
+  get() = Drawable21.icon_19741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19742: DrawableResource
+  get() = Drawable21.icon_19742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19743: DrawableResource
+  get() = Drawable21.icon_19743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19744: DrawableResource
+  get() = Drawable21.icon_19744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19745: DrawableResource
+  get() = Drawable21.icon_19745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19746: DrawableResource
+  get() = Drawable21.icon_19746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19747: DrawableResource
+  get() = Drawable21.icon_19747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19748: DrawableResource
+  get() = Drawable21.icon_19748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19749: DrawableResource
+  get() = Drawable21.icon_19749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1975: DrawableResource
+  get() = Drawable21.icon_1975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19750: DrawableResource
+  get() = Drawable21.icon_19750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19751: DrawableResource
+  get() = Drawable21.icon_19751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19752: DrawableResource
+  get() = Drawable21.icon_19752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19753: DrawableResource
+  get() = Drawable21.icon_19753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19754: DrawableResource
+  get() = Drawable21.icon_19754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19755: DrawableResource
+  get() = Drawable21.icon_19755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19756: DrawableResource
+  get() = Drawable21.icon_19756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19757: DrawableResource
+  get() = Drawable21.icon_19757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19758: DrawableResource
+  get() = Drawable21.icon_19758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19759: DrawableResource
+  get() = Drawable21.icon_19759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1976: DrawableResource
+  get() = Drawable21.icon_1976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19760: DrawableResource
+  get() = Drawable21.icon_19760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19761: DrawableResource
+  get() = Drawable21.icon_19761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19762: DrawableResource
+  get() = Drawable21.icon_19762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19763: DrawableResource
+  get() = Drawable21.icon_19763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19764: DrawableResource
+  get() = Drawable21.icon_19764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19765: DrawableResource
+  get() = Drawable21.icon_19765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19766: DrawableResource
+  get() = Drawable21.icon_19766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19767: DrawableResource
+  get() = Drawable21.icon_19767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19768: DrawableResource
+  get() = Drawable21.icon_19768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19769: DrawableResource
+  get() = Drawable21.icon_19769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1977: DrawableResource
+  get() = Drawable21.icon_1977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19770: DrawableResource
+  get() = Drawable21.icon_19770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19771: DrawableResource
+  get() = Drawable21.icon_19771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19772: DrawableResource
+  get() = Drawable21.icon_19772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19773: DrawableResource
+  get() = Drawable21.icon_19773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19774: DrawableResource
+  get() = Drawable21.icon_19774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19775: DrawableResource
+  get() = Drawable21.icon_19775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19776: DrawableResource
+  get() = Drawable21.icon_19776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19777: DrawableResource
+  get() = Drawable21.icon_19777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19778: DrawableResource
+  get() = Drawable21.icon_19778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19779: DrawableResource
+  get() = Drawable21.icon_19779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1978: DrawableResource
+  get() = Drawable21.icon_1978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19780: DrawableResource
+  get() = Drawable21.icon_19780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19781: DrawableResource
+  get() = Drawable21.icon_19781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19782: DrawableResource
+  get() = Drawable21.icon_19782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19783: DrawableResource
+  get() = Drawable21.icon_19783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19784: DrawableResource
+  get() = Drawable21.icon_19784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19785: DrawableResource
+  get() = Drawable21.icon_19785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19786: DrawableResource
+  get() = Drawable21.icon_19786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19787: DrawableResource
+  get() = Drawable21.icon_19787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19788: DrawableResource
+  get() = Drawable21.icon_19788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19789: DrawableResource
+  get() = Drawable21.icon_19789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1979: DrawableResource
+  get() = Drawable21.icon_1979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19790: DrawableResource
+  get() = Drawable21.icon_19790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19791: DrawableResource
+  get() = Drawable21.icon_19791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19792: DrawableResource
+  get() = Drawable21.icon_19792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19793: DrawableResource
+  get() = Drawable21.icon_19793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19794: DrawableResource
+  get() = Drawable21.icon_19794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19795: DrawableResource
+  get() = Drawable21.icon_19795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19796: DrawableResource
+  get() = Drawable21.icon_19796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19797: DrawableResource
+  get() = Drawable21.icon_19797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19798: DrawableResource
+  get() = Drawable21.icon_19798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19799: DrawableResource
+  get() = Drawable21.icon_19799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_198: DrawableResource
+  get() = Drawable21.icon_198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1980: DrawableResource
+  get() = Drawable21.icon_1980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19800: DrawableResource
+  get() = Drawable21.icon_19800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19801: DrawableResource
+  get() = Drawable21.icon_19801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19802: DrawableResource
+  get() = Drawable21.icon_19802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19803: DrawableResource
+  get() = Drawable21.icon_19803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19804: DrawableResource
+  get() = Drawable21.icon_19804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19805: DrawableResource
+  get() = Drawable21.icon_19805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19806: DrawableResource
+  get() = Drawable21.icon_19806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19807: DrawableResource
+  get() = Drawable21.icon_19807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19808: DrawableResource
+  get() = Drawable21.icon_19808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19809: DrawableResource
+  get() = Drawable21.icon_19809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1981: DrawableResource
+  get() = Drawable21.icon_1981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19810: DrawableResource
+  get() = Drawable21.icon_19810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19811: DrawableResource
+  get() = Drawable21.icon_19811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19812: DrawableResource
+  get() = Drawable21.icon_19812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19813: DrawableResource
+  get() = Drawable21.icon_19813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19814: DrawableResource
+  get() = Drawable21.icon_19814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19815: DrawableResource
+  get() = Drawable21.icon_19815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19816: DrawableResource
+  get() = Drawable21.icon_19816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19817: DrawableResource
+  get() = Drawable21.icon_19817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19818: DrawableResource
+  get() = Drawable21.icon_19818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19819: DrawableResource
+  get() = Drawable21.icon_19819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1982: DrawableResource
+  get() = Drawable21.icon_1982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19820: DrawableResource
+  get() = Drawable21.icon_19820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19821: DrawableResource
+  get() = Drawable21.icon_19821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19822: DrawableResource
+  get() = Drawable21.icon_19822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19823: DrawableResource
+  get() = Drawable21.icon_19823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19824: DrawableResource
+  get() = Drawable21.icon_19824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19825: DrawableResource
+  get() = Drawable21.icon_19825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19826: DrawableResource
+  get() = Drawable21.icon_19826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19827: DrawableResource
+  get() = Drawable21.icon_19827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19828: DrawableResource
+  get() = Drawable21.icon_19828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19829: DrawableResource
+  get() = Drawable21.icon_19829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1983: DrawableResource
+  get() = Drawable21.icon_1983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19830: DrawableResource
+  get() = Drawable21.icon_19830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19831: DrawableResource
+  get() = Drawable21.icon_19831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19832: DrawableResource
+  get() = Drawable21.icon_19832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19833: DrawableResource
+  get() = Drawable21.icon_19833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19834: DrawableResource
+  get() = Drawable21.icon_19834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19835: DrawableResource
+  get() = Drawable21.icon_19835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19836: DrawableResource
+  get() = Drawable21.icon_19836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19837: DrawableResource
+  get() = Drawable21.icon_19837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19838: DrawableResource
+  get() = Drawable21.icon_19838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19839: DrawableResource
+  get() = Drawable21.icon_19839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1984: DrawableResource
+  get() = Drawable21.icon_1984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19840: DrawableResource
+  get() = Drawable21.icon_19840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19841: DrawableResource
+  get() = Drawable21.icon_19841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19842: DrawableResource
+  get() = Drawable21.icon_19842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19843: DrawableResource
+  get() = Drawable21.icon_19843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19844: DrawableResource
+  get() = Drawable21.icon_19844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19845: DrawableResource
+  get() = Drawable21.icon_19845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19846: DrawableResource
+  get() = Drawable21.icon_19846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19847: DrawableResource
+  get() = Drawable21.icon_19847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19848: DrawableResource
+  get() = Drawable21.icon_19848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19849: DrawableResource
+  get() = Drawable21.icon_19849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1985: DrawableResource
+  get() = Drawable21.icon_1985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19850: DrawableResource
+  get() = Drawable21.icon_19850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19851: DrawableResource
+  get() = Drawable21.icon_19851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19852: DrawableResource
+  get() = Drawable21.icon_19852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19853: DrawableResource
+  get() = Drawable21.icon_19853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19854: DrawableResource
+  get() = Drawable21.icon_19854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19855: DrawableResource
+  get() = Drawable21.icon_19855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19856: DrawableResource
+  get() = Drawable21.icon_19856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19857: DrawableResource
+  get() = Drawable21.icon_19857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19858: DrawableResource
+  get() = Drawable21.icon_19858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19859: DrawableResource
+  get() = Drawable21.icon_19859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1986: DrawableResource
+  get() = Drawable21.icon_1986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19860: DrawableResource
+  get() = Drawable21.icon_19860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19861: DrawableResource
+  get() = Drawable21.icon_19861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19862: DrawableResource
+  get() = Drawable21.icon_19862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19863: DrawableResource
+  get() = Drawable21.icon_19863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19864: DrawableResource
+  get() = Drawable21.icon_19864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19865: DrawableResource
+  get() = Drawable21.icon_19865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19866: DrawableResource
+  get() = Drawable21.icon_19866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19867: DrawableResource
+  get() = Drawable21.icon_19867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19868: DrawableResource
+  get() = Drawable21.icon_19868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19869: DrawableResource
+  get() = Drawable21.icon_19869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1987: DrawableResource
+  get() = Drawable21.icon_1987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19870: DrawableResource
+  get() = Drawable21.icon_19870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19871: DrawableResource
+  get() = Drawable21.icon_19871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19872: DrawableResource
+  get() = Drawable21.icon_19872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19873: DrawableResource
+  get() = Drawable21.icon_19873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19874: DrawableResource
+  get() = Drawable21.icon_19874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19875: DrawableResource
+  get() = Drawable21.icon_19875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19876: DrawableResource
+  get() = Drawable21.icon_19876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19877: DrawableResource
+  get() = Drawable21.icon_19877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19878: DrawableResource
+  get() = Drawable21.icon_19878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19879: DrawableResource
+  get() = Drawable21.icon_19879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1988: DrawableResource
+  get() = Drawable21.icon_1988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19880: DrawableResource
+  get() = Drawable21.icon_19880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19881: DrawableResource
+  get() = Drawable21.icon_19881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19882: DrawableResource
+  get() = Drawable21.icon_19882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19883: DrawableResource
+  get() = Drawable21.icon_19883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19884: DrawableResource
+  get() = Drawable21.icon_19884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19885: DrawableResource
+  get() = Drawable21.icon_19885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19886: DrawableResource
+  get() = Drawable21.icon_19886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19887: DrawableResource
+  get() = Drawable21.icon_19887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19888: DrawableResource
+  get() = Drawable21.icon_19888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19889: DrawableResource
+  get() = Drawable21.icon_19889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1989: DrawableResource
+  get() = Drawable21.icon_1989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19890: DrawableResource
+  get() = Drawable21.icon_19890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19891: DrawableResource
+  get() = Drawable21.icon_19891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19892: DrawableResource
+  get() = Drawable21.icon_19892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19893: DrawableResource
+  get() = Drawable21.icon_19893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19894: DrawableResource
+  get() = Drawable21.icon_19894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19895: DrawableResource
+  get() = Drawable21.icon_19895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19896: DrawableResource
+  get() = Drawable21.icon_19896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19897: DrawableResource
+  get() = Drawable21.icon_19897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19898: DrawableResource
+  get() = Drawable21.icon_19898

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable22.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable22.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable22 {
+  public val icon_19899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19899.xml"),
+          )
+      )
+
+  public val icon_199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_199.xml"),
+          )
+      )
+
+  public val icon_1990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1990.xml"),
+          )
+      )
+
+  public val icon_19900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19900.xml"),
+          )
+      )
+
+  public val icon_19901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19901.xml"),
+          )
+      )
+
+  public val icon_19902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19902.xml"),
+          )
+      )
+
+  public val icon_19903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19903.xml"),
+          )
+      )
+
+  public val icon_19904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19904.xml"),
+          )
+      )
+
+  public val icon_19905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19905.xml"),
+          )
+      )
+
+  public val icon_19906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19906.xml"),
+          )
+      )
+
+  public val icon_19907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19907.xml"),
+          )
+      )
+
+  public val icon_19908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19908.xml"),
+          )
+      )
+
+  public val icon_19909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19909.xml"),
+          )
+      )
+
+  public val icon_1991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1991.xml"),
+          )
+      )
+
+  public val icon_19910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19910.xml"),
+          )
+      )
+
+  public val icon_19911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19911.xml"),
+          )
+      )
+
+  public val icon_19912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19912.xml"),
+          )
+      )
+
+  public val icon_19913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19913.xml"),
+          )
+      )
+
+  public val icon_19914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19914.xml"),
+          )
+      )
+
+  public val icon_19915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19915.xml"),
+          )
+      )
+
+  public val icon_19916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19916.xml"),
+          )
+      )
+
+  public val icon_19917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19917.xml"),
+          )
+      )
+
+  public val icon_19918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19918.xml"),
+          )
+      )
+
+  public val icon_19919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19919.xml"),
+          )
+      )
+
+  public val icon_1992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1992.xml"),
+          )
+      )
+
+  public val icon_19920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19920.xml"),
+          )
+      )
+
+  public val icon_19921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19921.xml"),
+          )
+      )
+
+  public val icon_19922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19922.xml"),
+          )
+      )
+
+  public val icon_19923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19923.xml"),
+          )
+      )
+
+  public val icon_19924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19924.xml"),
+          )
+      )
+
+  public val icon_19925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19925.xml"),
+          )
+      )
+
+  public val icon_19926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19926.xml"),
+          )
+      )
+
+  public val icon_19927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19927.xml"),
+          )
+      )
+
+  public val icon_19928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19928.xml"),
+          )
+      )
+
+  public val icon_19929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19929.xml"),
+          )
+      )
+
+  public val icon_1993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1993.xml"),
+          )
+      )
+
+  public val icon_19930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19930.xml"),
+          )
+      )
+
+  public val icon_19931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19931.xml"),
+          )
+      )
+
+  public val icon_19932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19932.xml"),
+          )
+      )
+
+  public val icon_19933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19933.xml"),
+          )
+      )
+
+  public val icon_19934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19934.xml"),
+          )
+      )
+
+  public val icon_19935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19935.xml"),
+          )
+      )
+
+  public val icon_19936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19936.xml"),
+          )
+      )
+
+  public val icon_19937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19937.xml"),
+          )
+      )
+
+  public val icon_19938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19938.xml"),
+          )
+      )
+
+  public val icon_19939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19939.xml"),
+          )
+      )
+
+  public val icon_1994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1994.xml"),
+          )
+      )
+
+  public val icon_19940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19940.xml"),
+          )
+      )
+
+  public val icon_19941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19941.xml"),
+          )
+      )
+
+  public val icon_19942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19942.xml"),
+          )
+      )
+
+  public val icon_19943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19943.xml"),
+          )
+      )
+
+  public val icon_19944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19944.xml"),
+          )
+      )
+
+  public val icon_19945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19945.xml"),
+          )
+      )
+
+  public val icon_19946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19946.xml"),
+          )
+      )
+
+  public val icon_19947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19947.xml"),
+          )
+      )
+
+  public val icon_19948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19948.xml"),
+          )
+      )
+
+  public val icon_19949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19949.xml"),
+          )
+      )
+
+  public val icon_1995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1995.xml"),
+          )
+      )
+
+  public val icon_19950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19950.xml"),
+          )
+      )
+
+  public val icon_19951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19951.xml"),
+          )
+      )
+
+  public val icon_19952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19952.xml"),
+          )
+      )
+
+  public val icon_19953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19953.xml"),
+          )
+      )
+
+  public val icon_19954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19954.xml"),
+          )
+      )
+
+  public val icon_19955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19955.xml"),
+          )
+      )
+
+  public val icon_19956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19956.xml"),
+          )
+      )
+
+  public val icon_19957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19957.xml"),
+          )
+      )
+
+  public val icon_19958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19958.xml"),
+          )
+      )
+
+  public val icon_19959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19959.xml"),
+          )
+      )
+
+  public val icon_1996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1996.xml"),
+          )
+      )
+
+  public val icon_19960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19960.xml"),
+          )
+      )
+
+  public val icon_19961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19961.xml"),
+          )
+      )
+
+  public val icon_19962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19962.xml"),
+          )
+      )
+
+  public val icon_19963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19963.xml"),
+          )
+      )
+
+  public val icon_19964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19964.xml"),
+          )
+      )
+
+  public val icon_19965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19965.xml"),
+          )
+      )
+
+  public val icon_19966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19966.xml"),
+          )
+      )
+
+  public val icon_19967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19967.xml"),
+          )
+      )
+
+  public val icon_19968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19968.xml"),
+          )
+      )
+
+  public val icon_19969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19969.xml"),
+          )
+      )
+
+  public val icon_1997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1997.xml"),
+          )
+      )
+
+  public val icon_19970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19970.xml"),
+          )
+      )
+
+  public val icon_19971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19971.xml"),
+          )
+      )
+
+  public val icon_19972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19972.xml"),
+          )
+      )
+
+  public val icon_19973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19973.xml"),
+          )
+      )
+
+  public val icon_19974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19974.xml"),
+          )
+      )
+
+  public val icon_19975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19975.xml"),
+          )
+      )
+
+  public val icon_19976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19976.xml"),
+          )
+      )
+
+  public val icon_19977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19977.xml"),
+          )
+      )
+
+  public val icon_19978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19978.xml"),
+          )
+      )
+
+  public val icon_19979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19979.xml"),
+          )
+      )
+
+  public val icon_1998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1998.xml"),
+          )
+      )
+
+  public val icon_19980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19980.xml"),
+          )
+      )
+
+  public val icon_19981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19981.xml"),
+          )
+      )
+
+  public val icon_19982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19982.xml"),
+          )
+      )
+
+  public val icon_19983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19983.xml"),
+          )
+      )
+
+  public val icon_19984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19984.xml"),
+          )
+      )
+
+  public val icon_19985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19985.xml"),
+          )
+      )
+
+  public val icon_19986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19986.xml"),
+          )
+      )
+
+  public val icon_19987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19987.xml"),
+          )
+      )
+
+  public val icon_19988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19988.xml"),
+          )
+      )
+
+  public val icon_19989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19989.xml"),
+          )
+      )
+
+  public val icon_1999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1999.xml"),
+          )
+      )
+
+  public val icon_19990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19990.xml"),
+          )
+      )
+
+  public val icon_19991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19991.xml"),
+          )
+      )
+
+  public val icon_19992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19992.xml"),
+          )
+      )
+
+  public val icon_19993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19993.xml"),
+          )
+      )
+
+  public val icon_19994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19994.xml"),
+          )
+      )
+
+  public val icon_19995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19995.xml"),
+          )
+      )
+
+  public val icon_19996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19996.xml"),
+          )
+      )
+
+  public val icon_19997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19997.xml"),
+          )
+      )
+
+  public val icon_19998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19998.xml"),
+          )
+      )
+
+  public val icon_19999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_19999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_19999.xml"),
+          )
+      )
+
+  public val icon_2: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2.xml"),
+          )
+      )
+
+  public val icon_20: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20.xml"),
+          )
+      )
+
+  public val icon_200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_200.xml"),
+          )
+      )
+
+  public val icon_2000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2000.xml"),
+          )
+      )
+
+  public val icon_20000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20000.xml"),
+          )
+      )
+
+  public val icon_20001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20001.xml"),
+          )
+      )
+
+  public val icon_20002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20002.xml"),
+          )
+      )
+
+  public val icon_20003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20003.xml"),
+          )
+      )
+
+  public val icon_20004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20004.xml"),
+          )
+      )
+
+  public val icon_20005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20005.xml"),
+          )
+      )
+
+  public val icon_20006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20006.xml"),
+          )
+      )
+
+  public val icon_20007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20007.xml"),
+          )
+      )
+
+  public val icon_20008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20008.xml"),
+          )
+      )
+
+  public val icon_20009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20009.xml"),
+          )
+      )
+
+  public val icon_2001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2001.xml"),
+          )
+      )
+
+  public val icon_20010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20010.xml"),
+          )
+      )
+
+  public val icon_20011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20011.xml"),
+          )
+      )
+
+  public val icon_20012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20012.xml"),
+          )
+      )
+
+  public val icon_20013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20013.xml"),
+          )
+      )
+
+  public val icon_20014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20014.xml"),
+          )
+      )
+
+  public val icon_20015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20015.xml"),
+          )
+      )
+
+  public val icon_20016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20016.xml"),
+          )
+      )
+
+  public val icon_20017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20017.xml"),
+          )
+      )
+
+  public val icon_20018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20018.xml"),
+          )
+      )
+
+  public val icon_20019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20019.xml"),
+          )
+      )
+
+  public val icon_2002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2002.xml"),
+          )
+      )
+
+  public val icon_20020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20020.xml"),
+          )
+      )
+
+  public val icon_20021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20021.xml"),
+          )
+      )
+
+  public val icon_20022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20022.xml"),
+          )
+      )
+
+  public val icon_20023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20023.xml"),
+          )
+      )
+
+  public val icon_20024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20024.xml"),
+          )
+      )
+
+  public val icon_20025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20025.xml"),
+          )
+      )
+
+  public val icon_20026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20026.xml"),
+          )
+      )
+
+  public val icon_20027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20027.xml"),
+          )
+      )
+
+  public val icon_20028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20028.xml"),
+          )
+      )
+
+  public val icon_20029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20029.xml"),
+          )
+      )
+
+  public val icon_2003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2003.xml"),
+          )
+      )
+
+  public val icon_20030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20030.xml"),
+          )
+      )
+
+  public val icon_20031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20031.xml"),
+          )
+      )
+
+  public val icon_20032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20032.xml"),
+          )
+      )
+
+  public val icon_20033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20033.xml"),
+          )
+      )
+
+  public val icon_20034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20034.xml"),
+          )
+      )
+
+  public val icon_20035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20035.xml"),
+          )
+      )
+
+  public val icon_20036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20036.xml"),
+          )
+      )
+
+  public val icon_20037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20037.xml"),
+          )
+      )
+
+  public val icon_20038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20038.xml"),
+          )
+      )
+
+  public val icon_20039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20039.xml"),
+          )
+      )
+
+  public val icon_2004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2004.xml"),
+          )
+      )
+
+  public val icon_20040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20040.xml"),
+          )
+      )
+
+  public val icon_20041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20041.xml"),
+          )
+      )
+
+  public val icon_20042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20042.xml"),
+          )
+      )
+
+  public val icon_20043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20043.xml"),
+          )
+      )
+
+  public val icon_20044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20044.xml"),
+          )
+      )
+
+  public val icon_20045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20045.xml"),
+          )
+      )
+
+  public val icon_20046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20046.xml"),
+          )
+      )
+
+  public val icon_20047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20047.xml"),
+          )
+      )
+
+  public val icon_20048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20048.xml"),
+          )
+      )
+
+  public val icon_20049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20049.xml"),
+          )
+      )
+
+  public val icon_2005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2005.xml"),
+          )
+      )
+
+  public val icon_20050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20050.xml"),
+          )
+      )
+
+  public val icon_20051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20051.xml"),
+          )
+      )
+
+  public val icon_20052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20052.xml"),
+          )
+      )
+
+  public val icon_20053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20053.xml"),
+          )
+      )
+
+  public val icon_20054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20054.xml"),
+          )
+      )
+
+  public val icon_20055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20055.xml"),
+          )
+      )
+
+  public val icon_20056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20056.xml"),
+          )
+      )
+
+  public val icon_20057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20057.xml"),
+          )
+      )
+
+  public val icon_20058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20058.xml"),
+          )
+      )
+
+  public val icon_20059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20059.xml"),
+          )
+      )
+
+  public val icon_2006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2006.xml"),
+          )
+      )
+
+  public val icon_20060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20060.xml"),
+          )
+      )
+
+  public val icon_20061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20061.xml"),
+          )
+      )
+
+  public val icon_20062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20062.xml"),
+          )
+      )
+
+  public val icon_20063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20063.xml"),
+          )
+      )
+
+  public val icon_20064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20064.xml"),
+          )
+      )
+
+  public val icon_20065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20065.xml"),
+          )
+      )
+
+  public val icon_20066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20066.xml"),
+          )
+      )
+
+  public val icon_20067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20067.xml"),
+          )
+      )
+
+  public val icon_20068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20068.xml"),
+          )
+      )
+
+  public val icon_20069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20069.xml"),
+          )
+      )
+
+  public val icon_2007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2007.xml"),
+          )
+      )
+
+  public val icon_20070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20070.xml"),
+          )
+      )
+
+  public val icon_20071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20071.xml"),
+          )
+      )
+
+  public val icon_20072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20072.xml"),
+          )
+      )
+
+  public val icon_20073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20073.xml"),
+          )
+      )
+
+  public val icon_20074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20074.xml"),
+          )
+      )
+
+  public val icon_20075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20075.xml"),
+          )
+      )
+
+  public val icon_20076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20076.xml"),
+          )
+      )
+
+  public val icon_20077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20077.xml"),
+          )
+      )
+
+  public val icon_20078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20078.xml"),
+          )
+      )
+
+  public val icon_20079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20079.xml"),
+          )
+      )
+
+  public val icon_2008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2008.xml"),
+          )
+      )
+
+  public val icon_20080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20080.xml"),
+          )
+      )
+
+  public val icon_20081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20081.xml"),
+          )
+      )
+
+  public val icon_20082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20082.xml"),
+          )
+      )
+
+  public val icon_20083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20083.xml"),
+          )
+      )
+
+  public val icon_20084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20084.xml"),
+          )
+      )
+
+  public val icon_20085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20085.xml"),
+          )
+      )
+
+  public val icon_20086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20086.xml"),
+          )
+      )
+
+  public val icon_20087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20087.xml"),
+          )
+      )
+
+  public val icon_20088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20088.xml"),
+          )
+      )
+
+  public val icon_20089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20089.xml"),
+          )
+      )
+
+  public val icon_2009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2009.xml"),
+          )
+      )
+
+  public val icon_20090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20090.xml"),
+          )
+      )
+
+  public val icon_20091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20091.xml"),
+          )
+      )
+
+  public val icon_20092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20092.xml"),
+          )
+      )
+
+  public val icon_20093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20093.xml"),
+          )
+      )
+
+  public val icon_20094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20094.xml"),
+          )
+      )
+
+  public val icon_20095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20095.xml"),
+          )
+      )
+
+  public val icon_20096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20096.xml"),
+          )
+      )
+
+  public val icon_20097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20097.xml"),
+          )
+      )
+
+  public val icon_20098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20098.xml"),
+          )
+      )
+
+  public val icon_20099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20099.xml"),
+          )
+      )
+
+  public val icon_201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_201.xml"),
+          )
+      )
+
+  public val icon_2010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2010.xml"),
+          )
+      )
+
+  public val icon_20100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20100.xml"),
+          )
+      )
+
+  public val icon_20101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20101.xml"),
+          )
+      )
+
+  public val icon_20102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20102.xml"),
+          )
+      )
+
+  public val icon_20103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20103.xml"),
+          )
+      )
+
+  public val icon_20104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20104.xml"),
+          )
+      )
+
+  public val icon_20105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20105.xml"),
+          )
+      )
+
+  public val icon_20106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20106.xml"),
+          )
+      )
+
+  public val icon_20107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20107.xml"),
+          )
+      )
+
+  public val icon_20108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20108.xml"),
+          )
+      )
+
+  public val icon_20109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20109.xml"),
+          )
+      )
+
+  public val icon_2011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2011.xml"),
+          )
+      )
+
+  public val icon_20110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20110.xml"),
+          )
+      )
+
+  public val icon_20111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20111.xml"),
+          )
+      )
+
+  public val icon_20112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20112.xml"),
+          )
+      )
+
+  public val icon_20113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20113.xml"),
+          )
+      )
+
+  public val icon_20114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20114.xml"),
+          )
+      )
+
+  public val icon_20115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20115.xml"),
+          )
+      )
+
+  public val icon_20116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20116.xml"),
+          )
+      )
+
+  public val icon_20117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20117.xml"),
+          )
+      )
+
+  public val icon_20118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20118.xml"),
+          )
+      )
+
+  public val icon_20119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20119.xml"),
+          )
+      )
+
+  public val icon_2012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2012.xml"),
+          )
+      )
+
+  public val icon_20120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20120.xml"),
+          )
+      )
+
+  public val icon_20121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20121.xml"),
+          )
+      )
+
+  public val icon_20122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20122.xml"),
+          )
+      )
+
+  public val icon_20123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20123.xml"),
+          )
+      )
+
+  public val icon_20124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20124.xml"),
+          )
+      )
+
+  public val icon_20125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20125.xml"),
+          )
+      )
+
+  public val icon_20126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20126.xml"),
+          )
+      )
+
+  public val icon_20127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20127.xml"),
+          )
+      )
+
+  public val icon_20128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20128.xml"),
+          )
+      )
+
+  public val icon_20129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20129.xml"),
+          )
+      )
+
+  public val icon_2013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2013.xml"),
+          )
+      )
+
+  public val icon_20130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20130.xml"),
+          )
+      )
+
+  public val icon_20131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20131.xml"),
+          )
+      )
+
+  public val icon_20132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20132.xml"),
+          )
+      )
+
+  public val icon_20133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20133.xml"),
+          )
+      )
+
+  public val icon_20134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20134.xml"),
+          )
+      )
+
+  public val icon_20135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20135.xml"),
+          )
+      )
+
+  public val icon_20136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20136.xml"),
+          )
+      )
+
+  public val icon_20137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20137.xml"),
+          )
+      )
+
+  public val icon_20138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20138.xml"),
+          )
+      )
+
+  public val icon_20139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20139.xml"),
+          )
+      )
+
+  public val icon_2014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2014.xml"),
+          )
+      )
+
+  public val icon_20140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20140.xml"),
+          )
+      )
+
+  public val icon_20141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20141.xml"),
+          )
+      )
+
+  public val icon_20142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20142.xml"),
+          )
+      )
+
+  public val icon_20143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20143.xml"),
+          )
+      )
+
+  public val icon_20144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20144.xml"),
+          )
+      )
+
+  public val icon_20145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20145.xml"),
+          )
+      )
+
+  public val icon_20146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20146.xml"),
+          )
+      )
+
+  public val icon_20147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20147.xml"),
+          )
+      )
+
+  public val icon_20148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20148.xml"),
+          )
+      )
+
+  public val icon_20149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20149.xml"),
+          )
+      )
+
+  public val icon_2015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2015.xml"),
+          )
+      )
+
+  public val icon_20150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20150.xml"),
+          )
+      )
+
+  public val icon_20151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20151.xml"),
+          )
+      )
+
+  public val icon_20152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20152.xml"),
+          )
+      )
+
+  public val icon_20153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20153.xml"),
+          )
+      )
+
+  public val icon_20154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20154.xml"),
+          )
+      )
+
+  public val icon_20155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20155.xml"),
+          )
+      )
+
+  public val icon_20156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20156.xml"),
+          )
+      )
+
+  public val icon_20157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20157.xml"),
+          )
+      )
+
+  public val icon_20158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20158.xml"),
+          )
+      )
+
+  public val icon_20159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20159.xml"),
+          )
+      )
+
+  public val icon_2016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2016.xml"),
+          )
+      )
+
+  public val icon_20160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20160.xml"),
+          )
+      )
+
+  public val icon_20161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20161.xml"),
+          )
+      )
+
+  public val icon_20162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20162.xml"),
+          )
+      )
+
+  public val icon_20163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20163.xml"),
+          )
+      )
+
+  public val icon_20164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20164.xml"),
+          )
+      )
+
+  public val icon_20165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20165.xml"),
+          )
+      )
+
+  public val icon_20166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20166.xml"),
+          )
+      )
+
+  public val icon_20167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20167.xml"),
+          )
+      )
+
+  public val icon_20168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20168.xml"),
+          )
+      )
+
+  public val icon_20169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20169.xml"),
+          )
+      )
+
+  public val icon_2017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2017.xml"),
+          )
+      )
+
+  public val icon_20170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20170.xml"),
+          )
+      )
+
+  public val icon_20171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20171.xml"),
+          )
+      )
+
+  public val icon_20172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20172.xml"),
+          )
+      )
+
+  public val icon_20173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20173.xml"),
+          )
+      )
+
+  public val icon_20174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20174.xml"),
+          )
+      )
+
+  public val icon_20175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20175.xml"),
+          )
+      )
+
+  public val icon_20176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20176.xml"),
+          )
+      )
+
+  public val icon_20177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20177.xml"),
+          )
+      )
+
+  public val icon_20178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20178.xml"),
+          )
+      )
+
+  public val icon_20179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20179.xml"),
+          )
+      )
+
+  public val icon_2018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2018.xml"),
+          )
+      )
+
+  public val icon_20180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20180.xml"),
+          )
+      )
+
+  public val icon_20181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20181.xml"),
+          )
+      )
+
+  public val icon_20182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20182.xml"),
+          )
+      )
+
+  public val icon_20183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20183.xml"),
+          )
+      )
+
+  public val icon_20184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20184.xml"),
+          )
+      )
+
+  public val icon_20185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20185.xml"),
+          )
+      )
+
+  public val icon_20186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20186.xml"),
+          )
+      )
+
+  public val icon_20187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20187.xml"),
+          )
+      )
+
+  public val icon_20188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20188.xml"),
+          )
+      )
+
+  public val icon_20189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20189.xml"),
+          )
+      )
+
+  public val icon_2019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2019.xml"),
+          )
+      )
+
+  public val icon_20190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20190.xml"),
+          )
+      )
+
+  public val icon_20191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20191.xml"),
+          )
+      )
+
+  public val icon_20192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20192.xml"),
+          )
+      )
+
+  public val icon_20193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20193.xml"),
+          )
+      )
+
+  public val icon_20194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20194.xml"),
+          )
+      )
+
+  public val icon_20195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20195.xml"),
+          )
+      )
+
+  public val icon_20196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20196.xml"),
+          )
+      )
+
+  public val icon_20197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20197.xml"),
+          )
+      )
+
+  public val icon_20198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20198.xml"),
+          )
+      )
+
+  public val icon_20199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20199.xml"),
+          )
+      )
+
+  public val icon_202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_202.xml"),
+          )
+      )
+
+  public val icon_2020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2020.xml"),
+          )
+      )
+
+  public val icon_20200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20200.xml"),
+          )
+      )
+
+  public val icon_20201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20201.xml"),
+          )
+      )
+
+  public val icon_20202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20202.xml"),
+          )
+      )
+
+  public val icon_20203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20203.xml"),
+          )
+      )
+
+  public val icon_20204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20204.xml"),
+          )
+      )
+
+  public val icon_20205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20205.xml"),
+          )
+      )
+
+  public val icon_20206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20206.xml"),
+          )
+      )
+
+  public val icon_20207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20207.xml"),
+          )
+      )
+
+  public val icon_20208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20208.xml"),
+          )
+      )
+
+  public val icon_20209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20209.xml"),
+          )
+      )
+
+  public val icon_2021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2021.xml"),
+          )
+      )
+
+  public val icon_20210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20210.xml"),
+          )
+      )
+
+  public val icon_20211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20211.xml"),
+          )
+      )
+
+  public val icon_20212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20212.xml"),
+          )
+      )
+
+  public val icon_20213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20213.xml"),
+          )
+      )
+
+  public val icon_20214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20214.xml"),
+          )
+      )
+
+  public val icon_20215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20215.xml"),
+          )
+      )
+
+  public val icon_20216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20216.xml"),
+          )
+      )
+
+  public val icon_20217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20217.xml"),
+          )
+      )
+
+  public val icon_20218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20218.xml"),
+          )
+      )
+
+  public val icon_20219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20219.xml"),
+          )
+      )
+
+  public val icon_2022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2022.xml"),
+          )
+      )
+
+  public val icon_20220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20220.xml"),
+          )
+      )
+
+  public val icon_20221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20221.xml"),
+          )
+      )
+
+  public val icon_20222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20222.xml"),
+          )
+      )
+
+  public val icon_20223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20223.xml"),
+          )
+      )
+
+  public val icon_20224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20224.xml"),
+          )
+      )
+
+  public val icon_20225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20225.xml"),
+          )
+      )
+
+  public val icon_20226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20226.xml"),
+          )
+      )
+
+  public val icon_20227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20227.xml"),
+          )
+      )
+
+  public val icon_20228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20228.xml"),
+          )
+      )
+
+  public val icon_20229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20229.xml"),
+          )
+      )
+
+  public val icon_2023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2023.xml"),
+          )
+      )
+
+  public val icon_20230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20230.xml"),
+          )
+      )
+
+  public val icon_20231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20231.xml"),
+          )
+      )
+
+  public val icon_20232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20232.xml"),
+          )
+      )
+
+  public val icon_20233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20233.xml"),
+          )
+      )
+
+  public val icon_20234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20234.xml"),
+          )
+      )
+
+  public val icon_20235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20235.xml"),
+          )
+      )
+
+  public val icon_20236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20236.xml"),
+          )
+      )
+
+  public val icon_20237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20237.xml"),
+          )
+      )
+
+  public val icon_20238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20238.xml"),
+          )
+      )
+
+  public val icon_20239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20239.xml"),
+          )
+      )
+
+  public val icon_2024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2024.xml"),
+          )
+      )
+
+  public val icon_20240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20240.xml"),
+          )
+      )
+
+  public val icon_20241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20241.xml"),
+          )
+      )
+
+  public val icon_20242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20242.xml"),
+          )
+      )
+
+  public val icon_20243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20243.xml"),
+          )
+      )
+
+  public val icon_20244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20244.xml"),
+          )
+      )
+
+  public val icon_20245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20245.xml"),
+          )
+      )
+
+  public val icon_20246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20246.xml"),
+          )
+      )
+
+  public val icon_20247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20247.xml"),
+          )
+      )
+
+  public val icon_20248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20248.xml"),
+          )
+      )
+
+  public val icon_20249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20249.xml"),
+          )
+      )
+
+  public val icon_2025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2025.xml"),
+          )
+      )
+
+  public val icon_20250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20250.xml"),
+          )
+      )
+
+  public val icon_20251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20251.xml"),
+          )
+      )
+
+  public val icon_20252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20252.xml"),
+          )
+      )
+
+  public val icon_20253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20253.xml"),
+          )
+      )
+
+  public val icon_20254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20254.xml"),
+          )
+      )
+
+  public val icon_20255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20255.xml"),
+          )
+      )
+
+  public val icon_20256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20256.xml"),
+          )
+      )
+
+  public val icon_20257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20257.xml"),
+          )
+      )
+
+  public val icon_20258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20258.xml"),
+          )
+      )
+
+  public val icon_20259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20259.xml"),
+          )
+      )
+
+  public val icon_2026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2026.xml"),
+          )
+      )
+
+  public val icon_20260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20260.xml"),
+          )
+      )
+
+  public val icon_20261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20261.xml"),
+          )
+      )
+
+  public val icon_20262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20262.xml"),
+          )
+      )
+
+  public val icon_20263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20263.xml"),
+          )
+      )
+
+  public val icon_20264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20264.xml"),
+          )
+      )
+
+  public val icon_20265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20265.xml"),
+          )
+      )
+
+  public val icon_20266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20266.xml"),
+          )
+      )
+
+  public val icon_20267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20267.xml"),
+          )
+      )
+
+  public val icon_20268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20268.xml"),
+          )
+      )
+
+  public val icon_20269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20269.xml"),
+          )
+      )
+
+  public val icon_2027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2027.xml"),
+          )
+      )
+
+  public val icon_20270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20270.xml"),
+          )
+      )
+
+  public val icon_20271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20271.xml"),
+          )
+      )
+
+  public val icon_20272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20272.xml"),
+          )
+      )
+
+  public val icon_20273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20273.xml"),
+          )
+      )
+
+  public val icon_20274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20274.xml"),
+          )
+      )
+
+  public val icon_20275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20275.xml"),
+          )
+      )
+
+  public val icon_20276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20276.xml"),
+          )
+      )
+
+  public val icon_20277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20277.xml"),
+          )
+      )
+
+  public val icon_20278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20278.xml"),
+          )
+      )
+
+  public val icon_20279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20279.xml"),
+          )
+      )
+
+  public val icon_2028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2028.xml"),
+          )
+      )
+
+  public val icon_20280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20280.xml"),
+          )
+      )
+
+  public val icon_20281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20281.xml"),
+          )
+      )
+
+  public val icon_20282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20282.xml"),
+          )
+      )
+
+  public val icon_20283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20283.xml"),
+          )
+      )
+
+  public val icon_20284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20284.xml"),
+          )
+      )
+
+  public val icon_20285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20285.xml"),
+          )
+      )
+
+  public val icon_20286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20286.xml"),
+          )
+      )
+
+  public val icon_20287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20287.xml"),
+          )
+      )
+
+  public val icon_20288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20288.xml"),
+          )
+      )
+
+  public val icon_20289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20289.xml"),
+          )
+      )
+
+  public val icon_2029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2029.xml"),
+          )
+      )
+
+  public val icon_20290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20290.xml"),
+          )
+      )
+
+  public val icon_20291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20291.xml"),
+          )
+      )
+
+  public val icon_20292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20292.xml"),
+          )
+      )
+
+  public val icon_20293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20293.xml"),
+          )
+      )
+
+  public val icon_20294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20294.xml"),
+          )
+      )
+
+  public val icon_20295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20295.xml"),
+          )
+      )
+
+  public val icon_20296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20296.xml"),
+          )
+      )
+
+  public val icon_20297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20297.xml"),
+          )
+      )
+
+  public val icon_20298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20298.xml"),
+          )
+      )
+
+  public val icon_20299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20299.xml"),
+          )
+      )
+
+  public val icon_203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_203.xml"),
+          )
+      )
+
+  public val icon_2030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2030.xml"),
+          )
+      )
+
+  public val icon_20300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20300.xml"),
+          )
+      )
+
+  public val icon_20301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20301.xml"),
+          )
+      )
+
+  public val icon_20302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20302.xml"),
+          )
+      )
+
+  public val icon_20303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20303.xml"),
+          )
+      )
+
+  public val icon_20304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20304.xml"),
+          )
+      )
+
+  public val icon_20305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20305.xml"),
+          )
+      )
+
+  public val icon_20306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20306.xml"),
+          )
+      )
+
+  public val icon_20307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20307.xml"),
+          )
+      )
+
+  public val icon_20308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20308.xml"),
+          )
+      )
+
+  public val icon_20309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20309.xml"),
+          )
+      )
+
+  public val icon_2031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2031.xml"),
+          )
+      )
+
+  public val icon_20310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20310.xml"),
+          )
+      )
+
+  public val icon_20311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20311.xml"),
+          )
+      )
+
+  public val icon_20312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20312.xml"),
+          )
+      )
+
+  public val icon_20313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20313.xml"),
+          )
+      )
+
+  public val icon_20314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20314.xml"),
+          )
+      )
+
+  public val icon_20315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20315.xml"),
+          )
+      )
+
+  public val icon_20316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20316.xml"),
+          )
+      )
+
+  public val icon_20317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20317.xml"),
+          )
+      )
+
+  public val icon_20318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20318.xml"),
+          )
+      )
+
+  public val icon_20319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20319.xml"),
+          )
+      )
+
+  public val icon_2032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2032.xml"),
+          )
+      )
+
+  public val icon_20320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20320.xml"),
+          )
+      )
+
+  public val icon_20321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20321.xml"),
+          )
+      )
+
+  public val icon_20322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20322.xml"),
+          )
+      )
+
+  public val icon_20323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20323.xml"),
+          )
+      )
+
+  public val icon_20324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20324.xml"),
+          )
+      )
+
+  public val icon_20325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20325.xml"),
+          )
+      )
+
+  public val icon_20326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20326.xml"),
+          )
+      )
+
+  public val icon_20327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20327.xml"),
+          )
+      )
+
+  public val icon_20328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20328.xml"),
+          )
+      )
+
+  public val icon_20329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20329.xml"),
+          )
+      )
+
+  public val icon_2033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2033.xml"),
+          )
+      )
+
+  public val icon_20330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20330.xml"),
+          )
+      )
+
+  public val icon_20331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20331.xml"),
+          )
+      )
+
+  public val icon_20332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20332.xml"),
+          )
+      )
+
+  public val icon_20333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20333.xml"),
+          )
+      )
+
+  public val icon_20334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20334.xml"),
+          )
+      )
+
+  public val icon_20335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20335.xml"),
+          )
+      )
+
+  public val icon_20336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20336.xml"),
+          )
+      )
+
+  public val icon_20337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20337.xml"),
+          )
+      )
+
+  public val icon_20338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20338.xml"),
+          )
+      )
+
+  public val icon_20339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20339.xml"),
+          )
+      )
+
+  public val icon_2034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2034.xml"),
+          )
+      )
+
+  public val icon_20340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20340.xml"),
+          )
+      )
+
+  public val icon_20341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20341.xml"),
+          )
+      )
+
+  public val icon_20342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20342.xml"),
+          )
+      )
+
+  public val icon_20343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20343.xml"),
+          )
+      )
+
+  public val icon_20344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20344.xml"),
+          )
+      )
+
+  public val icon_20345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20345.xml"),
+          )
+      )
+
+  public val icon_20346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20346.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19899: DrawableResource
+  get() = Drawable22.icon_19899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_199: DrawableResource
+  get() = Drawable22.icon_199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1990: DrawableResource
+  get() = Drawable22.icon_1990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19900: DrawableResource
+  get() = Drawable22.icon_19900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19901: DrawableResource
+  get() = Drawable22.icon_19901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19902: DrawableResource
+  get() = Drawable22.icon_19902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19903: DrawableResource
+  get() = Drawable22.icon_19903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19904: DrawableResource
+  get() = Drawable22.icon_19904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19905: DrawableResource
+  get() = Drawable22.icon_19905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19906: DrawableResource
+  get() = Drawable22.icon_19906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19907: DrawableResource
+  get() = Drawable22.icon_19907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19908: DrawableResource
+  get() = Drawable22.icon_19908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19909: DrawableResource
+  get() = Drawable22.icon_19909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1991: DrawableResource
+  get() = Drawable22.icon_1991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19910: DrawableResource
+  get() = Drawable22.icon_19910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19911: DrawableResource
+  get() = Drawable22.icon_19911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19912: DrawableResource
+  get() = Drawable22.icon_19912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19913: DrawableResource
+  get() = Drawable22.icon_19913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19914: DrawableResource
+  get() = Drawable22.icon_19914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19915: DrawableResource
+  get() = Drawable22.icon_19915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19916: DrawableResource
+  get() = Drawable22.icon_19916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19917: DrawableResource
+  get() = Drawable22.icon_19917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19918: DrawableResource
+  get() = Drawable22.icon_19918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19919: DrawableResource
+  get() = Drawable22.icon_19919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1992: DrawableResource
+  get() = Drawable22.icon_1992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19920: DrawableResource
+  get() = Drawable22.icon_19920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19921: DrawableResource
+  get() = Drawable22.icon_19921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19922: DrawableResource
+  get() = Drawable22.icon_19922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19923: DrawableResource
+  get() = Drawable22.icon_19923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19924: DrawableResource
+  get() = Drawable22.icon_19924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19925: DrawableResource
+  get() = Drawable22.icon_19925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19926: DrawableResource
+  get() = Drawable22.icon_19926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19927: DrawableResource
+  get() = Drawable22.icon_19927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19928: DrawableResource
+  get() = Drawable22.icon_19928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19929: DrawableResource
+  get() = Drawable22.icon_19929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1993: DrawableResource
+  get() = Drawable22.icon_1993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19930: DrawableResource
+  get() = Drawable22.icon_19930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19931: DrawableResource
+  get() = Drawable22.icon_19931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19932: DrawableResource
+  get() = Drawable22.icon_19932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19933: DrawableResource
+  get() = Drawable22.icon_19933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19934: DrawableResource
+  get() = Drawable22.icon_19934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19935: DrawableResource
+  get() = Drawable22.icon_19935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19936: DrawableResource
+  get() = Drawable22.icon_19936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19937: DrawableResource
+  get() = Drawable22.icon_19937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19938: DrawableResource
+  get() = Drawable22.icon_19938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19939: DrawableResource
+  get() = Drawable22.icon_19939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1994: DrawableResource
+  get() = Drawable22.icon_1994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19940: DrawableResource
+  get() = Drawable22.icon_19940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19941: DrawableResource
+  get() = Drawable22.icon_19941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19942: DrawableResource
+  get() = Drawable22.icon_19942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19943: DrawableResource
+  get() = Drawable22.icon_19943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19944: DrawableResource
+  get() = Drawable22.icon_19944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19945: DrawableResource
+  get() = Drawable22.icon_19945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19946: DrawableResource
+  get() = Drawable22.icon_19946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19947: DrawableResource
+  get() = Drawable22.icon_19947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19948: DrawableResource
+  get() = Drawable22.icon_19948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19949: DrawableResource
+  get() = Drawable22.icon_19949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1995: DrawableResource
+  get() = Drawable22.icon_1995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19950: DrawableResource
+  get() = Drawable22.icon_19950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19951: DrawableResource
+  get() = Drawable22.icon_19951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19952: DrawableResource
+  get() = Drawable22.icon_19952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19953: DrawableResource
+  get() = Drawable22.icon_19953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19954: DrawableResource
+  get() = Drawable22.icon_19954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19955: DrawableResource
+  get() = Drawable22.icon_19955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19956: DrawableResource
+  get() = Drawable22.icon_19956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19957: DrawableResource
+  get() = Drawable22.icon_19957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19958: DrawableResource
+  get() = Drawable22.icon_19958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19959: DrawableResource
+  get() = Drawable22.icon_19959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1996: DrawableResource
+  get() = Drawable22.icon_1996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19960: DrawableResource
+  get() = Drawable22.icon_19960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19961: DrawableResource
+  get() = Drawable22.icon_19961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19962: DrawableResource
+  get() = Drawable22.icon_19962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19963: DrawableResource
+  get() = Drawable22.icon_19963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19964: DrawableResource
+  get() = Drawable22.icon_19964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19965: DrawableResource
+  get() = Drawable22.icon_19965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19966: DrawableResource
+  get() = Drawable22.icon_19966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19967: DrawableResource
+  get() = Drawable22.icon_19967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19968: DrawableResource
+  get() = Drawable22.icon_19968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19969: DrawableResource
+  get() = Drawable22.icon_19969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1997: DrawableResource
+  get() = Drawable22.icon_1997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19970: DrawableResource
+  get() = Drawable22.icon_19970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19971: DrawableResource
+  get() = Drawable22.icon_19971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19972: DrawableResource
+  get() = Drawable22.icon_19972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19973: DrawableResource
+  get() = Drawable22.icon_19973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19974: DrawableResource
+  get() = Drawable22.icon_19974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19975: DrawableResource
+  get() = Drawable22.icon_19975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19976: DrawableResource
+  get() = Drawable22.icon_19976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19977: DrawableResource
+  get() = Drawable22.icon_19977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19978: DrawableResource
+  get() = Drawable22.icon_19978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19979: DrawableResource
+  get() = Drawable22.icon_19979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1998: DrawableResource
+  get() = Drawable22.icon_1998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19980: DrawableResource
+  get() = Drawable22.icon_19980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19981: DrawableResource
+  get() = Drawable22.icon_19981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19982: DrawableResource
+  get() = Drawable22.icon_19982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19983: DrawableResource
+  get() = Drawable22.icon_19983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19984: DrawableResource
+  get() = Drawable22.icon_19984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19985: DrawableResource
+  get() = Drawable22.icon_19985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19986: DrawableResource
+  get() = Drawable22.icon_19986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19987: DrawableResource
+  get() = Drawable22.icon_19987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19988: DrawableResource
+  get() = Drawable22.icon_19988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19989: DrawableResource
+  get() = Drawable22.icon_19989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1999: DrawableResource
+  get() = Drawable22.icon_1999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19990: DrawableResource
+  get() = Drawable22.icon_19990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19991: DrawableResource
+  get() = Drawable22.icon_19991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19992: DrawableResource
+  get() = Drawable22.icon_19992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19993: DrawableResource
+  get() = Drawable22.icon_19993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19994: DrawableResource
+  get() = Drawable22.icon_19994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19995: DrawableResource
+  get() = Drawable22.icon_19995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19996: DrawableResource
+  get() = Drawable22.icon_19996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19997: DrawableResource
+  get() = Drawable22.icon_19997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19998: DrawableResource
+  get() = Drawable22.icon_19998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_19999: DrawableResource
+  get() = Drawable22.icon_19999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2: DrawableResource
+  get() = Drawable22.icon_2
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20: DrawableResource
+  get() = Drawable22.icon_20
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_200: DrawableResource
+  get() = Drawable22.icon_200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2000: DrawableResource
+  get() = Drawable22.icon_2000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20000: DrawableResource
+  get() = Drawable22.icon_20000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20001: DrawableResource
+  get() = Drawable22.icon_20001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20002: DrawableResource
+  get() = Drawable22.icon_20002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20003: DrawableResource
+  get() = Drawable22.icon_20003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20004: DrawableResource
+  get() = Drawable22.icon_20004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20005: DrawableResource
+  get() = Drawable22.icon_20005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20006: DrawableResource
+  get() = Drawable22.icon_20006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20007: DrawableResource
+  get() = Drawable22.icon_20007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20008: DrawableResource
+  get() = Drawable22.icon_20008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20009: DrawableResource
+  get() = Drawable22.icon_20009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2001: DrawableResource
+  get() = Drawable22.icon_2001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20010: DrawableResource
+  get() = Drawable22.icon_20010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20011: DrawableResource
+  get() = Drawable22.icon_20011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20012: DrawableResource
+  get() = Drawable22.icon_20012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20013: DrawableResource
+  get() = Drawable22.icon_20013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20014: DrawableResource
+  get() = Drawable22.icon_20014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20015: DrawableResource
+  get() = Drawable22.icon_20015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20016: DrawableResource
+  get() = Drawable22.icon_20016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20017: DrawableResource
+  get() = Drawable22.icon_20017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20018: DrawableResource
+  get() = Drawable22.icon_20018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20019: DrawableResource
+  get() = Drawable22.icon_20019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2002: DrawableResource
+  get() = Drawable22.icon_2002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20020: DrawableResource
+  get() = Drawable22.icon_20020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20021: DrawableResource
+  get() = Drawable22.icon_20021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20022: DrawableResource
+  get() = Drawable22.icon_20022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20023: DrawableResource
+  get() = Drawable22.icon_20023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20024: DrawableResource
+  get() = Drawable22.icon_20024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20025: DrawableResource
+  get() = Drawable22.icon_20025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20026: DrawableResource
+  get() = Drawable22.icon_20026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20027: DrawableResource
+  get() = Drawable22.icon_20027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20028: DrawableResource
+  get() = Drawable22.icon_20028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20029: DrawableResource
+  get() = Drawable22.icon_20029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2003: DrawableResource
+  get() = Drawable22.icon_2003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20030: DrawableResource
+  get() = Drawable22.icon_20030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20031: DrawableResource
+  get() = Drawable22.icon_20031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20032: DrawableResource
+  get() = Drawable22.icon_20032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20033: DrawableResource
+  get() = Drawable22.icon_20033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20034: DrawableResource
+  get() = Drawable22.icon_20034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20035: DrawableResource
+  get() = Drawable22.icon_20035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20036: DrawableResource
+  get() = Drawable22.icon_20036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20037: DrawableResource
+  get() = Drawable22.icon_20037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20038: DrawableResource
+  get() = Drawable22.icon_20038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20039: DrawableResource
+  get() = Drawable22.icon_20039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2004: DrawableResource
+  get() = Drawable22.icon_2004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20040: DrawableResource
+  get() = Drawable22.icon_20040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20041: DrawableResource
+  get() = Drawable22.icon_20041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20042: DrawableResource
+  get() = Drawable22.icon_20042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20043: DrawableResource
+  get() = Drawable22.icon_20043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20044: DrawableResource
+  get() = Drawable22.icon_20044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20045: DrawableResource
+  get() = Drawable22.icon_20045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20046: DrawableResource
+  get() = Drawable22.icon_20046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20047: DrawableResource
+  get() = Drawable22.icon_20047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20048: DrawableResource
+  get() = Drawable22.icon_20048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20049: DrawableResource
+  get() = Drawable22.icon_20049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2005: DrawableResource
+  get() = Drawable22.icon_2005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20050: DrawableResource
+  get() = Drawable22.icon_20050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20051: DrawableResource
+  get() = Drawable22.icon_20051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20052: DrawableResource
+  get() = Drawable22.icon_20052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20053: DrawableResource
+  get() = Drawable22.icon_20053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20054: DrawableResource
+  get() = Drawable22.icon_20054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20055: DrawableResource
+  get() = Drawable22.icon_20055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20056: DrawableResource
+  get() = Drawable22.icon_20056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20057: DrawableResource
+  get() = Drawable22.icon_20057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20058: DrawableResource
+  get() = Drawable22.icon_20058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20059: DrawableResource
+  get() = Drawable22.icon_20059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2006: DrawableResource
+  get() = Drawable22.icon_2006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20060: DrawableResource
+  get() = Drawable22.icon_20060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20061: DrawableResource
+  get() = Drawable22.icon_20061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20062: DrawableResource
+  get() = Drawable22.icon_20062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20063: DrawableResource
+  get() = Drawable22.icon_20063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20064: DrawableResource
+  get() = Drawable22.icon_20064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20065: DrawableResource
+  get() = Drawable22.icon_20065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20066: DrawableResource
+  get() = Drawable22.icon_20066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20067: DrawableResource
+  get() = Drawable22.icon_20067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20068: DrawableResource
+  get() = Drawable22.icon_20068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20069: DrawableResource
+  get() = Drawable22.icon_20069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2007: DrawableResource
+  get() = Drawable22.icon_2007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20070: DrawableResource
+  get() = Drawable22.icon_20070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20071: DrawableResource
+  get() = Drawable22.icon_20071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20072: DrawableResource
+  get() = Drawable22.icon_20072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20073: DrawableResource
+  get() = Drawable22.icon_20073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20074: DrawableResource
+  get() = Drawable22.icon_20074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20075: DrawableResource
+  get() = Drawable22.icon_20075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20076: DrawableResource
+  get() = Drawable22.icon_20076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20077: DrawableResource
+  get() = Drawable22.icon_20077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20078: DrawableResource
+  get() = Drawable22.icon_20078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20079: DrawableResource
+  get() = Drawable22.icon_20079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2008: DrawableResource
+  get() = Drawable22.icon_2008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20080: DrawableResource
+  get() = Drawable22.icon_20080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20081: DrawableResource
+  get() = Drawable22.icon_20081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20082: DrawableResource
+  get() = Drawable22.icon_20082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20083: DrawableResource
+  get() = Drawable22.icon_20083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20084: DrawableResource
+  get() = Drawable22.icon_20084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20085: DrawableResource
+  get() = Drawable22.icon_20085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20086: DrawableResource
+  get() = Drawable22.icon_20086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20087: DrawableResource
+  get() = Drawable22.icon_20087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20088: DrawableResource
+  get() = Drawable22.icon_20088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20089: DrawableResource
+  get() = Drawable22.icon_20089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2009: DrawableResource
+  get() = Drawable22.icon_2009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20090: DrawableResource
+  get() = Drawable22.icon_20090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20091: DrawableResource
+  get() = Drawable22.icon_20091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20092: DrawableResource
+  get() = Drawable22.icon_20092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20093: DrawableResource
+  get() = Drawable22.icon_20093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20094: DrawableResource
+  get() = Drawable22.icon_20094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20095: DrawableResource
+  get() = Drawable22.icon_20095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20096: DrawableResource
+  get() = Drawable22.icon_20096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20097: DrawableResource
+  get() = Drawable22.icon_20097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20098: DrawableResource
+  get() = Drawable22.icon_20098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20099: DrawableResource
+  get() = Drawable22.icon_20099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_201: DrawableResource
+  get() = Drawable22.icon_201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2010: DrawableResource
+  get() = Drawable22.icon_2010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20100: DrawableResource
+  get() = Drawable22.icon_20100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20101: DrawableResource
+  get() = Drawable22.icon_20101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20102: DrawableResource
+  get() = Drawable22.icon_20102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20103: DrawableResource
+  get() = Drawable22.icon_20103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20104: DrawableResource
+  get() = Drawable22.icon_20104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20105: DrawableResource
+  get() = Drawable22.icon_20105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20106: DrawableResource
+  get() = Drawable22.icon_20106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20107: DrawableResource
+  get() = Drawable22.icon_20107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20108: DrawableResource
+  get() = Drawable22.icon_20108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20109: DrawableResource
+  get() = Drawable22.icon_20109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2011: DrawableResource
+  get() = Drawable22.icon_2011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20110: DrawableResource
+  get() = Drawable22.icon_20110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20111: DrawableResource
+  get() = Drawable22.icon_20111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20112: DrawableResource
+  get() = Drawable22.icon_20112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20113: DrawableResource
+  get() = Drawable22.icon_20113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20114: DrawableResource
+  get() = Drawable22.icon_20114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20115: DrawableResource
+  get() = Drawable22.icon_20115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20116: DrawableResource
+  get() = Drawable22.icon_20116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20117: DrawableResource
+  get() = Drawable22.icon_20117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20118: DrawableResource
+  get() = Drawable22.icon_20118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20119: DrawableResource
+  get() = Drawable22.icon_20119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2012: DrawableResource
+  get() = Drawable22.icon_2012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20120: DrawableResource
+  get() = Drawable22.icon_20120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20121: DrawableResource
+  get() = Drawable22.icon_20121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20122: DrawableResource
+  get() = Drawable22.icon_20122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20123: DrawableResource
+  get() = Drawable22.icon_20123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20124: DrawableResource
+  get() = Drawable22.icon_20124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20125: DrawableResource
+  get() = Drawable22.icon_20125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20126: DrawableResource
+  get() = Drawable22.icon_20126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20127: DrawableResource
+  get() = Drawable22.icon_20127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20128: DrawableResource
+  get() = Drawable22.icon_20128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20129: DrawableResource
+  get() = Drawable22.icon_20129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2013: DrawableResource
+  get() = Drawable22.icon_2013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20130: DrawableResource
+  get() = Drawable22.icon_20130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20131: DrawableResource
+  get() = Drawable22.icon_20131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20132: DrawableResource
+  get() = Drawable22.icon_20132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20133: DrawableResource
+  get() = Drawable22.icon_20133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20134: DrawableResource
+  get() = Drawable22.icon_20134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20135: DrawableResource
+  get() = Drawable22.icon_20135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20136: DrawableResource
+  get() = Drawable22.icon_20136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20137: DrawableResource
+  get() = Drawable22.icon_20137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20138: DrawableResource
+  get() = Drawable22.icon_20138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20139: DrawableResource
+  get() = Drawable22.icon_20139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2014: DrawableResource
+  get() = Drawable22.icon_2014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20140: DrawableResource
+  get() = Drawable22.icon_20140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20141: DrawableResource
+  get() = Drawable22.icon_20141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20142: DrawableResource
+  get() = Drawable22.icon_20142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20143: DrawableResource
+  get() = Drawable22.icon_20143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20144: DrawableResource
+  get() = Drawable22.icon_20144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20145: DrawableResource
+  get() = Drawable22.icon_20145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20146: DrawableResource
+  get() = Drawable22.icon_20146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20147: DrawableResource
+  get() = Drawable22.icon_20147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20148: DrawableResource
+  get() = Drawable22.icon_20148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20149: DrawableResource
+  get() = Drawable22.icon_20149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2015: DrawableResource
+  get() = Drawable22.icon_2015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20150: DrawableResource
+  get() = Drawable22.icon_20150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20151: DrawableResource
+  get() = Drawable22.icon_20151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20152: DrawableResource
+  get() = Drawable22.icon_20152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20153: DrawableResource
+  get() = Drawable22.icon_20153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20154: DrawableResource
+  get() = Drawable22.icon_20154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20155: DrawableResource
+  get() = Drawable22.icon_20155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20156: DrawableResource
+  get() = Drawable22.icon_20156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20157: DrawableResource
+  get() = Drawable22.icon_20157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20158: DrawableResource
+  get() = Drawable22.icon_20158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20159: DrawableResource
+  get() = Drawable22.icon_20159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2016: DrawableResource
+  get() = Drawable22.icon_2016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20160: DrawableResource
+  get() = Drawable22.icon_20160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20161: DrawableResource
+  get() = Drawable22.icon_20161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20162: DrawableResource
+  get() = Drawable22.icon_20162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20163: DrawableResource
+  get() = Drawable22.icon_20163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20164: DrawableResource
+  get() = Drawable22.icon_20164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20165: DrawableResource
+  get() = Drawable22.icon_20165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20166: DrawableResource
+  get() = Drawable22.icon_20166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20167: DrawableResource
+  get() = Drawable22.icon_20167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20168: DrawableResource
+  get() = Drawable22.icon_20168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20169: DrawableResource
+  get() = Drawable22.icon_20169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2017: DrawableResource
+  get() = Drawable22.icon_2017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20170: DrawableResource
+  get() = Drawable22.icon_20170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20171: DrawableResource
+  get() = Drawable22.icon_20171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20172: DrawableResource
+  get() = Drawable22.icon_20172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20173: DrawableResource
+  get() = Drawable22.icon_20173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20174: DrawableResource
+  get() = Drawable22.icon_20174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20175: DrawableResource
+  get() = Drawable22.icon_20175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20176: DrawableResource
+  get() = Drawable22.icon_20176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20177: DrawableResource
+  get() = Drawable22.icon_20177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20178: DrawableResource
+  get() = Drawable22.icon_20178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20179: DrawableResource
+  get() = Drawable22.icon_20179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2018: DrawableResource
+  get() = Drawable22.icon_2018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20180: DrawableResource
+  get() = Drawable22.icon_20180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20181: DrawableResource
+  get() = Drawable22.icon_20181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20182: DrawableResource
+  get() = Drawable22.icon_20182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20183: DrawableResource
+  get() = Drawable22.icon_20183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20184: DrawableResource
+  get() = Drawable22.icon_20184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20185: DrawableResource
+  get() = Drawable22.icon_20185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20186: DrawableResource
+  get() = Drawable22.icon_20186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20187: DrawableResource
+  get() = Drawable22.icon_20187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20188: DrawableResource
+  get() = Drawable22.icon_20188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20189: DrawableResource
+  get() = Drawable22.icon_20189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2019: DrawableResource
+  get() = Drawable22.icon_2019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20190: DrawableResource
+  get() = Drawable22.icon_20190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20191: DrawableResource
+  get() = Drawable22.icon_20191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20192: DrawableResource
+  get() = Drawable22.icon_20192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20193: DrawableResource
+  get() = Drawable22.icon_20193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20194: DrawableResource
+  get() = Drawable22.icon_20194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20195: DrawableResource
+  get() = Drawable22.icon_20195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20196: DrawableResource
+  get() = Drawable22.icon_20196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20197: DrawableResource
+  get() = Drawable22.icon_20197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20198: DrawableResource
+  get() = Drawable22.icon_20198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20199: DrawableResource
+  get() = Drawable22.icon_20199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_202: DrawableResource
+  get() = Drawable22.icon_202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2020: DrawableResource
+  get() = Drawable22.icon_2020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20200: DrawableResource
+  get() = Drawable22.icon_20200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20201: DrawableResource
+  get() = Drawable22.icon_20201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20202: DrawableResource
+  get() = Drawable22.icon_20202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20203: DrawableResource
+  get() = Drawable22.icon_20203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20204: DrawableResource
+  get() = Drawable22.icon_20204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20205: DrawableResource
+  get() = Drawable22.icon_20205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20206: DrawableResource
+  get() = Drawable22.icon_20206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20207: DrawableResource
+  get() = Drawable22.icon_20207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20208: DrawableResource
+  get() = Drawable22.icon_20208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20209: DrawableResource
+  get() = Drawable22.icon_20209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2021: DrawableResource
+  get() = Drawable22.icon_2021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20210: DrawableResource
+  get() = Drawable22.icon_20210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20211: DrawableResource
+  get() = Drawable22.icon_20211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20212: DrawableResource
+  get() = Drawable22.icon_20212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20213: DrawableResource
+  get() = Drawable22.icon_20213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20214: DrawableResource
+  get() = Drawable22.icon_20214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20215: DrawableResource
+  get() = Drawable22.icon_20215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20216: DrawableResource
+  get() = Drawable22.icon_20216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20217: DrawableResource
+  get() = Drawable22.icon_20217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20218: DrawableResource
+  get() = Drawable22.icon_20218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20219: DrawableResource
+  get() = Drawable22.icon_20219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2022: DrawableResource
+  get() = Drawable22.icon_2022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20220: DrawableResource
+  get() = Drawable22.icon_20220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20221: DrawableResource
+  get() = Drawable22.icon_20221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20222: DrawableResource
+  get() = Drawable22.icon_20222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20223: DrawableResource
+  get() = Drawable22.icon_20223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20224: DrawableResource
+  get() = Drawable22.icon_20224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20225: DrawableResource
+  get() = Drawable22.icon_20225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20226: DrawableResource
+  get() = Drawable22.icon_20226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20227: DrawableResource
+  get() = Drawable22.icon_20227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20228: DrawableResource
+  get() = Drawable22.icon_20228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20229: DrawableResource
+  get() = Drawable22.icon_20229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2023: DrawableResource
+  get() = Drawable22.icon_2023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20230: DrawableResource
+  get() = Drawable22.icon_20230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20231: DrawableResource
+  get() = Drawable22.icon_20231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20232: DrawableResource
+  get() = Drawable22.icon_20232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20233: DrawableResource
+  get() = Drawable22.icon_20233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20234: DrawableResource
+  get() = Drawable22.icon_20234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20235: DrawableResource
+  get() = Drawable22.icon_20235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20236: DrawableResource
+  get() = Drawable22.icon_20236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20237: DrawableResource
+  get() = Drawable22.icon_20237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20238: DrawableResource
+  get() = Drawable22.icon_20238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20239: DrawableResource
+  get() = Drawable22.icon_20239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2024: DrawableResource
+  get() = Drawable22.icon_2024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20240: DrawableResource
+  get() = Drawable22.icon_20240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20241: DrawableResource
+  get() = Drawable22.icon_20241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20242: DrawableResource
+  get() = Drawable22.icon_20242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20243: DrawableResource
+  get() = Drawable22.icon_20243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20244: DrawableResource
+  get() = Drawable22.icon_20244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20245: DrawableResource
+  get() = Drawable22.icon_20245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20246: DrawableResource
+  get() = Drawable22.icon_20246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20247: DrawableResource
+  get() = Drawable22.icon_20247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20248: DrawableResource
+  get() = Drawable22.icon_20248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20249: DrawableResource
+  get() = Drawable22.icon_20249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2025: DrawableResource
+  get() = Drawable22.icon_2025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20250: DrawableResource
+  get() = Drawable22.icon_20250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20251: DrawableResource
+  get() = Drawable22.icon_20251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20252: DrawableResource
+  get() = Drawable22.icon_20252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20253: DrawableResource
+  get() = Drawable22.icon_20253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20254: DrawableResource
+  get() = Drawable22.icon_20254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20255: DrawableResource
+  get() = Drawable22.icon_20255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20256: DrawableResource
+  get() = Drawable22.icon_20256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20257: DrawableResource
+  get() = Drawable22.icon_20257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20258: DrawableResource
+  get() = Drawable22.icon_20258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20259: DrawableResource
+  get() = Drawable22.icon_20259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2026: DrawableResource
+  get() = Drawable22.icon_2026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20260: DrawableResource
+  get() = Drawable22.icon_20260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20261: DrawableResource
+  get() = Drawable22.icon_20261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20262: DrawableResource
+  get() = Drawable22.icon_20262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20263: DrawableResource
+  get() = Drawable22.icon_20263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20264: DrawableResource
+  get() = Drawable22.icon_20264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20265: DrawableResource
+  get() = Drawable22.icon_20265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20266: DrawableResource
+  get() = Drawable22.icon_20266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20267: DrawableResource
+  get() = Drawable22.icon_20267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20268: DrawableResource
+  get() = Drawable22.icon_20268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20269: DrawableResource
+  get() = Drawable22.icon_20269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2027: DrawableResource
+  get() = Drawable22.icon_2027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20270: DrawableResource
+  get() = Drawable22.icon_20270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20271: DrawableResource
+  get() = Drawable22.icon_20271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20272: DrawableResource
+  get() = Drawable22.icon_20272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20273: DrawableResource
+  get() = Drawable22.icon_20273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20274: DrawableResource
+  get() = Drawable22.icon_20274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20275: DrawableResource
+  get() = Drawable22.icon_20275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20276: DrawableResource
+  get() = Drawable22.icon_20276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20277: DrawableResource
+  get() = Drawable22.icon_20277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20278: DrawableResource
+  get() = Drawable22.icon_20278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20279: DrawableResource
+  get() = Drawable22.icon_20279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2028: DrawableResource
+  get() = Drawable22.icon_2028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20280: DrawableResource
+  get() = Drawable22.icon_20280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20281: DrawableResource
+  get() = Drawable22.icon_20281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20282: DrawableResource
+  get() = Drawable22.icon_20282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20283: DrawableResource
+  get() = Drawable22.icon_20283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20284: DrawableResource
+  get() = Drawable22.icon_20284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20285: DrawableResource
+  get() = Drawable22.icon_20285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20286: DrawableResource
+  get() = Drawable22.icon_20286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20287: DrawableResource
+  get() = Drawable22.icon_20287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20288: DrawableResource
+  get() = Drawable22.icon_20288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20289: DrawableResource
+  get() = Drawable22.icon_20289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2029: DrawableResource
+  get() = Drawable22.icon_2029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20290: DrawableResource
+  get() = Drawable22.icon_20290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20291: DrawableResource
+  get() = Drawable22.icon_20291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20292: DrawableResource
+  get() = Drawable22.icon_20292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20293: DrawableResource
+  get() = Drawable22.icon_20293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20294: DrawableResource
+  get() = Drawable22.icon_20294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20295: DrawableResource
+  get() = Drawable22.icon_20295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20296: DrawableResource
+  get() = Drawable22.icon_20296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20297: DrawableResource
+  get() = Drawable22.icon_20297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20298: DrawableResource
+  get() = Drawable22.icon_20298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20299: DrawableResource
+  get() = Drawable22.icon_20299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_203: DrawableResource
+  get() = Drawable22.icon_203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2030: DrawableResource
+  get() = Drawable22.icon_2030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20300: DrawableResource
+  get() = Drawable22.icon_20300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20301: DrawableResource
+  get() = Drawable22.icon_20301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20302: DrawableResource
+  get() = Drawable22.icon_20302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20303: DrawableResource
+  get() = Drawable22.icon_20303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20304: DrawableResource
+  get() = Drawable22.icon_20304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20305: DrawableResource
+  get() = Drawable22.icon_20305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20306: DrawableResource
+  get() = Drawable22.icon_20306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20307: DrawableResource
+  get() = Drawable22.icon_20307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20308: DrawableResource
+  get() = Drawable22.icon_20308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20309: DrawableResource
+  get() = Drawable22.icon_20309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2031: DrawableResource
+  get() = Drawable22.icon_2031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20310: DrawableResource
+  get() = Drawable22.icon_20310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20311: DrawableResource
+  get() = Drawable22.icon_20311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20312: DrawableResource
+  get() = Drawable22.icon_20312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20313: DrawableResource
+  get() = Drawable22.icon_20313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20314: DrawableResource
+  get() = Drawable22.icon_20314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20315: DrawableResource
+  get() = Drawable22.icon_20315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20316: DrawableResource
+  get() = Drawable22.icon_20316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20317: DrawableResource
+  get() = Drawable22.icon_20317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20318: DrawableResource
+  get() = Drawable22.icon_20318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20319: DrawableResource
+  get() = Drawable22.icon_20319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2032: DrawableResource
+  get() = Drawable22.icon_2032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20320: DrawableResource
+  get() = Drawable22.icon_20320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20321: DrawableResource
+  get() = Drawable22.icon_20321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20322: DrawableResource
+  get() = Drawable22.icon_20322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20323: DrawableResource
+  get() = Drawable22.icon_20323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20324: DrawableResource
+  get() = Drawable22.icon_20324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20325: DrawableResource
+  get() = Drawable22.icon_20325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20326: DrawableResource
+  get() = Drawable22.icon_20326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20327: DrawableResource
+  get() = Drawable22.icon_20327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20328: DrawableResource
+  get() = Drawable22.icon_20328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20329: DrawableResource
+  get() = Drawable22.icon_20329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2033: DrawableResource
+  get() = Drawable22.icon_2033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20330: DrawableResource
+  get() = Drawable22.icon_20330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20331: DrawableResource
+  get() = Drawable22.icon_20331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20332: DrawableResource
+  get() = Drawable22.icon_20332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20333: DrawableResource
+  get() = Drawable22.icon_20333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20334: DrawableResource
+  get() = Drawable22.icon_20334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20335: DrawableResource
+  get() = Drawable22.icon_20335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20336: DrawableResource
+  get() = Drawable22.icon_20336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20337: DrawableResource
+  get() = Drawable22.icon_20337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20338: DrawableResource
+  get() = Drawable22.icon_20338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20339: DrawableResource
+  get() = Drawable22.icon_20339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2034: DrawableResource
+  get() = Drawable22.icon_2034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20340: DrawableResource
+  get() = Drawable22.icon_20340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20341: DrawableResource
+  get() = Drawable22.icon_20341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20342: DrawableResource
+  get() = Drawable22.icon_20342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20343: DrawableResource
+  get() = Drawable22.icon_20343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20344: DrawableResource
+  get() = Drawable22.icon_20344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20345: DrawableResource
+  get() = Drawable22.icon_20345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20346: DrawableResource
+  get() = Drawable22.icon_20346

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable23.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable23.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable23 {
+  public val icon_20347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20347.xml"),
+          )
+      )
+
+  public val icon_20348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20348.xml"),
+          )
+      )
+
+  public val icon_20349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20349.xml"),
+          )
+      )
+
+  public val icon_2035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2035.xml"),
+          )
+      )
+
+  public val icon_20350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20350.xml"),
+          )
+      )
+
+  public val icon_20351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20351.xml"),
+          )
+      )
+
+  public val icon_20352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20352.xml"),
+          )
+      )
+
+  public val icon_20353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20353.xml"),
+          )
+      )
+
+  public val icon_20354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20354.xml"),
+          )
+      )
+
+  public val icon_20355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20355.xml"),
+          )
+      )
+
+  public val icon_20356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20356.xml"),
+          )
+      )
+
+  public val icon_20357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20357.xml"),
+          )
+      )
+
+  public val icon_20358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20358.xml"),
+          )
+      )
+
+  public val icon_20359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20359.xml"),
+          )
+      )
+
+  public val icon_2036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2036.xml"),
+          )
+      )
+
+  public val icon_20360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20360.xml"),
+          )
+      )
+
+  public val icon_20361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20361.xml"),
+          )
+      )
+
+  public val icon_20362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20362.xml"),
+          )
+      )
+
+  public val icon_20363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20363.xml"),
+          )
+      )
+
+  public val icon_20364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20364.xml"),
+          )
+      )
+
+  public val icon_20365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20365.xml"),
+          )
+      )
+
+  public val icon_20366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20366.xml"),
+          )
+      )
+
+  public val icon_20367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20367.xml"),
+          )
+      )
+
+  public val icon_20368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20368.xml"),
+          )
+      )
+
+  public val icon_20369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20369.xml"),
+          )
+      )
+
+  public val icon_2037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2037.xml"),
+          )
+      )
+
+  public val icon_20370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20370.xml"),
+          )
+      )
+
+  public val icon_20371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20371.xml"),
+          )
+      )
+
+  public val icon_20372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20372.xml"),
+          )
+      )
+
+  public val icon_20373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20373.xml"),
+          )
+      )
+
+  public val icon_20374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20374.xml"),
+          )
+      )
+
+  public val icon_20375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20375.xml"),
+          )
+      )
+
+  public val icon_20376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20376.xml"),
+          )
+      )
+
+  public val icon_20377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20377.xml"),
+          )
+      )
+
+  public val icon_20378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20378.xml"),
+          )
+      )
+
+  public val icon_20379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20379.xml"),
+          )
+      )
+
+  public val icon_2038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2038.xml"),
+          )
+      )
+
+  public val icon_20380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20380.xml"),
+          )
+      )
+
+  public val icon_20381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20381.xml"),
+          )
+      )
+
+  public val icon_20382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20382.xml"),
+          )
+      )
+
+  public val icon_20383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20383.xml"),
+          )
+      )
+
+  public val icon_20384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20384.xml"),
+          )
+      )
+
+  public val icon_20385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20385.xml"),
+          )
+      )
+
+  public val icon_20386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20386.xml"),
+          )
+      )
+
+  public val icon_20387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20387.xml"),
+          )
+      )
+
+  public val icon_20388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20388.xml"),
+          )
+      )
+
+  public val icon_20389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20389.xml"),
+          )
+      )
+
+  public val icon_2039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2039.xml"),
+          )
+      )
+
+  public val icon_20390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20390.xml"),
+          )
+      )
+
+  public val icon_20391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20391.xml"),
+          )
+      )
+
+  public val icon_20392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20392.xml"),
+          )
+      )
+
+  public val icon_20393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20393.xml"),
+          )
+      )
+
+  public val icon_20394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20394.xml"),
+          )
+      )
+
+  public val icon_20395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20395.xml"),
+          )
+      )
+
+  public val icon_20396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20396.xml"),
+          )
+      )
+
+  public val icon_20397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20397.xml"),
+          )
+      )
+
+  public val icon_20398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20398.xml"),
+          )
+      )
+
+  public val icon_20399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20399.xml"),
+          )
+      )
+
+  public val icon_204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_204.xml"),
+          )
+      )
+
+  public val icon_2040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2040.xml"),
+          )
+      )
+
+  public val icon_20400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20400.xml"),
+          )
+      )
+
+  public val icon_20401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20401.xml"),
+          )
+      )
+
+  public val icon_20402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20402.xml"),
+          )
+      )
+
+  public val icon_20403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20403.xml"),
+          )
+      )
+
+  public val icon_20404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20404.xml"),
+          )
+      )
+
+  public val icon_20405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20405.xml"),
+          )
+      )
+
+  public val icon_20406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20406.xml"),
+          )
+      )
+
+  public val icon_20407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20407.xml"),
+          )
+      )
+
+  public val icon_20408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20408.xml"),
+          )
+      )
+
+  public val icon_20409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20409.xml"),
+          )
+      )
+
+  public val icon_2041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2041.xml"),
+          )
+      )
+
+  public val icon_20410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20410.xml"),
+          )
+      )
+
+  public val icon_20411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20411.xml"),
+          )
+      )
+
+  public val icon_20412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20412.xml"),
+          )
+      )
+
+  public val icon_20413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20413.xml"),
+          )
+      )
+
+  public val icon_20414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20414.xml"),
+          )
+      )
+
+  public val icon_20415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20415.xml"),
+          )
+      )
+
+  public val icon_20416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20416.xml"),
+          )
+      )
+
+  public val icon_20417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20417.xml"),
+          )
+      )
+
+  public val icon_20418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20418.xml"),
+          )
+      )
+
+  public val icon_20419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20419.xml"),
+          )
+      )
+
+  public val icon_2042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2042.xml"),
+          )
+      )
+
+  public val icon_20420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20420.xml"),
+          )
+      )
+
+  public val icon_20421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20421.xml"),
+          )
+      )
+
+  public val icon_20422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20422.xml"),
+          )
+      )
+
+  public val icon_20423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20423.xml"),
+          )
+      )
+
+  public val icon_20424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20424.xml"),
+          )
+      )
+
+  public val icon_20425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20425.xml"),
+          )
+      )
+
+  public val icon_20426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20426.xml"),
+          )
+      )
+
+  public val icon_20427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20427.xml"),
+          )
+      )
+
+  public val icon_20428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20428.xml"),
+          )
+      )
+
+  public val icon_20429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20429.xml"),
+          )
+      )
+
+  public val icon_2043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2043.xml"),
+          )
+      )
+
+  public val icon_20430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20430.xml"),
+          )
+      )
+
+  public val icon_20431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20431.xml"),
+          )
+      )
+
+  public val icon_20432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20432.xml"),
+          )
+      )
+
+  public val icon_20433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20433.xml"),
+          )
+      )
+
+  public val icon_20434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20434.xml"),
+          )
+      )
+
+  public val icon_20435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20435.xml"),
+          )
+      )
+
+  public val icon_20436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20436.xml"),
+          )
+      )
+
+  public val icon_20437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20437.xml"),
+          )
+      )
+
+  public val icon_20438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20438.xml"),
+          )
+      )
+
+  public val icon_20439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20439.xml"),
+          )
+      )
+
+  public val icon_2044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2044.xml"),
+          )
+      )
+
+  public val icon_20440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20440.xml"),
+          )
+      )
+
+  public val icon_20441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20441.xml"),
+          )
+      )
+
+  public val icon_20442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20442.xml"),
+          )
+      )
+
+  public val icon_20443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20443.xml"),
+          )
+      )
+
+  public val icon_20444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20444.xml"),
+          )
+      )
+
+  public val icon_20445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20445.xml"),
+          )
+      )
+
+  public val icon_20446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20446.xml"),
+          )
+      )
+
+  public val icon_20447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20447.xml"),
+          )
+      )
+
+  public val icon_20448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20448.xml"),
+          )
+      )
+
+  public val icon_20449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20449.xml"),
+          )
+      )
+
+  public val icon_2045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2045.xml"),
+          )
+      )
+
+  public val icon_20450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20450.xml"),
+          )
+      )
+
+  public val icon_20451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20451.xml"),
+          )
+      )
+
+  public val icon_20452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20452.xml"),
+          )
+      )
+
+  public val icon_20453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20453.xml"),
+          )
+      )
+
+  public val icon_20454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20454.xml"),
+          )
+      )
+
+  public val icon_20455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20455.xml"),
+          )
+      )
+
+  public val icon_20456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20456.xml"),
+          )
+      )
+
+  public val icon_20457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20457.xml"),
+          )
+      )
+
+  public val icon_20458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20458.xml"),
+          )
+      )
+
+  public val icon_20459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20459.xml"),
+          )
+      )
+
+  public val icon_2046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2046.xml"),
+          )
+      )
+
+  public val icon_20460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20460.xml"),
+          )
+      )
+
+  public val icon_20461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20461.xml"),
+          )
+      )
+
+  public val icon_20462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20462.xml"),
+          )
+      )
+
+  public val icon_20463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20463.xml"),
+          )
+      )
+
+  public val icon_20464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20464.xml"),
+          )
+      )
+
+  public val icon_20465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20465.xml"),
+          )
+      )
+
+  public val icon_20466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20466.xml"),
+          )
+      )
+
+  public val icon_20467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20467.xml"),
+          )
+      )
+
+  public val icon_20468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20468.xml"),
+          )
+      )
+
+  public val icon_20469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20469.xml"),
+          )
+      )
+
+  public val icon_2047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2047.xml"),
+          )
+      )
+
+  public val icon_20470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20470.xml"),
+          )
+      )
+
+  public val icon_20471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20471.xml"),
+          )
+      )
+
+  public val icon_20472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20472.xml"),
+          )
+      )
+
+  public val icon_20473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20473.xml"),
+          )
+      )
+
+  public val icon_20474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20474.xml"),
+          )
+      )
+
+  public val icon_20475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20475.xml"),
+          )
+      )
+
+  public val icon_20476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20476.xml"),
+          )
+      )
+
+  public val icon_20477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20477.xml"),
+          )
+      )
+
+  public val icon_20478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20478.xml"),
+          )
+      )
+
+  public val icon_20479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20479.xml"),
+          )
+      )
+
+  public val icon_2048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2048.xml"),
+          )
+      )
+
+  public val icon_20480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20480.xml"),
+          )
+      )
+
+  public val icon_20481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20481.xml"),
+          )
+      )
+
+  public val icon_20482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20482.xml"),
+          )
+      )
+
+  public val icon_20483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20483.xml"),
+          )
+      )
+
+  public val icon_20484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20484.xml"),
+          )
+      )
+
+  public val icon_20485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20485.xml"),
+          )
+      )
+
+  public val icon_20486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20486.xml"),
+          )
+      )
+
+  public val icon_20487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20487.xml"),
+          )
+      )
+
+  public val icon_20488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20488.xml"),
+          )
+      )
+
+  public val icon_20489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20489.xml"),
+          )
+      )
+
+  public val icon_2049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2049.xml"),
+          )
+      )
+
+  public val icon_20490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20490.xml"),
+          )
+      )
+
+  public val icon_20491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20491.xml"),
+          )
+      )
+
+  public val icon_20492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20492.xml"),
+          )
+      )
+
+  public val icon_20493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20493.xml"),
+          )
+      )
+
+  public val icon_20494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20494.xml"),
+          )
+      )
+
+  public val icon_20495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20495.xml"),
+          )
+      )
+
+  public val icon_20496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20496.xml"),
+          )
+      )
+
+  public val icon_20497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20497.xml"),
+          )
+      )
+
+  public val icon_20498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20498.xml"),
+          )
+      )
+
+  public val icon_20499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20499.xml"),
+          )
+      )
+
+  public val icon_205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_205.xml"),
+          )
+      )
+
+  public val icon_2050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2050.xml"),
+          )
+      )
+
+  public val icon_20500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20500.xml"),
+          )
+      )
+
+  public val icon_20501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20501.xml"),
+          )
+      )
+
+  public val icon_20502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20502.xml"),
+          )
+      )
+
+  public val icon_20503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20503.xml"),
+          )
+      )
+
+  public val icon_20504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20504.xml"),
+          )
+      )
+
+  public val icon_20505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20505.xml"),
+          )
+      )
+
+  public val icon_20506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20506.xml"),
+          )
+      )
+
+  public val icon_20507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20507.xml"),
+          )
+      )
+
+  public val icon_20508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20508.xml"),
+          )
+      )
+
+  public val icon_20509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20509.xml"),
+          )
+      )
+
+  public val icon_2051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2051.xml"),
+          )
+      )
+
+  public val icon_20510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20510.xml"),
+          )
+      )
+
+  public val icon_20511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20511.xml"),
+          )
+      )
+
+  public val icon_20512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20512.xml"),
+          )
+      )
+
+  public val icon_20513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20513.xml"),
+          )
+      )
+
+  public val icon_20514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20514.xml"),
+          )
+      )
+
+  public val icon_20515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20515.xml"),
+          )
+      )
+
+  public val icon_20516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20516.xml"),
+          )
+      )
+
+  public val icon_20517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20517.xml"),
+          )
+      )
+
+  public val icon_20518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20518.xml"),
+          )
+      )
+
+  public val icon_20519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20519.xml"),
+          )
+      )
+
+  public val icon_2052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2052.xml"),
+          )
+      )
+
+  public val icon_20520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20520.xml"),
+          )
+      )
+
+  public val icon_20521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20521.xml"),
+          )
+      )
+
+  public val icon_20522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20522.xml"),
+          )
+      )
+
+  public val icon_20523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20523.xml"),
+          )
+      )
+
+  public val icon_20524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20524.xml"),
+          )
+      )
+
+  public val icon_20525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20525.xml"),
+          )
+      )
+
+  public val icon_20526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20526.xml"),
+          )
+      )
+
+  public val icon_20527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20527.xml"),
+          )
+      )
+
+  public val icon_20528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20528.xml"),
+          )
+      )
+
+  public val icon_20529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20529.xml"),
+          )
+      )
+
+  public val icon_2053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2053.xml"),
+          )
+      )
+
+  public val icon_20530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20530.xml"),
+          )
+      )
+
+  public val icon_20531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20531.xml"),
+          )
+      )
+
+  public val icon_20532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20532.xml"),
+          )
+      )
+
+  public val icon_20533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20533.xml"),
+          )
+      )
+
+  public val icon_20534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20534.xml"),
+          )
+      )
+
+  public val icon_20535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20535.xml"),
+          )
+      )
+
+  public val icon_20536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20536.xml"),
+          )
+      )
+
+  public val icon_20537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20537.xml"),
+          )
+      )
+
+  public val icon_20538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20538.xml"),
+          )
+      )
+
+  public val icon_20539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20539.xml"),
+          )
+      )
+
+  public val icon_2054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2054.xml"),
+          )
+      )
+
+  public val icon_20540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20540.xml"),
+          )
+      )
+
+  public val icon_20541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20541.xml"),
+          )
+      )
+
+  public val icon_20542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20542.xml"),
+          )
+      )
+
+  public val icon_20543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20543.xml"),
+          )
+      )
+
+  public val icon_20544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20544.xml"),
+          )
+      )
+
+  public val icon_20545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20545.xml"),
+          )
+      )
+
+  public val icon_20546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20546.xml"),
+          )
+      )
+
+  public val icon_20547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20547.xml"),
+          )
+      )
+
+  public val icon_20548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20548.xml"),
+          )
+      )
+
+  public val icon_20549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20549.xml"),
+          )
+      )
+
+  public val icon_2055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2055.xml"),
+          )
+      )
+
+  public val icon_20550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20550.xml"),
+          )
+      )
+
+  public val icon_20551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20551.xml"),
+          )
+      )
+
+  public val icon_20552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20552.xml"),
+          )
+      )
+
+  public val icon_20553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20553.xml"),
+          )
+      )
+
+  public val icon_20554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20554.xml"),
+          )
+      )
+
+  public val icon_20555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20555.xml"),
+          )
+      )
+
+  public val icon_20556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20556.xml"),
+          )
+      )
+
+  public val icon_20557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20557.xml"),
+          )
+      )
+
+  public val icon_20558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20558.xml"),
+          )
+      )
+
+  public val icon_20559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20559.xml"),
+          )
+      )
+
+  public val icon_2056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2056.xml"),
+          )
+      )
+
+  public val icon_20560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20560.xml"),
+          )
+      )
+
+  public val icon_20561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20561.xml"),
+          )
+      )
+
+  public val icon_20562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20562.xml"),
+          )
+      )
+
+  public val icon_20563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20563.xml"),
+          )
+      )
+
+  public val icon_20564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20564.xml"),
+          )
+      )
+
+  public val icon_20565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20565.xml"),
+          )
+      )
+
+  public val icon_20566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20566.xml"),
+          )
+      )
+
+  public val icon_20567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20567.xml"),
+          )
+      )
+
+  public val icon_20568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20568.xml"),
+          )
+      )
+
+  public val icon_20569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20569.xml"),
+          )
+      )
+
+  public val icon_2057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2057.xml"),
+          )
+      )
+
+  public val icon_20570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20570.xml"),
+          )
+      )
+
+  public val icon_20571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20571.xml"),
+          )
+      )
+
+  public val icon_20572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20572.xml"),
+          )
+      )
+
+  public val icon_20573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20573.xml"),
+          )
+      )
+
+  public val icon_20574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20574.xml"),
+          )
+      )
+
+  public val icon_20575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20575.xml"),
+          )
+      )
+
+  public val icon_20576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20576.xml"),
+          )
+      )
+
+  public val icon_20577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20577.xml"),
+          )
+      )
+
+  public val icon_20578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20578.xml"),
+          )
+      )
+
+  public val icon_20579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20579.xml"),
+          )
+      )
+
+  public val icon_2058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2058.xml"),
+          )
+      )
+
+  public val icon_20580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20580.xml"),
+          )
+      )
+
+  public val icon_20581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20581.xml"),
+          )
+      )
+
+  public val icon_20582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20582.xml"),
+          )
+      )
+
+  public val icon_20583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20583.xml"),
+          )
+      )
+
+  public val icon_20584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20584.xml"),
+          )
+      )
+
+  public val icon_20585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20585.xml"),
+          )
+      )
+
+  public val icon_20586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20586.xml"),
+          )
+      )
+
+  public val icon_20587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20587.xml"),
+          )
+      )
+
+  public val icon_20588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20588.xml"),
+          )
+      )
+
+  public val icon_20589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20589.xml"),
+          )
+      )
+
+  public val icon_2059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2059.xml"),
+          )
+      )
+
+  public val icon_20590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20590.xml"),
+          )
+      )
+
+  public val icon_20591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20591.xml"),
+          )
+      )
+
+  public val icon_20592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20592.xml"),
+          )
+      )
+
+  public val icon_20593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20593.xml"),
+          )
+      )
+
+  public val icon_20594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20594.xml"),
+          )
+      )
+
+  public val icon_20595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20595.xml"),
+          )
+      )
+
+  public val icon_20596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20596.xml"),
+          )
+      )
+
+  public val icon_20597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20597.xml"),
+          )
+      )
+
+  public val icon_20598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20598.xml"),
+          )
+      )
+
+  public val icon_20599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20599.xml"),
+          )
+      )
+
+  public val icon_206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_206.xml"),
+          )
+      )
+
+  public val icon_2060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2060.xml"),
+          )
+      )
+
+  public val icon_20600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20600.xml"),
+          )
+      )
+
+  public val icon_20601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20601.xml"),
+          )
+      )
+
+  public val icon_20602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20602.xml"),
+          )
+      )
+
+  public val icon_20603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20603.xml"),
+          )
+      )
+
+  public val icon_20604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20604.xml"),
+          )
+      )
+
+  public val icon_20605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20605.xml"),
+          )
+      )
+
+  public val icon_20606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20606.xml"),
+          )
+      )
+
+  public val icon_20607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20607.xml"),
+          )
+      )
+
+  public val icon_20608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20608.xml"),
+          )
+      )
+
+  public val icon_20609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20609.xml"),
+          )
+      )
+
+  public val icon_2061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2061.xml"),
+          )
+      )
+
+  public val icon_20610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20610.xml"),
+          )
+      )
+
+  public val icon_20611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20611.xml"),
+          )
+      )
+
+  public val icon_20612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20612.xml"),
+          )
+      )
+
+  public val icon_20613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20613.xml"),
+          )
+      )
+
+  public val icon_20614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20614.xml"),
+          )
+      )
+
+  public val icon_20615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20615.xml"),
+          )
+      )
+
+  public val icon_20616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20616.xml"),
+          )
+      )
+
+  public val icon_20617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20617.xml"),
+          )
+      )
+
+  public val icon_20618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20618.xml"),
+          )
+      )
+
+  public val icon_20619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20619.xml"),
+          )
+      )
+
+  public val icon_2062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2062.xml"),
+          )
+      )
+
+  public val icon_20620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20620.xml"),
+          )
+      )
+
+  public val icon_20621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20621.xml"),
+          )
+      )
+
+  public val icon_20622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20622.xml"),
+          )
+      )
+
+  public val icon_20623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20623.xml"),
+          )
+      )
+
+  public val icon_20624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20624.xml"),
+          )
+      )
+
+  public val icon_20625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20625.xml"),
+          )
+      )
+
+  public val icon_20626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20626.xml"),
+          )
+      )
+
+  public val icon_20627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20627.xml"),
+          )
+      )
+
+  public val icon_20628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20628.xml"),
+          )
+      )
+
+  public val icon_20629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20629.xml"),
+          )
+      )
+
+  public val icon_2063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2063.xml"),
+          )
+      )
+
+  public val icon_20630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20630.xml"),
+          )
+      )
+
+  public val icon_20631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20631.xml"),
+          )
+      )
+
+  public val icon_20632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20632.xml"),
+          )
+      )
+
+  public val icon_20633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20633.xml"),
+          )
+      )
+
+  public val icon_20634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20634.xml"),
+          )
+      )
+
+  public val icon_20635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20635.xml"),
+          )
+      )
+
+  public val icon_20636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20636.xml"),
+          )
+      )
+
+  public val icon_20637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20637.xml"),
+          )
+      )
+
+  public val icon_20638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20638.xml"),
+          )
+      )
+
+  public val icon_20639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20639.xml"),
+          )
+      )
+
+  public val icon_2064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2064.xml"),
+          )
+      )
+
+  public val icon_20640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20640.xml"),
+          )
+      )
+
+  public val icon_20641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20641.xml"),
+          )
+      )
+
+  public val icon_20642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20642.xml"),
+          )
+      )
+
+  public val icon_20643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20643.xml"),
+          )
+      )
+
+  public val icon_20644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20644.xml"),
+          )
+      )
+
+  public val icon_20645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20645.xml"),
+          )
+      )
+
+  public val icon_20646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20646.xml"),
+          )
+      )
+
+  public val icon_20647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20647.xml"),
+          )
+      )
+
+  public val icon_20648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20648.xml"),
+          )
+      )
+
+  public val icon_20649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20649.xml"),
+          )
+      )
+
+  public val icon_2065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2065.xml"),
+          )
+      )
+
+  public val icon_20650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20650.xml"),
+          )
+      )
+
+  public val icon_20651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20651.xml"),
+          )
+      )
+
+  public val icon_20652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20652.xml"),
+          )
+      )
+
+  public val icon_20653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20653.xml"),
+          )
+      )
+
+  public val icon_20654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20654.xml"),
+          )
+      )
+
+  public val icon_20655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20655.xml"),
+          )
+      )
+
+  public val icon_20656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20656.xml"),
+          )
+      )
+
+  public val icon_20657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20657.xml"),
+          )
+      )
+
+  public val icon_20658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20658.xml"),
+          )
+      )
+
+  public val icon_20659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20659.xml"),
+          )
+      )
+
+  public val icon_2066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2066.xml"),
+          )
+      )
+
+  public val icon_20660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20660.xml"),
+          )
+      )
+
+  public val icon_20661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20661.xml"),
+          )
+      )
+
+  public val icon_20662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20662.xml"),
+          )
+      )
+
+  public val icon_20663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20663.xml"),
+          )
+      )
+
+  public val icon_20664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20664.xml"),
+          )
+      )
+
+  public val icon_20665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20665.xml"),
+          )
+      )
+
+  public val icon_20666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20666.xml"),
+          )
+      )
+
+  public val icon_20667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20667.xml"),
+          )
+      )
+
+  public val icon_20668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20668.xml"),
+          )
+      )
+
+  public val icon_20669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20669.xml"),
+          )
+      )
+
+  public val icon_2067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2067.xml"),
+          )
+      )
+
+  public val icon_20670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20670.xml"),
+          )
+      )
+
+  public val icon_20671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20671.xml"),
+          )
+      )
+
+  public val icon_20672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20672.xml"),
+          )
+      )
+
+  public val icon_20673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20673.xml"),
+          )
+      )
+
+  public val icon_20674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20674.xml"),
+          )
+      )
+
+  public val icon_20675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20675.xml"),
+          )
+      )
+
+  public val icon_20676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20676.xml"),
+          )
+      )
+
+  public val icon_20677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20677.xml"),
+          )
+      )
+
+  public val icon_20678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20678.xml"),
+          )
+      )
+
+  public val icon_20679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20679.xml"),
+          )
+      )
+
+  public val icon_2068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2068.xml"),
+          )
+      )
+
+  public val icon_20680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20680.xml"),
+          )
+      )
+
+  public val icon_20681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20681.xml"),
+          )
+      )
+
+  public val icon_20682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20682.xml"),
+          )
+      )
+
+  public val icon_20683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20683.xml"),
+          )
+      )
+
+  public val icon_20684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20684.xml"),
+          )
+      )
+
+  public val icon_20685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20685.xml"),
+          )
+      )
+
+  public val icon_20686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20686.xml"),
+          )
+      )
+
+  public val icon_20687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20687.xml"),
+          )
+      )
+
+  public val icon_20688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20688.xml"),
+          )
+      )
+
+  public val icon_20689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20689.xml"),
+          )
+      )
+
+  public val icon_2069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2069.xml"),
+          )
+      )
+
+  public val icon_20690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20690.xml"),
+          )
+      )
+
+  public val icon_20691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20691.xml"),
+          )
+      )
+
+  public val icon_20692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20692.xml"),
+          )
+      )
+
+  public val icon_20693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20693.xml"),
+          )
+      )
+
+  public val icon_20694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20694.xml"),
+          )
+      )
+
+  public val icon_20695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20695.xml"),
+          )
+      )
+
+  public val icon_20696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20696.xml"),
+          )
+      )
+
+  public val icon_20697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20697.xml"),
+          )
+      )
+
+  public val icon_20698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20698.xml"),
+          )
+      )
+
+  public val icon_20699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20699.xml"),
+          )
+      )
+
+  public val icon_207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_207.xml"),
+          )
+      )
+
+  public val icon_2070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2070.xml"),
+          )
+      )
+
+  public val icon_20700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20700.xml"),
+          )
+      )
+
+  public val icon_20701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20701.xml"),
+          )
+      )
+
+  public val icon_20702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20702.xml"),
+          )
+      )
+
+  public val icon_20703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20703.xml"),
+          )
+      )
+
+  public val icon_20704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20704.xml"),
+          )
+      )
+
+  public val icon_20705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20705.xml"),
+          )
+      )
+
+  public val icon_20706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20706.xml"),
+          )
+      )
+
+  public val icon_20707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20707.xml"),
+          )
+      )
+
+  public val icon_20708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20708.xml"),
+          )
+      )
+
+  public val icon_20709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20709.xml"),
+          )
+      )
+
+  public val icon_2071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2071.xml"),
+          )
+      )
+
+  public val icon_20710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20710.xml"),
+          )
+      )
+
+  public val icon_20711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20711.xml"),
+          )
+      )
+
+  public val icon_20712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20712.xml"),
+          )
+      )
+
+  public val icon_20713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20713.xml"),
+          )
+      )
+
+  public val icon_20714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20714.xml"),
+          )
+      )
+
+  public val icon_20715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20715.xml"),
+          )
+      )
+
+  public val icon_20716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20716.xml"),
+          )
+      )
+
+  public val icon_20717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20717.xml"),
+          )
+      )
+
+  public val icon_20718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20718.xml"),
+          )
+      )
+
+  public val icon_20719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20719.xml"),
+          )
+      )
+
+  public val icon_2072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2072.xml"),
+          )
+      )
+
+  public val icon_20720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20720.xml"),
+          )
+      )
+
+  public val icon_20721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20721.xml"),
+          )
+      )
+
+  public val icon_20722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20722.xml"),
+          )
+      )
+
+  public val icon_20723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20723.xml"),
+          )
+      )
+
+  public val icon_20724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20724.xml"),
+          )
+      )
+
+  public val icon_20725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20725.xml"),
+          )
+      )
+
+  public val icon_20726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20726.xml"),
+          )
+      )
+
+  public val icon_20727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20727.xml"),
+          )
+      )
+
+  public val icon_20728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20728.xml"),
+          )
+      )
+
+  public val icon_20729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20729.xml"),
+          )
+      )
+
+  public val icon_2073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2073.xml"),
+          )
+      )
+
+  public val icon_20730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20730.xml"),
+          )
+      )
+
+  public val icon_20731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20731.xml"),
+          )
+      )
+
+  public val icon_20732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20732.xml"),
+          )
+      )
+
+  public val icon_20733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20733.xml"),
+          )
+      )
+
+  public val icon_20734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20734.xml"),
+          )
+      )
+
+  public val icon_20735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20735.xml"),
+          )
+      )
+
+  public val icon_20736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20736.xml"),
+          )
+      )
+
+  public val icon_20737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20737.xml"),
+          )
+      )
+
+  public val icon_20738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20738.xml"),
+          )
+      )
+
+  public val icon_20739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20739.xml"),
+          )
+      )
+
+  public val icon_2074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2074.xml"),
+          )
+      )
+
+  public val icon_20740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20740.xml"),
+          )
+      )
+
+  public val icon_20741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20741.xml"),
+          )
+      )
+
+  public val icon_20742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20742.xml"),
+          )
+      )
+
+  public val icon_20743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20743.xml"),
+          )
+      )
+
+  public val icon_20744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20744.xml"),
+          )
+      )
+
+  public val icon_20745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20745.xml"),
+          )
+      )
+
+  public val icon_20746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20746.xml"),
+          )
+      )
+
+  public val icon_20747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20747.xml"),
+          )
+      )
+
+  public val icon_20748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20748.xml"),
+          )
+      )
+
+  public val icon_20749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20749.xml"),
+          )
+      )
+
+  public val icon_2075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2075.xml"),
+          )
+      )
+
+  public val icon_20750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20750.xml"),
+          )
+      )
+
+  public val icon_20751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20751.xml"),
+          )
+      )
+
+  public val icon_20752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20752.xml"),
+          )
+      )
+
+  public val icon_20753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20753.xml"),
+          )
+      )
+
+  public val icon_20754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20754.xml"),
+          )
+      )
+
+  public val icon_20755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20755.xml"),
+          )
+      )
+
+  public val icon_20756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20756.xml"),
+          )
+      )
+
+  public val icon_20757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20757.xml"),
+          )
+      )
+
+  public val icon_20758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20758.xml"),
+          )
+      )
+
+  public val icon_20759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20759.xml"),
+          )
+      )
+
+  public val icon_2076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2076.xml"),
+          )
+      )
+
+  public val icon_20760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20760.xml"),
+          )
+      )
+
+  public val icon_20761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20761.xml"),
+          )
+      )
+
+  public val icon_20762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20762.xml"),
+          )
+      )
+
+  public val icon_20763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20763.xml"),
+          )
+      )
+
+  public val icon_20764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20764.xml"),
+          )
+      )
+
+  public val icon_20765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20765.xml"),
+          )
+      )
+
+  public val icon_20766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20766.xml"),
+          )
+      )
+
+  public val icon_20767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20767.xml"),
+          )
+      )
+
+  public val icon_20768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20768.xml"),
+          )
+      )
+
+  public val icon_20769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20769.xml"),
+          )
+      )
+
+  public val icon_2077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2077.xml"),
+          )
+      )
+
+  public val icon_20770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20770.xml"),
+          )
+      )
+
+  public val icon_20771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20771.xml"),
+          )
+      )
+
+  public val icon_20772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20772.xml"),
+          )
+      )
+
+  public val icon_20773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20773.xml"),
+          )
+      )
+
+  public val icon_20774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20774.xml"),
+          )
+      )
+
+  public val icon_20775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20775.xml"),
+          )
+      )
+
+  public val icon_20776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20776.xml"),
+          )
+      )
+
+  public val icon_20777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20777.xml"),
+          )
+      )
+
+  public val icon_20778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20778.xml"),
+          )
+      )
+
+  public val icon_20779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20779.xml"),
+          )
+      )
+
+  public val icon_2078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2078.xml"),
+          )
+      )
+
+  public val icon_20780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20780.xml"),
+          )
+      )
+
+  public val icon_20781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20781.xml"),
+          )
+      )
+
+  public val icon_20782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20782.xml"),
+          )
+      )
+
+  public val icon_20783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20783.xml"),
+          )
+      )
+
+  public val icon_20784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20784.xml"),
+          )
+      )
+
+  public val icon_20785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20785.xml"),
+          )
+      )
+
+  public val icon_20786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20786.xml"),
+          )
+      )
+
+  public val icon_20787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20787.xml"),
+          )
+      )
+
+  public val icon_20788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20788.xml"),
+          )
+      )
+
+  public val icon_20789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20789.xml"),
+          )
+      )
+
+  public val icon_2079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2079.xml"),
+          )
+      )
+
+  public val icon_20790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20790.xml"),
+          )
+      )
+
+  public val icon_20791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20791.xml"),
+          )
+      )
+
+  public val icon_20792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20792.xml"),
+          )
+      )
+
+  public val icon_20793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20793.xml"),
+          )
+      )
+
+  public val icon_20794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20794.xml"),
+          )
+      )
+
+  public val icon_20795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20795.xml"),
+          )
+      )
+
+  public val icon_20796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20796.xml"),
+          )
+      )
+
+  public val icon_20797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20797.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20347: DrawableResource
+  get() = Drawable23.icon_20347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20348: DrawableResource
+  get() = Drawable23.icon_20348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20349: DrawableResource
+  get() = Drawable23.icon_20349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2035: DrawableResource
+  get() = Drawable23.icon_2035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20350: DrawableResource
+  get() = Drawable23.icon_20350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20351: DrawableResource
+  get() = Drawable23.icon_20351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20352: DrawableResource
+  get() = Drawable23.icon_20352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20353: DrawableResource
+  get() = Drawable23.icon_20353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20354: DrawableResource
+  get() = Drawable23.icon_20354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20355: DrawableResource
+  get() = Drawable23.icon_20355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20356: DrawableResource
+  get() = Drawable23.icon_20356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20357: DrawableResource
+  get() = Drawable23.icon_20357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20358: DrawableResource
+  get() = Drawable23.icon_20358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20359: DrawableResource
+  get() = Drawable23.icon_20359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2036: DrawableResource
+  get() = Drawable23.icon_2036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20360: DrawableResource
+  get() = Drawable23.icon_20360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20361: DrawableResource
+  get() = Drawable23.icon_20361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20362: DrawableResource
+  get() = Drawable23.icon_20362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20363: DrawableResource
+  get() = Drawable23.icon_20363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20364: DrawableResource
+  get() = Drawable23.icon_20364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20365: DrawableResource
+  get() = Drawable23.icon_20365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20366: DrawableResource
+  get() = Drawable23.icon_20366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20367: DrawableResource
+  get() = Drawable23.icon_20367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20368: DrawableResource
+  get() = Drawable23.icon_20368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20369: DrawableResource
+  get() = Drawable23.icon_20369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2037: DrawableResource
+  get() = Drawable23.icon_2037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20370: DrawableResource
+  get() = Drawable23.icon_20370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20371: DrawableResource
+  get() = Drawable23.icon_20371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20372: DrawableResource
+  get() = Drawable23.icon_20372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20373: DrawableResource
+  get() = Drawable23.icon_20373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20374: DrawableResource
+  get() = Drawable23.icon_20374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20375: DrawableResource
+  get() = Drawable23.icon_20375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20376: DrawableResource
+  get() = Drawable23.icon_20376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20377: DrawableResource
+  get() = Drawable23.icon_20377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20378: DrawableResource
+  get() = Drawable23.icon_20378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20379: DrawableResource
+  get() = Drawable23.icon_20379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2038: DrawableResource
+  get() = Drawable23.icon_2038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20380: DrawableResource
+  get() = Drawable23.icon_20380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20381: DrawableResource
+  get() = Drawable23.icon_20381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20382: DrawableResource
+  get() = Drawable23.icon_20382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20383: DrawableResource
+  get() = Drawable23.icon_20383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20384: DrawableResource
+  get() = Drawable23.icon_20384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20385: DrawableResource
+  get() = Drawable23.icon_20385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20386: DrawableResource
+  get() = Drawable23.icon_20386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20387: DrawableResource
+  get() = Drawable23.icon_20387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20388: DrawableResource
+  get() = Drawable23.icon_20388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20389: DrawableResource
+  get() = Drawable23.icon_20389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2039: DrawableResource
+  get() = Drawable23.icon_2039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20390: DrawableResource
+  get() = Drawable23.icon_20390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20391: DrawableResource
+  get() = Drawable23.icon_20391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20392: DrawableResource
+  get() = Drawable23.icon_20392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20393: DrawableResource
+  get() = Drawable23.icon_20393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20394: DrawableResource
+  get() = Drawable23.icon_20394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20395: DrawableResource
+  get() = Drawable23.icon_20395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20396: DrawableResource
+  get() = Drawable23.icon_20396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20397: DrawableResource
+  get() = Drawable23.icon_20397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20398: DrawableResource
+  get() = Drawable23.icon_20398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20399: DrawableResource
+  get() = Drawable23.icon_20399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_204: DrawableResource
+  get() = Drawable23.icon_204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2040: DrawableResource
+  get() = Drawable23.icon_2040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20400: DrawableResource
+  get() = Drawable23.icon_20400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20401: DrawableResource
+  get() = Drawable23.icon_20401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20402: DrawableResource
+  get() = Drawable23.icon_20402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20403: DrawableResource
+  get() = Drawable23.icon_20403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20404: DrawableResource
+  get() = Drawable23.icon_20404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20405: DrawableResource
+  get() = Drawable23.icon_20405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20406: DrawableResource
+  get() = Drawable23.icon_20406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20407: DrawableResource
+  get() = Drawable23.icon_20407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20408: DrawableResource
+  get() = Drawable23.icon_20408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20409: DrawableResource
+  get() = Drawable23.icon_20409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2041: DrawableResource
+  get() = Drawable23.icon_2041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20410: DrawableResource
+  get() = Drawable23.icon_20410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20411: DrawableResource
+  get() = Drawable23.icon_20411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20412: DrawableResource
+  get() = Drawable23.icon_20412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20413: DrawableResource
+  get() = Drawable23.icon_20413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20414: DrawableResource
+  get() = Drawable23.icon_20414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20415: DrawableResource
+  get() = Drawable23.icon_20415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20416: DrawableResource
+  get() = Drawable23.icon_20416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20417: DrawableResource
+  get() = Drawable23.icon_20417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20418: DrawableResource
+  get() = Drawable23.icon_20418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20419: DrawableResource
+  get() = Drawable23.icon_20419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2042: DrawableResource
+  get() = Drawable23.icon_2042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20420: DrawableResource
+  get() = Drawable23.icon_20420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20421: DrawableResource
+  get() = Drawable23.icon_20421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20422: DrawableResource
+  get() = Drawable23.icon_20422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20423: DrawableResource
+  get() = Drawable23.icon_20423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20424: DrawableResource
+  get() = Drawable23.icon_20424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20425: DrawableResource
+  get() = Drawable23.icon_20425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20426: DrawableResource
+  get() = Drawable23.icon_20426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20427: DrawableResource
+  get() = Drawable23.icon_20427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20428: DrawableResource
+  get() = Drawable23.icon_20428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20429: DrawableResource
+  get() = Drawable23.icon_20429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2043: DrawableResource
+  get() = Drawable23.icon_2043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20430: DrawableResource
+  get() = Drawable23.icon_20430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20431: DrawableResource
+  get() = Drawable23.icon_20431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20432: DrawableResource
+  get() = Drawable23.icon_20432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20433: DrawableResource
+  get() = Drawable23.icon_20433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20434: DrawableResource
+  get() = Drawable23.icon_20434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20435: DrawableResource
+  get() = Drawable23.icon_20435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20436: DrawableResource
+  get() = Drawable23.icon_20436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20437: DrawableResource
+  get() = Drawable23.icon_20437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20438: DrawableResource
+  get() = Drawable23.icon_20438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20439: DrawableResource
+  get() = Drawable23.icon_20439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2044: DrawableResource
+  get() = Drawable23.icon_2044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20440: DrawableResource
+  get() = Drawable23.icon_20440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20441: DrawableResource
+  get() = Drawable23.icon_20441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20442: DrawableResource
+  get() = Drawable23.icon_20442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20443: DrawableResource
+  get() = Drawable23.icon_20443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20444: DrawableResource
+  get() = Drawable23.icon_20444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20445: DrawableResource
+  get() = Drawable23.icon_20445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20446: DrawableResource
+  get() = Drawable23.icon_20446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20447: DrawableResource
+  get() = Drawable23.icon_20447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20448: DrawableResource
+  get() = Drawable23.icon_20448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20449: DrawableResource
+  get() = Drawable23.icon_20449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2045: DrawableResource
+  get() = Drawable23.icon_2045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20450: DrawableResource
+  get() = Drawable23.icon_20450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20451: DrawableResource
+  get() = Drawable23.icon_20451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20452: DrawableResource
+  get() = Drawable23.icon_20452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20453: DrawableResource
+  get() = Drawable23.icon_20453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20454: DrawableResource
+  get() = Drawable23.icon_20454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20455: DrawableResource
+  get() = Drawable23.icon_20455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20456: DrawableResource
+  get() = Drawable23.icon_20456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20457: DrawableResource
+  get() = Drawable23.icon_20457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20458: DrawableResource
+  get() = Drawable23.icon_20458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20459: DrawableResource
+  get() = Drawable23.icon_20459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2046: DrawableResource
+  get() = Drawable23.icon_2046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20460: DrawableResource
+  get() = Drawable23.icon_20460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20461: DrawableResource
+  get() = Drawable23.icon_20461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20462: DrawableResource
+  get() = Drawable23.icon_20462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20463: DrawableResource
+  get() = Drawable23.icon_20463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20464: DrawableResource
+  get() = Drawable23.icon_20464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20465: DrawableResource
+  get() = Drawable23.icon_20465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20466: DrawableResource
+  get() = Drawable23.icon_20466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20467: DrawableResource
+  get() = Drawable23.icon_20467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20468: DrawableResource
+  get() = Drawable23.icon_20468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20469: DrawableResource
+  get() = Drawable23.icon_20469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2047: DrawableResource
+  get() = Drawable23.icon_2047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20470: DrawableResource
+  get() = Drawable23.icon_20470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20471: DrawableResource
+  get() = Drawable23.icon_20471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20472: DrawableResource
+  get() = Drawable23.icon_20472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20473: DrawableResource
+  get() = Drawable23.icon_20473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20474: DrawableResource
+  get() = Drawable23.icon_20474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20475: DrawableResource
+  get() = Drawable23.icon_20475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20476: DrawableResource
+  get() = Drawable23.icon_20476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20477: DrawableResource
+  get() = Drawable23.icon_20477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20478: DrawableResource
+  get() = Drawable23.icon_20478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20479: DrawableResource
+  get() = Drawable23.icon_20479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2048: DrawableResource
+  get() = Drawable23.icon_2048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20480: DrawableResource
+  get() = Drawable23.icon_20480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20481: DrawableResource
+  get() = Drawable23.icon_20481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20482: DrawableResource
+  get() = Drawable23.icon_20482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20483: DrawableResource
+  get() = Drawable23.icon_20483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20484: DrawableResource
+  get() = Drawable23.icon_20484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20485: DrawableResource
+  get() = Drawable23.icon_20485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20486: DrawableResource
+  get() = Drawable23.icon_20486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20487: DrawableResource
+  get() = Drawable23.icon_20487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20488: DrawableResource
+  get() = Drawable23.icon_20488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20489: DrawableResource
+  get() = Drawable23.icon_20489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2049: DrawableResource
+  get() = Drawable23.icon_2049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20490: DrawableResource
+  get() = Drawable23.icon_20490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20491: DrawableResource
+  get() = Drawable23.icon_20491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20492: DrawableResource
+  get() = Drawable23.icon_20492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20493: DrawableResource
+  get() = Drawable23.icon_20493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20494: DrawableResource
+  get() = Drawable23.icon_20494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20495: DrawableResource
+  get() = Drawable23.icon_20495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20496: DrawableResource
+  get() = Drawable23.icon_20496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20497: DrawableResource
+  get() = Drawable23.icon_20497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20498: DrawableResource
+  get() = Drawable23.icon_20498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20499: DrawableResource
+  get() = Drawable23.icon_20499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_205: DrawableResource
+  get() = Drawable23.icon_205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2050: DrawableResource
+  get() = Drawable23.icon_2050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20500: DrawableResource
+  get() = Drawable23.icon_20500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20501: DrawableResource
+  get() = Drawable23.icon_20501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20502: DrawableResource
+  get() = Drawable23.icon_20502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20503: DrawableResource
+  get() = Drawable23.icon_20503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20504: DrawableResource
+  get() = Drawable23.icon_20504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20505: DrawableResource
+  get() = Drawable23.icon_20505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20506: DrawableResource
+  get() = Drawable23.icon_20506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20507: DrawableResource
+  get() = Drawable23.icon_20507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20508: DrawableResource
+  get() = Drawable23.icon_20508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20509: DrawableResource
+  get() = Drawable23.icon_20509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2051: DrawableResource
+  get() = Drawable23.icon_2051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20510: DrawableResource
+  get() = Drawable23.icon_20510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20511: DrawableResource
+  get() = Drawable23.icon_20511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20512: DrawableResource
+  get() = Drawable23.icon_20512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20513: DrawableResource
+  get() = Drawable23.icon_20513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20514: DrawableResource
+  get() = Drawable23.icon_20514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20515: DrawableResource
+  get() = Drawable23.icon_20515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20516: DrawableResource
+  get() = Drawable23.icon_20516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20517: DrawableResource
+  get() = Drawable23.icon_20517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20518: DrawableResource
+  get() = Drawable23.icon_20518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20519: DrawableResource
+  get() = Drawable23.icon_20519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2052: DrawableResource
+  get() = Drawable23.icon_2052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20520: DrawableResource
+  get() = Drawable23.icon_20520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20521: DrawableResource
+  get() = Drawable23.icon_20521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20522: DrawableResource
+  get() = Drawable23.icon_20522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20523: DrawableResource
+  get() = Drawable23.icon_20523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20524: DrawableResource
+  get() = Drawable23.icon_20524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20525: DrawableResource
+  get() = Drawable23.icon_20525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20526: DrawableResource
+  get() = Drawable23.icon_20526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20527: DrawableResource
+  get() = Drawable23.icon_20527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20528: DrawableResource
+  get() = Drawable23.icon_20528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20529: DrawableResource
+  get() = Drawable23.icon_20529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2053: DrawableResource
+  get() = Drawable23.icon_2053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20530: DrawableResource
+  get() = Drawable23.icon_20530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20531: DrawableResource
+  get() = Drawable23.icon_20531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20532: DrawableResource
+  get() = Drawable23.icon_20532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20533: DrawableResource
+  get() = Drawable23.icon_20533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20534: DrawableResource
+  get() = Drawable23.icon_20534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20535: DrawableResource
+  get() = Drawable23.icon_20535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20536: DrawableResource
+  get() = Drawable23.icon_20536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20537: DrawableResource
+  get() = Drawable23.icon_20537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20538: DrawableResource
+  get() = Drawable23.icon_20538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20539: DrawableResource
+  get() = Drawable23.icon_20539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2054: DrawableResource
+  get() = Drawable23.icon_2054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20540: DrawableResource
+  get() = Drawable23.icon_20540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20541: DrawableResource
+  get() = Drawable23.icon_20541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20542: DrawableResource
+  get() = Drawable23.icon_20542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20543: DrawableResource
+  get() = Drawable23.icon_20543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20544: DrawableResource
+  get() = Drawable23.icon_20544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20545: DrawableResource
+  get() = Drawable23.icon_20545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20546: DrawableResource
+  get() = Drawable23.icon_20546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20547: DrawableResource
+  get() = Drawable23.icon_20547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20548: DrawableResource
+  get() = Drawable23.icon_20548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20549: DrawableResource
+  get() = Drawable23.icon_20549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2055: DrawableResource
+  get() = Drawable23.icon_2055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20550: DrawableResource
+  get() = Drawable23.icon_20550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20551: DrawableResource
+  get() = Drawable23.icon_20551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20552: DrawableResource
+  get() = Drawable23.icon_20552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20553: DrawableResource
+  get() = Drawable23.icon_20553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20554: DrawableResource
+  get() = Drawable23.icon_20554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20555: DrawableResource
+  get() = Drawable23.icon_20555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20556: DrawableResource
+  get() = Drawable23.icon_20556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20557: DrawableResource
+  get() = Drawable23.icon_20557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20558: DrawableResource
+  get() = Drawable23.icon_20558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20559: DrawableResource
+  get() = Drawable23.icon_20559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2056: DrawableResource
+  get() = Drawable23.icon_2056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20560: DrawableResource
+  get() = Drawable23.icon_20560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20561: DrawableResource
+  get() = Drawable23.icon_20561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20562: DrawableResource
+  get() = Drawable23.icon_20562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20563: DrawableResource
+  get() = Drawable23.icon_20563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20564: DrawableResource
+  get() = Drawable23.icon_20564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20565: DrawableResource
+  get() = Drawable23.icon_20565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20566: DrawableResource
+  get() = Drawable23.icon_20566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20567: DrawableResource
+  get() = Drawable23.icon_20567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20568: DrawableResource
+  get() = Drawable23.icon_20568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20569: DrawableResource
+  get() = Drawable23.icon_20569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2057: DrawableResource
+  get() = Drawable23.icon_2057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20570: DrawableResource
+  get() = Drawable23.icon_20570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20571: DrawableResource
+  get() = Drawable23.icon_20571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20572: DrawableResource
+  get() = Drawable23.icon_20572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20573: DrawableResource
+  get() = Drawable23.icon_20573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20574: DrawableResource
+  get() = Drawable23.icon_20574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20575: DrawableResource
+  get() = Drawable23.icon_20575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20576: DrawableResource
+  get() = Drawable23.icon_20576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20577: DrawableResource
+  get() = Drawable23.icon_20577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20578: DrawableResource
+  get() = Drawable23.icon_20578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20579: DrawableResource
+  get() = Drawable23.icon_20579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2058: DrawableResource
+  get() = Drawable23.icon_2058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20580: DrawableResource
+  get() = Drawable23.icon_20580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20581: DrawableResource
+  get() = Drawable23.icon_20581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20582: DrawableResource
+  get() = Drawable23.icon_20582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20583: DrawableResource
+  get() = Drawable23.icon_20583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20584: DrawableResource
+  get() = Drawable23.icon_20584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20585: DrawableResource
+  get() = Drawable23.icon_20585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20586: DrawableResource
+  get() = Drawable23.icon_20586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20587: DrawableResource
+  get() = Drawable23.icon_20587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20588: DrawableResource
+  get() = Drawable23.icon_20588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20589: DrawableResource
+  get() = Drawable23.icon_20589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2059: DrawableResource
+  get() = Drawable23.icon_2059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20590: DrawableResource
+  get() = Drawable23.icon_20590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20591: DrawableResource
+  get() = Drawable23.icon_20591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20592: DrawableResource
+  get() = Drawable23.icon_20592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20593: DrawableResource
+  get() = Drawable23.icon_20593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20594: DrawableResource
+  get() = Drawable23.icon_20594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20595: DrawableResource
+  get() = Drawable23.icon_20595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20596: DrawableResource
+  get() = Drawable23.icon_20596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20597: DrawableResource
+  get() = Drawable23.icon_20597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20598: DrawableResource
+  get() = Drawable23.icon_20598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20599: DrawableResource
+  get() = Drawable23.icon_20599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_206: DrawableResource
+  get() = Drawable23.icon_206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2060: DrawableResource
+  get() = Drawable23.icon_2060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20600: DrawableResource
+  get() = Drawable23.icon_20600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20601: DrawableResource
+  get() = Drawable23.icon_20601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20602: DrawableResource
+  get() = Drawable23.icon_20602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20603: DrawableResource
+  get() = Drawable23.icon_20603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20604: DrawableResource
+  get() = Drawable23.icon_20604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20605: DrawableResource
+  get() = Drawable23.icon_20605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20606: DrawableResource
+  get() = Drawable23.icon_20606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20607: DrawableResource
+  get() = Drawable23.icon_20607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20608: DrawableResource
+  get() = Drawable23.icon_20608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20609: DrawableResource
+  get() = Drawable23.icon_20609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2061: DrawableResource
+  get() = Drawable23.icon_2061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20610: DrawableResource
+  get() = Drawable23.icon_20610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20611: DrawableResource
+  get() = Drawable23.icon_20611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20612: DrawableResource
+  get() = Drawable23.icon_20612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20613: DrawableResource
+  get() = Drawable23.icon_20613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20614: DrawableResource
+  get() = Drawable23.icon_20614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20615: DrawableResource
+  get() = Drawable23.icon_20615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20616: DrawableResource
+  get() = Drawable23.icon_20616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20617: DrawableResource
+  get() = Drawable23.icon_20617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20618: DrawableResource
+  get() = Drawable23.icon_20618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20619: DrawableResource
+  get() = Drawable23.icon_20619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2062: DrawableResource
+  get() = Drawable23.icon_2062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20620: DrawableResource
+  get() = Drawable23.icon_20620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20621: DrawableResource
+  get() = Drawable23.icon_20621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20622: DrawableResource
+  get() = Drawable23.icon_20622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20623: DrawableResource
+  get() = Drawable23.icon_20623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20624: DrawableResource
+  get() = Drawable23.icon_20624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20625: DrawableResource
+  get() = Drawable23.icon_20625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20626: DrawableResource
+  get() = Drawable23.icon_20626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20627: DrawableResource
+  get() = Drawable23.icon_20627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20628: DrawableResource
+  get() = Drawable23.icon_20628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20629: DrawableResource
+  get() = Drawable23.icon_20629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2063: DrawableResource
+  get() = Drawable23.icon_2063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20630: DrawableResource
+  get() = Drawable23.icon_20630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20631: DrawableResource
+  get() = Drawable23.icon_20631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20632: DrawableResource
+  get() = Drawable23.icon_20632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20633: DrawableResource
+  get() = Drawable23.icon_20633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20634: DrawableResource
+  get() = Drawable23.icon_20634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20635: DrawableResource
+  get() = Drawable23.icon_20635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20636: DrawableResource
+  get() = Drawable23.icon_20636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20637: DrawableResource
+  get() = Drawable23.icon_20637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20638: DrawableResource
+  get() = Drawable23.icon_20638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20639: DrawableResource
+  get() = Drawable23.icon_20639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2064: DrawableResource
+  get() = Drawable23.icon_2064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20640: DrawableResource
+  get() = Drawable23.icon_20640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20641: DrawableResource
+  get() = Drawable23.icon_20641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20642: DrawableResource
+  get() = Drawable23.icon_20642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20643: DrawableResource
+  get() = Drawable23.icon_20643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20644: DrawableResource
+  get() = Drawable23.icon_20644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20645: DrawableResource
+  get() = Drawable23.icon_20645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20646: DrawableResource
+  get() = Drawable23.icon_20646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20647: DrawableResource
+  get() = Drawable23.icon_20647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20648: DrawableResource
+  get() = Drawable23.icon_20648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20649: DrawableResource
+  get() = Drawable23.icon_20649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2065: DrawableResource
+  get() = Drawable23.icon_2065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20650: DrawableResource
+  get() = Drawable23.icon_20650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20651: DrawableResource
+  get() = Drawable23.icon_20651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20652: DrawableResource
+  get() = Drawable23.icon_20652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20653: DrawableResource
+  get() = Drawable23.icon_20653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20654: DrawableResource
+  get() = Drawable23.icon_20654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20655: DrawableResource
+  get() = Drawable23.icon_20655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20656: DrawableResource
+  get() = Drawable23.icon_20656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20657: DrawableResource
+  get() = Drawable23.icon_20657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20658: DrawableResource
+  get() = Drawable23.icon_20658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20659: DrawableResource
+  get() = Drawable23.icon_20659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2066: DrawableResource
+  get() = Drawable23.icon_2066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20660: DrawableResource
+  get() = Drawable23.icon_20660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20661: DrawableResource
+  get() = Drawable23.icon_20661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20662: DrawableResource
+  get() = Drawable23.icon_20662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20663: DrawableResource
+  get() = Drawable23.icon_20663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20664: DrawableResource
+  get() = Drawable23.icon_20664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20665: DrawableResource
+  get() = Drawable23.icon_20665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20666: DrawableResource
+  get() = Drawable23.icon_20666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20667: DrawableResource
+  get() = Drawable23.icon_20667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20668: DrawableResource
+  get() = Drawable23.icon_20668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20669: DrawableResource
+  get() = Drawable23.icon_20669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2067: DrawableResource
+  get() = Drawable23.icon_2067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20670: DrawableResource
+  get() = Drawable23.icon_20670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20671: DrawableResource
+  get() = Drawable23.icon_20671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20672: DrawableResource
+  get() = Drawable23.icon_20672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20673: DrawableResource
+  get() = Drawable23.icon_20673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20674: DrawableResource
+  get() = Drawable23.icon_20674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20675: DrawableResource
+  get() = Drawable23.icon_20675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20676: DrawableResource
+  get() = Drawable23.icon_20676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20677: DrawableResource
+  get() = Drawable23.icon_20677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20678: DrawableResource
+  get() = Drawable23.icon_20678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20679: DrawableResource
+  get() = Drawable23.icon_20679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2068: DrawableResource
+  get() = Drawable23.icon_2068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20680: DrawableResource
+  get() = Drawable23.icon_20680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20681: DrawableResource
+  get() = Drawable23.icon_20681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20682: DrawableResource
+  get() = Drawable23.icon_20682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20683: DrawableResource
+  get() = Drawable23.icon_20683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20684: DrawableResource
+  get() = Drawable23.icon_20684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20685: DrawableResource
+  get() = Drawable23.icon_20685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20686: DrawableResource
+  get() = Drawable23.icon_20686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20687: DrawableResource
+  get() = Drawable23.icon_20687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20688: DrawableResource
+  get() = Drawable23.icon_20688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20689: DrawableResource
+  get() = Drawable23.icon_20689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2069: DrawableResource
+  get() = Drawable23.icon_2069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20690: DrawableResource
+  get() = Drawable23.icon_20690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20691: DrawableResource
+  get() = Drawable23.icon_20691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20692: DrawableResource
+  get() = Drawable23.icon_20692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20693: DrawableResource
+  get() = Drawable23.icon_20693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20694: DrawableResource
+  get() = Drawable23.icon_20694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20695: DrawableResource
+  get() = Drawable23.icon_20695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20696: DrawableResource
+  get() = Drawable23.icon_20696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20697: DrawableResource
+  get() = Drawable23.icon_20697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20698: DrawableResource
+  get() = Drawable23.icon_20698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20699: DrawableResource
+  get() = Drawable23.icon_20699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_207: DrawableResource
+  get() = Drawable23.icon_207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2070: DrawableResource
+  get() = Drawable23.icon_2070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20700: DrawableResource
+  get() = Drawable23.icon_20700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20701: DrawableResource
+  get() = Drawable23.icon_20701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20702: DrawableResource
+  get() = Drawable23.icon_20702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20703: DrawableResource
+  get() = Drawable23.icon_20703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20704: DrawableResource
+  get() = Drawable23.icon_20704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20705: DrawableResource
+  get() = Drawable23.icon_20705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20706: DrawableResource
+  get() = Drawable23.icon_20706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20707: DrawableResource
+  get() = Drawable23.icon_20707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20708: DrawableResource
+  get() = Drawable23.icon_20708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20709: DrawableResource
+  get() = Drawable23.icon_20709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2071: DrawableResource
+  get() = Drawable23.icon_2071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20710: DrawableResource
+  get() = Drawable23.icon_20710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20711: DrawableResource
+  get() = Drawable23.icon_20711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20712: DrawableResource
+  get() = Drawable23.icon_20712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20713: DrawableResource
+  get() = Drawable23.icon_20713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20714: DrawableResource
+  get() = Drawable23.icon_20714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20715: DrawableResource
+  get() = Drawable23.icon_20715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20716: DrawableResource
+  get() = Drawable23.icon_20716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20717: DrawableResource
+  get() = Drawable23.icon_20717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20718: DrawableResource
+  get() = Drawable23.icon_20718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20719: DrawableResource
+  get() = Drawable23.icon_20719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2072: DrawableResource
+  get() = Drawable23.icon_2072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20720: DrawableResource
+  get() = Drawable23.icon_20720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20721: DrawableResource
+  get() = Drawable23.icon_20721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20722: DrawableResource
+  get() = Drawable23.icon_20722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20723: DrawableResource
+  get() = Drawable23.icon_20723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20724: DrawableResource
+  get() = Drawable23.icon_20724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20725: DrawableResource
+  get() = Drawable23.icon_20725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20726: DrawableResource
+  get() = Drawable23.icon_20726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20727: DrawableResource
+  get() = Drawable23.icon_20727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20728: DrawableResource
+  get() = Drawable23.icon_20728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20729: DrawableResource
+  get() = Drawable23.icon_20729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2073: DrawableResource
+  get() = Drawable23.icon_2073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20730: DrawableResource
+  get() = Drawable23.icon_20730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20731: DrawableResource
+  get() = Drawable23.icon_20731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20732: DrawableResource
+  get() = Drawable23.icon_20732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20733: DrawableResource
+  get() = Drawable23.icon_20733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20734: DrawableResource
+  get() = Drawable23.icon_20734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20735: DrawableResource
+  get() = Drawable23.icon_20735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20736: DrawableResource
+  get() = Drawable23.icon_20736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20737: DrawableResource
+  get() = Drawable23.icon_20737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20738: DrawableResource
+  get() = Drawable23.icon_20738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20739: DrawableResource
+  get() = Drawable23.icon_20739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2074: DrawableResource
+  get() = Drawable23.icon_2074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20740: DrawableResource
+  get() = Drawable23.icon_20740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20741: DrawableResource
+  get() = Drawable23.icon_20741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20742: DrawableResource
+  get() = Drawable23.icon_20742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20743: DrawableResource
+  get() = Drawable23.icon_20743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20744: DrawableResource
+  get() = Drawable23.icon_20744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20745: DrawableResource
+  get() = Drawable23.icon_20745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20746: DrawableResource
+  get() = Drawable23.icon_20746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20747: DrawableResource
+  get() = Drawable23.icon_20747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20748: DrawableResource
+  get() = Drawable23.icon_20748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20749: DrawableResource
+  get() = Drawable23.icon_20749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2075: DrawableResource
+  get() = Drawable23.icon_2075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20750: DrawableResource
+  get() = Drawable23.icon_20750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20751: DrawableResource
+  get() = Drawable23.icon_20751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20752: DrawableResource
+  get() = Drawable23.icon_20752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20753: DrawableResource
+  get() = Drawable23.icon_20753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20754: DrawableResource
+  get() = Drawable23.icon_20754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20755: DrawableResource
+  get() = Drawable23.icon_20755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20756: DrawableResource
+  get() = Drawable23.icon_20756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20757: DrawableResource
+  get() = Drawable23.icon_20757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20758: DrawableResource
+  get() = Drawable23.icon_20758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20759: DrawableResource
+  get() = Drawable23.icon_20759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2076: DrawableResource
+  get() = Drawable23.icon_2076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20760: DrawableResource
+  get() = Drawable23.icon_20760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20761: DrawableResource
+  get() = Drawable23.icon_20761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20762: DrawableResource
+  get() = Drawable23.icon_20762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20763: DrawableResource
+  get() = Drawable23.icon_20763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20764: DrawableResource
+  get() = Drawable23.icon_20764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20765: DrawableResource
+  get() = Drawable23.icon_20765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20766: DrawableResource
+  get() = Drawable23.icon_20766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20767: DrawableResource
+  get() = Drawable23.icon_20767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20768: DrawableResource
+  get() = Drawable23.icon_20768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20769: DrawableResource
+  get() = Drawable23.icon_20769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2077: DrawableResource
+  get() = Drawable23.icon_2077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20770: DrawableResource
+  get() = Drawable23.icon_20770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20771: DrawableResource
+  get() = Drawable23.icon_20771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20772: DrawableResource
+  get() = Drawable23.icon_20772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20773: DrawableResource
+  get() = Drawable23.icon_20773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20774: DrawableResource
+  get() = Drawable23.icon_20774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20775: DrawableResource
+  get() = Drawable23.icon_20775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20776: DrawableResource
+  get() = Drawable23.icon_20776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20777: DrawableResource
+  get() = Drawable23.icon_20777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20778: DrawableResource
+  get() = Drawable23.icon_20778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20779: DrawableResource
+  get() = Drawable23.icon_20779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2078: DrawableResource
+  get() = Drawable23.icon_2078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20780: DrawableResource
+  get() = Drawable23.icon_20780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20781: DrawableResource
+  get() = Drawable23.icon_20781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20782: DrawableResource
+  get() = Drawable23.icon_20782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20783: DrawableResource
+  get() = Drawable23.icon_20783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20784: DrawableResource
+  get() = Drawable23.icon_20784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20785: DrawableResource
+  get() = Drawable23.icon_20785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20786: DrawableResource
+  get() = Drawable23.icon_20786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20787: DrawableResource
+  get() = Drawable23.icon_20787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20788: DrawableResource
+  get() = Drawable23.icon_20788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20789: DrawableResource
+  get() = Drawable23.icon_20789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2079: DrawableResource
+  get() = Drawable23.icon_2079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20790: DrawableResource
+  get() = Drawable23.icon_20790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20791: DrawableResource
+  get() = Drawable23.icon_20791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20792: DrawableResource
+  get() = Drawable23.icon_20792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20793: DrawableResource
+  get() = Drawable23.icon_20793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20794: DrawableResource
+  get() = Drawable23.icon_20794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20795: DrawableResource
+  get() = Drawable23.icon_20795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20796: DrawableResource
+  get() = Drawable23.icon_20796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20797: DrawableResource
+  get() = Drawable23.icon_20797

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable24.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable24.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable24 {
+  public val icon_20798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20798.xml"),
+          )
+      )
+
+  public val icon_20799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20799.xml"),
+          )
+      )
+
+  public val icon_208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_208.xml"),
+          )
+      )
+
+  public val icon_2080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2080.xml"),
+          )
+      )
+
+  public val icon_20800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20800.xml"),
+          )
+      )
+
+  public val icon_20801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20801.xml"),
+          )
+      )
+
+  public val icon_20802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20802.xml"),
+          )
+      )
+
+  public val icon_20803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20803.xml"),
+          )
+      )
+
+  public val icon_20804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20804.xml"),
+          )
+      )
+
+  public val icon_20805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20805.xml"),
+          )
+      )
+
+  public val icon_20806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20806.xml"),
+          )
+      )
+
+  public val icon_20807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20807.xml"),
+          )
+      )
+
+  public val icon_20808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20808.xml"),
+          )
+      )
+
+  public val icon_20809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20809.xml"),
+          )
+      )
+
+  public val icon_2081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2081.xml"),
+          )
+      )
+
+  public val icon_20810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20810.xml"),
+          )
+      )
+
+  public val icon_20811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20811.xml"),
+          )
+      )
+
+  public val icon_20812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20812.xml"),
+          )
+      )
+
+  public val icon_20813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20813.xml"),
+          )
+      )
+
+  public val icon_20814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20814.xml"),
+          )
+      )
+
+  public val icon_20815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20815.xml"),
+          )
+      )
+
+  public val icon_20816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20816.xml"),
+          )
+      )
+
+  public val icon_20817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20817.xml"),
+          )
+      )
+
+  public val icon_20818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20818.xml"),
+          )
+      )
+
+  public val icon_20819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20819.xml"),
+          )
+      )
+
+  public val icon_2082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2082.xml"),
+          )
+      )
+
+  public val icon_20820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20820.xml"),
+          )
+      )
+
+  public val icon_20821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20821.xml"),
+          )
+      )
+
+  public val icon_20822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20822.xml"),
+          )
+      )
+
+  public val icon_20823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20823.xml"),
+          )
+      )
+
+  public val icon_20824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20824.xml"),
+          )
+      )
+
+  public val icon_20825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20825.xml"),
+          )
+      )
+
+  public val icon_20826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20826.xml"),
+          )
+      )
+
+  public val icon_20827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20827.xml"),
+          )
+      )
+
+  public val icon_20828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20828.xml"),
+          )
+      )
+
+  public val icon_20829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20829.xml"),
+          )
+      )
+
+  public val icon_2083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2083.xml"),
+          )
+      )
+
+  public val icon_20830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20830.xml"),
+          )
+      )
+
+  public val icon_20831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20831.xml"),
+          )
+      )
+
+  public val icon_20832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20832.xml"),
+          )
+      )
+
+  public val icon_20833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20833.xml"),
+          )
+      )
+
+  public val icon_20834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20834.xml"),
+          )
+      )
+
+  public val icon_20835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20835.xml"),
+          )
+      )
+
+  public val icon_20836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20836.xml"),
+          )
+      )
+
+  public val icon_20837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20837.xml"),
+          )
+      )
+
+  public val icon_20838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20838.xml"),
+          )
+      )
+
+  public val icon_20839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20839.xml"),
+          )
+      )
+
+  public val icon_2084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2084.xml"),
+          )
+      )
+
+  public val icon_20840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20840.xml"),
+          )
+      )
+
+  public val icon_20841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20841.xml"),
+          )
+      )
+
+  public val icon_20842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20842.xml"),
+          )
+      )
+
+  public val icon_20843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20843.xml"),
+          )
+      )
+
+  public val icon_20844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20844.xml"),
+          )
+      )
+
+  public val icon_20845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20845.xml"),
+          )
+      )
+
+  public val icon_20846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20846.xml"),
+          )
+      )
+
+  public val icon_20847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20847.xml"),
+          )
+      )
+
+  public val icon_20848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20848.xml"),
+          )
+      )
+
+  public val icon_20849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20849.xml"),
+          )
+      )
+
+  public val icon_2085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2085.xml"),
+          )
+      )
+
+  public val icon_20850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20850.xml"),
+          )
+      )
+
+  public val icon_20851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20851.xml"),
+          )
+      )
+
+  public val icon_20852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20852.xml"),
+          )
+      )
+
+  public val icon_20853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20853.xml"),
+          )
+      )
+
+  public val icon_20854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20854.xml"),
+          )
+      )
+
+  public val icon_20855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20855.xml"),
+          )
+      )
+
+  public val icon_20856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20856.xml"),
+          )
+      )
+
+  public val icon_20857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20857.xml"),
+          )
+      )
+
+  public val icon_20858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20858.xml"),
+          )
+      )
+
+  public val icon_20859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20859.xml"),
+          )
+      )
+
+  public val icon_2086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2086.xml"),
+          )
+      )
+
+  public val icon_20860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20860.xml"),
+          )
+      )
+
+  public val icon_20861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20861.xml"),
+          )
+      )
+
+  public val icon_20862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20862.xml"),
+          )
+      )
+
+  public val icon_20863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20863.xml"),
+          )
+      )
+
+  public val icon_20864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20864.xml"),
+          )
+      )
+
+  public val icon_20865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20865.xml"),
+          )
+      )
+
+  public val icon_20866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20866.xml"),
+          )
+      )
+
+  public val icon_20867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20867.xml"),
+          )
+      )
+
+  public val icon_20868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20868.xml"),
+          )
+      )
+
+  public val icon_20869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20869.xml"),
+          )
+      )
+
+  public val icon_2087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2087.xml"),
+          )
+      )
+
+  public val icon_20870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20870.xml"),
+          )
+      )
+
+  public val icon_20871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20871.xml"),
+          )
+      )
+
+  public val icon_20872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20872.xml"),
+          )
+      )
+
+  public val icon_20873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20873.xml"),
+          )
+      )
+
+  public val icon_20874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20874.xml"),
+          )
+      )
+
+  public val icon_20875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20875.xml"),
+          )
+      )
+
+  public val icon_20876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20876.xml"),
+          )
+      )
+
+  public val icon_20877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20877.xml"),
+          )
+      )
+
+  public val icon_20878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20878.xml"),
+          )
+      )
+
+  public val icon_20879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20879.xml"),
+          )
+      )
+
+  public val icon_2088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2088.xml"),
+          )
+      )
+
+  public val icon_20880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20880.xml"),
+          )
+      )
+
+  public val icon_20881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20881.xml"),
+          )
+      )
+
+  public val icon_20882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20882.xml"),
+          )
+      )
+
+  public val icon_20883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20883.xml"),
+          )
+      )
+
+  public val icon_20884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20884.xml"),
+          )
+      )
+
+  public val icon_20885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20885.xml"),
+          )
+      )
+
+  public val icon_20886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20886.xml"),
+          )
+      )
+
+  public val icon_20887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20887.xml"),
+          )
+      )
+
+  public val icon_20888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20888.xml"),
+          )
+      )
+
+  public val icon_20889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20889.xml"),
+          )
+      )
+
+  public val icon_2089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2089.xml"),
+          )
+      )
+
+  public val icon_20890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20890.xml"),
+          )
+      )
+
+  public val icon_20891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20891.xml"),
+          )
+      )
+
+  public val icon_20892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20892.xml"),
+          )
+      )
+
+  public val icon_20893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20893.xml"),
+          )
+      )
+
+  public val icon_20894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20894.xml"),
+          )
+      )
+
+  public val icon_20895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20895.xml"),
+          )
+      )
+
+  public val icon_20896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20896.xml"),
+          )
+      )
+
+  public val icon_20897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20897.xml"),
+          )
+      )
+
+  public val icon_20898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20898.xml"),
+          )
+      )
+
+  public val icon_20899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20899.xml"),
+          )
+      )
+
+  public val icon_209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_209.xml"),
+          )
+      )
+
+  public val icon_2090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2090.xml"),
+          )
+      )
+
+  public val icon_20900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20900.xml"),
+          )
+      )
+
+  public val icon_20901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20901.xml"),
+          )
+      )
+
+  public val icon_20902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20902.xml"),
+          )
+      )
+
+  public val icon_20903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20903.xml"),
+          )
+      )
+
+  public val icon_20904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20904.xml"),
+          )
+      )
+
+  public val icon_20905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20905.xml"),
+          )
+      )
+
+  public val icon_20906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20906.xml"),
+          )
+      )
+
+  public val icon_20907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20907.xml"),
+          )
+      )
+
+  public val icon_20908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20908.xml"),
+          )
+      )
+
+  public val icon_20909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20909.xml"),
+          )
+      )
+
+  public val icon_2091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2091.xml"),
+          )
+      )
+
+  public val icon_20910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20910.xml"),
+          )
+      )
+
+  public val icon_20911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20911.xml"),
+          )
+      )
+
+  public val icon_20912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20912.xml"),
+          )
+      )
+
+  public val icon_20913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20913.xml"),
+          )
+      )
+
+  public val icon_20914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20914.xml"),
+          )
+      )
+
+  public val icon_20915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20915.xml"),
+          )
+      )
+
+  public val icon_20916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20916.xml"),
+          )
+      )
+
+  public val icon_20917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20917.xml"),
+          )
+      )
+
+  public val icon_20918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20918.xml"),
+          )
+      )
+
+  public val icon_20919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20919.xml"),
+          )
+      )
+
+  public val icon_2092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2092.xml"),
+          )
+      )
+
+  public val icon_20920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20920.xml"),
+          )
+      )
+
+  public val icon_20921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20921.xml"),
+          )
+      )
+
+  public val icon_20922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20922.xml"),
+          )
+      )
+
+  public val icon_20923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20923.xml"),
+          )
+      )
+
+  public val icon_20924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20924.xml"),
+          )
+      )
+
+  public val icon_20925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20925.xml"),
+          )
+      )
+
+  public val icon_20926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20926.xml"),
+          )
+      )
+
+  public val icon_20927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20927.xml"),
+          )
+      )
+
+  public val icon_20928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20928.xml"),
+          )
+      )
+
+  public val icon_20929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20929.xml"),
+          )
+      )
+
+  public val icon_2093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2093.xml"),
+          )
+      )
+
+  public val icon_20930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20930.xml"),
+          )
+      )
+
+  public val icon_20931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20931.xml"),
+          )
+      )
+
+  public val icon_20932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20932.xml"),
+          )
+      )
+
+  public val icon_20933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20933.xml"),
+          )
+      )
+
+  public val icon_20934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20934.xml"),
+          )
+      )
+
+  public val icon_20935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20935.xml"),
+          )
+      )
+
+  public val icon_20936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20936.xml"),
+          )
+      )
+
+  public val icon_20937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20937.xml"),
+          )
+      )
+
+  public val icon_20938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20938.xml"),
+          )
+      )
+
+  public val icon_20939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20939.xml"),
+          )
+      )
+
+  public val icon_2094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2094.xml"),
+          )
+      )
+
+  public val icon_20940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20940.xml"),
+          )
+      )
+
+  public val icon_20941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20941.xml"),
+          )
+      )
+
+  public val icon_20942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20942.xml"),
+          )
+      )
+
+  public val icon_20943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20943.xml"),
+          )
+      )
+
+  public val icon_20944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20944.xml"),
+          )
+      )
+
+  public val icon_20945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20945.xml"),
+          )
+      )
+
+  public val icon_20946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20946.xml"),
+          )
+      )
+
+  public val icon_20947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20947.xml"),
+          )
+      )
+
+  public val icon_20948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20948.xml"),
+          )
+      )
+
+  public val icon_20949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20949.xml"),
+          )
+      )
+
+  public val icon_2095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2095.xml"),
+          )
+      )
+
+  public val icon_20950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20950.xml"),
+          )
+      )
+
+  public val icon_20951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20951.xml"),
+          )
+      )
+
+  public val icon_20952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20952.xml"),
+          )
+      )
+
+  public val icon_20953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20953.xml"),
+          )
+      )
+
+  public val icon_20954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20954.xml"),
+          )
+      )
+
+  public val icon_20955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20955.xml"),
+          )
+      )
+
+  public val icon_20956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20956.xml"),
+          )
+      )
+
+  public val icon_20957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20957.xml"),
+          )
+      )
+
+  public val icon_20958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20958.xml"),
+          )
+      )
+
+  public val icon_20959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20959.xml"),
+          )
+      )
+
+  public val icon_2096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2096.xml"),
+          )
+      )
+
+  public val icon_20960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20960.xml"),
+          )
+      )
+
+  public val icon_20961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20961.xml"),
+          )
+      )
+
+  public val icon_20962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20962.xml"),
+          )
+      )
+
+  public val icon_20963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20963.xml"),
+          )
+      )
+
+  public val icon_20964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20964.xml"),
+          )
+      )
+
+  public val icon_20965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20965.xml"),
+          )
+      )
+
+  public val icon_20966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20966.xml"),
+          )
+      )
+
+  public val icon_20967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20967.xml"),
+          )
+      )
+
+  public val icon_20968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20968.xml"),
+          )
+      )
+
+  public val icon_20969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20969.xml"),
+          )
+      )
+
+  public val icon_2097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2097.xml"),
+          )
+      )
+
+  public val icon_20970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20970.xml"),
+          )
+      )
+
+  public val icon_20971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20971.xml"),
+          )
+      )
+
+  public val icon_20972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20972.xml"),
+          )
+      )
+
+  public val icon_20973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20973.xml"),
+          )
+      )
+
+  public val icon_20974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20974.xml"),
+          )
+      )
+
+  public val icon_20975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20975.xml"),
+          )
+      )
+
+  public val icon_20976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20976.xml"),
+          )
+      )
+
+  public val icon_20977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20977.xml"),
+          )
+      )
+
+  public val icon_20978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20978.xml"),
+          )
+      )
+
+  public val icon_20979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20979.xml"),
+          )
+      )
+
+  public val icon_2098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2098.xml"),
+          )
+      )
+
+  public val icon_20980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20980.xml"),
+          )
+      )
+
+  public val icon_20981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20981.xml"),
+          )
+      )
+
+  public val icon_20982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20982.xml"),
+          )
+      )
+
+  public val icon_20983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20983.xml"),
+          )
+      )
+
+  public val icon_20984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20984.xml"),
+          )
+      )
+
+  public val icon_20985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20985.xml"),
+          )
+      )
+
+  public val icon_20986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20986.xml"),
+          )
+      )
+
+  public val icon_20987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20987.xml"),
+          )
+      )
+
+  public val icon_20988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20988.xml"),
+          )
+      )
+
+  public val icon_20989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20989.xml"),
+          )
+      )
+
+  public val icon_2099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2099.xml"),
+          )
+      )
+
+  public val icon_20990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20990.xml"),
+          )
+      )
+
+  public val icon_20991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20991.xml"),
+          )
+      )
+
+  public val icon_20992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20992.xml"),
+          )
+      )
+
+  public val icon_20993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20993.xml"),
+          )
+      )
+
+  public val icon_20994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20994.xml"),
+          )
+      )
+
+  public val icon_20995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20995.xml"),
+          )
+      )
+
+  public val icon_20996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20996.xml"),
+          )
+      )
+
+  public val icon_20997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20997.xml"),
+          )
+      )
+
+  public val icon_20998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20998.xml"),
+          )
+      )
+
+  public val icon_20999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_20999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_20999.xml"),
+          )
+      )
+
+  public val icon_21: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21.xml"),
+          )
+      )
+
+  public val icon_210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_210.xml"),
+          )
+      )
+
+  public val icon_2100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2100.xml"),
+          )
+      )
+
+  public val icon_21000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21000.xml"),
+          )
+      )
+
+  public val icon_21001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21001.xml"),
+          )
+      )
+
+  public val icon_21002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21002.xml"),
+          )
+      )
+
+  public val icon_21003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21003.xml"),
+          )
+      )
+
+  public val icon_21004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21004.xml"),
+          )
+      )
+
+  public val icon_21005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21005.xml"),
+          )
+      )
+
+  public val icon_21006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21006.xml"),
+          )
+      )
+
+  public val icon_21007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21007.xml"),
+          )
+      )
+
+  public val icon_21008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21008.xml"),
+          )
+      )
+
+  public val icon_21009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21009.xml"),
+          )
+      )
+
+  public val icon_2101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2101.xml"),
+          )
+      )
+
+  public val icon_21010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21010.xml"),
+          )
+      )
+
+  public val icon_21011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21011.xml"),
+          )
+      )
+
+  public val icon_21012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21012.xml"),
+          )
+      )
+
+  public val icon_21013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21013.xml"),
+          )
+      )
+
+  public val icon_21014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21014.xml"),
+          )
+      )
+
+  public val icon_21015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21015.xml"),
+          )
+      )
+
+  public val icon_21016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21016.xml"),
+          )
+      )
+
+  public val icon_21017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21017.xml"),
+          )
+      )
+
+  public val icon_21018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21018.xml"),
+          )
+      )
+
+  public val icon_21019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21019.xml"),
+          )
+      )
+
+  public val icon_2102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2102.xml"),
+          )
+      )
+
+  public val icon_21020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21020.xml"),
+          )
+      )
+
+  public val icon_21021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21021.xml"),
+          )
+      )
+
+  public val icon_21022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21022.xml"),
+          )
+      )
+
+  public val icon_21023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21023.xml"),
+          )
+      )
+
+  public val icon_21024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21024.xml"),
+          )
+      )
+
+  public val icon_21025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21025.xml"),
+          )
+      )
+
+  public val icon_21026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21026.xml"),
+          )
+      )
+
+  public val icon_21027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21027.xml"),
+          )
+      )
+
+  public val icon_21028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21028.xml"),
+          )
+      )
+
+  public val icon_21029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21029.xml"),
+          )
+      )
+
+  public val icon_2103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2103.xml"),
+          )
+      )
+
+  public val icon_21030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21030.xml"),
+          )
+      )
+
+  public val icon_21031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21031.xml"),
+          )
+      )
+
+  public val icon_21032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21032.xml"),
+          )
+      )
+
+  public val icon_21033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21033.xml"),
+          )
+      )
+
+  public val icon_21034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21034.xml"),
+          )
+      )
+
+  public val icon_21035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21035.xml"),
+          )
+      )
+
+  public val icon_21036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21036.xml"),
+          )
+      )
+
+  public val icon_21037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21037.xml"),
+          )
+      )
+
+  public val icon_21038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21038.xml"),
+          )
+      )
+
+  public val icon_21039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21039.xml"),
+          )
+      )
+
+  public val icon_2104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2104.xml"),
+          )
+      )
+
+  public val icon_21040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21040.xml"),
+          )
+      )
+
+  public val icon_21041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21041.xml"),
+          )
+      )
+
+  public val icon_21042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21042.xml"),
+          )
+      )
+
+  public val icon_21043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21043.xml"),
+          )
+      )
+
+  public val icon_21044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21044.xml"),
+          )
+      )
+
+  public val icon_21045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21045.xml"),
+          )
+      )
+
+  public val icon_21046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21046.xml"),
+          )
+      )
+
+  public val icon_21047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21047.xml"),
+          )
+      )
+
+  public val icon_21048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21048.xml"),
+          )
+      )
+
+  public val icon_21049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21049.xml"),
+          )
+      )
+
+  public val icon_2105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2105.xml"),
+          )
+      )
+
+  public val icon_21050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21050.xml"),
+          )
+      )
+
+  public val icon_21051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21051.xml"),
+          )
+      )
+
+  public val icon_21052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21052.xml"),
+          )
+      )
+
+  public val icon_21053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21053.xml"),
+          )
+      )
+
+  public val icon_21054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21054.xml"),
+          )
+      )
+
+  public val icon_21055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21055.xml"),
+          )
+      )
+
+  public val icon_21056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21056.xml"),
+          )
+      )
+
+  public val icon_21057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21057.xml"),
+          )
+      )
+
+  public val icon_21058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21058.xml"),
+          )
+      )
+
+  public val icon_21059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21059.xml"),
+          )
+      )
+
+  public val icon_2106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2106.xml"),
+          )
+      )
+
+  public val icon_21060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21060.xml"),
+          )
+      )
+
+  public val icon_21061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21061.xml"),
+          )
+      )
+
+  public val icon_21062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21062.xml"),
+          )
+      )
+
+  public val icon_21063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21063.xml"),
+          )
+      )
+
+  public val icon_21064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21064.xml"),
+          )
+      )
+
+  public val icon_21065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21065.xml"),
+          )
+      )
+
+  public val icon_21066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21066.xml"),
+          )
+      )
+
+  public val icon_21067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21067.xml"),
+          )
+      )
+
+  public val icon_21068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21068.xml"),
+          )
+      )
+
+  public val icon_21069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21069.xml"),
+          )
+      )
+
+  public val icon_2107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2107.xml"),
+          )
+      )
+
+  public val icon_21070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21070.xml"),
+          )
+      )
+
+  public val icon_21071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21071.xml"),
+          )
+      )
+
+  public val icon_21072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21072.xml"),
+          )
+      )
+
+  public val icon_21073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21073.xml"),
+          )
+      )
+
+  public val icon_21074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21074.xml"),
+          )
+      )
+
+  public val icon_21075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21075.xml"),
+          )
+      )
+
+  public val icon_21076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21076.xml"),
+          )
+      )
+
+  public val icon_21077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21077.xml"),
+          )
+      )
+
+  public val icon_21078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21078.xml"),
+          )
+      )
+
+  public val icon_21079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21079.xml"),
+          )
+      )
+
+  public val icon_2108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2108.xml"),
+          )
+      )
+
+  public val icon_21080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21080.xml"),
+          )
+      )
+
+  public val icon_21081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21081.xml"),
+          )
+      )
+
+  public val icon_21082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21082.xml"),
+          )
+      )
+
+  public val icon_21083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21083.xml"),
+          )
+      )
+
+  public val icon_21084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21084.xml"),
+          )
+      )
+
+  public val icon_21085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21085.xml"),
+          )
+      )
+
+  public val icon_21086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21086.xml"),
+          )
+      )
+
+  public val icon_21087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21087.xml"),
+          )
+      )
+
+  public val icon_21088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21088.xml"),
+          )
+      )
+
+  public val icon_21089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21089.xml"),
+          )
+      )
+
+  public val icon_2109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2109.xml"),
+          )
+      )
+
+  public val icon_21090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21090.xml"),
+          )
+      )
+
+  public val icon_21091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21091.xml"),
+          )
+      )
+
+  public val icon_21092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21092.xml"),
+          )
+      )
+
+  public val icon_21093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21093.xml"),
+          )
+      )
+
+  public val icon_21094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21094.xml"),
+          )
+      )
+
+  public val icon_21095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21095.xml"),
+          )
+      )
+
+  public val icon_21096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21096.xml"),
+          )
+      )
+
+  public val icon_21097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21097.xml"),
+          )
+      )
+
+  public val icon_21098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21098.xml"),
+          )
+      )
+
+  public val icon_21099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21099.xml"),
+          )
+      )
+
+  public val icon_211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_211.xml"),
+          )
+      )
+
+  public val icon_2110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2110.xml"),
+          )
+      )
+
+  public val icon_21100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21100.xml"),
+          )
+      )
+
+  public val icon_21101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21101.xml"),
+          )
+      )
+
+  public val icon_21102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21102.xml"),
+          )
+      )
+
+  public val icon_21103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21103.xml"),
+          )
+      )
+
+  public val icon_21104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21104.xml"),
+          )
+      )
+
+  public val icon_21105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21105.xml"),
+          )
+      )
+
+  public val icon_21106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21106.xml"),
+          )
+      )
+
+  public val icon_21107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21107.xml"),
+          )
+      )
+
+  public val icon_21108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21108.xml"),
+          )
+      )
+
+  public val icon_21109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21109.xml"),
+          )
+      )
+
+  public val icon_2111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2111.xml"),
+          )
+      )
+
+  public val icon_21110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21110.xml"),
+          )
+      )
+
+  public val icon_21111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21111.xml"),
+          )
+      )
+
+  public val icon_21112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21112.xml"),
+          )
+      )
+
+  public val icon_21113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21113.xml"),
+          )
+      )
+
+  public val icon_21114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21114.xml"),
+          )
+      )
+
+  public val icon_21115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21115.xml"),
+          )
+      )
+
+  public val icon_21116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21116.xml"),
+          )
+      )
+
+  public val icon_21117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21117.xml"),
+          )
+      )
+
+  public val icon_21118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21118.xml"),
+          )
+      )
+
+  public val icon_21119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21119.xml"),
+          )
+      )
+
+  public val icon_2112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2112.xml"),
+          )
+      )
+
+  public val icon_21120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21120.xml"),
+          )
+      )
+
+  public val icon_21121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21121.xml"),
+          )
+      )
+
+  public val icon_21122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21122.xml"),
+          )
+      )
+
+  public val icon_21123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21123.xml"),
+          )
+      )
+
+  public val icon_21124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21124.xml"),
+          )
+      )
+
+  public val icon_21125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21125.xml"),
+          )
+      )
+
+  public val icon_21126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21126.xml"),
+          )
+      )
+
+  public val icon_21127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21127.xml"),
+          )
+      )
+
+  public val icon_21128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21128.xml"),
+          )
+      )
+
+  public val icon_21129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21129.xml"),
+          )
+      )
+
+  public val icon_2113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2113.xml"),
+          )
+      )
+
+  public val icon_21130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21130.xml"),
+          )
+      )
+
+  public val icon_21131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21131.xml"),
+          )
+      )
+
+  public val icon_21132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21132.xml"),
+          )
+      )
+
+  public val icon_21133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21133.xml"),
+          )
+      )
+
+  public val icon_21134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21134.xml"),
+          )
+      )
+
+  public val icon_21135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21135.xml"),
+          )
+      )
+
+  public val icon_21136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21136.xml"),
+          )
+      )
+
+  public val icon_21137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21137.xml"),
+          )
+      )
+
+  public val icon_21138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21138.xml"),
+          )
+      )
+
+  public val icon_21139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21139.xml"),
+          )
+      )
+
+  public val icon_2114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2114.xml"),
+          )
+      )
+
+  public val icon_21140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21140.xml"),
+          )
+      )
+
+  public val icon_21141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21141.xml"),
+          )
+      )
+
+  public val icon_21142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21142.xml"),
+          )
+      )
+
+  public val icon_21143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21143.xml"),
+          )
+      )
+
+  public val icon_21144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21144.xml"),
+          )
+      )
+
+  public val icon_21145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21145.xml"),
+          )
+      )
+
+  public val icon_21146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21146.xml"),
+          )
+      )
+
+  public val icon_21147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21147.xml"),
+          )
+      )
+
+  public val icon_21148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21148.xml"),
+          )
+      )
+
+  public val icon_21149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21149.xml"),
+          )
+      )
+
+  public val icon_2115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2115.xml"),
+          )
+      )
+
+  public val icon_21150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21150.xml"),
+          )
+      )
+
+  public val icon_21151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21151.xml"),
+          )
+      )
+
+  public val icon_21152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21152.xml"),
+          )
+      )
+
+  public val icon_21153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21153.xml"),
+          )
+      )
+
+  public val icon_21154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21154.xml"),
+          )
+      )
+
+  public val icon_21155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21155.xml"),
+          )
+      )
+
+  public val icon_21156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21156.xml"),
+          )
+      )
+
+  public val icon_21157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21157.xml"),
+          )
+      )
+
+  public val icon_21158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21158.xml"),
+          )
+      )
+
+  public val icon_21159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21159.xml"),
+          )
+      )
+
+  public val icon_2116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2116.xml"),
+          )
+      )
+
+  public val icon_21160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21160.xml"),
+          )
+      )
+
+  public val icon_21161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21161.xml"),
+          )
+      )
+
+  public val icon_21162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21162.xml"),
+          )
+      )
+
+  public val icon_21163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21163.xml"),
+          )
+      )
+
+  public val icon_21164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21164.xml"),
+          )
+      )
+
+  public val icon_21165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21165.xml"),
+          )
+      )
+
+  public val icon_21166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21166.xml"),
+          )
+      )
+
+  public val icon_21167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21167.xml"),
+          )
+      )
+
+  public val icon_21168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21168.xml"),
+          )
+      )
+
+  public val icon_21169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21169.xml"),
+          )
+      )
+
+  public val icon_2117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2117.xml"),
+          )
+      )
+
+  public val icon_21170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21170.xml"),
+          )
+      )
+
+  public val icon_21171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21171.xml"),
+          )
+      )
+
+  public val icon_21172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21172.xml"),
+          )
+      )
+
+  public val icon_21173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21173.xml"),
+          )
+      )
+
+  public val icon_21174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21174.xml"),
+          )
+      )
+
+  public val icon_21175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21175.xml"),
+          )
+      )
+
+  public val icon_21176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21176.xml"),
+          )
+      )
+
+  public val icon_21177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21177.xml"),
+          )
+      )
+
+  public val icon_21178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21178.xml"),
+          )
+      )
+
+  public val icon_21179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21179.xml"),
+          )
+      )
+
+  public val icon_2118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2118.xml"),
+          )
+      )
+
+  public val icon_21180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21180.xml"),
+          )
+      )
+
+  public val icon_21181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21181.xml"),
+          )
+      )
+
+  public val icon_21182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21182.xml"),
+          )
+      )
+
+  public val icon_21183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21183.xml"),
+          )
+      )
+
+  public val icon_21184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21184.xml"),
+          )
+      )
+
+  public val icon_21185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21185.xml"),
+          )
+      )
+
+  public val icon_21186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21186.xml"),
+          )
+      )
+
+  public val icon_21187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21187.xml"),
+          )
+      )
+
+  public val icon_21188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21188.xml"),
+          )
+      )
+
+  public val icon_21189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21189.xml"),
+          )
+      )
+
+  public val icon_2119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2119.xml"),
+          )
+      )
+
+  public val icon_21190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21190.xml"),
+          )
+      )
+
+  public val icon_21191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21191.xml"),
+          )
+      )
+
+  public val icon_21192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21192.xml"),
+          )
+      )
+
+  public val icon_21193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21193.xml"),
+          )
+      )
+
+  public val icon_21194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21194.xml"),
+          )
+      )
+
+  public val icon_21195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21195.xml"),
+          )
+      )
+
+  public val icon_21196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21196.xml"),
+          )
+      )
+
+  public val icon_21197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21197.xml"),
+          )
+      )
+
+  public val icon_21198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21198.xml"),
+          )
+      )
+
+  public val icon_21199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21199.xml"),
+          )
+      )
+
+  public val icon_212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_212.xml"),
+          )
+      )
+
+  public val icon_2120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2120.xml"),
+          )
+      )
+
+  public val icon_21200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21200.xml"),
+          )
+      )
+
+  public val icon_21201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21201.xml"),
+          )
+      )
+
+  public val icon_21202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21202.xml"),
+          )
+      )
+
+  public val icon_21203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21203.xml"),
+          )
+      )
+
+  public val icon_21204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21204.xml"),
+          )
+      )
+
+  public val icon_21205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21205.xml"),
+          )
+      )
+
+  public val icon_21206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21206.xml"),
+          )
+      )
+
+  public val icon_21207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21207.xml"),
+          )
+      )
+
+  public val icon_21208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21208.xml"),
+          )
+      )
+
+  public val icon_21209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21209.xml"),
+          )
+      )
+
+  public val icon_2121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2121.xml"),
+          )
+      )
+
+  public val icon_21210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21210.xml"),
+          )
+      )
+
+  public val icon_21211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21211.xml"),
+          )
+      )
+
+  public val icon_21212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21212.xml"),
+          )
+      )
+
+  public val icon_21213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21213.xml"),
+          )
+      )
+
+  public val icon_21214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21214.xml"),
+          )
+      )
+
+  public val icon_21215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21215.xml"),
+          )
+      )
+
+  public val icon_21216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21216.xml"),
+          )
+      )
+
+  public val icon_21217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21217.xml"),
+          )
+      )
+
+  public val icon_21218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21218.xml"),
+          )
+      )
+
+  public val icon_21219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21219.xml"),
+          )
+      )
+
+  public val icon_2122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2122.xml"),
+          )
+      )
+
+  public val icon_21220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21220.xml"),
+          )
+      )
+
+  public val icon_21221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21221.xml"),
+          )
+      )
+
+  public val icon_21222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21222.xml"),
+          )
+      )
+
+  public val icon_21223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21223.xml"),
+          )
+      )
+
+  public val icon_21224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21224.xml"),
+          )
+      )
+
+  public val icon_21225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21225.xml"),
+          )
+      )
+
+  public val icon_21226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21226.xml"),
+          )
+      )
+
+  public val icon_21227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21227.xml"),
+          )
+      )
+
+  public val icon_21228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21228.xml"),
+          )
+      )
+
+  public val icon_21229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21229.xml"),
+          )
+      )
+
+  public val icon_2123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2123.xml"),
+          )
+      )
+
+  public val icon_21230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21230.xml"),
+          )
+      )
+
+  public val icon_21231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21231.xml"),
+          )
+      )
+
+  public val icon_21232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21232.xml"),
+          )
+      )
+
+  public val icon_21233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21233.xml"),
+          )
+      )
+
+  public val icon_21234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21234.xml"),
+          )
+      )
+
+  public val icon_21235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21235.xml"),
+          )
+      )
+
+  public val icon_21236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21236.xml"),
+          )
+      )
+
+  public val icon_21237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21237.xml"),
+          )
+      )
+
+  public val icon_21238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21238.xml"),
+          )
+      )
+
+  public val icon_21239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21239.xml"),
+          )
+      )
+
+  public val icon_2124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2124.xml"),
+          )
+      )
+
+  public val icon_21240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21240.xml"),
+          )
+      )
+
+  public val icon_21241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21241.xml"),
+          )
+      )
+
+  public val icon_21242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21242.xml"),
+          )
+      )
+
+  public val icon_21243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21243.xml"),
+          )
+      )
+
+  public val icon_21244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21244.xml"),
+          )
+      )
+
+  public val icon_21245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21245.xml"),
+          )
+      )
+
+  public val icon_21246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21246.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20798: DrawableResource
+  get() = Drawable24.icon_20798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20799: DrawableResource
+  get() = Drawable24.icon_20799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_208: DrawableResource
+  get() = Drawable24.icon_208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2080: DrawableResource
+  get() = Drawable24.icon_2080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20800: DrawableResource
+  get() = Drawable24.icon_20800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20801: DrawableResource
+  get() = Drawable24.icon_20801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20802: DrawableResource
+  get() = Drawable24.icon_20802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20803: DrawableResource
+  get() = Drawable24.icon_20803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20804: DrawableResource
+  get() = Drawable24.icon_20804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20805: DrawableResource
+  get() = Drawable24.icon_20805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20806: DrawableResource
+  get() = Drawable24.icon_20806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20807: DrawableResource
+  get() = Drawable24.icon_20807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20808: DrawableResource
+  get() = Drawable24.icon_20808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20809: DrawableResource
+  get() = Drawable24.icon_20809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2081: DrawableResource
+  get() = Drawable24.icon_2081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20810: DrawableResource
+  get() = Drawable24.icon_20810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20811: DrawableResource
+  get() = Drawable24.icon_20811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20812: DrawableResource
+  get() = Drawable24.icon_20812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20813: DrawableResource
+  get() = Drawable24.icon_20813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20814: DrawableResource
+  get() = Drawable24.icon_20814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20815: DrawableResource
+  get() = Drawable24.icon_20815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20816: DrawableResource
+  get() = Drawable24.icon_20816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20817: DrawableResource
+  get() = Drawable24.icon_20817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20818: DrawableResource
+  get() = Drawable24.icon_20818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20819: DrawableResource
+  get() = Drawable24.icon_20819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2082: DrawableResource
+  get() = Drawable24.icon_2082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20820: DrawableResource
+  get() = Drawable24.icon_20820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20821: DrawableResource
+  get() = Drawable24.icon_20821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20822: DrawableResource
+  get() = Drawable24.icon_20822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20823: DrawableResource
+  get() = Drawable24.icon_20823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20824: DrawableResource
+  get() = Drawable24.icon_20824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20825: DrawableResource
+  get() = Drawable24.icon_20825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20826: DrawableResource
+  get() = Drawable24.icon_20826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20827: DrawableResource
+  get() = Drawable24.icon_20827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20828: DrawableResource
+  get() = Drawable24.icon_20828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20829: DrawableResource
+  get() = Drawable24.icon_20829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2083: DrawableResource
+  get() = Drawable24.icon_2083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20830: DrawableResource
+  get() = Drawable24.icon_20830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20831: DrawableResource
+  get() = Drawable24.icon_20831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20832: DrawableResource
+  get() = Drawable24.icon_20832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20833: DrawableResource
+  get() = Drawable24.icon_20833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20834: DrawableResource
+  get() = Drawable24.icon_20834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20835: DrawableResource
+  get() = Drawable24.icon_20835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20836: DrawableResource
+  get() = Drawable24.icon_20836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20837: DrawableResource
+  get() = Drawable24.icon_20837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20838: DrawableResource
+  get() = Drawable24.icon_20838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20839: DrawableResource
+  get() = Drawable24.icon_20839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2084: DrawableResource
+  get() = Drawable24.icon_2084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20840: DrawableResource
+  get() = Drawable24.icon_20840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20841: DrawableResource
+  get() = Drawable24.icon_20841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20842: DrawableResource
+  get() = Drawable24.icon_20842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20843: DrawableResource
+  get() = Drawable24.icon_20843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20844: DrawableResource
+  get() = Drawable24.icon_20844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20845: DrawableResource
+  get() = Drawable24.icon_20845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20846: DrawableResource
+  get() = Drawable24.icon_20846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20847: DrawableResource
+  get() = Drawable24.icon_20847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20848: DrawableResource
+  get() = Drawable24.icon_20848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20849: DrawableResource
+  get() = Drawable24.icon_20849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2085: DrawableResource
+  get() = Drawable24.icon_2085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20850: DrawableResource
+  get() = Drawable24.icon_20850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20851: DrawableResource
+  get() = Drawable24.icon_20851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20852: DrawableResource
+  get() = Drawable24.icon_20852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20853: DrawableResource
+  get() = Drawable24.icon_20853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20854: DrawableResource
+  get() = Drawable24.icon_20854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20855: DrawableResource
+  get() = Drawable24.icon_20855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20856: DrawableResource
+  get() = Drawable24.icon_20856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20857: DrawableResource
+  get() = Drawable24.icon_20857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20858: DrawableResource
+  get() = Drawable24.icon_20858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20859: DrawableResource
+  get() = Drawable24.icon_20859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2086: DrawableResource
+  get() = Drawable24.icon_2086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20860: DrawableResource
+  get() = Drawable24.icon_20860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20861: DrawableResource
+  get() = Drawable24.icon_20861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20862: DrawableResource
+  get() = Drawable24.icon_20862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20863: DrawableResource
+  get() = Drawable24.icon_20863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20864: DrawableResource
+  get() = Drawable24.icon_20864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20865: DrawableResource
+  get() = Drawable24.icon_20865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20866: DrawableResource
+  get() = Drawable24.icon_20866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20867: DrawableResource
+  get() = Drawable24.icon_20867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20868: DrawableResource
+  get() = Drawable24.icon_20868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20869: DrawableResource
+  get() = Drawable24.icon_20869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2087: DrawableResource
+  get() = Drawable24.icon_2087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20870: DrawableResource
+  get() = Drawable24.icon_20870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20871: DrawableResource
+  get() = Drawable24.icon_20871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20872: DrawableResource
+  get() = Drawable24.icon_20872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20873: DrawableResource
+  get() = Drawable24.icon_20873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20874: DrawableResource
+  get() = Drawable24.icon_20874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20875: DrawableResource
+  get() = Drawable24.icon_20875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20876: DrawableResource
+  get() = Drawable24.icon_20876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20877: DrawableResource
+  get() = Drawable24.icon_20877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20878: DrawableResource
+  get() = Drawable24.icon_20878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20879: DrawableResource
+  get() = Drawable24.icon_20879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2088: DrawableResource
+  get() = Drawable24.icon_2088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20880: DrawableResource
+  get() = Drawable24.icon_20880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20881: DrawableResource
+  get() = Drawable24.icon_20881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20882: DrawableResource
+  get() = Drawable24.icon_20882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20883: DrawableResource
+  get() = Drawable24.icon_20883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20884: DrawableResource
+  get() = Drawable24.icon_20884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20885: DrawableResource
+  get() = Drawable24.icon_20885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20886: DrawableResource
+  get() = Drawable24.icon_20886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20887: DrawableResource
+  get() = Drawable24.icon_20887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20888: DrawableResource
+  get() = Drawable24.icon_20888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20889: DrawableResource
+  get() = Drawable24.icon_20889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2089: DrawableResource
+  get() = Drawable24.icon_2089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20890: DrawableResource
+  get() = Drawable24.icon_20890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20891: DrawableResource
+  get() = Drawable24.icon_20891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20892: DrawableResource
+  get() = Drawable24.icon_20892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20893: DrawableResource
+  get() = Drawable24.icon_20893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20894: DrawableResource
+  get() = Drawable24.icon_20894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20895: DrawableResource
+  get() = Drawable24.icon_20895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20896: DrawableResource
+  get() = Drawable24.icon_20896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20897: DrawableResource
+  get() = Drawable24.icon_20897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20898: DrawableResource
+  get() = Drawable24.icon_20898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20899: DrawableResource
+  get() = Drawable24.icon_20899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_209: DrawableResource
+  get() = Drawable24.icon_209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2090: DrawableResource
+  get() = Drawable24.icon_2090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20900: DrawableResource
+  get() = Drawable24.icon_20900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20901: DrawableResource
+  get() = Drawable24.icon_20901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20902: DrawableResource
+  get() = Drawable24.icon_20902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20903: DrawableResource
+  get() = Drawable24.icon_20903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20904: DrawableResource
+  get() = Drawable24.icon_20904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20905: DrawableResource
+  get() = Drawable24.icon_20905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20906: DrawableResource
+  get() = Drawable24.icon_20906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20907: DrawableResource
+  get() = Drawable24.icon_20907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20908: DrawableResource
+  get() = Drawable24.icon_20908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20909: DrawableResource
+  get() = Drawable24.icon_20909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2091: DrawableResource
+  get() = Drawable24.icon_2091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20910: DrawableResource
+  get() = Drawable24.icon_20910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20911: DrawableResource
+  get() = Drawable24.icon_20911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20912: DrawableResource
+  get() = Drawable24.icon_20912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20913: DrawableResource
+  get() = Drawable24.icon_20913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20914: DrawableResource
+  get() = Drawable24.icon_20914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20915: DrawableResource
+  get() = Drawable24.icon_20915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20916: DrawableResource
+  get() = Drawable24.icon_20916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20917: DrawableResource
+  get() = Drawable24.icon_20917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20918: DrawableResource
+  get() = Drawable24.icon_20918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20919: DrawableResource
+  get() = Drawable24.icon_20919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2092: DrawableResource
+  get() = Drawable24.icon_2092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20920: DrawableResource
+  get() = Drawable24.icon_20920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20921: DrawableResource
+  get() = Drawable24.icon_20921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20922: DrawableResource
+  get() = Drawable24.icon_20922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20923: DrawableResource
+  get() = Drawable24.icon_20923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20924: DrawableResource
+  get() = Drawable24.icon_20924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20925: DrawableResource
+  get() = Drawable24.icon_20925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20926: DrawableResource
+  get() = Drawable24.icon_20926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20927: DrawableResource
+  get() = Drawable24.icon_20927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20928: DrawableResource
+  get() = Drawable24.icon_20928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20929: DrawableResource
+  get() = Drawable24.icon_20929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2093: DrawableResource
+  get() = Drawable24.icon_2093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20930: DrawableResource
+  get() = Drawable24.icon_20930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20931: DrawableResource
+  get() = Drawable24.icon_20931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20932: DrawableResource
+  get() = Drawable24.icon_20932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20933: DrawableResource
+  get() = Drawable24.icon_20933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20934: DrawableResource
+  get() = Drawable24.icon_20934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20935: DrawableResource
+  get() = Drawable24.icon_20935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20936: DrawableResource
+  get() = Drawable24.icon_20936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20937: DrawableResource
+  get() = Drawable24.icon_20937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20938: DrawableResource
+  get() = Drawable24.icon_20938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20939: DrawableResource
+  get() = Drawable24.icon_20939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2094: DrawableResource
+  get() = Drawable24.icon_2094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20940: DrawableResource
+  get() = Drawable24.icon_20940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20941: DrawableResource
+  get() = Drawable24.icon_20941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20942: DrawableResource
+  get() = Drawable24.icon_20942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20943: DrawableResource
+  get() = Drawable24.icon_20943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20944: DrawableResource
+  get() = Drawable24.icon_20944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20945: DrawableResource
+  get() = Drawable24.icon_20945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20946: DrawableResource
+  get() = Drawable24.icon_20946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20947: DrawableResource
+  get() = Drawable24.icon_20947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20948: DrawableResource
+  get() = Drawable24.icon_20948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20949: DrawableResource
+  get() = Drawable24.icon_20949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2095: DrawableResource
+  get() = Drawable24.icon_2095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20950: DrawableResource
+  get() = Drawable24.icon_20950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20951: DrawableResource
+  get() = Drawable24.icon_20951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20952: DrawableResource
+  get() = Drawable24.icon_20952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20953: DrawableResource
+  get() = Drawable24.icon_20953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20954: DrawableResource
+  get() = Drawable24.icon_20954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20955: DrawableResource
+  get() = Drawable24.icon_20955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20956: DrawableResource
+  get() = Drawable24.icon_20956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20957: DrawableResource
+  get() = Drawable24.icon_20957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20958: DrawableResource
+  get() = Drawable24.icon_20958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20959: DrawableResource
+  get() = Drawable24.icon_20959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2096: DrawableResource
+  get() = Drawable24.icon_2096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20960: DrawableResource
+  get() = Drawable24.icon_20960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20961: DrawableResource
+  get() = Drawable24.icon_20961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20962: DrawableResource
+  get() = Drawable24.icon_20962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20963: DrawableResource
+  get() = Drawable24.icon_20963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20964: DrawableResource
+  get() = Drawable24.icon_20964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20965: DrawableResource
+  get() = Drawable24.icon_20965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20966: DrawableResource
+  get() = Drawable24.icon_20966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20967: DrawableResource
+  get() = Drawable24.icon_20967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20968: DrawableResource
+  get() = Drawable24.icon_20968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20969: DrawableResource
+  get() = Drawable24.icon_20969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2097: DrawableResource
+  get() = Drawable24.icon_2097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20970: DrawableResource
+  get() = Drawable24.icon_20970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20971: DrawableResource
+  get() = Drawable24.icon_20971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20972: DrawableResource
+  get() = Drawable24.icon_20972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20973: DrawableResource
+  get() = Drawable24.icon_20973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20974: DrawableResource
+  get() = Drawable24.icon_20974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20975: DrawableResource
+  get() = Drawable24.icon_20975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20976: DrawableResource
+  get() = Drawable24.icon_20976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20977: DrawableResource
+  get() = Drawable24.icon_20977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20978: DrawableResource
+  get() = Drawable24.icon_20978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20979: DrawableResource
+  get() = Drawable24.icon_20979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2098: DrawableResource
+  get() = Drawable24.icon_2098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20980: DrawableResource
+  get() = Drawable24.icon_20980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20981: DrawableResource
+  get() = Drawable24.icon_20981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20982: DrawableResource
+  get() = Drawable24.icon_20982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20983: DrawableResource
+  get() = Drawable24.icon_20983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20984: DrawableResource
+  get() = Drawable24.icon_20984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20985: DrawableResource
+  get() = Drawable24.icon_20985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20986: DrawableResource
+  get() = Drawable24.icon_20986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20987: DrawableResource
+  get() = Drawable24.icon_20987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20988: DrawableResource
+  get() = Drawable24.icon_20988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20989: DrawableResource
+  get() = Drawable24.icon_20989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2099: DrawableResource
+  get() = Drawable24.icon_2099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20990: DrawableResource
+  get() = Drawable24.icon_20990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20991: DrawableResource
+  get() = Drawable24.icon_20991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20992: DrawableResource
+  get() = Drawable24.icon_20992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20993: DrawableResource
+  get() = Drawable24.icon_20993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20994: DrawableResource
+  get() = Drawable24.icon_20994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20995: DrawableResource
+  get() = Drawable24.icon_20995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20996: DrawableResource
+  get() = Drawable24.icon_20996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20997: DrawableResource
+  get() = Drawable24.icon_20997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20998: DrawableResource
+  get() = Drawable24.icon_20998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_20999: DrawableResource
+  get() = Drawable24.icon_20999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21: DrawableResource
+  get() = Drawable24.icon_21
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_210: DrawableResource
+  get() = Drawable24.icon_210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2100: DrawableResource
+  get() = Drawable24.icon_2100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21000: DrawableResource
+  get() = Drawable24.icon_21000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21001: DrawableResource
+  get() = Drawable24.icon_21001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21002: DrawableResource
+  get() = Drawable24.icon_21002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21003: DrawableResource
+  get() = Drawable24.icon_21003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21004: DrawableResource
+  get() = Drawable24.icon_21004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21005: DrawableResource
+  get() = Drawable24.icon_21005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21006: DrawableResource
+  get() = Drawable24.icon_21006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21007: DrawableResource
+  get() = Drawable24.icon_21007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21008: DrawableResource
+  get() = Drawable24.icon_21008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21009: DrawableResource
+  get() = Drawable24.icon_21009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2101: DrawableResource
+  get() = Drawable24.icon_2101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21010: DrawableResource
+  get() = Drawable24.icon_21010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21011: DrawableResource
+  get() = Drawable24.icon_21011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21012: DrawableResource
+  get() = Drawable24.icon_21012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21013: DrawableResource
+  get() = Drawable24.icon_21013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21014: DrawableResource
+  get() = Drawable24.icon_21014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21015: DrawableResource
+  get() = Drawable24.icon_21015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21016: DrawableResource
+  get() = Drawable24.icon_21016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21017: DrawableResource
+  get() = Drawable24.icon_21017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21018: DrawableResource
+  get() = Drawable24.icon_21018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21019: DrawableResource
+  get() = Drawable24.icon_21019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2102: DrawableResource
+  get() = Drawable24.icon_2102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21020: DrawableResource
+  get() = Drawable24.icon_21020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21021: DrawableResource
+  get() = Drawable24.icon_21021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21022: DrawableResource
+  get() = Drawable24.icon_21022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21023: DrawableResource
+  get() = Drawable24.icon_21023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21024: DrawableResource
+  get() = Drawable24.icon_21024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21025: DrawableResource
+  get() = Drawable24.icon_21025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21026: DrawableResource
+  get() = Drawable24.icon_21026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21027: DrawableResource
+  get() = Drawable24.icon_21027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21028: DrawableResource
+  get() = Drawable24.icon_21028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21029: DrawableResource
+  get() = Drawable24.icon_21029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2103: DrawableResource
+  get() = Drawable24.icon_2103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21030: DrawableResource
+  get() = Drawable24.icon_21030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21031: DrawableResource
+  get() = Drawable24.icon_21031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21032: DrawableResource
+  get() = Drawable24.icon_21032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21033: DrawableResource
+  get() = Drawable24.icon_21033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21034: DrawableResource
+  get() = Drawable24.icon_21034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21035: DrawableResource
+  get() = Drawable24.icon_21035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21036: DrawableResource
+  get() = Drawable24.icon_21036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21037: DrawableResource
+  get() = Drawable24.icon_21037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21038: DrawableResource
+  get() = Drawable24.icon_21038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21039: DrawableResource
+  get() = Drawable24.icon_21039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2104: DrawableResource
+  get() = Drawable24.icon_2104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21040: DrawableResource
+  get() = Drawable24.icon_21040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21041: DrawableResource
+  get() = Drawable24.icon_21041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21042: DrawableResource
+  get() = Drawable24.icon_21042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21043: DrawableResource
+  get() = Drawable24.icon_21043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21044: DrawableResource
+  get() = Drawable24.icon_21044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21045: DrawableResource
+  get() = Drawable24.icon_21045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21046: DrawableResource
+  get() = Drawable24.icon_21046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21047: DrawableResource
+  get() = Drawable24.icon_21047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21048: DrawableResource
+  get() = Drawable24.icon_21048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21049: DrawableResource
+  get() = Drawable24.icon_21049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2105: DrawableResource
+  get() = Drawable24.icon_2105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21050: DrawableResource
+  get() = Drawable24.icon_21050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21051: DrawableResource
+  get() = Drawable24.icon_21051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21052: DrawableResource
+  get() = Drawable24.icon_21052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21053: DrawableResource
+  get() = Drawable24.icon_21053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21054: DrawableResource
+  get() = Drawable24.icon_21054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21055: DrawableResource
+  get() = Drawable24.icon_21055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21056: DrawableResource
+  get() = Drawable24.icon_21056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21057: DrawableResource
+  get() = Drawable24.icon_21057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21058: DrawableResource
+  get() = Drawable24.icon_21058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21059: DrawableResource
+  get() = Drawable24.icon_21059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2106: DrawableResource
+  get() = Drawable24.icon_2106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21060: DrawableResource
+  get() = Drawable24.icon_21060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21061: DrawableResource
+  get() = Drawable24.icon_21061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21062: DrawableResource
+  get() = Drawable24.icon_21062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21063: DrawableResource
+  get() = Drawable24.icon_21063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21064: DrawableResource
+  get() = Drawable24.icon_21064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21065: DrawableResource
+  get() = Drawable24.icon_21065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21066: DrawableResource
+  get() = Drawable24.icon_21066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21067: DrawableResource
+  get() = Drawable24.icon_21067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21068: DrawableResource
+  get() = Drawable24.icon_21068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21069: DrawableResource
+  get() = Drawable24.icon_21069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2107: DrawableResource
+  get() = Drawable24.icon_2107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21070: DrawableResource
+  get() = Drawable24.icon_21070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21071: DrawableResource
+  get() = Drawable24.icon_21071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21072: DrawableResource
+  get() = Drawable24.icon_21072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21073: DrawableResource
+  get() = Drawable24.icon_21073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21074: DrawableResource
+  get() = Drawable24.icon_21074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21075: DrawableResource
+  get() = Drawable24.icon_21075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21076: DrawableResource
+  get() = Drawable24.icon_21076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21077: DrawableResource
+  get() = Drawable24.icon_21077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21078: DrawableResource
+  get() = Drawable24.icon_21078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21079: DrawableResource
+  get() = Drawable24.icon_21079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2108: DrawableResource
+  get() = Drawable24.icon_2108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21080: DrawableResource
+  get() = Drawable24.icon_21080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21081: DrawableResource
+  get() = Drawable24.icon_21081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21082: DrawableResource
+  get() = Drawable24.icon_21082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21083: DrawableResource
+  get() = Drawable24.icon_21083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21084: DrawableResource
+  get() = Drawable24.icon_21084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21085: DrawableResource
+  get() = Drawable24.icon_21085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21086: DrawableResource
+  get() = Drawable24.icon_21086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21087: DrawableResource
+  get() = Drawable24.icon_21087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21088: DrawableResource
+  get() = Drawable24.icon_21088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21089: DrawableResource
+  get() = Drawable24.icon_21089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2109: DrawableResource
+  get() = Drawable24.icon_2109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21090: DrawableResource
+  get() = Drawable24.icon_21090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21091: DrawableResource
+  get() = Drawable24.icon_21091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21092: DrawableResource
+  get() = Drawable24.icon_21092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21093: DrawableResource
+  get() = Drawable24.icon_21093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21094: DrawableResource
+  get() = Drawable24.icon_21094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21095: DrawableResource
+  get() = Drawable24.icon_21095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21096: DrawableResource
+  get() = Drawable24.icon_21096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21097: DrawableResource
+  get() = Drawable24.icon_21097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21098: DrawableResource
+  get() = Drawable24.icon_21098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21099: DrawableResource
+  get() = Drawable24.icon_21099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_211: DrawableResource
+  get() = Drawable24.icon_211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2110: DrawableResource
+  get() = Drawable24.icon_2110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21100: DrawableResource
+  get() = Drawable24.icon_21100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21101: DrawableResource
+  get() = Drawable24.icon_21101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21102: DrawableResource
+  get() = Drawable24.icon_21102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21103: DrawableResource
+  get() = Drawable24.icon_21103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21104: DrawableResource
+  get() = Drawable24.icon_21104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21105: DrawableResource
+  get() = Drawable24.icon_21105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21106: DrawableResource
+  get() = Drawable24.icon_21106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21107: DrawableResource
+  get() = Drawable24.icon_21107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21108: DrawableResource
+  get() = Drawable24.icon_21108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21109: DrawableResource
+  get() = Drawable24.icon_21109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2111: DrawableResource
+  get() = Drawable24.icon_2111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21110: DrawableResource
+  get() = Drawable24.icon_21110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21111: DrawableResource
+  get() = Drawable24.icon_21111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21112: DrawableResource
+  get() = Drawable24.icon_21112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21113: DrawableResource
+  get() = Drawable24.icon_21113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21114: DrawableResource
+  get() = Drawable24.icon_21114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21115: DrawableResource
+  get() = Drawable24.icon_21115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21116: DrawableResource
+  get() = Drawable24.icon_21116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21117: DrawableResource
+  get() = Drawable24.icon_21117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21118: DrawableResource
+  get() = Drawable24.icon_21118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21119: DrawableResource
+  get() = Drawable24.icon_21119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2112: DrawableResource
+  get() = Drawable24.icon_2112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21120: DrawableResource
+  get() = Drawable24.icon_21120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21121: DrawableResource
+  get() = Drawable24.icon_21121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21122: DrawableResource
+  get() = Drawable24.icon_21122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21123: DrawableResource
+  get() = Drawable24.icon_21123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21124: DrawableResource
+  get() = Drawable24.icon_21124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21125: DrawableResource
+  get() = Drawable24.icon_21125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21126: DrawableResource
+  get() = Drawable24.icon_21126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21127: DrawableResource
+  get() = Drawable24.icon_21127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21128: DrawableResource
+  get() = Drawable24.icon_21128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21129: DrawableResource
+  get() = Drawable24.icon_21129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2113: DrawableResource
+  get() = Drawable24.icon_2113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21130: DrawableResource
+  get() = Drawable24.icon_21130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21131: DrawableResource
+  get() = Drawable24.icon_21131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21132: DrawableResource
+  get() = Drawable24.icon_21132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21133: DrawableResource
+  get() = Drawable24.icon_21133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21134: DrawableResource
+  get() = Drawable24.icon_21134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21135: DrawableResource
+  get() = Drawable24.icon_21135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21136: DrawableResource
+  get() = Drawable24.icon_21136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21137: DrawableResource
+  get() = Drawable24.icon_21137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21138: DrawableResource
+  get() = Drawable24.icon_21138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21139: DrawableResource
+  get() = Drawable24.icon_21139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2114: DrawableResource
+  get() = Drawable24.icon_2114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21140: DrawableResource
+  get() = Drawable24.icon_21140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21141: DrawableResource
+  get() = Drawable24.icon_21141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21142: DrawableResource
+  get() = Drawable24.icon_21142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21143: DrawableResource
+  get() = Drawable24.icon_21143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21144: DrawableResource
+  get() = Drawable24.icon_21144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21145: DrawableResource
+  get() = Drawable24.icon_21145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21146: DrawableResource
+  get() = Drawable24.icon_21146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21147: DrawableResource
+  get() = Drawable24.icon_21147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21148: DrawableResource
+  get() = Drawable24.icon_21148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21149: DrawableResource
+  get() = Drawable24.icon_21149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2115: DrawableResource
+  get() = Drawable24.icon_2115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21150: DrawableResource
+  get() = Drawable24.icon_21150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21151: DrawableResource
+  get() = Drawable24.icon_21151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21152: DrawableResource
+  get() = Drawable24.icon_21152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21153: DrawableResource
+  get() = Drawable24.icon_21153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21154: DrawableResource
+  get() = Drawable24.icon_21154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21155: DrawableResource
+  get() = Drawable24.icon_21155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21156: DrawableResource
+  get() = Drawable24.icon_21156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21157: DrawableResource
+  get() = Drawable24.icon_21157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21158: DrawableResource
+  get() = Drawable24.icon_21158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21159: DrawableResource
+  get() = Drawable24.icon_21159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2116: DrawableResource
+  get() = Drawable24.icon_2116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21160: DrawableResource
+  get() = Drawable24.icon_21160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21161: DrawableResource
+  get() = Drawable24.icon_21161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21162: DrawableResource
+  get() = Drawable24.icon_21162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21163: DrawableResource
+  get() = Drawable24.icon_21163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21164: DrawableResource
+  get() = Drawable24.icon_21164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21165: DrawableResource
+  get() = Drawable24.icon_21165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21166: DrawableResource
+  get() = Drawable24.icon_21166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21167: DrawableResource
+  get() = Drawable24.icon_21167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21168: DrawableResource
+  get() = Drawable24.icon_21168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21169: DrawableResource
+  get() = Drawable24.icon_21169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2117: DrawableResource
+  get() = Drawable24.icon_2117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21170: DrawableResource
+  get() = Drawable24.icon_21170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21171: DrawableResource
+  get() = Drawable24.icon_21171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21172: DrawableResource
+  get() = Drawable24.icon_21172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21173: DrawableResource
+  get() = Drawable24.icon_21173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21174: DrawableResource
+  get() = Drawable24.icon_21174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21175: DrawableResource
+  get() = Drawable24.icon_21175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21176: DrawableResource
+  get() = Drawable24.icon_21176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21177: DrawableResource
+  get() = Drawable24.icon_21177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21178: DrawableResource
+  get() = Drawable24.icon_21178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21179: DrawableResource
+  get() = Drawable24.icon_21179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2118: DrawableResource
+  get() = Drawable24.icon_2118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21180: DrawableResource
+  get() = Drawable24.icon_21180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21181: DrawableResource
+  get() = Drawable24.icon_21181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21182: DrawableResource
+  get() = Drawable24.icon_21182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21183: DrawableResource
+  get() = Drawable24.icon_21183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21184: DrawableResource
+  get() = Drawable24.icon_21184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21185: DrawableResource
+  get() = Drawable24.icon_21185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21186: DrawableResource
+  get() = Drawable24.icon_21186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21187: DrawableResource
+  get() = Drawable24.icon_21187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21188: DrawableResource
+  get() = Drawable24.icon_21188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21189: DrawableResource
+  get() = Drawable24.icon_21189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2119: DrawableResource
+  get() = Drawable24.icon_2119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21190: DrawableResource
+  get() = Drawable24.icon_21190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21191: DrawableResource
+  get() = Drawable24.icon_21191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21192: DrawableResource
+  get() = Drawable24.icon_21192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21193: DrawableResource
+  get() = Drawable24.icon_21193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21194: DrawableResource
+  get() = Drawable24.icon_21194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21195: DrawableResource
+  get() = Drawable24.icon_21195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21196: DrawableResource
+  get() = Drawable24.icon_21196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21197: DrawableResource
+  get() = Drawable24.icon_21197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21198: DrawableResource
+  get() = Drawable24.icon_21198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21199: DrawableResource
+  get() = Drawable24.icon_21199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_212: DrawableResource
+  get() = Drawable24.icon_212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2120: DrawableResource
+  get() = Drawable24.icon_2120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21200: DrawableResource
+  get() = Drawable24.icon_21200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21201: DrawableResource
+  get() = Drawable24.icon_21201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21202: DrawableResource
+  get() = Drawable24.icon_21202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21203: DrawableResource
+  get() = Drawable24.icon_21203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21204: DrawableResource
+  get() = Drawable24.icon_21204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21205: DrawableResource
+  get() = Drawable24.icon_21205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21206: DrawableResource
+  get() = Drawable24.icon_21206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21207: DrawableResource
+  get() = Drawable24.icon_21207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21208: DrawableResource
+  get() = Drawable24.icon_21208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21209: DrawableResource
+  get() = Drawable24.icon_21209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2121: DrawableResource
+  get() = Drawable24.icon_2121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21210: DrawableResource
+  get() = Drawable24.icon_21210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21211: DrawableResource
+  get() = Drawable24.icon_21211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21212: DrawableResource
+  get() = Drawable24.icon_21212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21213: DrawableResource
+  get() = Drawable24.icon_21213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21214: DrawableResource
+  get() = Drawable24.icon_21214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21215: DrawableResource
+  get() = Drawable24.icon_21215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21216: DrawableResource
+  get() = Drawable24.icon_21216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21217: DrawableResource
+  get() = Drawable24.icon_21217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21218: DrawableResource
+  get() = Drawable24.icon_21218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21219: DrawableResource
+  get() = Drawable24.icon_21219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2122: DrawableResource
+  get() = Drawable24.icon_2122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21220: DrawableResource
+  get() = Drawable24.icon_21220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21221: DrawableResource
+  get() = Drawable24.icon_21221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21222: DrawableResource
+  get() = Drawable24.icon_21222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21223: DrawableResource
+  get() = Drawable24.icon_21223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21224: DrawableResource
+  get() = Drawable24.icon_21224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21225: DrawableResource
+  get() = Drawable24.icon_21225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21226: DrawableResource
+  get() = Drawable24.icon_21226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21227: DrawableResource
+  get() = Drawable24.icon_21227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21228: DrawableResource
+  get() = Drawable24.icon_21228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21229: DrawableResource
+  get() = Drawable24.icon_21229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2123: DrawableResource
+  get() = Drawable24.icon_2123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21230: DrawableResource
+  get() = Drawable24.icon_21230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21231: DrawableResource
+  get() = Drawable24.icon_21231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21232: DrawableResource
+  get() = Drawable24.icon_21232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21233: DrawableResource
+  get() = Drawable24.icon_21233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21234: DrawableResource
+  get() = Drawable24.icon_21234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21235: DrawableResource
+  get() = Drawable24.icon_21235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21236: DrawableResource
+  get() = Drawable24.icon_21236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21237: DrawableResource
+  get() = Drawable24.icon_21237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21238: DrawableResource
+  get() = Drawable24.icon_21238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21239: DrawableResource
+  get() = Drawable24.icon_21239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2124: DrawableResource
+  get() = Drawable24.icon_2124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21240: DrawableResource
+  get() = Drawable24.icon_21240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21241: DrawableResource
+  get() = Drawable24.icon_21241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21242: DrawableResource
+  get() = Drawable24.icon_21242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21243: DrawableResource
+  get() = Drawable24.icon_21243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21244: DrawableResource
+  get() = Drawable24.icon_21244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21245: DrawableResource
+  get() = Drawable24.icon_21245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21246: DrawableResource
+  get() = Drawable24.icon_21246

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable25.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable25.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable25 {
+  public val icon_21247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21247.xml"),
+          )
+      )
+
+  public val icon_21248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21248.xml"),
+          )
+      )
+
+  public val icon_21249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21249.xml"),
+          )
+      )
+
+  public val icon_2125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2125.xml"),
+          )
+      )
+
+  public val icon_21250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21250.xml"),
+          )
+      )
+
+  public val icon_21251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21251.xml"),
+          )
+      )
+
+  public val icon_21252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21252.xml"),
+          )
+      )
+
+  public val icon_21253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21253.xml"),
+          )
+      )
+
+  public val icon_21254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21254.xml"),
+          )
+      )
+
+  public val icon_21255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21255.xml"),
+          )
+      )
+
+  public val icon_21256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21256.xml"),
+          )
+      )
+
+  public val icon_21257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21257.xml"),
+          )
+      )
+
+  public val icon_21258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21258.xml"),
+          )
+      )
+
+  public val icon_21259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21259.xml"),
+          )
+      )
+
+  public val icon_2126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2126.xml"),
+          )
+      )
+
+  public val icon_21260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21260.xml"),
+          )
+      )
+
+  public val icon_21261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21261.xml"),
+          )
+      )
+
+  public val icon_21262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21262.xml"),
+          )
+      )
+
+  public val icon_21263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21263.xml"),
+          )
+      )
+
+  public val icon_21264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21264.xml"),
+          )
+      )
+
+  public val icon_21265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21265.xml"),
+          )
+      )
+
+  public val icon_21266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21266.xml"),
+          )
+      )
+
+  public val icon_21267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21267.xml"),
+          )
+      )
+
+  public val icon_21268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21268.xml"),
+          )
+      )
+
+  public val icon_21269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21269.xml"),
+          )
+      )
+
+  public val icon_2127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2127.xml"),
+          )
+      )
+
+  public val icon_21270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21270.xml"),
+          )
+      )
+
+  public val icon_21271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21271.xml"),
+          )
+      )
+
+  public val icon_21272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21272.xml"),
+          )
+      )
+
+  public val icon_21273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21273.xml"),
+          )
+      )
+
+  public val icon_21274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21274.xml"),
+          )
+      )
+
+  public val icon_21275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21275.xml"),
+          )
+      )
+
+  public val icon_21276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21276.xml"),
+          )
+      )
+
+  public val icon_21277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21277.xml"),
+          )
+      )
+
+  public val icon_21278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21278.xml"),
+          )
+      )
+
+  public val icon_21279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21279.xml"),
+          )
+      )
+
+  public val icon_2128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2128.xml"),
+          )
+      )
+
+  public val icon_21280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21280.xml"),
+          )
+      )
+
+  public val icon_21281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21281.xml"),
+          )
+      )
+
+  public val icon_21282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21282.xml"),
+          )
+      )
+
+  public val icon_21283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21283.xml"),
+          )
+      )
+
+  public val icon_21284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21284.xml"),
+          )
+      )
+
+  public val icon_21285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21285.xml"),
+          )
+      )
+
+  public val icon_21286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21286.xml"),
+          )
+      )
+
+  public val icon_21287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21287.xml"),
+          )
+      )
+
+  public val icon_21288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21288.xml"),
+          )
+      )
+
+  public val icon_21289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21289.xml"),
+          )
+      )
+
+  public val icon_2129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2129.xml"),
+          )
+      )
+
+  public val icon_21290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21290.xml"),
+          )
+      )
+
+  public val icon_21291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21291.xml"),
+          )
+      )
+
+  public val icon_21292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21292.xml"),
+          )
+      )
+
+  public val icon_21293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21293.xml"),
+          )
+      )
+
+  public val icon_21294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21294.xml"),
+          )
+      )
+
+  public val icon_21295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21295.xml"),
+          )
+      )
+
+  public val icon_21296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21296.xml"),
+          )
+      )
+
+  public val icon_21297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21297.xml"),
+          )
+      )
+
+  public val icon_21298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21298.xml"),
+          )
+      )
+
+  public val icon_21299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21299.xml"),
+          )
+      )
+
+  public val icon_213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_213.xml"),
+          )
+      )
+
+  public val icon_2130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2130.xml"),
+          )
+      )
+
+  public val icon_21300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21300.xml"),
+          )
+      )
+
+  public val icon_21301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21301.xml"),
+          )
+      )
+
+  public val icon_21302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21302.xml"),
+          )
+      )
+
+  public val icon_21303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21303.xml"),
+          )
+      )
+
+  public val icon_21304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21304.xml"),
+          )
+      )
+
+  public val icon_21305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21305.xml"),
+          )
+      )
+
+  public val icon_21306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21306.xml"),
+          )
+      )
+
+  public val icon_21307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21307.xml"),
+          )
+      )
+
+  public val icon_21308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21308.xml"),
+          )
+      )
+
+  public val icon_21309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21309.xml"),
+          )
+      )
+
+  public val icon_2131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2131.xml"),
+          )
+      )
+
+  public val icon_21310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21310.xml"),
+          )
+      )
+
+  public val icon_21311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21311.xml"),
+          )
+      )
+
+  public val icon_21312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21312.xml"),
+          )
+      )
+
+  public val icon_21313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21313.xml"),
+          )
+      )
+
+  public val icon_21314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21314.xml"),
+          )
+      )
+
+  public val icon_21315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21315.xml"),
+          )
+      )
+
+  public val icon_21316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21316.xml"),
+          )
+      )
+
+  public val icon_21317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21317.xml"),
+          )
+      )
+
+  public val icon_21318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21318.xml"),
+          )
+      )
+
+  public val icon_21319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21319.xml"),
+          )
+      )
+
+  public val icon_2132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2132.xml"),
+          )
+      )
+
+  public val icon_21320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21320.xml"),
+          )
+      )
+
+  public val icon_21321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21321.xml"),
+          )
+      )
+
+  public val icon_21322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21322.xml"),
+          )
+      )
+
+  public val icon_21323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21323.xml"),
+          )
+      )
+
+  public val icon_21324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21324.xml"),
+          )
+      )
+
+  public val icon_21325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21325.xml"),
+          )
+      )
+
+  public val icon_21326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21326.xml"),
+          )
+      )
+
+  public val icon_21327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21327.xml"),
+          )
+      )
+
+  public val icon_21328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21328.xml"),
+          )
+      )
+
+  public val icon_21329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21329.xml"),
+          )
+      )
+
+  public val icon_2133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2133.xml"),
+          )
+      )
+
+  public val icon_21330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21330.xml"),
+          )
+      )
+
+  public val icon_21331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21331.xml"),
+          )
+      )
+
+  public val icon_21332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21332.xml"),
+          )
+      )
+
+  public val icon_21333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21333.xml"),
+          )
+      )
+
+  public val icon_21334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21334.xml"),
+          )
+      )
+
+  public val icon_21335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21335.xml"),
+          )
+      )
+
+  public val icon_21336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21336.xml"),
+          )
+      )
+
+  public val icon_21337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21337.xml"),
+          )
+      )
+
+  public val icon_21338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21338.xml"),
+          )
+      )
+
+  public val icon_21339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21339.xml"),
+          )
+      )
+
+  public val icon_2134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2134.xml"),
+          )
+      )
+
+  public val icon_21340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21340.xml"),
+          )
+      )
+
+  public val icon_21341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21341.xml"),
+          )
+      )
+
+  public val icon_21342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21342.xml"),
+          )
+      )
+
+  public val icon_21343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21343.xml"),
+          )
+      )
+
+  public val icon_21344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21344.xml"),
+          )
+      )
+
+  public val icon_21345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21345.xml"),
+          )
+      )
+
+  public val icon_21346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21346.xml"),
+          )
+      )
+
+  public val icon_21347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21347.xml"),
+          )
+      )
+
+  public val icon_21348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21348.xml"),
+          )
+      )
+
+  public val icon_21349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21349.xml"),
+          )
+      )
+
+  public val icon_2135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2135.xml"),
+          )
+      )
+
+  public val icon_21350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21350.xml"),
+          )
+      )
+
+  public val icon_21351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21351.xml"),
+          )
+      )
+
+  public val icon_21352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21352.xml"),
+          )
+      )
+
+  public val icon_21353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21353.xml"),
+          )
+      )
+
+  public val icon_21354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21354.xml"),
+          )
+      )
+
+  public val icon_21355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21355.xml"),
+          )
+      )
+
+  public val icon_21356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21356.xml"),
+          )
+      )
+
+  public val icon_21357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21357.xml"),
+          )
+      )
+
+  public val icon_21358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21358.xml"),
+          )
+      )
+
+  public val icon_21359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21359.xml"),
+          )
+      )
+
+  public val icon_2136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2136.xml"),
+          )
+      )
+
+  public val icon_21360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21360.xml"),
+          )
+      )
+
+  public val icon_21361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21361.xml"),
+          )
+      )
+
+  public val icon_21362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21362.xml"),
+          )
+      )
+
+  public val icon_21363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21363.xml"),
+          )
+      )
+
+  public val icon_21364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21364.xml"),
+          )
+      )
+
+  public val icon_21365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21365.xml"),
+          )
+      )
+
+  public val icon_21366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21366.xml"),
+          )
+      )
+
+  public val icon_21367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21367.xml"),
+          )
+      )
+
+  public val icon_21368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21368.xml"),
+          )
+      )
+
+  public val icon_21369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21369.xml"),
+          )
+      )
+
+  public val icon_2137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2137.xml"),
+          )
+      )
+
+  public val icon_21370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21370.xml"),
+          )
+      )
+
+  public val icon_21371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21371.xml"),
+          )
+      )
+
+  public val icon_21372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21372.xml"),
+          )
+      )
+
+  public val icon_21373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21373.xml"),
+          )
+      )
+
+  public val icon_21374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21374.xml"),
+          )
+      )
+
+  public val icon_21375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21375.xml"),
+          )
+      )
+
+  public val icon_21376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21376.xml"),
+          )
+      )
+
+  public val icon_21377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21377.xml"),
+          )
+      )
+
+  public val icon_21378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21378.xml"),
+          )
+      )
+
+  public val icon_21379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21379.xml"),
+          )
+      )
+
+  public val icon_2138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2138.xml"),
+          )
+      )
+
+  public val icon_21380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21380.xml"),
+          )
+      )
+
+  public val icon_21381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21381.xml"),
+          )
+      )
+
+  public val icon_21382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21382.xml"),
+          )
+      )
+
+  public val icon_21383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21383.xml"),
+          )
+      )
+
+  public val icon_21384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21384.xml"),
+          )
+      )
+
+  public val icon_21385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21385.xml"),
+          )
+      )
+
+  public val icon_21386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21386.xml"),
+          )
+      )
+
+  public val icon_21387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21387.xml"),
+          )
+      )
+
+  public val icon_21388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21388.xml"),
+          )
+      )
+
+  public val icon_21389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21389.xml"),
+          )
+      )
+
+  public val icon_2139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2139.xml"),
+          )
+      )
+
+  public val icon_21390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21390.xml"),
+          )
+      )
+
+  public val icon_21391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21391.xml"),
+          )
+      )
+
+  public val icon_21392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21392.xml"),
+          )
+      )
+
+  public val icon_21393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21393.xml"),
+          )
+      )
+
+  public val icon_21394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21394.xml"),
+          )
+      )
+
+  public val icon_21395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21395.xml"),
+          )
+      )
+
+  public val icon_21396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21396.xml"),
+          )
+      )
+
+  public val icon_21397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21397.xml"),
+          )
+      )
+
+  public val icon_21398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21398.xml"),
+          )
+      )
+
+  public val icon_21399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21399.xml"),
+          )
+      )
+
+  public val icon_214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_214.xml"),
+          )
+      )
+
+  public val icon_2140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2140.xml"),
+          )
+      )
+
+  public val icon_21400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21400.xml"),
+          )
+      )
+
+  public val icon_21401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21401.xml"),
+          )
+      )
+
+  public val icon_21402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21402.xml"),
+          )
+      )
+
+  public val icon_21403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21403.xml"),
+          )
+      )
+
+  public val icon_21404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21404.xml"),
+          )
+      )
+
+  public val icon_21405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21405.xml"),
+          )
+      )
+
+  public val icon_21406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21406.xml"),
+          )
+      )
+
+  public val icon_21407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21407.xml"),
+          )
+      )
+
+  public val icon_21408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21408.xml"),
+          )
+      )
+
+  public val icon_21409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21409.xml"),
+          )
+      )
+
+  public val icon_2141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2141.xml"),
+          )
+      )
+
+  public val icon_21410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21410.xml"),
+          )
+      )
+
+  public val icon_21411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21411.xml"),
+          )
+      )
+
+  public val icon_21412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21412.xml"),
+          )
+      )
+
+  public val icon_21413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21413.xml"),
+          )
+      )
+
+  public val icon_21414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21414.xml"),
+          )
+      )
+
+  public val icon_21415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21415.xml"),
+          )
+      )
+
+  public val icon_21416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21416.xml"),
+          )
+      )
+
+  public val icon_21417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21417.xml"),
+          )
+      )
+
+  public val icon_21418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21418.xml"),
+          )
+      )
+
+  public val icon_21419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21419.xml"),
+          )
+      )
+
+  public val icon_2142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2142.xml"),
+          )
+      )
+
+  public val icon_21420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21420.xml"),
+          )
+      )
+
+  public val icon_21421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21421.xml"),
+          )
+      )
+
+  public val icon_21422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21422.xml"),
+          )
+      )
+
+  public val icon_21423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21423.xml"),
+          )
+      )
+
+  public val icon_21424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21424.xml"),
+          )
+      )
+
+  public val icon_21425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21425.xml"),
+          )
+      )
+
+  public val icon_21426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21426.xml"),
+          )
+      )
+
+  public val icon_21427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21427.xml"),
+          )
+      )
+
+  public val icon_21428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21428.xml"),
+          )
+      )
+
+  public val icon_21429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21429.xml"),
+          )
+      )
+
+  public val icon_2143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2143.xml"),
+          )
+      )
+
+  public val icon_21430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21430.xml"),
+          )
+      )
+
+  public val icon_21431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21431.xml"),
+          )
+      )
+
+  public val icon_21432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21432.xml"),
+          )
+      )
+
+  public val icon_21433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21433.xml"),
+          )
+      )
+
+  public val icon_21434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21434.xml"),
+          )
+      )
+
+  public val icon_21435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21435.xml"),
+          )
+      )
+
+  public val icon_21436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21436.xml"),
+          )
+      )
+
+  public val icon_21437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21437.xml"),
+          )
+      )
+
+  public val icon_21438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21438.xml"),
+          )
+      )
+
+  public val icon_21439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21439.xml"),
+          )
+      )
+
+  public val icon_2144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2144.xml"),
+          )
+      )
+
+  public val icon_21440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21440.xml"),
+          )
+      )
+
+  public val icon_21441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21441.xml"),
+          )
+      )
+
+  public val icon_21442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21442.xml"),
+          )
+      )
+
+  public val icon_21443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21443.xml"),
+          )
+      )
+
+  public val icon_21444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21444.xml"),
+          )
+      )
+
+  public val icon_21445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21445.xml"),
+          )
+      )
+
+  public val icon_21446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21446.xml"),
+          )
+      )
+
+  public val icon_21447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21447.xml"),
+          )
+      )
+
+  public val icon_21448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21448.xml"),
+          )
+      )
+
+  public val icon_21449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21449.xml"),
+          )
+      )
+
+  public val icon_2145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2145.xml"),
+          )
+      )
+
+  public val icon_21450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21450.xml"),
+          )
+      )
+
+  public val icon_21451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21451.xml"),
+          )
+      )
+
+  public val icon_21452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21452.xml"),
+          )
+      )
+
+  public val icon_21453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21453.xml"),
+          )
+      )
+
+  public val icon_21454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21454.xml"),
+          )
+      )
+
+  public val icon_21455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21455.xml"),
+          )
+      )
+
+  public val icon_21456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21456.xml"),
+          )
+      )
+
+  public val icon_21457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21457.xml"),
+          )
+      )
+
+  public val icon_21458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21458.xml"),
+          )
+      )
+
+  public val icon_21459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21459.xml"),
+          )
+      )
+
+  public val icon_2146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2146.xml"),
+          )
+      )
+
+  public val icon_21460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21460.xml"),
+          )
+      )
+
+  public val icon_21461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21461.xml"),
+          )
+      )
+
+  public val icon_21462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21462.xml"),
+          )
+      )
+
+  public val icon_21463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21463.xml"),
+          )
+      )
+
+  public val icon_21464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21464.xml"),
+          )
+      )
+
+  public val icon_21465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21465.xml"),
+          )
+      )
+
+  public val icon_21466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21466.xml"),
+          )
+      )
+
+  public val icon_21467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21467.xml"),
+          )
+      )
+
+  public val icon_21468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21468.xml"),
+          )
+      )
+
+  public val icon_21469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21469.xml"),
+          )
+      )
+
+  public val icon_2147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2147.xml"),
+          )
+      )
+
+  public val icon_21470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21470.xml"),
+          )
+      )
+
+  public val icon_21471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21471.xml"),
+          )
+      )
+
+  public val icon_21472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21472.xml"),
+          )
+      )
+
+  public val icon_21473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21473.xml"),
+          )
+      )
+
+  public val icon_21474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21474.xml"),
+          )
+      )
+
+  public val icon_21475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21475.xml"),
+          )
+      )
+
+  public val icon_21476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21476.xml"),
+          )
+      )
+
+  public val icon_21477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21477.xml"),
+          )
+      )
+
+  public val icon_21478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21478.xml"),
+          )
+      )
+
+  public val icon_21479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21479.xml"),
+          )
+      )
+
+  public val icon_2148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2148.xml"),
+          )
+      )
+
+  public val icon_21480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21480.xml"),
+          )
+      )
+
+  public val icon_21481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21481.xml"),
+          )
+      )
+
+  public val icon_21482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21482.xml"),
+          )
+      )
+
+  public val icon_21483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21483.xml"),
+          )
+      )
+
+  public val icon_21484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21484.xml"),
+          )
+      )
+
+  public val icon_21485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21485.xml"),
+          )
+      )
+
+  public val icon_21486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21486.xml"),
+          )
+      )
+
+  public val icon_21487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21487.xml"),
+          )
+      )
+
+  public val icon_21488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21488.xml"),
+          )
+      )
+
+  public val icon_21489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21489.xml"),
+          )
+      )
+
+  public val icon_2149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2149.xml"),
+          )
+      )
+
+  public val icon_21490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21490.xml"),
+          )
+      )
+
+  public val icon_21491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21491.xml"),
+          )
+      )
+
+  public val icon_21492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21492.xml"),
+          )
+      )
+
+  public val icon_21493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21493.xml"),
+          )
+      )
+
+  public val icon_21494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21494.xml"),
+          )
+      )
+
+  public val icon_21495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21495.xml"),
+          )
+      )
+
+  public val icon_21496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21496.xml"),
+          )
+      )
+
+  public val icon_21497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21497.xml"),
+          )
+      )
+
+  public val icon_21498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21498.xml"),
+          )
+      )
+
+  public val icon_21499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21499.xml"),
+          )
+      )
+
+  public val icon_215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_215.xml"),
+          )
+      )
+
+  public val icon_2150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2150.xml"),
+          )
+      )
+
+  public val icon_21500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21500.xml"),
+          )
+      )
+
+  public val icon_21501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21501.xml"),
+          )
+      )
+
+  public val icon_21502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21502.xml"),
+          )
+      )
+
+  public val icon_21503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21503.xml"),
+          )
+      )
+
+  public val icon_21504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21504.xml"),
+          )
+      )
+
+  public val icon_21505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21505.xml"),
+          )
+      )
+
+  public val icon_21506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21506.xml"),
+          )
+      )
+
+  public val icon_21507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21507.xml"),
+          )
+      )
+
+  public val icon_21508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21508.xml"),
+          )
+      )
+
+  public val icon_21509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21509.xml"),
+          )
+      )
+
+  public val icon_2151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2151.xml"),
+          )
+      )
+
+  public val icon_21510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21510.xml"),
+          )
+      )
+
+  public val icon_21511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21511.xml"),
+          )
+      )
+
+  public val icon_21512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21512.xml"),
+          )
+      )
+
+  public val icon_21513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21513.xml"),
+          )
+      )
+
+  public val icon_21514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21514.xml"),
+          )
+      )
+
+  public val icon_21515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21515.xml"),
+          )
+      )
+
+  public val icon_21516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21516.xml"),
+          )
+      )
+
+  public val icon_21517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21517.xml"),
+          )
+      )
+
+  public val icon_21518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21518.xml"),
+          )
+      )
+
+  public val icon_21519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21519.xml"),
+          )
+      )
+
+  public val icon_2152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2152.xml"),
+          )
+      )
+
+  public val icon_21520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21520.xml"),
+          )
+      )
+
+  public val icon_21521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21521.xml"),
+          )
+      )
+
+  public val icon_21522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21522.xml"),
+          )
+      )
+
+  public val icon_21523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21523.xml"),
+          )
+      )
+
+  public val icon_21524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21524.xml"),
+          )
+      )
+
+  public val icon_21525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21525.xml"),
+          )
+      )
+
+  public val icon_21526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21526.xml"),
+          )
+      )
+
+  public val icon_21527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21527.xml"),
+          )
+      )
+
+  public val icon_21528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21528.xml"),
+          )
+      )
+
+  public val icon_21529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21529.xml"),
+          )
+      )
+
+  public val icon_2153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2153.xml"),
+          )
+      )
+
+  public val icon_21530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21530.xml"),
+          )
+      )
+
+  public val icon_21531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21531.xml"),
+          )
+      )
+
+  public val icon_21532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21532.xml"),
+          )
+      )
+
+  public val icon_21533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21533.xml"),
+          )
+      )
+
+  public val icon_21534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21534.xml"),
+          )
+      )
+
+  public val icon_21535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21535.xml"),
+          )
+      )
+
+  public val icon_21536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21536.xml"),
+          )
+      )
+
+  public val icon_21537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21537.xml"),
+          )
+      )
+
+  public val icon_21538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21538.xml"),
+          )
+      )
+
+  public val icon_21539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21539.xml"),
+          )
+      )
+
+  public val icon_2154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2154.xml"),
+          )
+      )
+
+  public val icon_21540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21540.xml"),
+          )
+      )
+
+  public val icon_21541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21541.xml"),
+          )
+      )
+
+  public val icon_21542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21542.xml"),
+          )
+      )
+
+  public val icon_21543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21543.xml"),
+          )
+      )
+
+  public val icon_21544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21544.xml"),
+          )
+      )
+
+  public val icon_21545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21545.xml"),
+          )
+      )
+
+  public val icon_21546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21546.xml"),
+          )
+      )
+
+  public val icon_21547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21547.xml"),
+          )
+      )
+
+  public val icon_21548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21548.xml"),
+          )
+      )
+
+  public val icon_21549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21549.xml"),
+          )
+      )
+
+  public val icon_2155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2155.xml"),
+          )
+      )
+
+  public val icon_21550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21550.xml"),
+          )
+      )
+
+  public val icon_21551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21551.xml"),
+          )
+      )
+
+  public val icon_21552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21552.xml"),
+          )
+      )
+
+  public val icon_21553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21553.xml"),
+          )
+      )
+
+  public val icon_21554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21554.xml"),
+          )
+      )
+
+  public val icon_21555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21555.xml"),
+          )
+      )
+
+  public val icon_21556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21556.xml"),
+          )
+      )
+
+  public val icon_21557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21557.xml"),
+          )
+      )
+
+  public val icon_21558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21558.xml"),
+          )
+      )
+
+  public val icon_21559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21559.xml"),
+          )
+      )
+
+  public val icon_2156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2156.xml"),
+          )
+      )
+
+  public val icon_21560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21560.xml"),
+          )
+      )
+
+  public val icon_21561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21561.xml"),
+          )
+      )
+
+  public val icon_21562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21562.xml"),
+          )
+      )
+
+  public val icon_21563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21563.xml"),
+          )
+      )
+
+  public val icon_21564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21564.xml"),
+          )
+      )
+
+  public val icon_21565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21565.xml"),
+          )
+      )
+
+  public val icon_21566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21566.xml"),
+          )
+      )
+
+  public val icon_21567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21567.xml"),
+          )
+      )
+
+  public val icon_21568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21568.xml"),
+          )
+      )
+
+  public val icon_21569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21569.xml"),
+          )
+      )
+
+  public val icon_2157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2157.xml"),
+          )
+      )
+
+  public val icon_21570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21570.xml"),
+          )
+      )
+
+  public val icon_21571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21571.xml"),
+          )
+      )
+
+  public val icon_21572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21572.xml"),
+          )
+      )
+
+  public val icon_21573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21573.xml"),
+          )
+      )
+
+  public val icon_21574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21574.xml"),
+          )
+      )
+
+  public val icon_21575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21575.xml"),
+          )
+      )
+
+  public val icon_21576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21576.xml"),
+          )
+      )
+
+  public val icon_21577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21577.xml"),
+          )
+      )
+
+  public val icon_21578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21578.xml"),
+          )
+      )
+
+  public val icon_21579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21579.xml"),
+          )
+      )
+
+  public val icon_2158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2158.xml"),
+          )
+      )
+
+  public val icon_21580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21580.xml"),
+          )
+      )
+
+  public val icon_21581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21581.xml"),
+          )
+      )
+
+  public val icon_21582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21582.xml"),
+          )
+      )
+
+  public val icon_21583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21583.xml"),
+          )
+      )
+
+  public val icon_21584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21584.xml"),
+          )
+      )
+
+  public val icon_21585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21585.xml"),
+          )
+      )
+
+  public val icon_21586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21586.xml"),
+          )
+      )
+
+  public val icon_21587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21587.xml"),
+          )
+      )
+
+  public val icon_21588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21588.xml"),
+          )
+      )
+
+  public val icon_21589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21589.xml"),
+          )
+      )
+
+  public val icon_2159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2159.xml"),
+          )
+      )
+
+  public val icon_21590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21590.xml"),
+          )
+      )
+
+  public val icon_21591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21591.xml"),
+          )
+      )
+
+  public val icon_21592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21592.xml"),
+          )
+      )
+
+  public val icon_21593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21593.xml"),
+          )
+      )
+
+  public val icon_21594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21594.xml"),
+          )
+      )
+
+  public val icon_21595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21595.xml"),
+          )
+      )
+
+  public val icon_21596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21596.xml"),
+          )
+      )
+
+  public val icon_21597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21597.xml"),
+          )
+      )
+
+  public val icon_21598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21598.xml"),
+          )
+      )
+
+  public val icon_21599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21599.xml"),
+          )
+      )
+
+  public val icon_216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_216.xml"),
+          )
+      )
+
+  public val icon_2160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2160.xml"),
+          )
+      )
+
+  public val icon_21600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21600.xml"),
+          )
+      )
+
+  public val icon_21601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21601.xml"),
+          )
+      )
+
+  public val icon_21602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21602.xml"),
+          )
+      )
+
+  public val icon_21603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21603.xml"),
+          )
+      )
+
+  public val icon_21604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21604.xml"),
+          )
+      )
+
+  public val icon_21605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21605.xml"),
+          )
+      )
+
+  public val icon_21606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21606.xml"),
+          )
+      )
+
+  public val icon_21607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21607.xml"),
+          )
+      )
+
+  public val icon_21608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21608.xml"),
+          )
+      )
+
+  public val icon_21609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21609.xml"),
+          )
+      )
+
+  public val icon_2161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2161.xml"),
+          )
+      )
+
+  public val icon_21610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21610.xml"),
+          )
+      )
+
+  public val icon_21611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21611.xml"),
+          )
+      )
+
+  public val icon_21612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21612.xml"),
+          )
+      )
+
+  public val icon_21613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21613.xml"),
+          )
+      )
+
+  public val icon_21614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21614.xml"),
+          )
+      )
+
+  public val icon_21615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21615.xml"),
+          )
+      )
+
+  public val icon_21616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21616.xml"),
+          )
+      )
+
+  public val icon_21617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21617.xml"),
+          )
+      )
+
+  public val icon_21618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21618.xml"),
+          )
+      )
+
+  public val icon_21619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21619.xml"),
+          )
+      )
+
+  public val icon_2162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2162.xml"),
+          )
+      )
+
+  public val icon_21620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21620.xml"),
+          )
+      )
+
+  public val icon_21621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21621.xml"),
+          )
+      )
+
+  public val icon_21622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21622.xml"),
+          )
+      )
+
+  public val icon_21623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21623.xml"),
+          )
+      )
+
+  public val icon_21624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21624.xml"),
+          )
+      )
+
+  public val icon_21625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21625.xml"),
+          )
+      )
+
+  public val icon_21626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21626.xml"),
+          )
+      )
+
+  public val icon_21627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21627.xml"),
+          )
+      )
+
+  public val icon_21628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21628.xml"),
+          )
+      )
+
+  public val icon_21629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21629.xml"),
+          )
+      )
+
+  public val icon_2163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2163.xml"),
+          )
+      )
+
+  public val icon_21630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21630.xml"),
+          )
+      )
+
+  public val icon_21631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21631.xml"),
+          )
+      )
+
+  public val icon_21632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21632.xml"),
+          )
+      )
+
+  public val icon_21633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21633.xml"),
+          )
+      )
+
+  public val icon_21634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21634.xml"),
+          )
+      )
+
+  public val icon_21635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21635.xml"),
+          )
+      )
+
+  public val icon_21636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21636.xml"),
+          )
+      )
+
+  public val icon_21637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21637.xml"),
+          )
+      )
+
+  public val icon_21638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21638.xml"),
+          )
+      )
+
+  public val icon_21639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21639.xml"),
+          )
+      )
+
+  public val icon_2164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2164.xml"),
+          )
+      )
+
+  public val icon_21640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21640.xml"),
+          )
+      )
+
+  public val icon_21641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21641.xml"),
+          )
+      )
+
+  public val icon_21642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21642.xml"),
+          )
+      )
+
+  public val icon_21643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21643.xml"),
+          )
+      )
+
+  public val icon_21644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21644.xml"),
+          )
+      )
+
+  public val icon_21645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21645.xml"),
+          )
+      )
+
+  public val icon_21646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21646.xml"),
+          )
+      )
+
+  public val icon_21647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21647.xml"),
+          )
+      )
+
+  public val icon_21648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21648.xml"),
+          )
+      )
+
+  public val icon_21649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21649.xml"),
+          )
+      )
+
+  public val icon_2165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2165.xml"),
+          )
+      )
+
+  public val icon_21650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21650.xml"),
+          )
+      )
+
+  public val icon_21651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21651.xml"),
+          )
+      )
+
+  public val icon_21652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21652.xml"),
+          )
+      )
+
+  public val icon_21653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21653.xml"),
+          )
+      )
+
+  public val icon_21654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21654.xml"),
+          )
+      )
+
+  public val icon_21655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21655.xml"),
+          )
+      )
+
+  public val icon_21656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21656.xml"),
+          )
+      )
+
+  public val icon_21657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21657.xml"),
+          )
+      )
+
+  public val icon_21658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21658.xml"),
+          )
+      )
+
+  public val icon_21659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21659.xml"),
+          )
+      )
+
+  public val icon_2166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2166.xml"),
+          )
+      )
+
+  public val icon_21660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21660.xml"),
+          )
+      )
+
+  public val icon_21661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21661.xml"),
+          )
+      )
+
+  public val icon_21662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21662.xml"),
+          )
+      )
+
+  public val icon_21663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21663.xml"),
+          )
+      )
+
+  public val icon_21664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21664.xml"),
+          )
+      )
+
+  public val icon_21665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21665.xml"),
+          )
+      )
+
+  public val icon_21666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21666.xml"),
+          )
+      )
+
+  public val icon_21667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21667.xml"),
+          )
+      )
+
+  public val icon_21668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21668.xml"),
+          )
+      )
+
+  public val icon_21669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21669.xml"),
+          )
+      )
+
+  public val icon_2167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2167.xml"),
+          )
+      )
+
+  public val icon_21670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21670.xml"),
+          )
+      )
+
+  public val icon_21671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21671.xml"),
+          )
+      )
+
+  public val icon_21672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21672.xml"),
+          )
+      )
+
+  public val icon_21673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21673.xml"),
+          )
+      )
+
+  public val icon_21674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21674.xml"),
+          )
+      )
+
+  public val icon_21675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21675.xml"),
+          )
+      )
+
+  public val icon_21676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21676.xml"),
+          )
+      )
+
+  public val icon_21677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21677.xml"),
+          )
+      )
+
+  public val icon_21678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21678.xml"),
+          )
+      )
+
+  public val icon_21679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21679.xml"),
+          )
+      )
+
+  public val icon_2168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2168.xml"),
+          )
+      )
+
+  public val icon_21680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21680.xml"),
+          )
+      )
+
+  public val icon_21681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21681.xml"),
+          )
+      )
+
+  public val icon_21682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21682.xml"),
+          )
+      )
+
+  public val icon_21683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21683.xml"),
+          )
+      )
+
+  public val icon_21684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21684.xml"),
+          )
+      )
+
+  public val icon_21685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21685.xml"),
+          )
+      )
+
+  public val icon_21686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21686.xml"),
+          )
+      )
+
+  public val icon_21687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21687.xml"),
+          )
+      )
+
+  public val icon_21688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21688.xml"),
+          )
+      )
+
+  public val icon_21689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21689.xml"),
+          )
+      )
+
+  public val icon_2169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2169.xml"),
+          )
+      )
+
+  public val icon_21690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21690.xml"),
+          )
+      )
+
+  public val icon_21691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21691.xml"),
+          )
+      )
+
+  public val icon_21692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21692.xml"),
+          )
+      )
+
+  public val icon_21693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21693.xml"),
+          )
+      )
+
+  public val icon_21694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21694.xml"),
+          )
+      )
+
+  public val icon_21695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21695.xml"),
+          )
+      )
+
+  public val icon_21696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21696.xml"),
+          )
+      )
+
+  public val icon_21697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21697.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21247: DrawableResource
+  get() = Drawable25.icon_21247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21248: DrawableResource
+  get() = Drawable25.icon_21248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21249: DrawableResource
+  get() = Drawable25.icon_21249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2125: DrawableResource
+  get() = Drawable25.icon_2125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21250: DrawableResource
+  get() = Drawable25.icon_21250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21251: DrawableResource
+  get() = Drawable25.icon_21251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21252: DrawableResource
+  get() = Drawable25.icon_21252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21253: DrawableResource
+  get() = Drawable25.icon_21253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21254: DrawableResource
+  get() = Drawable25.icon_21254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21255: DrawableResource
+  get() = Drawable25.icon_21255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21256: DrawableResource
+  get() = Drawable25.icon_21256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21257: DrawableResource
+  get() = Drawable25.icon_21257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21258: DrawableResource
+  get() = Drawable25.icon_21258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21259: DrawableResource
+  get() = Drawable25.icon_21259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2126: DrawableResource
+  get() = Drawable25.icon_2126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21260: DrawableResource
+  get() = Drawable25.icon_21260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21261: DrawableResource
+  get() = Drawable25.icon_21261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21262: DrawableResource
+  get() = Drawable25.icon_21262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21263: DrawableResource
+  get() = Drawable25.icon_21263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21264: DrawableResource
+  get() = Drawable25.icon_21264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21265: DrawableResource
+  get() = Drawable25.icon_21265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21266: DrawableResource
+  get() = Drawable25.icon_21266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21267: DrawableResource
+  get() = Drawable25.icon_21267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21268: DrawableResource
+  get() = Drawable25.icon_21268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21269: DrawableResource
+  get() = Drawable25.icon_21269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2127: DrawableResource
+  get() = Drawable25.icon_2127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21270: DrawableResource
+  get() = Drawable25.icon_21270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21271: DrawableResource
+  get() = Drawable25.icon_21271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21272: DrawableResource
+  get() = Drawable25.icon_21272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21273: DrawableResource
+  get() = Drawable25.icon_21273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21274: DrawableResource
+  get() = Drawable25.icon_21274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21275: DrawableResource
+  get() = Drawable25.icon_21275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21276: DrawableResource
+  get() = Drawable25.icon_21276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21277: DrawableResource
+  get() = Drawable25.icon_21277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21278: DrawableResource
+  get() = Drawable25.icon_21278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21279: DrawableResource
+  get() = Drawable25.icon_21279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2128: DrawableResource
+  get() = Drawable25.icon_2128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21280: DrawableResource
+  get() = Drawable25.icon_21280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21281: DrawableResource
+  get() = Drawable25.icon_21281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21282: DrawableResource
+  get() = Drawable25.icon_21282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21283: DrawableResource
+  get() = Drawable25.icon_21283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21284: DrawableResource
+  get() = Drawable25.icon_21284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21285: DrawableResource
+  get() = Drawable25.icon_21285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21286: DrawableResource
+  get() = Drawable25.icon_21286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21287: DrawableResource
+  get() = Drawable25.icon_21287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21288: DrawableResource
+  get() = Drawable25.icon_21288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21289: DrawableResource
+  get() = Drawable25.icon_21289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2129: DrawableResource
+  get() = Drawable25.icon_2129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21290: DrawableResource
+  get() = Drawable25.icon_21290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21291: DrawableResource
+  get() = Drawable25.icon_21291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21292: DrawableResource
+  get() = Drawable25.icon_21292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21293: DrawableResource
+  get() = Drawable25.icon_21293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21294: DrawableResource
+  get() = Drawable25.icon_21294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21295: DrawableResource
+  get() = Drawable25.icon_21295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21296: DrawableResource
+  get() = Drawable25.icon_21296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21297: DrawableResource
+  get() = Drawable25.icon_21297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21298: DrawableResource
+  get() = Drawable25.icon_21298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21299: DrawableResource
+  get() = Drawable25.icon_21299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_213: DrawableResource
+  get() = Drawable25.icon_213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2130: DrawableResource
+  get() = Drawable25.icon_2130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21300: DrawableResource
+  get() = Drawable25.icon_21300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21301: DrawableResource
+  get() = Drawable25.icon_21301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21302: DrawableResource
+  get() = Drawable25.icon_21302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21303: DrawableResource
+  get() = Drawable25.icon_21303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21304: DrawableResource
+  get() = Drawable25.icon_21304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21305: DrawableResource
+  get() = Drawable25.icon_21305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21306: DrawableResource
+  get() = Drawable25.icon_21306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21307: DrawableResource
+  get() = Drawable25.icon_21307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21308: DrawableResource
+  get() = Drawable25.icon_21308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21309: DrawableResource
+  get() = Drawable25.icon_21309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2131: DrawableResource
+  get() = Drawable25.icon_2131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21310: DrawableResource
+  get() = Drawable25.icon_21310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21311: DrawableResource
+  get() = Drawable25.icon_21311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21312: DrawableResource
+  get() = Drawable25.icon_21312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21313: DrawableResource
+  get() = Drawable25.icon_21313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21314: DrawableResource
+  get() = Drawable25.icon_21314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21315: DrawableResource
+  get() = Drawable25.icon_21315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21316: DrawableResource
+  get() = Drawable25.icon_21316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21317: DrawableResource
+  get() = Drawable25.icon_21317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21318: DrawableResource
+  get() = Drawable25.icon_21318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21319: DrawableResource
+  get() = Drawable25.icon_21319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2132: DrawableResource
+  get() = Drawable25.icon_2132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21320: DrawableResource
+  get() = Drawable25.icon_21320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21321: DrawableResource
+  get() = Drawable25.icon_21321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21322: DrawableResource
+  get() = Drawable25.icon_21322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21323: DrawableResource
+  get() = Drawable25.icon_21323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21324: DrawableResource
+  get() = Drawable25.icon_21324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21325: DrawableResource
+  get() = Drawable25.icon_21325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21326: DrawableResource
+  get() = Drawable25.icon_21326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21327: DrawableResource
+  get() = Drawable25.icon_21327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21328: DrawableResource
+  get() = Drawable25.icon_21328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21329: DrawableResource
+  get() = Drawable25.icon_21329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2133: DrawableResource
+  get() = Drawable25.icon_2133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21330: DrawableResource
+  get() = Drawable25.icon_21330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21331: DrawableResource
+  get() = Drawable25.icon_21331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21332: DrawableResource
+  get() = Drawable25.icon_21332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21333: DrawableResource
+  get() = Drawable25.icon_21333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21334: DrawableResource
+  get() = Drawable25.icon_21334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21335: DrawableResource
+  get() = Drawable25.icon_21335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21336: DrawableResource
+  get() = Drawable25.icon_21336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21337: DrawableResource
+  get() = Drawable25.icon_21337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21338: DrawableResource
+  get() = Drawable25.icon_21338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21339: DrawableResource
+  get() = Drawable25.icon_21339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2134: DrawableResource
+  get() = Drawable25.icon_2134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21340: DrawableResource
+  get() = Drawable25.icon_21340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21341: DrawableResource
+  get() = Drawable25.icon_21341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21342: DrawableResource
+  get() = Drawable25.icon_21342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21343: DrawableResource
+  get() = Drawable25.icon_21343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21344: DrawableResource
+  get() = Drawable25.icon_21344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21345: DrawableResource
+  get() = Drawable25.icon_21345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21346: DrawableResource
+  get() = Drawable25.icon_21346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21347: DrawableResource
+  get() = Drawable25.icon_21347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21348: DrawableResource
+  get() = Drawable25.icon_21348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21349: DrawableResource
+  get() = Drawable25.icon_21349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2135: DrawableResource
+  get() = Drawable25.icon_2135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21350: DrawableResource
+  get() = Drawable25.icon_21350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21351: DrawableResource
+  get() = Drawable25.icon_21351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21352: DrawableResource
+  get() = Drawable25.icon_21352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21353: DrawableResource
+  get() = Drawable25.icon_21353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21354: DrawableResource
+  get() = Drawable25.icon_21354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21355: DrawableResource
+  get() = Drawable25.icon_21355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21356: DrawableResource
+  get() = Drawable25.icon_21356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21357: DrawableResource
+  get() = Drawable25.icon_21357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21358: DrawableResource
+  get() = Drawable25.icon_21358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21359: DrawableResource
+  get() = Drawable25.icon_21359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2136: DrawableResource
+  get() = Drawable25.icon_2136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21360: DrawableResource
+  get() = Drawable25.icon_21360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21361: DrawableResource
+  get() = Drawable25.icon_21361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21362: DrawableResource
+  get() = Drawable25.icon_21362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21363: DrawableResource
+  get() = Drawable25.icon_21363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21364: DrawableResource
+  get() = Drawable25.icon_21364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21365: DrawableResource
+  get() = Drawable25.icon_21365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21366: DrawableResource
+  get() = Drawable25.icon_21366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21367: DrawableResource
+  get() = Drawable25.icon_21367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21368: DrawableResource
+  get() = Drawable25.icon_21368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21369: DrawableResource
+  get() = Drawable25.icon_21369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2137: DrawableResource
+  get() = Drawable25.icon_2137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21370: DrawableResource
+  get() = Drawable25.icon_21370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21371: DrawableResource
+  get() = Drawable25.icon_21371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21372: DrawableResource
+  get() = Drawable25.icon_21372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21373: DrawableResource
+  get() = Drawable25.icon_21373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21374: DrawableResource
+  get() = Drawable25.icon_21374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21375: DrawableResource
+  get() = Drawable25.icon_21375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21376: DrawableResource
+  get() = Drawable25.icon_21376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21377: DrawableResource
+  get() = Drawable25.icon_21377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21378: DrawableResource
+  get() = Drawable25.icon_21378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21379: DrawableResource
+  get() = Drawable25.icon_21379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2138: DrawableResource
+  get() = Drawable25.icon_2138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21380: DrawableResource
+  get() = Drawable25.icon_21380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21381: DrawableResource
+  get() = Drawable25.icon_21381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21382: DrawableResource
+  get() = Drawable25.icon_21382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21383: DrawableResource
+  get() = Drawable25.icon_21383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21384: DrawableResource
+  get() = Drawable25.icon_21384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21385: DrawableResource
+  get() = Drawable25.icon_21385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21386: DrawableResource
+  get() = Drawable25.icon_21386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21387: DrawableResource
+  get() = Drawable25.icon_21387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21388: DrawableResource
+  get() = Drawable25.icon_21388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21389: DrawableResource
+  get() = Drawable25.icon_21389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2139: DrawableResource
+  get() = Drawable25.icon_2139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21390: DrawableResource
+  get() = Drawable25.icon_21390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21391: DrawableResource
+  get() = Drawable25.icon_21391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21392: DrawableResource
+  get() = Drawable25.icon_21392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21393: DrawableResource
+  get() = Drawable25.icon_21393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21394: DrawableResource
+  get() = Drawable25.icon_21394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21395: DrawableResource
+  get() = Drawable25.icon_21395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21396: DrawableResource
+  get() = Drawable25.icon_21396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21397: DrawableResource
+  get() = Drawable25.icon_21397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21398: DrawableResource
+  get() = Drawable25.icon_21398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21399: DrawableResource
+  get() = Drawable25.icon_21399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_214: DrawableResource
+  get() = Drawable25.icon_214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2140: DrawableResource
+  get() = Drawable25.icon_2140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21400: DrawableResource
+  get() = Drawable25.icon_21400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21401: DrawableResource
+  get() = Drawable25.icon_21401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21402: DrawableResource
+  get() = Drawable25.icon_21402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21403: DrawableResource
+  get() = Drawable25.icon_21403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21404: DrawableResource
+  get() = Drawable25.icon_21404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21405: DrawableResource
+  get() = Drawable25.icon_21405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21406: DrawableResource
+  get() = Drawable25.icon_21406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21407: DrawableResource
+  get() = Drawable25.icon_21407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21408: DrawableResource
+  get() = Drawable25.icon_21408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21409: DrawableResource
+  get() = Drawable25.icon_21409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2141: DrawableResource
+  get() = Drawable25.icon_2141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21410: DrawableResource
+  get() = Drawable25.icon_21410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21411: DrawableResource
+  get() = Drawable25.icon_21411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21412: DrawableResource
+  get() = Drawable25.icon_21412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21413: DrawableResource
+  get() = Drawable25.icon_21413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21414: DrawableResource
+  get() = Drawable25.icon_21414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21415: DrawableResource
+  get() = Drawable25.icon_21415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21416: DrawableResource
+  get() = Drawable25.icon_21416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21417: DrawableResource
+  get() = Drawable25.icon_21417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21418: DrawableResource
+  get() = Drawable25.icon_21418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21419: DrawableResource
+  get() = Drawable25.icon_21419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2142: DrawableResource
+  get() = Drawable25.icon_2142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21420: DrawableResource
+  get() = Drawable25.icon_21420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21421: DrawableResource
+  get() = Drawable25.icon_21421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21422: DrawableResource
+  get() = Drawable25.icon_21422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21423: DrawableResource
+  get() = Drawable25.icon_21423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21424: DrawableResource
+  get() = Drawable25.icon_21424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21425: DrawableResource
+  get() = Drawable25.icon_21425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21426: DrawableResource
+  get() = Drawable25.icon_21426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21427: DrawableResource
+  get() = Drawable25.icon_21427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21428: DrawableResource
+  get() = Drawable25.icon_21428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21429: DrawableResource
+  get() = Drawable25.icon_21429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2143: DrawableResource
+  get() = Drawable25.icon_2143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21430: DrawableResource
+  get() = Drawable25.icon_21430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21431: DrawableResource
+  get() = Drawable25.icon_21431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21432: DrawableResource
+  get() = Drawable25.icon_21432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21433: DrawableResource
+  get() = Drawable25.icon_21433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21434: DrawableResource
+  get() = Drawable25.icon_21434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21435: DrawableResource
+  get() = Drawable25.icon_21435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21436: DrawableResource
+  get() = Drawable25.icon_21436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21437: DrawableResource
+  get() = Drawable25.icon_21437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21438: DrawableResource
+  get() = Drawable25.icon_21438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21439: DrawableResource
+  get() = Drawable25.icon_21439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2144: DrawableResource
+  get() = Drawable25.icon_2144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21440: DrawableResource
+  get() = Drawable25.icon_21440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21441: DrawableResource
+  get() = Drawable25.icon_21441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21442: DrawableResource
+  get() = Drawable25.icon_21442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21443: DrawableResource
+  get() = Drawable25.icon_21443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21444: DrawableResource
+  get() = Drawable25.icon_21444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21445: DrawableResource
+  get() = Drawable25.icon_21445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21446: DrawableResource
+  get() = Drawable25.icon_21446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21447: DrawableResource
+  get() = Drawable25.icon_21447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21448: DrawableResource
+  get() = Drawable25.icon_21448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21449: DrawableResource
+  get() = Drawable25.icon_21449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2145: DrawableResource
+  get() = Drawable25.icon_2145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21450: DrawableResource
+  get() = Drawable25.icon_21450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21451: DrawableResource
+  get() = Drawable25.icon_21451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21452: DrawableResource
+  get() = Drawable25.icon_21452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21453: DrawableResource
+  get() = Drawable25.icon_21453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21454: DrawableResource
+  get() = Drawable25.icon_21454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21455: DrawableResource
+  get() = Drawable25.icon_21455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21456: DrawableResource
+  get() = Drawable25.icon_21456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21457: DrawableResource
+  get() = Drawable25.icon_21457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21458: DrawableResource
+  get() = Drawable25.icon_21458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21459: DrawableResource
+  get() = Drawable25.icon_21459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2146: DrawableResource
+  get() = Drawable25.icon_2146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21460: DrawableResource
+  get() = Drawable25.icon_21460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21461: DrawableResource
+  get() = Drawable25.icon_21461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21462: DrawableResource
+  get() = Drawable25.icon_21462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21463: DrawableResource
+  get() = Drawable25.icon_21463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21464: DrawableResource
+  get() = Drawable25.icon_21464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21465: DrawableResource
+  get() = Drawable25.icon_21465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21466: DrawableResource
+  get() = Drawable25.icon_21466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21467: DrawableResource
+  get() = Drawable25.icon_21467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21468: DrawableResource
+  get() = Drawable25.icon_21468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21469: DrawableResource
+  get() = Drawable25.icon_21469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2147: DrawableResource
+  get() = Drawable25.icon_2147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21470: DrawableResource
+  get() = Drawable25.icon_21470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21471: DrawableResource
+  get() = Drawable25.icon_21471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21472: DrawableResource
+  get() = Drawable25.icon_21472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21473: DrawableResource
+  get() = Drawable25.icon_21473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21474: DrawableResource
+  get() = Drawable25.icon_21474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21475: DrawableResource
+  get() = Drawable25.icon_21475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21476: DrawableResource
+  get() = Drawable25.icon_21476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21477: DrawableResource
+  get() = Drawable25.icon_21477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21478: DrawableResource
+  get() = Drawable25.icon_21478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21479: DrawableResource
+  get() = Drawable25.icon_21479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2148: DrawableResource
+  get() = Drawable25.icon_2148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21480: DrawableResource
+  get() = Drawable25.icon_21480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21481: DrawableResource
+  get() = Drawable25.icon_21481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21482: DrawableResource
+  get() = Drawable25.icon_21482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21483: DrawableResource
+  get() = Drawable25.icon_21483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21484: DrawableResource
+  get() = Drawable25.icon_21484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21485: DrawableResource
+  get() = Drawable25.icon_21485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21486: DrawableResource
+  get() = Drawable25.icon_21486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21487: DrawableResource
+  get() = Drawable25.icon_21487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21488: DrawableResource
+  get() = Drawable25.icon_21488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21489: DrawableResource
+  get() = Drawable25.icon_21489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2149: DrawableResource
+  get() = Drawable25.icon_2149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21490: DrawableResource
+  get() = Drawable25.icon_21490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21491: DrawableResource
+  get() = Drawable25.icon_21491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21492: DrawableResource
+  get() = Drawable25.icon_21492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21493: DrawableResource
+  get() = Drawable25.icon_21493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21494: DrawableResource
+  get() = Drawable25.icon_21494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21495: DrawableResource
+  get() = Drawable25.icon_21495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21496: DrawableResource
+  get() = Drawable25.icon_21496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21497: DrawableResource
+  get() = Drawable25.icon_21497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21498: DrawableResource
+  get() = Drawable25.icon_21498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21499: DrawableResource
+  get() = Drawable25.icon_21499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_215: DrawableResource
+  get() = Drawable25.icon_215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2150: DrawableResource
+  get() = Drawable25.icon_2150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21500: DrawableResource
+  get() = Drawable25.icon_21500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21501: DrawableResource
+  get() = Drawable25.icon_21501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21502: DrawableResource
+  get() = Drawable25.icon_21502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21503: DrawableResource
+  get() = Drawable25.icon_21503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21504: DrawableResource
+  get() = Drawable25.icon_21504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21505: DrawableResource
+  get() = Drawable25.icon_21505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21506: DrawableResource
+  get() = Drawable25.icon_21506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21507: DrawableResource
+  get() = Drawable25.icon_21507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21508: DrawableResource
+  get() = Drawable25.icon_21508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21509: DrawableResource
+  get() = Drawable25.icon_21509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2151: DrawableResource
+  get() = Drawable25.icon_2151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21510: DrawableResource
+  get() = Drawable25.icon_21510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21511: DrawableResource
+  get() = Drawable25.icon_21511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21512: DrawableResource
+  get() = Drawable25.icon_21512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21513: DrawableResource
+  get() = Drawable25.icon_21513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21514: DrawableResource
+  get() = Drawable25.icon_21514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21515: DrawableResource
+  get() = Drawable25.icon_21515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21516: DrawableResource
+  get() = Drawable25.icon_21516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21517: DrawableResource
+  get() = Drawable25.icon_21517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21518: DrawableResource
+  get() = Drawable25.icon_21518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21519: DrawableResource
+  get() = Drawable25.icon_21519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2152: DrawableResource
+  get() = Drawable25.icon_2152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21520: DrawableResource
+  get() = Drawable25.icon_21520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21521: DrawableResource
+  get() = Drawable25.icon_21521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21522: DrawableResource
+  get() = Drawable25.icon_21522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21523: DrawableResource
+  get() = Drawable25.icon_21523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21524: DrawableResource
+  get() = Drawable25.icon_21524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21525: DrawableResource
+  get() = Drawable25.icon_21525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21526: DrawableResource
+  get() = Drawable25.icon_21526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21527: DrawableResource
+  get() = Drawable25.icon_21527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21528: DrawableResource
+  get() = Drawable25.icon_21528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21529: DrawableResource
+  get() = Drawable25.icon_21529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2153: DrawableResource
+  get() = Drawable25.icon_2153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21530: DrawableResource
+  get() = Drawable25.icon_21530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21531: DrawableResource
+  get() = Drawable25.icon_21531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21532: DrawableResource
+  get() = Drawable25.icon_21532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21533: DrawableResource
+  get() = Drawable25.icon_21533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21534: DrawableResource
+  get() = Drawable25.icon_21534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21535: DrawableResource
+  get() = Drawable25.icon_21535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21536: DrawableResource
+  get() = Drawable25.icon_21536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21537: DrawableResource
+  get() = Drawable25.icon_21537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21538: DrawableResource
+  get() = Drawable25.icon_21538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21539: DrawableResource
+  get() = Drawable25.icon_21539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2154: DrawableResource
+  get() = Drawable25.icon_2154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21540: DrawableResource
+  get() = Drawable25.icon_21540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21541: DrawableResource
+  get() = Drawable25.icon_21541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21542: DrawableResource
+  get() = Drawable25.icon_21542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21543: DrawableResource
+  get() = Drawable25.icon_21543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21544: DrawableResource
+  get() = Drawable25.icon_21544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21545: DrawableResource
+  get() = Drawable25.icon_21545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21546: DrawableResource
+  get() = Drawable25.icon_21546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21547: DrawableResource
+  get() = Drawable25.icon_21547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21548: DrawableResource
+  get() = Drawable25.icon_21548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21549: DrawableResource
+  get() = Drawable25.icon_21549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2155: DrawableResource
+  get() = Drawable25.icon_2155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21550: DrawableResource
+  get() = Drawable25.icon_21550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21551: DrawableResource
+  get() = Drawable25.icon_21551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21552: DrawableResource
+  get() = Drawable25.icon_21552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21553: DrawableResource
+  get() = Drawable25.icon_21553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21554: DrawableResource
+  get() = Drawable25.icon_21554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21555: DrawableResource
+  get() = Drawable25.icon_21555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21556: DrawableResource
+  get() = Drawable25.icon_21556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21557: DrawableResource
+  get() = Drawable25.icon_21557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21558: DrawableResource
+  get() = Drawable25.icon_21558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21559: DrawableResource
+  get() = Drawable25.icon_21559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2156: DrawableResource
+  get() = Drawable25.icon_2156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21560: DrawableResource
+  get() = Drawable25.icon_21560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21561: DrawableResource
+  get() = Drawable25.icon_21561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21562: DrawableResource
+  get() = Drawable25.icon_21562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21563: DrawableResource
+  get() = Drawable25.icon_21563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21564: DrawableResource
+  get() = Drawable25.icon_21564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21565: DrawableResource
+  get() = Drawable25.icon_21565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21566: DrawableResource
+  get() = Drawable25.icon_21566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21567: DrawableResource
+  get() = Drawable25.icon_21567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21568: DrawableResource
+  get() = Drawable25.icon_21568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21569: DrawableResource
+  get() = Drawable25.icon_21569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2157: DrawableResource
+  get() = Drawable25.icon_2157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21570: DrawableResource
+  get() = Drawable25.icon_21570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21571: DrawableResource
+  get() = Drawable25.icon_21571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21572: DrawableResource
+  get() = Drawable25.icon_21572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21573: DrawableResource
+  get() = Drawable25.icon_21573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21574: DrawableResource
+  get() = Drawable25.icon_21574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21575: DrawableResource
+  get() = Drawable25.icon_21575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21576: DrawableResource
+  get() = Drawable25.icon_21576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21577: DrawableResource
+  get() = Drawable25.icon_21577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21578: DrawableResource
+  get() = Drawable25.icon_21578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21579: DrawableResource
+  get() = Drawable25.icon_21579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2158: DrawableResource
+  get() = Drawable25.icon_2158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21580: DrawableResource
+  get() = Drawable25.icon_21580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21581: DrawableResource
+  get() = Drawable25.icon_21581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21582: DrawableResource
+  get() = Drawable25.icon_21582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21583: DrawableResource
+  get() = Drawable25.icon_21583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21584: DrawableResource
+  get() = Drawable25.icon_21584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21585: DrawableResource
+  get() = Drawable25.icon_21585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21586: DrawableResource
+  get() = Drawable25.icon_21586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21587: DrawableResource
+  get() = Drawable25.icon_21587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21588: DrawableResource
+  get() = Drawable25.icon_21588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21589: DrawableResource
+  get() = Drawable25.icon_21589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2159: DrawableResource
+  get() = Drawable25.icon_2159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21590: DrawableResource
+  get() = Drawable25.icon_21590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21591: DrawableResource
+  get() = Drawable25.icon_21591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21592: DrawableResource
+  get() = Drawable25.icon_21592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21593: DrawableResource
+  get() = Drawable25.icon_21593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21594: DrawableResource
+  get() = Drawable25.icon_21594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21595: DrawableResource
+  get() = Drawable25.icon_21595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21596: DrawableResource
+  get() = Drawable25.icon_21596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21597: DrawableResource
+  get() = Drawable25.icon_21597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21598: DrawableResource
+  get() = Drawable25.icon_21598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21599: DrawableResource
+  get() = Drawable25.icon_21599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_216: DrawableResource
+  get() = Drawable25.icon_216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2160: DrawableResource
+  get() = Drawable25.icon_2160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21600: DrawableResource
+  get() = Drawable25.icon_21600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21601: DrawableResource
+  get() = Drawable25.icon_21601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21602: DrawableResource
+  get() = Drawable25.icon_21602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21603: DrawableResource
+  get() = Drawable25.icon_21603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21604: DrawableResource
+  get() = Drawable25.icon_21604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21605: DrawableResource
+  get() = Drawable25.icon_21605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21606: DrawableResource
+  get() = Drawable25.icon_21606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21607: DrawableResource
+  get() = Drawable25.icon_21607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21608: DrawableResource
+  get() = Drawable25.icon_21608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21609: DrawableResource
+  get() = Drawable25.icon_21609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2161: DrawableResource
+  get() = Drawable25.icon_2161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21610: DrawableResource
+  get() = Drawable25.icon_21610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21611: DrawableResource
+  get() = Drawable25.icon_21611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21612: DrawableResource
+  get() = Drawable25.icon_21612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21613: DrawableResource
+  get() = Drawable25.icon_21613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21614: DrawableResource
+  get() = Drawable25.icon_21614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21615: DrawableResource
+  get() = Drawable25.icon_21615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21616: DrawableResource
+  get() = Drawable25.icon_21616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21617: DrawableResource
+  get() = Drawable25.icon_21617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21618: DrawableResource
+  get() = Drawable25.icon_21618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21619: DrawableResource
+  get() = Drawable25.icon_21619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2162: DrawableResource
+  get() = Drawable25.icon_2162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21620: DrawableResource
+  get() = Drawable25.icon_21620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21621: DrawableResource
+  get() = Drawable25.icon_21621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21622: DrawableResource
+  get() = Drawable25.icon_21622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21623: DrawableResource
+  get() = Drawable25.icon_21623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21624: DrawableResource
+  get() = Drawable25.icon_21624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21625: DrawableResource
+  get() = Drawable25.icon_21625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21626: DrawableResource
+  get() = Drawable25.icon_21626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21627: DrawableResource
+  get() = Drawable25.icon_21627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21628: DrawableResource
+  get() = Drawable25.icon_21628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21629: DrawableResource
+  get() = Drawable25.icon_21629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2163: DrawableResource
+  get() = Drawable25.icon_2163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21630: DrawableResource
+  get() = Drawable25.icon_21630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21631: DrawableResource
+  get() = Drawable25.icon_21631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21632: DrawableResource
+  get() = Drawable25.icon_21632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21633: DrawableResource
+  get() = Drawable25.icon_21633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21634: DrawableResource
+  get() = Drawable25.icon_21634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21635: DrawableResource
+  get() = Drawable25.icon_21635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21636: DrawableResource
+  get() = Drawable25.icon_21636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21637: DrawableResource
+  get() = Drawable25.icon_21637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21638: DrawableResource
+  get() = Drawable25.icon_21638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21639: DrawableResource
+  get() = Drawable25.icon_21639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2164: DrawableResource
+  get() = Drawable25.icon_2164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21640: DrawableResource
+  get() = Drawable25.icon_21640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21641: DrawableResource
+  get() = Drawable25.icon_21641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21642: DrawableResource
+  get() = Drawable25.icon_21642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21643: DrawableResource
+  get() = Drawable25.icon_21643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21644: DrawableResource
+  get() = Drawable25.icon_21644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21645: DrawableResource
+  get() = Drawable25.icon_21645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21646: DrawableResource
+  get() = Drawable25.icon_21646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21647: DrawableResource
+  get() = Drawable25.icon_21647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21648: DrawableResource
+  get() = Drawable25.icon_21648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21649: DrawableResource
+  get() = Drawable25.icon_21649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2165: DrawableResource
+  get() = Drawable25.icon_2165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21650: DrawableResource
+  get() = Drawable25.icon_21650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21651: DrawableResource
+  get() = Drawable25.icon_21651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21652: DrawableResource
+  get() = Drawable25.icon_21652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21653: DrawableResource
+  get() = Drawable25.icon_21653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21654: DrawableResource
+  get() = Drawable25.icon_21654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21655: DrawableResource
+  get() = Drawable25.icon_21655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21656: DrawableResource
+  get() = Drawable25.icon_21656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21657: DrawableResource
+  get() = Drawable25.icon_21657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21658: DrawableResource
+  get() = Drawable25.icon_21658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21659: DrawableResource
+  get() = Drawable25.icon_21659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2166: DrawableResource
+  get() = Drawable25.icon_2166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21660: DrawableResource
+  get() = Drawable25.icon_21660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21661: DrawableResource
+  get() = Drawable25.icon_21661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21662: DrawableResource
+  get() = Drawable25.icon_21662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21663: DrawableResource
+  get() = Drawable25.icon_21663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21664: DrawableResource
+  get() = Drawable25.icon_21664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21665: DrawableResource
+  get() = Drawable25.icon_21665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21666: DrawableResource
+  get() = Drawable25.icon_21666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21667: DrawableResource
+  get() = Drawable25.icon_21667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21668: DrawableResource
+  get() = Drawable25.icon_21668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21669: DrawableResource
+  get() = Drawable25.icon_21669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2167: DrawableResource
+  get() = Drawable25.icon_2167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21670: DrawableResource
+  get() = Drawable25.icon_21670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21671: DrawableResource
+  get() = Drawable25.icon_21671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21672: DrawableResource
+  get() = Drawable25.icon_21672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21673: DrawableResource
+  get() = Drawable25.icon_21673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21674: DrawableResource
+  get() = Drawable25.icon_21674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21675: DrawableResource
+  get() = Drawable25.icon_21675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21676: DrawableResource
+  get() = Drawable25.icon_21676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21677: DrawableResource
+  get() = Drawable25.icon_21677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21678: DrawableResource
+  get() = Drawable25.icon_21678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21679: DrawableResource
+  get() = Drawable25.icon_21679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2168: DrawableResource
+  get() = Drawable25.icon_2168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21680: DrawableResource
+  get() = Drawable25.icon_21680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21681: DrawableResource
+  get() = Drawable25.icon_21681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21682: DrawableResource
+  get() = Drawable25.icon_21682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21683: DrawableResource
+  get() = Drawable25.icon_21683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21684: DrawableResource
+  get() = Drawable25.icon_21684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21685: DrawableResource
+  get() = Drawable25.icon_21685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21686: DrawableResource
+  get() = Drawable25.icon_21686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21687: DrawableResource
+  get() = Drawable25.icon_21687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21688: DrawableResource
+  get() = Drawable25.icon_21688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21689: DrawableResource
+  get() = Drawable25.icon_21689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2169: DrawableResource
+  get() = Drawable25.icon_2169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21690: DrawableResource
+  get() = Drawable25.icon_21690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21691: DrawableResource
+  get() = Drawable25.icon_21691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21692: DrawableResource
+  get() = Drawable25.icon_21692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21693: DrawableResource
+  get() = Drawable25.icon_21693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21694: DrawableResource
+  get() = Drawable25.icon_21694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21695: DrawableResource
+  get() = Drawable25.icon_21695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21696: DrawableResource
+  get() = Drawable25.icon_21696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21697: DrawableResource
+  get() = Drawable25.icon_21697

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable26.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable26.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable26 {
+  public val icon_21698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21698.xml"),
+          )
+      )
+
+  public val icon_21699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21699.xml"),
+          )
+      )
+
+  public val icon_217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_217.xml"),
+          )
+      )
+
+  public val icon_2170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2170.xml"),
+          )
+      )
+
+  public val icon_21700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21700.xml"),
+          )
+      )
+
+  public val icon_21701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21701.xml"),
+          )
+      )
+
+  public val icon_21702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21702.xml"),
+          )
+      )
+
+  public val icon_21703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21703.xml"),
+          )
+      )
+
+  public val icon_21704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21704.xml"),
+          )
+      )
+
+  public val icon_21705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21705.xml"),
+          )
+      )
+
+  public val icon_21706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21706.xml"),
+          )
+      )
+
+  public val icon_21707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21707.xml"),
+          )
+      )
+
+  public val icon_21708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21708.xml"),
+          )
+      )
+
+  public val icon_21709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21709.xml"),
+          )
+      )
+
+  public val icon_2171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2171.xml"),
+          )
+      )
+
+  public val icon_21710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21710.xml"),
+          )
+      )
+
+  public val icon_21711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21711.xml"),
+          )
+      )
+
+  public val icon_21712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21712.xml"),
+          )
+      )
+
+  public val icon_21713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21713.xml"),
+          )
+      )
+
+  public val icon_21714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21714.xml"),
+          )
+      )
+
+  public val icon_21715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21715.xml"),
+          )
+      )
+
+  public val icon_21716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21716.xml"),
+          )
+      )
+
+  public val icon_21717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21717.xml"),
+          )
+      )
+
+  public val icon_21718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21718.xml"),
+          )
+      )
+
+  public val icon_21719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21719.xml"),
+          )
+      )
+
+  public val icon_2172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2172.xml"),
+          )
+      )
+
+  public val icon_21720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21720.xml"),
+          )
+      )
+
+  public val icon_21721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21721.xml"),
+          )
+      )
+
+  public val icon_21722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21722.xml"),
+          )
+      )
+
+  public val icon_21723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21723.xml"),
+          )
+      )
+
+  public val icon_21724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21724.xml"),
+          )
+      )
+
+  public val icon_21725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21725.xml"),
+          )
+      )
+
+  public val icon_21726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21726.xml"),
+          )
+      )
+
+  public val icon_21727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21727.xml"),
+          )
+      )
+
+  public val icon_21728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21728.xml"),
+          )
+      )
+
+  public val icon_21729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21729.xml"),
+          )
+      )
+
+  public val icon_2173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2173.xml"),
+          )
+      )
+
+  public val icon_21730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21730.xml"),
+          )
+      )
+
+  public val icon_21731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21731.xml"),
+          )
+      )
+
+  public val icon_21732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21732.xml"),
+          )
+      )
+
+  public val icon_21733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21733.xml"),
+          )
+      )
+
+  public val icon_21734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21734.xml"),
+          )
+      )
+
+  public val icon_21735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21735.xml"),
+          )
+      )
+
+  public val icon_21736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21736.xml"),
+          )
+      )
+
+  public val icon_21737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21737.xml"),
+          )
+      )
+
+  public val icon_21738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21738.xml"),
+          )
+      )
+
+  public val icon_21739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21739.xml"),
+          )
+      )
+
+  public val icon_2174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2174.xml"),
+          )
+      )
+
+  public val icon_21740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21740.xml"),
+          )
+      )
+
+  public val icon_21741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21741.xml"),
+          )
+      )
+
+  public val icon_21742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21742.xml"),
+          )
+      )
+
+  public val icon_21743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21743.xml"),
+          )
+      )
+
+  public val icon_21744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21744.xml"),
+          )
+      )
+
+  public val icon_21745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21745.xml"),
+          )
+      )
+
+  public val icon_21746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21746.xml"),
+          )
+      )
+
+  public val icon_21747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21747.xml"),
+          )
+      )
+
+  public val icon_21748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21748.xml"),
+          )
+      )
+
+  public val icon_21749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21749.xml"),
+          )
+      )
+
+  public val icon_2175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2175.xml"),
+          )
+      )
+
+  public val icon_21750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21750.xml"),
+          )
+      )
+
+  public val icon_21751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21751.xml"),
+          )
+      )
+
+  public val icon_21752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21752.xml"),
+          )
+      )
+
+  public val icon_21753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21753.xml"),
+          )
+      )
+
+  public val icon_21754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21754.xml"),
+          )
+      )
+
+  public val icon_21755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21755.xml"),
+          )
+      )
+
+  public val icon_21756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21756.xml"),
+          )
+      )
+
+  public val icon_21757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21757.xml"),
+          )
+      )
+
+  public val icon_21758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21758.xml"),
+          )
+      )
+
+  public val icon_21759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21759.xml"),
+          )
+      )
+
+  public val icon_2176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2176.xml"),
+          )
+      )
+
+  public val icon_21760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21760.xml"),
+          )
+      )
+
+  public val icon_21761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21761.xml"),
+          )
+      )
+
+  public val icon_21762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21762.xml"),
+          )
+      )
+
+  public val icon_21763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21763.xml"),
+          )
+      )
+
+  public val icon_21764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21764.xml"),
+          )
+      )
+
+  public val icon_21765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21765.xml"),
+          )
+      )
+
+  public val icon_21766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21766.xml"),
+          )
+      )
+
+  public val icon_21767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21767.xml"),
+          )
+      )
+
+  public val icon_21768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21768.xml"),
+          )
+      )
+
+  public val icon_21769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21769.xml"),
+          )
+      )
+
+  public val icon_2177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2177.xml"),
+          )
+      )
+
+  public val icon_21770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21770.xml"),
+          )
+      )
+
+  public val icon_21771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21771.xml"),
+          )
+      )
+
+  public val icon_21772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21772.xml"),
+          )
+      )
+
+  public val icon_21773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21773.xml"),
+          )
+      )
+
+  public val icon_21774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21774.xml"),
+          )
+      )
+
+  public val icon_21775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21775.xml"),
+          )
+      )
+
+  public val icon_21776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21776.xml"),
+          )
+      )
+
+  public val icon_21777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21777.xml"),
+          )
+      )
+
+  public val icon_21778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21778.xml"),
+          )
+      )
+
+  public val icon_21779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21779.xml"),
+          )
+      )
+
+  public val icon_2178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2178.xml"),
+          )
+      )
+
+  public val icon_21780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21780.xml"),
+          )
+      )
+
+  public val icon_21781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21781.xml"),
+          )
+      )
+
+  public val icon_21782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21782.xml"),
+          )
+      )
+
+  public val icon_21783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21783.xml"),
+          )
+      )
+
+  public val icon_21784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21784.xml"),
+          )
+      )
+
+  public val icon_21785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21785.xml"),
+          )
+      )
+
+  public val icon_21786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21786.xml"),
+          )
+      )
+
+  public val icon_21787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21787.xml"),
+          )
+      )
+
+  public val icon_21788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21788.xml"),
+          )
+      )
+
+  public val icon_21789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21789.xml"),
+          )
+      )
+
+  public val icon_2179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2179.xml"),
+          )
+      )
+
+  public val icon_21790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21790.xml"),
+          )
+      )
+
+  public val icon_21791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21791.xml"),
+          )
+      )
+
+  public val icon_21792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21792.xml"),
+          )
+      )
+
+  public val icon_21793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21793.xml"),
+          )
+      )
+
+  public val icon_21794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21794.xml"),
+          )
+      )
+
+  public val icon_21795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21795.xml"),
+          )
+      )
+
+  public val icon_21796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21796.xml"),
+          )
+      )
+
+  public val icon_21797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21797.xml"),
+          )
+      )
+
+  public val icon_21798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21798.xml"),
+          )
+      )
+
+  public val icon_21799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21799.xml"),
+          )
+      )
+
+  public val icon_218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_218.xml"),
+          )
+      )
+
+  public val icon_2180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2180.xml"),
+          )
+      )
+
+  public val icon_21800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21800.xml"),
+          )
+      )
+
+  public val icon_21801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21801.xml"),
+          )
+      )
+
+  public val icon_21802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21802.xml"),
+          )
+      )
+
+  public val icon_21803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21803.xml"),
+          )
+      )
+
+  public val icon_21804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21804.xml"),
+          )
+      )
+
+  public val icon_21805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21805.xml"),
+          )
+      )
+
+  public val icon_21806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21806.xml"),
+          )
+      )
+
+  public val icon_21807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21807.xml"),
+          )
+      )
+
+  public val icon_21808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21808.xml"),
+          )
+      )
+
+  public val icon_21809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21809.xml"),
+          )
+      )
+
+  public val icon_2181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2181.xml"),
+          )
+      )
+
+  public val icon_21810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21810.xml"),
+          )
+      )
+
+  public val icon_21811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21811.xml"),
+          )
+      )
+
+  public val icon_21812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21812.xml"),
+          )
+      )
+
+  public val icon_21813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21813.xml"),
+          )
+      )
+
+  public val icon_21814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21814.xml"),
+          )
+      )
+
+  public val icon_21815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21815.xml"),
+          )
+      )
+
+  public val icon_21816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21816.xml"),
+          )
+      )
+
+  public val icon_21817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21817.xml"),
+          )
+      )
+
+  public val icon_21818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21818.xml"),
+          )
+      )
+
+  public val icon_21819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21819.xml"),
+          )
+      )
+
+  public val icon_2182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2182.xml"),
+          )
+      )
+
+  public val icon_21820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21820.xml"),
+          )
+      )
+
+  public val icon_21821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21821.xml"),
+          )
+      )
+
+  public val icon_21822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21822.xml"),
+          )
+      )
+
+  public val icon_21823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21823.xml"),
+          )
+      )
+
+  public val icon_21824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21824.xml"),
+          )
+      )
+
+  public val icon_21825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21825.xml"),
+          )
+      )
+
+  public val icon_21826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21826.xml"),
+          )
+      )
+
+  public val icon_21827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21827.xml"),
+          )
+      )
+
+  public val icon_21828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21828.xml"),
+          )
+      )
+
+  public val icon_21829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21829.xml"),
+          )
+      )
+
+  public val icon_2183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2183.xml"),
+          )
+      )
+
+  public val icon_21830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21830.xml"),
+          )
+      )
+
+  public val icon_21831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21831.xml"),
+          )
+      )
+
+  public val icon_21832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21832.xml"),
+          )
+      )
+
+  public val icon_21833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21833.xml"),
+          )
+      )
+
+  public val icon_21834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21834.xml"),
+          )
+      )
+
+  public val icon_21835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21835.xml"),
+          )
+      )
+
+  public val icon_21836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21836.xml"),
+          )
+      )
+
+  public val icon_21837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21837.xml"),
+          )
+      )
+
+  public val icon_21838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21838.xml"),
+          )
+      )
+
+  public val icon_21839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21839.xml"),
+          )
+      )
+
+  public val icon_2184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2184.xml"),
+          )
+      )
+
+  public val icon_21840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21840.xml"),
+          )
+      )
+
+  public val icon_21841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21841.xml"),
+          )
+      )
+
+  public val icon_21842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21842.xml"),
+          )
+      )
+
+  public val icon_21843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21843.xml"),
+          )
+      )
+
+  public val icon_21844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21844.xml"),
+          )
+      )
+
+  public val icon_21845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21845.xml"),
+          )
+      )
+
+  public val icon_21846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21846.xml"),
+          )
+      )
+
+  public val icon_21847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21847.xml"),
+          )
+      )
+
+  public val icon_21848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21848.xml"),
+          )
+      )
+
+  public val icon_21849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21849.xml"),
+          )
+      )
+
+  public val icon_2185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2185.xml"),
+          )
+      )
+
+  public val icon_21850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21850.xml"),
+          )
+      )
+
+  public val icon_21851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21851.xml"),
+          )
+      )
+
+  public val icon_21852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21852.xml"),
+          )
+      )
+
+  public val icon_21853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21853.xml"),
+          )
+      )
+
+  public val icon_21854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21854.xml"),
+          )
+      )
+
+  public val icon_21855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21855.xml"),
+          )
+      )
+
+  public val icon_21856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21856.xml"),
+          )
+      )
+
+  public val icon_21857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21857.xml"),
+          )
+      )
+
+  public val icon_21858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21858.xml"),
+          )
+      )
+
+  public val icon_21859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21859.xml"),
+          )
+      )
+
+  public val icon_2186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2186.xml"),
+          )
+      )
+
+  public val icon_21860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21860.xml"),
+          )
+      )
+
+  public val icon_21861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21861.xml"),
+          )
+      )
+
+  public val icon_21862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21862.xml"),
+          )
+      )
+
+  public val icon_21863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21863.xml"),
+          )
+      )
+
+  public val icon_21864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21864.xml"),
+          )
+      )
+
+  public val icon_21865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21865.xml"),
+          )
+      )
+
+  public val icon_21866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21866.xml"),
+          )
+      )
+
+  public val icon_21867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21867.xml"),
+          )
+      )
+
+  public val icon_21868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21868.xml"),
+          )
+      )
+
+  public val icon_21869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21869.xml"),
+          )
+      )
+
+  public val icon_2187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2187.xml"),
+          )
+      )
+
+  public val icon_21870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21870.xml"),
+          )
+      )
+
+  public val icon_21871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21871.xml"),
+          )
+      )
+
+  public val icon_21872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21872.xml"),
+          )
+      )
+
+  public val icon_21873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21873.xml"),
+          )
+      )
+
+  public val icon_21874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21874.xml"),
+          )
+      )
+
+  public val icon_21875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21875.xml"),
+          )
+      )
+
+  public val icon_21876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21876.xml"),
+          )
+      )
+
+  public val icon_21877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21877.xml"),
+          )
+      )
+
+  public val icon_21878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21878.xml"),
+          )
+      )
+
+  public val icon_21879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21879.xml"),
+          )
+      )
+
+  public val icon_2188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2188.xml"),
+          )
+      )
+
+  public val icon_21880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21880.xml"),
+          )
+      )
+
+  public val icon_21881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21881.xml"),
+          )
+      )
+
+  public val icon_21882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21882.xml"),
+          )
+      )
+
+  public val icon_21883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21883.xml"),
+          )
+      )
+
+  public val icon_21884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21884.xml"),
+          )
+      )
+
+  public val icon_21885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21885.xml"),
+          )
+      )
+
+  public val icon_21886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21886.xml"),
+          )
+      )
+
+  public val icon_21887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21887.xml"),
+          )
+      )
+
+  public val icon_21888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21888.xml"),
+          )
+      )
+
+  public val icon_21889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21889.xml"),
+          )
+      )
+
+  public val icon_2189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2189.xml"),
+          )
+      )
+
+  public val icon_21890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21890.xml"),
+          )
+      )
+
+  public val icon_21891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21891.xml"),
+          )
+      )
+
+  public val icon_21892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21892.xml"),
+          )
+      )
+
+  public val icon_21893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21893.xml"),
+          )
+      )
+
+  public val icon_21894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21894.xml"),
+          )
+      )
+
+  public val icon_21895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21895.xml"),
+          )
+      )
+
+  public val icon_21896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21896.xml"),
+          )
+      )
+
+  public val icon_21897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21897.xml"),
+          )
+      )
+
+  public val icon_21898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21898.xml"),
+          )
+      )
+
+  public val icon_21899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21899.xml"),
+          )
+      )
+
+  public val icon_219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_219.xml"),
+          )
+      )
+
+  public val icon_2190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2190.xml"),
+          )
+      )
+
+  public val icon_21900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21900.xml"),
+          )
+      )
+
+  public val icon_21901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21901.xml"),
+          )
+      )
+
+  public val icon_21902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21902.xml"),
+          )
+      )
+
+  public val icon_21903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21903.xml"),
+          )
+      )
+
+  public val icon_21904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21904.xml"),
+          )
+      )
+
+  public val icon_21905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21905.xml"),
+          )
+      )
+
+  public val icon_21906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21906.xml"),
+          )
+      )
+
+  public val icon_21907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21907.xml"),
+          )
+      )
+
+  public val icon_21908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21908.xml"),
+          )
+      )
+
+  public val icon_21909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21909.xml"),
+          )
+      )
+
+  public val icon_2191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2191.xml"),
+          )
+      )
+
+  public val icon_21910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21910.xml"),
+          )
+      )
+
+  public val icon_21911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21911.xml"),
+          )
+      )
+
+  public val icon_21912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21912.xml"),
+          )
+      )
+
+  public val icon_21913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21913.xml"),
+          )
+      )
+
+  public val icon_21914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21914.xml"),
+          )
+      )
+
+  public val icon_21915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21915.xml"),
+          )
+      )
+
+  public val icon_21916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21916.xml"),
+          )
+      )
+
+  public val icon_21917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21917.xml"),
+          )
+      )
+
+  public val icon_21918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21918.xml"),
+          )
+      )
+
+  public val icon_21919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21919.xml"),
+          )
+      )
+
+  public val icon_2192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2192.xml"),
+          )
+      )
+
+  public val icon_21920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21920.xml"),
+          )
+      )
+
+  public val icon_21921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21921.xml"),
+          )
+      )
+
+  public val icon_21922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21922.xml"),
+          )
+      )
+
+  public val icon_21923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21923.xml"),
+          )
+      )
+
+  public val icon_21924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21924.xml"),
+          )
+      )
+
+  public val icon_21925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21925.xml"),
+          )
+      )
+
+  public val icon_21926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21926.xml"),
+          )
+      )
+
+  public val icon_21927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21927.xml"),
+          )
+      )
+
+  public val icon_21928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21928.xml"),
+          )
+      )
+
+  public val icon_21929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21929.xml"),
+          )
+      )
+
+  public val icon_2193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2193.xml"),
+          )
+      )
+
+  public val icon_21930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21930.xml"),
+          )
+      )
+
+  public val icon_21931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21931.xml"),
+          )
+      )
+
+  public val icon_21932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21932.xml"),
+          )
+      )
+
+  public val icon_21933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21933.xml"),
+          )
+      )
+
+  public val icon_21934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21934.xml"),
+          )
+      )
+
+  public val icon_21935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21935.xml"),
+          )
+      )
+
+  public val icon_21936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21936.xml"),
+          )
+      )
+
+  public val icon_21937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21937.xml"),
+          )
+      )
+
+  public val icon_21938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21938.xml"),
+          )
+      )
+
+  public val icon_21939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21939.xml"),
+          )
+      )
+
+  public val icon_2194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2194.xml"),
+          )
+      )
+
+  public val icon_21940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21940.xml"),
+          )
+      )
+
+  public val icon_21941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21941.xml"),
+          )
+      )
+
+  public val icon_21942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21942.xml"),
+          )
+      )
+
+  public val icon_21943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21943.xml"),
+          )
+      )
+
+  public val icon_21944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21944.xml"),
+          )
+      )
+
+  public val icon_21945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21945.xml"),
+          )
+      )
+
+  public val icon_21946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21946.xml"),
+          )
+      )
+
+  public val icon_21947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21947.xml"),
+          )
+      )
+
+  public val icon_21948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21948.xml"),
+          )
+      )
+
+  public val icon_21949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21949.xml"),
+          )
+      )
+
+  public val icon_2195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2195.xml"),
+          )
+      )
+
+  public val icon_21950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21950.xml"),
+          )
+      )
+
+  public val icon_21951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21951.xml"),
+          )
+      )
+
+  public val icon_21952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21952.xml"),
+          )
+      )
+
+  public val icon_21953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21953.xml"),
+          )
+      )
+
+  public val icon_21954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21954.xml"),
+          )
+      )
+
+  public val icon_21955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21955.xml"),
+          )
+      )
+
+  public val icon_21956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21956.xml"),
+          )
+      )
+
+  public val icon_21957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21957.xml"),
+          )
+      )
+
+  public val icon_21958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21958.xml"),
+          )
+      )
+
+  public val icon_21959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21959.xml"),
+          )
+      )
+
+  public val icon_2196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2196.xml"),
+          )
+      )
+
+  public val icon_21960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21960.xml"),
+          )
+      )
+
+  public val icon_21961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21961.xml"),
+          )
+      )
+
+  public val icon_21962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21962.xml"),
+          )
+      )
+
+  public val icon_21963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21963.xml"),
+          )
+      )
+
+  public val icon_21964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21964.xml"),
+          )
+      )
+
+  public val icon_21965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21965.xml"),
+          )
+      )
+
+  public val icon_21966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21966.xml"),
+          )
+      )
+
+  public val icon_21967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21967.xml"),
+          )
+      )
+
+  public val icon_21968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21968.xml"),
+          )
+      )
+
+  public val icon_21969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21969.xml"),
+          )
+      )
+
+  public val icon_2197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2197.xml"),
+          )
+      )
+
+  public val icon_21970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21970.xml"),
+          )
+      )
+
+  public val icon_21971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21971.xml"),
+          )
+      )
+
+  public val icon_21972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21972.xml"),
+          )
+      )
+
+  public val icon_21973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21973.xml"),
+          )
+      )
+
+  public val icon_21974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21974.xml"),
+          )
+      )
+
+  public val icon_21975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21975.xml"),
+          )
+      )
+
+  public val icon_21976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21976.xml"),
+          )
+      )
+
+  public val icon_21977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21977.xml"),
+          )
+      )
+
+  public val icon_21978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21978.xml"),
+          )
+      )
+
+  public val icon_21979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21979.xml"),
+          )
+      )
+
+  public val icon_2198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2198.xml"),
+          )
+      )
+
+  public val icon_21980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21980.xml"),
+          )
+      )
+
+  public val icon_21981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21981.xml"),
+          )
+      )
+
+  public val icon_21982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21982.xml"),
+          )
+      )
+
+  public val icon_21983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21983.xml"),
+          )
+      )
+
+  public val icon_21984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21984.xml"),
+          )
+      )
+
+  public val icon_21985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21985.xml"),
+          )
+      )
+
+  public val icon_21986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21986.xml"),
+          )
+      )
+
+  public val icon_21987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21987.xml"),
+          )
+      )
+
+  public val icon_21988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21988.xml"),
+          )
+      )
+
+  public val icon_21989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21989.xml"),
+          )
+      )
+
+  public val icon_2199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2199.xml"),
+          )
+      )
+
+  public val icon_21990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21990.xml"),
+          )
+      )
+
+  public val icon_21991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21991.xml"),
+          )
+      )
+
+  public val icon_21992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21992.xml"),
+          )
+      )
+
+  public val icon_21993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21993.xml"),
+          )
+      )
+
+  public val icon_21994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21994.xml"),
+          )
+      )
+
+  public val icon_21995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21995.xml"),
+          )
+      )
+
+  public val icon_21996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21996.xml"),
+          )
+      )
+
+  public val icon_21997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21997.xml"),
+          )
+      )
+
+  public val icon_21998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21998.xml"),
+          )
+      )
+
+  public val icon_21999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_21999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_21999.xml"),
+          )
+      )
+
+  public val icon_22: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22.xml"),
+          )
+      )
+
+  public val icon_220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_220.xml"),
+          )
+      )
+
+  public val icon_2200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2200.xml"),
+          )
+      )
+
+  public val icon_22000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22000.xml"),
+          )
+      )
+
+  public val icon_22001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22001.xml"),
+          )
+      )
+
+  public val icon_22002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22002.xml"),
+          )
+      )
+
+  public val icon_22003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22003.xml"),
+          )
+      )
+
+  public val icon_22004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22004.xml"),
+          )
+      )
+
+  public val icon_22005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22005.xml"),
+          )
+      )
+
+  public val icon_22006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22006.xml"),
+          )
+      )
+
+  public val icon_22007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22007.xml"),
+          )
+      )
+
+  public val icon_22008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22008.xml"),
+          )
+      )
+
+  public val icon_22009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22009.xml"),
+          )
+      )
+
+  public val icon_2201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2201.xml"),
+          )
+      )
+
+  public val icon_22010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22010.xml"),
+          )
+      )
+
+  public val icon_22011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22011.xml"),
+          )
+      )
+
+  public val icon_22012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22012.xml"),
+          )
+      )
+
+  public val icon_22013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22013.xml"),
+          )
+      )
+
+  public val icon_22014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22014.xml"),
+          )
+      )
+
+  public val icon_22015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22015.xml"),
+          )
+      )
+
+  public val icon_22016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22016.xml"),
+          )
+      )
+
+  public val icon_22017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22017.xml"),
+          )
+      )
+
+  public val icon_22018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22018.xml"),
+          )
+      )
+
+  public val icon_22019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22019.xml"),
+          )
+      )
+
+  public val icon_2202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2202.xml"),
+          )
+      )
+
+  public val icon_22020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22020.xml"),
+          )
+      )
+
+  public val icon_22021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22021.xml"),
+          )
+      )
+
+  public val icon_22022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22022.xml"),
+          )
+      )
+
+  public val icon_22023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22023.xml"),
+          )
+      )
+
+  public val icon_22024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22024.xml"),
+          )
+      )
+
+  public val icon_22025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22025.xml"),
+          )
+      )
+
+  public val icon_22026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22026.xml"),
+          )
+      )
+
+  public val icon_22027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22027.xml"),
+          )
+      )
+
+  public val icon_22028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22028.xml"),
+          )
+      )
+
+  public val icon_22029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22029.xml"),
+          )
+      )
+
+  public val icon_2203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2203.xml"),
+          )
+      )
+
+  public val icon_22030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22030.xml"),
+          )
+      )
+
+  public val icon_22031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22031.xml"),
+          )
+      )
+
+  public val icon_22032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22032.xml"),
+          )
+      )
+
+  public val icon_22033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22033.xml"),
+          )
+      )
+
+  public val icon_22034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22034.xml"),
+          )
+      )
+
+  public val icon_22035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22035.xml"),
+          )
+      )
+
+  public val icon_22036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22036.xml"),
+          )
+      )
+
+  public val icon_22037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22037.xml"),
+          )
+      )
+
+  public val icon_22038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22038.xml"),
+          )
+      )
+
+  public val icon_22039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22039.xml"),
+          )
+      )
+
+  public val icon_2204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2204.xml"),
+          )
+      )
+
+  public val icon_22040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22040.xml"),
+          )
+      )
+
+  public val icon_22041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22041.xml"),
+          )
+      )
+
+  public val icon_22042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22042.xml"),
+          )
+      )
+
+  public val icon_22043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22043.xml"),
+          )
+      )
+
+  public val icon_22044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22044.xml"),
+          )
+      )
+
+  public val icon_22045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22045.xml"),
+          )
+      )
+
+  public val icon_22046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22046.xml"),
+          )
+      )
+
+  public val icon_22047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22047.xml"),
+          )
+      )
+
+  public val icon_22048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22048.xml"),
+          )
+      )
+
+  public val icon_22049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22049.xml"),
+          )
+      )
+
+  public val icon_2205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2205.xml"),
+          )
+      )
+
+  public val icon_22050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22050.xml"),
+          )
+      )
+
+  public val icon_22051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22051.xml"),
+          )
+      )
+
+  public val icon_22052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22052.xml"),
+          )
+      )
+
+  public val icon_22053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22053.xml"),
+          )
+      )
+
+  public val icon_22054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22054.xml"),
+          )
+      )
+
+  public val icon_22055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22055.xml"),
+          )
+      )
+
+  public val icon_22056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22056.xml"),
+          )
+      )
+
+  public val icon_22057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22057.xml"),
+          )
+      )
+
+  public val icon_22058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22058.xml"),
+          )
+      )
+
+  public val icon_22059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22059.xml"),
+          )
+      )
+
+  public val icon_2206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2206.xml"),
+          )
+      )
+
+  public val icon_22060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22060.xml"),
+          )
+      )
+
+  public val icon_22061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22061.xml"),
+          )
+      )
+
+  public val icon_22062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22062.xml"),
+          )
+      )
+
+  public val icon_22063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22063.xml"),
+          )
+      )
+
+  public val icon_22064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22064.xml"),
+          )
+      )
+
+  public val icon_22065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22065.xml"),
+          )
+      )
+
+  public val icon_22066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22066.xml"),
+          )
+      )
+
+  public val icon_22067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22067.xml"),
+          )
+      )
+
+  public val icon_22068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22068.xml"),
+          )
+      )
+
+  public val icon_22069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22069.xml"),
+          )
+      )
+
+  public val icon_2207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2207.xml"),
+          )
+      )
+
+  public val icon_22070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22070.xml"),
+          )
+      )
+
+  public val icon_22071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22071.xml"),
+          )
+      )
+
+  public val icon_22072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22072.xml"),
+          )
+      )
+
+  public val icon_22073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22073.xml"),
+          )
+      )
+
+  public val icon_22074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22074.xml"),
+          )
+      )
+
+  public val icon_22075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22075.xml"),
+          )
+      )
+
+  public val icon_22076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22076.xml"),
+          )
+      )
+
+  public val icon_22077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22077.xml"),
+          )
+      )
+
+  public val icon_22078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22078.xml"),
+          )
+      )
+
+  public val icon_22079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22079.xml"),
+          )
+      )
+
+  public val icon_2208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2208.xml"),
+          )
+      )
+
+  public val icon_22080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22080.xml"),
+          )
+      )
+
+  public val icon_22081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22081.xml"),
+          )
+      )
+
+  public val icon_22082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22082.xml"),
+          )
+      )
+
+  public val icon_22083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22083.xml"),
+          )
+      )
+
+  public val icon_22084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22084.xml"),
+          )
+      )
+
+  public val icon_22085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22085.xml"),
+          )
+      )
+
+  public val icon_22086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22086.xml"),
+          )
+      )
+
+  public val icon_22087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22087.xml"),
+          )
+      )
+
+  public val icon_22088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22088.xml"),
+          )
+      )
+
+  public val icon_22089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22089.xml"),
+          )
+      )
+
+  public val icon_2209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2209.xml"),
+          )
+      )
+
+  public val icon_22090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22090.xml"),
+          )
+      )
+
+  public val icon_22091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22091.xml"),
+          )
+      )
+
+  public val icon_22092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22092.xml"),
+          )
+      )
+
+  public val icon_22093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22093.xml"),
+          )
+      )
+
+  public val icon_22094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22094.xml"),
+          )
+      )
+
+  public val icon_22095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22095.xml"),
+          )
+      )
+
+  public val icon_22096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22096.xml"),
+          )
+      )
+
+  public val icon_22097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22097.xml"),
+          )
+      )
+
+  public val icon_22098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22098.xml"),
+          )
+      )
+
+  public val icon_22099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22099.xml"),
+          )
+      )
+
+  public val icon_221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_221.xml"),
+          )
+      )
+
+  public val icon_2210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2210.xml"),
+          )
+      )
+
+  public val icon_22100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22100.xml"),
+          )
+      )
+
+  public val icon_22101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22101.xml"),
+          )
+      )
+
+  public val icon_22102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22102.xml"),
+          )
+      )
+
+  public val icon_22103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22103.xml"),
+          )
+      )
+
+  public val icon_22104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22104.xml"),
+          )
+      )
+
+  public val icon_22105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22105.xml"),
+          )
+      )
+
+  public val icon_22106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22106.xml"),
+          )
+      )
+
+  public val icon_22107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22107.xml"),
+          )
+      )
+
+  public val icon_22108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22108.xml"),
+          )
+      )
+
+  public val icon_22109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22109.xml"),
+          )
+      )
+
+  public val icon_2211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2211.xml"),
+          )
+      )
+
+  public val icon_22110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22110.xml"),
+          )
+      )
+
+  public val icon_22111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22111.xml"),
+          )
+      )
+
+  public val icon_22112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22112.xml"),
+          )
+      )
+
+  public val icon_22113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22113.xml"),
+          )
+      )
+
+  public val icon_22114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22114.xml"),
+          )
+      )
+
+  public val icon_22115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22115.xml"),
+          )
+      )
+
+  public val icon_22116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22116.xml"),
+          )
+      )
+
+  public val icon_22117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22117.xml"),
+          )
+      )
+
+  public val icon_22118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22118.xml"),
+          )
+      )
+
+  public val icon_22119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22119.xml"),
+          )
+      )
+
+  public val icon_2212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2212.xml"),
+          )
+      )
+
+  public val icon_22120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22120.xml"),
+          )
+      )
+
+  public val icon_22121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22121.xml"),
+          )
+      )
+
+  public val icon_22122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22122.xml"),
+          )
+      )
+
+  public val icon_22123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22123.xml"),
+          )
+      )
+
+  public val icon_22124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22124.xml"),
+          )
+      )
+
+  public val icon_22125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22125.xml"),
+          )
+      )
+
+  public val icon_22126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22126.xml"),
+          )
+      )
+
+  public val icon_22127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22127.xml"),
+          )
+      )
+
+  public val icon_22128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22128.xml"),
+          )
+      )
+
+  public val icon_22129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22129.xml"),
+          )
+      )
+
+  public val icon_2213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2213.xml"),
+          )
+      )
+
+  public val icon_22130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22130.xml"),
+          )
+      )
+
+  public val icon_22131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22131.xml"),
+          )
+      )
+
+  public val icon_22132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22132.xml"),
+          )
+      )
+
+  public val icon_22133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22133.xml"),
+          )
+      )
+
+  public val icon_22134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22134.xml"),
+          )
+      )
+
+  public val icon_22135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22135.xml"),
+          )
+      )
+
+  public val icon_22136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22136.xml"),
+          )
+      )
+
+  public val icon_22137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22137.xml"),
+          )
+      )
+
+  public val icon_22138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22138.xml"),
+          )
+      )
+
+  public val icon_22139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22139.xml"),
+          )
+      )
+
+  public val icon_2214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2214.xml"),
+          )
+      )
+
+  public val icon_22140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22140.xml"),
+          )
+      )
+
+  public val icon_22141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22141.xml"),
+          )
+      )
+
+  public val icon_22142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22142.xml"),
+          )
+      )
+
+  public val icon_22143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22143.xml"),
+          )
+      )
+
+  public val icon_22144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22144.xml"),
+          )
+      )
+
+  public val icon_22145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22145.xml"),
+          )
+      )
+
+  public val icon_22146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22146.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21698: DrawableResource
+  get() = Drawable26.icon_21698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21699: DrawableResource
+  get() = Drawable26.icon_21699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_217: DrawableResource
+  get() = Drawable26.icon_217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2170: DrawableResource
+  get() = Drawable26.icon_2170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21700: DrawableResource
+  get() = Drawable26.icon_21700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21701: DrawableResource
+  get() = Drawable26.icon_21701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21702: DrawableResource
+  get() = Drawable26.icon_21702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21703: DrawableResource
+  get() = Drawable26.icon_21703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21704: DrawableResource
+  get() = Drawable26.icon_21704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21705: DrawableResource
+  get() = Drawable26.icon_21705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21706: DrawableResource
+  get() = Drawable26.icon_21706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21707: DrawableResource
+  get() = Drawable26.icon_21707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21708: DrawableResource
+  get() = Drawable26.icon_21708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21709: DrawableResource
+  get() = Drawable26.icon_21709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2171: DrawableResource
+  get() = Drawable26.icon_2171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21710: DrawableResource
+  get() = Drawable26.icon_21710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21711: DrawableResource
+  get() = Drawable26.icon_21711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21712: DrawableResource
+  get() = Drawable26.icon_21712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21713: DrawableResource
+  get() = Drawable26.icon_21713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21714: DrawableResource
+  get() = Drawable26.icon_21714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21715: DrawableResource
+  get() = Drawable26.icon_21715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21716: DrawableResource
+  get() = Drawable26.icon_21716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21717: DrawableResource
+  get() = Drawable26.icon_21717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21718: DrawableResource
+  get() = Drawable26.icon_21718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21719: DrawableResource
+  get() = Drawable26.icon_21719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2172: DrawableResource
+  get() = Drawable26.icon_2172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21720: DrawableResource
+  get() = Drawable26.icon_21720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21721: DrawableResource
+  get() = Drawable26.icon_21721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21722: DrawableResource
+  get() = Drawable26.icon_21722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21723: DrawableResource
+  get() = Drawable26.icon_21723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21724: DrawableResource
+  get() = Drawable26.icon_21724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21725: DrawableResource
+  get() = Drawable26.icon_21725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21726: DrawableResource
+  get() = Drawable26.icon_21726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21727: DrawableResource
+  get() = Drawable26.icon_21727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21728: DrawableResource
+  get() = Drawable26.icon_21728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21729: DrawableResource
+  get() = Drawable26.icon_21729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2173: DrawableResource
+  get() = Drawable26.icon_2173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21730: DrawableResource
+  get() = Drawable26.icon_21730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21731: DrawableResource
+  get() = Drawable26.icon_21731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21732: DrawableResource
+  get() = Drawable26.icon_21732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21733: DrawableResource
+  get() = Drawable26.icon_21733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21734: DrawableResource
+  get() = Drawable26.icon_21734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21735: DrawableResource
+  get() = Drawable26.icon_21735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21736: DrawableResource
+  get() = Drawable26.icon_21736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21737: DrawableResource
+  get() = Drawable26.icon_21737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21738: DrawableResource
+  get() = Drawable26.icon_21738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21739: DrawableResource
+  get() = Drawable26.icon_21739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2174: DrawableResource
+  get() = Drawable26.icon_2174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21740: DrawableResource
+  get() = Drawable26.icon_21740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21741: DrawableResource
+  get() = Drawable26.icon_21741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21742: DrawableResource
+  get() = Drawable26.icon_21742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21743: DrawableResource
+  get() = Drawable26.icon_21743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21744: DrawableResource
+  get() = Drawable26.icon_21744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21745: DrawableResource
+  get() = Drawable26.icon_21745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21746: DrawableResource
+  get() = Drawable26.icon_21746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21747: DrawableResource
+  get() = Drawable26.icon_21747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21748: DrawableResource
+  get() = Drawable26.icon_21748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21749: DrawableResource
+  get() = Drawable26.icon_21749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2175: DrawableResource
+  get() = Drawable26.icon_2175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21750: DrawableResource
+  get() = Drawable26.icon_21750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21751: DrawableResource
+  get() = Drawable26.icon_21751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21752: DrawableResource
+  get() = Drawable26.icon_21752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21753: DrawableResource
+  get() = Drawable26.icon_21753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21754: DrawableResource
+  get() = Drawable26.icon_21754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21755: DrawableResource
+  get() = Drawable26.icon_21755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21756: DrawableResource
+  get() = Drawable26.icon_21756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21757: DrawableResource
+  get() = Drawable26.icon_21757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21758: DrawableResource
+  get() = Drawable26.icon_21758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21759: DrawableResource
+  get() = Drawable26.icon_21759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2176: DrawableResource
+  get() = Drawable26.icon_2176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21760: DrawableResource
+  get() = Drawable26.icon_21760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21761: DrawableResource
+  get() = Drawable26.icon_21761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21762: DrawableResource
+  get() = Drawable26.icon_21762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21763: DrawableResource
+  get() = Drawable26.icon_21763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21764: DrawableResource
+  get() = Drawable26.icon_21764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21765: DrawableResource
+  get() = Drawable26.icon_21765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21766: DrawableResource
+  get() = Drawable26.icon_21766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21767: DrawableResource
+  get() = Drawable26.icon_21767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21768: DrawableResource
+  get() = Drawable26.icon_21768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21769: DrawableResource
+  get() = Drawable26.icon_21769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2177: DrawableResource
+  get() = Drawable26.icon_2177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21770: DrawableResource
+  get() = Drawable26.icon_21770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21771: DrawableResource
+  get() = Drawable26.icon_21771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21772: DrawableResource
+  get() = Drawable26.icon_21772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21773: DrawableResource
+  get() = Drawable26.icon_21773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21774: DrawableResource
+  get() = Drawable26.icon_21774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21775: DrawableResource
+  get() = Drawable26.icon_21775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21776: DrawableResource
+  get() = Drawable26.icon_21776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21777: DrawableResource
+  get() = Drawable26.icon_21777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21778: DrawableResource
+  get() = Drawable26.icon_21778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21779: DrawableResource
+  get() = Drawable26.icon_21779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2178: DrawableResource
+  get() = Drawable26.icon_2178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21780: DrawableResource
+  get() = Drawable26.icon_21780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21781: DrawableResource
+  get() = Drawable26.icon_21781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21782: DrawableResource
+  get() = Drawable26.icon_21782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21783: DrawableResource
+  get() = Drawable26.icon_21783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21784: DrawableResource
+  get() = Drawable26.icon_21784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21785: DrawableResource
+  get() = Drawable26.icon_21785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21786: DrawableResource
+  get() = Drawable26.icon_21786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21787: DrawableResource
+  get() = Drawable26.icon_21787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21788: DrawableResource
+  get() = Drawable26.icon_21788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21789: DrawableResource
+  get() = Drawable26.icon_21789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2179: DrawableResource
+  get() = Drawable26.icon_2179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21790: DrawableResource
+  get() = Drawable26.icon_21790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21791: DrawableResource
+  get() = Drawable26.icon_21791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21792: DrawableResource
+  get() = Drawable26.icon_21792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21793: DrawableResource
+  get() = Drawable26.icon_21793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21794: DrawableResource
+  get() = Drawable26.icon_21794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21795: DrawableResource
+  get() = Drawable26.icon_21795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21796: DrawableResource
+  get() = Drawable26.icon_21796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21797: DrawableResource
+  get() = Drawable26.icon_21797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21798: DrawableResource
+  get() = Drawable26.icon_21798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21799: DrawableResource
+  get() = Drawable26.icon_21799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_218: DrawableResource
+  get() = Drawable26.icon_218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2180: DrawableResource
+  get() = Drawable26.icon_2180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21800: DrawableResource
+  get() = Drawable26.icon_21800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21801: DrawableResource
+  get() = Drawable26.icon_21801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21802: DrawableResource
+  get() = Drawable26.icon_21802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21803: DrawableResource
+  get() = Drawable26.icon_21803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21804: DrawableResource
+  get() = Drawable26.icon_21804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21805: DrawableResource
+  get() = Drawable26.icon_21805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21806: DrawableResource
+  get() = Drawable26.icon_21806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21807: DrawableResource
+  get() = Drawable26.icon_21807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21808: DrawableResource
+  get() = Drawable26.icon_21808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21809: DrawableResource
+  get() = Drawable26.icon_21809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2181: DrawableResource
+  get() = Drawable26.icon_2181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21810: DrawableResource
+  get() = Drawable26.icon_21810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21811: DrawableResource
+  get() = Drawable26.icon_21811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21812: DrawableResource
+  get() = Drawable26.icon_21812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21813: DrawableResource
+  get() = Drawable26.icon_21813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21814: DrawableResource
+  get() = Drawable26.icon_21814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21815: DrawableResource
+  get() = Drawable26.icon_21815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21816: DrawableResource
+  get() = Drawable26.icon_21816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21817: DrawableResource
+  get() = Drawable26.icon_21817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21818: DrawableResource
+  get() = Drawable26.icon_21818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21819: DrawableResource
+  get() = Drawable26.icon_21819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2182: DrawableResource
+  get() = Drawable26.icon_2182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21820: DrawableResource
+  get() = Drawable26.icon_21820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21821: DrawableResource
+  get() = Drawable26.icon_21821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21822: DrawableResource
+  get() = Drawable26.icon_21822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21823: DrawableResource
+  get() = Drawable26.icon_21823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21824: DrawableResource
+  get() = Drawable26.icon_21824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21825: DrawableResource
+  get() = Drawable26.icon_21825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21826: DrawableResource
+  get() = Drawable26.icon_21826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21827: DrawableResource
+  get() = Drawable26.icon_21827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21828: DrawableResource
+  get() = Drawable26.icon_21828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21829: DrawableResource
+  get() = Drawable26.icon_21829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2183: DrawableResource
+  get() = Drawable26.icon_2183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21830: DrawableResource
+  get() = Drawable26.icon_21830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21831: DrawableResource
+  get() = Drawable26.icon_21831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21832: DrawableResource
+  get() = Drawable26.icon_21832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21833: DrawableResource
+  get() = Drawable26.icon_21833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21834: DrawableResource
+  get() = Drawable26.icon_21834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21835: DrawableResource
+  get() = Drawable26.icon_21835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21836: DrawableResource
+  get() = Drawable26.icon_21836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21837: DrawableResource
+  get() = Drawable26.icon_21837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21838: DrawableResource
+  get() = Drawable26.icon_21838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21839: DrawableResource
+  get() = Drawable26.icon_21839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2184: DrawableResource
+  get() = Drawable26.icon_2184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21840: DrawableResource
+  get() = Drawable26.icon_21840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21841: DrawableResource
+  get() = Drawable26.icon_21841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21842: DrawableResource
+  get() = Drawable26.icon_21842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21843: DrawableResource
+  get() = Drawable26.icon_21843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21844: DrawableResource
+  get() = Drawable26.icon_21844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21845: DrawableResource
+  get() = Drawable26.icon_21845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21846: DrawableResource
+  get() = Drawable26.icon_21846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21847: DrawableResource
+  get() = Drawable26.icon_21847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21848: DrawableResource
+  get() = Drawable26.icon_21848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21849: DrawableResource
+  get() = Drawable26.icon_21849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2185: DrawableResource
+  get() = Drawable26.icon_2185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21850: DrawableResource
+  get() = Drawable26.icon_21850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21851: DrawableResource
+  get() = Drawable26.icon_21851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21852: DrawableResource
+  get() = Drawable26.icon_21852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21853: DrawableResource
+  get() = Drawable26.icon_21853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21854: DrawableResource
+  get() = Drawable26.icon_21854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21855: DrawableResource
+  get() = Drawable26.icon_21855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21856: DrawableResource
+  get() = Drawable26.icon_21856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21857: DrawableResource
+  get() = Drawable26.icon_21857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21858: DrawableResource
+  get() = Drawable26.icon_21858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21859: DrawableResource
+  get() = Drawable26.icon_21859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2186: DrawableResource
+  get() = Drawable26.icon_2186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21860: DrawableResource
+  get() = Drawable26.icon_21860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21861: DrawableResource
+  get() = Drawable26.icon_21861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21862: DrawableResource
+  get() = Drawable26.icon_21862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21863: DrawableResource
+  get() = Drawable26.icon_21863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21864: DrawableResource
+  get() = Drawable26.icon_21864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21865: DrawableResource
+  get() = Drawable26.icon_21865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21866: DrawableResource
+  get() = Drawable26.icon_21866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21867: DrawableResource
+  get() = Drawable26.icon_21867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21868: DrawableResource
+  get() = Drawable26.icon_21868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21869: DrawableResource
+  get() = Drawable26.icon_21869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2187: DrawableResource
+  get() = Drawable26.icon_2187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21870: DrawableResource
+  get() = Drawable26.icon_21870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21871: DrawableResource
+  get() = Drawable26.icon_21871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21872: DrawableResource
+  get() = Drawable26.icon_21872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21873: DrawableResource
+  get() = Drawable26.icon_21873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21874: DrawableResource
+  get() = Drawable26.icon_21874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21875: DrawableResource
+  get() = Drawable26.icon_21875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21876: DrawableResource
+  get() = Drawable26.icon_21876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21877: DrawableResource
+  get() = Drawable26.icon_21877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21878: DrawableResource
+  get() = Drawable26.icon_21878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21879: DrawableResource
+  get() = Drawable26.icon_21879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2188: DrawableResource
+  get() = Drawable26.icon_2188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21880: DrawableResource
+  get() = Drawable26.icon_21880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21881: DrawableResource
+  get() = Drawable26.icon_21881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21882: DrawableResource
+  get() = Drawable26.icon_21882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21883: DrawableResource
+  get() = Drawable26.icon_21883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21884: DrawableResource
+  get() = Drawable26.icon_21884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21885: DrawableResource
+  get() = Drawable26.icon_21885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21886: DrawableResource
+  get() = Drawable26.icon_21886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21887: DrawableResource
+  get() = Drawable26.icon_21887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21888: DrawableResource
+  get() = Drawable26.icon_21888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21889: DrawableResource
+  get() = Drawable26.icon_21889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2189: DrawableResource
+  get() = Drawable26.icon_2189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21890: DrawableResource
+  get() = Drawable26.icon_21890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21891: DrawableResource
+  get() = Drawable26.icon_21891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21892: DrawableResource
+  get() = Drawable26.icon_21892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21893: DrawableResource
+  get() = Drawable26.icon_21893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21894: DrawableResource
+  get() = Drawable26.icon_21894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21895: DrawableResource
+  get() = Drawable26.icon_21895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21896: DrawableResource
+  get() = Drawable26.icon_21896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21897: DrawableResource
+  get() = Drawable26.icon_21897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21898: DrawableResource
+  get() = Drawable26.icon_21898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21899: DrawableResource
+  get() = Drawable26.icon_21899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_219: DrawableResource
+  get() = Drawable26.icon_219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2190: DrawableResource
+  get() = Drawable26.icon_2190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21900: DrawableResource
+  get() = Drawable26.icon_21900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21901: DrawableResource
+  get() = Drawable26.icon_21901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21902: DrawableResource
+  get() = Drawable26.icon_21902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21903: DrawableResource
+  get() = Drawable26.icon_21903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21904: DrawableResource
+  get() = Drawable26.icon_21904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21905: DrawableResource
+  get() = Drawable26.icon_21905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21906: DrawableResource
+  get() = Drawable26.icon_21906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21907: DrawableResource
+  get() = Drawable26.icon_21907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21908: DrawableResource
+  get() = Drawable26.icon_21908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21909: DrawableResource
+  get() = Drawable26.icon_21909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2191: DrawableResource
+  get() = Drawable26.icon_2191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21910: DrawableResource
+  get() = Drawable26.icon_21910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21911: DrawableResource
+  get() = Drawable26.icon_21911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21912: DrawableResource
+  get() = Drawable26.icon_21912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21913: DrawableResource
+  get() = Drawable26.icon_21913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21914: DrawableResource
+  get() = Drawable26.icon_21914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21915: DrawableResource
+  get() = Drawable26.icon_21915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21916: DrawableResource
+  get() = Drawable26.icon_21916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21917: DrawableResource
+  get() = Drawable26.icon_21917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21918: DrawableResource
+  get() = Drawable26.icon_21918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21919: DrawableResource
+  get() = Drawable26.icon_21919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2192: DrawableResource
+  get() = Drawable26.icon_2192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21920: DrawableResource
+  get() = Drawable26.icon_21920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21921: DrawableResource
+  get() = Drawable26.icon_21921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21922: DrawableResource
+  get() = Drawable26.icon_21922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21923: DrawableResource
+  get() = Drawable26.icon_21923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21924: DrawableResource
+  get() = Drawable26.icon_21924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21925: DrawableResource
+  get() = Drawable26.icon_21925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21926: DrawableResource
+  get() = Drawable26.icon_21926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21927: DrawableResource
+  get() = Drawable26.icon_21927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21928: DrawableResource
+  get() = Drawable26.icon_21928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21929: DrawableResource
+  get() = Drawable26.icon_21929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2193: DrawableResource
+  get() = Drawable26.icon_2193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21930: DrawableResource
+  get() = Drawable26.icon_21930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21931: DrawableResource
+  get() = Drawable26.icon_21931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21932: DrawableResource
+  get() = Drawable26.icon_21932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21933: DrawableResource
+  get() = Drawable26.icon_21933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21934: DrawableResource
+  get() = Drawable26.icon_21934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21935: DrawableResource
+  get() = Drawable26.icon_21935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21936: DrawableResource
+  get() = Drawable26.icon_21936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21937: DrawableResource
+  get() = Drawable26.icon_21937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21938: DrawableResource
+  get() = Drawable26.icon_21938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21939: DrawableResource
+  get() = Drawable26.icon_21939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2194: DrawableResource
+  get() = Drawable26.icon_2194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21940: DrawableResource
+  get() = Drawable26.icon_21940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21941: DrawableResource
+  get() = Drawable26.icon_21941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21942: DrawableResource
+  get() = Drawable26.icon_21942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21943: DrawableResource
+  get() = Drawable26.icon_21943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21944: DrawableResource
+  get() = Drawable26.icon_21944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21945: DrawableResource
+  get() = Drawable26.icon_21945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21946: DrawableResource
+  get() = Drawable26.icon_21946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21947: DrawableResource
+  get() = Drawable26.icon_21947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21948: DrawableResource
+  get() = Drawable26.icon_21948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21949: DrawableResource
+  get() = Drawable26.icon_21949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2195: DrawableResource
+  get() = Drawable26.icon_2195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21950: DrawableResource
+  get() = Drawable26.icon_21950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21951: DrawableResource
+  get() = Drawable26.icon_21951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21952: DrawableResource
+  get() = Drawable26.icon_21952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21953: DrawableResource
+  get() = Drawable26.icon_21953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21954: DrawableResource
+  get() = Drawable26.icon_21954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21955: DrawableResource
+  get() = Drawable26.icon_21955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21956: DrawableResource
+  get() = Drawable26.icon_21956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21957: DrawableResource
+  get() = Drawable26.icon_21957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21958: DrawableResource
+  get() = Drawable26.icon_21958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21959: DrawableResource
+  get() = Drawable26.icon_21959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2196: DrawableResource
+  get() = Drawable26.icon_2196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21960: DrawableResource
+  get() = Drawable26.icon_21960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21961: DrawableResource
+  get() = Drawable26.icon_21961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21962: DrawableResource
+  get() = Drawable26.icon_21962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21963: DrawableResource
+  get() = Drawable26.icon_21963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21964: DrawableResource
+  get() = Drawable26.icon_21964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21965: DrawableResource
+  get() = Drawable26.icon_21965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21966: DrawableResource
+  get() = Drawable26.icon_21966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21967: DrawableResource
+  get() = Drawable26.icon_21967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21968: DrawableResource
+  get() = Drawable26.icon_21968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21969: DrawableResource
+  get() = Drawable26.icon_21969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2197: DrawableResource
+  get() = Drawable26.icon_2197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21970: DrawableResource
+  get() = Drawable26.icon_21970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21971: DrawableResource
+  get() = Drawable26.icon_21971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21972: DrawableResource
+  get() = Drawable26.icon_21972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21973: DrawableResource
+  get() = Drawable26.icon_21973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21974: DrawableResource
+  get() = Drawable26.icon_21974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21975: DrawableResource
+  get() = Drawable26.icon_21975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21976: DrawableResource
+  get() = Drawable26.icon_21976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21977: DrawableResource
+  get() = Drawable26.icon_21977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21978: DrawableResource
+  get() = Drawable26.icon_21978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21979: DrawableResource
+  get() = Drawable26.icon_21979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2198: DrawableResource
+  get() = Drawable26.icon_2198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21980: DrawableResource
+  get() = Drawable26.icon_21980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21981: DrawableResource
+  get() = Drawable26.icon_21981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21982: DrawableResource
+  get() = Drawable26.icon_21982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21983: DrawableResource
+  get() = Drawable26.icon_21983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21984: DrawableResource
+  get() = Drawable26.icon_21984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21985: DrawableResource
+  get() = Drawable26.icon_21985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21986: DrawableResource
+  get() = Drawable26.icon_21986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21987: DrawableResource
+  get() = Drawable26.icon_21987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21988: DrawableResource
+  get() = Drawable26.icon_21988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21989: DrawableResource
+  get() = Drawable26.icon_21989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2199: DrawableResource
+  get() = Drawable26.icon_2199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21990: DrawableResource
+  get() = Drawable26.icon_21990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21991: DrawableResource
+  get() = Drawable26.icon_21991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21992: DrawableResource
+  get() = Drawable26.icon_21992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21993: DrawableResource
+  get() = Drawable26.icon_21993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21994: DrawableResource
+  get() = Drawable26.icon_21994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21995: DrawableResource
+  get() = Drawable26.icon_21995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21996: DrawableResource
+  get() = Drawable26.icon_21996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21997: DrawableResource
+  get() = Drawable26.icon_21997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21998: DrawableResource
+  get() = Drawable26.icon_21998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_21999: DrawableResource
+  get() = Drawable26.icon_21999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22: DrawableResource
+  get() = Drawable26.icon_22
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_220: DrawableResource
+  get() = Drawable26.icon_220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2200: DrawableResource
+  get() = Drawable26.icon_2200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22000: DrawableResource
+  get() = Drawable26.icon_22000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22001: DrawableResource
+  get() = Drawable26.icon_22001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22002: DrawableResource
+  get() = Drawable26.icon_22002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22003: DrawableResource
+  get() = Drawable26.icon_22003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22004: DrawableResource
+  get() = Drawable26.icon_22004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22005: DrawableResource
+  get() = Drawable26.icon_22005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22006: DrawableResource
+  get() = Drawable26.icon_22006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22007: DrawableResource
+  get() = Drawable26.icon_22007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22008: DrawableResource
+  get() = Drawable26.icon_22008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22009: DrawableResource
+  get() = Drawable26.icon_22009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2201: DrawableResource
+  get() = Drawable26.icon_2201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22010: DrawableResource
+  get() = Drawable26.icon_22010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22011: DrawableResource
+  get() = Drawable26.icon_22011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22012: DrawableResource
+  get() = Drawable26.icon_22012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22013: DrawableResource
+  get() = Drawable26.icon_22013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22014: DrawableResource
+  get() = Drawable26.icon_22014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22015: DrawableResource
+  get() = Drawable26.icon_22015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22016: DrawableResource
+  get() = Drawable26.icon_22016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22017: DrawableResource
+  get() = Drawable26.icon_22017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22018: DrawableResource
+  get() = Drawable26.icon_22018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22019: DrawableResource
+  get() = Drawable26.icon_22019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2202: DrawableResource
+  get() = Drawable26.icon_2202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22020: DrawableResource
+  get() = Drawable26.icon_22020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22021: DrawableResource
+  get() = Drawable26.icon_22021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22022: DrawableResource
+  get() = Drawable26.icon_22022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22023: DrawableResource
+  get() = Drawable26.icon_22023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22024: DrawableResource
+  get() = Drawable26.icon_22024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22025: DrawableResource
+  get() = Drawable26.icon_22025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22026: DrawableResource
+  get() = Drawable26.icon_22026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22027: DrawableResource
+  get() = Drawable26.icon_22027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22028: DrawableResource
+  get() = Drawable26.icon_22028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22029: DrawableResource
+  get() = Drawable26.icon_22029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2203: DrawableResource
+  get() = Drawable26.icon_2203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22030: DrawableResource
+  get() = Drawable26.icon_22030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22031: DrawableResource
+  get() = Drawable26.icon_22031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22032: DrawableResource
+  get() = Drawable26.icon_22032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22033: DrawableResource
+  get() = Drawable26.icon_22033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22034: DrawableResource
+  get() = Drawable26.icon_22034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22035: DrawableResource
+  get() = Drawable26.icon_22035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22036: DrawableResource
+  get() = Drawable26.icon_22036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22037: DrawableResource
+  get() = Drawable26.icon_22037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22038: DrawableResource
+  get() = Drawable26.icon_22038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22039: DrawableResource
+  get() = Drawable26.icon_22039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2204: DrawableResource
+  get() = Drawable26.icon_2204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22040: DrawableResource
+  get() = Drawable26.icon_22040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22041: DrawableResource
+  get() = Drawable26.icon_22041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22042: DrawableResource
+  get() = Drawable26.icon_22042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22043: DrawableResource
+  get() = Drawable26.icon_22043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22044: DrawableResource
+  get() = Drawable26.icon_22044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22045: DrawableResource
+  get() = Drawable26.icon_22045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22046: DrawableResource
+  get() = Drawable26.icon_22046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22047: DrawableResource
+  get() = Drawable26.icon_22047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22048: DrawableResource
+  get() = Drawable26.icon_22048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22049: DrawableResource
+  get() = Drawable26.icon_22049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2205: DrawableResource
+  get() = Drawable26.icon_2205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22050: DrawableResource
+  get() = Drawable26.icon_22050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22051: DrawableResource
+  get() = Drawable26.icon_22051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22052: DrawableResource
+  get() = Drawable26.icon_22052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22053: DrawableResource
+  get() = Drawable26.icon_22053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22054: DrawableResource
+  get() = Drawable26.icon_22054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22055: DrawableResource
+  get() = Drawable26.icon_22055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22056: DrawableResource
+  get() = Drawable26.icon_22056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22057: DrawableResource
+  get() = Drawable26.icon_22057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22058: DrawableResource
+  get() = Drawable26.icon_22058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22059: DrawableResource
+  get() = Drawable26.icon_22059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2206: DrawableResource
+  get() = Drawable26.icon_2206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22060: DrawableResource
+  get() = Drawable26.icon_22060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22061: DrawableResource
+  get() = Drawable26.icon_22061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22062: DrawableResource
+  get() = Drawable26.icon_22062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22063: DrawableResource
+  get() = Drawable26.icon_22063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22064: DrawableResource
+  get() = Drawable26.icon_22064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22065: DrawableResource
+  get() = Drawable26.icon_22065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22066: DrawableResource
+  get() = Drawable26.icon_22066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22067: DrawableResource
+  get() = Drawable26.icon_22067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22068: DrawableResource
+  get() = Drawable26.icon_22068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22069: DrawableResource
+  get() = Drawable26.icon_22069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2207: DrawableResource
+  get() = Drawable26.icon_2207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22070: DrawableResource
+  get() = Drawable26.icon_22070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22071: DrawableResource
+  get() = Drawable26.icon_22071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22072: DrawableResource
+  get() = Drawable26.icon_22072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22073: DrawableResource
+  get() = Drawable26.icon_22073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22074: DrawableResource
+  get() = Drawable26.icon_22074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22075: DrawableResource
+  get() = Drawable26.icon_22075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22076: DrawableResource
+  get() = Drawable26.icon_22076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22077: DrawableResource
+  get() = Drawable26.icon_22077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22078: DrawableResource
+  get() = Drawable26.icon_22078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22079: DrawableResource
+  get() = Drawable26.icon_22079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2208: DrawableResource
+  get() = Drawable26.icon_2208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22080: DrawableResource
+  get() = Drawable26.icon_22080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22081: DrawableResource
+  get() = Drawable26.icon_22081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22082: DrawableResource
+  get() = Drawable26.icon_22082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22083: DrawableResource
+  get() = Drawable26.icon_22083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22084: DrawableResource
+  get() = Drawable26.icon_22084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22085: DrawableResource
+  get() = Drawable26.icon_22085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22086: DrawableResource
+  get() = Drawable26.icon_22086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22087: DrawableResource
+  get() = Drawable26.icon_22087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22088: DrawableResource
+  get() = Drawable26.icon_22088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22089: DrawableResource
+  get() = Drawable26.icon_22089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2209: DrawableResource
+  get() = Drawable26.icon_2209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22090: DrawableResource
+  get() = Drawable26.icon_22090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22091: DrawableResource
+  get() = Drawable26.icon_22091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22092: DrawableResource
+  get() = Drawable26.icon_22092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22093: DrawableResource
+  get() = Drawable26.icon_22093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22094: DrawableResource
+  get() = Drawable26.icon_22094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22095: DrawableResource
+  get() = Drawable26.icon_22095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22096: DrawableResource
+  get() = Drawable26.icon_22096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22097: DrawableResource
+  get() = Drawable26.icon_22097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22098: DrawableResource
+  get() = Drawable26.icon_22098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22099: DrawableResource
+  get() = Drawable26.icon_22099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_221: DrawableResource
+  get() = Drawable26.icon_221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2210: DrawableResource
+  get() = Drawable26.icon_2210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22100: DrawableResource
+  get() = Drawable26.icon_22100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22101: DrawableResource
+  get() = Drawable26.icon_22101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22102: DrawableResource
+  get() = Drawable26.icon_22102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22103: DrawableResource
+  get() = Drawable26.icon_22103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22104: DrawableResource
+  get() = Drawable26.icon_22104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22105: DrawableResource
+  get() = Drawable26.icon_22105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22106: DrawableResource
+  get() = Drawable26.icon_22106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22107: DrawableResource
+  get() = Drawable26.icon_22107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22108: DrawableResource
+  get() = Drawable26.icon_22108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22109: DrawableResource
+  get() = Drawable26.icon_22109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2211: DrawableResource
+  get() = Drawable26.icon_2211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22110: DrawableResource
+  get() = Drawable26.icon_22110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22111: DrawableResource
+  get() = Drawable26.icon_22111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22112: DrawableResource
+  get() = Drawable26.icon_22112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22113: DrawableResource
+  get() = Drawable26.icon_22113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22114: DrawableResource
+  get() = Drawable26.icon_22114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22115: DrawableResource
+  get() = Drawable26.icon_22115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22116: DrawableResource
+  get() = Drawable26.icon_22116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22117: DrawableResource
+  get() = Drawable26.icon_22117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22118: DrawableResource
+  get() = Drawable26.icon_22118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22119: DrawableResource
+  get() = Drawable26.icon_22119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2212: DrawableResource
+  get() = Drawable26.icon_2212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22120: DrawableResource
+  get() = Drawable26.icon_22120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22121: DrawableResource
+  get() = Drawable26.icon_22121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22122: DrawableResource
+  get() = Drawable26.icon_22122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22123: DrawableResource
+  get() = Drawable26.icon_22123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22124: DrawableResource
+  get() = Drawable26.icon_22124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22125: DrawableResource
+  get() = Drawable26.icon_22125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22126: DrawableResource
+  get() = Drawable26.icon_22126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22127: DrawableResource
+  get() = Drawable26.icon_22127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22128: DrawableResource
+  get() = Drawable26.icon_22128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22129: DrawableResource
+  get() = Drawable26.icon_22129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2213: DrawableResource
+  get() = Drawable26.icon_2213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22130: DrawableResource
+  get() = Drawable26.icon_22130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22131: DrawableResource
+  get() = Drawable26.icon_22131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22132: DrawableResource
+  get() = Drawable26.icon_22132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22133: DrawableResource
+  get() = Drawable26.icon_22133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22134: DrawableResource
+  get() = Drawable26.icon_22134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22135: DrawableResource
+  get() = Drawable26.icon_22135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22136: DrawableResource
+  get() = Drawable26.icon_22136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22137: DrawableResource
+  get() = Drawable26.icon_22137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22138: DrawableResource
+  get() = Drawable26.icon_22138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22139: DrawableResource
+  get() = Drawable26.icon_22139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2214: DrawableResource
+  get() = Drawable26.icon_2214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22140: DrawableResource
+  get() = Drawable26.icon_22140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22141: DrawableResource
+  get() = Drawable26.icon_22141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22142: DrawableResource
+  get() = Drawable26.icon_22142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22143: DrawableResource
+  get() = Drawable26.icon_22143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22144: DrawableResource
+  get() = Drawable26.icon_22144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22145: DrawableResource
+  get() = Drawable26.icon_22145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22146: DrawableResource
+  get() = Drawable26.icon_22146

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable27.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable27.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable27 {
+  public val icon_22147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22147.xml"),
+          )
+      )
+
+  public val icon_22148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22148.xml"),
+          )
+      )
+
+  public val icon_22149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22149.xml"),
+          )
+      )
+
+  public val icon_2215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2215.xml"),
+          )
+      )
+
+  public val icon_22150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22150.xml"),
+          )
+      )
+
+  public val icon_22151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22151.xml"),
+          )
+      )
+
+  public val icon_22152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22152.xml"),
+          )
+      )
+
+  public val icon_22153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22153.xml"),
+          )
+      )
+
+  public val icon_22154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22154.xml"),
+          )
+      )
+
+  public val icon_22155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22155.xml"),
+          )
+      )
+
+  public val icon_22156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22156.xml"),
+          )
+      )
+
+  public val icon_22157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22157.xml"),
+          )
+      )
+
+  public val icon_22158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22158.xml"),
+          )
+      )
+
+  public val icon_22159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22159.xml"),
+          )
+      )
+
+  public val icon_2216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2216.xml"),
+          )
+      )
+
+  public val icon_22160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22160.xml"),
+          )
+      )
+
+  public val icon_22161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22161.xml"),
+          )
+      )
+
+  public val icon_22162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22162.xml"),
+          )
+      )
+
+  public val icon_22163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22163.xml"),
+          )
+      )
+
+  public val icon_22164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22164.xml"),
+          )
+      )
+
+  public val icon_22165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22165.xml"),
+          )
+      )
+
+  public val icon_22166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22166.xml"),
+          )
+      )
+
+  public val icon_22167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22167.xml"),
+          )
+      )
+
+  public val icon_22168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22168.xml"),
+          )
+      )
+
+  public val icon_22169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22169.xml"),
+          )
+      )
+
+  public val icon_2217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2217.xml"),
+          )
+      )
+
+  public val icon_22170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22170.xml"),
+          )
+      )
+
+  public val icon_22171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22171.xml"),
+          )
+      )
+
+  public val icon_22172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22172.xml"),
+          )
+      )
+
+  public val icon_22173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22173.xml"),
+          )
+      )
+
+  public val icon_22174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22174.xml"),
+          )
+      )
+
+  public val icon_22175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22175.xml"),
+          )
+      )
+
+  public val icon_22176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22176.xml"),
+          )
+      )
+
+  public val icon_22177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22177.xml"),
+          )
+      )
+
+  public val icon_22178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22178.xml"),
+          )
+      )
+
+  public val icon_22179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22179.xml"),
+          )
+      )
+
+  public val icon_2218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2218.xml"),
+          )
+      )
+
+  public val icon_22180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22180.xml"),
+          )
+      )
+
+  public val icon_22181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22181.xml"),
+          )
+      )
+
+  public val icon_22182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22182.xml"),
+          )
+      )
+
+  public val icon_22183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22183.xml"),
+          )
+      )
+
+  public val icon_22184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22184.xml"),
+          )
+      )
+
+  public val icon_22185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22185.xml"),
+          )
+      )
+
+  public val icon_22186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22186.xml"),
+          )
+      )
+
+  public val icon_22187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22187.xml"),
+          )
+      )
+
+  public val icon_22188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22188.xml"),
+          )
+      )
+
+  public val icon_22189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22189.xml"),
+          )
+      )
+
+  public val icon_2219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2219.xml"),
+          )
+      )
+
+  public val icon_22190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22190.xml"),
+          )
+      )
+
+  public val icon_22191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22191.xml"),
+          )
+      )
+
+  public val icon_22192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22192.xml"),
+          )
+      )
+
+  public val icon_22193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22193.xml"),
+          )
+      )
+
+  public val icon_22194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22194.xml"),
+          )
+      )
+
+  public val icon_22195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22195.xml"),
+          )
+      )
+
+  public val icon_22196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22196.xml"),
+          )
+      )
+
+  public val icon_22197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22197.xml"),
+          )
+      )
+
+  public val icon_22198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22198.xml"),
+          )
+      )
+
+  public val icon_22199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22199.xml"),
+          )
+      )
+
+  public val icon_222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_222.xml"),
+          )
+      )
+
+  public val icon_2220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2220.xml"),
+          )
+      )
+
+  public val icon_22200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22200.xml"),
+          )
+      )
+
+  public val icon_22201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22201.xml"),
+          )
+      )
+
+  public val icon_22202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22202.xml"),
+          )
+      )
+
+  public val icon_22203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22203.xml"),
+          )
+      )
+
+  public val icon_22204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22204.xml"),
+          )
+      )
+
+  public val icon_22205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22205.xml"),
+          )
+      )
+
+  public val icon_22206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22206.xml"),
+          )
+      )
+
+  public val icon_22207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22207.xml"),
+          )
+      )
+
+  public val icon_22208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22208.xml"),
+          )
+      )
+
+  public val icon_22209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22209.xml"),
+          )
+      )
+
+  public val icon_2221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2221.xml"),
+          )
+      )
+
+  public val icon_22210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22210.xml"),
+          )
+      )
+
+  public val icon_22211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22211.xml"),
+          )
+      )
+
+  public val icon_22212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22212.xml"),
+          )
+      )
+
+  public val icon_22213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22213.xml"),
+          )
+      )
+
+  public val icon_22214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22214.xml"),
+          )
+      )
+
+  public val icon_22215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22215.xml"),
+          )
+      )
+
+  public val icon_22216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22216.xml"),
+          )
+      )
+
+  public val icon_22217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22217.xml"),
+          )
+      )
+
+  public val icon_22218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22218.xml"),
+          )
+      )
+
+  public val icon_22219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22219.xml"),
+          )
+      )
+
+  public val icon_2222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2222.xml"),
+          )
+      )
+
+  public val icon_22220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22220.xml"),
+          )
+      )
+
+  public val icon_22221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22221.xml"),
+          )
+      )
+
+  public val icon_22222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22222.xml"),
+          )
+      )
+
+  public val icon_22223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22223.xml"),
+          )
+      )
+
+  public val icon_22224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22224.xml"),
+          )
+      )
+
+  public val icon_22225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22225.xml"),
+          )
+      )
+
+  public val icon_22226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22226.xml"),
+          )
+      )
+
+  public val icon_22227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22227.xml"),
+          )
+      )
+
+  public val icon_22228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22228.xml"),
+          )
+      )
+
+  public val icon_22229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22229.xml"),
+          )
+      )
+
+  public val icon_2223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2223.xml"),
+          )
+      )
+
+  public val icon_22230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22230.xml"),
+          )
+      )
+
+  public val icon_22231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22231.xml"),
+          )
+      )
+
+  public val icon_22232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22232.xml"),
+          )
+      )
+
+  public val icon_22233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22233.xml"),
+          )
+      )
+
+  public val icon_22234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22234.xml"),
+          )
+      )
+
+  public val icon_22235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22235.xml"),
+          )
+      )
+
+  public val icon_22236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22236.xml"),
+          )
+      )
+
+  public val icon_22237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22237.xml"),
+          )
+      )
+
+  public val icon_22238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22238.xml"),
+          )
+      )
+
+  public val icon_22239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22239.xml"),
+          )
+      )
+
+  public val icon_2224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2224.xml"),
+          )
+      )
+
+  public val icon_22240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22240.xml"),
+          )
+      )
+
+  public val icon_22241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22241.xml"),
+          )
+      )
+
+  public val icon_22242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22242.xml"),
+          )
+      )
+
+  public val icon_22243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22243.xml"),
+          )
+      )
+
+  public val icon_22244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22244.xml"),
+          )
+      )
+
+  public val icon_22245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22245.xml"),
+          )
+      )
+
+  public val icon_22246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22246.xml"),
+          )
+      )
+
+  public val icon_22247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22247.xml"),
+          )
+      )
+
+  public val icon_22248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22248.xml"),
+          )
+      )
+
+  public val icon_22249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22249.xml"),
+          )
+      )
+
+  public val icon_2225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2225.xml"),
+          )
+      )
+
+  public val icon_22250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22250.xml"),
+          )
+      )
+
+  public val icon_22251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22251.xml"),
+          )
+      )
+
+  public val icon_22252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22252.xml"),
+          )
+      )
+
+  public val icon_22253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22253.xml"),
+          )
+      )
+
+  public val icon_22254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22254.xml"),
+          )
+      )
+
+  public val icon_22255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22255.xml"),
+          )
+      )
+
+  public val icon_22256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22256.xml"),
+          )
+      )
+
+  public val icon_22257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22257.xml"),
+          )
+      )
+
+  public val icon_22258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22258.xml"),
+          )
+      )
+
+  public val icon_22259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22259.xml"),
+          )
+      )
+
+  public val icon_2226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2226.xml"),
+          )
+      )
+
+  public val icon_22260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22260.xml"),
+          )
+      )
+
+  public val icon_22261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22261.xml"),
+          )
+      )
+
+  public val icon_22262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22262.xml"),
+          )
+      )
+
+  public val icon_22263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22263.xml"),
+          )
+      )
+
+  public val icon_22264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22264.xml"),
+          )
+      )
+
+  public val icon_22265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22265.xml"),
+          )
+      )
+
+  public val icon_22266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22266.xml"),
+          )
+      )
+
+  public val icon_22267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22267.xml"),
+          )
+      )
+
+  public val icon_22268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22268.xml"),
+          )
+      )
+
+  public val icon_22269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22269.xml"),
+          )
+      )
+
+  public val icon_2227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2227.xml"),
+          )
+      )
+
+  public val icon_22270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22270.xml"),
+          )
+      )
+
+  public val icon_22271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22271.xml"),
+          )
+      )
+
+  public val icon_22272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22272.xml"),
+          )
+      )
+
+  public val icon_22273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22273.xml"),
+          )
+      )
+
+  public val icon_22274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22274.xml"),
+          )
+      )
+
+  public val icon_22275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22275.xml"),
+          )
+      )
+
+  public val icon_22276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22276.xml"),
+          )
+      )
+
+  public val icon_22277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22277.xml"),
+          )
+      )
+
+  public val icon_22278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22278.xml"),
+          )
+      )
+
+  public val icon_22279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22279.xml"),
+          )
+      )
+
+  public val icon_2228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2228.xml"),
+          )
+      )
+
+  public val icon_22280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22280.xml"),
+          )
+      )
+
+  public val icon_22281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22281.xml"),
+          )
+      )
+
+  public val icon_22282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22282.xml"),
+          )
+      )
+
+  public val icon_22283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22283.xml"),
+          )
+      )
+
+  public val icon_22284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22284.xml"),
+          )
+      )
+
+  public val icon_22285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22285.xml"),
+          )
+      )
+
+  public val icon_22286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22286.xml"),
+          )
+      )
+
+  public val icon_22287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22287.xml"),
+          )
+      )
+
+  public val icon_22288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22288.xml"),
+          )
+      )
+
+  public val icon_22289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22289.xml"),
+          )
+      )
+
+  public val icon_2229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2229.xml"),
+          )
+      )
+
+  public val icon_22290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22290.xml"),
+          )
+      )
+
+  public val icon_22291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22291.xml"),
+          )
+      )
+
+  public val icon_22292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22292.xml"),
+          )
+      )
+
+  public val icon_22293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22293.xml"),
+          )
+      )
+
+  public val icon_22294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22294.xml"),
+          )
+      )
+
+  public val icon_22295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22295.xml"),
+          )
+      )
+
+  public val icon_22296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22296.xml"),
+          )
+      )
+
+  public val icon_22297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22297.xml"),
+          )
+      )
+
+  public val icon_22298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22298.xml"),
+          )
+      )
+
+  public val icon_22299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22299.xml"),
+          )
+      )
+
+  public val icon_223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_223.xml"),
+          )
+      )
+
+  public val icon_2230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2230.xml"),
+          )
+      )
+
+  public val icon_22300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22300.xml"),
+          )
+      )
+
+  public val icon_22301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22301.xml"),
+          )
+      )
+
+  public val icon_22302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22302.xml"),
+          )
+      )
+
+  public val icon_22303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22303.xml"),
+          )
+      )
+
+  public val icon_22304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22304.xml"),
+          )
+      )
+
+  public val icon_22305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22305.xml"),
+          )
+      )
+
+  public val icon_22306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22306.xml"),
+          )
+      )
+
+  public val icon_22307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22307.xml"),
+          )
+      )
+
+  public val icon_22308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22308.xml"),
+          )
+      )
+
+  public val icon_22309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22309.xml"),
+          )
+      )
+
+  public val icon_2231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2231.xml"),
+          )
+      )
+
+  public val icon_22310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22310.xml"),
+          )
+      )
+
+  public val icon_22311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22311.xml"),
+          )
+      )
+
+  public val icon_22312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22312.xml"),
+          )
+      )
+
+  public val icon_22313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22313.xml"),
+          )
+      )
+
+  public val icon_22314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22314.xml"),
+          )
+      )
+
+  public val icon_22315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22315.xml"),
+          )
+      )
+
+  public val icon_22316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22316.xml"),
+          )
+      )
+
+  public val icon_22317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22317.xml"),
+          )
+      )
+
+  public val icon_22318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22318.xml"),
+          )
+      )
+
+  public val icon_22319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22319.xml"),
+          )
+      )
+
+  public val icon_2232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2232.xml"),
+          )
+      )
+
+  public val icon_22320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22320.xml"),
+          )
+      )
+
+  public val icon_22321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22321.xml"),
+          )
+      )
+
+  public val icon_22322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22322.xml"),
+          )
+      )
+
+  public val icon_22323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22323.xml"),
+          )
+      )
+
+  public val icon_22324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22324.xml"),
+          )
+      )
+
+  public val icon_22325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22325.xml"),
+          )
+      )
+
+  public val icon_22326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22326.xml"),
+          )
+      )
+
+  public val icon_22327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22327.xml"),
+          )
+      )
+
+  public val icon_22328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22328.xml"),
+          )
+      )
+
+  public val icon_22329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22329.xml"),
+          )
+      )
+
+  public val icon_2233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2233.xml"),
+          )
+      )
+
+  public val icon_22330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22330.xml"),
+          )
+      )
+
+  public val icon_22331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22331.xml"),
+          )
+      )
+
+  public val icon_22332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22332.xml"),
+          )
+      )
+
+  public val icon_22333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22333.xml"),
+          )
+      )
+
+  public val icon_22334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22334.xml"),
+          )
+      )
+
+  public val icon_22335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22335.xml"),
+          )
+      )
+
+  public val icon_22336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22336.xml"),
+          )
+      )
+
+  public val icon_22337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22337.xml"),
+          )
+      )
+
+  public val icon_22338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22338.xml"),
+          )
+      )
+
+  public val icon_22339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22339.xml"),
+          )
+      )
+
+  public val icon_2234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2234.xml"),
+          )
+      )
+
+  public val icon_22340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22340.xml"),
+          )
+      )
+
+  public val icon_22341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22341.xml"),
+          )
+      )
+
+  public val icon_22342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22342.xml"),
+          )
+      )
+
+  public val icon_22343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22343.xml"),
+          )
+      )
+
+  public val icon_22344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22344.xml"),
+          )
+      )
+
+  public val icon_22345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22345.xml"),
+          )
+      )
+
+  public val icon_22346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22346.xml"),
+          )
+      )
+
+  public val icon_22347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22347.xml"),
+          )
+      )
+
+  public val icon_22348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22348.xml"),
+          )
+      )
+
+  public val icon_22349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22349.xml"),
+          )
+      )
+
+  public val icon_2235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2235.xml"),
+          )
+      )
+
+  public val icon_22350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22350.xml"),
+          )
+      )
+
+  public val icon_22351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22351.xml"),
+          )
+      )
+
+  public val icon_22352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22352.xml"),
+          )
+      )
+
+  public val icon_22353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22353.xml"),
+          )
+      )
+
+  public val icon_22354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22354.xml"),
+          )
+      )
+
+  public val icon_22355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22355.xml"),
+          )
+      )
+
+  public val icon_22356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22356.xml"),
+          )
+      )
+
+  public val icon_22357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22357.xml"),
+          )
+      )
+
+  public val icon_22358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22358.xml"),
+          )
+      )
+
+  public val icon_22359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22359.xml"),
+          )
+      )
+
+  public val icon_2236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2236.xml"),
+          )
+      )
+
+  public val icon_22360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22360.xml"),
+          )
+      )
+
+  public val icon_22361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22361.xml"),
+          )
+      )
+
+  public val icon_22362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22362.xml"),
+          )
+      )
+
+  public val icon_22363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22363.xml"),
+          )
+      )
+
+  public val icon_22364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22364.xml"),
+          )
+      )
+
+  public val icon_22365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22365.xml"),
+          )
+      )
+
+  public val icon_22366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22366.xml"),
+          )
+      )
+
+  public val icon_22367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22367.xml"),
+          )
+      )
+
+  public val icon_22368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22368.xml"),
+          )
+      )
+
+  public val icon_22369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22369.xml"),
+          )
+      )
+
+  public val icon_2237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2237.xml"),
+          )
+      )
+
+  public val icon_22370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22370.xml"),
+          )
+      )
+
+  public val icon_22371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22371.xml"),
+          )
+      )
+
+  public val icon_22372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22372.xml"),
+          )
+      )
+
+  public val icon_22373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22373.xml"),
+          )
+      )
+
+  public val icon_22374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22374.xml"),
+          )
+      )
+
+  public val icon_22375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22375.xml"),
+          )
+      )
+
+  public val icon_22376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22376.xml"),
+          )
+      )
+
+  public val icon_22377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22377.xml"),
+          )
+      )
+
+  public val icon_22378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22378.xml"),
+          )
+      )
+
+  public val icon_22379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22379.xml"),
+          )
+      )
+
+  public val icon_2238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2238.xml"),
+          )
+      )
+
+  public val icon_22380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22380.xml"),
+          )
+      )
+
+  public val icon_22381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22381.xml"),
+          )
+      )
+
+  public val icon_22382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22382.xml"),
+          )
+      )
+
+  public val icon_22383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22383.xml"),
+          )
+      )
+
+  public val icon_22384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22384.xml"),
+          )
+      )
+
+  public val icon_22385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22385.xml"),
+          )
+      )
+
+  public val icon_22386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22386.xml"),
+          )
+      )
+
+  public val icon_22387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22387.xml"),
+          )
+      )
+
+  public val icon_22388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22388.xml"),
+          )
+      )
+
+  public val icon_22389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22389.xml"),
+          )
+      )
+
+  public val icon_2239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2239.xml"),
+          )
+      )
+
+  public val icon_22390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22390.xml"),
+          )
+      )
+
+  public val icon_22391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22391.xml"),
+          )
+      )
+
+  public val icon_22392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22392.xml"),
+          )
+      )
+
+  public val icon_22393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22393.xml"),
+          )
+      )
+
+  public val icon_22394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22394.xml"),
+          )
+      )
+
+  public val icon_22395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22395.xml"),
+          )
+      )
+
+  public val icon_22396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22396.xml"),
+          )
+      )
+
+  public val icon_22397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22397.xml"),
+          )
+      )
+
+  public val icon_22398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22398.xml"),
+          )
+      )
+
+  public val icon_22399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22399.xml"),
+          )
+      )
+
+  public val icon_224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_224.xml"),
+          )
+      )
+
+  public val icon_2240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2240.xml"),
+          )
+      )
+
+  public val icon_22400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22400.xml"),
+          )
+      )
+
+  public val icon_22401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22401.xml"),
+          )
+      )
+
+  public val icon_22402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22402.xml"),
+          )
+      )
+
+  public val icon_22403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22403.xml"),
+          )
+      )
+
+  public val icon_22404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22404.xml"),
+          )
+      )
+
+  public val icon_22405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22405.xml"),
+          )
+      )
+
+  public val icon_22406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22406.xml"),
+          )
+      )
+
+  public val icon_22407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22407.xml"),
+          )
+      )
+
+  public val icon_22408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22408.xml"),
+          )
+      )
+
+  public val icon_22409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22409.xml"),
+          )
+      )
+
+  public val icon_2241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2241.xml"),
+          )
+      )
+
+  public val icon_22410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22410.xml"),
+          )
+      )
+
+  public val icon_22411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22411.xml"),
+          )
+      )
+
+  public val icon_22412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22412.xml"),
+          )
+      )
+
+  public val icon_22413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22413.xml"),
+          )
+      )
+
+  public val icon_22414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22414.xml"),
+          )
+      )
+
+  public val icon_22415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22415.xml"),
+          )
+      )
+
+  public val icon_22416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22416.xml"),
+          )
+      )
+
+  public val icon_22417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22417.xml"),
+          )
+      )
+
+  public val icon_22418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22418.xml"),
+          )
+      )
+
+  public val icon_22419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22419.xml"),
+          )
+      )
+
+  public val icon_2242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2242.xml"),
+          )
+      )
+
+  public val icon_22420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22420.xml"),
+          )
+      )
+
+  public val icon_22421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22421.xml"),
+          )
+      )
+
+  public val icon_22422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22422.xml"),
+          )
+      )
+
+  public val icon_22423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22423.xml"),
+          )
+      )
+
+  public val icon_22424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22424.xml"),
+          )
+      )
+
+  public val icon_22425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22425.xml"),
+          )
+      )
+
+  public val icon_22426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22426.xml"),
+          )
+      )
+
+  public val icon_22427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22427.xml"),
+          )
+      )
+
+  public val icon_22428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22428.xml"),
+          )
+      )
+
+  public val icon_22429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22429.xml"),
+          )
+      )
+
+  public val icon_2243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2243.xml"),
+          )
+      )
+
+  public val icon_22430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22430.xml"),
+          )
+      )
+
+  public val icon_22431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22431.xml"),
+          )
+      )
+
+  public val icon_22432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22432.xml"),
+          )
+      )
+
+  public val icon_22433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22433.xml"),
+          )
+      )
+
+  public val icon_22434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22434.xml"),
+          )
+      )
+
+  public val icon_22435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22435.xml"),
+          )
+      )
+
+  public val icon_22436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22436.xml"),
+          )
+      )
+
+  public val icon_22437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22437.xml"),
+          )
+      )
+
+  public val icon_22438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22438.xml"),
+          )
+      )
+
+  public val icon_22439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22439.xml"),
+          )
+      )
+
+  public val icon_2244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2244.xml"),
+          )
+      )
+
+  public val icon_22440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22440.xml"),
+          )
+      )
+
+  public val icon_22441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22441.xml"),
+          )
+      )
+
+  public val icon_22442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22442.xml"),
+          )
+      )
+
+  public val icon_22443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22443.xml"),
+          )
+      )
+
+  public val icon_22444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22444.xml"),
+          )
+      )
+
+  public val icon_22445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22445.xml"),
+          )
+      )
+
+  public val icon_22446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22446.xml"),
+          )
+      )
+
+  public val icon_22447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22447.xml"),
+          )
+      )
+
+  public val icon_22448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22448.xml"),
+          )
+      )
+
+  public val icon_22449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22449.xml"),
+          )
+      )
+
+  public val icon_2245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2245.xml"),
+          )
+      )
+
+  public val icon_22450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22450.xml"),
+          )
+      )
+
+  public val icon_22451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22451.xml"),
+          )
+      )
+
+  public val icon_22452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22452.xml"),
+          )
+      )
+
+  public val icon_22453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22453.xml"),
+          )
+      )
+
+  public val icon_22454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22454.xml"),
+          )
+      )
+
+  public val icon_22455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22455.xml"),
+          )
+      )
+
+  public val icon_22456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22456.xml"),
+          )
+      )
+
+  public val icon_22457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22457.xml"),
+          )
+      )
+
+  public val icon_22458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22458.xml"),
+          )
+      )
+
+  public val icon_22459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22459.xml"),
+          )
+      )
+
+  public val icon_2246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2246.xml"),
+          )
+      )
+
+  public val icon_22460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22460.xml"),
+          )
+      )
+
+  public val icon_22461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22461.xml"),
+          )
+      )
+
+  public val icon_22462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22462.xml"),
+          )
+      )
+
+  public val icon_22463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22463.xml"),
+          )
+      )
+
+  public val icon_22464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22464.xml"),
+          )
+      )
+
+  public val icon_22465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22465.xml"),
+          )
+      )
+
+  public val icon_22466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22466.xml"),
+          )
+      )
+
+  public val icon_22467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22467.xml"),
+          )
+      )
+
+  public val icon_22468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22468.xml"),
+          )
+      )
+
+  public val icon_22469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22469.xml"),
+          )
+      )
+
+  public val icon_2247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2247.xml"),
+          )
+      )
+
+  public val icon_22470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22470.xml"),
+          )
+      )
+
+  public val icon_22471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22471.xml"),
+          )
+      )
+
+  public val icon_22472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22472.xml"),
+          )
+      )
+
+  public val icon_22473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22473.xml"),
+          )
+      )
+
+  public val icon_22474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22474.xml"),
+          )
+      )
+
+  public val icon_22475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22475.xml"),
+          )
+      )
+
+  public val icon_22476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22476.xml"),
+          )
+      )
+
+  public val icon_22477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22477.xml"),
+          )
+      )
+
+  public val icon_22478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22478.xml"),
+          )
+      )
+
+  public val icon_22479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22479.xml"),
+          )
+      )
+
+  public val icon_2248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2248.xml"),
+          )
+      )
+
+  public val icon_22480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22480.xml"),
+          )
+      )
+
+  public val icon_22481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22481.xml"),
+          )
+      )
+
+  public val icon_22482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22482.xml"),
+          )
+      )
+
+  public val icon_22483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22483.xml"),
+          )
+      )
+
+  public val icon_22484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22484.xml"),
+          )
+      )
+
+  public val icon_22485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22485.xml"),
+          )
+      )
+
+  public val icon_22486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22486.xml"),
+          )
+      )
+
+  public val icon_22487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22487.xml"),
+          )
+      )
+
+  public val icon_22488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22488.xml"),
+          )
+      )
+
+  public val icon_22489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22489.xml"),
+          )
+      )
+
+  public val icon_2249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2249.xml"),
+          )
+      )
+
+  public val icon_22490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22490.xml"),
+          )
+      )
+
+  public val icon_22491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22491.xml"),
+          )
+      )
+
+  public val icon_22492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22492.xml"),
+          )
+      )
+
+  public val icon_22493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22493.xml"),
+          )
+      )
+
+  public val icon_22494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22494.xml"),
+          )
+      )
+
+  public val icon_22495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22495.xml"),
+          )
+      )
+
+  public val icon_22496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22496.xml"),
+          )
+      )
+
+  public val icon_22497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22497.xml"),
+          )
+      )
+
+  public val icon_22498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22498.xml"),
+          )
+      )
+
+  public val icon_22499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22499.xml"),
+          )
+      )
+
+  public val icon_225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_225.xml"),
+          )
+      )
+
+  public val icon_2250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2250.xml"),
+          )
+      )
+
+  public val icon_22500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22500.xml"),
+          )
+      )
+
+  public val icon_22501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22501.xml"),
+          )
+      )
+
+  public val icon_22502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22502.xml"),
+          )
+      )
+
+  public val icon_22503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22503.xml"),
+          )
+      )
+
+  public val icon_22504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22504.xml"),
+          )
+      )
+
+  public val icon_22505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22505.xml"),
+          )
+      )
+
+  public val icon_22506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22506.xml"),
+          )
+      )
+
+  public val icon_22507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22507.xml"),
+          )
+      )
+
+  public val icon_22508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22508.xml"),
+          )
+      )
+
+  public val icon_22509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22509.xml"),
+          )
+      )
+
+  public val icon_2251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2251.xml"),
+          )
+      )
+
+  public val icon_22510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22510.xml"),
+          )
+      )
+
+  public val icon_22511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22511.xml"),
+          )
+      )
+
+  public val icon_22512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22512.xml"),
+          )
+      )
+
+  public val icon_22513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22513.xml"),
+          )
+      )
+
+  public val icon_22514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22514.xml"),
+          )
+      )
+
+  public val icon_22515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22515.xml"),
+          )
+      )
+
+  public val icon_22516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22516.xml"),
+          )
+      )
+
+  public val icon_22517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22517.xml"),
+          )
+      )
+
+  public val icon_22518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22518.xml"),
+          )
+      )
+
+  public val icon_22519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22519.xml"),
+          )
+      )
+
+  public val icon_2252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2252.xml"),
+          )
+      )
+
+  public val icon_22520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22520.xml"),
+          )
+      )
+
+  public val icon_22521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22521.xml"),
+          )
+      )
+
+  public val icon_22522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22522.xml"),
+          )
+      )
+
+  public val icon_22523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22523.xml"),
+          )
+      )
+
+  public val icon_22524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22524.xml"),
+          )
+      )
+
+  public val icon_22525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22525.xml"),
+          )
+      )
+
+  public val icon_22526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22526.xml"),
+          )
+      )
+
+  public val icon_22527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22527.xml"),
+          )
+      )
+
+  public val icon_22528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22528.xml"),
+          )
+      )
+
+  public val icon_22529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22529.xml"),
+          )
+      )
+
+  public val icon_2253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2253.xml"),
+          )
+      )
+
+  public val icon_22530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22530.xml"),
+          )
+      )
+
+  public val icon_22531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22531.xml"),
+          )
+      )
+
+  public val icon_22532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22532.xml"),
+          )
+      )
+
+  public val icon_22533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22533.xml"),
+          )
+      )
+
+  public val icon_22534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22534.xml"),
+          )
+      )
+
+  public val icon_22535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22535.xml"),
+          )
+      )
+
+  public val icon_22536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22536.xml"),
+          )
+      )
+
+  public val icon_22537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22537.xml"),
+          )
+      )
+
+  public val icon_22538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22538.xml"),
+          )
+      )
+
+  public val icon_22539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22539.xml"),
+          )
+      )
+
+  public val icon_2254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2254.xml"),
+          )
+      )
+
+  public val icon_22540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22540.xml"),
+          )
+      )
+
+  public val icon_22541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22541.xml"),
+          )
+      )
+
+  public val icon_22542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22542.xml"),
+          )
+      )
+
+  public val icon_22543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22543.xml"),
+          )
+      )
+
+  public val icon_22544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22544.xml"),
+          )
+      )
+
+  public val icon_22545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22545.xml"),
+          )
+      )
+
+  public val icon_22546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22546.xml"),
+          )
+      )
+
+  public val icon_22547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22547.xml"),
+          )
+      )
+
+  public val icon_22548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22548.xml"),
+          )
+      )
+
+  public val icon_22549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22549.xml"),
+          )
+      )
+
+  public val icon_2255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2255.xml"),
+          )
+      )
+
+  public val icon_22550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22550.xml"),
+          )
+      )
+
+  public val icon_22551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22551.xml"),
+          )
+      )
+
+  public val icon_22552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22552.xml"),
+          )
+      )
+
+  public val icon_22553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22553.xml"),
+          )
+      )
+
+  public val icon_22554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22554.xml"),
+          )
+      )
+
+  public val icon_22555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22555.xml"),
+          )
+      )
+
+  public val icon_22556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22556.xml"),
+          )
+      )
+
+  public val icon_22557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22557.xml"),
+          )
+      )
+
+  public val icon_22558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22558.xml"),
+          )
+      )
+
+  public val icon_22559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22559.xml"),
+          )
+      )
+
+  public val icon_2256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2256.xml"),
+          )
+      )
+
+  public val icon_22560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22560.xml"),
+          )
+      )
+
+  public val icon_22561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22561.xml"),
+          )
+      )
+
+  public val icon_22562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22562.xml"),
+          )
+      )
+
+  public val icon_22563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22563.xml"),
+          )
+      )
+
+  public val icon_22564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22564.xml"),
+          )
+      )
+
+  public val icon_22565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22565.xml"),
+          )
+      )
+
+  public val icon_22566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22566.xml"),
+          )
+      )
+
+  public val icon_22567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22567.xml"),
+          )
+      )
+
+  public val icon_22568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22568.xml"),
+          )
+      )
+
+  public val icon_22569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22569.xml"),
+          )
+      )
+
+  public val icon_2257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2257.xml"),
+          )
+      )
+
+  public val icon_22570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22570.xml"),
+          )
+      )
+
+  public val icon_22571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22571.xml"),
+          )
+      )
+
+  public val icon_22572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22572.xml"),
+          )
+      )
+
+  public val icon_22573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22573.xml"),
+          )
+      )
+
+  public val icon_22574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22574.xml"),
+          )
+      )
+
+  public val icon_22575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22575.xml"),
+          )
+      )
+
+  public val icon_22576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22576.xml"),
+          )
+      )
+
+  public val icon_22577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22577.xml"),
+          )
+      )
+
+  public val icon_22578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22578.xml"),
+          )
+      )
+
+  public val icon_22579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22579.xml"),
+          )
+      )
+
+  public val icon_2258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2258.xml"),
+          )
+      )
+
+  public val icon_22580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22580.xml"),
+          )
+      )
+
+  public val icon_22581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22581.xml"),
+          )
+      )
+
+  public val icon_22582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22582.xml"),
+          )
+      )
+
+  public val icon_22583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22583.xml"),
+          )
+      )
+
+  public val icon_22584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22584.xml"),
+          )
+      )
+
+  public val icon_22585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22585.xml"),
+          )
+      )
+
+  public val icon_22586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22586.xml"),
+          )
+      )
+
+  public val icon_22587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22587.xml"),
+          )
+      )
+
+  public val icon_22588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22588.xml"),
+          )
+      )
+
+  public val icon_22589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22589.xml"),
+          )
+      )
+
+  public val icon_2259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2259.xml"),
+          )
+      )
+
+  public val icon_22590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22590.xml"),
+          )
+      )
+
+  public val icon_22591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22591.xml"),
+          )
+      )
+
+  public val icon_22592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22592.xml"),
+          )
+      )
+
+  public val icon_22593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22593.xml"),
+          )
+      )
+
+  public val icon_22594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22594.xml"),
+          )
+      )
+
+  public val icon_22595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22595.xml"),
+          )
+      )
+
+  public val icon_22596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22596.xml"),
+          )
+      )
+
+  public val icon_22597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22597.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22147: DrawableResource
+  get() = Drawable27.icon_22147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22148: DrawableResource
+  get() = Drawable27.icon_22148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22149: DrawableResource
+  get() = Drawable27.icon_22149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2215: DrawableResource
+  get() = Drawable27.icon_2215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22150: DrawableResource
+  get() = Drawable27.icon_22150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22151: DrawableResource
+  get() = Drawable27.icon_22151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22152: DrawableResource
+  get() = Drawable27.icon_22152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22153: DrawableResource
+  get() = Drawable27.icon_22153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22154: DrawableResource
+  get() = Drawable27.icon_22154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22155: DrawableResource
+  get() = Drawable27.icon_22155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22156: DrawableResource
+  get() = Drawable27.icon_22156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22157: DrawableResource
+  get() = Drawable27.icon_22157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22158: DrawableResource
+  get() = Drawable27.icon_22158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22159: DrawableResource
+  get() = Drawable27.icon_22159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2216: DrawableResource
+  get() = Drawable27.icon_2216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22160: DrawableResource
+  get() = Drawable27.icon_22160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22161: DrawableResource
+  get() = Drawable27.icon_22161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22162: DrawableResource
+  get() = Drawable27.icon_22162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22163: DrawableResource
+  get() = Drawable27.icon_22163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22164: DrawableResource
+  get() = Drawable27.icon_22164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22165: DrawableResource
+  get() = Drawable27.icon_22165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22166: DrawableResource
+  get() = Drawable27.icon_22166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22167: DrawableResource
+  get() = Drawable27.icon_22167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22168: DrawableResource
+  get() = Drawable27.icon_22168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22169: DrawableResource
+  get() = Drawable27.icon_22169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2217: DrawableResource
+  get() = Drawable27.icon_2217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22170: DrawableResource
+  get() = Drawable27.icon_22170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22171: DrawableResource
+  get() = Drawable27.icon_22171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22172: DrawableResource
+  get() = Drawable27.icon_22172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22173: DrawableResource
+  get() = Drawable27.icon_22173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22174: DrawableResource
+  get() = Drawable27.icon_22174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22175: DrawableResource
+  get() = Drawable27.icon_22175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22176: DrawableResource
+  get() = Drawable27.icon_22176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22177: DrawableResource
+  get() = Drawable27.icon_22177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22178: DrawableResource
+  get() = Drawable27.icon_22178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22179: DrawableResource
+  get() = Drawable27.icon_22179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2218: DrawableResource
+  get() = Drawable27.icon_2218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22180: DrawableResource
+  get() = Drawable27.icon_22180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22181: DrawableResource
+  get() = Drawable27.icon_22181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22182: DrawableResource
+  get() = Drawable27.icon_22182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22183: DrawableResource
+  get() = Drawable27.icon_22183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22184: DrawableResource
+  get() = Drawable27.icon_22184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22185: DrawableResource
+  get() = Drawable27.icon_22185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22186: DrawableResource
+  get() = Drawable27.icon_22186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22187: DrawableResource
+  get() = Drawable27.icon_22187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22188: DrawableResource
+  get() = Drawable27.icon_22188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22189: DrawableResource
+  get() = Drawable27.icon_22189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2219: DrawableResource
+  get() = Drawable27.icon_2219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22190: DrawableResource
+  get() = Drawable27.icon_22190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22191: DrawableResource
+  get() = Drawable27.icon_22191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22192: DrawableResource
+  get() = Drawable27.icon_22192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22193: DrawableResource
+  get() = Drawable27.icon_22193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22194: DrawableResource
+  get() = Drawable27.icon_22194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22195: DrawableResource
+  get() = Drawable27.icon_22195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22196: DrawableResource
+  get() = Drawable27.icon_22196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22197: DrawableResource
+  get() = Drawable27.icon_22197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22198: DrawableResource
+  get() = Drawable27.icon_22198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22199: DrawableResource
+  get() = Drawable27.icon_22199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_222: DrawableResource
+  get() = Drawable27.icon_222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2220: DrawableResource
+  get() = Drawable27.icon_2220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22200: DrawableResource
+  get() = Drawable27.icon_22200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22201: DrawableResource
+  get() = Drawable27.icon_22201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22202: DrawableResource
+  get() = Drawable27.icon_22202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22203: DrawableResource
+  get() = Drawable27.icon_22203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22204: DrawableResource
+  get() = Drawable27.icon_22204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22205: DrawableResource
+  get() = Drawable27.icon_22205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22206: DrawableResource
+  get() = Drawable27.icon_22206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22207: DrawableResource
+  get() = Drawable27.icon_22207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22208: DrawableResource
+  get() = Drawable27.icon_22208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22209: DrawableResource
+  get() = Drawable27.icon_22209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2221: DrawableResource
+  get() = Drawable27.icon_2221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22210: DrawableResource
+  get() = Drawable27.icon_22210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22211: DrawableResource
+  get() = Drawable27.icon_22211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22212: DrawableResource
+  get() = Drawable27.icon_22212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22213: DrawableResource
+  get() = Drawable27.icon_22213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22214: DrawableResource
+  get() = Drawable27.icon_22214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22215: DrawableResource
+  get() = Drawable27.icon_22215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22216: DrawableResource
+  get() = Drawable27.icon_22216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22217: DrawableResource
+  get() = Drawable27.icon_22217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22218: DrawableResource
+  get() = Drawable27.icon_22218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22219: DrawableResource
+  get() = Drawable27.icon_22219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2222: DrawableResource
+  get() = Drawable27.icon_2222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22220: DrawableResource
+  get() = Drawable27.icon_22220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22221: DrawableResource
+  get() = Drawable27.icon_22221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22222: DrawableResource
+  get() = Drawable27.icon_22222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22223: DrawableResource
+  get() = Drawable27.icon_22223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22224: DrawableResource
+  get() = Drawable27.icon_22224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22225: DrawableResource
+  get() = Drawable27.icon_22225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22226: DrawableResource
+  get() = Drawable27.icon_22226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22227: DrawableResource
+  get() = Drawable27.icon_22227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22228: DrawableResource
+  get() = Drawable27.icon_22228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22229: DrawableResource
+  get() = Drawable27.icon_22229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2223: DrawableResource
+  get() = Drawable27.icon_2223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22230: DrawableResource
+  get() = Drawable27.icon_22230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22231: DrawableResource
+  get() = Drawable27.icon_22231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22232: DrawableResource
+  get() = Drawable27.icon_22232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22233: DrawableResource
+  get() = Drawable27.icon_22233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22234: DrawableResource
+  get() = Drawable27.icon_22234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22235: DrawableResource
+  get() = Drawable27.icon_22235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22236: DrawableResource
+  get() = Drawable27.icon_22236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22237: DrawableResource
+  get() = Drawable27.icon_22237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22238: DrawableResource
+  get() = Drawable27.icon_22238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22239: DrawableResource
+  get() = Drawable27.icon_22239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2224: DrawableResource
+  get() = Drawable27.icon_2224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22240: DrawableResource
+  get() = Drawable27.icon_22240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22241: DrawableResource
+  get() = Drawable27.icon_22241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22242: DrawableResource
+  get() = Drawable27.icon_22242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22243: DrawableResource
+  get() = Drawable27.icon_22243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22244: DrawableResource
+  get() = Drawable27.icon_22244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22245: DrawableResource
+  get() = Drawable27.icon_22245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22246: DrawableResource
+  get() = Drawable27.icon_22246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22247: DrawableResource
+  get() = Drawable27.icon_22247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22248: DrawableResource
+  get() = Drawable27.icon_22248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22249: DrawableResource
+  get() = Drawable27.icon_22249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2225: DrawableResource
+  get() = Drawable27.icon_2225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22250: DrawableResource
+  get() = Drawable27.icon_22250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22251: DrawableResource
+  get() = Drawable27.icon_22251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22252: DrawableResource
+  get() = Drawable27.icon_22252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22253: DrawableResource
+  get() = Drawable27.icon_22253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22254: DrawableResource
+  get() = Drawable27.icon_22254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22255: DrawableResource
+  get() = Drawable27.icon_22255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22256: DrawableResource
+  get() = Drawable27.icon_22256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22257: DrawableResource
+  get() = Drawable27.icon_22257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22258: DrawableResource
+  get() = Drawable27.icon_22258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22259: DrawableResource
+  get() = Drawable27.icon_22259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2226: DrawableResource
+  get() = Drawable27.icon_2226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22260: DrawableResource
+  get() = Drawable27.icon_22260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22261: DrawableResource
+  get() = Drawable27.icon_22261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22262: DrawableResource
+  get() = Drawable27.icon_22262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22263: DrawableResource
+  get() = Drawable27.icon_22263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22264: DrawableResource
+  get() = Drawable27.icon_22264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22265: DrawableResource
+  get() = Drawable27.icon_22265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22266: DrawableResource
+  get() = Drawable27.icon_22266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22267: DrawableResource
+  get() = Drawable27.icon_22267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22268: DrawableResource
+  get() = Drawable27.icon_22268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22269: DrawableResource
+  get() = Drawable27.icon_22269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2227: DrawableResource
+  get() = Drawable27.icon_2227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22270: DrawableResource
+  get() = Drawable27.icon_22270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22271: DrawableResource
+  get() = Drawable27.icon_22271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22272: DrawableResource
+  get() = Drawable27.icon_22272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22273: DrawableResource
+  get() = Drawable27.icon_22273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22274: DrawableResource
+  get() = Drawable27.icon_22274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22275: DrawableResource
+  get() = Drawable27.icon_22275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22276: DrawableResource
+  get() = Drawable27.icon_22276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22277: DrawableResource
+  get() = Drawable27.icon_22277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22278: DrawableResource
+  get() = Drawable27.icon_22278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22279: DrawableResource
+  get() = Drawable27.icon_22279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2228: DrawableResource
+  get() = Drawable27.icon_2228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22280: DrawableResource
+  get() = Drawable27.icon_22280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22281: DrawableResource
+  get() = Drawable27.icon_22281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22282: DrawableResource
+  get() = Drawable27.icon_22282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22283: DrawableResource
+  get() = Drawable27.icon_22283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22284: DrawableResource
+  get() = Drawable27.icon_22284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22285: DrawableResource
+  get() = Drawable27.icon_22285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22286: DrawableResource
+  get() = Drawable27.icon_22286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22287: DrawableResource
+  get() = Drawable27.icon_22287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22288: DrawableResource
+  get() = Drawable27.icon_22288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22289: DrawableResource
+  get() = Drawable27.icon_22289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2229: DrawableResource
+  get() = Drawable27.icon_2229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22290: DrawableResource
+  get() = Drawable27.icon_22290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22291: DrawableResource
+  get() = Drawable27.icon_22291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22292: DrawableResource
+  get() = Drawable27.icon_22292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22293: DrawableResource
+  get() = Drawable27.icon_22293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22294: DrawableResource
+  get() = Drawable27.icon_22294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22295: DrawableResource
+  get() = Drawable27.icon_22295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22296: DrawableResource
+  get() = Drawable27.icon_22296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22297: DrawableResource
+  get() = Drawable27.icon_22297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22298: DrawableResource
+  get() = Drawable27.icon_22298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22299: DrawableResource
+  get() = Drawable27.icon_22299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_223: DrawableResource
+  get() = Drawable27.icon_223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2230: DrawableResource
+  get() = Drawable27.icon_2230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22300: DrawableResource
+  get() = Drawable27.icon_22300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22301: DrawableResource
+  get() = Drawable27.icon_22301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22302: DrawableResource
+  get() = Drawable27.icon_22302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22303: DrawableResource
+  get() = Drawable27.icon_22303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22304: DrawableResource
+  get() = Drawable27.icon_22304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22305: DrawableResource
+  get() = Drawable27.icon_22305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22306: DrawableResource
+  get() = Drawable27.icon_22306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22307: DrawableResource
+  get() = Drawable27.icon_22307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22308: DrawableResource
+  get() = Drawable27.icon_22308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22309: DrawableResource
+  get() = Drawable27.icon_22309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2231: DrawableResource
+  get() = Drawable27.icon_2231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22310: DrawableResource
+  get() = Drawable27.icon_22310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22311: DrawableResource
+  get() = Drawable27.icon_22311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22312: DrawableResource
+  get() = Drawable27.icon_22312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22313: DrawableResource
+  get() = Drawable27.icon_22313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22314: DrawableResource
+  get() = Drawable27.icon_22314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22315: DrawableResource
+  get() = Drawable27.icon_22315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22316: DrawableResource
+  get() = Drawable27.icon_22316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22317: DrawableResource
+  get() = Drawable27.icon_22317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22318: DrawableResource
+  get() = Drawable27.icon_22318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22319: DrawableResource
+  get() = Drawable27.icon_22319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2232: DrawableResource
+  get() = Drawable27.icon_2232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22320: DrawableResource
+  get() = Drawable27.icon_22320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22321: DrawableResource
+  get() = Drawable27.icon_22321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22322: DrawableResource
+  get() = Drawable27.icon_22322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22323: DrawableResource
+  get() = Drawable27.icon_22323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22324: DrawableResource
+  get() = Drawable27.icon_22324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22325: DrawableResource
+  get() = Drawable27.icon_22325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22326: DrawableResource
+  get() = Drawable27.icon_22326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22327: DrawableResource
+  get() = Drawable27.icon_22327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22328: DrawableResource
+  get() = Drawable27.icon_22328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22329: DrawableResource
+  get() = Drawable27.icon_22329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2233: DrawableResource
+  get() = Drawable27.icon_2233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22330: DrawableResource
+  get() = Drawable27.icon_22330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22331: DrawableResource
+  get() = Drawable27.icon_22331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22332: DrawableResource
+  get() = Drawable27.icon_22332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22333: DrawableResource
+  get() = Drawable27.icon_22333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22334: DrawableResource
+  get() = Drawable27.icon_22334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22335: DrawableResource
+  get() = Drawable27.icon_22335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22336: DrawableResource
+  get() = Drawable27.icon_22336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22337: DrawableResource
+  get() = Drawable27.icon_22337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22338: DrawableResource
+  get() = Drawable27.icon_22338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22339: DrawableResource
+  get() = Drawable27.icon_22339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2234: DrawableResource
+  get() = Drawable27.icon_2234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22340: DrawableResource
+  get() = Drawable27.icon_22340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22341: DrawableResource
+  get() = Drawable27.icon_22341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22342: DrawableResource
+  get() = Drawable27.icon_22342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22343: DrawableResource
+  get() = Drawable27.icon_22343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22344: DrawableResource
+  get() = Drawable27.icon_22344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22345: DrawableResource
+  get() = Drawable27.icon_22345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22346: DrawableResource
+  get() = Drawable27.icon_22346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22347: DrawableResource
+  get() = Drawable27.icon_22347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22348: DrawableResource
+  get() = Drawable27.icon_22348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22349: DrawableResource
+  get() = Drawable27.icon_22349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2235: DrawableResource
+  get() = Drawable27.icon_2235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22350: DrawableResource
+  get() = Drawable27.icon_22350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22351: DrawableResource
+  get() = Drawable27.icon_22351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22352: DrawableResource
+  get() = Drawable27.icon_22352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22353: DrawableResource
+  get() = Drawable27.icon_22353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22354: DrawableResource
+  get() = Drawable27.icon_22354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22355: DrawableResource
+  get() = Drawable27.icon_22355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22356: DrawableResource
+  get() = Drawable27.icon_22356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22357: DrawableResource
+  get() = Drawable27.icon_22357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22358: DrawableResource
+  get() = Drawable27.icon_22358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22359: DrawableResource
+  get() = Drawable27.icon_22359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2236: DrawableResource
+  get() = Drawable27.icon_2236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22360: DrawableResource
+  get() = Drawable27.icon_22360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22361: DrawableResource
+  get() = Drawable27.icon_22361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22362: DrawableResource
+  get() = Drawable27.icon_22362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22363: DrawableResource
+  get() = Drawable27.icon_22363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22364: DrawableResource
+  get() = Drawable27.icon_22364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22365: DrawableResource
+  get() = Drawable27.icon_22365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22366: DrawableResource
+  get() = Drawable27.icon_22366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22367: DrawableResource
+  get() = Drawable27.icon_22367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22368: DrawableResource
+  get() = Drawable27.icon_22368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22369: DrawableResource
+  get() = Drawable27.icon_22369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2237: DrawableResource
+  get() = Drawable27.icon_2237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22370: DrawableResource
+  get() = Drawable27.icon_22370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22371: DrawableResource
+  get() = Drawable27.icon_22371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22372: DrawableResource
+  get() = Drawable27.icon_22372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22373: DrawableResource
+  get() = Drawable27.icon_22373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22374: DrawableResource
+  get() = Drawable27.icon_22374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22375: DrawableResource
+  get() = Drawable27.icon_22375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22376: DrawableResource
+  get() = Drawable27.icon_22376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22377: DrawableResource
+  get() = Drawable27.icon_22377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22378: DrawableResource
+  get() = Drawable27.icon_22378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22379: DrawableResource
+  get() = Drawable27.icon_22379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2238: DrawableResource
+  get() = Drawable27.icon_2238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22380: DrawableResource
+  get() = Drawable27.icon_22380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22381: DrawableResource
+  get() = Drawable27.icon_22381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22382: DrawableResource
+  get() = Drawable27.icon_22382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22383: DrawableResource
+  get() = Drawable27.icon_22383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22384: DrawableResource
+  get() = Drawable27.icon_22384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22385: DrawableResource
+  get() = Drawable27.icon_22385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22386: DrawableResource
+  get() = Drawable27.icon_22386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22387: DrawableResource
+  get() = Drawable27.icon_22387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22388: DrawableResource
+  get() = Drawable27.icon_22388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22389: DrawableResource
+  get() = Drawable27.icon_22389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2239: DrawableResource
+  get() = Drawable27.icon_2239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22390: DrawableResource
+  get() = Drawable27.icon_22390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22391: DrawableResource
+  get() = Drawable27.icon_22391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22392: DrawableResource
+  get() = Drawable27.icon_22392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22393: DrawableResource
+  get() = Drawable27.icon_22393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22394: DrawableResource
+  get() = Drawable27.icon_22394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22395: DrawableResource
+  get() = Drawable27.icon_22395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22396: DrawableResource
+  get() = Drawable27.icon_22396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22397: DrawableResource
+  get() = Drawable27.icon_22397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22398: DrawableResource
+  get() = Drawable27.icon_22398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22399: DrawableResource
+  get() = Drawable27.icon_22399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_224: DrawableResource
+  get() = Drawable27.icon_224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2240: DrawableResource
+  get() = Drawable27.icon_2240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22400: DrawableResource
+  get() = Drawable27.icon_22400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22401: DrawableResource
+  get() = Drawable27.icon_22401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22402: DrawableResource
+  get() = Drawable27.icon_22402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22403: DrawableResource
+  get() = Drawable27.icon_22403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22404: DrawableResource
+  get() = Drawable27.icon_22404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22405: DrawableResource
+  get() = Drawable27.icon_22405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22406: DrawableResource
+  get() = Drawable27.icon_22406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22407: DrawableResource
+  get() = Drawable27.icon_22407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22408: DrawableResource
+  get() = Drawable27.icon_22408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22409: DrawableResource
+  get() = Drawable27.icon_22409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2241: DrawableResource
+  get() = Drawable27.icon_2241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22410: DrawableResource
+  get() = Drawable27.icon_22410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22411: DrawableResource
+  get() = Drawable27.icon_22411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22412: DrawableResource
+  get() = Drawable27.icon_22412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22413: DrawableResource
+  get() = Drawable27.icon_22413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22414: DrawableResource
+  get() = Drawable27.icon_22414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22415: DrawableResource
+  get() = Drawable27.icon_22415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22416: DrawableResource
+  get() = Drawable27.icon_22416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22417: DrawableResource
+  get() = Drawable27.icon_22417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22418: DrawableResource
+  get() = Drawable27.icon_22418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22419: DrawableResource
+  get() = Drawable27.icon_22419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2242: DrawableResource
+  get() = Drawable27.icon_2242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22420: DrawableResource
+  get() = Drawable27.icon_22420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22421: DrawableResource
+  get() = Drawable27.icon_22421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22422: DrawableResource
+  get() = Drawable27.icon_22422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22423: DrawableResource
+  get() = Drawable27.icon_22423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22424: DrawableResource
+  get() = Drawable27.icon_22424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22425: DrawableResource
+  get() = Drawable27.icon_22425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22426: DrawableResource
+  get() = Drawable27.icon_22426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22427: DrawableResource
+  get() = Drawable27.icon_22427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22428: DrawableResource
+  get() = Drawable27.icon_22428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22429: DrawableResource
+  get() = Drawable27.icon_22429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2243: DrawableResource
+  get() = Drawable27.icon_2243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22430: DrawableResource
+  get() = Drawable27.icon_22430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22431: DrawableResource
+  get() = Drawable27.icon_22431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22432: DrawableResource
+  get() = Drawable27.icon_22432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22433: DrawableResource
+  get() = Drawable27.icon_22433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22434: DrawableResource
+  get() = Drawable27.icon_22434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22435: DrawableResource
+  get() = Drawable27.icon_22435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22436: DrawableResource
+  get() = Drawable27.icon_22436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22437: DrawableResource
+  get() = Drawable27.icon_22437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22438: DrawableResource
+  get() = Drawable27.icon_22438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22439: DrawableResource
+  get() = Drawable27.icon_22439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2244: DrawableResource
+  get() = Drawable27.icon_2244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22440: DrawableResource
+  get() = Drawable27.icon_22440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22441: DrawableResource
+  get() = Drawable27.icon_22441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22442: DrawableResource
+  get() = Drawable27.icon_22442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22443: DrawableResource
+  get() = Drawable27.icon_22443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22444: DrawableResource
+  get() = Drawable27.icon_22444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22445: DrawableResource
+  get() = Drawable27.icon_22445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22446: DrawableResource
+  get() = Drawable27.icon_22446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22447: DrawableResource
+  get() = Drawable27.icon_22447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22448: DrawableResource
+  get() = Drawable27.icon_22448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22449: DrawableResource
+  get() = Drawable27.icon_22449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2245: DrawableResource
+  get() = Drawable27.icon_2245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22450: DrawableResource
+  get() = Drawable27.icon_22450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22451: DrawableResource
+  get() = Drawable27.icon_22451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22452: DrawableResource
+  get() = Drawable27.icon_22452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22453: DrawableResource
+  get() = Drawable27.icon_22453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22454: DrawableResource
+  get() = Drawable27.icon_22454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22455: DrawableResource
+  get() = Drawable27.icon_22455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22456: DrawableResource
+  get() = Drawable27.icon_22456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22457: DrawableResource
+  get() = Drawable27.icon_22457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22458: DrawableResource
+  get() = Drawable27.icon_22458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22459: DrawableResource
+  get() = Drawable27.icon_22459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2246: DrawableResource
+  get() = Drawable27.icon_2246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22460: DrawableResource
+  get() = Drawable27.icon_22460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22461: DrawableResource
+  get() = Drawable27.icon_22461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22462: DrawableResource
+  get() = Drawable27.icon_22462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22463: DrawableResource
+  get() = Drawable27.icon_22463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22464: DrawableResource
+  get() = Drawable27.icon_22464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22465: DrawableResource
+  get() = Drawable27.icon_22465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22466: DrawableResource
+  get() = Drawable27.icon_22466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22467: DrawableResource
+  get() = Drawable27.icon_22467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22468: DrawableResource
+  get() = Drawable27.icon_22468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22469: DrawableResource
+  get() = Drawable27.icon_22469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2247: DrawableResource
+  get() = Drawable27.icon_2247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22470: DrawableResource
+  get() = Drawable27.icon_22470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22471: DrawableResource
+  get() = Drawable27.icon_22471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22472: DrawableResource
+  get() = Drawable27.icon_22472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22473: DrawableResource
+  get() = Drawable27.icon_22473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22474: DrawableResource
+  get() = Drawable27.icon_22474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22475: DrawableResource
+  get() = Drawable27.icon_22475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22476: DrawableResource
+  get() = Drawable27.icon_22476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22477: DrawableResource
+  get() = Drawable27.icon_22477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22478: DrawableResource
+  get() = Drawable27.icon_22478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22479: DrawableResource
+  get() = Drawable27.icon_22479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2248: DrawableResource
+  get() = Drawable27.icon_2248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22480: DrawableResource
+  get() = Drawable27.icon_22480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22481: DrawableResource
+  get() = Drawable27.icon_22481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22482: DrawableResource
+  get() = Drawable27.icon_22482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22483: DrawableResource
+  get() = Drawable27.icon_22483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22484: DrawableResource
+  get() = Drawable27.icon_22484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22485: DrawableResource
+  get() = Drawable27.icon_22485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22486: DrawableResource
+  get() = Drawable27.icon_22486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22487: DrawableResource
+  get() = Drawable27.icon_22487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22488: DrawableResource
+  get() = Drawable27.icon_22488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22489: DrawableResource
+  get() = Drawable27.icon_22489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2249: DrawableResource
+  get() = Drawable27.icon_2249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22490: DrawableResource
+  get() = Drawable27.icon_22490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22491: DrawableResource
+  get() = Drawable27.icon_22491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22492: DrawableResource
+  get() = Drawable27.icon_22492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22493: DrawableResource
+  get() = Drawable27.icon_22493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22494: DrawableResource
+  get() = Drawable27.icon_22494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22495: DrawableResource
+  get() = Drawable27.icon_22495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22496: DrawableResource
+  get() = Drawable27.icon_22496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22497: DrawableResource
+  get() = Drawable27.icon_22497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22498: DrawableResource
+  get() = Drawable27.icon_22498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22499: DrawableResource
+  get() = Drawable27.icon_22499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_225: DrawableResource
+  get() = Drawable27.icon_225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2250: DrawableResource
+  get() = Drawable27.icon_2250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22500: DrawableResource
+  get() = Drawable27.icon_22500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22501: DrawableResource
+  get() = Drawable27.icon_22501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22502: DrawableResource
+  get() = Drawable27.icon_22502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22503: DrawableResource
+  get() = Drawable27.icon_22503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22504: DrawableResource
+  get() = Drawable27.icon_22504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22505: DrawableResource
+  get() = Drawable27.icon_22505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22506: DrawableResource
+  get() = Drawable27.icon_22506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22507: DrawableResource
+  get() = Drawable27.icon_22507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22508: DrawableResource
+  get() = Drawable27.icon_22508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22509: DrawableResource
+  get() = Drawable27.icon_22509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2251: DrawableResource
+  get() = Drawable27.icon_2251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22510: DrawableResource
+  get() = Drawable27.icon_22510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22511: DrawableResource
+  get() = Drawable27.icon_22511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22512: DrawableResource
+  get() = Drawable27.icon_22512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22513: DrawableResource
+  get() = Drawable27.icon_22513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22514: DrawableResource
+  get() = Drawable27.icon_22514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22515: DrawableResource
+  get() = Drawable27.icon_22515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22516: DrawableResource
+  get() = Drawable27.icon_22516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22517: DrawableResource
+  get() = Drawable27.icon_22517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22518: DrawableResource
+  get() = Drawable27.icon_22518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22519: DrawableResource
+  get() = Drawable27.icon_22519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2252: DrawableResource
+  get() = Drawable27.icon_2252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22520: DrawableResource
+  get() = Drawable27.icon_22520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22521: DrawableResource
+  get() = Drawable27.icon_22521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22522: DrawableResource
+  get() = Drawable27.icon_22522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22523: DrawableResource
+  get() = Drawable27.icon_22523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22524: DrawableResource
+  get() = Drawable27.icon_22524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22525: DrawableResource
+  get() = Drawable27.icon_22525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22526: DrawableResource
+  get() = Drawable27.icon_22526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22527: DrawableResource
+  get() = Drawable27.icon_22527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22528: DrawableResource
+  get() = Drawable27.icon_22528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22529: DrawableResource
+  get() = Drawable27.icon_22529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2253: DrawableResource
+  get() = Drawable27.icon_2253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22530: DrawableResource
+  get() = Drawable27.icon_22530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22531: DrawableResource
+  get() = Drawable27.icon_22531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22532: DrawableResource
+  get() = Drawable27.icon_22532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22533: DrawableResource
+  get() = Drawable27.icon_22533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22534: DrawableResource
+  get() = Drawable27.icon_22534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22535: DrawableResource
+  get() = Drawable27.icon_22535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22536: DrawableResource
+  get() = Drawable27.icon_22536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22537: DrawableResource
+  get() = Drawable27.icon_22537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22538: DrawableResource
+  get() = Drawable27.icon_22538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22539: DrawableResource
+  get() = Drawable27.icon_22539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2254: DrawableResource
+  get() = Drawable27.icon_2254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22540: DrawableResource
+  get() = Drawable27.icon_22540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22541: DrawableResource
+  get() = Drawable27.icon_22541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22542: DrawableResource
+  get() = Drawable27.icon_22542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22543: DrawableResource
+  get() = Drawable27.icon_22543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22544: DrawableResource
+  get() = Drawable27.icon_22544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22545: DrawableResource
+  get() = Drawable27.icon_22545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22546: DrawableResource
+  get() = Drawable27.icon_22546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22547: DrawableResource
+  get() = Drawable27.icon_22547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22548: DrawableResource
+  get() = Drawable27.icon_22548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22549: DrawableResource
+  get() = Drawable27.icon_22549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2255: DrawableResource
+  get() = Drawable27.icon_2255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22550: DrawableResource
+  get() = Drawable27.icon_22550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22551: DrawableResource
+  get() = Drawable27.icon_22551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22552: DrawableResource
+  get() = Drawable27.icon_22552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22553: DrawableResource
+  get() = Drawable27.icon_22553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22554: DrawableResource
+  get() = Drawable27.icon_22554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22555: DrawableResource
+  get() = Drawable27.icon_22555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22556: DrawableResource
+  get() = Drawable27.icon_22556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22557: DrawableResource
+  get() = Drawable27.icon_22557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22558: DrawableResource
+  get() = Drawable27.icon_22558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22559: DrawableResource
+  get() = Drawable27.icon_22559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2256: DrawableResource
+  get() = Drawable27.icon_2256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22560: DrawableResource
+  get() = Drawable27.icon_22560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22561: DrawableResource
+  get() = Drawable27.icon_22561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22562: DrawableResource
+  get() = Drawable27.icon_22562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22563: DrawableResource
+  get() = Drawable27.icon_22563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22564: DrawableResource
+  get() = Drawable27.icon_22564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22565: DrawableResource
+  get() = Drawable27.icon_22565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22566: DrawableResource
+  get() = Drawable27.icon_22566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22567: DrawableResource
+  get() = Drawable27.icon_22567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22568: DrawableResource
+  get() = Drawable27.icon_22568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22569: DrawableResource
+  get() = Drawable27.icon_22569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2257: DrawableResource
+  get() = Drawable27.icon_2257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22570: DrawableResource
+  get() = Drawable27.icon_22570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22571: DrawableResource
+  get() = Drawable27.icon_22571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22572: DrawableResource
+  get() = Drawable27.icon_22572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22573: DrawableResource
+  get() = Drawable27.icon_22573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22574: DrawableResource
+  get() = Drawable27.icon_22574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22575: DrawableResource
+  get() = Drawable27.icon_22575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22576: DrawableResource
+  get() = Drawable27.icon_22576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22577: DrawableResource
+  get() = Drawable27.icon_22577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22578: DrawableResource
+  get() = Drawable27.icon_22578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22579: DrawableResource
+  get() = Drawable27.icon_22579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2258: DrawableResource
+  get() = Drawable27.icon_2258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22580: DrawableResource
+  get() = Drawable27.icon_22580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22581: DrawableResource
+  get() = Drawable27.icon_22581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22582: DrawableResource
+  get() = Drawable27.icon_22582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22583: DrawableResource
+  get() = Drawable27.icon_22583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22584: DrawableResource
+  get() = Drawable27.icon_22584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22585: DrawableResource
+  get() = Drawable27.icon_22585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22586: DrawableResource
+  get() = Drawable27.icon_22586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22587: DrawableResource
+  get() = Drawable27.icon_22587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22588: DrawableResource
+  get() = Drawable27.icon_22588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22589: DrawableResource
+  get() = Drawable27.icon_22589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2259: DrawableResource
+  get() = Drawable27.icon_2259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22590: DrawableResource
+  get() = Drawable27.icon_22590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22591: DrawableResource
+  get() = Drawable27.icon_22591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22592: DrawableResource
+  get() = Drawable27.icon_22592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22593: DrawableResource
+  get() = Drawable27.icon_22593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22594: DrawableResource
+  get() = Drawable27.icon_22594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22595: DrawableResource
+  get() = Drawable27.icon_22595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22596: DrawableResource
+  get() = Drawable27.icon_22596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22597: DrawableResource
+  get() = Drawable27.icon_22597

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable28.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable28.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable28 {
+  public val icon_22598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22598.xml"),
+          )
+      )
+
+  public val icon_22599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22599.xml"),
+          )
+      )
+
+  public val icon_226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_226.xml"),
+          )
+      )
+
+  public val icon_2260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2260.xml"),
+          )
+      )
+
+  public val icon_22600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22600.xml"),
+          )
+      )
+
+  public val icon_22601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22601.xml"),
+          )
+      )
+
+  public val icon_22602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22602.xml"),
+          )
+      )
+
+  public val icon_22603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22603.xml"),
+          )
+      )
+
+  public val icon_22604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22604.xml"),
+          )
+      )
+
+  public val icon_22605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22605.xml"),
+          )
+      )
+
+  public val icon_22606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22606.xml"),
+          )
+      )
+
+  public val icon_22607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22607.xml"),
+          )
+      )
+
+  public val icon_22608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22608.xml"),
+          )
+      )
+
+  public val icon_22609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22609.xml"),
+          )
+      )
+
+  public val icon_2261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2261.xml"),
+          )
+      )
+
+  public val icon_22610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22610.xml"),
+          )
+      )
+
+  public val icon_22611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22611.xml"),
+          )
+      )
+
+  public val icon_22612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22612.xml"),
+          )
+      )
+
+  public val icon_22613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22613.xml"),
+          )
+      )
+
+  public val icon_22614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22614.xml"),
+          )
+      )
+
+  public val icon_22615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22615.xml"),
+          )
+      )
+
+  public val icon_22616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22616.xml"),
+          )
+      )
+
+  public val icon_22617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22617.xml"),
+          )
+      )
+
+  public val icon_22618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22618.xml"),
+          )
+      )
+
+  public val icon_22619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22619.xml"),
+          )
+      )
+
+  public val icon_2262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2262.xml"),
+          )
+      )
+
+  public val icon_22620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22620.xml"),
+          )
+      )
+
+  public val icon_22621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22621.xml"),
+          )
+      )
+
+  public val icon_22622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22622.xml"),
+          )
+      )
+
+  public val icon_22623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22623.xml"),
+          )
+      )
+
+  public val icon_22624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22624.xml"),
+          )
+      )
+
+  public val icon_22625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22625.xml"),
+          )
+      )
+
+  public val icon_22626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22626.xml"),
+          )
+      )
+
+  public val icon_22627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22627.xml"),
+          )
+      )
+
+  public val icon_22628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22628.xml"),
+          )
+      )
+
+  public val icon_22629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22629.xml"),
+          )
+      )
+
+  public val icon_2263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2263.xml"),
+          )
+      )
+
+  public val icon_22630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22630.xml"),
+          )
+      )
+
+  public val icon_22631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22631.xml"),
+          )
+      )
+
+  public val icon_22632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22632.xml"),
+          )
+      )
+
+  public val icon_22633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22633.xml"),
+          )
+      )
+
+  public val icon_22634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22634.xml"),
+          )
+      )
+
+  public val icon_22635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22635.xml"),
+          )
+      )
+
+  public val icon_22636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22636.xml"),
+          )
+      )
+
+  public val icon_22637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22637.xml"),
+          )
+      )
+
+  public val icon_22638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22638.xml"),
+          )
+      )
+
+  public val icon_22639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22639.xml"),
+          )
+      )
+
+  public val icon_2264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2264.xml"),
+          )
+      )
+
+  public val icon_22640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22640.xml"),
+          )
+      )
+
+  public val icon_22641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22641.xml"),
+          )
+      )
+
+  public val icon_22642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22642.xml"),
+          )
+      )
+
+  public val icon_22643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22643.xml"),
+          )
+      )
+
+  public val icon_22644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22644.xml"),
+          )
+      )
+
+  public val icon_22645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22645.xml"),
+          )
+      )
+
+  public val icon_22646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22646.xml"),
+          )
+      )
+
+  public val icon_22647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22647.xml"),
+          )
+      )
+
+  public val icon_22648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22648.xml"),
+          )
+      )
+
+  public val icon_22649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22649.xml"),
+          )
+      )
+
+  public val icon_2265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2265.xml"),
+          )
+      )
+
+  public val icon_22650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22650.xml"),
+          )
+      )
+
+  public val icon_22651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22651.xml"),
+          )
+      )
+
+  public val icon_22652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22652.xml"),
+          )
+      )
+
+  public val icon_22653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22653.xml"),
+          )
+      )
+
+  public val icon_22654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22654.xml"),
+          )
+      )
+
+  public val icon_22655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22655.xml"),
+          )
+      )
+
+  public val icon_22656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22656.xml"),
+          )
+      )
+
+  public val icon_22657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22657.xml"),
+          )
+      )
+
+  public val icon_22658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22658.xml"),
+          )
+      )
+
+  public val icon_22659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22659.xml"),
+          )
+      )
+
+  public val icon_2266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2266.xml"),
+          )
+      )
+
+  public val icon_22660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22660.xml"),
+          )
+      )
+
+  public val icon_22661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22661.xml"),
+          )
+      )
+
+  public val icon_22662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22662.xml"),
+          )
+      )
+
+  public val icon_22663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22663.xml"),
+          )
+      )
+
+  public val icon_22664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22664.xml"),
+          )
+      )
+
+  public val icon_22665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22665.xml"),
+          )
+      )
+
+  public val icon_22666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22666.xml"),
+          )
+      )
+
+  public val icon_22667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22667.xml"),
+          )
+      )
+
+  public val icon_22668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22668.xml"),
+          )
+      )
+
+  public val icon_22669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22669.xml"),
+          )
+      )
+
+  public val icon_2267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2267.xml"),
+          )
+      )
+
+  public val icon_22670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22670.xml"),
+          )
+      )
+
+  public val icon_22671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22671.xml"),
+          )
+      )
+
+  public val icon_22672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22672.xml"),
+          )
+      )
+
+  public val icon_22673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22673.xml"),
+          )
+      )
+
+  public val icon_22674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22674.xml"),
+          )
+      )
+
+  public val icon_22675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22675.xml"),
+          )
+      )
+
+  public val icon_22676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22676.xml"),
+          )
+      )
+
+  public val icon_22677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22677.xml"),
+          )
+      )
+
+  public val icon_22678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22678.xml"),
+          )
+      )
+
+  public val icon_22679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22679.xml"),
+          )
+      )
+
+  public val icon_2268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2268.xml"),
+          )
+      )
+
+  public val icon_22680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22680.xml"),
+          )
+      )
+
+  public val icon_22681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22681.xml"),
+          )
+      )
+
+  public val icon_22682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22682.xml"),
+          )
+      )
+
+  public val icon_22683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22683.xml"),
+          )
+      )
+
+  public val icon_22684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22684.xml"),
+          )
+      )
+
+  public val icon_22685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22685.xml"),
+          )
+      )
+
+  public val icon_22686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22686.xml"),
+          )
+      )
+
+  public val icon_22687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22687.xml"),
+          )
+      )
+
+  public val icon_22688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22688.xml"),
+          )
+      )
+
+  public val icon_22689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22689.xml"),
+          )
+      )
+
+  public val icon_2269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2269.xml"),
+          )
+      )
+
+  public val icon_22690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22690.xml"),
+          )
+      )
+
+  public val icon_22691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22691.xml"),
+          )
+      )
+
+  public val icon_22692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22692.xml"),
+          )
+      )
+
+  public val icon_22693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22693.xml"),
+          )
+      )
+
+  public val icon_22694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22694.xml"),
+          )
+      )
+
+  public val icon_22695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22695.xml"),
+          )
+      )
+
+  public val icon_22696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22696.xml"),
+          )
+      )
+
+  public val icon_22697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22697.xml"),
+          )
+      )
+
+  public val icon_22698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22698.xml"),
+          )
+      )
+
+  public val icon_22699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22699.xml"),
+          )
+      )
+
+  public val icon_227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_227.xml"),
+          )
+      )
+
+  public val icon_2270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2270.xml"),
+          )
+      )
+
+  public val icon_22700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22700.xml"),
+          )
+      )
+
+  public val icon_22701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22701.xml"),
+          )
+      )
+
+  public val icon_22702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22702.xml"),
+          )
+      )
+
+  public val icon_22703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22703.xml"),
+          )
+      )
+
+  public val icon_22704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22704.xml"),
+          )
+      )
+
+  public val icon_22705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22705.xml"),
+          )
+      )
+
+  public val icon_22706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22706.xml"),
+          )
+      )
+
+  public val icon_22707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22707.xml"),
+          )
+      )
+
+  public val icon_22708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22708.xml"),
+          )
+      )
+
+  public val icon_22709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22709.xml"),
+          )
+      )
+
+  public val icon_2271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2271.xml"),
+          )
+      )
+
+  public val icon_22710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22710.xml"),
+          )
+      )
+
+  public val icon_22711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22711.xml"),
+          )
+      )
+
+  public val icon_22712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22712.xml"),
+          )
+      )
+
+  public val icon_22713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22713.xml"),
+          )
+      )
+
+  public val icon_22714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22714.xml"),
+          )
+      )
+
+  public val icon_22715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22715.xml"),
+          )
+      )
+
+  public val icon_22716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22716.xml"),
+          )
+      )
+
+  public val icon_22717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22717.xml"),
+          )
+      )
+
+  public val icon_22718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22718.xml"),
+          )
+      )
+
+  public val icon_22719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22719.xml"),
+          )
+      )
+
+  public val icon_2272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2272.xml"),
+          )
+      )
+
+  public val icon_22720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22720.xml"),
+          )
+      )
+
+  public val icon_22721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22721.xml"),
+          )
+      )
+
+  public val icon_22722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22722.xml"),
+          )
+      )
+
+  public val icon_22723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22723.xml"),
+          )
+      )
+
+  public val icon_22724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22724.xml"),
+          )
+      )
+
+  public val icon_22725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22725.xml"),
+          )
+      )
+
+  public val icon_22726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22726.xml"),
+          )
+      )
+
+  public val icon_22727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22727.xml"),
+          )
+      )
+
+  public val icon_22728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22728.xml"),
+          )
+      )
+
+  public val icon_22729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22729.xml"),
+          )
+      )
+
+  public val icon_2273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2273.xml"),
+          )
+      )
+
+  public val icon_22730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22730.xml"),
+          )
+      )
+
+  public val icon_22731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22731.xml"),
+          )
+      )
+
+  public val icon_22732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22732.xml"),
+          )
+      )
+
+  public val icon_22733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22733.xml"),
+          )
+      )
+
+  public val icon_22734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22734.xml"),
+          )
+      )
+
+  public val icon_22735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22735.xml"),
+          )
+      )
+
+  public val icon_22736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22736.xml"),
+          )
+      )
+
+  public val icon_22737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22737.xml"),
+          )
+      )
+
+  public val icon_22738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22738.xml"),
+          )
+      )
+
+  public val icon_22739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22739.xml"),
+          )
+      )
+
+  public val icon_2274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2274.xml"),
+          )
+      )
+
+  public val icon_22740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22740.xml"),
+          )
+      )
+
+  public val icon_22741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22741.xml"),
+          )
+      )
+
+  public val icon_22742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22742.xml"),
+          )
+      )
+
+  public val icon_22743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22743.xml"),
+          )
+      )
+
+  public val icon_22744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22744.xml"),
+          )
+      )
+
+  public val icon_22745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22745.xml"),
+          )
+      )
+
+  public val icon_22746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22746.xml"),
+          )
+      )
+
+  public val icon_22747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22747.xml"),
+          )
+      )
+
+  public val icon_22748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22748.xml"),
+          )
+      )
+
+  public val icon_22749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22749.xml"),
+          )
+      )
+
+  public val icon_2275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2275.xml"),
+          )
+      )
+
+  public val icon_22750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22750.xml"),
+          )
+      )
+
+  public val icon_22751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22751.xml"),
+          )
+      )
+
+  public val icon_22752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22752.xml"),
+          )
+      )
+
+  public val icon_22753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22753.xml"),
+          )
+      )
+
+  public val icon_22754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22754.xml"),
+          )
+      )
+
+  public val icon_22755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22755.xml"),
+          )
+      )
+
+  public val icon_22756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22756.xml"),
+          )
+      )
+
+  public val icon_22757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22757.xml"),
+          )
+      )
+
+  public val icon_22758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22758.xml"),
+          )
+      )
+
+  public val icon_22759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22759.xml"),
+          )
+      )
+
+  public val icon_2276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2276.xml"),
+          )
+      )
+
+  public val icon_22760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22760.xml"),
+          )
+      )
+
+  public val icon_22761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22761.xml"),
+          )
+      )
+
+  public val icon_22762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22762.xml"),
+          )
+      )
+
+  public val icon_22763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22763.xml"),
+          )
+      )
+
+  public val icon_22764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22764.xml"),
+          )
+      )
+
+  public val icon_22765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22765.xml"),
+          )
+      )
+
+  public val icon_22766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22766.xml"),
+          )
+      )
+
+  public val icon_22767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22767.xml"),
+          )
+      )
+
+  public val icon_22768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22768.xml"),
+          )
+      )
+
+  public val icon_22769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22769.xml"),
+          )
+      )
+
+  public val icon_2277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2277.xml"),
+          )
+      )
+
+  public val icon_22770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22770.xml"),
+          )
+      )
+
+  public val icon_22771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22771.xml"),
+          )
+      )
+
+  public val icon_22772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22772.xml"),
+          )
+      )
+
+  public val icon_22773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22773.xml"),
+          )
+      )
+
+  public val icon_22774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22774.xml"),
+          )
+      )
+
+  public val icon_22775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22775.xml"),
+          )
+      )
+
+  public val icon_22776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22776.xml"),
+          )
+      )
+
+  public val icon_22777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22777.xml"),
+          )
+      )
+
+  public val icon_22778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22778.xml"),
+          )
+      )
+
+  public val icon_22779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22779.xml"),
+          )
+      )
+
+  public val icon_2278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2278.xml"),
+          )
+      )
+
+  public val icon_22780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22780.xml"),
+          )
+      )
+
+  public val icon_22781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22781.xml"),
+          )
+      )
+
+  public val icon_22782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22782.xml"),
+          )
+      )
+
+  public val icon_22783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22783.xml"),
+          )
+      )
+
+  public val icon_22784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22784.xml"),
+          )
+      )
+
+  public val icon_22785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22785.xml"),
+          )
+      )
+
+  public val icon_22786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22786.xml"),
+          )
+      )
+
+  public val icon_22787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22787.xml"),
+          )
+      )
+
+  public val icon_22788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22788.xml"),
+          )
+      )
+
+  public val icon_22789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22789.xml"),
+          )
+      )
+
+  public val icon_2279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2279.xml"),
+          )
+      )
+
+  public val icon_22790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22790.xml"),
+          )
+      )
+
+  public val icon_22791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22791.xml"),
+          )
+      )
+
+  public val icon_22792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22792.xml"),
+          )
+      )
+
+  public val icon_22793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22793.xml"),
+          )
+      )
+
+  public val icon_22794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22794.xml"),
+          )
+      )
+
+  public val icon_22795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22795.xml"),
+          )
+      )
+
+  public val icon_22796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22796.xml"),
+          )
+      )
+
+  public val icon_22797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22797.xml"),
+          )
+      )
+
+  public val icon_22798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22798.xml"),
+          )
+      )
+
+  public val icon_22799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22799.xml"),
+          )
+      )
+
+  public val icon_228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_228.xml"),
+          )
+      )
+
+  public val icon_2280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2280.xml"),
+          )
+      )
+
+  public val icon_22800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22800.xml"),
+          )
+      )
+
+  public val icon_22801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22801.xml"),
+          )
+      )
+
+  public val icon_22802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22802.xml"),
+          )
+      )
+
+  public val icon_22803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22803.xml"),
+          )
+      )
+
+  public val icon_22804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22804.xml"),
+          )
+      )
+
+  public val icon_22805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22805.xml"),
+          )
+      )
+
+  public val icon_22806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22806.xml"),
+          )
+      )
+
+  public val icon_22807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22807.xml"),
+          )
+      )
+
+  public val icon_22808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22808.xml"),
+          )
+      )
+
+  public val icon_22809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22809.xml"),
+          )
+      )
+
+  public val icon_2281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2281.xml"),
+          )
+      )
+
+  public val icon_22810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22810.xml"),
+          )
+      )
+
+  public val icon_22811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22811.xml"),
+          )
+      )
+
+  public val icon_22812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22812.xml"),
+          )
+      )
+
+  public val icon_22813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22813.xml"),
+          )
+      )
+
+  public val icon_22814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22814.xml"),
+          )
+      )
+
+  public val icon_22815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22815.xml"),
+          )
+      )
+
+  public val icon_22816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22816.xml"),
+          )
+      )
+
+  public val icon_22817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22817.xml"),
+          )
+      )
+
+  public val icon_22818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22818.xml"),
+          )
+      )
+
+  public val icon_22819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22819.xml"),
+          )
+      )
+
+  public val icon_2282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2282.xml"),
+          )
+      )
+
+  public val icon_22820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22820.xml"),
+          )
+      )
+
+  public val icon_22821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22821.xml"),
+          )
+      )
+
+  public val icon_22822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22822.xml"),
+          )
+      )
+
+  public val icon_22823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22823.xml"),
+          )
+      )
+
+  public val icon_22824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22824.xml"),
+          )
+      )
+
+  public val icon_22825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22825.xml"),
+          )
+      )
+
+  public val icon_22826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22826.xml"),
+          )
+      )
+
+  public val icon_22827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22827.xml"),
+          )
+      )
+
+  public val icon_22828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22828.xml"),
+          )
+      )
+
+  public val icon_22829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22829.xml"),
+          )
+      )
+
+  public val icon_2283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2283.xml"),
+          )
+      )
+
+  public val icon_22830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22830.xml"),
+          )
+      )
+
+  public val icon_22831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22831.xml"),
+          )
+      )
+
+  public val icon_22832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22832.xml"),
+          )
+      )
+
+  public val icon_22833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22833.xml"),
+          )
+      )
+
+  public val icon_22834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22834.xml"),
+          )
+      )
+
+  public val icon_22835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22835.xml"),
+          )
+      )
+
+  public val icon_22836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22836.xml"),
+          )
+      )
+
+  public val icon_22837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22837.xml"),
+          )
+      )
+
+  public val icon_22838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22838.xml"),
+          )
+      )
+
+  public val icon_22839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22839.xml"),
+          )
+      )
+
+  public val icon_2284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2284.xml"),
+          )
+      )
+
+  public val icon_22840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22840.xml"),
+          )
+      )
+
+  public val icon_22841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22841.xml"),
+          )
+      )
+
+  public val icon_22842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22842.xml"),
+          )
+      )
+
+  public val icon_22843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22843.xml"),
+          )
+      )
+
+  public val icon_22844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22844.xml"),
+          )
+      )
+
+  public val icon_22845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22845.xml"),
+          )
+      )
+
+  public val icon_22846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22846.xml"),
+          )
+      )
+
+  public val icon_22847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22847.xml"),
+          )
+      )
+
+  public val icon_22848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22848.xml"),
+          )
+      )
+
+  public val icon_22849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22849.xml"),
+          )
+      )
+
+  public val icon_2285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2285.xml"),
+          )
+      )
+
+  public val icon_22850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22850.xml"),
+          )
+      )
+
+  public val icon_22851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22851.xml"),
+          )
+      )
+
+  public val icon_22852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22852.xml"),
+          )
+      )
+
+  public val icon_22853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22853.xml"),
+          )
+      )
+
+  public val icon_22854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22854.xml"),
+          )
+      )
+
+  public val icon_22855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22855.xml"),
+          )
+      )
+
+  public val icon_22856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22856.xml"),
+          )
+      )
+
+  public val icon_22857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22857.xml"),
+          )
+      )
+
+  public val icon_22858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22858.xml"),
+          )
+      )
+
+  public val icon_22859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22859.xml"),
+          )
+      )
+
+  public val icon_2286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2286.xml"),
+          )
+      )
+
+  public val icon_22860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22860.xml"),
+          )
+      )
+
+  public val icon_22861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22861.xml"),
+          )
+      )
+
+  public val icon_22862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22862.xml"),
+          )
+      )
+
+  public val icon_22863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22863.xml"),
+          )
+      )
+
+  public val icon_22864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22864.xml"),
+          )
+      )
+
+  public val icon_22865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22865.xml"),
+          )
+      )
+
+  public val icon_22866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22866.xml"),
+          )
+      )
+
+  public val icon_22867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22867.xml"),
+          )
+      )
+
+  public val icon_22868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22868.xml"),
+          )
+      )
+
+  public val icon_22869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22869.xml"),
+          )
+      )
+
+  public val icon_2287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2287.xml"),
+          )
+      )
+
+  public val icon_22870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22870.xml"),
+          )
+      )
+
+  public val icon_22871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22871.xml"),
+          )
+      )
+
+  public val icon_22872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22872.xml"),
+          )
+      )
+
+  public val icon_22873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22873.xml"),
+          )
+      )
+
+  public val icon_22874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22874.xml"),
+          )
+      )
+
+  public val icon_22875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22875.xml"),
+          )
+      )
+
+  public val icon_22876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22876.xml"),
+          )
+      )
+
+  public val icon_22877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22877.xml"),
+          )
+      )
+
+  public val icon_22878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22878.xml"),
+          )
+      )
+
+  public val icon_22879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22879.xml"),
+          )
+      )
+
+  public val icon_2288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2288.xml"),
+          )
+      )
+
+  public val icon_22880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22880.xml"),
+          )
+      )
+
+  public val icon_22881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22881.xml"),
+          )
+      )
+
+  public val icon_22882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22882.xml"),
+          )
+      )
+
+  public val icon_22883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22883.xml"),
+          )
+      )
+
+  public val icon_22884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22884.xml"),
+          )
+      )
+
+  public val icon_22885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22885.xml"),
+          )
+      )
+
+  public val icon_22886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22886.xml"),
+          )
+      )
+
+  public val icon_22887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22887.xml"),
+          )
+      )
+
+  public val icon_22888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22888.xml"),
+          )
+      )
+
+  public val icon_22889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22889.xml"),
+          )
+      )
+
+  public val icon_2289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2289.xml"),
+          )
+      )
+
+  public val icon_22890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22890.xml"),
+          )
+      )
+
+  public val icon_22891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22891.xml"),
+          )
+      )
+
+  public val icon_22892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22892.xml"),
+          )
+      )
+
+  public val icon_22893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22893.xml"),
+          )
+      )
+
+  public val icon_22894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22894.xml"),
+          )
+      )
+
+  public val icon_22895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22895.xml"),
+          )
+      )
+
+  public val icon_22896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22896.xml"),
+          )
+      )
+
+  public val icon_22897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22897.xml"),
+          )
+      )
+
+  public val icon_22898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22898.xml"),
+          )
+      )
+
+  public val icon_22899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22899.xml"),
+          )
+      )
+
+  public val icon_229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_229.xml"),
+          )
+      )
+
+  public val icon_2290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2290.xml"),
+          )
+      )
+
+  public val icon_22900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22900.xml"),
+          )
+      )
+
+  public val icon_22901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22901.xml"),
+          )
+      )
+
+  public val icon_22902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22902.xml"),
+          )
+      )
+
+  public val icon_22903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22903.xml"),
+          )
+      )
+
+  public val icon_22904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22904.xml"),
+          )
+      )
+
+  public val icon_22905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22905.xml"),
+          )
+      )
+
+  public val icon_22906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22906.xml"),
+          )
+      )
+
+  public val icon_22907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22907.xml"),
+          )
+      )
+
+  public val icon_22908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22908.xml"),
+          )
+      )
+
+  public val icon_22909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22909.xml"),
+          )
+      )
+
+  public val icon_2291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2291.xml"),
+          )
+      )
+
+  public val icon_22910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22910.xml"),
+          )
+      )
+
+  public val icon_22911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22911.xml"),
+          )
+      )
+
+  public val icon_22912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22912.xml"),
+          )
+      )
+
+  public val icon_22913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22913.xml"),
+          )
+      )
+
+  public val icon_22914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22914.xml"),
+          )
+      )
+
+  public val icon_22915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22915.xml"),
+          )
+      )
+
+  public val icon_22916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22916.xml"),
+          )
+      )
+
+  public val icon_22917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22917.xml"),
+          )
+      )
+
+  public val icon_22918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22918.xml"),
+          )
+      )
+
+  public val icon_22919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22919.xml"),
+          )
+      )
+
+  public val icon_2292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2292.xml"),
+          )
+      )
+
+  public val icon_22920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22920.xml"),
+          )
+      )
+
+  public val icon_22921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22921.xml"),
+          )
+      )
+
+  public val icon_22922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22922.xml"),
+          )
+      )
+
+  public val icon_22923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22923.xml"),
+          )
+      )
+
+  public val icon_22924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22924.xml"),
+          )
+      )
+
+  public val icon_22925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22925.xml"),
+          )
+      )
+
+  public val icon_22926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22926.xml"),
+          )
+      )
+
+  public val icon_22927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22927.xml"),
+          )
+      )
+
+  public val icon_22928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22928.xml"),
+          )
+      )
+
+  public val icon_22929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22929.xml"),
+          )
+      )
+
+  public val icon_2293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2293.xml"),
+          )
+      )
+
+  public val icon_22930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22930.xml"),
+          )
+      )
+
+  public val icon_22931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22931.xml"),
+          )
+      )
+
+  public val icon_22932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22932.xml"),
+          )
+      )
+
+  public val icon_22933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22933.xml"),
+          )
+      )
+
+  public val icon_22934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22934.xml"),
+          )
+      )
+
+  public val icon_22935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22935.xml"),
+          )
+      )
+
+  public val icon_22936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22936.xml"),
+          )
+      )
+
+  public val icon_22937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22937.xml"),
+          )
+      )
+
+  public val icon_22938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22938.xml"),
+          )
+      )
+
+  public val icon_22939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22939.xml"),
+          )
+      )
+
+  public val icon_2294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2294.xml"),
+          )
+      )
+
+  public val icon_22940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22940.xml"),
+          )
+      )
+
+  public val icon_22941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22941.xml"),
+          )
+      )
+
+  public val icon_22942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22942.xml"),
+          )
+      )
+
+  public val icon_22943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22943.xml"),
+          )
+      )
+
+  public val icon_22944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22944.xml"),
+          )
+      )
+
+  public val icon_22945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22945.xml"),
+          )
+      )
+
+  public val icon_22946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22946.xml"),
+          )
+      )
+
+  public val icon_22947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22947.xml"),
+          )
+      )
+
+  public val icon_22948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22948.xml"),
+          )
+      )
+
+  public val icon_22949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22949.xml"),
+          )
+      )
+
+  public val icon_2295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2295.xml"),
+          )
+      )
+
+  public val icon_22950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22950.xml"),
+          )
+      )
+
+  public val icon_22951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22951.xml"),
+          )
+      )
+
+  public val icon_22952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22952.xml"),
+          )
+      )
+
+  public val icon_22953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22953.xml"),
+          )
+      )
+
+  public val icon_22954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22954.xml"),
+          )
+      )
+
+  public val icon_22955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22955.xml"),
+          )
+      )
+
+  public val icon_22956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22956.xml"),
+          )
+      )
+
+  public val icon_22957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22957.xml"),
+          )
+      )
+
+  public val icon_22958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22958.xml"),
+          )
+      )
+
+  public val icon_22959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22959.xml"),
+          )
+      )
+
+  public val icon_2296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2296.xml"),
+          )
+      )
+
+  public val icon_22960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22960.xml"),
+          )
+      )
+
+  public val icon_22961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22961.xml"),
+          )
+      )
+
+  public val icon_22962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22962.xml"),
+          )
+      )
+
+  public val icon_22963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22963.xml"),
+          )
+      )
+
+  public val icon_22964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22964.xml"),
+          )
+      )
+
+  public val icon_22965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22965.xml"),
+          )
+      )
+
+  public val icon_22966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22966.xml"),
+          )
+      )
+
+  public val icon_22967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22967.xml"),
+          )
+      )
+
+  public val icon_22968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22968.xml"),
+          )
+      )
+
+  public val icon_22969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22969.xml"),
+          )
+      )
+
+  public val icon_2297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2297.xml"),
+          )
+      )
+
+  public val icon_22970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22970.xml"),
+          )
+      )
+
+  public val icon_22971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22971.xml"),
+          )
+      )
+
+  public val icon_22972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22972.xml"),
+          )
+      )
+
+  public val icon_22973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22973.xml"),
+          )
+      )
+
+  public val icon_22974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22974.xml"),
+          )
+      )
+
+  public val icon_22975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22975.xml"),
+          )
+      )
+
+  public val icon_22976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22976.xml"),
+          )
+      )
+
+  public val icon_22977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22977.xml"),
+          )
+      )
+
+  public val icon_22978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22978.xml"),
+          )
+      )
+
+  public val icon_22979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22979.xml"),
+          )
+      )
+
+  public val icon_2298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2298.xml"),
+          )
+      )
+
+  public val icon_22980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22980.xml"),
+          )
+      )
+
+  public val icon_22981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22981.xml"),
+          )
+      )
+
+  public val icon_22982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22982.xml"),
+          )
+      )
+
+  public val icon_22983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22983.xml"),
+          )
+      )
+
+  public val icon_22984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22984.xml"),
+          )
+      )
+
+  public val icon_22985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22985.xml"),
+          )
+      )
+
+  public val icon_22986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22986.xml"),
+          )
+      )
+
+  public val icon_22987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22987.xml"),
+          )
+      )
+
+  public val icon_22988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22988.xml"),
+          )
+      )
+
+  public val icon_22989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22989.xml"),
+          )
+      )
+
+  public val icon_2299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2299.xml"),
+          )
+      )
+
+  public val icon_22990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22990.xml"),
+          )
+      )
+
+  public val icon_22991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22991.xml"),
+          )
+      )
+
+  public val icon_22992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22992.xml"),
+          )
+      )
+
+  public val icon_22993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22993.xml"),
+          )
+      )
+
+  public val icon_22994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22994.xml"),
+          )
+      )
+
+  public val icon_22995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22995.xml"),
+          )
+      )
+
+  public val icon_22996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22996.xml"),
+          )
+      )
+
+  public val icon_22997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22997.xml"),
+          )
+      )
+
+  public val icon_22998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22998.xml"),
+          )
+      )
+
+  public val icon_22999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_22999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_22999.xml"),
+          )
+      )
+
+  public val icon_23: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23.xml"),
+          )
+      )
+
+  public val icon_230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_230.xml"),
+          )
+      )
+
+  public val icon_2300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2300.xml"),
+          )
+      )
+
+  public val icon_23000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23000.xml"),
+          )
+      )
+
+  public val icon_23001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23001.xml"),
+          )
+      )
+
+  public val icon_23002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23002.xml"),
+          )
+      )
+
+  public val icon_23003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23003.xml"),
+          )
+      )
+
+  public val icon_23004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23004.xml"),
+          )
+      )
+
+  public val icon_23005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23005.xml"),
+          )
+      )
+
+  public val icon_23006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23006.xml"),
+          )
+      )
+
+  public val icon_23007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23007.xml"),
+          )
+      )
+
+  public val icon_23008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23008.xml"),
+          )
+      )
+
+  public val icon_23009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23009.xml"),
+          )
+      )
+
+  public val icon_2301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2301.xml"),
+          )
+      )
+
+  public val icon_23010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23010.xml"),
+          )
+      )
+
+  public val icon_23011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23011.xml"),
+          )
+      )
+
+  public val icon_23012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23012.xml"),
+          )
+      )
+
+  public val icon_23013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23013.xml"),
+          )
+      )
+
+  public val icon_23014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23014.xml"),
+          )
+      )
+
+  public val icon_23015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23015.xml"),
+          )
+      )
+
+  public val icon_23016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23016.xml"),
+          )
+      )
+
+  public val icon_23017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23017.xml"),
+          )
+      )
+
+  public val icon_23018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23018.xml"),
+          )
+      )
+
+  public val icon_23019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23019.xml"),
+          )
+      )
+
+  public val icon_2302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2302.xml"),
+          )
+      )
+
+  public val icon_23020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23020.xml"),
+          )
+      )
+
+  public val icon_23021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23021.xml"),
+          )
+      )
+
+  public val icon_23022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23022.xml"),
+          )
+      )
+
+  public val icon_23023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23023.xml"),
+          )
+      )
+
+  public val icon_23024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23024.xml"),
+          )
+      )
+
+  public val icon_23025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23025.xml"),
+          )
+      )
+
+  public val icon_23026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23026.xml"),
+          )
+      )
+
+  public val icon_23027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23027.xml"),
+          )
+      )
+
+  public val icon_23028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23028.xml"),
+          )
+      )
+
+  public val icon_23029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23029.xml"),
+          )
+      )
+
+  public val icon_2303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2303.xml"),
+          )
+      )
+
+  public val icon_23030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23030.xml"),
+          )
+      )
+
+  public val icon_23031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23031.xml"),
+          )
+      )
+
+  public val icon_23032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23032.xml"),
+          )
+      )
+
+  public val icon_23033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23033.xml"),
+          )
+      )
+
+  public val icon_23034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23034.xml"),
+          )
+      )
+
+  public val icon_23035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23035.xml"),
+          )
+      )
+
+  public val icon_23036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23036.xml"),
+          )
+      )
+
+  public val icon_23037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23037.xml"),
+          )
+      )
+
+  public val icon_23038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23038.xml"),
+          )
+      )
+
+  public val icon_23039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23039.xml"),
+          )
+      )
+
+  public val icon_2304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2304.xml"),
+          )
+      )
+
+  public val icon_23040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23040.xml"),
+          )
+      )
+
+  public val icon_23041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23041.xml"),
+          )
+      )
+
+  public val icon_23042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23042.xml"),
+          )
+      )
+
+  public val icon_23043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23043.xml"),
+          )
+      )
+
+  public val icon_23044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23044.xml"),
+          )
+      )
+
+  public val icon_23045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23045.xml"),
+          )
+      )
+
+  public val icon_23046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23046.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22598: DrawableResource
+  get() = Drawable28.icon_22598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22599: DrawableResource
+  get() = Drawable28.icon_22599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_226: DrawableResource
+  get() = Drawable28.icon_226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2260: DrawableResource
+  get() = Drawable28.icon_2260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22600: DrawableResource
+  get() = Drawable28.icon_22600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22601: DrawableResource
+  get() = Drawable28.icon_22601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22602: DrawableResource
+  get() = Drawable28.icon_22602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22603: DrawableResource
+  get() = Drawable28.icon_22603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22604: DrawableResource
+  get() = Drawable28.icon_22604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22605: DrawableResource
+  get() = Drawable28.icon_22605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22606: DrawableResource
+  get() = Drawable28.icon_22606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22607: DrawableResource
+  get() = Drawable28.icon_22607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22608: DrawableResource
+  get() = Drawable28.icon_22608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22609: DrawableResource
+  get() = Drawable28.icon_22609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2261: DrawableResource
+  get() = Drawable28.icon_2261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22610: DrawableResource
+  get() = Drawable28.icon_22610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22611: DrawableResource
+  get() = Drawable28.icon_22611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22612: DrawableResource
+  get() = Drawable28.icon_22612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22613: DrawableResource
+  get() = Drawable28.icon_22613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22614: DrawableResource
+  get() = Drawable28.icon_22614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22615: DrawableResource
+  get() = Drawable28.icon_22615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22616: DrawableResource
+  get() = Drawable28.icon_22616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22617: DrawableResource
+  get() = Drawable28.icon_22617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22618: DrawableResource
+  get() = Drawable28.icon_22618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22619: DrawableResource
+  get() = Drawable28.icon_22619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2262: DrawableResource
+  get() = Drawable28.icon_2262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22620: DrawableResource
+  get() = Drawable28.icon_22620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22621: DrawableResource
+  get() = Drawable28.icon_22621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22622: DrawableResource
+  get() = Drawable28.icon_22622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22623: DrawableResource
+  get() = Drawable28.icon_22623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22624: DrawableResource
+  get() = Drawable28.icon_22624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22625: DrawableResource
+  get() = Drawable28.icon_22625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22626: DrawableResource
+  get() = Drawable28.icon_22626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22627: DrawableResource
+  get() = Drawable28.icon_22627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22628: DrawableResource
+  get() = Drawable28.icon_22628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22629: DrawableResource
+  get() = Drawable28.icon_22629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2263: DrawableResource
+  get() = Drawable28.icon_2263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22630: DrawableResource
+  get() = Drawable28.icon_22630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22631: DrawableResource
+  get() = Drawable28.icon_22631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22632: DrawableResource
+  get() = Drawable28.icon_22632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22633: DrawableResource
+  get() = Drawable28.icon_22633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22634: DrawableResource
+  get() = Drawable28.icon_22634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22635: DrawableResource
+  get() = Drawable28.icon_22635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22636: DrawableResource
+  get() = Drawable28.icon_22636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22637: DrawableResource
+  get() = Drawable28.icon_22637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22638: DrawableResource
+  get() = Drawable28.icon_22638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22639: DrawableResource
+  get() = Drawable28.icon_22639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2264: DrawableResource
+  get() = Drawable28.icon_2264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22640: DrawableResource
+  get() = Drawable28.icon_22640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22641: DrawableResource
+  get() = Drawable28.icon_22641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22642: DrawableResource
+  get() = Drawable28.icon_22642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22643: DrawableResource
+  get() = Drawable28.icon_22643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22644: DrawableResource
+  get() = Drawable28.icon_22644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22645: DrawableResource
+  get() = Drawable28.icon_22645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22646: DrawableResource
+  get() = Drawable28.icon_22646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22647: DrawableResource
+  get() = Drawable28.icon_22647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22648: DrawableResource
+  get() = Drawable28.icon_22648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22649: DrawableResource
+  get() = Drawable28.icon_22649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2265: DrawableResource
+  get() = Drawable28.icon_2265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22650: DrawableResource
+  get() = Drawable28.icon_22650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22651: DrawableResource
+  get() = Drawable28.icon_22651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22652: DrawableResource
+  get() = Drawable28.icon_22652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22653: DrawableResource
+  get() = Drawable28.icon_22653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22654: DrawableResource
+  get() = Drawable28.icon_22654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22655: DrawableResource
+  get() = Drawable28.icon_22655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22656: DrawableResource
+  get() = Drawable28.icon_22656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22657: DrawableResource
+  get() = Drawable28.icon_22657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22658: DrawableResource
+  get() = Drawable28.icon_22658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22659: DrawableResource
+  get() = Drawable28.icon_22659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2266: DrawableResource
+  get() = Drawable28.icon_2266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22660: DrawableResource
+  get() = Drawable28.icon_22660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22661: DrawableResource
+  get() = Drawable28.icon_22661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22662: DrawableResource
+  get() = Drawable28.icon_22662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22663: DrawableResource
+  get() = Drawable28.icon_22663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22664: DrawableResource
+  get() = Drawable28.icon_22664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22665: DrawableResource
+  get() = Drawable28.icon_22665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22666: DrawableResource
+  get() = Drawable28.icon_22666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22667: DrawableResource
+  get() = Drawable28.icon_22667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22668: DrawableResource
+  get() = Drawable28.icon_22668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22669: DrawableResource
+  get() = Drawable28.icon_22669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2267: DrawableResource
+  get() = Drawable28.icon_2267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22670: DrawableResource
+  get() = Drawable28.icon_22670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22671: DrawableResource
+  get() = Drawable28.icon_22671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22672: DrawableResource
+  get() = Drawable28.icon_22672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22673: DrawableResource
+  get() = Drawable28.icon_22673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22674: DrawableResource
+  get() = Drawable28.icon_22674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22675: DrawableResource
+  get() = Drawable28.icon_22675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22676: DrawableResource
+  get() = Drawable28.icon_22676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22677: DrawableResource
+  get() = Drawable28.icon_22677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22678: DrawableResource
+  get() = Drawable28.icon_22678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22679: DrawableResource
+  get() = Drawable28.icon_22679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2268: DrawableResource
+  get() = Drawable28.icon_2268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22680: DrawableResource
+  get() = Drawable28.icon_22680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22681: DrawableResource
+  get() = Drawable28.icon_22681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22682: DrawableResource
+  get() = Drawable28.icon_22682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22683: DrawableResource
+  get() = Drawable28.icon_22683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22684: DrawableResource
+  get() = Drawable28.icon_22684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22685: DrawableResource
+  get() = Drawable28.icon_22685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22686: DrawableResource
+  get() = Drawable28.icon_22686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22687: DrawableResource
+  get() = Drawable28.icon_22687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22688: DrawableResource
+  get() = Drawable28.icon_22688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22689: DrawableResource
+  get() = Drawable28.icon_22689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2269: DrawableResource
+  get() = Drawable28.icon_2269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22690: DrawableResource
+  get() = Drawable28.icon_22690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22691: DrawableResource
+  get() = Drawable28.icon_22691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22692: DrawableResource
+  get() = Drawable28.icon_22692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22693: DrawableResource
+  get() = Drawable28.icon_22693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22694: DrawableResource
+  get() = Drawable28.icon_22694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22695: DrawableResource
+  get() = Drawable28.icon_22695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22696: DrawableResource
+  get() = Drawable28.icon_22696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22697: DrawableResource
+  get() = Drawable28.icon_22697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22698: DrawableResource
+  get() = Drawable28.icon_22698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22699: DrawableResource
+  get() = Drawable28.icon_22699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_227: DrawableResource
+  get() = Drawable28.icon_227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2270: DrawableResource
+  get() = Drawable28.icon_2270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22700: DrawableResource
+  get() = Drawable28.icon_22700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22701: DrawableResource
+  get() = Drawable28.icon_22701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22702: DrawableResource
+  get() = Drawable28.icon_22702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22703: DrawableResource
+  get() = Drawable28.icon_22703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22704: DrawableResource
+  get() = Drawable28.icon_22704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22705: DrawableResource
+  get() = Drawable28.icon_22705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22706: DrawableResource
+  get() = Drawable28.icon_22706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22707: DrawableResource
+  get() = Drawable28.icon_22707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22708: DrawableResource
+  get() = Drawable28.icon_22708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22709: DrawableResource
+  get() = Drawable28.icon_22709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2271: DrawableResource
+  get() = Drawable28.icon_2271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22710: DrawableResource
+  get() = Drawable28.icon_22710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22711: DrawableResource
+  get() = Drawable28.icon_22711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22712: DrawableResource
+  get() = Drawable28.icon_22712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22713: DrawableResource
+  get() = Drawable28.icon_22713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22714: DrawableResource
+  get() = Drawable28.icon_22714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22715: DrawableResource
+  get() = Drawable28.icon_22715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22716: DrawableResource
+  get() = Drawable28.icon_22716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22717: DrawableResource
+  get() = Drawable28.icon_22717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22718: DrawableResource
+  get() = Drawable28.icon_22718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22719: DrawableResource
+  get() = Drawable28.icon_22719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2272: DrawableResource
+  get() = Drawable28.icon_2272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22720: DrawableResource
+  get() = Drawable28.icon_22720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22721: DrawableResource
+  get() = Drawable28.icon_22721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22722: DrawableResource
+  get() = Drawable28.icon_22722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22723: DrawableResource
+  get() = Drawable28.icon_22723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22724: DrawableResource
+  get() = Drawable28.icon_22724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22725: DrawableResource
+  get() = Drawable28.icon_22725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22726: DrawableResource
+  get() = Drawable28.icon_22726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22727: DrawableResource
+  get() = Drawable28.icon_22727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22728: DrawableResource
+  get() = Drawable28.icon_22728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22729: DrawableResource
+  get() = Drawable28.icon_22729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2273: DrawableResource
+  get() = Drawable28.icon_2273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22730: DrawableResource
+  get() = Drawable28.icon_22730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22731: DrawableResource
+  get() = Drawable28.icon_22731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22732: DrawableResource
+  get() = Drawable28.icon_22732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22733: DrawableResource
+  get() = Drawable28.icon_22733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22734: DrawableResource
+  get() = Drawable28.icon_22734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22735: DrawableResource
+  get() = Drawable28.icon_22735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22736: DrawableResource
+  get() = Drawable28.icon_22736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22737: DrawableResource
+  get() = Drawable28.icon_22737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22738: DrawableResource
+  get() = Drawable28.icon_22738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22739: DrawableResource
+  get() = Drawable28.icon_22739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2274: DrawableResource
+  get() = Drawable28.icon_2274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22740: DrawableResource
+  get() = Drawable28.icon_22740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22741: DrawableResource
+  get() = Drawable28.icon_22741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22742: DrawableResource
+  get() = Drawable28.icon_22742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22743: DrawableResource
+  get() = Drawable28.icon_22743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22744: DrawableResource
+  get() = Drawable28.icon_22744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22745: DrawableResource
+  get() = Drawable28.icon_22745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22746: DrawableResource
+  get() = Drawable28.icon_22746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22747: DrawableResource
+  get() = Drawable28.icon_22747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22748: DrawableResource
+  get() = Drawable28.icon_22748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22749: DrawableResource
+  get() = Drawable28.icon_22749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2275: DrawableResource
+  get() = Drawable28.icon_2275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22750: DrawableResource
+  get() = Drawable28.icon_22750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22751: DrawableResource
+  get() = Drawable28.icon_22751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22752: DrawableResource
+  get() = Drawable28.icon_22752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22753: DrawableResource
+  get() = Drawable28.icon_22753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22754: DrawableResource
+  get() = Drawable28.icon_22754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22755: DrawableResource
+  get() = Drawable28.icon_22755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22756: DrawableResource
+  get() = Drawable28.icon_22756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22757: DrawableResource
+  get() = Drawable28.icon_22757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22758: DrawableResource
+  get() = Drawable28.icon_22758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22759: DrawableResource
+  get() = Drawable28.icon_22759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2276: DrawableResource
+  get() = Drawable28.icon_2276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22760: DrawableResource
+  get() = Drawable28.icon_22760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22761: DrawableResource
+  get() = Drawable28.icon_22761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22762: DrawableResource
+  get() = Drawable28.icon_22762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22763: DrawableResource
+  get() = Drawable28.icon_22763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22764: DrawableResource
+  get() = Drawable28.icon_22764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22765: DrawableResource
+  get() = Drawable28.icon_22765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22766: DrawableResource
+  get() = Drawable28.icon_22766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22767: DrawableResource
+  get() = Drawable28.icon_22767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22768: DrawableResource
+  get() = Drawable28.icon_22768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22769: DrawableResource
+  get() = Drawable28.icon_22769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2277: DrawableResource
+  get() = Drawable28.icon_2277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22770: DrawableResource
+  get() = Drawable28.icon_22770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22771: DrawableResource
+  get() = Drawable28.icon_22771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22772: DrawableResource
+  get() = Drawable28.icon_22772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22773: DrawableResource
+  get() = Drawable28.icon_22773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22774: DrawableResource
+  get() = Drawable28.icon_22774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22775: DrawableResource
+  get() = Drawable28.icon_22775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22776: DrawableResource
+  get() = Drawable28.icon_22776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22777: DrawableResource
+  get() = Drawable28.icon_22777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22778: DrawableResource
+  get() = Drawable28.icon_22778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22779: DrawableResource
+  get() = Drawable28.icon_22779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2278: DrawableResource
+  get() = Drawable28.icon_2278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22780: DrawableResource
+  get() = Drawable28.icon_22780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22781: DrawableResource
+  get() = Drawable28.icon_22781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22782: DrawableResource
+  get() = Drawable28.icon_22782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22783: DrawableResource
+  get() = Drawable28.icon_22783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22784: DrawableResource
+  get() = Drawable28.icon_22784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22785: DrawableResource
+  get() = Drawable28.icon_22785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22786: DrawableResource
+  get() = Drawable28.icon_22786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22787: DrawableResource
+  get() = Drawable28.icon_22787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22788: DrawableResource
+  get() = Drawable28.icon_22788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22789: DrawableResource
+  get() = Drawable28.icon_22789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2279: DrawableResource
+  get() = Drawable28.icon_2279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22790: DrawableResource
+  get() = Drawable28.icon_22790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22791: DrawableResource
+  get() = Drawable28.icon_22791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22792: DrawableResource
+  get() = Drawable28.icon_22792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22793: DrawableResource
+  get() = Drawable28.icon_22793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22794: DrawableResource
+  get() = Drawable28.icon_22794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22795: DrawableResource
+  get() = Drawable28.icon_22795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22796: DrawableResource
+  get() = Drawable28.icon_22796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22797: DrawableResource
+  get() = Drawable28.icon_22797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22798: DrawableResource
+  get() = Drawable28.icon_22798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22799: DrawableResource
+  get() = Drawable28.icon_22799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_228: DrawableResource
+  get() = Drawable28.icon_228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2280: DrawableResource
+  get() = Drawable28.icon_2280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22800: DrawableResource
+  get() = Drawable28.icon_22800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22801: DrawableResource
+  get() = Drawable28.icon_22801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22802: DrawableResource
+  get() = Drawable28.icon_22802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22803: DrawableResource
+  get() = Drawable28.icon_22803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22804: DrawableResource
+  get() = Drawable28.icon_22804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22805: DrawableResource
+  get() = Drawable28.icon_22805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22806: DrawableResource
+  get() = Drawable28.icon_22806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22807: DrawableResource
+  get() = Drawable28.icon_22807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22808: DrawableResource
+  get() = Drawable28.icon_22808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22809: DrawableResource
+  get() = Drawable28.icon_22809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2281: DrawableResource
+  get() = Drawable28.icon_2281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22810: DrawableResource
+  get() = Drawable28.icon_22810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22811: DrawableResource
+  get() = Drawable28.icon_22811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22812: DrawableResource
+  get() = Drawable28.icon_22812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22813: DrawableResource
+  get() = Drawable28.icon_22813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22814: DrawableResource
+  get() = Drawable28.icon_22814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22815: DrawableResource
+  get() = Drawable28.icon_22815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22816: DrawableResource
+  get() = Drawable28.icon_22816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22817: DrawableResource
+  get() = Drawable28.icon_22817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22818: DrawableResource
+  get() = Drawable28.icon_22818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22819: DrawableResource
+  get() = Drawable28.icon_22819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2282: DrawableResource
+  get() = Drawable28.icon_2282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22820: DrawableResource
+  get() = Drawable28.icon_22820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22821: DrawableResource
+  get() = Drawable28.icon_22821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22822: DrawableResource
+  get() = Drawable28.icon_22822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22823: DrawableResource
+  get() = Drawable28.icon_22823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22824: DrawableResource
+  get() = Drawable28.icon_22824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22825: DrawableResource
+  get() = Drawable28.icon_22825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22826: DrawableResource
+  get() = Drawable28.icon_22826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22827: DrawableResource
+  get() = Drawable28.icon_22827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22828: DrawableResource
+  get() = Drawable28.icon_22828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22829: DrawableResource
+  get() = Drawable28.icon_22829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2283: DrawableResource
+  get() = Drawable28.icon_2283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22830: DrawableResource
+  get() = Drawable28.icon_22830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22831: DrawableResource
+  get() = Drawable28.icon_22831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22832: DrawableResource
+  get() = Drawable28.icon_22832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22833: DrawableResource
+  get() = Drawable28.icon_22833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22834: DrawableResource
+  get() = Drawable28.icon_22834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22835: DrawableResource
+  get() = Drawable28.icon_22835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22836: DrawableResource
+  get() = Drawable28.icon_22836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22837: DrawableResource
+  get() = Drawable28.icon_22837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22838: DrawableResource
+  get() = Drawable28.icon_22838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22839: DrawableResource
+  get() = Drawable28.icon_22839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2284: DrawableResource
+  get() = Drawable28.icon_2284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22840: DrawableResource
+  get() = Drawable28.icon_22840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22841: DrawableResource
+  get() = Drawable28.icon_22841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22842: DrawableResource
+  get() = Drawable28.icon_22842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22843: DrawableResource
+  get() = Drawable28.icon_22843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22844: DrawableResource
+  get() = Drawable28.icon_22844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22845: DrawableResource
+  get() = Drawable28.icon_22845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22846: DrawableResource
+  get() = Drawable28.icon_22846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22847: DrawableResource
+  get() = Drawable28.icon_22847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22848: DrawableResource
+  get() = Drawable28.icon_22848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22849: DrawableResource
+  get() = Drawable28.icon_22849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2285: DrawableResource
+  get() = Drawable28.icon_2285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22850: DrawableResource
+  get() = Drawable28.icon_22850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22851: DrawableResource
+  get() = Drawable28.icon_22851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22852: DrawableResource
+  get() = Drawable28.icon_22852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22853: DrawableResource
+  get() = Drawable28.icon_22853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22854: DrawableResource
+  get() = Drawable28.icon_22854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22855: DrawableResource
+  get() = Drawable28.icon_22855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22856: DrawableResource
+  get() = Drawable28.icon_22856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22857: DrawableResource
+  get() = Drawable28.icon_22857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22858: DrawableResource
+  get() = Drawable28.icon_22858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22859: DrawableResource
+  get() = Drawable28.icon_22859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2286: DrawableResource
+  get() = Drawable28.icon_2286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22860: DrawableResource
+  get() = Drawable28.icon_22860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22861: DrawableResource
+  get() = Drawable28.icon_22861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22862: DrawableResource
+  get() = Drawable28.icon_22862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22863: DrawableResource
+  get() = Drawable28.icon_22863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22864: DrawableResource
+  get() = Drawable28.icon_22864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22865: DrawableResource
+  get() = Drawable28.icon_22865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22866: DrawableResource
+  get() = Drawable28.icon_22866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22867: DrawableResource
+  get() = Drawable28.icon_22867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22868: DrawableResource
+  get() = Drawable28.icon_22868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22869: DrawableResource
+  get() = Drawable28.icon_22869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2287: DrawableResource
+  get() = Drawable28.icon_2287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22870: DrawableResource
+  get() = Drawable28.icon_22870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22871: DrawableResource
+  get() = Drawable28.icon_22871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22872: DrawableResource
+  get() = Drawable28.icon_22872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22873: DrawableResource
+  get() = Drawable28.icon_22873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22874: DrawableResource
+  get() = Drawable28.icon_22874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22875: DrawableResource
+  get() = Drawable28.icon_22875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22876: DrawableResource
+  get() = Drawable28.icon_22876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22877: DrawableResource
+  get() = Drawable28.icon_22877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22878: DrawableResource
+  get() = Drawable28.icon_22878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22879: DrawableResource
+  get() = Drawable28.icon_22879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2288: DrawableResource
+  get() = Drawable28.icon_2288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22880: DrawableResource
+  get() = Drawable28.icon_22880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22881: DrawableResource
+  get() = Drawable28.icon_22881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22882: DrawableResource
+  get() = Drawable28.icon_22882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22883: DrawableResource
+  get() = Drawable28.icon_22883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22884: DrawableResource
+  get() = Drawable28.icon_22884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22885: DrawableResource
+  get() = Drawable28.icon_22885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22886: DrawableResource
+  get() = Drawable28.icon_22886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22887: DrawableResource
+  get() = Drawable28.icon_22887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22888: DrawableResource
+  get() = Drawable28.icon_22888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22889: DrawableResource
+  get() = Drawable28.icon_22889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2289: DrawableResource
+  get() = Drawable28.icon_2289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22890: DrawableResource
+  get() = Drawable28.icon_22890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22891: DrawableResource
+  get() = Drawable28.icon_22891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22892: DrawableResource
+  get() = Drawable28.icon_22892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22893: DrawableResource
+  get() = Drawable28.icon_22893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22894: DrawableResource
+  get() = Drawable28.icon_22894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22895: DrawableResource
+  get() = Drawable28.icon_22895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22896: DrawableResource
+  get() = Drawable28.icon_22896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22897: DrawableResource
+  get() = Drawable28.icon_22897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22898: DrawableResource
+  get() = Drawable28.icon_22898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22899: DrawableResource
+  get() = Drawable28.icon_22899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_229: DrawableResource
+  get() = Drawable28.icon_229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2290: DrawableResource
+  get() = Drawable28.icon_2290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22900: DrawableResource
+  get() = Drawable28.icon_22900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22901: DrawableResource
+  get() = Drawable28.icon_22901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22902: DrawableResource
+  get() = Drawable28.icon_22902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22903: DrawableResource
+  get() = Drawable28.icon_22903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22904: DrawableResource
+  get() = Drawable28.icon_22904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22905: DrawableResource
+  get() = Drawable28.icon_22905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22906: DrawableResource
+  get() = Drawable28.icon_22906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22907: DrawableResource
+  get() = Drawable28.icon_22907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22908: DrawableResource
+  get() = Drawable28.icon_22908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22909: DrawableResource
+  get() = Drawable28.icon_22909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2291: DrawableResource
+  get() = Drawable28.icon_2291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22910: DrawableResource
+  get() = Drawable28.icon_22910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22911: DrawableResource
+  get() = Drawable28.icon_22911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22912: DrawableResource
+  get() = Drawable28.icon_22912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22913: DrawableResource
+  get() = Drawable28.icon_22913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22914: DrawableResource
+  get() = Drawable28.icon_22914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22915: DrawableResource
+  get() = Drawable28.icon_22915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22916: DrawableResource
+  get() = Drawable28.icon_22916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22917: DrawableResource
+  get() = Drawable28.icon_22917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22918: DrawableResource
+  get() = Drawable28.icon_22918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22919: DrawableResource
+  get() = Drawable28.icon_22919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2292: DrawableResource
+  get() = Drawable28.icon_2292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22920: DrawableResource
+  get() = Drawable28.icon_22920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22921: DrawableResource
+  get() = Drawable28.icon_22921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22922: DrawableResource
+  get() = Drawable28.icon_22922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22923: DrawableResource
+  get() = Drawable28.icon_22923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22924: DrawableResource
+  get() = Drawable28.icon_22924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22925: DrawableResource
+  get() = Drawable28.icon_22925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22926: DrawableResource
+  get() = Drawable28.icon_22926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22927: DrawableResource
+  get() = Drawable28.icon_22927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22928: DrawableResource
+  get() = Drawable28.icon_22928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22929: DrawableResource
+  get() = Drawable28.icon_22929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2293: DrawableResource
+  get() = Drawable28.icon_2293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22930: DrawableResource
+  get() = Drawable28.icon_22930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22931: DrawableResource
+  get() = Drawable28.icon_22931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22932: DrawableResource
+  get() = Drawable28.icon_22932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22933: DrawableResource
+  get() = Drawable28.icon_22933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22934: DrawableResource
+  get() = Drawable28.icon_22934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22935: DrawableResource
+  get() = Drawable28.icon_22935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22936: DrawableResource
+  get() = Drawable28.icon_22936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22937: DrawableResource
+  get() = Drawable28.icon_22937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22938: DrawableResource
+  get() = Drawable28.icon_22938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22939: DrawableResource
+  get() = Drawable28.icon_22939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2294: DrawableResource
+  get() = Drawable28.icon_2294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22940: DrawableResource
+  get() = Drawable28.icon_22940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22941: DrawableResource
+  get() = Drawable28.icon_22941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22942: DrawableResource
+  get() = Drawable28.icon_22942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22943: DrawableResource
+  get() = Drawable28.icon_22943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22944: DrawableResource
+  get() = Drawable28.icon_22944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22945: DrawableResource
+  get() = Drawable28.icon_22945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22946: DrawableResource
+  get() = Drawable28.icon_22946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22947: DrawableResource
+  get() = Drawable28.icon_22947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22948: DrawableResource
+  get() = Drawable28.icon_22948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22949: DrawableResource
+  get() = Drawable28.icon_22949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2295: DrawableResource
+  get() = Drawable28.icon_2295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22950: DrawableResource
+  get() = Drawable28.icon_22950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22951: DrawableResource
+  get() = Drawable28.icon_22951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22952: DrawableResource
+  get() = Drawable28.icon_22952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22953: DrawableResource
+  get() = Drawable28.icon_22953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22954: DrawableResource
+  get() = Drawable28.icon_22954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22955: DrawableResource
+  get() = Drawable28.icon_22955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22956: DrawableResource
+  get() = Drawable28.icon_22956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22957: DrawableResource
+  get() = Drawable28.icon_22957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22958: DrawableResource
+  get() = Drawable28.icon_22958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22959: DrawableResource
+  get() = Drawable28.icon_22959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2296: DrawableResource
+  get() = Drawable28.icon_2296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22960: DrawableResource
+  get() = Drawable28.icon_22960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22961: DrawableResource
+  get() = Drawable28.icon_22961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22962: DrawableResource
+  get() = Drawable28.icon_22962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22963: DrawableResource
+  get() = Drawable28.icon_22963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22964: DrawableResource
+  get() = Drawable28.icon_22964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22965: DrawableResource
+  get() = Drawable28.icon_22965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22966: DrawableResource
+  get() = Drawable28.icon_22966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22967: DrawableResource
+  get() = Drawable28.icon_22967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22968: DrawableResource
+  get() = Drawable28.icon_22968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22969: DrawableResource
+  get() = Drawable28.icon_22969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2297: DrawableResource
+  get() = Drawable28.icon_2297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22970: DrawableResource
+  get() = Drawable28.icon_22970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22971: DrawableResource
+  get() = Drawable28.icon_22971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22972: DrawableResource
+  get() = Drawable28.icon_22972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22973: DrawableResource
+  get() = Drawable28.icon_22973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22974: DrawableResource
+  get() = Drawable28.icon_22974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22975: DrawableResource
+  get() = Drawable28.icon_22975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22976: DrawableResource
+  get() = Drawable28.icon_22976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22977: DrawableResource
+  get() = Drawable28.icon_22977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22978: DrawableResource
+  get() = Drawable28.icon_22978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22979: DrawableResource
+  get() = Drawable28.icon_22979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2298: DrawableResource
+  get() = Drawable28.icon_2298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22980: DrawableResource
+  get() = Drawable28.icon_22980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22981: DrawableResource
+  get() = Drawable28.icon_22981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22982: DrawableResource
+  get() = Drawable28.icon_22982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22983: DrawableResource
+  get() = Drawable28.icon_22983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22984: DrawableResource
+  get() = Drawable28.icon_22984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22985: DrawableResource
+  get() = Drawable28.icon_22985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22986: DrawableResource
+  get() = Drawable28.icon_22986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22987: DrawableResource
+  get() = Drawable28.icon_22987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22988: DrawableResource
+  get() = Drawable28.icon_22988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22989: DrawableResource
+  get() = Drawable28.icon_22989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2299: DrawableResource
+  get() = Drawable28.icon_2299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22990: DrawableResource
+  get() = Drawable28.icon_22990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22991: DrawableResource
+  get() = Drawable28.icon_22991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22992: DrawableResource
+  get() = Drawable28.icon_22992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22993: DrawableResource
+  get() = Drawable28.icon_22993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22994: DrawableResource
+  get() = Drawable28.icon_22994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22995: DrawableResource
+  get() = Drawable28.icon_22995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22996: DrawableResource
+  get() = Drawable28.icon_22996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22997: DrawableResource
+  get() = Drawable28.icon_22997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22998: DrawableResource
+  get() = Drawable28.icon_22998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_22999: DrawableResource
+  get() = Drawable28.icon_22999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23: DrawableResource
+  get() = Drawable28.icon_23
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_230: DrawableResource
+  get() = Drawable28.icon_230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2300: DrawableResource
+  get() = Drawable28.icon_2300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23000: DrawableResource
+  get() = Drawable28.icon_23000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23001: DrawableResource
+  get() = Drawable28.icon_23001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23002: DrawableResource
+  get() = Drawable28.icon_23002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23003: DrawableResource
+  get() = Drawable28.icon_23003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23004: DrawableResource
+  get() = Drawable28.icon_23004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23005: DrawableResource
+  get() = Drawable28.icon_23005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23006: DrawableResource
+  get() = Drawable28.icon_23006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23007: DrawableResource
+  get() = Drawable28.icon_23007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23008: DrawableResource
+  get() = Drawable28.icon_23008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23009: DrawableResource
+  get() = Drawable28.icon_23009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2301: DrawableResource
+  get() = Drawable28.icon_2301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23010: DrawableResource
+  get() = Drawable28.icon_23010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23011: DrawableResource
+  get() = Drawable28.icon_23011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23012: DrawableResource
+  get() = Drawable28.icon_23012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23013: DrawableResource
+  get() = Drawable28.icon_23013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23014: DrawableResource
+  get() = Drawable28.icon_23014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23015: DrawableResource
+  get() = Drawable28.icon_23015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23016: DrawableResource
+  get() = Drawable28.icon_23016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23017: DrawableResource
+  get() = Drawable28.icon_23017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23018: DrawableResource
+  get() = Drawable28.icon_23018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23019: DrawableResource
+  get() = Drawable28.icon_23019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2302: DrawableResource
+  get() = Drawable28.icon_2302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23020: DrawableResource
+  get() = Drawable28.icon_23020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23021: DrawableResource
+  get() = Drawable28.icon_23021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23022: DrawableResource
+  get() = Drawable28.icon_23022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23023: DrawableResource
+  get() = Drawable28.icon_23023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23024: DrawableResource
+  get() = Drawable28.icon_23024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23025: DrawableResource
+  get() = Drawable28.icon_23025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23026: DrawableResource
+  get() = Drawable28.icon_23026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23027: DrawableResource
+  get() = Drawable28.icon_23027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23028: DrawableResource
+  get() = Drawable28.icon_23028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23029: DrawableResource
+  get() = Drawable28.icon_23029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2303: DrawableResource
+  get() = Drawable28.icon_2303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23030: DrawableResource
+  get() = Drawable28.icon_23030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23031: DrawableResource
+  get() = Drawable28.icon_23031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23032: DrawableResource
+  get() = Drawable28.icon_23032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23033: DrawableResource
+  get() = Drawable28.icon_23033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23034: DrawableResource
+  get() = Drawable28.icon_23034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23035: DrawableResource
+  get() = Drawable28.icon_23035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23036: DrawableResource
+  get() = Drawable28.icon_23036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23037: DrawableResource
+  get() = Drawable28.icon_23037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23038: DrawableResource
+  get() = Drawable28.icon_23038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23039: DrawableResource
+  get() = Drawable28.icon_23039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2304: DrawableResource
+  get() = Drawable28.icon_2304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23040: DrawableResource
+  get() = Drawable28.icon_23040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23041: DrawableResource
+  get() = Drawable28.icon_23041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23042: DrawableResource
+  get() = Drawable28.icon_23042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23043: DrawableResource
+  get() = Drawable28.icon_23043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23044: DrawableResource
+  get() = Drawable28.icon_23044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23045: DrawableResource
+  get() = Drawable28.icon_23045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23046: DrawableResource
+  get() = Drawable28.icon_23046

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable29.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable29.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable29 {
+  public val icon_23047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23047.xml"),
+          )
+      )
+
+  public val icon_23048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23048.xml"),
+          )
+      )
+
+  public val icon_23049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23049.xml"),
+          )
+      )
+
+  public val icon_2305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2305.xml"),
+          )
+      )
+
+  public val icon_23050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23050.xml"),
+          )
+      )
+
+  public val icon_23051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23051.xml"),
+          )
+      )
+
+  public val icon_23052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23052.xml"),
+          )
+      )
+
+  public val icon_23053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23053.xml"),
+          )
+      )
+
+  public val icon_23054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23054.xml"),
+          )
+      )
+
+  public val icon_23055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23055.xml"),
+          )
+      )
+
+  public val icon_23056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23056.xml"),
+          )
+      )
+
+  public val icon_23057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23057.xml"),
+          )
+      )
+
+  public val icon_23058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23058.xml"),
+          )
+      )
+
+  public val icon_23059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23059.xml"),
+          )
+      )
+
+  public val icon_2306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2306.xml"),
+          )
+      )
+
+  public val icon_23060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23060.xml"),
+          )
+      )
+
+  public val icon_23061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23061.xml"),
+          )
+      )
+
+  public val icon_23062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23062.xml"),
+          )
+      )
+
+  public val icon_23063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23063.xml"),
+          )
+      )
+
+  public val icon_23064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23064.xml"),
+          )
+      )
+
+  public val icon_23065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23065.xml"),
+          )
+      )
+
+  public val icon_23066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23066.xml"),
+          )
+      )
+
+  public val icon_23067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23067.xml"),
+          )
+      )
+
+  public val icon_23068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23068.xml"),
+          )
+      )
+
+  public val icon_23069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23069.xml"),
+          )
+      )
+
+  public val icon_2307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2307.xml"),
+          )
+      )
+
+  public val icon_23070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23070.xml"),
+          )
+      )
+
+  public val icon_23071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23071.xml"),
+          )
+      )
+
+  public val icon_23072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23072.xml"),
+          )
+      )
+
+  public val icon_23073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23073.xml"),
+          )
+      )
+
+  public val icon_23074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23074.xml"),
+          )
+      )
+
+  public val icon_23075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23075.xml"),
+          )
+      )
+
+  public val icon_23076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23076.xml"),
+          )
+      )
+
+  public val icon_23077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23077.xml"),
+          )
+      )
+
+  public val icon_23078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23078.xml"),
+          )
+      )
+
+  public val icon_23079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23079.xml"),
+          )
+      )
+
+  public val icon_2308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2308.xml"),
+          )
+      )
+
+  public val icon_23080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23080.xml"),
+          )
+      )
+
+  public val icon_23081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23081.xml"),
+          )
+      )
+
+  public val icon_23082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23082.xml"),
+          )
+      )
+
+  public val icon_23083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23083.xml"),
+          )
+      )
+
+  public val icon_23084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23084.xml"),
+          )
+      )
+
+  public val icon_23085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23085.xml"),
+          )
+      )
+
+  public val icon_23086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23086.xml"),
+          )
+      )
+
+  public val icon_23087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23087.xml"),
+          )
+      )
+
+  public val icon_23088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23088.xml"),
+          )
+      )
+
+  public val icon_23089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23089.xml"),
+          )
+      )
+
+  public val icon_2309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2309.xml"),
+          )
+      )
+
+  public val icon_23090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23090.xml"),
+          )
+      )
+
+  public val icon_23091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23091.xml"),
+          )
+      )
+
+  public val icon_23092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23092.xml"),
+          )
+      )
+
+  public val icon_23093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23093.xml"),
+          )
+      )
+
+  public val icon_23094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23094.xml"),
+          )
+      )
+
+  public val icon_23095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23095.xml"),
+          )
+      )
+
+  public val icon_23096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23096.xml"),
+          )
+      )
+
+  public val icon_23097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23097.xml"),
+          )
+      )
+
+  public val icon_23098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23098.xml"),
+          )
+      )
+
+  public val icon_23099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23099.xml"),
+          )
+      )
+
+  public val icon_231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_231.xml"),
+          )
+      )
+
+  public val icon_2310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2310.xml"),
+          )
+      )
+
+  public val icon_23100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23100.xml"),
+          )
+      )
+
+  public val icon_23101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23101.xml"),
+          )
+      )
+
+  public val icon_23102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23102.xml"),
+          )
+      )
+
+  public val icon_23103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23103.xml"),
+          )
+      )
+
+  public val icon_23104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23104.xml"),
+          )
+      )
+
+  public val icon_23105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23105.xml"),
+          )
+      )
+
+  public val icon_23106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23106.xml"),
+          )
+      )
+
+  public val icon_23107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23107.xml"),
+          )
+      )
+
+  public val icon_23108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23108.xml"),
+          )
+      )
+
+  public val icon_23109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23109.xml"),
+          )
+      )
+
+  public val icon_2311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2311.xml"),
+          )
+      )
+
+  public val icon_23110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23110.xml"),
+          )
+      )
+
+  public val icon_23111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23111.xml"),
+          )
+      )
+
+  public val icon_23112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23112.xml"),
+          )
+      )
+
+  public val icon_23113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23113.xml"),
+          )
+      )
+
+  public val icon_23114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23114.xml"),
+          )
+      )
+
+  public val icon_23115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23115.xml"),
+          )
+      )
+
+  public val icon_23116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23116.xml"),
+          )
+      )
+
+  public val icon_23117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23117.xml"),
+          )
+      )
+
+  public val icon_23118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23118.xml"),
+          )
+      )
+
+  public val icon_23119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23119.xml"),
+          )
+      )
+
+  public val icon_2312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2312.xml"),
+          )
+      )
+
+  public val icon_23120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23120.xml"),
+          )
+      )
+
+  public val icon_23121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23121.xml"),
+          )
+      )
+
+  public val icon_23122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23122.xml"),
+          )
+      )
+
+  public val icon_23123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23123.xml"),
+          )
+      )
+
+  public val icon_23124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23124.xml"),
+          )
+      )
+
+  public val icon_23125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23125.xml"),
+          )
+      )
+
+  public val icon_23126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23126.xml"),
+          )
+      )
+
+  public val icon_23127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23127.xml"),
+          )
+      )
+
+  public val icon_23128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23128.xml"),
+          )
+      )
+
+  public val icon_23129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23129.xml"),
+          )
+      )
+
+  public val icon_2313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2313.xml"),
+          )
+      )
+
+  public val icon_23130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23130.xml"),
+          )
+      )
+
+  public val icon_23131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23131.xml"),
+          )
+      )
+
+  public val icon_23132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23132.xml"),
+          )
+      )
+
+  public val icon_23133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23133.xml"),
+          )
+      )
+
+  public val icon_23134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23134.xml"),
+          )
+      )
+
+  public val icon_23135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23135.xml"),
+          )
+      )
+
+  public val icon_23136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23136.xml"),
+          )
+      )
+
+  public val icon_23137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23137.xml"),
+          )
+      )
+
+  public val icon_23138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23138.xml"),
+          )
+      )
+
+  public val icon_23139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23139.xml"),
+          )
+      )
+
+  public val icon_2314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2314.xml"),
+          )
+      )
+
+  public val icon_23140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23140.xml"),
+          )
+      )
+
+  public val icon_23141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23141.xml"),
+          )
+      )
+
+  public val icon_23142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23142.xml"),
+          )
+      )
+
+  public val icon_23143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23143.xml"),
+          )
+      )
+
+  public val icon_23144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23144.xml"),
+          )
+      )
+
+  public val icon_23145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23145.xml"),
+          )
+      )
+
+  public val icon_23146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23146.xml"),
+          )
+      )
+
+  public val icon_23147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23147.xml"),
+          )
+      )
+
+  public val icon_23148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23148.xml"),
+          )
+      )
+
+  public val icon_23149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23149.xml"),
+          )
+      )
+
+  public val icon_2315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2315.xml"),
+          )
+      )
+
+  public val icon_23150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23150.xml"),
+          )
+      )
+
+  public val icon_23151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23151.xml"),
+          )
+      )
+
+  public val icon_23152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23152.xml"),
+          )
+      )
+
+  public val icon_23153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23153.xml"),
+          )
+      )
+
+  public val icon_23154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23154.xml"),
+          )
+      )
+
+  public val icon_23155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23155.xml"),
+          )
+      )
+
+  public val icon_23156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23156.xml"),
+          )
+      )
+
+  public val icon_23157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23157.xml"),
+          )
+      )
+
+  public val icon_23158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23158.xml"),
+          )
+      )
+
+  public val icon_23159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23159.xml"),
+          )
+      )
+
+  public val icon_2316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2316.xml"),
+          )
+      )
+
+  public val icon_23160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23160.xml"),
+          )
+      )
+
+  public val icon_23161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23161.xml"),
+          )
+      )
+
+  public val icon_23162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23162.xml"),
+          )
+      )
+
+  public val icon_23163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23163.xml"),
+          )
+      )
+
+  public val icon_23164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23164.xml"),
+          )
+      )
+
+  public val icon_23165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23165.xml"),
+          )
+      )
+
+  public val icon_23166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23166.xml"),
+          )
+      )
+
+  public val icon_23167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23167.xml"),
+          )
+      )
+
+  public val icon_23168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23168.xml"),
+          )
+      )
+
+  public val icon_23169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23169.xml"),
+          )
+      )
+
+  public val icon_2317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2317.xml"),
+          )
+      )
+
+  public val icon_23170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23170.xml"),
+          )
+      )
+
+  public val icon_23171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23171.xml"),
+          )
+      )
+
+  public val icon_23172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23172.xml"),
+          )
+      )
+
+  public val icon_23173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23173.xml"),
+          )
+      )
+
+  public val icon_23174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23174.xml"),
+          )
+      )
+
+  public val icon_23175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23175.xml"),
+          )
+      )
+
+  public val icon_23176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23176.xml"),
+          )
+      )
+
+  public val icon_23177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23177.xml"),
+          )
+      )
+
+  public val icon_23178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23178.xml"),
+          )
+      )
+
+  public val icon_23179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23179.xml"),
+          )
+      )
+
+  public val icon_2318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2318.xml"),
+          )
+      )
+
+  public val icon_23180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23180.xml"),
+          )
+      )
+
+  public val icon_23181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23181.xml"),
+          )
+      )
+
+  public val icon_23182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23182.xml"),
+          )
+      )
+
+  public val icon_23183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23183.xml"),
+          )
+      )
+
+  public val icon_23184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23184.xml"),
+          )
+      )
+
+  public val icon_23185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23185.xml"),
+          )
+      )
+
+  public val icon_23186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23186.xml"),
+          )
+      )
+
+  public val icon_23187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23187.xml"),
+          )
+      )
+
+  public val icon_23188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23188.xml"),
+          )
+      )
+
+  public val icon_23189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23189.xml"),
+          )
+      )
+
+  public val icon_2319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2319.xml"),
+          )
+      )
+
+  public val icon_23190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23190.xml"),
+          )
+      )
+
+  public val icon_23191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23191.xml"),
+          )
+      )
+
+  public val icon_23192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23192.xml"),
+          )
+      )
+
+  public val icon_23193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23193.xml"),
+          )
+      )
+
+  public val icon_23194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23194.xml"),
+          )
+      )
+
+  public val icon_23195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23195.xml"),
+          )
+      )
+
+  public val icon_23196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23196.xml"),
+          )
+      )
+
+  public val icon_23197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23197.xml"),
+          )
+      )
+
+  public val icon_23198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23198.xml"),
+          )
+      )
+
+  public val icon_23199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23199.xml"),
+          )
+      )
+
+  public val icon_232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_232.xml"),
+          )
+      )
+
+  public val icon_2320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2320.xml"),
+          )
+      )
+
+  public val icon_23200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23200.xml"),
+          )
+      )
+
+  public val icon_23201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23201.xml"),
+          )
+      )
+
+  public val icon_23202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23202.xml"),
+          )
+      )
+
+  public val icon_23203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23203.xml"),
+          )
+      )
+
+  public val icon_23204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23204.xml"),
+          )
+      )
+
+  public val icon_23205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23205.xml"),
+          )
+      )
+
+  public val icon_23206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23206.xml"),
+          )
+      )
+
+  public val icon_23207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23207.xml"),
+          )
+      )
+
+  public val icon_23208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23208.xml"),
+          )
+      )
+
+  public val icon_23209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23209.xml"),
+          )
+      )
+
+  public val icon_2321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2321.xml"),
+          )
+      )
+
+  public val icon_23210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23210.xml"),
+          )
+      )
+
+  public val icon_23211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23211.xml"),
+          )
+      )
+
+  public val icon_23212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23212.xml"),
+          )
+      )
+
+  public val icon_23213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23213.xml"),
+          )
+      )
+
+  public val icon_23214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23214.xml"),
+          )
+      )
+
+  public val icon_23215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23215.xml"),
+          )
+      )
+
+  public val icon_23216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23216.xml"),
+          )
+      )
+
+  public val icon_23217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23217.xml"),
+          )
+      )
+
+  public val icon_23218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23218.xml"),
+          )
+      )
+
+  public val icon_23219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23219.xml"),
+          )
+      )
+
+  public val icon_2322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2322.xml"),
+          )
+      )
+
+  public val icon_23220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23220.xml"),
+          )
+      )
+
+  public val icon_23221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23221.xml"),
+          )
+      )
+
+  public val icon_23222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23222.xml"),
+          )
+      )
+
+  public val icon_23223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23223.xml"),
+          )
+      )
+
+  public val icon_23224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23224.xml"),
+          )
+      )
+
+  public val icon_23225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23225.xml"),
+          )
+      )
+
+  public val icon_23226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23226.xml"),
+          )
+      )
+
+  public val icon_23227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23227.xml"),
+          )
+      )
+
+  public val icon_23228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23228.xml"),
+          )
+      )
+
+  public val icon_23229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23229.xml"),
+          )
+      )
+
+  public val icon_2323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2323.xml"),
+          )
+      )
+
+  public val icon_23230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23230.xml"),
+          )
+      )
+
+  public val icon_23231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23231.xml"),
+          )
+      )
+
+  public val icon_23232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23232.xml"),
+          )
+      )
+
+  public val icon_23233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23233.xml"),
+          )
+      )
+
+  public val icon_23234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23234.xml"),
+          )
+      )
+
+  public val icon_23235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23235.xml"),
+          )
+      )
+
+  public val icon_23236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23236.xml"),
+          )
+      )
+
+  public val icon_23237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23237.xml"),
+          )
+      )
+
+  public val icon_23238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23238.xml"),
+          )
+      )
+
+  public val icon_23239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23239.xml"),
+          )
+      )
+
+  public val icon_2324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2324.xml"),
+          )
+      )
+
+  public val icon_23240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23240.xml"),
+          )
+      )
+
+  public val icon_23241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23241.xml"),
+          )
+      )
+
+  public val icon_23242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23242.xml"),
+          )
+      )
+
+  public val icon_23243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23243.xml"),
+          )
+      )
+
+  public val icon_23244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23244.xml"),
+          )
+      )
+
+  public val icon_23245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23245.xml"),
+          )
+      )
+
+  public val icon_23246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23246.xml"),
+          )
+      )
+
+  public val icon_23247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23247.xml"),
+          )
+      )
+
+  public val icon_23248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23248.xml"),
+          )
+      )
+
+  public val icon_23249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23249.xml"),
+          )
+      )
+
+  public val icon_2325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2325.xml"),
+          )
+      )
+
+  public val icon_23250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23250.xml"),
+          )
+      )
+
+  public val icon_23251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23251.xml"),
+          )
+      )
+
+  public val icon_23252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23252.xml"),
+          )
+      )
+
+  public val icon_23253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23253.xml"),
+          )
+      )
+
+  public val icon_23254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23254.xml"),
+          )
+      )
+
+  public val icon_23255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23255.xml"),
+          )
+      )
+
+  public val icon_23256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23256.xml"),
+          )
+      )
+
+  public val icon_23257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23257.xml"),
+          )
+      )
+
+  public val icon_23258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23258.xml"),
+          )
+      )
+
+  public val icon_23259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23259.xml"),
+          )
+      )
+
+  public val icon_2326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2326.xml"),
+          )
+      )
+
+  public val icon_23260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23260.xml"),
+          )
+      )
+
+  public val icon_23261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23261.xml"),
+          )
+      )
+
+  public val icon_23262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23262.xml"),
+          )
+      )
+
+  public val icon_23263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23263.xml"),
+          )
+      )
+
+  public val icon_23264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23264.xml"),
+          )
+      )
+
+  public val icon_23265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23265.xml"),
+          )
+      )
+
+  public val icon_23266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23266.xml"),
+          )
+      )
+
+  public val icon_23267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23267.xml"),
+          )
+      )
+
+  public val icon_23268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23268.xml"),
+          )
+      )
+
+  public val icon_23269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23269.xml"),
+          )
+      )
+
+  public val icon_2327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2327.xml"),
+          )
+      )
+
+  public val icon_23270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23270.xml"),
+          )
+      )
+
+  public val icon_23271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23271.xml"),
+          )
+      )
+
+  public val icon_23272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23272.xml"),
+          )
+      )
+
+  public val icon_23273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23273.xml"),
+          )
+      )
+
+  public val icon_23274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23274.xml"),
+          )
+      )
+
+  public val icon_23275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23275.xml"),
+          )
+      )
+
+  public val icon_23276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23276.xml"),
+          )
+      )
+
+  public val icon_23277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23277.xml"),
+          )
+      )
+
+  public val icon_23278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23278.xml"),
+          )
+      )
+
+  public val icon_23279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23279.xml"),
+          )
+      )
+
+  public val icon_2328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2328.xml"),
+          )
+      )
+
+  public val icon_23280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23280.xml"),
+          )
+      )
+
+  public val icon_23281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23281.xml"),
+          )
+      )
+
+  public val icon_23282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23282.xml"),
+          )
+      )
+
+  public val icon_23283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23283.xml"),
+          )
+      )
+
+  public val icon_23284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23284.xml"),
+          )
+      )
+
+  public val icon_23285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23285.xml"),
+          )
+      )
+
+  public val icon_23286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23286.xml"),
+          )
+      )
+
+  public val icon_23287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23287.xml"),
+          )
+      )
+
+  public val icon_23288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23288.xml"),
+          )
+      )
+
+  public val icon_23289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23289.xml"),
+          )
+      )
+
+  public val icon_2329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2329.xml"),
+          )
+      )
+
+  public val icon_23290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23290.xml"),
+          )
+      )
+
+  public val icon_23291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23291.xml"),
+          )
+      )
+
+  public val icon_23292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23292.xml"),
+          )
+      )
+
+  public val icon_23293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23293.xml"),
+          )
+      )
+
+  public val icon_23294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23294.xml"),
+          )
+      )
+
+  public val icon_23295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23295.xml"),
+          )
+      )
+
+  public val icon_23296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23296.xml"),
+          )
+      )
+
+  public val icon_23297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23297.xml"),
+          )
+      )
+
+  public val icon_23298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23298.xml"),
+          )
+      )
+
+  public val icon_23299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23299.xml"),
+          )
+      )
+
+  public val icon_233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_233.xml"),
+          )
+      )
+
+  public val icon_2330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2330.xml"),
+          )
+      )
+
+  public val icon_23300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23300.xml"),
+          )
+      )
+
+  public val icon_23301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23301.xml"),
+          )
+      )
+
+  public val icon_23302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23302.xml"),
+          )
+      )
+
+  public val icon_23303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23303.xml"),
+          )
+      )
+
+  public val icon_23304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23304.xml"),
+          )
+      )
+
+  public val icon_23305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23305.xml"),
+          )
+      )
+
+  public val icon_23306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23306.xml"),
+          )
+      )
+
+  public val icon_23307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23307.xml"),
+          )
+      )
+
+  public val icon_23308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23308.xml"),
+          )
+      )
+
+  public val icon_23309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23309.xml"),
+          )
+      )
+
+  public val icon_2331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2331.xml"),
+          )
+      )
+
+  public val icon_23310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23310.xml"),
+          )
+      )
+
+  public val icon_23311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23311.xml"),
+          )
+      )
+
+  public val icon_23312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23312.xml"),
+          )
+      )
+
+  public val icon_23313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23313.xml"),
+          )
+      )
+
+  public val icon_23314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23314.xml"),
+          )
+      )
+
+  public val icon_23315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23315.xml"),
+          )
+      )
+
+  public val icon_23316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23316.xml"),
+          )
+      )
+
+  public val icon_23317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23317.xml"),
+          )
+      )
+
+  public val icon_23318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23318.xml"),
+          )
+      )
+
+  public val icon_23319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23319.xml"),
+          )
+      )
+
+  public val icon_2332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2332.xml"),
+          )
+      )
+
+  public val icon_23320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23320.xml"),
+          )
+      )
+
+  public val icon_23321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23321.xml"),
+          )
+      )
+
+  public val icon_23322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23322.xml"),
+          )
+      )
+
+  public val icon_23323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23323.xml"),
+          )
+      )
+
+  public val icon_23324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23324.xml"),
+          )
+      )
+
+  public val icon_23325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23325.xml"),
+          )
+      )
+
+  public val icon_23326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23326.xml"),
+          )
+      )
+
+  public val icon_23327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23327.xml"),
+          )
+      )
+
+  public val icon_23328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23328.xml"),
+          )
+      )
+
+  public val icon_23329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23329.xml"),
+          )
+      )
+
+  public val icon_2333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2333.xml"),
+          )
+      )
+
+  public val icon_23330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23330.xml"),
+          )
+      )
+
+  public val icon_23331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23331.xml"),
+          )
+      )
+
+  public val icon_23332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23332.xml"),
+          )
+      )
+
+  public val icon_23333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23333.xml"),
+          )
+      )
+
+  public val icon_23334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23334.xml"),
+          )
+      )
+
+  public val icon_23335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23335.xml"),
+          )
+      )
+
+  public val icon_23336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23336.xml"),
+          )
+      )
+
+  public val icon_23337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23337.xml"),
+          )
+      )
+
+  public val icon_23338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23338.xml"),
+          )
+      )
+
+  public val icon_23339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23339.xml"),
+          )
+      )
+
+  public val icon_2334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2334.xml"),
+          )
+      )
+
+  public val icon_23340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23340.xml"),
+          )
+      )
+
+  public val icon_23341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23341.xml"),
+          )
+      )
+
+  public val icon_23342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23342.xml"),
+          )
+      )
+
+  public val icon_23343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23343.xml"),
+          )
+      )
+
+  public val icon_23344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23344.xml"),
+          )
+      )
+
+  public val icon_23345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23345.xml"),
+          )
+      )
+
+  public val icon_23346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23346.xml"),
+          )
+      )
+
+  public val icon_23347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23347.xml"),
+          )
+      )
+
+  public val icon_23348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23348.xml"),
+          )
+      )
+
+  public val icon_23349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23349.xml"),
+          )
+      )
+
+  public val icon_2335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2335.xml"),
+          )
+      )
+
+  public val icon_23350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23350.xml"),
+          )
+      )
+
+  public val icon_23351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23351.xml"),
+          )
+      )
+
+  public val icon_23352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23352.xml"),
+          )
+      )
+
+  public val icon_23353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23353.xml"),
+          )
+      )
+
+  public val icon_23354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23354.xml"),
+          )
+      )
+
+  public val icon_23355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23355.xml"),
+          )
+      )
+
+  public val icon_23356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23356.xml"),
+          )
+      )
+
+  public val icon_23357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23357.xml"),
+          )
+      )
+
+  public val icon_23358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23358.xml"),
+          )
+      )
+
+  public val icon_23359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23359.xml"),
+          )
+      )
+
+  public val icon_2336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2336.xml"),
+          )
+      )
+
+  public val icon_23360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23360.xml"),
+          )
+      )
+
+  public val icon_23361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23361.xml"),
+          )
+      )
+
+  public val icon_23362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23362.xml"),
+          )
+      )
+
+  public val icon_23363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23363.xml"),
+          )
+      )
+
+  public val icon_23364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23364.xml"),
+          )
+      )
+
+  public val icon_23365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23365.xml"),
+          )
+      )
+
+  public val icon_23366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23366.xml"),
+          )
+      )
+
+  public val icon_23367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23367.xml"),
+          )
+      )
+
+  public val icon_23368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23368.xml"),
+          )
+      )
+
+  public val icon_23369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23369.xml"),
+          )
+      )
+
+  public val icon_2337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2337.xml"),
+          )
+      )
+
+  public val icon_23370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23370.xml"),
+          )
+      )
+
+  public val icon_23371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23371.xml"),
+          )
+      )
+
+  public val icon_23372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23372.xml"),
+          )
+      )
+
+  public val icon_23373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23373.xml"),
+          )
+      )
+
+  public val icon_23374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23374.xml"),
+          )
+      )
+
+  public val icon_23375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23375.xml"),
+          )
+      )
+
+  public val icon_23376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23376.xml"),
+          )
+      )
+
+  public val icon_23377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23377.xml"),
+          )
+      )
+
+  public val icon_23378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23378.xml"),
+          )
+      )
+
+  public val icon_23379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23379.xml"),
+          )
+      )
+
+  public val icon_2338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2338.xml"),
+          )
+      )
+
+  public val icon_23380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23380.xml"),
+          )
+      )
+
+  public val icon_23381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23381.xml"),
+          )
+      )
+
+  public val icon_23382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23382.xml"),
+          )
+      )
+
+  public val icon_23383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23383.xml"),
+          )
+      )
+
+  public val icon_23384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23384.xml"),
+          )
+      )
+
+  public val icon_23385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23385.xml"),
+          )
+      )
+
+  public val icon_23386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23386.xml"),
+          )
+      )
+
+  public val icon_23387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23387.xml"),
+          )
+      )
+
+  public val icon_23388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23388.xml"),
+          )
+      )
+
+  public val icon_23389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23389.xml"),
+          )
+      )
+
+  public val icon_2339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2339.xml"),
+          )
+      )
+
+  public val icon_23390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23390.xml"),
+          )
+      )
+
+  public val icon_23391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23391.xml"),
+          )
+      )
+
+  public val icon_23392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23392.xml"),
+          )
+      )
+
+  public val icon_23393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23393.xml"),
+          )
+      )
+
+  public val icon_23394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23394.xml"),
+          )
+      )
+
+  public val icon_23395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23395.xml"),
+          )
+      )
+
+  public val icon_23396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23396.xml"),
+          )
+      )
+
+  public val icon_23397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23397.xml"),
+          )
+      )
+
+  public val icon_23398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23398.xml"),
+          )
+      )
+
+  public val icon_23399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23399.xml"),
+          )
+      )
+
+  public val icon_234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_234.xml"),
+          )
+      )
+
+  public val icon_2340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2340.xml"),
+          )
+      )
+
+  public val icon_23400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23400.xml"),
+          )
+      )
+
+  public val icon_23401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23401.xml"),
+          )
+      )
+
+  public val icon_23402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23402.xml"),
+          )
+      )
+
+  public val icon_23403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23403.xml"),
+          )
+      )
+
+  public val icon_23404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23404.xml"),
+          )
+      )
+
+  public val icon_23405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23405.xml"),
+          )
+      )
+
+  public val icon_23406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23406.xml"),
+          )
+      )
+
+  public val icon_23407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23407.xml"),
+          )
+      )
+
+  public val icon_23408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23408.xml"),
+          )
+      )
+
+  public val icon_23409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23409.xml"),
+          )
+      )
+
+  public val icon_2341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2341.xml"),
+          )
+      )
+
+  public val icon_23410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23410.xml"),
+          )
+      )
+
+  public val icon_23411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23411.xml"),
+          )
+      )
+
+  public val icon_23412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23412.xml"),
+          )
+      )
+
+  public val icon_23413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23413.xml"),
+          )
+      )
+
+  public val icon_23414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23414.xml"),
+          )
+      )
+
+  public val icon_23415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23415.xml"),
+          )
+      )
+
+  public val icon_23416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23416.xml"),
+          )
+      )
+
+  public val icon_23417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23417.xml"),
+          )
+      )
+
+  public val icon_23418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23418.xml"),
+          )
+      )
+
+  public val icon_23419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23419.xml"),
+          )
+      )
+
+  public val icon_2342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2342.xml"),
+          )
+      )
+
+  public val icon_23420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23420.xml"),
+          )
+      )
+
+  public val icon_23421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23421.xml"),
+          )
+      )
+
+  public val icon_23422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23422.xml"),
+          )
+      )
+
+  public val icon_23423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23423.xml"),
+          )
+      )
+
+  public val icon_23424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23424.xml"),
+          )
+      )
+
+  public val icon_23425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23425.xml"),
+          )
+      )
+
+  public val icon_23426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23426.xml"),
+          )
+      )
+
+  public val icon_23427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23427.xml"),
+          )
+      )
+
+  public val icon_23428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23428.xml"),
+          )
+      )
+
+  public val icon_23429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23429.xml"),
+          )
+      )
+
+  public val icon_2343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2343.xml"),
+          )
+      )
+
+  public val icon_23430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23430.xml"),
+          )
+      )
+
+  public val icon_23431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23431.xml"),
+          )
+      )
+
+  public val icon_23432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23432.xml"),
+          )
+      )
+
+  public val icon_23433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23433.xml"),
+          )
+      )
+
+  public val icon_23434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23434.xml"),
+          )
+      )
+
+  public val icon_23435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23435.xml"),
+          )
+      )
+
+  public val icon_23436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23436.xml"),
+          )
+      )
+
+  public val icon_23437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23437.xml"),
+          )
+      )
+
+  public val icon_23438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23438.xml"),
+          )
+      )
+
+  public val icon_23439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23439.xml"),
+          )
+      )
+
+  public val icon_2344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2344.xml"),
+          )
+      )
+
+  public val icon_23440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23440.xml"),
+          )
+      )
+
+  public val icon_23441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23441.xml"),
+          )
+      )
+
+  public val icon_23442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23442.xml"),
+          )
+      )
+
+  public val icon_23443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23443.xml"),
+          )
+      )
+
+  public val icon_23444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23444.xml"),
+          )
+      )
+
+  public val icon_23445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23445.xml"),
+          )
+      )
+
+  public val icon_23446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23446.xml"),
+          )
+      )
+
+  public val icon_23447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23447.xml"),
+          )
+      )
+
+  public val icon_23448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23448.xml"),
+          )
+      )
+
+  public val icon_23449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23449.xml"),
+          )
+      )
+
+  public val icon_2345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2345.xml"),
+          )
+      )
+
+  public val icon_23450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23450.xml"),
+          )
+      )
+
+  public val icon_23451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23451.xml"),
+          )
+      )
+
+  public val icon_23452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23452.xml"),
+          )
+      )
+
+  public val icon_23453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23453.xml"),
+          )
+      )
+
+  public val icon_23454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23454.xml"),
+          )
+      )
+
+  public val icon_23455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23455.xml"),
+          )
+      )
+
+  public val icon_23456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23456.xml"),
+          )
+      )
+
+  public val icon_23457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23457.xml"),
+          )
+      )
+
+  public val icon_23458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23458.xml"),
+          )
+      )
+
+  public val icon_23459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23459.xml"),
+          )
+      )
+
+  public val icon_2346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2346.xml"),
+          )
+      )
+
+  public val icon_23460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23460.xml"),
+          )
+      )
+
+  public val icon_23461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23461.xml"),
+          )
+      )
+
+  public val icon_23462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23462.xml"),
+          )
+      )
+
+  public val icon_23463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23463.xml"),
+          )
+      )
+
+  public val icon_23464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23464.xml"),
+          )
+      )
+
+  public val icon_23465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23465.xml"),
+          )
+      )
+
+  public val icon_23466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23466.xml"),
+          )
+      )
+
+  public val icon_23467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23467.xml"),
+          )
+      )
+
+  public val icon_23468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23468.xml"),
+          )
+      )
+
+  public val icon_23469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23469.xml"),
+          )
+      )
+
+  public val icon_2347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2347.xml"),
+          )
+      )
+
+  public val icon_23470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23470.xml"),
+          )
+      )
+
+  public val icon_23471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23471.xml"),
+          )
+      )
+
+  public val icon_23472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23472.xml"),
+          )
+      )
+
+  public val icon_23473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23473.xml"),
+          )
+      )
+
+  public val icon_23474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23474.xml"),
+          )
+      )
+
+  public val icon_23475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23475.xml"),
+          )
+      )
+
+  public val icon_23476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23476.xml"),
+          )
+      )
+
+  public val icon_23477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23477.xml"),
+          )
+      )
+
+  public val icon_23478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23478.xml"),
+          )
+      )
+
+  public val icon_23479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23479.xml"),
+          )
+      )
+
+  public val icon_2348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2348.xml"),
+          )
+      )
+
+  public val icon_23480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23480.xml"),
+          )
+      )
+
+  public val icon_23481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23481.xml"),
+          )
+      )
+
+  public val icon_23482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23482.xml"),
+          )
+      )
+
+  public val icon_23483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23483.xml"),
+          )
+      )
+
+  public val icon_23484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23484.xml"),
+          )
+      )
+
+  public val icon_23485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23485.xml"),
+          )
+      )
+
+  public val icon_23486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23486.xml"),
+          )
+      )
+
+  public val icon_23487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23487.xml"),
+          )
+      )
+
+  public val icon_23488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23488.xml"),
+          )
+      )
+
+  public val icon_23489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23489.xml"),
+          )
+      )
+
+  public val icon_2349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2349.xml"),
+          )
+      )
+
+  public val icon_23490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23490.xml"),
+          )
+      )
+
+  public val icon_23491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23491.xml"),
+          )
+      )
+
+  public val icon_23492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23492.xml"),
+          )
+      )
+
+  public val icon_23493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23493.xml"),
+          )
+      )
+
+  public val icon_23494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23494.xml"),
+          )
+      )
+
+  public val icon_23495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23495.xml"),
+          )
+      )
+
+  public val icon_23496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23496.xml"),
+          )
+      )
+
+  public val icon_23497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23497.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23047: DrawableResource
+  get() = Drawable29.icon_23047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23048: DrawableResource
+  get() = Drawable29.icon_23048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23049: DrawableResource
+  get() = Drawable29.icon_23049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2305: DrawableResource
+  get() = Drawable29.icon_2305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23050: DrawableResource
+  get() = Drawable29.icon_23050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23051: DrawableResource
+  get() = Drawable29.icon_23051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23052: DrawableResource
+  get() = Drawable29.icon_23052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23053: DrawableResource
+  get() = Drawable29.icon_23053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23054: DrawableResource
+  get() = Drawable29.icon_23054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23055: DrawableResource
+  get() = Drawable29.icon_23055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23056: DrawableResource
+  get() = Drawable29.icon_23056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23057: DrawableResource
+  get() = Drawable29.icon_23057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23058: DrawableResource
+  get() = Drawable29.icon_23058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23059: DrawableResource
+  get() = Drawable29.icon_23059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2306: DrawableResource
+  get() = Drawable29.icon_2306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23060: DrawableResource
+  get() = Drawable29.icon_23060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23061: DrawableResource
+  get() = Drawable29.icon_23061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23062: DrawableResource
+  get() = Drawable29.icon_23062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23063: DrawableResource
+  get() = Drawable29.icon_23063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23064: DrawableResource
+  get() = Drawable29.icon_23064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23065: DrawableResource
+  get() = Drawable29.icon_23065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23066: DrawableResource
+  get() = Drawable29.icon_23066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23067: DrawableResource
+  get() = Drawable29.icon_23067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23068: DrawableResource
+  get() = Drawable29.icon_23068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23069: DrawableResource
+  get() = Drawable29.icon_23069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2307: DrawableResource
+  get() = Drawable29.icon_2307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23070: DrawableResource
+  get() = Drawable29.icon_23070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23071: DrawableResource
+  get() = Drawable29.icon_23071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23072: DrawableResource
+  get() = Drawable29.icon_23072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23073: DrawableResource
+  get() = Drawable29.icon_23073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23074: DrawableResource
+  get() = Drawable29.icon_23074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23075: DrawableResource
+  get() = Drawable29.icon_23075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23076: DrawableResource
+  get() = Drawable29.icon_23076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23077: DrawableResource
+  get() = Drawable29.icon_23077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23078: DrawableResource
+  get() = Drawable29.icon_23078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23079: DrawableResource
+  get() = Drawable29.icon_23079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2308: DrawableResource
+  get() = Drawable29.icon_2308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23080: DrawableResource
+  get() = Drawable29.icon_23080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23081: DrawableResource
+  get() = Drawable29.icon_23081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23082: DrawableResource
+  get() = Drawable29.icon_23082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23083: DrawableResource
+  get() = Drawable29.icon_23083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23084: DrawableResource
+  get() = Drawable29.icon_23084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23085: DrawableResource
+  get() = Drawable29.icon_23085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23086: DrawableResource
+  get() = Drawable29.icon_23086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23087: DrawableResource
+  get() = Drawable29.icon_23087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23088: DrawableResource
+  get() = Drawable29.icon_23088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23089: DrawableResource
+  get() = Drawable29.icon_23089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2309: DrawableResource
+  get() = Drawable29.icon_2309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23090: DrawableResource
+  get() = Drawable29.icon_23090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23091: DrawableResource
+  get() = Drawable29.icon_23091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23092: DrawableResource
+  get() = Drawable29.icon_23092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23093: DrawableResource
+  get() = Drawable29.icon_23093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23094: DrawableResource
+  get() = Drawable29.icon_23094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23095: DrawableResource
+  get() = Drawable29.icon_23095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23096: DrawableResource
+  get() = Drawable29.icon_23096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23097: DrawableResource
+  get() = Drawable29.icon_23097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23098: DrawableResource
+  get() = Drawable29.icon_23098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23099: DrawableResource
+  get() = Drawable29.icon_23099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_231: DrawableResource
+  get() = Drawable29.icon_231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2310: DrawableResource
+  get() = Drawable29.icon_2310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23100: DrawableResource
+  get() = Drawable29.icon_23100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23101: DrawableResource
+  get() = Drawable29.icon_23101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23102: DrawableResource
+  get() = Drawable29.icon_23102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23103: DrawableResource
+  get() = Drawable29.icon_23103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23104: DrawableResource
+  get() = Drawable29.icon_23104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23105: DrawableResource
+  get() = Drawable29.icon_23105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23106: DrawableResource
+  get() = Drawable29.icon_23106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23107: DrawableResource
+  get() = Drawable29.icon_23107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23108: DrawableResource
+  get() = Drawable29.icon_23108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23109: DrawableResource
+  get() = Drawable29.icon_23109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2311: DrawableResource
+  get() = Drawable29.icon_2311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23110: DrawableResource
+  get() = Drawable29.icon_23110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23111: DrawableResource
+  get() = Drawable29.icon_23111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23112: DrawableResource
+  get() = Drawable29.icon_23112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23113: DrawableResource
+  get() = Drawable29.icon_23113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23114: DrawableResource
+  get() = Drawable29.icon_23114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23115: DrawableResource
+  get() = Drawable29.icon_23115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23116: DrawableResource
+  get() = Drawable29.icon_23116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23117: DrawableResource
+  get() = Drawable29.icon_23117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23118: DrawableResource
+  get() = Drawable29.icon_23118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23119: DrawableResource
+  get() = Drawable29.icon_23119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2312: DrawableResource
+  get() = Drawable29.icon_2312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23120: DrawableResource
+  get() = Drawable29.icon_23120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23121: DrawableResource
+  get() = Drawable29.icon_23121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23122: DrawableResource
+  get() = Drawable29.icon_23122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23123: DrawableResource
+  get() = Drawable29.icon_23123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23124: DrawableResource
+  get() = Drawable29.icon_23124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23125: DrawableResource
+  get() = Drawable29.icon_23125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23126: DrawableResource
+  get() = Drawable29.icon_23126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23127: DrawableResource
+  get() = Drawable29.icon_23127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23128: DrawableResource
+  get() = Drawable29.icon_23128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23129: DrawableResource
+  get() = Drawable29.icon_23129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2313: DrawableResource
+  get() = Drawable29.icon_2313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23130: DrawableResource
+  get() = Drawable29.icon_23130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23131: DrawableResource
+  get() = Drawable29.icon_23131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23132: DrawableResource
+  get() = Drawable29.icon_23132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23133: DrawableResource
+  get() = Drawable29.icon_23133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23134: DrawableResource
+  get() = Drawable29.icon_23134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23135: DrawableResource
+  get() = Drawable29.icon_23135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23136: DrawableResource
+  get() = Drawable29.icon_23136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23137: DrawableResource
+  get() = Drawable29.icon_23137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23138: DrawableResource
+  get() = Drawable29.icon_23138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23139: DrawableResource
+  get() = Drawable29.icon_23139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2314: DrawableResource
+  get() = Drawable29.icon_2314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23140: DrawableResource
+  get() = Drawable29.icon_23140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23141: DrawableResource
+  get() = Drawable29.icon_23141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23142: DrawableResource
+  get() = Drawable29.icon_23142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23143: DrawableResource
+  get() = Drawable29.icon_23143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23144: DrawableResource
+  get() = Drawable29.icon_23144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23145: DrawableResource
+  get() = Drawable29.icon_23145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23146: DrawableResource
+  get() = Drawable29.icon_23146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23147: DrawableResource
+  get() = Drawable29.icon_23147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23148: DrawableResource
+  get() = Drawable29.icon_23148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23149: DrawableResource
+  get() = Drawable29.icon_23149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2315: DrawableResource
+  get() = Drawable29.icon_2315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23150: DrawableResource
+  get() = Drawable29.icon_23150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23151: DrawableResource
+  get() = Drawable29.icon_23151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23152: DrawableResource
+  get() = Drawable29.icon_23152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23153: DrawableResource
+  get() = Drawable29.icon_23153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23154: DrawableResource
+  get() = Drawable29.icon_23154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23155: DrawableResource
+  get() = Drawable29.icon_23155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23156: DrawableResource
+  get() = Drawable29.icon_23156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23157: DrawableResource
+  get() = Drawable29.icon_23157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23158: DrawableResource
+  get() = Drawable29.icon_23158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23159: DrawableResource
+  get() = Drawable29.icon_23159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2316: DrawableResource
+  get() = Drawable29.icon_2316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23160: DrawableResource
+  get() = Drawable29.icon_23160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23161: DrawableResource
+  get() = Drawable29.icon_23161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23162: DrawableResource
+  get() = Drawable29.icon_23162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23163: DrawableResource
+  get() = Drawable29.icon_23163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23164: DrawableResource
+  get() = Drawable29.icon_23164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23165: DrawableResource
+  get() = Drawable29.icon_23165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23166: DrawableResource
+  get() = Drawable29.icon_23166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23167: DrawableResource
+  get() = Drawable29.icon_23167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23168: DrawableResource
+  get() = Drawable29.icon_23168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23169: DrawableResource
+  get() = Drawable29.icon_23169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2317: DrawableResource
+  get() = Drawable29.icon_2317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23170: DrawableResource
+  get() = Drawable29.icon_23170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23171: DrawableResource
+  get() = Drawable29.icon_23171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23172: DrawableResource
+  get() = Drawable29.icon_23172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23173: DrawableResource
+  get() = Drawable29.icon_23173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23174: DrawableResource
+  get() = Drawable29.icon_23174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23175: DrawableResource
+  get() = Drawable29.icon_23175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23176: DrawableResource
+  get() = Drawable29.icon_23176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23177: DrawableResource
+  get() = Drawable29.icon_23177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23178: DrawableResource
+  get() = Drawable29.icon_23178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23179: DrawableResource
+  get() = Drawable29.icon_23179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2318: DrawableResource
+  get() = Drawable29.icon_2318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23180: DrawableResource
+  get() = Drawable29.icon_23180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23181: DrawableResource
+  get() = Drawable29.icon_23181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23182: DrawableResource
+  get() = Drawable29.icon_23182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23183: DrawableResource
+  get() = Drawable29.icon_23183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23184: DrawableResource
+  get() = Drawable29.icon_23184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23185: DrawableResource
+  get() = Drawable29.icon_23185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23186: DrawableResource
+  get() = Drawable29.icon_23186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23187: DrawableResource
+  get() = Drawable29.icon_23187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23188: DrawableResource
+  get() = Drawable29.icon_23188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23189: DrawableResource
+  get() = Drawable29.icon_23189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2319: DrawableResource
+  get() = Drawable29.icon_2319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23190: DrawableResource
+  get() = Drawable29.icon_23190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23191: DrawableResource
+  get() = Drawable29.icon_23191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23192: DrawableResource
+  get() = Drawable29.icon_23192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23193: DrawableResource
+  get() = Drawable29.icon_23193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23194: DrawableResource
+  get() = Drawable29.icon_23194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23195: DrawableResource
+  get() = Drawable29.icon_23195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23196: DrawableResource
+  get() = Drawable29.icon_23196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23197: DrawableResource
+  get() = Drawable29.icon_23197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23198: DrawableResource
+  get() = Drawable29.icon_23198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23199: DrawableResource
+  get() = Drawable29.icon_23199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_232: DrawableResource
+  get() = Drawable29.icon_232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2320: DrawableResource
+  get() = Drawable29.icon_2320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23200: DrawableResource
+  get() = Drawable29.icon_23200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23201: DrawableResource
+  get() = Drawable29.icon_23201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23202: DrawableResource
+  get() = Drawable29.icon_23202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23203: DrawableResource
+  get() = Drawable29.icon_23203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23204: DrawableResource
+  get() = Drawable29.icon_23204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23205: DrawableResource
+  get() = Drawable29.icon_23205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23206: DrawableResource
+  get() = Drawable29.icon_23206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23207: DrawableResource
+  get() = Drawable29.icon_23207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23208: DrawableResource
+  get() = Drawable29.icon_23208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23209: DrawableResource
+  get() = Drawable29.icon_23209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2321: DrawableResource
+  get() = Drawable29.icon_2321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23210: DrawableResource
+  get() = Drawable29.icon_23210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23211: DrawableResource
+  get() = Drawable29.icon_23211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23212: DrawableResource
+  get() = Drawable29.icon_23212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23213: DrawableResource
+  get() = Drawable29.icon_23213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23214: DrawableResource
+  get() = Drawable29.icon_23214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23215: DrawableResource
+  get() = Drawable29.icon_23215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23216: DrawableResource
+  get() = Drawable29.icon_23216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23217: DrawableResource
+  get() = Drawable29.icon_23217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23218: DrawableResource
+  get() = Drawable29.icon_23218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23219: DrawableResource
+  get() = Drawable29.icon_23219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2322: DrawableResource
+  get() = Drawable29.icon_2322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23220: DrawableResource
+  get() = Drawable29.icon_23220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23221: DrawableResource
+  get() = Drawable29.icon_23221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23222: DrawableResource
+  get() = Drawable29.icon_23222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23223: DrawableResource
+  get() = Drawable29.icon_23223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23224: DrawableResource
+  get() = Drawable29.icon_23224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23225: DrawableResource
+  get() = Drawable29.icon_23225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23226: DrawableResource
+  get() = Drawable29.icon_23226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23227: DrawableResource
+  get() = Drawable29.icon_23227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23228: DrawableResource
+  get() = Drawable29.icon_23228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23229: DrawableResource
+  get() = Drawable29.icon_23229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2323: DrawableResource
+  get() = Drawable29.icon_2323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23230: DrawableResource
+  get() = Drawable29.icon_23230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23231: DrawableResource
+  get() = Drawable29.icon_23231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23232: DrawableResource
+  get() = Drawable29.icon_23232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23233: DrawableResource
+  get() = Drawable29.icon_23233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23234: DrawableResource
+  get() = Drawable29.icon_23234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23235: DrawableResource
+  get() = Drawable29.icon_23235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23236: DrawableResource
+  get() = Drawable29.icon_23236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23237: DrawableResource
+  get() = Drawable29.icon_23237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23238: DrawableResource
+  get() = Drawable29.icon_23238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23239: DrawableResource
+  get() = Drawable29.icon_23239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2324: DrawableResource
+  get() = Drawable29.icon_2324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23240: DrawableResource
+  get() = Drawable29.icon_23240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23241: DrawableResource
+  get() = Drawable29.icon_23241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23242: DrawableResource
+  get() = Drawable29.icon_23242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23243: DrawableResource
+  get() = Drawable29.icon_23243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23244: DrawableResource
+  get() = Drawable29.icon_23244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23245: DrawableResource
+  get() = Drawable29.icon_23245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23246: DrawableResource
+  get() = Drawable29.icon_23246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23247: DrawableResource
+  get() = Drawable29.icon_23247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23248: DrawableResource
+  get() = Drawable29.icon_23248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23249: DrawableResource
+  get() = Drawable29.icon_23249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2325: DrawableResource
+  get() = Drawable29.icon_2325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23250: DrawableResource
+  get() = Drawable29.icon_23250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23251: DrawableResource
+  get() = Drawable29.icon_23251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23252: DrawableResource
+  get() = Drawable29.icon_23252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23253: DrawableResource
+  get() = Drawable29.icon_23253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23254: DrawableResource
+  get() = Drawable29.icon_23254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23255: DrawableResource
+  get() = Drawable29.icon_23255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23256: DrawableResource
+  get() = Drawable29.icon_23256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23257: DrawableResource
+  get() = Drawable29.icon_23257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23258: DrawableResource
+  get() = Drawable29.icon_23258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23259: DrawableResource
+  get() = Drawable29.icon_23259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2326: DrawableResource
+  get() = Drawable29.icon_2326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23260: DrawableResource
+  get() = Drawable29.icon_23260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23261: DrawableResource
+  get() = Drawable29.icon_23261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23262: DrawableResource
+  get() = Drawable29.icon_23262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23263: DrawableResource
+  get() = Drawable29.icon_23263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23264: DrawableResource
+  get() = Drawable29.icon_23264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23265: DrawableResource
+  get() = Drawable29.icon_23265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23266: DrawableResource
+  get() = Drawable29.icon_23266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23267: DrawableResource
+  get() = Drawable29.icon_23267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23268: DrawableResource
+  get() = Drawable29.icon_23268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23269: DrawableResource
+  get() = Drawable29.icon_23269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2327: DrawableResource
+  get() = Drawable29.icon_2327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23270: DrawableResource
+  get() = Drawable29.icon_23270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23271: DrawableResource
+  get() = Drawable29.icon_23271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23272: DrawableResource
+  get() = Drawable29.icon_23272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23273: DrawableResource
+  get() = Drawable29.icon_23273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23274: DrawableResource
+  get() = Drawable29.icon_23274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23275: DrawableResource
+  get() = Drawable29.icon_23275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23276: DrawableResource
+  get() = Drawable29.icon_23276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23277: DrawableResource
+  get() = Drawable29.icon_23277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23278: DrawableResource
+  get() = Drawable29.icon_23278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23279: DrawableResource
+  get() = Drawable29.icon_23279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2328: DrawableResource
+  get() = Drawable29.icon_2328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23280: DrawableResource
+  get() = Drawable29.icon_23280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23281: DrawableResource
+  get() = Drawable29.icon_23281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23282: DrawableResource
+  get() = Drawable29.icon_23282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23283: DrawableResource
+  get() = Drawable29.icon_23283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23284: DrawableResource
+  get() = Drawable29.icon_23284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23285: DrawableResource
+  get() = Drawable29.icon_23285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23286: DrawableResource
+  get() = Drawable29.icon_23286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23287: DrawableResource
+  get() = Drawable29.icon_23287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23288: DrawableResource
+  get() = Drawable29.icon_23288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23289: DrawableResource
+  get() = Drawable29.icon_23289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2329: DrawableResource
+  get() = Drawable29.icon_2329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23290: DrawableResource
+  get() = Drawable29.icon_23290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23291: DrawableResource
+  get() = Drawable29.icon_23291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23292: DrawableResource
+  get() = Drawable29.icon_23292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23293: DrawableResource
+  get() = Drawable29.icon_23293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23294: DrawableResource
+  get() = Drawable29.icon_23294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23295: DrawableResource
+  get() = Drawable29.icon_23295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23296: DrawableResource
+  get() = Drawable29.icon_23296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23297: DrawableResource
+  get() = Drawable29.icon_23297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23298: DrawableResource
+  get() = Drawable29.icon_23298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23299: DrawableResource
+  get() = Drawable29.icon_23299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_233: DrawableResource
+  get() = Drawable29.icon_233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2330: DrawableResource
+  get() = Drawable29.icon_2330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23300: DrawableResource
+  get() = Drawable29.icon_23300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23301: DrawableResource
+  get() = Drawable29.icon_23301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23302: DrawableResource
+  get() = Drawable29.icon_23302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23303: DrawableResource
+  get() = Drawable29.icon_23303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23304: DrawableResource
+  get() = Drawable29.icon_23304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23305: DrawableResource
+  get() = Drawable29.icon_23305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23306: DrawableResource
+  get() = Drawable29.icon_23306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23307: DrawableResource
+  get() = Drawable29.icon_23307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23308: DrawableResource
+  get() = Drawable29.icon_23308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23309: DrawableResource
+  get() = Drawable29.icon_23309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2331: DrawableResource
+  get() = Drawable29.icon_2331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23310: DrawableResource
+  get() = Drawable29.icon_23310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23311: DrawableResource
+  get() = Drawable29.icon_23311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23312: DrawableResource
+  get() = Drawable29.icon_23312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23313: DrawableResource
+  get() = Drawable29.icon_23313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23314: DrawableResource
+  get() = Drawable29.icon_23314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23315: DrawableResource
+  get() = Drawable29.icon_23315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23316: DrawableResource
+  get() = Drawable29.icon_23316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23317: DrawableResource
+  get() = Drawable29.icon_23317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23318: DrawableResource
+  get() = Drawable29.icon_23318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23319: DrawableResource
+  get() = Drawable29.icon_23319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2332: DrawableResource
+  get() = Drawable29.icon_2332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23320: DrawableResource
+  get() = Drawable29.icon_23320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23321: DrawableResource
+  get() = Drawable29.icon_23321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23322: DrawableResource
+  get() = Drawable29.icon_23322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23323: DrawableResource
+  get() = Drawable29.icon_23323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23324: DrawableResource
+  get() = Drawable29.icon_23324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23325: DrawableResource
+  get() = Drawable29.icon_23325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23326: DrawableResource
+  get() = Drawable29.icon_23326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23327: DrawableResource
+  get() = Drawable29.icon_23327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23328: DrawableResource
+  get() = Drawable29.icon_23328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23329: DrawableResource
+  get() = Drawable29.icon_23329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2333: DrawableResource
+  get() = Drawable29.icon_2333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23330: DrawableResource
+  get() = Drawable29.icon_23330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23331: DrawableResource
+  get() = Drawable29.icon_23331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23332: DrawableResource
+  get() = Drawable29.icon_23332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23333: DrawableResource
+  get() = Drawable29.icon_23333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23334: DrawableResource
+  get() = Drawable29.icon_23334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23335: DrawableResource
+  get() = Drawable29.icon_23335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23336: DrawableResource
+  get() = Drawable29.icon_23336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23337: DrawableResource
+  get() = Drawable29.icon_23337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23338: DrawableResource
+  get() = Drawable29.icon_23338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23339: DrawableResource
+  get() = Drawable29.icon_23339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2334: DrawableResource
+  get() = Drawable29.icon_2334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23340: DrawableResource
+  get() = Drawable29.icon_23340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23341: DrawableResource
+  get() = Drawable29.icon_23341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23342: DrawableResource
+  get() = Drawable29.icon_23342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23343: DrawableResource
+  get() = Drawable29.icon_23343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23344: DrawableResource
+  get() = Drawable29.icon_23344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23345: DrawableResource
+  get() = Drawable29.icon_23345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23346: DrawableResource
+  get() = Drawable29.icon_23346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23347: DrawableResource
+  get() = Drawable29.icon_23347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23348: DrawableResource
+  get() = Drawable29.icon_23348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23349: DrawableResource
+  get() = Drawable29.icon_23349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2335: DrawableResource
+  get() = Drawable29.icon_2335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23350: DrawableResource
+  get() = Drawable29.icon_23350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23351: DrawableResource
+  get() = Drawable29.icon_23351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23352: DrawableResource
+  get() = Drawable29.icon_23352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23353: DrawableResource
+  get() = Drawable29.icon_23353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23354: DrawableResource
+  get() = Drawable29.icon_23354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23355: DrawableResource
+  get() = Drawable29.icon_23355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23356: DrawableResource
+  get() = Drawable29.icon_23356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23357: DrawableResource
+  get() = Drawable29.icon_23357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23358: DrawableResource
+  get() = Drawable29.icon_23358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23359: DrawableResource
+  get() = Drawable29.icon_23359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2336: DrawableResource
+  get() = Drawable29.icon_2336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23360: DrawableResource
+  get() = Drawable29.icon_23360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23361: DrawableResource
+  get() = Drawable29.icon_23361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23362: DrawableResource
+  get() = Drawable29.icon_23362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23363: DrawableResource
+  get() = Drawable29.icon_23363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23364: DrawableResource
+  get() = Drawable29.icon_23364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23365: DrawableResource
+  get() = Drawable29.icon_23365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23366: DrawableResource
+  get() = Drawable29.icon_23366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23367: DrawableResource
+  get() = Drawable29.icon_23367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23368: DrawableResource
+  get() = Drawable29.icon_23368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23369: DrawableResource
+  get() = Drawable29.icon_23369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2337: DrawableResource
+  get() = Drawable29.icon_2337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23370: DrawableResource
+  get() = Drawable29.icon_23370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23371: DrawableResource
+  get() = Drawable29.icon_23371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23372: DrawableResource
+  get() = Drawable29.icon_23372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23373: DrawableResource
+  get() = Drawable29.icon_23373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23374: DrawableResource
+  get() = Drawable29.icon_23374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23375: DrawableResource
+  get() = Drawable29.icon_23375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23376: DrawableResource
+  get() = Drawable29.icon_23376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23377: DrawableResource
+  get() = Drawable29.icon_23377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23378: DrawableResource
+  get() = Drawable29.icon_23378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23379: DrawableResource
+  get() = Drawable29.icon_23379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2338: DrawableResource
+  get() = Drawable29.icon_2338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23380: DrawableResource
+  get() = Drawable29.icon_23380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23381: DrawableResource
+  get() = Drawable29.icon_23381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23382: DrawableResource
+  get() = Drawable29.icon_23382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23383: DrawableResource
+  get() = Drawable29.icon_23383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23384: DrawableResource
+  get() = Drawable29.icon_23384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23385: DrawableResource
+  get() = Drawable29.icon_23385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23386: DrawableResource
+  get() = Drawable29.icon_23386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23387: DrawableResource
+  get() = Drawable29.icon_23387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23388: DrawableResource
+  get() = Drawable29.icon_23388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23389: DrawableResource
+  get() = Drawable29.icon_23389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2339: DrawableResource
+  get() = Drawable29.icon_2339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23390: DrawableResource
+  get() = Drawable29.icon_23390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23391: DrawableResource
+  get() = Drawable29.icon_23391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23392: DrawableResource
+  get() = Drawable29.icon_23392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23393: DrawableResource
+  get() = Drawable29.icon_23393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23394: DrawableResource
+  get() = Drawable29.icon_23394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23395: DrawableResource
+  get() = Drawable29.icon_23395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23396: DrawableResource
+  get() = Drawable29.icon_23396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23397: DrawableResource
+  get() = Drawable29.icon_23397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23398: DrawableResource
+  get() = Drawable29.icon_23398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23399: DrawableResource
+  get() = Drawable29.icon_23399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_234: DrawableResource
+  get() = Drawable29.icon_234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2340: DrawableResource
+  get() = Drawable29.icon_2340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23400: DrawableResource
+  get() = Drawable29.icon_23400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23401: DrawableResource
+  get() = Drawable29.icon_23401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23402: DrawableResource
+  get() = Drawable29.icon_23402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23403: DrawableResource
+  get() = Drawable29.icon_23403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23404: DrawableResource
+  get() = Drawable29.icon_23404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23405: DrawableResource
+  get() = Drawable29.icon_23405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23406: DrawableResource
+  get() = Drawable29.icon_23406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23407: DrawableResource
+  get() = Drawable29.icon_23407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23408: DrawableResource
+  get() = Drawable29.icon_23408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23409: DrawableResource
+  get() = Drawable29.icon_23409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2341: DrawableResource
+  get() = Drawable29.icon_2341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23410: DrawableResource
+  get() = Drawable29.icon_23410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23411: DrawableResource
+  get() = Drawable29.icon_23411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23412: DrawableResource
+  get() = Drawable29.icon_23412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23413: DrawableResource
+  get() = Drawable29.icon_23413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23414: DrawableResource
+  get() = Drawable29.icon_23414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23415: DrawableResource
+  get() = Drawable29.icon_23415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23416: DrawableResource
+  get() = Drawable29.icon_23416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23417: DrawableResource
+  get() = Drawable29.icon_23417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23418: DrawableResource
+  get() = Drawable29.icon_23418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23419: DrawableResource
+  get() = Drawable29.icon_23419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2342: DrawableResource
+  get() = Drawable29.icon_2342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23420: DrawableResource
+  get() = Drawable29.icon_23420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23421: DrawableResource
+  get() = Drawable29.icon_23421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23422: DrawableResource
+  get() = Drawable29.icon_23422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23423: DrawableResource
+  get() = Drawable29.icon_23423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23424: DrawableResource
+  get() = Drawable29.icon_23424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23425: DrawableResource
+  get() = Drawable29.icon_23425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23426: DrawableResource
+  get() = Drawable29.icon_23426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23427: DrawableResource
+  get() = Drawable29.icon_23427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23428: DrawableResource
+  get() = Drawable29.icon_23428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23429: DrawableResource
+  get() = Drawable29.icon_23429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2343: DrawableResource
+  get() = Drawable29.icon_2343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23430: DrawableResource
+  get() = Drawable29.icon_23430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23431: DrawableResource
+  get() = Drawable29.icon_23431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23432: DrawableResource
+  get() = Drawable29.icon_23432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23433: DrawableResource
+  get() = Drawable29.icon_23433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23434: DrawableResource
+  get() = Drawable29.icon_23434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23435: DrawableResource
+  get() = Drawable29.icon_23435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23436: DrawableResource
+  get() = Drawable29.icon_23436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23437: DrawableResource
+  get() = Drawable29.icon_23437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23438: DrawableResource
+  get() = Drawable29.icon_23438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23439: DrawableResource
+  get() = Drawable29.icon_23439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2344: DrawableResource
+  get() = Drawable29.icon_2344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23440: DrawableResource
+  get() = Drawable29.icon_23440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23441: DrawableResource
+  get() = Drawable29.icon_23441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23442: DrawableResource
+  get() = Drawable29.icon_23442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23443: DrawableResource
+  get() = Drawable29.icon_23443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23444: DrawableResource
+  get() = Drawable29.icon_23444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23445: DrawableResource
+  get() = Drawable29.icon_23445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23446: DrawableResource
+  get() = Drawable29.icon_23446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23447: DrawableResource
+  get() = Drawable29.icon_23447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23448: DrawableResource
+  get() = Drawable29.icon_23448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23449: DrawableResource
+  get() = Drawable29.icon_23449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2345: DrawableResource
+  get() = Drawable29.icon_2345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23450: DrawableResource
+  get() = Drawable29.icon_23450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23451: DrawableResource
+  get() = Drawable29.icon_23451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23452: DrawableResource
+  get() = Drawable29.icon_23452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23453: DrawableResource
+  get() = Drawable29.icon_23453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23454: DrawableResource
+  get() = Drawable29.icon_23454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23455: DrawableResource
+  get() = Drawable29.icon_23455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23456: DrawableResource
+  get() = Drawable29.icon_23456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23457: DrawableResource
+  get() = Drawable29.icon_23457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23458: DrawableResource
+  get() = Drawable29.icon_23458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23459: DrawableResource
+  get() = Drawable29.icon_23459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2346: DrawableResource
+  get() = Drawable29.icon_2346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23460: DrawableResource
+  get() = Drawable29.icon_23460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23461: DrawableResource
+  get() = Drawable29.icon_23461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23462: DrawableResource
+  get() = Drawable29.icon_23462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23463: DrawableResource
+  get() = Drawable29.icon_23463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23464: DrawableResource
+  get() = Drawable29.icon_23464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23465: DrawableResource
+  get() = Drawable29.icon_23465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23466: DrawableResource
+  get() = Drawable29.icon_23466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23467: DrawableResource
+  get() = Drawable29.icon_23467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23468: DrawableResource
+  get() = Drawable29.icon_23468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23469: DrawableResource
+  get() = Drawable29.icon_23469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2347: DrawableResource
+  get() = Drawable29.icon_2347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23470: DrawableResource
+  get() = Drawable29.icon_23470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23471: DrawableResource
+  get() = Drawable29.icon_23471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23472: DrawableResource
+  get() = Drawable29.icon_23472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23473: DrawableResource
+  get() = Drawable29.icon_23473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23474: DrawableResource
+  get() = Drawable29.icon_23474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23475: DrawableResource
+  get() = Drawable29.icon_23475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23476: DrawableResource
+  get() = Drawable29.icon_23476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23477: DrawableResource
+  get() = Drawable29.icon_23477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23478: DrawableResource
+  get() = Drawable29.icon_23478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23479: DrawableResource
+  get() = Drawable29.icon_23479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2348: DrawableResource
+  get() = Drawable29.icon_2348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23480: DrawableResource
+  get() = Drawable29.icon_23480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23481: DrawableResource
+  get() = Drawable29.icon_23481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23482: DrawableResource
+  get() = Drawable29.icon_23482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23483: DrawableResource
+  get() = Drawable29.icon_23483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23484: DrawableResource
+  get() = Drawable29.icon_23484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23485: DrawableResource
+  get() = Drawable29.icon_23485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23486: DrawableResource
+  get() = Drawable29.icon_23486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23487: DrawableResource
+  get() = Drawable29.icon_23487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23488: DrawableResource
+  get() = Drawable29.icon_23488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23489: DrawableResource
+  get() = Drawable29.icon_23489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2349: DrawableResource
+  get() = Drawable29.icon_2349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23490: DrawableResource
+  get() = Drawable29.icon_23490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23491: DrawableResource
+  get() = Drawable29.icon_23491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23492: DrawableResource
+  get() = Drawable29.icon_23492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23493: DrawableResource
+  get() = Drawable29.icon_23493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23494: DrawableResource
+  get() = Drawable29.icon_23494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23495: DrawableResource
+  get() = Drawable29.icon_23495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23496: DrawableResource
+  get() = Drawable29.icon_23496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23497: DrawableResource
+  get() = Drawable29.icon_23497

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable3.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable3.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable3 {
+  public val icon_11347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11347.xml"),
+          )
+      )
+
+  public val icon_11348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11348.xml"),
+          )
+      )
+
+  public val icon_11349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11349.xml"),
+          )
+      )
+
+  public val icon_1135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1135.xml"),
+          )
+      )
+
+  public val icon_11350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11350.xml"),
+          )
+      )
+
+  public val icon_11351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11351.xml"),
+          )
+      )
+
+  public val icon_11352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11352.xml"),
+          )
+      )
+
+  public val icon_11353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11353.xml"),
+          )
+      )
+
+  public val icon_11354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11354.xml"),
+          )
+      )
+
+  public val icon_11355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11355.xml"),
+          )
+      )
+
+  public val icon_11356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11356.xml"),
+          )
+      )
+
+  public val icon_11357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11357.xml"),
+          )
+      )
+
+  public val icon_11358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11358.xml"),
+          )
+      )
+
+  public val icon_11359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11359.xml"),
+          )
+      )
+
+  public val icon_1136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1136.xml"),
+          )
+      )
+
+  public val icon_11360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11360.xml"),
+          )
+      )
+
+  public val icon_11361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11361.xml"),
+          )
+      )
+
+  public val icon_11362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11362.xml"),
+          )
+      )
+
+  public val icon_11363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11363.xml"),
+          )
+      )
+
+  public val icon_11364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11364.xml"),
+          )
+      )
+
+  public val icon_11365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11365.xml"),
+          )
+      )
+
+  public val icon_11366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11366.xml"),
+          )
+      )
+
+  public val icon_11367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11367.xml"),
+          )
+      )
+
+  public val icon_11368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11368.xml"),
+          )
+      )
+
+  public val icon_11369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11369.xml"),
+          )
+      )
+
+  public val icon_1137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1137.xml"),
+          )
+      )
+
+  public val icon_11370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11370.xml"),
+          )
+      )
+
+  public val icon_11371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11371.xml"),
+          )
+      )
+
+  public val icon_11372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11372.xml"),
+          )
+      )
+
+  public val icon_11373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11373.xml"),
+          )
+      )
+
+  public val icon_11374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11374.xml"),
+          )
+      )
+
+  public val icon_11375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11375.xml"),
+          )
+      )
+
+  public val icon_11376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11376.xml"),
+          )
+      )
+
+  public val icon_11377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11377.xml"),
+          )
+      )
+
+  public val icon_11378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11378.xml"),
+          )
+      )
+
+  public val icon_11379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11379.xml"),
+          )
+      )
+
+  public val icon_1138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1138.xml"),
+          )
+      )
+
+  public val icon_11380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11380.xml"),
+          )
+      )
+
+  public val icon_11381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11381.xml"),
+          )
+      )
+
+  public val icon_11382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11382.xml"),
+          )
+      )
+
+  public val icon_11383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11383.xml"),
+          )
+      )
+
+  public val icon_11384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11384.xml"),
+          )
+      )
+
+  public val icon_11385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11385.xml"),
+          )
+      )
+
+  public val icon_11386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11386.xml"),
+          )
+      )
+
+  public val icon_11387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11387.xml"),
+          )
+      )
+
+  public val icon_11388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11388.xml"),
+          )
+      )
+
+  public val icon_11389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11389.xml"),
+          )
+      )
+
+  public val icon_1139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1139.xml"),
+          )
+      )
+
+  public val icon_11390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11390.xml"),
+          )
+      )
+
+  public val icon_11391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11391.xml"),
+          )
+      )
+
+  public val icon_11392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11392.xml"),
+          )
+      )
+
+  public val icon_11393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11393.xml"),
+          )
+      )
+
+  public val icon_11394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11394.xml"),
+          )
+      )
+
+  public val icon_11395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11395.xml"),
+          )
+      )
+
+  public val icon_11396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11396.xml"),
+          )
+      )
+
+  public val icon_11397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11397.xml"),
+          )
+      )
+
+  public val icon_11398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11398.xml"),
+          )
+      )
+
+  public val icon_11399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11399.xml"),
+          )
+      )
+
+  public val icon_114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_114.xml"),
+          )
+      )
+
+  public val icon_1140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1140.xml"),
+          )
+      )
+
+  public val icon_11400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11400.xml"),
+          )
+      )
+
+  public val icon_11401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11401.xml"),
+          )
+      )
+
+  public val icon_11402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11402.xml"),
+          )
+      )
+
+  public val icon_11403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11403.xml"),
+          )
+      )
+
+  public val icon_11404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11404.xml"),
+          )
+      )
+
+  public val icon_11405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11405.xml"),
+          )
+      )
+
+  public val icon_11406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11406.xml"),
+          )
+      )
+
+  public val icon_11407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11407.xml"),
+          )
+      )
+
+  public val icon_11408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11408.xml"),
+          )
+      )
+
+  public val icon_11409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11409.xml"),
+          )
+      )
+
+  public val icon_1141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1141.xml"),
+          )
+      )
+
+  public val icon_11410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11410.xml"),
+          )
+      )
+
+  public val icon_11411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11411.xml"),
+          )
+      )
+
+  public val icon_11412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11412.xml"),
+          )
+      )
+
+  public val icon_11413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11413.xml"),
+          )
+      )
+
+  public val icon_11414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11414.xml"),
+          )
+      )
+
+  public val icon_11415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11415.xml"),
+          )
+      )
+
+  public val icon_11416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11416.xml"),
+          )
+      )
+
+  public val icon_11417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11417.xml"),
+          )
+      )
+
+  public val icon_11418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11418.xml"),
+          )
+      )
+
+  public val icon_11419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11419.xml"),
+          )
+      )
+
+  public val icon_1142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1142.xml"),
+          )
+      )
+
+  public val icon_11420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11420.xml"),
+          )
+      )
+
+  public val icon_11421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11421.xml"),
+          )
+      )
+
+  public val icon_11422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11422.xml"),
+          )
+      )
+
+  public val icon_11423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11423.xml"),
+          )
+      )
+
+  public val icon_11424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11424.xml"),
+          )
+      )
+
+  public val icon_11425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11425.xml"),
+          )
+      )
+
+  public val icon_11426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11426.xml"),
+          )
+      )
+
+  public val icon_11427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11427.xml"),
+          )
+      )
+
+  public val icon_11428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11428.xml"),
+          )
+      )
+
+  public val icon_11429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11429.xml"),
+          )
+      )
+
+  public val icon_1143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1143.xml"),
+          )
+      )
+
+  public val icon_11430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11430.xml"),
+          )
+      )
+
+  public val icon_11431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11431.xml"),
+          )
+      )
+
+  public val icon_11432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11432.xml"),
+          )
+      )
+
+  public val icon_11433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11433.xml"),
+          )
+      )
+
+  public val icon_11434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11434.xml"),
+          )
+      )
+
+  public val icon_11435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11435.xml"),
+          )
+      )
+
+  public val icon_11436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11436.xml"),
+          )
+      )
+
+  public val icon_11437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11437.xml"),
+          )
+      )
+
+  public val icon_11438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11438.xml"),
+          )
+      )
+
+  public val icon_11439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11439.xml"),
+          )
+      )
+
+  public val icon_1144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1144.xml"),
+          )
+      )
+
+  public val icon_11440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11440.xml"),
+          )
+      )
+
+  public val icon_11441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11441.xml"),
+          )
+      )
+
+  public val icon_11442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11442.xml"),
+          )
+      )
+
+  public val icon_11443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11443.xml"),
+          )
+      )
+
+  public val icon_11444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11444.xml"),
+          )
+      )
+
+  public val icon_11445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11445.xml"),
+          )
+      )
+
+  public val icon_11446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11446.xml"),
+          )
+      )
+
+  public val icon_11447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11447.xml"),
+          )
+      )
+
+  public val icon_11448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11448.xml"),
+          )
+      )
+
+  public val icon_11449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11449.xml"),
+          )
+      )
+
+  public val icon_1145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1145.xml"),
+          )
+      )
+
+  public val icon_11450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11450.xml"),
+          )
+      )
+
+  public val icon_11451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11451.xml"),
+          )
+      )
+
+  public val icon_11452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11452.xml"),
+          )
+      )
+
+  public val icon_11453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11453.xml"),
+          )
+      )
+
+  public val icon_11454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11454.xml"),
+          )
+      )
+
+  public val icon_11455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11455.xml"),
+          )
+      )
+
+  public val icon_11456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11456.xml"),
+          )
+      )
+
+  public val icon_11457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11457.xml"),
+          )
+      )
+
+  public val icon_11458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11458.xml"),
+          )
+      )
+
+  public val icon_11459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11459.xml"),
+          )
+      )
+
+  public val icon_1146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1146.xml"),
+          )
+      )
+
+  public val icon_11460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11460.xml"),
+          )
+      )
+
+  public val icon_11461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11461.xml"),
+          )
+      )
+
+  public val icon_11462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11462.xml"),
+          )
+      )
+
+  public val icon_11463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11463.xml"),
+          )
+      )
+
+  public val icon_11464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11464.xml"),
+          )
+      )
+
+  public val icon_11465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11465.xml"),
+          )
+      )
+
+  public val icon_11466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11466.xml"),
+          )
+      )
+
+  public val icon_11467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11467.xml"),
+          )
+      )
+
+  public val icon_11468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11468.xml"),
+          )
+      )
+
+  public val icon_11469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11469.xml"),
+          )
+      )
+
+  public val icon_1147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1147.xml"),
+          )
+      )
+
+  public val icon_11470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11470.xml"),
+          )
+      )
+
+  public val icon_11471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11471.xml"),
+          )
+      )
+
+  public val icon_11472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11472.xml"),
+          )
+      )
+
+  public val icon_11473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11473.xml"),
+          )
+      )
+
+  public val icon_11474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11474.xml"),
+          )
+      )
+
+  public val icon_11475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11475.xml"),
+          )
+      )
+
+  public val icon_11476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11476.xml"),
+          )
+      )
+
+  public val icon_11477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11477.xml"),
+          )
+      )
+
+  public val icon_11478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11478.xml"),
+          )
+      )
+
+  public val icon_11479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11479.xml"),
+          )
+      )
+
+  public val icon_1148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1148.xml"),
+          )
+      )
+
+  public val icon_11480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11480.xml"),
+          )
+      )
+
+  public val icon_11481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11481.xml"),
+          )
+      )
+
+  public val icon_11482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11482.xml"),
+          )
+      )
+
+  public val icon_11483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11483.xml"),
+          )
+      )
+
+  public val icon_11484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11484.xml"),
+          )
+      )
+
+  public val icon_11485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11485.xml"),
+          )
+      )
+
+  public val icon_11486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11486.xml"),
+          )
+      )
+
+  public val icon_11487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11487.xml"),
+          )
+      )
+
+  public val icon_11488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11488.xml"),
+          )
+      )
+
+  public val icon_11489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11489.xml"),
+          )
+      )
+
+  public val icon_1149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1149.xml"),
+          )
+      )
+
+  public val icon_11490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11490.xml"),
+          )
+      )
+
+  public val icon_11491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11491.xml"),
+          )
+      )
+
+  public val icon_11492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11492.xml"),
+          )
+      )
+
+  public val icon_11493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11493.xml"),
+          )
+      )
+
+  public val icon_11494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11494.xml"),
+          )
+      )
+
+  public val icon_11495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11495.xml"),
+          )
+      )
+
+  public val icon_11496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11496.xml"),
+          )
+      )
+
+  public val icon_11497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11497.xml"),
+          )
+      )
+
+  public val icon_11498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11498.xml"),
+          )
+      )
+
+  public val icon_11499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11499.xml"),
+          )
+      )
+
+  public val icon_115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_115.xml"),
+          )
+      )
+
+  public val icon_1150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1150.xml"),
+          )
+      )
+
+  public val icon_11500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11500.xml"),
+          )
+      )
+
+  public val icon_11501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11501.xml"),
+          )
+      )
+
+  public val icon_11502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11502.xml"),
+          )
+      )
+
+  public val icon_11503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11503.xml"),
+          )
+      )
+
+  public val icon_11504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11504.xml"),
+          )
+      )
+
+  public val icon_11505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11505.xml"),
+          )
+      )
+
+  public val icon_11506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11506.xml"),
+          )
+      )
+
+  public val icon_11507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11507.xml"),
+          )
+      )
+
+  public val icon_11508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11508.xml"),
+          )
+      )
+
+  public val icon_11509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11509.xml"),
+          )
+      )
+
+  public val icon_1151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1151.xml"),
+          )
+      )
+
+  public val icon_11510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11510.xml"),
+          )
+      )
+
+  public val icon_11511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11511.xml"),
+          )
+      )
+
+  public val icon_11512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11512.xml"),
+          )
+      )
+
+  public val icon_11513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11513.xml"),
+          )
+      )
+
+  public val icon_11514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11514.xml"),
+          )
+      )
+
+  public val icon_11515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11515.xml"),
+          )
+      )
+
+  public val icon_11516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11516.xml"),
+          )
+      )
+
+  public val icon_11517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11517.xml"),
+          )
+      )
+
+  public val icon_11518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11518.xml"),
+          )
+      )
+
+  public val icon_11519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11519.xml"),
+          )
+      )
+
+  public val icon_1152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1152.xml"),
+          )
+      )
+
+  public val icon_11520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11520.xml"),
+          )
+      )
+
+  public val icon_11521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11521.xml"),
+          )
+      )
+
+  public val icon_11522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11522.xml"),
+          )
+      )
+
+  public val icon_11523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11523.xml"),
+          )
+      )
+
+  public val icon_11524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11524.xml"),
+          )
+      )
+
+  public val icon_11525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11525.xml"),
+          )
+      )
+
+  public val icon_11526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11526.xml"),
+          )
+      )
+
+  public val icon_11527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11527.xml"),
+          )
+      )
+
+  public val icon_11528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11528.xml"),
+          )
+      )
+
+  public val icon_11529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11529.xml"),
+          )
+      )
+
+  public val icon_1153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1153.xml"),
+          )
+      )
+
+  public val icon_11530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11530.xml"),
+          )
+      )
+
+  public val icon_11531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11531.xml"),
+          )
+      )
+
+  public val icon_11532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11532.xml"),
+          )
+      )
+
+  public val icon_11533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11533.xml"),
+          )
+      )
+
+  public val icon_11534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11534.xml"),
+          )
+      )
+
+  public val icon_11535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11535.xml"),
+          )
+      )
+
+  public val icon_11536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11536.xml"),
+          )
+      )
+
+  public val icon_11537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11537.xml"),
+          )
+      )
+
+  public val icon_11538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11538.xml"),
+          )
+      )
+
+  public val icon_11539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11539.xml"),
+          )
+      )
+
+  public val icon_1154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1154.xml"),
+          )
+      )
+
+  public val icon_11540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11540.xml"),
+          )
+      )
+
+  public val icon_11541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11541.xml"),
+          )
+      )
+
+  public val icon_11542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11542.xml"),
+          )
+      )
+
+  public val icon_11543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11543.xml"),
+          )
+      )
+
+  public val icon_11544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11544.xml"),
+          )
+      )
+
+  public val icon_11545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11545.xml"),
+          )
+      )
+
+  public val icon_11546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11546.xml"),
+          )
+      )
+
+  public val icon_11547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11547.xml"),
+          )
+      )
+
+  public val icon_11548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11548.xml"),
+          )
+      )
+
+  public val icon_11549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11549.xml"),
+          )
+      )
+
+  public val icon_1155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1155.xml"),
+          )
+      )
+
+  public val icon_11550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11550.xml"),
+          )
+      )
+
+  public val icon_11551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11551.xml"),
+          )
+      )
+
+  public val icon_11552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11552.xml"),
+          )
+      )
+
+  public val icon_11553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11553.xml"),
+          )
+      )
+
+  public val icon_11554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11554.xml"),
+          )
+      )
+
+  public val icon_11555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11555.xml"),
+          )
+      )
+
+  public val icon_11556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11556.xml"),
+          )
+      )
+
+  public val icon_11557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11557.xml"),
+          )
+      )
+
+  public val icon_11558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11558.xml"),
+          )
+      )
+
+  public val icon_11559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11559.xml"),
+          )
+      )
+
+  public val icon_1156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1156.xml"),
+          )
+      )
+
+  public val icon_11560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11560.xml"),
+          )
+      )
+
+  public val icon_11561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11561.xml"),
+          )
+      )
+
+  public val icon_11562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11562.xml"),
+          )
+      )
+
+  public val icon_11563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11563.xml"),
+          )
+      )
+
+  public val icon_11564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11564.xml"),
+          )
+      )
+
+  public val icon_11565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11565.xml"),
+          )
+      )
+
+  public val icon_11566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11566.xml"),
+          )
+      )
+
+  public val icon_11567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11567.xml"),
+          )
+      )
+
+  public val icon_11568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11568.xml"),
+          )
+      )
+
+  public val icon_11569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11569.xml"),
+          )
+      )
+
+  public val icon_1157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1157.xml"),
+          )
+      )
+
+  public val icon_11570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11570.xml"),
+          )
+      )
+
+  public val icon_11571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11571.xml"),
+          )
+      )
+
+  public val icon_11572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11572.xml"),
+          )
+      )
+
+  public val icon_11573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11573.xml"),
+          )
+      )
+
+  public val icon_11574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11574.xml"),
+          )
+      )
+
+  public val icon_11575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11575.xml"),
+          )
+      )
+
+  public val icon_11576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11576.xml"),
+          )
+      )
+
+  public val icon_11577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11577.xml"),
+          )
+      )
+
+  public val icon_11578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11578.xml"),
+          )
+      )
+
+  public val icon_11579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11579.xml"),
+          )
+      )
+
+  public val icon_1158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1158.xml"),
+          )
+      )
+
+  public val icon_11580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11580.xml"),
+          )
+      )
+
+  public val icon_11581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11581.xml"),
+          )
+      )
+
+  public val icon_11582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11582.xml"),
+          )
+      )
+
+  public val icon_11583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11583.xml"),
+          )
+      )
+
+  public val icon_11584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11584.xml"),
+          )
+      )
+
+  public val icon_11585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11585.xml"),
+          )
+      )
+
+  public val icon_11586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11586.xml"),
+          )
+      )
+
+  public val icon_11587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11587.xml"),
+          )
+      )
+
+  public val icon_11588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11588.xml"),
+          )
+      )
+
+  public val icon_11589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11589.xml"),
+          )
+      )
+
+  public val icon_1159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1159.xml"),
+          )
+      )
+
+  public val icon_11590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11590.xml"),
+          )
+      )
+
+  public val icon_11591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11591.xml"),
+          )
+      )
+
+  public val icon_11592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11592.xml"),
+          )
+      )
+
+  public val icon_11593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11593.xml"),
+          )
+      )
+
+  public val icon_11594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11594.xml"),
+          )
+      )
+
+  public val icon_11595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11595.xml"),
+          )
+      )
+
+  public val icon_11596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11596.xml"),
+          )
+      )
+
+  public val icon_11597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11597.xml"),
+          )
+      )
+
+  public val icon_11598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11598.xml"),
+          )
+      )
+
+  public val icon_11599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11599.xml"),
+          )
+      )
+
+  public val icon_116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_116.xml"),
+          )
+      )
+
+  public val icon_1160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1160.xml"),
+          )
+      )
+
+  public val icon_11600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11600.xml"),
+          )
+      )
+
+  public val icon_11601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11601.xml"),
+          )
+      )
+
+  public val icon_11602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11602.xml"),
+          )
+      )
+
+  public val icon_11603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11603.xml"),
+          )
+      )
+
+  public val icon_11604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11604.xml"),
+          )
+      )
+
+  public val icon_11605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11605.xml"),
+          )
+      )
+
+  public val icon_11606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11606.xml"),
+          )
+      )
+
+  public val icon_11607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11607.xml"),
+          )
+      )
+
+  public val icon_11608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11608.xml"),
+          )
+      )
+
+  public val icon_11609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11609.xml"),
+          )
+      )
+
+  public val icon_1161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1161.xml"),
+          )
+      )
+
+  public val icon_11610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11610.xml"),
+          )
+      )
+
+  public val icon_11611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11611.xml"),
+          )
+      )
+
+  public val icon_11612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11612.xml"),
+          )
+      )
+
+  public val icon_11613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11613.xml"),
+          )
+      )
+
+  public val icon_11614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11614.xml"),
+          )
+      )
+
+  public val icon_11615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11615.xml"),
+          )
+      )
+
+  public val icon_11616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11616.xml"),
+          )
+      )
+
+  public val icon_11617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11617.xml"),
+          )
+      )
+
+  public val icon_11618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11618.xml"),
+          )
+      )
+
+  public val icon_11619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11619.xml"),
+          )
+      )
+
+  public val icon_1162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1162.xml"),
+          )
+      )
+
+  public val icon_11620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11620.xml"),
+          )
+      )
+
+  public val icon_11621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11621.xml"),
+          )
+      )
+
+  public val icon_11622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11622.xml"),
+          )
+      )
+
+  public val icon_11623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11623.xml"),
+          )
+      )
+
+  public val icon_11624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11624.xml"),
+          )
+      )
+
+  public val icon_11625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11625.xml"),
+          )
+      )
+
+  public val icon_11626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11626.xml"),
+          )
+      )
+
+  public val icon_11627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11627.xml"),
+          )
+      )
+
+  public val icon_11628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11628.xml"),
+          )
+      )
+
+  public val icon_11629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11629.xml"),
+          )
+      )
+
+  public val icon_1163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1163.xml"),
+          )
+      )
+
+  public val icon_11630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11630.xml"),
+          )
+      )
+
+  public val icon_11631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11631.xml"),
+          )
+      )
+
+  public val icon_11632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11632.xml"),
+          )
+      )
+
+  public val icon_11633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11633.xml"),
+          )
+      )
+
+  public val icon_11634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11634.xml"),
+          )
+      )
+
+  public val icon_11635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11635.xml"),
+          )
+      )
+
+  public val icon_11636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11636.xml"),
+          )
+      )
+
+  public val icon_11637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11637.xml"),
+          )
+      )
+
+  public val icon_11638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11638.xml"),
+          )
+      )
+
+  public val icon_11639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11639.xml"),
+          )
+      )
+
+  public val icon_1164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1164.xml"),
+          )
+      )
+
+  public val icon_11640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11640.xml"),
+          )
+      )
+
+  public val icon_11641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11641.xml"),
+          )
+      )
+
+  public val icon_11642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11642.xml"),
+          )
+      )
+
+  public val icon_11643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11643.xml"),
+          )
+      )
+
+  public val icon_11644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11644.xml"),
+          )
+      )
+
+  public val icon_11645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11645.xml"),
+          )
+      )
+
+  public val icon_11646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11646.xml"),
+          )
+      )
+
+  public val icon_11647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11647.xml"),
+          )
+      )
+
+  public val icon_11648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11648.xml"),
+          )
+      )
+
+  public val icon_11649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11649.xml"),
+          )
+      )
+
+  public val icon_1165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1165.xml"),
+          )
+      )
+
+  public val icon_11650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11650.xml"),
+          )
+      )
+
+  public val icon_11651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11651.xml"),
+          )
+      )
+
+  public val icon_11652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11652.xml"),
+          )
+      )
+
+  public val icon_11653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11653.xml"),
+          )
+      )
+
+  public val icon_11654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11654.xml"),
+          )
+      )
+
+  public val icon_11655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11655.xml"),
+          )
+      )
+
+  public val icon_11656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11656.xml"),
+          )
+      )
+
+  public val icon_11657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11657.xml"),
+          )
+      )
+
+  public val icon_11658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11658.xml"),
+          )
+      )
+
+  public val icon_11659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11659.xml"),
+          )
+      )
+
+  public val icon_1166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1166.xml"),
+          )
+      )
+
+  public val icon_11660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11660.xml"),
+          )
+      )
+
+  public val icon_11661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11661.xml"),
+          )
+      )
+
+  public val icon_11662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11662.xml"),
+          )
+      )
+
+  public val icon_11663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11663.xml"),
+          )
+      )
+
+  public val icon_11664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11664.xml"),
+          )
+      )
+
+  public val icon_11665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11665.xml"),
+          )
+      )
+
+  public val icon_11666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11666.xml"),
+          )
+      )
+
+  public val icon_11667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11667.xml"),
+          )
+      )
+
+  public val icon_11668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11668.xml"),
+          )
+      )
+
+  public val icon_11669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11669.xml"),
+          )
+      )
+
+  public val icon_1167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1167.xml"),
+          )
+      )
+
+  public val icon_11670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11670.xml"),
+          )
+      )
+
+  public val icon_11671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11671.xml"),
+          )
+      )
+
+  public val icon_11672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11672.xml"),
+          )
+      )
+
+  public val icon_11673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11673.xml"),
+          )
+      )
+
+  public val icon_11674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11674.xml"),
+          )
+      )
+
+  public val icon_11675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11675.xml"),
+          )
+      )
+
+  public val icon_11676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11676.xml"),
+          )
+      )
+
+  public val icon_11677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11677.xml"),
+          )
+      )
+
+  public val icon_11678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11678.xml"),
+          )
+      )
+
+  public val icon_11679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11679.xml"),
+          )
+      )
+
+  public val icon_1168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1168.xml"),
+          )
+      )
+
+  public val icon_11680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11680.xml"),
+          )
+      )
+
+  public val icon_11681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11681.xml"),
+          )
+      )
+
+  public val icon_11682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11682.xml"),
+          )
+      )
+
+  public val icon_11683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11683.xml"),
+          )
+      )
+
+  public val icon_11684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11684.xml"),
+          )
+      )
+
+  public val icon_11685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11685.xml"),
+          )
+      )
+
+  public val icon_11686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11686.xml"),
+          )
+      )
+
+  public val icon_11687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11687.xml"),
+          )
+      )
+
+  public val icon_11688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11688.xml"),
+          )
+      )
+
+  public val icon_11689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11689.xml"),
+          )
+      )
+
+  public val icon_1169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1169.xml"),
+          )
+      )
+
+  public val icon_11690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11690.xml"),
+          )
+      )
+
+  public val icon_11691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11691.xml"),
+          )
+      )
+
+  public val icon_11692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11692.xml"),
+          )
+      )
+
+  public val icon_11693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11693.xml"),
+          )
+      )
+
+  public val icon_11694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11694.xml"),
+          )
+      )
+
+  public val icon_11695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11695.xml"),
+          )
+      )
+
+  public val icon_11696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11696.xml"),
+          )
+      )
+
+  public val icon_11697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11697.xml"),
+          )
+      )
+
+  public val icon_11698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11698.xml"),
+          )
+      )
+
+  public val icon_11699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11699.xml"),
+          )
+      )
+
+  public val icon_117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_117.xml"),
+          )
+      )
+
+  public val icon_1170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1170.xml"),
+          )
+      )
+
+  public val icon_11700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11700.xml"),
+          )
+      )
+
+  public val icon_11701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11701.xml"),
+          )
+      )
+
+  public val icon_11702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11702.xml"),
+          )
+      )
+
+  public val icon_11703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11703.xml"),
+          )
+      )
+
+  public val icon_11704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11704.xml"),
+          )
+      )
+
+  public val icon_11705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11705.xml"),
+          )
+      )
+
+  public val icon_11706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11706.xml"),
+          )
+      )
+
+  public val icon_11707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11707.xml"),
+          )
+      )
+
+  public val icon_11708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11708.xml"),
+          )
+      )
+
+  public val icon_11709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11709.xml"),
+          )
+      )
+
+  public val icon_1171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1171.xml"),
+          )
+      )
+
+  public val icon_11710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11710.xml"),
+          )
+      )
+
+  public val icon_11711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11711.xml"),
+          )
+      )
+
+  public val icon_11712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11712.xml"),
+          )
+      )
+
+  public val icon_11713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11713.xml"),
+          )
+      )
+
+  public val icon_11714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11714.xml"),
+          )
+      )
+
+  public val icon_11715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11715.xml"),
+          )
+      )
+
+  public val icon_11716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11716.xml"),
+          )
+      )
+
+  public val icon_11717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11717.xml"),
+          )
+      )
+
+  public val icon_11718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11718.xml"),
+          )
+      )
+
+  public val icon_11719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11719.xml"),
+          )
+      )
+
+  public val icon_1172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1172.xml"),
+          )
+      )
+
+  public val icon_11720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11720.xml"),
+          )
+      )
+
+  public val icon_11721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11721.xml"),
+          )
+      )
+
+  public val icon_11722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11722.xml"),
+          )
+      )
+
+  public val icon_11723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11723.xml"),
+          )
+      )
+
+  public val icon_11724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11724.xml"),
+          )
+      )
+
+  public val icon_11725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11725.xml"),
+          )
+      )
+
+  public val icon_11726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11726.xml"),
+          )
+      )
+
+  public val icon_11727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11727.xml"),
+          )
+      )
+
+  public val icon_11728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11728.xml"),
+          )
+      )
+
+  public val icon_11729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11729.xml"),
+          )
+      )
+
+  public val icon_1173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1173.xml"),
+          )
+      )
+
+  public val icon_11730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11730.xml"),
+          )
+      )
+
+  public val icon_11731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11731.xml"),
+          )
+      )
+
+  public val icon_11732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11732.xml"),
+          )
+      )
+
+  public val icon_11733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11733.xml"),
+          )
+      )
+
+  public val icon_11734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11734.xml"),
+          )
+      )
+
+  public val icon_11735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11735.xml"),
+          )
+      )
+
+  public val icon_11736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11736.xml"),
+          )
+      )
+
+  public val icon_11737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11737.xml"),
+          )
+      )
+
+  public val icon_11738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11738.xml"),
+          )
+      )
+
+  public val icon_11739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11739.xml"),
+          )
+      )
+
+  public val icon_1174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1174.xml"),
+          )
+      )
+
+  public val icon_11740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11740.xml"),
+          )
+      )
+
+  public val icon_11741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11741.xml"),
+          )
+      )
+
+  public val icon_11742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11742.xml"),
+          )
+      )
+
+  public val icon_11743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11743.xml"),
+          )
+      )
+
+  public val icon_11744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11744.xml"),
+          )
+      )
+
+  public val icon_11745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11745.xml"),
+          )
+      )
+
+  public val icon_11746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11746.xml"),
+          )
+      )
+
+  public val icon_11747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11747.xml"),
+          )
+      )
+
+  public val icon_11748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11748.xml"),
+          )
+      )
+
+  public val icon_11749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11749.xml"),
+          )
+      )
+
+  public val icon_1175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1175.xml"),
+          )
+      )
+
+  public val icon_11750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11750.xml"),
+          )
+      )
+
+  public val icon_11751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11751.xml"),
+          )
+      )
+
+  public val icon_11752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11752.xml"),
+          )
+      )
+
+  public val icon_11753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11753.xml"),
+          )
+      )
+
+  public val icon_11754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11754.xml"),
+          )
+      )
+
+  public val icon_11755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11755.xml"),
+          )
+      )
+
+  public val icon_11756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11756.xml"),
+          )
+      )
+
+  public val icon_11757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11757.xml"),
+          )
+      )
+
+  public val icon_11758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11758.xml"),
+          )
+      )
+
+  public val icon_11759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11759.xml"),
+          )
+      )
+
+  public val icon_1176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1176.xml"),
+          )
+      )
+
+  public val icon_11760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11760.xml"),
+          )
+      )
+
+  public val icon_11761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11761.xml"),
+          )
+      )
+
+  public val icon_11762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11762.xml"),
+          )
+      )
+
+  public val icon_11763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11763.xml"),
+          )
+      )
+
+  public val icon_11764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11764.xml"),
+          )
+      )
+
+  public val icon_11765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11765.xml"),
+          )
+      )
+
+  public val icon_11766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11766.xml"),
+          )
+      )
+
+  public val icon_11767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11767.xml"),
+          )
+      )
+
+  public val icon_11768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11768.xml"),
+          )
+      )
+
+  public val icon_11769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11769.xml"),
+          )
+      )
+
+  public val icon_1177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1177.xml"),
+          )
+      )
+
+  public val icon_11770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11770.xml"),
+          )
+      )
+
+  public val icon_11771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11771.xml"),
+          )
+      )
+
+  public val icon_11772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11772.xml"),
+          )
+      )
+
+  public val icon_11773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11773.xml"),
+          )
+      )
+
+  public val icon_11774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11774.xml"),
+          )
+      )
+
+  public val icon_11775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11775.xml"),
+          )
+      )
+
+  public val icon_11776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11776.xml"),
+          )
+      )
+
+  public val icon_11777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11777.xml"),
+          )
+      )
+
+  public val icon_11778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11778.xml"),
+          )
+      )
+
+  public val icon_11779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11779.xml"),
+          )
+      )
+
+  public val icon_1178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1178.xml"),
+          )
+      )
+
+  public val icon_11780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11780.xml"),
+          )
+      )
+
+  public val icon_11781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11781.xml"),
+          )
+      )
+
+  public val icon_11782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11782.xml"),
+          )
+      )
+
+  public val icon_11783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11783.xml"),
+          )
+      )
+
+  public val icon_11784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11784.xml"),
+          )
+      )
+
+  public val icon_11785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11785.xml"),
+          )
+      )
+
+  public val icon_11786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11786.xml"),
+          )
+      )
+
+  public val icon_11787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11787.xml"),
+          )
+      )
+
+  public val icon_11788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11788.xml"),
+          )
+      )
+
+  public val icon_11789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11789.xml"),
+          )
+      )
+
+  public val icon_1179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1179.xml"),
+          )
+      )
+
+  public val icon_11790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11790.xml"),
+          )
+      )
+
+  public val icon_11791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11791.xml"),
+          )
+      )
+
+  public val icon_11792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11792.xml"),
+          )
+      )
+
+  public val icon_11793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11793.xml"),
+          )
+      )
+
+  public val icon_11794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11794.xml"),
+          )
+      )
+
+  public val icon_11795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11795.xml"),
+          )
+      )
+
+  public val icon_11796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11796.xml"),
+          )
+      )
+
+  public val icon_11797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11797.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11347: DrawableResource
+  get() = Drawable3.icon_11347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11348: DrawableResource
+  get() = Drawable3.icon_11348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11349: DrawableResource
+  get() = Drawable3.icon_11349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1135: DrawableResource
+  get() = Drawable3.icon_1135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11350: DrawableResource
+  get() = Drawable3.icon_11350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11351: DrawableResource
+  get() = Drawable3.icon_11351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11352: DrawableResource
+  get() = Drawable3.icon_11352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11353: DrawableResource
+  get() = Drawable3.icon_11353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11354: DrawableResource
+  get() = Drawable3.icon_11354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11355: DrawableResource
+  get() = Drawable3.icon_11355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11356: DrawableResource
+  get() = Drawable3.icon_11356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11357: DrawableResource
+  get() = Drawable3.icon_11357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11358: DrawableResource
+  get() = Drawable3.icon_11358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11359: DrawableResource
+  get() = Drawable3.icon_11359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1136: DrawableResource
+  get() = Drawable3.icon_1136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11360: DrawableResource
+  get() = Drawable3.icon_11360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11361: DrawableResource
+  get() = Drawable3.icon_11361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11362: DrawableResource
+  get() = Drawable3.icon_11362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11363: DrawableResource
+  get() = Drawable3.icon_11363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11364: DrawableResource
+  get() = Drawable3.icon_11364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11365: DrawableResource
+  get() = Drawable3.icon_11365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11366: DrawableResource
+  get() = Drawable3.icon_11366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11367: DrawableResource
+  get() = Drawable3.icon_11367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11368: DrawableResource
+  get() = Drawable3.icon_11368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11369: DrawableResource
+  get() = Drawable3.icon_11369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1137: DrawableResource
+  get() = Drawable3.icon_1137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11370: DrawableResource
+  get() = Drawable3.icon_11370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11371: DrawableResource
+  get() = Drawable3.icon_11371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11372: DrawableResource
+  get() = Drawable3.icon_11372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11373: DrawableResource
+  get() = Drawable3.icon_11373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11374: DrawableResource
+  get() = Drawable3.icon_11374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11375: DrawableResource
+  get() = Drawable3.icon_11375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11376: DrawableResource
+  get() = Drawable3.icon_11376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11377: DrawableResource
+  get() = Drawable3.icon_11377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11378: DrawableResource
+  get() = Drawable3.icon_11378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11379: DrawableResource
+  get() = Drawable3.icon_11379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1138: DrawableResource
+  get() = Drawable3.icon_1138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11380: DrawableResource
+  get() = Drawable3.icon_11380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11381: DrawableResource
+  get() = Drawable3.icon_11381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11382: DrawableResource
+  get() = Drawable3.icon_11382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11383: DrawableResource
+  get() = Drawable3.icon_11383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11384: DrawableResource
+  get() = Drawable3.icon_11384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11385: DrawableResource
+  get() = Drawable3.icon_11385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11386: DrawableResource
+  get() = Drawable3.icon_11386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11387: DrawableResource
+  get() = Drawable3.icon_11387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11388: DrawableResource
+  get() = Drawable3.icon_11388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11389: DrawableResource
+  get() = Drawable3.icon_11389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1139: DrawableResource
+  get() = Drawable3.icon_1139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11390: DrawableResource
+  get() = Drawable3.icon_11390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11391: DrawableResource
+  get() = Drawable3.icon_11391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11392: DrawableResource
+  get() = Drawable3.icon_11392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11393: DrawableResource
+  get() = Drawable3.icon_11393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11394: DrawableResource
+  get() = Drawable3.icon_11394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11395: DrawableResource
+  get() = Drawable3.icon_11395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11396: DrawableResource
+  get() = Drawable3.icon_11396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11397: DrawableResource
+  get() = Drawable3.icon_11397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11398: DrawableResource
+  get() = Drawable3.icon_11398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11399: DrawableResource
+  get() = Drawable3.icon_11399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_114: DrawableResource
+  get() = Drawable3.icon_114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1140: DrawableResource
+  get() = Drawable3.icon_1140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11400: DrawableResource
+  get() = Drawable3.icon_11400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11401: DrawableResource
+  get() = Drawable3.icon_11401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11402: DrawableResource
+  get() = Drawable3.icon_11402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11403: DrawableResource
+  get() = Drawable3.icon_11403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11404: DrawableResource
+  get() = Drawable3.icon_11404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11405: DrawableResource
+  get() = Drawable3.icon_11405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11406: DrawableResource
+  get() = Drawable3.icon_11406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11407: DrawableResource
+  get() = Drawable3.icon_11407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11408: DrawableResource
+  get() = Drawable3.icon_11408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11409: DrawableResource
+  get() = Drawable3.icon_11409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1141: DrawableResource
+  get() = Drawable3.icon_1141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11410: DrawableResource
+  get() = Drawable3.icon_11410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11411: DrawableResource
+  get() = Drawable3.icon_11411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11412: DrawableResource
+  get() = Drawable3.icon_11412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11413: DrawableResource
+  get() = Drawable3.icon_11413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11414: DrawableResource
+  get() = Drawable3.icon_11414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11415: DrawableResource
+  get() = Drawable3.icon_11415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11416: DrawableResource
+  get() = Drawable3.icon_11416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11417: DrawableResource
+  get() = Drawable3.icon_11417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11418: DrawableResource
+  get() = Drawable3.icon_11418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11419: DrawableResource
+  get() = Drawable3.icon_11419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1142: DrawableResource
+  get() = Drawable3.icon_1142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11420: DrawableResource
+  get() = Drawable3.icon_11420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11421: DrawableResource
+  get() = Drawable3.icon_11421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11422: DrawableResource
+  get() = Drawable3.icon_11422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11423: DrawableResource
+  get() = Drawable3.icon_11423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11424: DrawableResource
+  get() = Drawable3.icon_11424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11425: DrawableResource
+  get() = Drawable3.icon_11425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11426: DrawableResource
+  get() = Drawable3.icon_11426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11427: DrawableResource
+  get() = Drawable3.icon_11427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11428: DrawableResource
+  get() = Drawable3.icon_11428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11429: DrawableResource
+  get() = Drawable3.icon_11429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1143: DrawableResource
+  get() = Drawable3.icon_1143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11430: DrawableResource
+  get() = Drawable3.icon_11430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11431: DrawableResource
+  get() = Drawable3.icon_11431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11432: DrawableResource
+  get() = Drawable3.icon_11432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11433: DrawableResource
+  get() = Drawable3.icon_11433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11434: DrawableResource
+  get() = Drawable3.icon_11434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11435: DrawableResource
+  get() = Drawable3.icon_11435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11436: DrawableResource
+  get() = Drawable3.icon_11436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11437: DrawableResource
+  get() = Drawable3.icon_11437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11438: DrawableResource
+  get() = Drawable3.icon_11438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11439: DrawableResource
+  get() = Drawable3.icon_11439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1144: DrawableResource
+  get() = Drawable3.icon_1144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11440: DrawableResource
+  get() = Drawable3.icon_11440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11441: DrawableResource
+  get() = Drawable3.icon_11441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11442: DrawableResource
+  get() = Drawable3.icon_11442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11443: DrawableResource
+  get() = Drawable3.icon_11443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11444: DrawableResource
+  get() = Drawable3.icon_11444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11445: DrawableResource
+  get() = Drawable3.icon_11445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11446: DrawableResource
+  get() = Drawable3.icon_11446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11447: DrawableResource
+  get() = Drawable3.icon_11447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11448: DrawableResource
+  get() = Drawable3.icon_11448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11449: DrawableResource
+  get() = Drawable3.icon_11449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1145: DrawableResource
+  get() = Drawable3.icon_1145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11450: DrawableResource
+  get() = Drawable3.icon_11450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11451: DrawableResource
+  get() = Drawable3.icon_11451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11452: DrawableResource
+  get() = Drawable3.icon_11452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11453: DrawableResource
+  get() = Drawable3.icon_11453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11454: DrawableResource
+  get() = Drawable3.icon_11454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11455: DrawableResource
+  get() = Drawable3.icon_11455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11456: DrawableResource
+  get() = Drawable3.icon_11456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11457: DrawableResource
+  get() = Drawable3.icon_11457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11458: DrawableResource
+  get() = Drawable3.icon_11458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11459: DrawableResource
+  get() = Drawable3.icon_11459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1146: DrawableResource
+  get() = Drawable3.icon_1146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11460: DrawableResource
+  get() = Drawable3.icon_11460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11461: DrawableResource
+  get() = Drawable3.icon_11461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11462: DrawableResource
+  get() = Drawable3.icon_11462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11463: DrawableResource
+  get() = Drawable3.icon_11463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11464: DrawableResource
+  get() = Drawable3.icon_11464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11465: DrawableResource
+  get() = Drawable3.icon_11465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11466: DrawableResource
+  get() = Drawable3.icon_11466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11467: DrawableResource
+  get() = Drawable3.icon_11467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11468: DrawableResource
+  get() = Drawable3.icon_11468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11469: DrawableResource
+  get() = Drawable3.icon_11469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1147: DrawableResource
+  get() = Drawable3.icon_1147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11470: DrawableResource
+  get() = Drawable3.icon_11470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11471: DrawableResource
+  get() = Drawable3.icon_11471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11472: DrawableResource
+  get() = Drawable3.icon_11472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11473: DrawableResource
+  get() = Drawable3.icon_11473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11474: DrawableResource
+  get() = Drawable3.icon_11474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11475: DrawableResource
+  get() = Drawable3.icon_11475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11476: DrawableResource
+  get() = Drawable3.icon_11476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11477: DrawableResource
+  get() = Drawable3.icon_11477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11478: DrawableResource
+  get() = Drawable3.icon_11478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11479: DrawableResource
+  get() = Drawable3.icon_11479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1148: DrawableResource
+  get() = Drawable3.icon_1148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11480: DrawableResource
+  get() = Drawable3.icon_11480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11481: DrawableResource
+  get() = Drawable3.icon_11481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11482: DrawableResource
+  get() = Drawable3.icon_11482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11483: DrawableResource
+  get() = Drawable3.icon_11483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11484: DrawableResource
+  get() = Drawable3.icon_11484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11485: DrawableResource
+  get() = Drawable3.icon_11485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11486: DrawableResource
+  get() = Drawable3.icon_11486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11487: DrawableResource
+  get() = Drawable3.icon_11487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11488: DrawableResource
+  get() = Drawable3.icon_11488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11489: DrawableResource
+  get() = Drawable3.icon_11489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1149: DrawableResource
+  get() = Drawable3.icon_1149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11490: DrawableResource
+  get() = Drawable3.icon_11490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11491: DrawableResource
+  get() = Drawable3.icon_11491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11492: DrawableResource
+  get() = Drawable3.icon_11492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11493: DrawableResource
+  get() = Drawable3.icon_11493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11494: DrawableResource
+  get() = Drawable3.icon_11494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11495: DrawableResource
+  get() = Drawable3.icon_11495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11496: DrawableResource
+  get() = Drawable3.icon_11496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11497: DrawableResource
+  get() = Drawable3.icon_11497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11498: DrawableResource
+  get() = Drawable3.icon_11498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11499: DrawableResource
+  get() = Drawable3.icon_11499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_115: DrawableResource
+  get() = Drawable3.icon_115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1150: DrawableResource
+  get() = Drawable3.icon_1150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11500: DrawableResource
+  get() = Drawable3.icon_11500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11501: DrawableResource
+  get() = Drawable3.icon_11501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11502: DrawableResource
+  get() = Drawable3.icon_11502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11503: DrawableResource
+  get() = Drawable3.icon_11503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11504: DrawableResource
+  get() = Drawable3.icon_11504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11505: DrawableResource
+  get() = Drawable3.icon_11505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11506: DrawableResource
+  get() = Drawable3.icon_11506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11507: DrawableResource
+  get() = Drawable3.icon_11507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11508: DrawableResource
+  get() = Drawable3.icon_11508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11509: DrawableResource
+  get() = Drawable3.icon_11509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1151: DrawableResource
+  get() = Drawable3.icon_1151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11510: DrawableResource
+  get() = Drawable3.icon_11510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11511: DrawableResource
+  get() = Drawable3.icon_11511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11512: DrawableResource
+  get() = Drawable3.icon_11512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11513: DrawableResource
+  get() = Drawable3.icon_11513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11514: DrawableResource
+  get() = Drawable3.icon_11514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11515: DrawableResource
+  get() = Drawable3.icon_11515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11516: DrawableResource
+  get() = Drawable3.icon_11516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11517: DrawableResource
+  get() = Drawable3.icon_11517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11518: DrawableResource
+  get() = Drawable3.icon_11518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11519: DrawableResource
+  get() = Drawable3.icon_11519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1152: DrawableResource
+  get() = Drawable3.icon_1152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11520: DrawableResource
+  get() = Drawable3.icon_11520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11521: DrawableResource
+  get() = Drawable3.icon_11521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11522: DrawableResource
+  get() = Drawable3.icon_11522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11523: DrawableResource
+  get() = Drawable3.icon_11523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11524: DrawableResource
+  get() = Drawable3.icon_11524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11525: DrawableResource
+  get() = Drawable3.icon_11525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11526: DrawableResource
+  get() = Drawable3.icon_11526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11527: DrawableResource
+  get() = Drawable3.icon_11527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11528: DrawableResource
+  get() = Drawable3.icon_11528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11529: DrawableResource
+  get() = Drawable3.icon_11529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1153: DrawableResource
+  get() = Drawable3.icon_1153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11530: DrawableResource
+  get() = Drawable3.icon_11530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11531: DrawableResource
+  get() = Drawable3.icon_11531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11532: DrawableResource
+  get() = Drawable3.icon_11532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11533: DrawableResource
+  get() = Drawable3.icon_11533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11534: DrawableResource
+  get() = Drawable3.icon_11534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11535: DrawableResource
+  get() = Drawable3.icon_11535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11536: DrawableResource
+  get() = Drawable3.icon_11536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11537: DrawableResource
+  get() = Drawable3.icon_11537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11538: DrawableResource
+  get() = Drawable3.icon_11538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11539: DrawableResource
+  get() = Drawable3.icon_11539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1154: DrawableResource
+  get() = Drawable3.icon_1154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11540: DrawableResource
+  get() = Drawable3.icon_11540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11541: DrawableResource
+  get() = Drawable3.icon_11541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11542: DrawableResource
+  get() = Drawable3.icon_11542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11543: DrawableResource
+  get() = Drawable3.icon_11543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11544: DrawableResource
+  get() = Drawable3.icon_11544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11545: DrawableResource
+  get() = Drawable3.icon_11545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11546: DrawableResource
+  get() = Drawable3.icon_11546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11547: DrawableResource
+  get() = Drawable3.icon_11547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11548: DrawableResource
+  get() = Drawable3.icon_11548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11549: DrawableResource
+  get() = Drawable3.icon_11549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1155: DrawableResource
+  get() = Drawable3.icon_1155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11550: DrawableResource
+  get() = Drawable3.icon_11550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11551: DrawableResource
+  get() = Drawable3.icon_11551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11552: DrawableResource
+  get() = Drawable3.icon_11552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11553: DrawableResource
+  get() = Drawable3.icon_11553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11554: DrawableResource
+  get() = Drawable3.icon_11554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11555: DrawableResource
+  get() = Drawable3.icon_11555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11556: DrawableResource
+  get() = Drawable3.icon_11556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11557: DrawableResource
+  get() = Drawable3.icon_11557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11558: DrawableResource
+  get() = Drawable3.icon_11558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11559: DrawableResource
+  get() = Drawable3.icon_11559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1156: DrawableResource
+  get() = Drawable3.icon_1156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11560: DrawableResource
+  get() = Drawable3.icon_11560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11561: DrawableResource
+  get() = Drawable3.icon_11561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11562: DrawableResource
+  get() = Drawable3.icon_11562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11563: DrawableResource
+  get() = Drawable3.icon_11563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11564: DrawableResource
+  get() = Drawable3.icon_11564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11565: DrawableResource
+  get() = Drawable3.icon_11565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11566: DrawableResource
+  get() = Drawable3.icon_11566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11567: DrawableResource
+  get() = Drawable3.icon_11567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11568: DrawableResource
+  get() = Drawable3.icon_11568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11569: DrawableResource
+  get() = Drawable3.icon_11569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1157: DrawableResource
+  get() = Drawable3.icon_1157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11570: DrawableResource
+  get() = Drawable3.icon_11570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11571: DrawableResource
+  get() = Drawable3.icon_11571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11572: DrawableResource
+  get() = Drawable3.icon_11572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11573: DrawableResource
+  get() = Drawable3.icon_11573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11574: DrawableResource
+  get() = Drawable3.icon_11574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11575: DrawableResource
+  get() = Drawable3.icon_11575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11576: DrawableResource
+  get() = Drawable3.icon_11576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11577: DrawableResource
+  get() = Drawable3.icon_11577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11578: DrawableResource
+  get() = Drawable3.icon_11578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11579: DrawableResource
+  get() = Drawable3.icon_11579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1158: DrawableResource
+  get() = Drawable3.icon_1158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11580: DrawableResource
+  get() = Drawable3.icon_11580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11581: DrawableResource
+  get() = Drawable3.icon_11581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11582: DrawableResource
+  get() = Drawable3.icon_11582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11583: DrawableResource
+  get() = Drawable3.icon_11583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11584: DrawableResource
+  get() = Drawable3.icon_11584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11585: DrawableResource
+  get() = Drawable3.icon_11585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11586: DrawableResource
+  get() = Drawable3.icon_11586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11587: DrawableResource
+  get() = Drawable3.icon_11587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11588: DrawableResource
+  get() = Drawable3.icon_11588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11589: DrawableResource
+  get() = Drawable3.icon_11589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1159: DrawableResource
+  get() = Drawable3.icon_1159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11590: DrawableResource
+  get() = Drawable3.icon_11590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11591: DrawableResource
+  get() = Drawable3.icon_11591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11592: DrawableResource
+  get() = Drawable3.icon_11592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11593: DrawableResource
+  get() = Drawable3.icon_11593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11594: DrawableResource
+  get() = Drawable3.icon_11594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11595: DrawableResource
+  get() = Drawable3.icon_11595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11596: DrawableResource
+  get() = Drawable3.icon_11596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11597: DrawableResource
+  get() = Drawable3.icon_11597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11598: DrawableResource
+  get() = Drawable3.icon_11598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11599: DrawableResource
+  get() = Drawable3.icon_11599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_116: DrawableResource
+  get() = Drawable3.icon_116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1160: DrawableResource
+  get() = Drawable3.icon_1160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11600: DrawableResource
+  get() = Drawable3.icon_11600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11601: DrawableResource
+  get() = Drawable3.icon_11601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11602: DrawableResource
+  get() = Drawable3.icon_11602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11603: DrawableResource
+  get() = Drawable3.icon_11603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11604: DrawableResource
+  get() = Drawable3.icon_11604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11605: DrawableResource
+  get() = Drawable3.icon_11605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11606: DrawableResource
+  get() = Drawable3.icon_11606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11607: DrawableResource
+  get() = Drawable3.icon_11607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11608: DrawableResource
+  get() = Drawable3.icon_11608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11609: DrawableResource
+  get() = Drawable3.icon_11609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1161: DrawableResource
+  get() = Drawable3.icon_1161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11610: DrawableResource
+  get() = Drawable3.icon_11610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11611: DrawableResource
+  get() = Drawable3.icon_11611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11612: DrawableResource
+  get() = Drawable3.icon_11612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11613: DrawableResource
+  get() = Drawable3.icon_11613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11614: DrawableResource
+  get() = Drawable3.icon_11614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11615: DrawableResource
+  get() = Drawable3.icon_11615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11616: DrawableResource
+  get() = Drawable3.icon_11616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11617: DrawableResource
+  get() = Drawable3.icon_11617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11618: DrawableResource
+  get() = Drawable3.icon_11618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11619: DrawableResource
+  get() = Drawable3.icon_11619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1162: DrawableResource
+  get() = Drawable3.icon_1162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11620: DrawableResource
+  get() = Drawable3.icon_11620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11621: DrawableResource
+  get() = Drawable3.icon_11621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11622: DrawableResource
+  get() = Drawable3.icon_11622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11623: DrawableResource
+  get() = Drawable3.icon_11623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11624: DrawableResource
+  get() = Drawable3.icon_11624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11625: DrawableResource
+  get() = Drawable3.icon_11625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11626: DrawableResource
+  get() = Drawable3.icon_11626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11627: DrawableResource
+  get() = Drawable3.icon_11627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11628: DrawableResource
+  get() = Drawable3.icon_11628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11629: DrawableResource
+  get() = Drawable3.icon_11629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1163: DrawableResource
+  get() = Drawable3.icon_1163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11630: DrawableResource
+  get() = Drawable3.icon_11630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11631: DrawableResource
+  get() = Drawable3.icon_11631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11632: DrawableResource
+  get() = Drawable3.icon_11632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11633: DrawableResource
+  get() = Drawable3.icon_11633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11634: DrawableResource
+  get() = Drawable3.icon_11634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11635: DrawableResource
+  get() = Drawable3.icon_11635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11636: DrawableResource
+  get() = Drawable3.icon_11636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11637: DrawableResource
+  get() = Drawable3.icon_11637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11638: DrawableResource
+  get() = Drawable3.icon_11638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11639: DrawableResource
+  get() = Drawable3.icon_11639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1164: DrawableResource
+  get() = Drawable3.icon_1164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11640: DrawableResource
+  get() = Drawable3.icon_11640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11641: DrawableResource
+  get() = Drawable3.icon_11641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11642: DrawableResource
+  get() = Drawable3.icon_11642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11643: DrawableResource
+  get() = Drawable3.icon_11643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11644: DrawableResource
+  get() = Drawable3.icon_11644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11645: DrawableResource
+  get() = Drawable3.icon_11645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11646: DrawableResource
+  get() = Drawable3.icon_11646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11647: DrawableResource
+  get() = Drawable3.icon_11647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11648: DrawableResource
+  get() = Drawable3.icon_11648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11649: DrawableResource
+  get() = Drawable3.icon_11649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1165: DrawableResource
+  get() = Drawable3.icon_1165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11650: DrawableResource
+  get() = Drawable3.icon_11650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11651: DrawableResource
+  get() = Drawable3.icon_11651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11652: DrawableResource
+  get() = Drawable3.icon_11652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11653: DrawableResource
+  get() = Drawable3.icon_11653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11654: DrawableResource
+  get() = Drawable3.icon_11654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11655: DrawableResource
+  get() = Drawable3.icon_11655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11656: DrawableResource
+  get() = Drawable3.icon_11656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11657: DrawableResource
+  get() = Drawable3.icon_11657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11658: DrawableResource
+  get() = Drawable3.icon_11658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11659: DrawableResource
+  get() = Drawable3.icon_11659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1166: DrawableResource
+  get() = Drawable3.icon_1166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11660: DrawableResource
+  get() = Drawable3.icon_11660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11661: DrawableResource
+  get() = Drawable3.icon_11661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11662: DrawableResource
+  get() = Drawable3.icon_11662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11663: DrawableResource
+  get() = Drawable3.icon_11663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11664: DrawableResource
+  get() = Drawable3.icon_11664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11665: DrawableResource
+  get() = Drawable3.icon_11665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11666: DrawableResource
+  get() = Drawable3.icon_11666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11667: DrawableResource
+  get() = Drawable3.icon_11667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11668: DrawableResource
+  get() = Drawable3.icon_11668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11669: DrawableResource
+  get() = Drawable3.icon_11669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1167: DrawableResource
+  get() = Drawable3.icon_1167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11670: DrawableResource
+  get() = Drawable3.icon_11670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11671: DrawableResource
+  get() = Drawable3.icon_11671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11672: DrawableResource
+  get() = Drawable3.icon_11672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11673: DrawableResource
+  get() = Drawable3.icon_11673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11674: DrawableResource
+  get() = Drawable3.icon_11674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11675: DrawableResource
+  get() = Drawable3.icon_11675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11676: DrawableResource
+  get() = Drawable3.icon_11676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11677: DrawableResource
+  get() = Drawable3.icon_11677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11678: DrawableResource
+  get() = Drawable3.icon_11678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11679: DrawableResource
+  get() = Drawable3.icon_11679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1168: DrawableResource
+  get() = Drawable3.icon_1168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11680: DrawableResource
+  get() = Drawable3.icon_11680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11681: DrawableResource
+  get() = Drawable3.icon_11681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11682: DrawableResource
+  get() = Drawable3.icon_11682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11683: DrawableResource
+  get() = Drawable3.icon_11683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11684: DrawableResource
+  get() = Drawable3.icon_11684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11685: DrawableResource
+  get() = Drawable3.icon_11685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11686: DrawableResource
+  get() = Drawable3.icon_11686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11687: DrawableResource
+  get() = Drawable3.icon_11687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11688: DrawableResource
+  get() = Drawable3.icon_11688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11689: DrawableResource
+  get() = Drawable3.icon_11689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1169: DrawableResource
+  get() = Drawable3.icon_1169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11690: DrawableResource
+  get() = Drawable3.icon_11690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11691: DrawableResource
+  get() = Drawable3.icon_11691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11692: DrawableResource
+  get() = Drawable3.icon_11692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11693: DrawableResource
+  get() = Drawable3.icon_11693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11694: DrawableResource
+  get() = Drawable3.icon_11694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11695: DrawableResource
+  get() = Drawable3.icon_11695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11696: DrawableResource
+  get() = Drawable3.icon_11696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11697: DrawableResource
+  get() = Drawable3.icon_11697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11698: DrawableResource
+  get() = Drawable3.icon_11698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11699: DrawableResource
+  get() = Drawable3.icon_11699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_117: DrawableResource
+  get() = Drawable3.icon_117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1170: DrawableResource
+  get() = Drawable3.icon_1170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11700: DrawableResource
+  get() = Drawable3.icon_11700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11701: DrawableResource
+  get() = Drawable3.icon_11701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11702: DrawableResource
+  get() = Drawable3.icon_11702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11703: DrawableResource
+  get() = Drawable3.icon_11703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11704: DrawableResource
+  get() = Drawable3.icon_11704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11705: DrawableResource
+  get() = Drawable3.icon_11705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11706: DrawableResource
+  get() = Drawable3.icon_11706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11707: DrawableResource
+  get() = Drawable3.icon_11707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11708: DrawableResource
+  get() = Drawable3.icon_11708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11709: DrawableResource
+  get() = Drawable3.icon_11709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1171: DrawableResource
+  get() = Drawable3.icon_1171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11710: DrawableResource
+  get() = Drawable3.icon_11710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11711: DrawableResource
+  get() = Drawable3.icon_11711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11712: DrawableResource
+  get() = Drawable3.icon_11712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11713: DrawableResource
+  get() = Drawable3.icon_11713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11714: DrawableResource
+  get() = Drawable3.icon_11714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11715: DrawableResource
+  get() = Drawable3.icon_11715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11716: DrawableResource
+  get() = Drawable3.icon_11716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11717: DrawableResource
+  get() = Drawable3.icon_11717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11718: DrawableResource
+  get() = Drawable3.icon_11718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11719: DrawableResource
+  get() = Drawable3.icon_11719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1172: DrawableResource
+  get() = Drawable3.icon_1172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11720: DrawableResource
+  get() = Drawable3.icon_11720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11721: DrawableResource
+  get() = Drawable3.icon_11721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11722: DrawableResource
+  get() = Drawable3.icon_11722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11723: DrawableResource
+  get() = Drawable3.icon_11723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11724: DrawableResource
+  get() = Drawable3.icon_11724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11725: DrawableResource
+  get() = Drawable3.icon_11725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11726: DrawableResource
+  get() = Drawable3.icon_11726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11727: DrawableResource
+  get() = Drawable3.icon_11727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11728: DrawableResource
+  get() = Drawable3.icon_11728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11729: DrawableResource
+  get() = Drawable3.icon_11729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1173: DrawableResource
+  get() = Drawable3.icon_1173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11730: DrawableResource
+  get() = Drawable3.icon_11730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11731: DrawableResource
+  get() = Drawable3.icon_11731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11732: DrawableResource
+  get() = Drawable3.icon_11732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11733: DrawableResource
+  get() = Drawable3.icon_11733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11734: DrawableResource
+  get() = Drawable3.icon_11734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11735: DrawableResource
+  get() = Drawable3.icon_11735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11736: DrawableResource
+  get() = Drawable3.icon_11736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11737: DrawableResource
+  get() = Drawable3.icon_11737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11738: DrawableResource
+  get() = Drawable3.icon_11738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11739: DrawableResource
+  get() = Drawable3.icon_11739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1174: DrawableResource
+  get() = Drawable3.icon_1174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11740: DrawableResource
+  get() = Drawable3.icon_11740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11741: DrawableResource
+  get() = Drawable3.icon_11741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11742: DrawableResource
+  get() = Drawable3.icon_11742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11743: DrawableResource
+  get() = Drawable3.icon_11743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11744: DrawableResource
+  get() = Drawable3.icon_11744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11745: DrawableResource
+  get() = Drawable3.icon_11745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11746: DrawableResource
+  get() = Drawable3.icon_11746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11747: DrawableResource
+  get() = Drawable3.icon_11747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11748: DrawableResource
+  get() = Drawable3.icon_11748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11749: DrawableResource
+  get() = Drawable3.icon_11749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1175: DrawableResource
+  get() = Drawable3.icon_1175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11750: DrawableResource
+  get() = Drawable3.icon_11750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11751: DrawableResource
+  get() = Drawable3.icon_11751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11752: DrawableResource
+  get() = Drawable3.icon_11752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11753: DrawableResource
+  get() = Drawable3.icon_11753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11754: DrawableResource
+  get() = Drawable3.icon_11754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11755: DrawableResource
+  get() = Drawable3.icon_11755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11756: DrawableResource
+  get() = Drawable3.icon_11756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11757: DrawableResource
+  get() = Drawable3.icon_11757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11758: DrawableResource
+  get() = Drawable3.icon_11758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11759: DrawableResource
+  get() = Drawable3.icon_11759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1176: DrawableResource
+  get() = Drawable3.icon_1176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11760: DrawableResource
+  get() = Drawable3.icon_11760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11761: DrawableResource
+  get() = Drawable3.icon_11761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11762: DrawableResource
+  get() = Drawable3.icon_11762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11763: DrawableResource
+  get() = Drawable3.icon_11763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11764: DrawableResource
+  get() = Drawable3.icon_11764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11765: DrawableResource
+  get() = Drawable3.icon_11765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11766: DrawableResource
+  get() = Drawable3.icon_11766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11767: DrawableResource
+  get() = Drawable3.icon_11767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11768: DrawableResource
+  get() = Drawable3.icon_11768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11769: DrawableResource
+  get() = Drawable3.icon_11769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1177: DrawableResource
+  get() = Drawable3.icon_1177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11770: DrawableResource
+  get() = Drawable3.icon_11770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11771: DrawableResource
+  get() = Drawable3.icon_11771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11772: DrawableResource
+  get() = Drawable3.icon_11772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11773: DrawableResource
+  get() = Drawable3.icon_11773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11774: DrawableResource
+  get() = Drawable3.icon_11774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11775: DrawableResource
+  get() = Drawable3.icon_11775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11776: DrawableResource
+  get() = Drawable3.icon_11776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11777: DrawableResource
+  get() = Drawable3.icon_11777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11778: DrawableResource
+  get() = Drawable3.icon_11778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11779: DrawableResource
+  get() = Drawable3.icon_11779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1178: DrawableResource
+  get() = Drawable3.icon_1178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11780: DrawableResource
+  get() = Drawable3.icon_11780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11781: DrawableResource
+  get() = Drawable3.icon_11781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11782: DrawableResource
+  get() = Drawable3.icon_11782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11783: DrawableResource
+  get() = Drawable3.icon_11783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11784: DrawableResource
+  get() = Drawable3.icon_11784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11785: DrawableResource
+  get() = Drawable3.icon_11785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11786: DrawableResource
+  get() = Drawable3.icon_11786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11787: DrawableResource
+  get() = Drawable3.icon_11787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11788: DrawableResource
+  get() = Drawable3.icon_11788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11789: DrawableResource
+  get() = Drawable3.icon_11789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1179: DrawableResource
+  get() = Drawable3.icon_1179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11790: DrawableResource
+  get() = Drawable3.icon_11790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11791: DrawableResource
+  get() = Drawable3.icon_11791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11792: DrawableResource
+  get() = Drawable3.icon_11792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11793: DrawableResource
+  get() = Drawable3.icon_11793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11794: DrawableResource
+  get() = Drawable3.icon_11794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11795: DrawableResource
+  get() = Drawable3.icon_11795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11796: DrawableResource
+  get() = Drawable3.icon_11796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11797: DrawableResource
+  get() = Drawable3.icon_11797

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable30.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable30.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable30 {
+  public val icon_23498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23498.xml"),
+          )
+      )
+
+  public val icon_23499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23499.xml"),
+          )
+      )
+
+  public val icon_235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_235.xml"),
+          )
+      )
+
+  public val icon_2350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2350.xml"),
+          )
+      )
+
+  public val icon_23500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23500.xml"),
+          )
+      )
+
+  public val icon_23501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23501.xml"),
+          )
+      )
+
+  public val icon_23502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23502.xml"),
+          )
+      )
+
+  public val icon_23503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23503.xml"),
+          )
+      )
+
+  public val icon_23504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23504.xml"),
+          )
+      )
+
+  public val icon_23505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23505.xml"),
+          )
+      )
+
+  public val icon_23506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23506.xml"),
+          )
+      )
+
+  public val icon_23507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23507.xml"),
+          )
+      )
+
+  public val icon_23508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23508.xml"),
+          )
+      )
+
+  public val icon_23509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23509.xml"),
+          )
+      )
+
+  public val icon_2351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2351.xml"),
+          )
+      )
+
+  public val icon_23510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23510.xml"),
+          )
+      )
+
+  public val icon_23511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23511.xml"),
+          )
+      )
+
+  public val icon_23512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23512.xml"),
+          )
+      )
+
+  public val icon_23513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23513.xml"),
+          )
+      )
+
+  public val icon_23514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23514.xml"),
+          )
+      )
+
+  public val icon_23515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23515.xml"),
+          )
+      )
+
+  public val icon_23516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23516.xml"),
+          )
+      )
+
+  public val icon_23517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23517.xml"),
+          )
+      )
+
+  public val icon_23518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23518.xml"),
+          )
+      )
+
+  public val icon_23519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23519.xml"),
+          )
+      )
+
+  public val icon_2352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2352.xml"),
+          )
+      )
+
+  public val icon_23520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23520.xml"),
+          )
+      )
+
+  public val icon_23521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23521.xml"),
+          )
+      )
+
+  public val icon_23522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23522.xml"),
+          )
+      )
+
+  public val icon_23523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23523.xml"),
+          )
+      )
+
+  public val icon_23524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23524.xml"),
+          )
+      )
+
+  public val icon_23525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23525.xml"),
+          )
+      )
+
+  public val icon_23526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23526.xml"),
+          )
+      )
+
+  public val icon_23527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23527.xml"),
+          )
+      )
+
+  public val icon_23528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23528.xml"),
+          )
+      )
+
+  public val icon_23529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23529.xml"),
+          )
+      )
+
+  public val icon_2353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2353.xml"),
+          )
+      )
+
+  public val icon_23530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23530.xml"),
+          )
+      )
+
+  public val icon_23531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23531.xml"),
+          )
+      )
+
+  public val icon_23532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23532.xml"),
+          )
+      )
+
+  public val icon_23533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23533.xml"),
+          )
+      )
+
+  public val icon_23534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23534.xml"),
+          )
+      )
+
+  public val icon_23535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23535.xml"),
+          )
+      )
+
+  public val icon_23536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23536.xml"),
+          )
+      )
+
+  public val icon_23537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23537.xml"),
+          )
+      )
+
+  public val icon_23538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23538.xml"),
+          )
+      )
+
+  public val icon_23539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23539.xml"),
+          )
+      )
+
+  public val icon_2354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2354.xml"),
+          )
+      )
+
+  public val icon_23540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23540.xml"),
+          )
+      )
+
+  public val icon_23541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23541.xml"),
+          )
+      )
+
+  public val icon_23542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23542.xml"),
+          )
+      )
+
+  public val icon_23543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23543.xml"),
+          )
+      )
+
+  public val icon_23544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23544.xml"),
+          )
+      )
+
+  public val icon_23545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23545.xml"),
+          )
+      )
+
+  public val icon_23546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23546.xml"),
+          )
+      )
+
+  public val icon_23547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23547.xml"),
+          )
+      )
+
+  public val icon_23548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23548.xml"),
+          )
+      )
+
+  public val icon_23549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23549.xml"),
+          )
+      )
+
+  public val icon_2355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2355.xml"),
+          )
+      )
+
+  public val icon_23550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23550.xml"),
+          )
+      )
+
+  public val icon_23551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23551.xml"),
+          )
+      )
+
+  public val icon_23552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23552.xml"),
+          )
+      )
+
+  public val icon_23553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23553.xml"),
+          )
+      )
+
+  public val icon_23554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23554.xml"),
+          )
+      )
+
+  public val icon_23555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23555.xml"),
+          )
+      )
+
+  public val icon_23556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23556.xml"),
+          )
+      )
+
+  public val icon_23557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23557.xml"),
+          )
+      )
+
+  public val icon_23558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23558.xml"),
+          )
+      )
+
+  public val icon_23559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23559.xml"),
+          )
+      )
+
+  public val icon_2356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2356.xml"),
+          )
+      )
+
+  public val icon_23560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23560.xml"),
+          )
+      )
+
+  public val icon_23561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23561.xml"),
+          )
+      )
+
+  public val icon_23562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23562.xml"),
+          )
+      )
+
+  public val icon_23563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23563.xml"),
+          )
+      )
+
+  public val icon_23564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23564.xml"),
+          )
+      )
+
+  public val icon_23565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23565.xml"),
+          )
+      )
+
+  public val icon_23566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23566.xml"),
+          )
+      )
+
+  public val icon_23567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23567.xml"),
+          )
+      )
+
+  public val icon_23568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23568.xml"),
+          )
+      )
+
+  public val icon_23569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23569.xml"),
+          )
+      )
+
+  public val icon_2357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2357.xml"),
+          )
+      )
+
+  public val icon_23570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23570.xml"),
+          )
+      )
+
+  public val icon_23571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23571.xml"),
+          )
+      )
+
+  public val icon_23572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23572.xml"),
+          )
+      )
+
+  public val icon_23573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23573.xml"),
+          )
+      )
+
+  public val icon_23574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23574.xml"),
+          )
+      )
+
+  public val icon_23575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23575.xml"),
+          )
+      )
+
+  public val icon_23576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23576.xml"),
+          )
+      )
+
+  public val icon_23577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23577.xml"),
+          )
+      )
+
+  public val icon_23578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23578.xml"),
+          )
+      )
+
+  public val icon_23579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23579.xml"),
+          )
+      )
+
+  public val icon_2358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2358.xml"),
+          )
+      )
+
+  public val icon_23580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23580.xml"),
+          )
+      )
+
+  public val icon_23581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23581.xml"),
+          )
+      )
+
+  public val icon_23582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23582.xml"),
+          )
+      )
+
+  public val icon_23583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23583.xml"),
+          )
+      )
+
+  public val icon_23584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23584.xml"),
+          )
+      )
+
+  public val icon_23585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23585.xml"),
+          )
+      )
+
+  public val icon_23586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23586.xml"),
+          )
+      )
+
+  public val icon_23587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23587.xml"),
+          )
+      )
+
+  public val icon_23588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23588.xml"),
+          )
+      )
+
+  public val icon_23589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23589.xml"),
+          )
+      )
+
+  public val icon_2359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2359.xml"),
+          )
+      )
+
+  public val icon_23590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23590.xml"),
+          )
+      )
+
+  public val icon_23591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23591.xml"),
+          )
+      )
+
+  public val icon_23592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23592.xml"),
+          )
+      )
+
+  public val icon_23593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23593.xml"),
+          )
+      )
+
+  public val icon_23594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23594.xml"),
+          )
+      )
+
+  public val icon_23595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23595.xml"),
+          )
+      )
+
+  public val icon_23596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23596.xml"),
+          )
+      )
+
+  public val icon_23597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23597.xml"),
+          )
+      )
+
+  public val icon_23598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23598.xml"),
+          )
+      )
+
+  public val icon_23599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23599.xml"),
+          )
+      )
+
+  public val icon_236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_236.xml"),
+          )
+      )
+
+  public val icon_2360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2360.xml"),
+          )
+      )
+
+  public val icon_23600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23600.xml"),
+          )
+      )
+
+  public val icon_23601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23601.xml"),
+          )
+      )
+
+  public val icon_23602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23602.xml"),
+          )
+      )
+
+  public val icon_23603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23603.xml"),
+          )
+      )
+
+  public val icon_23604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23604.xml"),
+          )
+      )
+
+  public val icon_23605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23605.xml"),
+          )
+      )
+
+  public val icon_23606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23606.xml"),
+          )
+      )
+
+  public val icon_23607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23607.xml"),
+          )
+      )
+
+  public val icon_23608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23608.xml"),
+          )
+      )
+
+  public val icon_23609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23609.xml"),
+          )
+      )
+
+  public val icon_2361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2361.xml"),
+          )
+      )
+
+  public val icon_23610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23610.xml"),
+          )
+      )
+
+  public val icon_23611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23611.xml"),
+          )
+      )
+
+  public val icon_23612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23612.xml"),
+          )
+      )
+
+  public val icon_23613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23613.xml"),
+          )
+      )
+
+  public val icon_23614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23614.xml"),
+          )
+      )
+
+  public val icon_23615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23615.xml"),
+          )
+      )
+
+  public val icon_23616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23616.xml"),
+          )
+      )
+
+  public val icon_23617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23617.xml"),
+          )
+      )
+
+  public val icon_23618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23618.xml"),
+          )
+      )
+
+  public val icon_23619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23619.xml"),
+          )
+      )
+
+  public val icon_2362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2362.xml"),
+          )
+      )
+
+  public val icon_23620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23620.xml"),
+          )
+      )
+
+  public val icon_23621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23621.xml"),
+          )
+      )
+
+  public val icon_23622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23622.xml"),
+          )
+      )
+
+  public val icon_23623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23623.xml"),
+          )
+      )
+
+  public val icon_23624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23624.xml"),
+          )
+      )
+
+  public val icon_23625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23625.xml"),
+          )
+      )
+
+  public val icon_23626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23626.xml"),
+          )
+      )
+
+  public val icon_23627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23627.xml"),
+          )
+      )
+
+  public val icon_23628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23628.xml"),
+          )
+      )
+
+  public val icon_23629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23629.xml"),
+          )
+      )
+
+  public val icon_2363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2363.xml"),
+          )
+      )
+
+  public val icon_23630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23630.xml"),
+          )
+      )
+
+  public val icon_23631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23631.xml"),
+          )
+      )
+
+  public val icon_23632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23632.xml"),
+          )
+      )
+
+  public val icon_23633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23633.xml"),
+          )
+      )
+
+  public val icon_23634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23634.xml"),
+          )
+      )
+
+  public val icon_23635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23635.xml"),
+          )
+      )
+
+  public val icon_23636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23636.xml"),
+          )
+      )
+
+  public val icon_23637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23637.xml"),
+          )
+      )
+
+  public val icon_23638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23638.xml"),
+          )
+      )
+
+  public val icon_23639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23639.xml"),
+          )
+      )
+
+  public val icon_2364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2364.xml"),
+          )
+      )
+
+  public val icon_23640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23640.xml"),
+          )
+      )
+
+  public val icon_23641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23641.xml"),
+          )
+      )
+
+  public val icon_23642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23642.xml"),
+          )
+      )
+
+  public val icon_23643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23643.xml"),
+          )
+      )
+
+  public val icon_23644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23644.xml"),
+          )
+      )
+
+  public val icon_23645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23645.xml"),
+          )
+      )
+
+  public val icon_23646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23646.xml"),
+          )
+      )
+
+  public val icon_23647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23647.xml"),
+          )
+      )
+
+  public val icon_23648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23648.xml"),
+          )
+      )
+
+  public val icon_23649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23649.xml"),
+          )
+      )
+
+  public val icon_2365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2365.xml"),
+          )
+      )
+
+  public val icon_23650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23650.xml"),
+          )
+      )
+
+  public val icon_23651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23651.xml"),
+          )
+      )
+
+  public val icon_23652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23652.xml"),
+          )
+      )
+
+  public val icon_23653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23653.xml"),
+          )
+      )
+
+  public val icon_23654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23654.xml"),
+          )
+      )
+
+  public val icon_23655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23655.xml"),
+          )
+      )
+
+  public val icon_23656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23656.xml"),
+          )
+      )
+
+  public val icon_23657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23657.xml"),
+          )
+      )
+
+  public val icon_23658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23658.xml"),
+          )
+      )
+
+  public val icon_23659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23659.xml"),
+          )
+      )
+
+  public val icon_2366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2366.xml"),
+          )
+      )
+
+  public val icon_23660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23660.xml"),
+          )
+      )
+
+  public val icon_23661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23661.xml"),
+          )
+      )
+
+  public val icon_23662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23662.xml"),
+          )
+      )
+
+  public val icon_23663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23663.xml"),
+          )
+      )
+
+  public val icon_23664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23664.xml"),
+          )
+      )
+
+  public val icon_23665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23665.xml"),
+          )
+      )
+
+  public val icon_23666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23666.xml"),
+          )
+      )
+
+  public val icon_23667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23667.xml"),
+          )
+      )
+
+  public val icon_23668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23668.xml"),
+          )
+      )
+
+  public val icon_23669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23669.xml"),
+          )
+      )
+
+  public val icon_2367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2367.xml"),
+          )
+      )
+
+  public val icon_23670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23670.xml"),
+          )
+      )
+
+  public val icon_23671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23671.xml"),
+          )
+      )
+
+  public val icon_23672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23672.xml"),
+          )
+      )
+
+  public val icon_23673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23673.xml"),
+          )
+      )
+
+  public val icon_23674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23674.xml"),
+          )
+      )
+
+  public val icon_23675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23675.xml"),
+          )
+      )
+
+  public val icon_23676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23676.xml"),
+          )
+      )
+
+  public val icon_23677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23677.xml"),
+          )
+      )
+
+  public val icon_23678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23678.xml"),
+          )
+      )
+
+  public val icon_23679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23679.xml"),
+          )
+      )
+
+  public val icon_2368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2368.xml"),
+          )
+      )
+
+  public val icon_23680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23680.xml"),
+          )
+      )
+
+  public val icon_23681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23681.xml"),
+          )
+      )
+
+  public val icon_23682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23682.xml"),
+          )
+      )
+
+  public val icon_23683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23683.xml"),
+          )
+      )
+
+  public val icon_23684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23684.xml"),
+          )
+      )
+
+  public val icon_23685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23685.xml"),
+          )
+      )
+
+  public val icon_23686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23686.xml"),
+          )
+      )
+
+  public val icon_23687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23687.xml"),
+          )
+      )
+
+  public val icon_23688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23688.xml"),
+          )
+      )
+
+  public val icon_23689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23689.xml"),
+          )
+      )
+
+  public val icon_2369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2369.xml"),
+          )
+      )
+
+  public val icon_23690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23690.xml"),
+          )
+      )
+
+  public val icon_23691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23691.xml"),
+          )
+      )
+
+  public val icon_23692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23692.xml"),
+          )
+      )
+
+  public val icon_23693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23693.xml"),
+          )
+      )
+
+  public val icon_23694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23694.xml"),
+          )
+      )
+
+  public val icon_23695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23695.xml"),
+          )
+      )
+
+  public val icon_23696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23696.xml"),
+          )
+      )
+
+  public val icon_23697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23697.xml"),
+          )
+      )
+
+  public val icon_23698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23698.xml"),
+          )
+      )
+
+  public val icon_23699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23699.xml"),
+          )
+      )
+
+  public val icon_237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_237.xml"),
+          )
+      )
+
+  public val icon_2370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2370.xml"),
+          )
+      )
+
+  public val icon_23700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23700.xml"),
+          )
+      )
+
+  public val icon_23701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23701.xml"),
+          )
+      )
+
+  public val icon_23702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23702.xml"),
+          )
+      )
+
+  public val icon_23703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23703.xml"),
+          )
+      )
+
+  public val icon_23704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23704.xml"),
+          )
+      )
+
+  public val icon_23705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23705.xml"),
+          )
+      )
+
+  public val icon_23706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23706.xml"),
+          )
+      )
+
+  public val icon_23707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23707.xml"),
+          )
+      )
+
+  public val icon_23708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23708.xml"),
+          )
+      )
+
+  public val icon_23709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23709.xml"),
+          )
+      )
+
+  public val icon_2371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2371.xml"),
+          )
+      )
+
+  public val icon_23710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23710.xml"),
+          )
+      )
+
+  public val icon_23711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23711.xml"),
+          )
+      )
+
+  public val icon_23712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23712.xml"),
+          )
+      )
+
+  public val icon_23713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23713.xml"),
+          )
+      )
+
+  public val icon_23714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23714.xml"),
+          )
+      )
+
+  public val icon_23715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23715.xml"),
+          )
+      )
+
+  public val icon_23716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23716.xml"),
+          )
+      )
+
+  public val icon_23717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23717.xml"),
+          )
+      )
+
+  public val icon_23718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23718.xml"),
+          )
+      )
+
+  public val icon_23719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23719.xml"),
+          )
+      )
+
+  public val icon_2372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2372.xml"),
+          )
+      )
+
+  public val icon_23720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23720.xml"),
+          )
+      )
+
+  public val icon_23721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23721.xml"),
+          )
+      )
+
+  public val icon_23722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23722.xml"),
+          )
+      )
+
+  public val icon_23723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23723.xml"),
+          )
+      )
+
+  public val icon_23724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23724.xml"),
+          )
+      )
+
+  public val icon_23725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23725.xml"),
+          )
+      )
+
+  public val icon_23726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23726.xml"),
+          )
+      )
+
+  public val icon_23727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23727.xml"),
+          )
+      )
+
+  public val icon_23728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23728.xml"),
+          )
+      )
+
+  public val icon_23729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23729.xml"),
+          )
+      )
+
+  public val icon_2373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2373.xml"),
+          )
+      )
+
+  public val icon_23730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23730.xml"),
+          )
+      )
+
+  public val icon_23731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23731.xml"),
+          )
+      )
+
+  public val icon_23732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23732.xml"),
+          )
+      )
+
+  public val icon_23733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23733.xml"),
+          )
+      )
+
+  public val icon_23734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23734.xml"),
+          )
+      )
+
+  public val icon_23735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23735.xml"),
+          )
+      )
+
+  public val icon_23736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23736.xml"),
+          )
+      )
+
+  public val icon_23737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23737.xml"),
+          )
+      )
+
+  public val icon_23738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23738.xml"),
+          )
+      )
+
+  public val icon_23739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23739.xml"),
+          )
+      )
+
+  public val icon_2374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2374.xml"),
+          )
+      )
+
+  public val icon_23740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23740.xml"),
+          )
+      )
+
+  public val icon_23741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23741.xml"),
+          )
+      )
+
+  public val icon_23742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23742.xml"),
+          )
+      )
+
+  public val icon_23743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23743.xml"),
+          )
+      )
+
+  public val icon_23744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23744.xml"),
+          )
+      )
+
+  public val icon_23745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23745.xml"),
+          )
+      )
+
+  public val icon_23746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23746.xml"),
+          )
+      )
+
+  public val icon_23747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23747.xml"),
+          )
+      )
+
+  public val icon_23748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23748.xml"),
+          )
+      )
+
+  public val icon_23749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23749.xml"),
+          )
+      )
+
+  public val icon_2375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2375.xml"),
+          )
+      )
+
+  public val icon_23750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23750.xml"),
+          )
+      )
+
+  public val icon_23751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23751.xml"),
+          )
+      )
+
+  public val icon_23752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23752.xml"),
+          )
+      )
+
+  public val icon_23753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23753.xml"),
+          )
+      )
+
+  public val icon_23754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23754.xml"),
+          )
+      )
+
+  public val icon_23755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23755.xml"),
+          )
+      )
+
+  public val icon_23756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23756.xml"),
+          )
+      )
+
+  public val icon_23757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23757.xml"),
+          )
+      )
+
+  public val icon_23758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23758.xml"),
+          )
+      )
+
+  public val icon_23759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23759.xml"),
+          )
+      )
+
+  public val icon_2376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2376.xml"),
+          )
+      )
+
+  public val icon_23760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23760.xml"),
+          )
+      )
+
+  public val icon_23761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23761.xml"),
+          )
+      )
+
+  public val icon_23762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23762.xml"),
+          )
+      )
+
+  public val icon_23763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23763.xml"),
+          )
+      )
+
+  public val icon_23764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23764.xml"),
+          )
+      )
+
+  public val icon_23765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23765.xml"),
+          )
+      )
+
+  public val icon_23766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23766.xml"),
+          )
+      )
+
+  public val icon_23767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23767.xml"),
+          )
+      )
+
+  public val icon_23768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23768.xml"),
+          )
+      )
+
+  public val icon_23769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23769.xml"),
+          )
+      )
+
+  public val icon_2377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2377.xml"),
+          )
+      )
+
+  public val icon_23770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23770.xml"),
+          )
+      )
+
+  public val icon_23771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23771.xml"),
+          )
+      )
+
+  public val icon_23772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23772.xml"),
+          )
+      )
+
+  public val icon_23773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23773.xml"),
+          )
+      )
+
+  public val icon_23774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23774.xml"),
+          )
+      )
+
+  public val icon_23775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23775.xml"),
+          )
+      )
+
+  public val icon_23776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23776.xml"),
+          )
+      )
+
+  public val icon_23777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23777.xml"),
+          )
+      )
+
+  public val icon_23778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23778.xml"),
+          )
+      )
+
+  public val icon_23779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23779.xml"),
+          )
+      )
+
+  public val icon_2378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2378.xml"),
+          )
+      )
+
+  public val icon_23780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23780.xml"),
+          )
+      )
+
+  public val icon_23781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23781.xml"),
+          )
+      )
+
+  public val icon_23782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23782.xml"),
+          )
+      )
+
+  public val icon_23783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23783.xml"),
+          )
+      )
+
+  public val icon_23784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23784.xml"),
+          )
+      )
+
+  public val icon_23785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23785.xml"),
+          )
+      )
+
+  public val icon_23786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23786.xml"),
+          )
+      )
+
+  public val icon_23787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23787.xml"),
+          )
+      )
+
+  public val icon_23788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23788.xml"),
+          )
+      )
+
+  public val icon_23789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23789.xml"),
+          )
+      )
+
+  public val icon_2379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2379.xml"),
+          )
+      )
+
+  public val icon_23790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23790.xml"),
+          )
+      )
+
+  public val icon_23791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23791.xml"),
+          )
+      )
+
+  public val icon_23792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23792.xml"),
+          )
+      )
+
+  public val icon_23793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23793.xml"),
+          )
+      )
+
+  public val icon_23794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23794.xml"),
+          )
+      )
+
+  public val icon_23795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23795.xml"),
+          )
+      )
+
+  public val icon_23796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23796.xml"),
+          )
+      )
+
+  public val icon_23797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23797.xml"),
+          )
+      )
+
+  public val icon_23798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23798.xml"),
+          )
+      )
+
+  public val icon_23799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23799.xml"),
+          )
+      )
+
+  public val icon_238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_238.xml"),
+          )
+      )
+
+  public val icon_2380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2380.xml"),
+          )
+      )
+
+  public val icon_23800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23800.xml"),
+          )
+      )
+
+  public val icon_23801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23801.xml"),
+          )
+      )
+
+  public val icon_23802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23802.xml"),
+          )
+      )
+
+  public val icon_23803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23803.xml"),
+          )
+      )
+
+  public val icon_23804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23804.xml"),
+          )
+      )
+
+  public val icon_23805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23805.xml"),
+          )
+      )
+
+  public val icon_23806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23806.xml"),
+          )
+      )
+
+  public val icon_23807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23807.xml"),
+          )
+      )
+
+  public val icon_23808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23808.xml"),
+          )
+      )
+
+  public val icon_23809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23809.xml"),
+          )
+      )
+
+  public val icon_2381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2381.xml"),
+          )
+      )
+
+  public val icon_23810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23810.xml"),
+          )
+      )
+
+  public val icon_23811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23811.xml"),
+          )
+      )
+
+  public val icon_23812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23812.xml"),
+          )
+      )
+
+  public val icon_23813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23813.xml"),
+          )
+      )
+
+  public val icon_23814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23814.xml"),
+          )
+      )
+
+  public val icon_23815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23815.xml"),
+          )
+      )
+
+  public val icon_23816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23816.xml"),
+          )
+      )
+
+  public val icon_23817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23817.xml"),
+          )
+      )
+
+  public val icon_23818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23818.xml"),
+          )
+      )
+
+  public val icon_23819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23819.xml"),
+          )
+      )
+
+  public val icon_2382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2382.xml"),
+          )
+      )
+
+  public val icon_23820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23820.xml"),
+          )
+      )
+
+  public val icon_23821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23821.xml"),
+          )
+      )
+
+  public val icon_23822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23822.xml"),
+          )
+      )
+
+  public val icon_23823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23823.xml"),
+          )
+      )
+
+  public val icon_23824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23824.xml"),
+          )
+      )
+
+  public val icon_23825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23825.xml"),
+          )
+      )
+
+  public val icon_23826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23826.xml"),
+          )
+      )
+
+  public val icon_23827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23827.xml"),
+          )
+      )
+
+  public val icon_23828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23828.xml"),
+          )
+      )
+
+  public val icon_23829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23829.xml"),
+          )
+      )
+
+  public val icon_2383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2383.xml"),
+          )
+      )
+
+  public val icon_23830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23830.xml"),
+          )
+      )
+
+  public val icon_23831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23831.xml"),
+          )
+      )
+
+  public val icon_23832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23832.xml"),
+          )
+      )
+
+  public val icon_23833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23833.xml"),
+          )
+      )
+
+  public val icon_23834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23834.xml"),
+          )
+      )
+
+  public val icon_23835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23835.xml"),
+          )
+      )
+
+  public val icon_23836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23836.xml"),
+          )
+      )
+
+  public val icon_23837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23837.xml"),
+          )
+      )
+
+  public val icon_23838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23838.xml"),
+          )
+      )
+
+  public val icon_23839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23839.xml"),
+          )
+      )
+
+  public val icon_2384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2384.xml"),
+          )
+      )
+
+  public val icon_23840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23840.xml"),
+          )
+      )
+
+  public val icon_23841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23841.xml"),
+          )
+      )
+
+  public val icon_23842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23842.xml"),
+          )
+      )
+
+  public val icon_23843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23843.xml"),
+          )
+      )
+
+  public val icon_23844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23844.xml"),
+          )
+      )
+
+  public val icon_23845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23845.xml"),
+          )
+      )
+
+  public val icon_23846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23846.xml"),
+          )
+      )
+
+  public val icon_23847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23847.xml"),
+          )
+      )
+
+  public val icon_23848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23848.xml"),
+          )
+      )
+
+  public val icon_23849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23849.xml"),
+          )
+      )
+
+  public val icon_2385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2385.xml"),
+          )
+      )
+
+  public val icon_23850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23850.xml"),
+          )
+      )
+
+  public val icon_23851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23851.xml"),
+          )
+      )
+
+  public val icon_23852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23852.xml"),
+          )
+      )
+
+  public val icon_23853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23853.xml"),
+          )
+      )
+
+  public val icon_23854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23854.xml"),
+          )
+      )
+
+  public val icon_23855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23855.xml"),
+          )
+      )
+
+  public val icon_23856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23856.xml"),
+          )
+      )
+
+  public val icon_23857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23857.xml"),
+          )
+      )
+
+  public val icon_23858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23858.xml"),
+          )
+      )
+
+  public val icon_23859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23859.xml"),
+          )
+      )
+
+  public val icon_2386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2386.xml"),
+          )
+      )
+
+  public val icon_23860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23860.xml"),
+          )
+      )
+
+  public val icon_23861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23861.xml"),
+          )
+      )
+
+  public val icon_23862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23862.xml"),
+          )
+      )
+
+  public val icon_23863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23863.xml"),
+          )
+      )
+
+  public val icon_23864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23864.xml"),
+          )
+      )
+
+  public val icon_23865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23865.xml"),
+          )
+      )
+
+  public val icon_23866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23866.xml"),
+          )
+      )
+
+  public val icon_23867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23867.xml"),
+          )
+      )
+
+  public val icon_23868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23868.xml"),
+          )
+      )
+
+  public val icon_23869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23869.xml"),
+          )
+      )
+
+  public val icon_2387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2387.xml"),
+          )
+      )
+
+  public val icon_23870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23870.xml"),
+          )
+      )
+
+  public val icon_23871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23871.xml"),
+          )
+      )
+
+  public val icon_23872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23872.xml"),
+          )
+      )
+
+  public val icon_23873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23873.xml"),
+          )
+      )
+
+  public val icon_23874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23874.xml"),
+          )
+      )
+
+  public val icon_23875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23875.xml"),
+          )
+      )
+
+  public val icon_23876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23876.xml"),
+          )
+      )
+
+  public val icon_23877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23877.xml"),
+          )
+      )
+
+  public val icon_23878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23878.xml"),
+          )
+      )
+
+  public val icon_23879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23879.xml"),
+          )
+      )
+
+  public val icon_2388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2388.xml"),
+          )
+      )
+
+  public val icon_23880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23880.xml"),
+          )
+      )
+
+  public val icon_23881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23881.xml"),
+          )
+      )
+
+  public val icon_23882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23882.xml"),
+          )
+      )
+
+  public val icon_23883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23883.xml"),
+          )
+      )
+
+  public val icon_23884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23884.xml"),
+          )
+      )
+
+  public val icon_23885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23885.xml"),
+          )
+      )
+
+  public val icon_23886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23886.xml"),
+          )
+      )
+
+  public val icon_23887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23887.xml"),
+          )
+      )
+
+  public val icon_23888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23888.xml"),
+          )
+      )
+
+  public val icon_23889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23889.xml"),
+          )
+      )
+
+  public val icon_2389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2389.xml"),
+          )
+      )
+
+  public val icon_23890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23890.xml"),
+          )
+      )
+
+  public val icon_23891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23891.xml"),
+          )
+      )
+
+  public val icon_23892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23892.xml"),
+          )
+      )
+
+  public val icon_23893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23893.xml"),
+          )
+      )
+
+  public val icon_23894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23894.xml"),
+          )
+      )
+
+  public val icon_23895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23895.xml"),
+          )
+      )
+
+  public val icon_23896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23896.xml"),
+          )
+      )
+
+  public val icon_23897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23897.xml"),
+          )
+      )
+
+  public val icon_23898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23898.xml"),
+          )
+      )
+
+  public val icon_23899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23899.xml"),
+          )
+      )
+
+  public val icon_239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_239.xml"),
+          )
+      )
+
+  public val icon_2390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2390.xml"),
+          )
+      )
+
+  public val icon_23900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23900.xml"),
+          )
+      )
+
+  public val icon_23901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23901.xml"),
+          )
+      )
+
+  public val icon_23902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23902.xml"),
+          )
+      )
+
+  public val icon_23903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23903.xml"),
+          )
+      )
+
+  public val icon_23904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23904.xml"),
+          )
+      )
+
+  public val icon_23905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23905.xml"),
+          )
+      )
+
+  public val icon_23906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23906.xml"),
+          )
+      )
+
+  public val icon_23907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23907.xml"),
+          )
+      )
+
+  public val icon_23908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23908.xml"),
+          )
+      )
+
+  public val icon_23909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23909.xml"),
+          )
+      )
+
+  public val icon_2391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2391.xml"),
+          )
+      )
+
+  public val icon_23910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23910.xml"),
+          )
+      )
+
+  public val icon_23911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23911.xml"),
+          )
+      )
+
+  public val icon_23912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23912.xml"),
+          )
+      )
+
+  public val icon_23913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23913.xml"),
+          )
+      )
+
+  public val icon_23914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23914.xml"),
+          )
+      )
+
+  public val icon_23915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23915.xml"),
+          )
+      )
+
+  public val icon_23916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23916.xml"),
+          )
+      )
+
+  public val icon_23917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23917.xml"),
+          )
+      )
+
+  public val icon_23918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23918.xml"),
+          )
+      )
+
+  public val icon_23919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23919.xml"),
+          )
+      )
+
+  public val icon_2392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2392.xml"),
+          )
+      )
+
+  public val icon_23920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23920.xml"),
+          )
+      )
+
+  public val icon_23921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23921.xml"),
+          )
+      )
+
+  public val icon_23922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23922.xml"),
+          )
+      )
+
+  public val icon_23923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23923.xml"),
+          )
+      )
+
+  public val icon_23924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23924.xml"),
+          )
+      )
+
+  public val icon_23925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23925.xml"),
+          )
+      )
+
+  public val icon_23926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23926.xml"),
+          )
+      )
+
+  public val icon_23927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23927.xml"),
+          )
+      )
+
+  public val icon_23928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23928.xml"),
+          )
+      )
+
+  public val icon_23929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23929.xml"),
+          )
+      )
+
+  public val icon_2393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2393.xml"),
+          )
+      )
+
+  public val icon_23930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23930.xml"),
+          )
+      )
+
+  public val icon_23931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23931.xml"),
+          )
+      )
+
+  public val icon_23932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23932.xml"),
+          )
+      )
+
+  public val icon_23933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23933.xml"),
+          )
+      )
+
+  public val icon_23934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23934.xml"),
+          )
+      )
+
+  public val icon_23935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23935.xml"),
+          )
+      )
+
+  public val icon_23936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23936.xml"),
+          )
+      )
+
+  public val icon_23937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23937.xml"),
+          )
+      )
+
+  public val icon_23938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23938.xml"),
+          )
+      )
+
+  public val icon_23939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23939.xml"),
+          )
+      )
+
+  public val icon_2394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2394.xml"),
+          )
+      )
+
+  public val icon_23940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23940.xml"),
+          )
+      )
+
+  public val icon_23941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23941.xml"),
+          )
+      )
+
+  public val icon_23942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23942.xml"),
+          )
+      )
+
+  public val icon_23943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23943.xml"),
+          )
+      )
+
+  public val icon_23944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23944.xml"),
+          )
+      )
+
+  public val icon_23945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23945.xml"),
+          )
+      )
+
+  public val icon_23946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23946.xml"),
+          )
+      )
+
+  public val icon_23947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23947.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23498: DrawableResource
+  get() = Drawable30.icon_23498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23499: DrawableResource
+  get() = Drawable30.icon_23499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_235: DrawableResource
+  get() = Drawable30.icon_235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2350: DrawableResource
+  get() = Drawable30.icon_2350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23500: DrawableResource
+  get() = Drawable30.icon_23500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23501: DrawableResource
+  get() = Drawable30.icon_23501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23502: DrawableResource
+  get() = Drawable30.icon_23502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23503: DrawableResource
+  get() = Drawable30.icon_23503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23504: DrawableResource
+  get() = Drawable30.icon_23504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23505: DrawableResource
+  get() = Drawable30.icon_23505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23506: DrawableResource
+  get() = Drawable30.icon_23506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23507: DrawableResource
+  get() = Drawable30.icon_23507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23508: DrawableResource
+  get() = Drawable30.icon_23508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23509: DrawableResource
+  get() = Drawable30.icon_23509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2351: DrawableResource
+  get() = Drawable30.icon_2351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23510: DrawableResource
+  get() = Drawable30.icon_23510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23511: DrawableResource
+  get() = Drawable30.icon_23511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23512: DrawableResource
+  get() = Drawable30.icon_23512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23513: DrawableResource
+  get() = Drawable30.icon_23513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23514: DrawableResource
+  get() = Drawable30.icon_23514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23515: DrawableResource
+  get() = Drawable30.icon_23515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23516: DrawableResource
+  get() = Drawable30.icon_23516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23517: DrawableResource
+  get() = Drawable30.icon_23517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23518: DrawableResource
+  get() = Drawable30.icon_23518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23519: DrawableResource
+  get() = Drawable30.icon_23519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2352: DrawableResource
+  get() = Drawable30.icon_2352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23520: DrawableResource
+  get() = Drawable30.icon_23520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23521: DrawableResource
+  get() = Drawable30.icon_23521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23522: DrawableResource
+  get() = Drawable30.icon_23522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23523: DrawableResource
+  get() = Drawable30.icon_23523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23524: DrawableResource
+  get() = Drawable30.icon_23524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23525: DrawableResource
+  get() = Drawable30.icon_23525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23526: DrawableResource
+  get() = Drawable30.icon_23526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23527: DrawableResource
+  get() = Drawable30.icon_23527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23528: DrawableResource
+  get() = Drawable30.icon_23528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23529: DrawableResource
+  get() = Drawable30.icon_23529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2353: DrawableResource
+  get() = Drawable30.icon_2353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23530: DrawableResource
+  get() = Drawable30.icon_23530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23531: DrawableResource
+  get() = Drawable30.icon_23531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23532: DrawableResource
+  get() = Drawable30.icon_23532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23533: DrawableResource
+  get() = Drawable30.icon_23533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23534: DrawableResource
+  get() = Drawable30.icon_23534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23535: DrawableResource
+  get() = Drawable30.icon_23535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23536: DrawableResource
+  get() = Drawable30.icon_23536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23537: DrawableResource
+  get() = Drawable30.icon_23537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23538: DrawableResource
+  get() = Drawable30.icon_23538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23539: DrawableResource
+  get() = Drawable30.icon_23539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2354: DrawableResource
+  get() = Drawable30.icon_2354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23540: DrawableResource
+  get() = Drawable30.icon_23540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23541: DrawableResource
+  get() = Drawable30.icon_23541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23542: DrawableResource
+  get() = Drawable30.icon_23542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23543: DrawableResource
+  get() = Drawable30.icon_23543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23544: DrawableResource
+  get() = Drawable30.icon_23544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23545: DrawableResource
+  get() = Drawable30.icon_23545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23546: DrawableResource
+  get() = Drawable30.icon_23546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23547: DrawableResource
+  get() = Drawable30.icon_23547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23548: DrawableResource
+  get() = Drawable30.icon_23548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23549: DrawableResource
+  get() = Drawable30.icon_23549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2355: DrawableResource
+  get() = Drawable30.icon_2355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23550: DrawableResource
+  get() = Drawable30.icon_23550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23551: DrawableResource
+  get() = Drawable30.icon_23551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23552: DrawableResource
+  get() = Drawable30.icon_23552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23553: DrawableResource
+  get() = Drawable30.icon_23553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23554: DrawableResource
+  get() = Drawable30.icon_23554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23555: DrawableResource
+  get() = Drawable30.icon_23555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23556: DrawableResource
+  get() = Drawable30.icon_23556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23557: DrawableResource
+  get() = Drawable30.icon_23557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23558: DrawableResource
+  get() = Drawable30.icon_23558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23559: DrawableResource
+  get() = Drawable30.icon_23559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2356: DrawableResource
+  get() = Drawable30.icon_2356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23560: DrawableResource
+  get() = Drawable30.icon_23560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23561: DrawableResource
+  get() = Drawable30.icon_23561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23562: DrawableResource
+  get() = Drawable30.icon_23562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23563: DrawableResource
+  get() = Drawable30.icon_23563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23564: DrawableResource
+  get() = Drawable30.icon_23564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23565: DrawableResource
+  get() = Drawable30.icon_23565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23566: DrawableResource
+  get() = Drawable30.icon_23566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23567: DrawableResource
+  get() = Drawable30.icon_23567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23568: DrawableResource
+  get() = Drawable30.icon_23568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23569: DrawableResource
+  get() = Drawable30.icon_23569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2357: DrawableResource
+  get() = Drawable30.icon_2357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23570: DrawableResource
+  get() = Drawable30.icon_23570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23571: DrawableResource
+  get() = Drawable30.icon_23571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23572: DrawableResource
+  get() = Drawable30.icon_23572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23573: DrawableResource
+  get() = Drawable30.icon_23573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23574: DrawableResource
+  get() = Drawable30.icon_23574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23575: DrawableResource
+  get() = Drawable30.icon_23575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23576: DrawableResource
+  get() = Drawable30.icon_23576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23577: DrawableResource
+  get() = Drawable30.icon_23577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23578: DrawableResource
+  get() = Drawable30.icon_23578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23579: DrawableResource
+  get() = Drawable30.icon_23579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2358: DrawableResource
+  get() = Drawable30.icon_2358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23580: DrawableResource
+  get() = Drawable30.icon_23580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23581: DrawableResource
+  get() = Drawable30.icon_23581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23582: DrawableResource
+  get() = Drawable30.icon_23582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23583: DrawableResource
+  get() = Drawable30.icon_23583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23584: DrawableResource
+  get() = Drawable30.icon_23584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23585: DrawableResource
+  get() = Drawable30.icon_23585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23586: DrawableResource
+  get() = Drawable30.icon_23586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23587: DrawableResource
+  get() = Drawable30.icon_23587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23588: DrawableResource
+  get() = Drawable30.icon_23588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23589: DrawableResource
+  get() = Drawable30.icon_23589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2359: DrawableResource
+  get() = Drawable30.icon_2359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23590: DrawableResource
+  get() = Drawable30.icon_23590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23591: DrawableResource
+  get() = Drawable30.icon_23591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23592: DrawableResource
+  get() = Drawable30.icon_23592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23593: DrawableResource
+  get() = Drawable30.icon_23593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23594: DrawableResource
+  get() = Drawable30.icon_23594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23595: DrawableResource
+  get() = Drawable30.icon_23595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23596: DrawableResource
+  get() = Drawable30.icon_23596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23597: DrawableResource
+  get() = Drawable30.icon_23597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23598: DrawableResource
+  get() = Drawable30.icon_23598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23599: DrawableResource
+  get() = Drawable30.icon_23599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_236: DrawableResource
+  get() = Drawable30.icon_236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2360: DrawableResource
+  get() = Drawable30.icon_2360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23600: DrawableResource
+  get() = Drawable30.icon_23600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23601: DrawableResource
+  get() = Drawable30.icon_23601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23602: DrawableResource
+  get() = Drawable30.icon_23602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23603: DrawableResource
+  get() = Drawable30.icon_23603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23604: DrawableResource
+  get() = Drawable30.icon_23604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23605: DrawableResource
+  get() = Drawable30.icon_23605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23606: DrawableResource
+  get() = Drawable30.icon_23606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23607: DrawableResource
+  get() = Drawable30.icon_23607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23608: DrawableResource
+  get() = Drawable30.icon_23608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23609: DrawableResource
+  get() = Drawable30.icon_23609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2361: DrawableResource
+  get() = Drawable30.icon_2361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23610: DrawableResource
+  get() = Drawable30.icon_23610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23611: DrawableResource
+  get() = Drawable30.icon_23611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23612: DrawableResource
+  get() = Drawable30.icon_23612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23613: DrawableResource
+  get() = Drawable30.icon_23613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23614: DrawableResource
+  get() = Drawable30.icon_23614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23615: DrawableResource
+  get() = Drawable30.icon_23615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23616: DrawableResource
+  get() = Drawable30.icon_23616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23617: DrawableResource
+  get() = Drawable30.icon_23617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23618: DrawableResource
+  get() = Drawable30.icon_23618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23619: DrawableResource
+  get() = Drawable30.icon_23619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2362: DrawableResource
+  get() = Drawable30.icon_2362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23620: DrawableResource
+  get() = Drawable30.icon_23620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23621: DrawableResource
+  get() = Drawable30.icon_23621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23622: DrawableResource
+  get() = Drawable30.icon_23622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23623: DrawableResource
+  get() = Drawable30.icon_23623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23624: DrawableResource
+  get() = Drawable30.icon_23624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23625: DrawableResource
+  get() = Drawable30.icon_23625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23626: DrawableResource
+  get() = Drawable30.icon_23626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23627: DrawableResource
+  get() = Drawable30.icon_23627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23628: DrawableResource
+  get() = Drawable30.icon_23628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23629: DrawableResource
+  get() = Drawable30.icon_23629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2363: DrawableResource
+  get() = Drawable30.icon_2363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23630: DrawableResource
+  get() = Drawable30.icon_23630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23631: DrawableResource
+  get() = Drawable30.icon_23631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23632: DrawableResource
+  get() = Drawable30.icon_23632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23633: DrawableResource
+  get() = Drawable30.icon_23633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23634: DrawableResource
+  get() = Drawable30.icon_23634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23635: DrawableResource
+  get() = Drawable30.icon_23635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23636: DrawableResource
+  get() = Drawable30.icon_23636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23637: DrawableResource
+  get() = Drawable30.icon_23637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23638: DrawableResource
+  get() = Drawable30.icon_23638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23639: DrawableResource
+  get() = Drawable30.icon_23639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2364: DrawableResource
+  get() = Drawable30.icon_2364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23640: DrawableResource
+  get() = Drawable30.icon_23640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23641: DrawableResource
+  get() = Drawable30.icon_23641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23642: DrawableResource
+  get() = Drawable30.icon_23642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23643: DrawableResource
+  get() = Drawable30.icon_23643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23644: DrawableResource
+  get() = Drawable30.icon_23644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23645: DrawableResource
+  get() = Drawable30.icon_23645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23646: DrawableResource
+  get() = Drawable30.icon_23646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23647: DrawableResource
+  get() = Drawable30.icon_23647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23648: DrawableResource
+  get() = Drawable30.icon_23648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23649: DrawableResource
+  get() = Drawable30.icon_23649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2365: DrawableResource
+  get() = Drawable30.icon_2365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23650: DrawableResource
+  get() = Drawable30.icon_23650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23651: DrawableResource
+  get() = Drawable30.icon_23651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23652: DrawableResource
+  get() = Drawable30.icon_23652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23653: DrawableResource
+  get() = Drawable30.icon_23653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23654: DrawableResource
+  get() = Drawable30.icon_23654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23655: DrawableResource
+  get() = Drawable30.icon_23655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23656: DrawableResource
+  get() = Drawable30.icon_23656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23657: DrawableResource
+  get() = Drawable30.icon_23657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23658: DrawableResource
+  get() = Drawable30.icon_23658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23659: DrawableResource
+  get() = Drawable30.icon_23659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2366: DrawableResource
+  get() = Drawable30.icon_2366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23660: DrawableResource
+  get() = Drawable30.icon_23660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23661: DrawableResource
+  get() = Drawable30.icon_23661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23662: DrawableResource
+  get() = Drawable30.icon_23662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23663: DrawableResource
+  get() = Drawable30.icon_23663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23664: DrawableResource
+  get() = Drawable30.icon_23664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23665: DrawableResource
+  get() = Drawable30.icon_23665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23666: DrawableResource
+  get() = Drawable30.icon_23666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23667: DrawableResource
+  get() = Drawable30.icon_23667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23668: DrawableResource
+  get() = Drawable30.icon_23668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23669: DrawableResource
+  get() = Drawable30.icon_23669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2367: DrawableResource
+  get() = Drawable30.icon_2367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23670: DrawableResource
+  get() = Drawable30.icon_23670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23671: DrawableResource
+  get() = Drawable30.icon_23671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23672: DrawableResource
+  get() = Drawable30.icon_23672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23673: DrawableResource
+  get() = Drawable30.icon_23673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23674: DrawableResource
+  get() = Drawable30.icon_23674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23675: DrawableResource
+  get() = Drawable30.icon_23675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23676: DrawableResource
+  get() = Drawable30.icon_23676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23677: DrawableResource
+  get() = Drawable30.icon_23677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23678: DrawableResource
+  get() = Drawable30.icon_23678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23679: DrawableResource
+  get() = Drawable30.icon_23679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2368: DrawableResource
+  get() = Drawable30.icon_2368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23680: DrawableResource
+  get() = Drawable30.icon_23680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23681: DrawableResource
+  get() = Drawable30.icon_23681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23682: DrawableResource
+  get() = Drawable30.icon_23682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23683: DrawableResource
+  get() = Drawable30.icon_23683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23684: DrawableResource
+  get() = Drawable30.icon_23684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23685: DrawableResource
+  get() = Drawable30.icon_23685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23686: DrawableResource
+  get() = Drawable30.icon_23686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23687: DrawableResource
+  get() = Drawable30.icon_23687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23688: DrawableResource
+  get() = Drawable30.icon_23688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23689: DrawableResource
+  get() = Drawable30.icon_23689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2369: DrawableResource
+  get() = Drawable30.icon_2369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23690: DrawableResource
+  get() = Drawable30.icon_23690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23691: DrawableResource
+  get() = Drawable30.icon_23691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23692: DrawableResource
+  get() = Drawable30.icon_23692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23693: DrawableResource
+  get() = Drawable30.icon_23693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23694: DrawableResource
+  get() = Drawable30.icon_23694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23695: DrawableResource
+  get() = Drawable30.icon_23695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23696: DrawableResource
+  get() = Drawable30.icon_23696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23697: DrawableResource
+  get() = Drawable30.icon_23697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23698: DrawableResource
+  get() = Drawable30.icon_23698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23699: DrawableResource
+  get() = Drawable30.icon_23699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_237: DrawableResource
+  get() = Drawable30.icon_237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2370: DrawableResource
+  get() = Drawable30.icon_2370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23700: DrawableResource
+  get() = Drawable30.icon_23700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23701: DrawableResource
+  get() = Drawable30.icon_23701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23702: DrawableResource
+  get() = Drawable30.icon_23702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23703: DrawableResource
+  get() = Drawable30.icon_23703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23704: DrawableResource
+  get() = Drawable30.icon_23704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23705: DrawableResource
+  get() = Drawable30.icon_23705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23706: DrawableResource
+  get() = Drawable30.icon_23706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23707: DrawableResource
+  get() = Drawable30.icon_23707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23708: DrawableResource
+  get() = Drawable30.icon_23708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23709: DrawableResource
+  get() = Drawable30.icon_23709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2371: DrawableResource
+  get() = Drawable30.icon_2371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23710: DrawableResource
+  get() = Drawable30.icon_23710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23711: DrawableResource
+  get() = Drawable30.icon_23711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23712: DrawableResource
+  get() = Drawable30.icon_23712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23713: DrawableResource
+  get() = Drawable30.icon_23713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23714: DrawableResource
+  get() = Drawable30.icon_23714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23715: DrawableResource
+  get() = Drawable30.icon_23715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23716: DrawableResource
+  get() = Drawable30.icon_23716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23717: DrawableResource
+  get() = Drawable30.icon_23717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23718: DrawableResource
+  get() = Drawable30.icon_23718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23719: DrawableResource
+  get() = Drawable30.icon_23719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2372: DrawableResource
+  get() = Drawable30.icon_2372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23720: DrawableResource
+  get() = Drawable30.icon_23720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23721: DrawableResource
+  get() = Drawable30.icon_23721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23722: DrawableResource
+  get() = Drawable30.icon_23722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23723: DrawableResource
+  get() = Drawable30.icon_23723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23724: DrawableResource
+  get() = Drawable30.icon_23724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23725: DrawableResource
+  get() = Drawable30.icon_23725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23726: DrawableResource
+  get() = Drawable30.icon_23726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23727: DrawableResource
+  get() = Drawable30.icon_23727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23728: DrawableResource
+  get() = Drawable30.icon_23728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23729: DrawableResource
+  get() = Drawable30.icon_23729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2373: DrawableResource
+  get() = Drawable30.icon_2373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23730: DrawableResource
+  get() = Drawable30.icon_23730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23731: DrawableResource
+  get() = Drawable30.icon_23731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23732: DrawableResource
+  get() = Drawable30.icon_23732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23733: DrawableResource
+  get() = Drawable30.icon_23733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23734: DrawableResource
+  get() = Drawable30.icon_23734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23735: DrawableResource
+  get() = Drawable30.icon_23735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23736: DrawableResource
+  get() = Drawable30.icon_23736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23737: DrawableResource
+  get() = Drawable30.icon_23737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23738: DrawableResource
+  get() = Drawable30.icon_23738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23739: DrawableResource
+  get() = Drawable30.icon_23739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2374: DrawableResource
+  get() = Drawable30.icon_2374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23740: DrawableResource
+  get() = Drawable30.icon_23740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23741: DrawableResource
+  get() = Drawable30.icon_23741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23742: DrawableResource
+  get() = Drawable30.icon_23742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23743: DrawableResource
+  get() = Drawable30.icon_23743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23744: DrawableResource
+  get() = Drawable30.icon_23744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23745: DrawableResource
+  get() = Drawable30.icon_23745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23746: DrawableResource
+  get() = Drawable30.icon_23746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23747: DrawableResource
+  get() = Drawable30.icon_23747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23748: DrawableResource
+  get() = Drawable30.icon_23748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23749: DrawableResource
+  get() = Drawable30.icon_23749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2375: DrawableResource
+  get() = Drawable30.icon_2375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23750: DrawableResource
+  get() = Drawable30.icon_23750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23751: DrawableResource
+  get() = Drawable30.icon_23751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23752: DrawableResource
+  get() = Drawable30.icon_23752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23753: DrawableResource
+  get() = Drawable30.icon_23753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23754: DrawableResource
+  get() = Drawable30.icon_23754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23755: DrawableResource
+  get() = Drawable30.icon_23755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23756: DrawableResource
+  get() = Drawable30.icon_23756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23757: DrawableResource
+  get() = Drawable30.icon_23757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23758: DrawableResource
+  get() = Drawable30.icon_23758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23759: DrawableResource
+  get() = Drawable30.icon_23759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2376: DrawableResource
+  get() = Drawable30.icon_2376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23760: DrawableResource
+  get() = Drawable30.icon_23760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23761: DrawableResource
+  get() = Drawable30.icon_23761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23762: DrawableResource
+  get() = Drawable30.icon_23762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23763: DrawableResource
+  get() = Drawable30.icon_23763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23764: DrawableResource
+  get() = Drawable30.icon_23764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23765: DrawableResource
+  get() = Drawable30.icon_23765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23766: DrawableResource
+  get() = Drawable30.icon_23766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23767: DrawableResource
+  get() = Drawable30.icon_23767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23768: DrawableResource
+  get() = Drawable30.icon_23768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23769: DrawableResource
+  get() = Drawable30.icon_23769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2377: DrawableResource
+  get() = Drawable30.icon_2377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23770: DrawableResource
+  get() = Drawable30.icon_23770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23771: DrawableResource
+  get() = Drawable30.icon_23771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23772: DrawableResource
+  get() = Drawable30.icon_23772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23773: DrawableResource
+  get() = Drawable30.icon_23773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23774: DrawableResource
+  get() = Drawable30.icon_23774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23775: DrawableResource
+  get() = Drawable30.icon_23775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23776: DrawableResource
+  get() = Drawable30.icon_23776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23777: DrawableResource
+  get() = Drawable30.icon_23777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23778: DrawableResource
+  get() = Drawable30.icon_23778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23779: DrawableResource
+  get() = Drawable30.icon_23779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2378: DrawableResource
+  get() = Drawable30.icon_2378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23780: DrawableResource
+  get() = Drawable30.icon_23780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23781: DrawableResource
+  get() = Drawable30.icon_23781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23782: DrawableResource
+  get() = Drawable30.icon_23782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23783: DrawableResource
+  get() = Drawable30.icon_23783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23784: DrawableResource
+  get() = Drawable30.icon_23784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23785: DrawableResource
+  get() = Drawable30.icon_23785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23786: DrawableResource
+  get() = Drawable30.icon_23786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23787: DrawableResource
+  get() = Drawable30.icon_23787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23788: DrawableResource
+  get() = Drawable30.icon_23788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23789: DrawableResource
+  get() = Drawable30.icon_23789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2379: DrawableResource
+  get() = Drawable30.icon_2379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23790: DrawableResource
+  get() = Drawable30.icon_23790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23791: DrawableResource
+  get() = Drawable30.icon_23791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23792: DrawableResource
+  get() = Drawable30.icon_23792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23793: DrawableResource
+  get() = Drawable30.icon_23793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23794: DrawableResource
+  get() = Drawable30.icon_23794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23795: DrawableResource
+  get() = Drawable30.icon_23795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23796: DrawableResource
+  get() = Drawable30.icon_23796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23797: DrawableResource
+  get() = Drawable30.icon_23797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23798: DrawableResource
+  get() = Drawable30.icon_23798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23799: DrawableResource
+  get() = Drawable30.icon_23799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_238: DrawableResource
+  get() = Drawable30.icon_238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2380: DrawableResource
+  get() = Drawable30.icon_2380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23800: DrawableResource
+  get() = Drawable30.icon_23800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23801: DrawableResource
+  get() = Drawable30.icon_23801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23802: DrawableResource
+  get() = Drawable30.icon_23802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23803: DrawableResource
+  get() = Drawable30.icon_23803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23804: DrawableResource
+  get() = Drawable30.icon_23804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23805: DrawableResource
+  get() = Drawable30.icon_23805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23806: DrawableResource
+  get() = Drawable30.icon_23806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23807: DrawableResource
+  get() = Drawable30.icon_23807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23808: DrawableResource
+  get() = Drawable30.icon_23808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23809: DrawableResource
+  get() = Drawable30.icon_23809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2381: DrawableResource
+  get() = Drawable30.icon_2381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23810: DrawableResource
+  get() = Drawable30.icon_23810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23811: DrawableResource
+  get() = Drawable30.icon_23811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23812: DrawableResource
+  get() = Drawable30.icon_23812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23813: DrawableResource
+  get() = Drawable30.icon_23813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23814: DrawableResource
+  get() = Drawable30.icon_23814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23815: DrawableResource
+  get() = Drawable30.icon_23815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23816: DrawableResource
+  get() = Drawable30.icon_23816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23817: DrawableResource
+  get() = Drawable30.icon_23817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23818: DrawableResource
+  get() = Drawable30.icon_23818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23819: DrawableResource
+  get() = Drawable30.icon_23819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2382: DrawableResource
+  get() = Drawable30.icon_2382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23820: DrawableResource
+  get() = Drawable30.icon_23820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23821: DrawableResource
+  get() = Drawable30.icon_23821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23822: DrawableResource
+  get() = Drawable30.icon_23822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23823: DrawableResource
+  get() = Drawable30.icon_23823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23824: DrawableResource
+  get() = Drawable30.icon_23824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23825: DrawableResource
+  get() = Drawable30.icon_23825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23826: DrawableResource
+  get() = Drawable30.icon_23826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23827: DrawableResource
+  get() = Drawable30.icon_23827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23828: DrawableResource
+  get() = Drawable30.icon_23828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23829: DrawableResource
+  get() = Drawable30.icon_23829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2383: DrawableResource
+  get() = Drawable30.icon_2383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23830: DrawableResource
+  get() = Drawable30.icon_23830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23831: DrawableResource
+  get() = Drawable30.icon_23831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23832: DrawableResource
+  get() = Drawable30.icon_23832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23833: DrawableResource
+  get() = Drawable30.icon_23833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23834: DrawableResource
+  get() = Drawable30.icon_23834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23835: DrawableResource
+  get() = Drawable30.icon_23835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23836: DrawableResource
+  get() = Drawable30.icon_23836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23837: DrawableResource
+  get() = Drawable30.icon_23837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23838: DrawableResource
+  get() = Drawable30.icon_23838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23839: DrawableResource
+  get() = Drawable30.icon_23839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2384: DrawableResource
+  get() = Drawable30.icon_2384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23840: DrawableResource
+  get() = Drawable30.icon_23840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23841: DrawableResource
+  get() = Drawable30.icon_23841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23842: DrawableResource
+  get() = Drawable30.icon_23842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23843: DrawableResource
+  get() = Drawable30.icon_23843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23844: DrawableResource
+  get() = Drawable30.icon_23844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23845: DrawableResource
+  get() = Drawable30.icon_23845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23846: DrawableResource
+  get() = Drawable30.icon_23846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23847: DrawableResource
+  get() = Drawable30.icon_23847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23848: DrawableResource
+  get() = Drawable30.icon_23848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23849: DrawableResource
+  get() = Drawable30.icon_23849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2385: DrawableResource
+  get() = Drawable30.icon_2385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23850: DrawableResource
+  get() = Drawable30.icon_23850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23851: DrawableResource
+  get() = Drawable30.icon_23851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23852: DrawableResource
+  get() = Drawable30.icon_23852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23853: DrawableResource
+  get() = Drawable30.icon_23853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23854: DrawableResource
+  get() = Drawable30.icon_23854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23855: DrawableResource
+  get() = Drawable30.icon_23855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23856: DrawableResource
+  get() = Drawable30.icon_23856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23857: DrawableResource
+  get() = Drawable30.icon_23857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23858: DrawableResource
+  get() = Drawable30.icon_23858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23859: DrawableResource
+  get() = Drawable30.icon_23859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2386: DrawableResource
+  get() = Drawable30.icon_2386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23860: DrawableResource
+  get() = Drawable30.icon_23860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23861: DrawableResource
+  get() = Drawable30.icon_23861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23862: DrawableResource
+  get() = Drawable30.icon_23862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23863: DrawableResource
+  get() = Drawable30.icon_23863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23864: DrawableResource
+  get() = Drawable30.icon_23864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23865: DrawableResource
+  get() = Drawable30.icon_23865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23866: DrawableResource
+  get() = Drawable30.icon_23866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23867: DrawableResource
+  get() = Drawable30.icon_23867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23868: DrawableResource
+  get() = Drawable30.icon_23868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23869: DrawableResource
+  get() = Drawable30.icon_23869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2387: DrawableResource
+  get() = Drawable30.icon_2387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23870: DrawableResource
+  get() = Drawable30.icon_23870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23871: DrawableResource
+  get() = Drawable30.icon_23871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23872: DrawableResource
+  get() = Drawable30.icon_23872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23873: DrawableResource
+  get() = Drawable30.icon_23873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23874: DrawableResource
+  get() = Drawable30.icon_23874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23875: DrawableResource
+  get() = Drawable30.icon_23875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23876: DrawableResource
+  get() = Drawable30.icon_23876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23877: DrawableResource
+  get() = Drawable30.icon_23877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23878: DrawableResource
+  get() = Drawable30.icon_23878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23879: DrawableResource
+  get() = Drawable30.icon_23879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2388: DrawableResource
+  get() = Drawable30.icon_2388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23880: DrawableResource
+  get() = Drawable30.icon_23880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23881: DrawableResource
+  get() = Drawable30.icon_23881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23882: DrawableResource
+  get() = Drawable30.icon_23882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23883: DrawableResource
+  get() = Drawable30.icon_23883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23884: DrawableResource
+  get() = Drawable30.icon_23884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23885: DrawableResource
+  get() = Drawable30.icon_23885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23886: DrawableResource
+  get() = Drawable30.icon_23886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23887: DrawableResource
+  get() = Drawable30.icon_23887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23888: DrawableResource
+  get() = Drawable30.icon_23888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23889: DrawableResource
+  get() = Drawable30.icon_23889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2389: DrawableResource
+  get() = Drawable30.icon_2389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23890: DrawableResource
+  get() = Drawable30.icon_23890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23891: DrawableResource
+  get() = Drawable30.icon_23891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23892: DrawableResource
+  get() = Drawable30.icon_23892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23893: DrawableResource
+  get() = Drawable30.icon_23893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23894: DrawableResource
+  get() = Drawable30.icon_23894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23895: DrawableResource
+  get() = Drawable30.icon_23895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23896: DrawableResource
+  get() = Drawable30.icon_23896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23897: DrawableResource
+  get() = Drawable30.icon_23897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23898: DrawableResource
+  get() = Drawable30.icon_23898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23899: DrawableResource
+  get() = Drawable30.icon_23899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_239: DrawableResource
+  get() = Drawable30.icon_239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2390: DrawableResource
+  get() = Drawable30.icon_2390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23900: DrawableResource
+  get() = Drawable30.icon_23900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23901: DrawableResource
+  get() = Drawable30.icon_23901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23902: DrawableResource
+  get() = Drawable30.icon_23902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23903: DrawableResource
+  get() = Drawable30.icon_23903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23904: DrawableResource
+  get() = Drawable30.icon_23904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23905: DrawableResource
+  get() = Drawable30.icon_23905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23906: DrawableResource
+  get() = Drawable30.icon_23906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23907: DrawableResource
+  get() = Drawable30.icon_23907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23908: DrawableResource
+  get() = Drawable30.icon_23908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23909: DrawableResource
+  get() = Drawable30.icon_23909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2391: DrawableResource
+  get() = Drawable30.icon_2391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23910: DrawableResource
+  get() = Drawable30.icon_23910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23911: DrawableResource
+  get() = Drawable30.icon_23911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23912: DrawableResource
+  get() = Drawable30.icon_23912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23913: DrawableResource
+  get() = Drawable30.icon_23913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23914: DrawableResource
+  get() = Drawable30.icon_23914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23915: DrawableResource
+  get() = Drawable30.icon_23915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23916: DrawableResource
+  get() = Drawable30.icon_23916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23917: DrawableResource
+  get() = Drawable30.icon_23917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23918: DrawableResource
+  get() = Drawable30.icon_23918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23919: DrawableResource
+  get() = Drawable30.icon_23919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2392: DrawableResource
+  get() = Drawable30.icon_2392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23920: DrawableResource
+  get() = Drawable30.icon_23920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23921: DrawableResource
+  get() = Drawable30.icon_23921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23922: DrawableResource
+  get() = Drawable30.icon_23922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23923: DrawableResource
+  get() = Drawable30.icon_23923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23924: DrawableResource
+  get() = Drawable30.icon_23924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23925: DrawableResource
+  get() = Drawable30.icon_23925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23926: DrawableResource
+  get() = Drawable30.icon_23926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23927: DrawableResource
+  get() = Drawable30.icon_23927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23928: DrawableResource
+  get() = Drawable30.icon_23928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23929: DrawableResource
+  get() = Drawable30.icon_23929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2393: DrawableResource
+  get() = Drawable30.icon_2393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23930: DrawableResource
+  get() = Drawable30.icon_23930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23931: DrawableResource
+  get() = Drawable30.icon_23931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23932: DrawableResource
+  get() = Drawable30.icon_23932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23933: DrawableResource
+  get() = Drawable30.icon_23933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23934: DrawableResource
+  get() = Drawable30.icon_23934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23935: DrawableResource
+  get() = Drawable30.icon_23935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23936: DrawableResource
+  get() = Drawable30.icon_23936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23937: DrawableResource
+  get() = Drawable30.icon_23937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23938: DrawableResource
+  get() = Drawable30.icon_23938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23939: DrawableResource
+  get() = Drawable30.icon_23939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2394: DrawableResource
+  get() = Drawable30.icon_2394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23940: DrawableResource
+  get() = Drawable30.icon_23940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23941: DrawableResource
+  get() = Drawable30.icon_23941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23942: DrawableResource
+  get() = Drawable30.icon_23942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23943: DrawableResource
+  get() = Drawable30.icon_23943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23944: DrawableResource
+  get() = Drawable30.icon_23944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23945: DrawableResource
+  get() = Drawable30.icon_23945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23946: DrawableResource
+  get() = Drawable30.icon_23946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23947: DrawableResource
+  get() = Drawable30.icon_23947

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable31.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable31.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable31 {
+  public val icon_23948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23948.xml"),
+          )
+      )
+
+  public val icon_23949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23949.xml"),
+          )
+      )
+
+  public val icon_2395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2395.xml"),
+          )
+      )
+
+  public val icon_23950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23950.xml"),
+          )
+      )
+
+  public val icon_23951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23951.xml"),
+          )
+      )
+
+  public val icon_23952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23952.xml"),
+          )
+      )
+
+  public val icon_23953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23953.xml"),
+          )
+      )
+
+  public val icon_23954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23954.xml"),
+          )
+      )
+
+  public val icon_23955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23955.xml"),
+          )
+      )
+
+  public val icon_23956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23956.xml"),
+          )
+      )
+
+  public val icon_23957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23957.xml"),
+          )
+      )
+
+  public val icon_23958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23958.xml"),
+          )
+      )
+
+  public val icon_23959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23959.xml"),
+          )
+      )
+
+  public val icon_2396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2396.xml"),
+          )
+      )
+
+  public val icon_23960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23960.xml"),
+          )
+      )
+
+  public val icon_23961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23961.xml"),
+          )
+      )
+
+  public val icon_23962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23962.xml"),
+          )
+      )
+
+  public val icon_23963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23963.xml"),
+          )
+      )
+
+  public val icon_23964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23964.xml"),
+          )
+      )
+
+  public val icon_23965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23965.xml"),
+          )
+      )
+
+  public val icon_23966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23966.xml"),
+          )
+      )
+
+  public val icon_23967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23967.xml"),
+          )
+      )
+
+  public val icon_23968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23968.xml"),
+          )
+      )
+
+  public val icon_23969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23969.xml"),
+          )
+      )
+
+  public val icon_2397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2397.xml"),
+          )
+      )
+
+  public val icon_23970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23970.xml"),
+          )
+      )
+
+  public val icon_23971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23971.xml"),
+          )
+      )
+
+  public val icon_23972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23972.xml"),
+          )
+      )
+
+  public val icon_23973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23973.xml"),
+          )
+      )
+
+  public val icon_23974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23974.xml"),
+          )
+      )
+
+  public val icon_23975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23975.xml"),
+          )
+      )
+
+  public val icon_23976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23976.xml"),
+          )
+      )
+
+  public val icon_23977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23977.xml"),
+          )
+      )
+
+  public val icon_23978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23978.xml"),
+          )
+      )
+
+  public val icon_23979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23979.xml"),
+          )
+      )
+
+  public val icon_2398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2398.xml"),
+          )
+      )
+
+  public val icon_23980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23980.xml"),
+          )
+      )
+
+  public val icon_23981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23981.xml"),
+          )
+      )
+
+  public val icon_23982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23982.xml"),
+          )
+      )
+
+  public val icon_23983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23983.xml"),
+          )
+      )
+
+  public val icon_23984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23984.xml"),
+          )
+      )
+
+  public val icon_23985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23985.xml"),
+          )
+      )
+
+  public val icon_23986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23986.xml"),
+          )
+      )
+
+  public val icon_23987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23987.xml"),
+          )
+      )
+
+  public val icon_23988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23988.xml"),
+          )
+      )
+
+  public val icon_23989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23989.xml"),
+          )
+      )
+
+  public val icon_2399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2399.xml"),
+          )
+      )
+
+  public val icon_23990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23990.xml"),
+          )
+      )
+
+  public val icon_23991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23991.xml"),
+          )
+      )
+
+  public val icon_23992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23992.xml"),
+          )
+      )
+
+  public val icon_23993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23993.xml"),
+          )
+      )
+
+  public val icon_23994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23994.xml"),
+          )
+      )
+
+  public val icon_23995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23995.xml"),
+          )
+      )
+
+  public val icon_23996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23996.xml"),
+          )
+      )
+
+  public val icon_23997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23997.xml"),
+          )
+      )
+
+  public val icon_23998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23998.xml"),
+          )
+      )
+
+  public val icon_23999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_23999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_23999.xml"),
+          )
+      )
+
+  public val icon_24: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24.xml"),
+          )
+      )
+
+  public val icon_240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_240.xml"),
+          )
+      )
+
+  public val icon_2400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2400.xml"),
+          )
+      )
+
+  public val icon_24000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24000.xml"),
+          )
+      )
+
+  public val icon_24001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24001.xml"),
+          )
+      )
+
+  public val icon_24002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24002.xml"),
+          )
+      )
+
+  public val icon_24003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24003.xml"),
+          )
+      )
+
+  public val icon_24004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24004.xml"),
+          )
+      )
+
+  public val icon_24005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24005.xml"),
+          )
+      )
+
+  public val icon_24006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24006.xml"),
+          )
+      )
+
+  public val icon_24007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24007.xml"),
+          )
+      )
+
+  public val icon_24008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24008.xml"),
+          )
+      )
+
+  public val icon_24009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24009.xml"),
+          )
+      )
+
+  public val icon_2401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2401.xml"),
+          )
+      )
+
+  public val icon_24010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24010.xml"),
+          )
+      )
+
+  public val icon_24011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24011.xml"),
+          )
+      )
+
+  public val icon_24012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24012.xml"),
+          )
+      )
+
+  public val icon_24013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24013.xml"),
+          )
+      )
+
+  public val icon_24014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24014.xml"),
+          )
+      )
+
+  public val icon_24015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24015.xml"),
+          )
+      )
+
+  public val icon_24016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24016.xml"),
+          )
+      )
+
+  public val icon_24017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24017.xml"),
+          )
+      )
+
+  public val icon_24018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24018.xml"),
+          )
+      )
+
+  public val icon_24019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24019.xml"),
+          )
+      )
+
+  public val icon_2402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2402.xml"),
+          )
+      )
+
+  public val icon_24020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24020.xml"),
+          )
+      )
+
+  public val icon_24021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24021.xml"),
+          )
+      )
+
+  public val icon_24022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24022.xml"),
+          )
+      )
+
+  public val icon_24023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24023.xml"),
+          )
+      )
+
+  public val icon_24024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24024.xml"),
+          )
+      )
+
+  public val icon_24025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24025.xml"),
+          )
+      )
+
+  public val icon_24026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24026.xml"),
+          )
+      )
+
+  public val icon_24027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24027.xml"),
+          )
+      )
+
+  public val icon_24028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24028.xml"),
+          )
+      )
+
+  public val icon_24029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24029.xml"),
+          )
+      )
+
+  public val icon_2403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2403.xml"),
+          )
+      )
+
+  public val icon_24030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24030.xml"),
+          )
+      )
+
+  public val icon_24031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24031.xml"),
+          )
+      )
+
+  public val icon_24032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24032.xml"),
+          )
+      )
+
+  public val icon_24033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24033.xml"),
+          )
+      )
+
+  public val icon_24034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24034.xml"),
+          )
+      )
+
+  public val icon_24035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24035.xml"),
+          )
+      )
+
+  public val icon_24036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24036.xml"),
+          )
+      )
+
+  public val icon_24037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24037.xml"),
+          )
+      )
+
+  public val icon_24038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24038.xml"),
+          )
+      )
+
+  public val icon_24039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24039.xml"),
+          )
+      )
+
+  public val icon_2404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2404.xml"),
+          )
+      )
+
+  public val icon_24040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24040.xml"),
+          )
+      )
+
+  public val icon_24041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24041.xml"),
+          )
+      )
+
+  public val icon_24042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24042.xml"),
+          )
+      )
+
+  public val icon_24043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24043.xml"),
+          )
+      )
+
+  public val icon_24044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24044.xml"),
+          )
+      )
+
+  public val icon_24045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24045.xml"),
+          )
+      )
+
+  public val icon_24046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24046.xml"),
+          )
+      )
+
+  public val icon_24047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24047.xml"),
+          )
+      )
+
+  public val icon_24048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24048.xml"),
+          )
+      )
+
+  public val icon_24049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24049.xml"),
+          )
+      )
+
+  public val icon_2405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2405.xml"),
+          )
+      )
+
+  public val icon_24050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24050.xml"),
+          )
+      )
+
+  public val icon_24051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24051.xml"),
+          )
+      )
+
+  public val icon_24052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24052.xml"),
+          )
+      )
+
+  public val icon_24053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24053.xml"),
+          )
+      )
+
+  public val icon_24054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24054.xml"),
+          )
+      )
+
+  public val icon_24055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24055.xml"),
+          )
+      )
+
+  public val icon_24056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24056.xml"),
+          )
+      )
+
+  public val icon_24057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24057.xml"),
+          )
+      )
+
+  public val icon_24058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24058.xml"),
+          )
+      )
+
+  public val icon_24059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24059.xml"),
+          )
+      )
+
+  public val icon_2406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2406.xml"),
+          )
+      )
+
+  public val icon_24060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24060.xml"),
+          )
+      )
+
+  public val icon_24061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24061.xml"),
+          )
+      )
+
+  public val icon_24062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24062.xml"),
+          )
+      )
+
+  public val icon_24063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24063.xml"),
+          )
+      )
+
+  public val icon_24064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24064.xml"),
+          )
+      )
+
+  public val icon_24065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24065.xml"),
+          )
+      )
+
+  public val icon_24066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24066.xml"),
+          )
+      )
+
+  public val icon_24067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24067.xml"),
+          )
+      )
+
+  public val icon_24068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24068.xml"),
+          )
+      )
+
+  public val icon_24069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24069.xml"),
+          )
+      )
+
+  public val icon_2407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2407.xml"),
+          )
+      )
+
+  public val icon_24070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24070.xml"),
+          )
+      )
+
+  public val icon_24071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24071.xml"),
+          )
+      )
+
+  public val icon_24072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24072.xml"),
+          )
+      )
+
+  public val icon_24073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24073.xml"),
+          )
+      )
+
+  public val icon_24074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24074.xml"),
+          )
+      )
+
+  public val icon_24075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24075.xml"),
+          )
+      )
+
+  public val icon_24076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24076.xml"),
+          )
+      )
+
+  public val icon_24077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24077.xml"),
+          )
+      )
+
+  public val icon_24078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24078.xml"),
+          )
+      )
+
+  public val icon_24079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24079.xml"),
+          )
+      )
+
+  public val icon_2408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2408.xml"),
+          )
+      )
+
+  public val icon_24080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24080.xml"),
+          )
+      )
+
+  public val icon_24081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24081.xml"),
+          )
+      )
+
+  public val icon_24082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24082.xml"),
+          )
+      )
+
+  public val icon_24083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24083.xml"),
+          )
+      )
+
+  public val icon_24084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24084.xml"),
+          )
+      )
+
+  public val icon_24085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24085.xml"),
+          )
+      )
+
+  public val icon_24086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24086.xml"),
+          )
+      )
+
+  public val icon_24087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24087.xml"),
+          )
+      )
+
+  public val icon_24088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24088.xml"),
+          )
+      )
+
+  public val icon_24089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24089.xml"),
+          )
+      )
+
+  public val icon_2409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2409.xml"),
+          )
+      )
+
+  public val icon_24090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24090.xml"),
+          )
+      )
+
+  public val icon_24091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24091.xml"),
+          )
+      )
+
+  public val icon_24092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24092.xml"),
+          )
+      )
+
+  public val icon_24093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24093.xml"),
+          )
+      )
+
+  public val icon_24094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24094.xml"),
+          )
+      )
+
+  public val icon_24095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24095.xml"),
+          )
+      )
+
+  public val icon_24096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24096.xml"),
+          )
+      )
+
+  public val icon_24097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24097.xml"),
+          )
+      )
+
+  public val icon_24098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24098.xml"),
+          )
+      )
+
+  public val icon_24099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24099.xml"),
+          )
+      )
+
+  public val icon_241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_241.xml"),
+          )
+      )
+
+  public val icon_2410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2410.xml"),
+          )
+      )
+
+  public val icon_24100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24100.xml"),
+          )
+      )
+
+  public val icon_24101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24101.xml"),
+          )
+      )
+
+  public val icon_24102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24102.xml"),
+          )
+      )
+
+  public val icon_24103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24103.xml"),
+          )
+      )
+
+  public val icon_24104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24104.xml"),
+          )
+      )
+
+  public val icon_24105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24105.xml"),
+          )
+      )
+
+  public val icon_24106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24106.xml"),
+          )
+      )
+
+  public val icon_24107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24107.xml"),
+          )
+      )
+
+  public val icon_24108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24108.xml"),
+          )
+      )
+
+  public val icon_24109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24109.xml"),
+          )
+      )
+
+  public val icon_2411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2411.xml"),
+          )
+      )
+
+  public val icon_24110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24110.xml"),
+          )
+      )
+
+  public val icon_24111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24111.xml"),
+          )
+      )
+
+  public val icon_24112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24112.xml"),
+          )
+      )
+
+  public val icon_24113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24113.xml"),
+          )
+      )
+
+  public val icon_24114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24114.xml"),
+          )
+      )
+
+  public val icon_24115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24115.xml"),
+          )
+      )
+
+  public val icon_24116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24116.xml"),
+          )
+      )
+
+  public val icon_24117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24117.xml"),
+          )
+      )
+
+  public val icon_24118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24118.xml"),
+          )
+      )
+
+  public val icon_24119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24119.xml"),
+          )
+      )
+
+  public val icon_2412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2412.xml"),
+          )
+      )
+
+  public val icon_24120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24120.xml"),
+          )
+      )
+
+  public val icon_24121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24121.xml"),
+          )
+      )
+
+  public val icon_24122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24122.xml"),
+          )
+      )
+
+  public val icon_24123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24123.xml"),
+          )
+      )
+
+  public val icon_24124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24124.xml"),
+          )
+      )
+
+  public val icon_24125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24125.xml"),
+          )
+      )
+
+  public val icon_24126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24126.xml"),
+          )
+      )
+
+  public val icon_24127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24127.xml"),
+          )
+      )
+
+  public val icon_24128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24128.xml"),
+          )
+      )
+
+  public val icon_24129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24129.xml"),
+          )
+      )
+
+  public val icon_2413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2413.xml"),
+          )
+      )
+
+  public val icon_24130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24130.xml"),
+          )
+      )
+
+  public val icon_24131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24131.xml"),
+          )
+      )
+
+  public val icon_24132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24132.xml"),
+          )
+      )
+
+  public val icon_24133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24133.xml"),
+          )
+      )
+
+  public val icon_24134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24134.xml"),
+          )
+      )
+
+  public val icon_24135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24135.xml"),
+          )
+      )
+
+  public val icon_24136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24136.xml"),
+          )
+      )
+
+  public val icon_24137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24137.xml"),
+          )
+      )
+
+  public val icon_24138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24138.xml"),
+          )
+      )
+
+  public val icon_24139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24139.xml"),
+          )
+      )
+
+  public val icon_2414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2414.xml"),
+          )
+      )
+
+  public val icon_24140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24140.xml"),
+          )
+      )
+
+  public val icon_24141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24141.xml"),
+          )
+      )
+
+  public val icon_24142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24142.xml"),
+          )
+      )
+
+  public val icon_24143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24143.xml"),
+          )
+      )
+
+  public val icon_24144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24144.xml"),
+          )
+      )
+
+  public val icon_24145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24145.xml"),
+          )
+      )
+
+  public val icon_24146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24146.xml"),
+          )
+      )
+
+  public val icon_24147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24147.xml"),
+          )
+      )
+
+  public val icon_24148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24148.xml"),
+          )
+      )
+
+  public val icon_24149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24149.xml"),
+          )
+      )
+
+  public val icon_2415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2415.xml"),
+          )
+      )
+
+  public val icon_24150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24150.xml"),
+          )
+      )
+
+  public val icon_24151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24151.xml"),
+          )
+      )
+
+  public val icon_24152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24152.xml"),
+          )
+      )
+
+  public val icon_24153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24153.xml"),
+          )
+      )
+
+  public val icon_24154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24154.xml"),
+          )
+      )
+
+  public val icon_24155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24155.xml"),
+          )
+      )
+
+  public val icon_24156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24156.xml"),
+          )
+      )
+
+  public val icon_24157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24157.xml"),
+          )
+      )
+
+  public val icon_24158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24158.xml"),
+          )
+      )
+
+  public val icon_24159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24159.xml"),
+          )
+      )
+
+  public val icon_2416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2416.xml"),
+          )
+      )
+
+  public val icon_24160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24160.xml"),
+          )
+      )
+
+  public val icon_24161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24161.xml"),
+          )
+      )
+
+  public val icon_24162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24162.xml"),
+          )
+      )
+
+  public val icon_24163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24163.xml"),
+          )
+      )
+
+  public val icon_24164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24164.xml"),
+          )
+      )
+
+  public val icon_24165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24165.xml"),
+          )
+      )
+
+  public val icon_24166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24166.xml"),
+          )
+      )
+
+  public val icon_24167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24167.xml"),
+          )
+      )
+
+  public val icon_24168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24168.xml"),
+          )
+      )
+
+  public val icon_24169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24169.xml"),
+          )
+      )
+
+  public val icon_2417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2417.xml"),
+          )
+      )
+
+  public val icon_24170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24170.xml"),
+          )
+      )
+
+  public val icon_24171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24171.xml"),
+          )
+      )
+
+  public val icon_24172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24172.xml"),
+          )
+      )
+
+  public val icon_24173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24173.xml"),
+          )
+      )
+
+  public val icon_24174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24174.xml"),
+          )
+      )
+
+  public val icon_24175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24175.xml"),
+          )
+      )
+
+  public val icon_24176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24176.xml"),
+          )
+      )
+
+  public val icon_24177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24177.xml"),
+          )
+      )
+
+  public val icon_24178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24178.xml"),
+          )
+      )
+
+  public val icon_24179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24179.xml"),
+          )
+      )
+
+  public val icon_2418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2418.xml"),
+          )
+      )
+
+  public val icon_24180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24180.xml"),
+          )
+      )
+
+  public val icon_24181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24181.xml"),
+          )
+      )
+
+  public val icon_24182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24182.xml"),
+          )
+      )
+
+  public val icon_24183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24183.xml"),
+          )
+      )
+
+  public val icon_24184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24184.xml"),
+          )
+      )
+
+  public val icon_24185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24185.xml"),
+          )
+      )
+
+  public val icon_24186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24186.xml"),
+          )
+      )
+
+  public val icon_24187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24187.xml"),
+          )
+      )
+
+  public val icon_24188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24188.xml"),
+          )
+      )
+
+  public val icon_24189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24189.xml"),
+          )
+      )
+
+  public val icon_2419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2419.xml"),
+          )
+      )
+
+  public val icon_24190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24190.xml"),
+          )
+      )
+
+  public val icon_24191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24191.xml"),
+          )
+      )
+
+  public val icon_24192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24192.xml"),
+          )
+      )
+
+  public val icon_24193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24193.xml"),
+          )
+      )
+
+  public val icon_24194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24194.xml"),
+          )
+      )
+
+  public val icon_24195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24195.xml"),
+          )
+      )
+
+  public val icon_24196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24196.xml"),
+          )
+      )
+
+  public val icon_24197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24197.xml"),
+          )
+      )
+
+  public val icon_24198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24198.xml"),
+          )
+      )
+
+  public val icon_24199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24199.xml"),
+          )
+      )
+
+  public val icon_242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_242.xml"),
+          )
+      )
+
+  public val icon_2420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2420.xml"),
+          )
+      )
+
+  public val icon_24200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24200.xml"),
+          )
+      )
+
+  public val icon_24201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24201.xml"),
+          )
+      )
+
+  public val icon_24202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24202.xml"),
+          )
+      )
+
+  public val icon_24203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24203.xml"),
+          )
+      )
+
+  public val icon_24204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24204.xml"),
+          )
+      )
+
+  public val icon_24205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24205.xml"),
+          )
+      )
+
+  public val icon_24206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24206.xml"),
+          )
+      )
+
+  public val icon_24207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24207.xml"),
+          )
+      )
+
+  public val icon_24208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24208.xml"),
+          )
+      )
+
+  public val icon_24209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24209.xml"),
+          )
+      )
+
+  public val icon_2421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2421.xml"),
+          )
+      )
+
+  public val icon_24210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24210.xml"),
+          )
+      )
+
+  public val icon_24211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24211.xml"),
+          )
+      )
+
+  public val icon_24212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24212.xml"),
+          )
+      )
+
+  public val icon_24213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24213.xml"),
+          )
+      )
+
+  public val icon_24214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24214.xml"),
+          )
+      )
+
+  public val icon_24215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24215.xml"),
+          )
+      )
+
+  public val icon_24216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24216.xml"),
+          )
+      )
+
+  public val icon_24217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24217.xml"),
+          )
+      )
+
+  public val icon_24218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24218.xml"),
+          )
+      )
+
+  public val icon_24219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24219.xml"),
+          )
+      )
+
+  public val icon_2422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2422.xml"),
+          )
+      )
+
+  public val icon_24220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24220.xml"),
+          )
+      )
+
+  public val icon_24221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24221.xml"),
+          )
+      )
+
+  public val icon_24222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24222.xml"),
+          )
+      )
+
+  public val icon_24223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24223.xml"),
+          )
+      )
+
+  public val icon_24224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24224.xml"),
+          )
+      )
+
+  public val icon_24225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24225.xml"),
+          )
+      )
+
+  public val icon_24226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24226.xml"),
+          )
+      )
+
+  public val icon_24227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24227.xml"),
+          )
+      )
+
+  public val icon_24228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24228.xml"),
+          )
+      )
+
+  public val icon_24229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24229.xml"),
+          )
+      )
+
+  public val icon_2423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2423.xml"),
+          )
+      )
+
+  public val icon_24230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24230.xml"),
+          )
+      )
+
+  public val icon_24231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24231.xml"),
+          )
+      )
+
+  public val icon_24232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24232.xml"),
+          )
+      )
+
+  public val icon_24233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24233.xml"),
+          )
+      )
+
+  public val icon_24234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24234.xml"),
+          )
+      )
+
+  public val icon_24235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24235.xml"),
+          )
+      )
+
+  public val icon_24236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24236.xml"),
+          )
+      )
+
+  public val icon_24237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24237.xml"),
+          )
+      )
+
+  public val icon_24238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24238.xml"),
+          )
+      )
+
+  public val icon_24239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24239.xml"),
+          )
+      )
+
+  public val icon_2424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2424.xml"),
+          )
+      )
+
+  public val icon_24240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24240.xml"),
+          )
+      )
+
+  public val icon_24241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24241.xml"),
+          )
+      )
+
+  public val icon_24242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24242.xml"),
+          )
+      )
+
+  public val icon_24243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24243.xml"),
+          )
+      )
+
+  public val icon_24244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24244.xml"),
+          )
+      )
+
+  public val icon_24245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24245.xml"),
+          )
+      )
+
+  public val icon_24246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24246.xml"),
+          )
+      )
+
+  public val icon_24247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24247.xml"),
+          )
+      )
+
+  public val icon_24248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24248.xml"),
+          )
+      )
+
+  public val icon_24249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24249.xml"),
+          )
+      )
+
+  public val icon_2425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2425.xml"),
+          )
+      )
+
+  public val icon_24250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24250.xml"),
+          )
+      )
+
+  public val icon_24251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24251.xml"),
+          )
+      )
+
+  public val icon_24252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24252.xml"),
+          )
+      )
+
+  public val icon_24253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24253.xml"),
+          )
+      )
+
+  public val icon_24254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24254.xml"),
+          )
+      )
+
+  public val icon_24255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24255.xml"),
+          )
+      )
+
+  public val icon_24256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24256.xml"),
+          )
+      )
+
+  public val icon_24257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24257.xml"),
+          )
+      )
+
+  public val icon_24258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24258.xml"),
+          )
+      )
+
+  public val icon_24259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24259.xml"),
+          )
+      )
+
+  public val icon_2426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2426.xml"),
+          )
+      )
+
+  public val icon_24260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24260.xml"),
+          )
+      )
+
+  public val icon_24261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24261.xml"),
+          )
+      )
+
+  public val icon_24262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24262.xml"),
+          )
+      )
+
+  public val icon_24263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24263.xml"),
+          )
+      )
+
+  public val icon_24264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24264.xml"),
+          )
+      )
+
+  public val icon_24265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24265.xml"),
+          )
+      )
+
+  public val icon_24266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24266.xml"),
+          )
+      )
+
+  public val icon_24267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24267.xml"),
+          )
+      )
+
+  public val icon_24268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24268.xml"),
+          )
+      )
+
+  public val icon_24269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24269.xml"),
+          )
+      )
+
+  public val icon_2427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2427.xml"),
+          )
+      )
+
+  public val icon_24270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24270.xml"),
+          )
+      )
+
+  public val icon_24271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24271.xml"),
+          )
+      )
+
+  public val icon_24272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24272.xml"),
+          )
+      )
+
+  public val icon_24273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24273.xml"),
+          )
+      )
+
+  public val icon_24274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24274.xml"),
+          )
+      )
+
+  public val icon_24275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24275.xml"),
+          )
+      )
+
+  public val icon_24276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24276.xml"),
+          )
+      )
+
+  public val icon_24277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24277.xml"),
+          )
+      )
+
+  public val icon_24278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24278.xml"),
+          )
+      )
+
+  public val icon_24279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24279.xml"),
+          )
+      )
+
+  public val icon_2428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2428.xml"),
+          )
+      )
+
+  public val icon_24280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24280.xml"),
+          )
+      )
+
+  public val icon_24281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24281.xml"),
+          )
+      )
+
+  public val icon_24282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24282.xml"),
+          )
+      )
+
+  public val icon_24283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24283.xml"),
+          )
+      )
+
+  public val icon_24284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24284.xml"),
+          )
+      )
+
+  public val icon_24285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24285.xml"),
+          )
+      )
+
+  public val icon_24286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24286.xml"),
+          )
+      )
+
+  public val icon_24287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24287.xml"),
+          )
+      )
+
+  public val icon_24288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24288.xml"),
+          )
+      )
+
+  public val icon_24289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24289.xml"),
+          )
+      )
+
+  public val icon_2429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2429.xml"),
+          )
+      )
+
+  public val icon_24290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24290.xml"),
+          )
+      )
+
+  public val icon_24291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24291.xml"),
+          )
+      )
+
+  public val icon_24292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24292.xml"),
+          )
+      )
+
+  public val icon_24293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24293.xml"),
+          )
+      )
+
+  public val icon_24294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24294.xml"),
+          )
+      )
+
+  public val icon_24295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24295.xml"),
+          )
+      )
+
+  public val icon_24296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24296.xml"),
+          )
+      )
+
+  public val icon_24297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24297.xml"),
+          )
+      )
+
+  public val icon_24298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24298.xml"),
+          )
+      )
+
+  public val icon_24299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24299.xml"),
+          )
+      )
+
+  public val icon_243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_243.xml"),
+          )
+      )
+
+  public val icon_2430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2430.xml"),
+          )
+      )
+
+  public val icon_24300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24300.xml"),
+          )
+      )
+
+  public val icon_24301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24301.xml"),
+          )
+      )
+
+  public val icon_24302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24302.xml"),
+          )
+      )
+
+  public val icon_24303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24303.xml"),
+          )
+      )
+
+  public val icon_24304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24304.xml"),
+          )
+      )
+
+  public val icon_24305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24305.xml"),
+          )
+      )
+
+  public val icon_24306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24306.xml"),
+          )
+      )
+
+  public val icon_24307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24307.xml"),
+          )
+      )
+
+  public val icon_24308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24308.xml"),
+          )
+      )
+
+  public val icon_24309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24309.xml"),
+          )
+      )
+
+  public val icon_2431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2431.xml"),
+          )
+      )
+
+  public val icon_24310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24310.xml"),
+          )
+      )
+
+  public val icon_24311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24311.xml"),
+          )
+      )
+
+  public val icon_24312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24312.xml"),
+          )
+      )
+
+  public val icon_24313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24313.xml"),
+          )
+      )
+
+  public val icon_24314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24314.xml"),
+          )
+      )
+
+  public val icon_24315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24315.xml"),
+          )
+      )
+
+  public val icon_24316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24316.xml"),
+          )
+      )
+
+  public val icon_24317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24317.xml"),
+          )
+      )
+
+  public val icon_24318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24318.xml"),
+          )
+      )
+
+  public val icon_24319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24319.xml"),
+          )
+      )
+
+  public val icon_2432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2432.xml"),
+          )
+      )
+
+  public val icon_24320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24320.xml"),
+          )
+      )
+
+  public val icon_24321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24321.xml"),
+          )
+      )
+
+  public val icon_24322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24322.xml"),
+          )
+      )
+
+  public val icon_24323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24323.xml"),
+          )
+      )
+
+  public val icon_24324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24324.xml"),
+          )
+      )
+
+  public val icon_24325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24325.xml"),
+          )
+      )
+
+  public val icon_24326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24326.xml"),
+          )
+      )
+
+  public val icon_24327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24327.xml"),
+          )
+      )
+
+  public val icon_24328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24328.xml"),
+          )
+      )
+
+  public val icon_24329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24329.xml"),
+          )
+      )
+
+  public val icon_2433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2433.xml"),
+          )
+      )
+
+  public val icon_24330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24330.xml"),
+          )
+      )
+
+  public val icon_24331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24331.xml"),
+          )
+      )
+
+  public val icon_24332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24332.xml"),
+          )
+      )
+
+  public val icon_24333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24333.xml"),
+          )
+      )
+
+  public val icon_24334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24334.xml"),
+          )
+      )
+
+  public val icon_24335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24335.xml"),
+          )
+      )
+
+  public val icon_24336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24336.xml"),
+          )
+      )
+
+  public val icon_24337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24337.xml"),
+          )
+      )
+
+  public val icon_24338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24338.xml"),
+          )
+      )
+
+  public val icon_24339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24339.xml"),
+          )
+      )
+
+  public val icon_2434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2434.xml"),
+          )
+      )
+
+  public val icon_24340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24340.xml"),
+          )
+      )
+
+  public val icon_24341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24341.xml"),
+          )
+      )
+
+  public val icon_24342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24342.xml"),
+          )
+      )
+
+  public val icon_24343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24343.xml"),
+          )
+      )
+
+  public val icon_24344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24344.xml"),
+          )
+      )
+
+  public val icon_24345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24345.xml"),
+          )
+      )
+
+  public val icon_24346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24346.xml"),
+          )
+      )
+
+  public val icon_24347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24347.xml"),
+          )
+      )
+
+  public val icon_24348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24348.xml"),
+          )
+      )
+
+  public val icon_24349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24349.xml"),
+          )
+      )
+
+  public val icon_2435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2435.xml"),
+          )
+      )
+
+  public val icon_24350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24350.xml"),
+          )
+      )
+
+  public val icon_24351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24351.xml"),
+          )
+      )
+
+  public val icon_24352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24352.xml"),
+          )
+      )
+
+  public val icon_24353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24353.xml"),
+          )
+      )
+
+  public val icon_24354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24354.xml"),
+          )
+      )
+
+  public val icon_24355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24355.xml"),
+          )
+      )
+
+  public val icon_24356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24356.xml"),
+          )
+      )
+
+  public val icon_24357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24357.xml"),
+          )
+      )
+
+  public val icon_24358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24358.xml"),
+          )
+      )
+
+  public val icon_24359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24359.xml"),
+          )
+      )
+
+  public val icon_2436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2436.xml"),
+          )
+      )
+
+  public val icon_24360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24360.xml"),
+          )
+      )
+
+  public val icon_24361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24361.xml"),
+          )
+      )
+
+  public val icon_24362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24362.xml"),
+          )
+      )
+
+  public val icon_24363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24363.xml"),
+          )
+      )
+
+  public val icon_24364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24364.xml"),
+          )
+      )
+
+  public val icon_24365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24365.xml"),
+          )
+      )
+
+  public val icon_24366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24366.xml"),
+          )
+      )
+
+  public val icon_24367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24367.xml"),
+          )
+      )
+
+  public val icon_24368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24368.xml"),
+          )
+      )
+
+  public val icon_24369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24369.xml"),
+          )
+      )
+
+  public val icon_2437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2437.xml"),
+          )
+      )
+
+  public val icon_24370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24370.xml"),
+          )
+      )
+
+  public val icon_24371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24371.xml"),
+          )
+      )
+
+  public val icon_24372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24372.xml"),
+          )
+      )
+
+  public val icon_24373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24373.xml"),
+          )
+      )
+
+  public val icon_24374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24374.xml"),
+          )
+      )
+
+  public val icon_24375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24375.xml"),
+          )
+      )
+
+  public val icon_24376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24376.xml"),
+          )
+      )
+
+  public val icon_24377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24377.xml"),
+          )
+      )
+
+  public val icon_24378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24378.xml"),
+          )
+      )
+
+  public val icon_24379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24379.xml"),
+          )
+      )
+
+  public val icon_2438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2438.xml"),
+          )
+      )
+
+  public val icon_24380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24380.xml"),
+          )
+      )
+
+  public val icon_24381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24381.xml"),
+          )
+      )
+
+  public val icon_24382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24382.xml"),
+          )
+      )
+
+  public val icon_24383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24383.xml"),
+          )
+      )
+
+  public val icon_24384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24384.xml"),
+          )
+      )
+
+  public val icon_24385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24385.xml"),
+          )
+      )
+
+  public val icon_24386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24386.xml"),
+          )
+      )
+
+  public val icon_24387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24387.xml"),
+          )
+      )
+
+  public val icon_24388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24388.xml"),
+          )
+      )
+
+  public val icon_24389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24389.xml"),
+          )
+      )
+
+  public val icon_2439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2439.xml"),
+          )
+      )
+
+  public val icon_24390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24390.xml"),
+          )
+      )
+
+  public val icon_24391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24391.xml"),
+          )
+      )
+
+  public val icon_24392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24392.xml"),
+          )
+      )
+
+  public val icon_24393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24393.xml"),
+          )
+      )
+
+  public val icon_24394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24394.xml"),
+          )
+      )
+
+  public val icon_24395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24395.xml"),
+          )
+      )
+
+  public val icon_24396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24396.xml"),
+          )
+      )
+
+  public val icon_24397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24397.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23948: DrawableResource
+  get() = Drawable31.icon_23948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23949: DrawableResource
+  get() = Drawable31.icon_23949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2395: DrawableResource
+  get() = Drawable31.icon_2395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23950: DrawableResource
+  get() = Drawable31.icon_23950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23951: DrawableResource
+  get() = Drawable31.icon_23951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23952: DrawableResource
+  get() = Drawable31.icon_23952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23953: DrawableResource
+  get() = Drawable31.icon_23953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23954: DrawableResource
+  get() = Drawable31.icon_23954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23955: DrawableResource
+  get() = Drawable31.icon_23955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23956: DrawableResource
+  get() = Drawable31.icon_23956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23957: DrawableResource
+  get() = Drawable31.icon_23957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23958: DrawableResource
+  get() = Drawable31.icon_23958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23959: DrawableResource
+  get() = Drawable31.icon_23959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2396: DrawableResource
+  get() = Drawable31.icon_2396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23960: DrawableResource
+  get() = Drawable31.icon_23960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23961: DrawableResource
+  get() = Drawable31.icon_23961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23962: DrawableResource
+  get() = Drawable31.icon_23962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23963: DrawableResource
+  get() = Drawable31.icon_23963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23964: DrawableResource
+  get() = Drawable31.icon_23964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23965: DrawableResource
+  get() = Drawable31.icon_23965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23966: DrawableResource
+  get() = Drawable31.icon_23966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23967: DrawableResource
+  get() = Drawable31.icon_23967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23968: DrawableResource
+  get() = Drawable31.icon_23968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23969: DrawableResource
+  get() = Drawable31.icon_23969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2397: DrawableResource
+  get() = Drawable31.icon_2397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23970: DrawableResource
+  get() = Drawable31.icon_23970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23971: DrawableResource
+  get() = Drawable31.icon_23971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23972: DrawableResource
+  get() = Drawable31.icon_23972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23973: DrawableResource
+  get() = Drawable31.icon_23973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23974: DrawableResource
+  get() = Drawable31.icon_23974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23975: DrawableResource
+  get() = Drawable31.icon_23975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23976: DrawableResource
+  get() = Drawable31.icon_23976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23977: DrawableResource
+  get() = Drawable31.icon_23977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23978: DrawableResource
+  get() = Drawable31.icon_23978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23979: DrawableResource
+  get() = Drawable31.icon_23979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2398: DrawableResource
+  get() = Drawable31.icon_2398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23980: DrawableResource
+  get() = Drawable31.icon_23980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23981: DrawableResource
+  get() = Drawable31.icon_23981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23982: DrawableResource
+  get() = Drawable31.icon_23982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23983: DrawableResource
+  get() = Drawable31.icon_23983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23984: DrawableResource
+  get() = Drawable31.icon_23984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23985: DrawableResource
+  get() = Drawable31.icon_23985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23986: DrawableResource
+  get() = Drawable31.icon_23986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23987: DrawableResource
+  get() = Drawable31.icon_23987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23988: DrawableResource
+  get() = Drawable31.icon_23988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23989: DrawableResource
+  get() = Drawable31.icon_23989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2399: DrawableResource
+  get() = Drawable31.icon_2399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23990: DrawableResource
+  get() = Drawable31.icon_23990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23991: DrawableResource
+  get() = Drawable31.icon_23991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23992: DrawableResource
+  get() = Drawable31.icon_23992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23993: DrawableResource
+  get() = Drawable31.icon_23993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23994: DrawableResource
+  get() = Drawable31.icon_23994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23995: DrawableResource
+  get() = Drawable31.icon_23995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23996: DrawableResource
+  get() = Drawable31.icon_23996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23997: DrawableResource
+  get() = Drawable31.icon_23997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23998: DrawableResource
+  get() = Drawable31.icon_23998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_23999: DrawableResource
+  get() = Drawable31.icon_23999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24: DrawableResource
+  get() = Drawable31.icon_24
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_240: DrawableResource
+  get() = Drawable31.icon_240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2400: DrawableResource
+  get() = Drawable31.icon_2400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24000: DrawableResource
+  get() = Drawable31.icon_24000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24001: DrawableResource
+  get() = Drawable31.icon_24001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24002: DrawableResource
+  get() = Drawable31.icon_24002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24003: DrawableResource
+  get() = Drawable31.icon_24003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24004: DrawableResource
+  get() = Drawable31.icon_24004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24005: DrawableResource
+  get() = Drawable31.icon_24005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24006: DrawableResource
+  get() = Drawable31.icon_24006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24007: DrawableResource
+  get() = Drawable31.icon_24007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24008: DrawableResource
+  get() = Drawable31.icon_24008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24009: DrawableResource
+  get() = Drawable31.icon_24009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2401: DrawableResource
+  get() = Drawable31.icon_2401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24010: DrawableResource
+  get() = Drawable31.icon_24010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24011: DrawableResource
+  get() = Drawable31.icon_24011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24012: DrawableResource
+  get() = Drawable31.icon_24012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24013: DrawableResource
+  get() = Drawable31.icon_24013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24014: DrawableResource
+  get() = Drawable31.icon_24014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24015: DrawableResource
+  get() = Drawable31.icon_24015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24016: DrawableResource
+  get() = Drawable31.icon_24016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24017: DrawableResource
+  get() = Drawable31.icon_24017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24018: DrawableResource
+  get() = Drawable31.icon_24018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24019: DrawableResource
+  get() = Drawable31.icon_24019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2402: DrawableResource
+  get() = Drawable31.icon_2402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24020: DrawableResource
+  get() = Drawable31.icon_24020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24021: DrawableResource
+  get() = Drawable31.icon_24021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24022: DrawableResource
+  get() = Drawable31.icon_24022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24023: DrawableResource
+  get() = Drawable31.icon_24023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24024: DrawableResource
+  get() = Drawable31.icon_24024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24025: DrawableResource
+  get() = Drawable31.icon_24025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24026: DrawableResource
+  get() = Drawable31.icon_24026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24027: DrawableResource
+  get() = Drawable31.icon_24027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24028: DrawableResource
+  get() = Drawable31.icon_24028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24029: DrawableResource
+  get() = Drawable31.icon_24029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2403: DrawableResource
+  get() = Drawable31.icon_2403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24030: DrawableResource
+  get() = Drawable31.icon_24030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24031: DrawableResource
+  get() = Drawable31.icon_24031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24032: DrawableResource
+  get() = Drawable31.icon_24032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24033: DrawableResource
+  get() = Drawable31.icon_24033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24034: DrawableResource
+  get() = Drawable31.icon_24034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24035: DrawableResource
+  get() = Drawable31.icon_24035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24036: DrawableResource
+  get() = Drawable31.icon_24036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24037: DrawableResource
+  get() = Drawable31.icon_24037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24038: DrawableResource
+  get() = Drawable31.icon_24038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24039: DrawableResource
+  get() = Drawable31.icon_24039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2404: DrawableResource
+  get() = Drawable31.icon_2404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24040: DrawableResource
+  get() = Drawable31.icon_24040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24041: DrawableResource
+  get() = Drawable31.icon_24041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24042: DrawableResource
+  get() = Drawable31.icon_24042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24043: DrawableResource
+  get() = Drawable31.icon_24043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24044: DrawableResource
+  get() = Drawable31.icon_24044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24045: DrawableResource
+  get() = Drawable31.icon_24045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24046: DrawableResource
+  get() = Drawable31.icon_24046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24047: DrawableResource
+  get() = Drawable31.icon_24047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24048: DrawableResource
+  get() = Drawable31.icon_24048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24049: DrawableResource
+  get() = Drawable31.icon_24049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2405: DrawableResource
+  get() = Drawable31.icon_2405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24050: DrawableResource
+  get() = Drawable31.icon_24050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24051: DrawableResource
+  get() = Drawable31.icon_24051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24052: DrawableResource
+  get() = Drawable31.icon_24052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24053: DrawableResource
+  get() = Drawable31.icon_24053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24054: DrawableResource
+  get() = Drawable31.icon_24054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24055: DrawableResource
+  get() = Drawable31.icon_24055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24056: DrawableResource
+  get() = Drawable31.icon_24056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24057: DrawableResource
+  get() = Drawable31.icon_24057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24058: DrawableResource
+  get() = Drawable31.icon_24058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24059: DrawableResource
+  get() = Drawable31.icon_24059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2406: DrawableResource
+  get() = Drawable31.icon_2406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24060: DrawableResource
+  get() = Drawable31.icon_24060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24061: DrawableResource
+  get() = Drawable31.icon_24061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24062: DrawableResource
+  get() = Drawable31.icon_24062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24063: DrawableResource
+  get() = Drawable31.icon_24063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24064: DrawableResource
+  get() = Drawable31.icon_24064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24065: DrawableResource
+  get() = Drawable31.icon_24065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24066: DrawableResource
+  get() = Drawable31.icon_24066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24067: DrawableResource
+  get() = Drawable31.icon_24067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24068: DrawableResource
+  get() = Drawable31.icon_24068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24069: DrawableResource
+  get() = Drawable31.icon_24069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2407: DrawableResource
+  get() = Drawable31.icon_2407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24070: DrawableResource
+  get() = Drawable31.icon_24070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24071: DrawableResource
+  get() = Drawable31.icon_24071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24072: DrawableResource
+  get() = Drawable31.icon_24072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24073: DrawableResource
+  get() = Drawable31.icon_24073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24074: DrawableResource
+  get() = Drawable31.icon_24074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24075: DrawableResource
+  get() = Drawable31.icon_24075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24076: DrawableResource
+  get() = Drawable31.icon_24076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24077: DrawableResource
+  get() = Drawable31.icon_24077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24078: DrawableResource
+  get() = Drawable31.icon_24078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24079: DrawableResource
+  get() = Drawable31.icon_24079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2408: DrawableResource
+  get() = Drawable31.icon_2408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24080: DrawableResource
+  get() = Drawable31.icon_24080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24081: DrawableResource
+  get() = Drawable31.icon_24081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24082: DrawableResource
+  get() = Drawable31.icon_24082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24083: DrawableResource
+  get() = Drawable31.icon_24083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24084: DrawableResource
+  get() = Drawable31.icon_24084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24085: DrawableResource
+  get() = Drawable31.icon_24085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24086: DrawableResource
+  get() = Drawable31.icon_24086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24087: DrawableResource
+  get() = Drawable31.icon_24087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24088: DrawableResource
+  get() = Drawable31.icon_24088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24089: DrawableResource
+  get() = Drawable31.icon_24089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2409: DrawableResource
+  get() = Drawable31.icon_2409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24090: DrawableResource
+  get() = Drawable31.icon_24090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24091: DrawableResource
+  get() = Drawable31.icon_24091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24092: DrawableResource
+  get() = Drawable31.icon_24092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24093: DrawableResource
+  get() = Drawable31.icon_24093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24094: DrawableResource
+  get() = Drawable31.icon_24094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24095: DrawableResource
+  get() = Drawable31.icon_24095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24096: DrawableResource
+  get() = Drawable31.icon_24096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24097: DrawableResource
+  get() = Drawable31.icon_24097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24098: DrawableResource
+  get() = Drawable31.icon_24098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24099: DrawableResource
+  get() = Drawable31.icon_24099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_241: DrawableResource
+  get() = Drawable31.icon_241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2410: DrawableResource
+  get() = Drawable31.icon_2410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24100: DrawableResource
+  get() = Drawable31.icon_24100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24101: DrawableResource
+  get() = Drawable31.icon_24101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24102: DrawableResource
+  get() = Drawable31.icon_24102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24103: DrawableResource
+  get() = Drawable31.icon_24103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24104: DrawableResource
+  get() = Drawable31.icon_24104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24105: DrawableResource
+  get() = Drawable31.icon_24105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24106: DrawableResource
+  get() = Drawable31.icon_24106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24107: DrawableResource
+  get() = Drawable31.icon_24107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24108: DrawableResource
+  get() = Drawable31.icon_24108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24109: DrawableResource
+  get() = Drawable31.icon_24109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2411: DrawableResource
+  get() = Drawable31.icon_2411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24110: DrawableResource
+  get() = Drawable31.icon_24110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24111: DrawableResource
+  get() = Drawable31.icon_24111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24112: DrawableResource
+  get() = Drawable31.icon_24112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24113: DrawableResource
+  get() = Drawable31.icon_24113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24114: DrawableResource
+  get() = Drawable31.icon_24114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24115: DrawableResource
+  get() = Drawable31.icon_24115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24116: DrawableResource
+  get() = Drawable31.icon_24116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24117: DrawableResource
+  get() = Drawable31.icon_24117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24118: DrawableResource
+  get() = Drawable31.icon_24118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24119: DrawableResource
+  get() = Drawable31.icon_24119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2412: DrawableResource
+  get() = Drawable31.icon_2412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24120: DrawableResource
+  get() = Drawable31.icon_24120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24121: DrawableResource
+  get() = Drawable31.icon_24121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24122: DrawableResource
+  get() = Drawable31.icon_24122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24123: DrawableResource
+  get() = Drawable31.icon_24123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24124: DrawableResource
+  get() = Drawable31.icon_24124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24125: DrawableResource
+  get() = Drawable31.icon_24125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24126: DrawableResource
+  get() = Drawable31.icon_24126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24127: DrawableResource
+  get() = Drawable31.icon_24127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24128: DrawableResource
+  get() = Drawable31.icon_24128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24129: DrawableResource
+  get() = Drawable31.icon_24129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2413: DrawableResource
+  get() = Drawable31.icon_2413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24130: DrawableResource
+  get() = Drawable31.icon_24130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24131: DrawableResource
+  get() = Drawable31.icon_24131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24132: DrawableResource
+  get() = Drawable31.icon_24132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24133: DrawableResource
+  get() = Drawable31.icon_24133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24134: DrawableResource
+  get() = Drawable31.icon_24134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24135: DrawableResource
+  get() = Drawable31.icon_24135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24136: DrawableResource
+  get() = Drawable31.icon_24136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24137: DrawableResource
+  get() = Drawable31.icon_24137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24138: DrawableResource
+  get() = Drawable31.icon_24138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24139: DrawableResource
+  get() = Drawable31.icon_24139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2414: DrawableResource
+  get() = Drawable31.icon_2414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24140: DrawableResource
+  get() = Drawable31.icon_24140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24141: DrawableResource
+  get() = Drawable31.icon_24141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24142: DrawableResource
+  get() = Drawable31.icon_24142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24143: DrawableResource
+  get() = Drawable31.icon_24143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24144: DrawableResource
+  get() = Drawable31.icon_24144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24145: DrawableResource
+  get() = Drawable31.icon_24145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24146: DrawableResource
+  get() = Drawable31.icon_24146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24147: DrawableResource
+  get() = Drawable31.icon_24147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24148: DrawableResource
+  get() = Drawable31.icon_24148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24149: DrawableResource
+  get() = Drawable31.icon_24149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2415: DrawableResource
+  get() = Drawable31.icon_2415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24150: DrawableResource
+  get() = Drawable31.icon_24150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24151: DrawableResource
+  get() = Drawable31.icon_24151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24152: DrawableResource
+  get() = Drawable31.icon_24152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24153: DrawableResource
+  get() = Drawable31.icon_24153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24154: DrawableResource
+  get() = Drawable31.icon_24154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24155: DrawableResource
+  get() = Drawable31.icon_24155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24156: DrawableResource
+  get() = Drawable31.icon_24156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24157: DrawableResource
+  get() = Drawable31.icon_24157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24158: DrawableResource
+  get() = Drawable31.icon_24158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24159: DrawableResource
+  get() = Drawable31.icon_24159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2416: DrawableResource
+  get() = Drawable31.icon_2416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24160: DrawableResource
+  get() = Drawable31.icon_24160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24161: DrawableResource
+  get() = Drawable31.icon_24161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24162: DrawableResource
+  get() = Drawable31.icon_24162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24163: DrawableResource
+  get() = Drawable31.icon_24163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24164: DrawableResource
+  get() = Drawable31.icon_24164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24165: DrawableResource
+  get() = Drawable31.icon_24165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24166: DrawableResource
+  get() = Drawable31.icon_24166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24167: DrawableResource
+  get() = Drawable31.icon_24167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24168: DrawableResource
+  get() = Drawable31.icon_24168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24169: DrawableResource
+  get() = Drawable31.icon_24169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2417: DrawableResource
+  get() = Drawable31.icon_2417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24170: DrawableResource
+  get() = Drawable31.icon_24170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24171: DrawableResource
+  get() = Drawable31.icon_24171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24172: DrawableResource
+  get() = Drawable31.icon_24172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24173: DrawableResource
+  get() = Drawable31.icon_24173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24174: DrawableResource
+  get() = Drawable31.icon_24174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24175: DrawableResource
+  get() = Drawable31.icon_24175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24176: DrawableResource
+  get() = Drawable31.icon_24176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24177: DrawableResource
+  get() = Drawable31.icon_24177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24178: DrawableResource
+  get() = Drawable31.icon_24178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24179: DrawableResource
+  get() = Drawable31.icon_24179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2418: DrawableResource
+  get() = Drawable31.icon_2418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24180: DrawableResource
+  get() = Drawable31.icon_24180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24181: DrawableResource
+  get() = Drawable31.icon_24181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24182: DrawableResource
+  get() = Drawable31.icon_24182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24183: DrawableResource
+  get() = Drawable31.icon_24183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24184: DrawableResource
+  get() = Drawable31.icon_24184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24185: DrawableResource
+  get() = Drawable31.icon_24185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24186: DrawableResource
+  get() = Drawable31.icon_24186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24187: DrawableResource
+  get() = Drawable31.icon_24187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24188: DrawableResource
+  get() = Drawable31.icon_24188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24189: DrawableResource
+  get() = Drawable31.icon_24189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2419: DrawableResource
+  get() = Drawable31.icon_2419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24190: DrawableResource
+  get() = Drawable31.icon_24190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24191: DrawableResource
+  get() = Drawable31.icon_24191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24192: DrawableResource
+  get() = Drawable31.icon_24192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24193: DrawableResource
+  get() = Drawable31.icon_24193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24194: DrawableResource
+  get() = Drawable31.icon_24194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24195: DrawableResource
+  get() = Drawable31.icon_24195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24196: DrawableResource
+  get() = Drawable31.icon_24196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24197: DrawableResource
+  get() = Drawable31.icon_24197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24198: DrawableResource
+  get() = Drawable31.icon_24198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24199: DrawableResource
+  get() = Drawable31.icon_24199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_242: DrawableResource
+  get() = Drawable31.icon_242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2420: DrawableResource
+  get() = Drawable31.icon_2420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24200: DrawableResource
+  get() = Drawable31.icon_24200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24201: DrawableResource
+  get() = Drawable31.icon_24201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24202: DrawableResource
+  get() = Drawable31.icon_24202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24203: DrawableResource
+  get() = Drawable31.icon_24203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24204: DrawableResource
+  get() = Drawable31.icon_24204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24205: DrawableResource
+  get() = Drawable31.icon_24205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24206: DrawableResource
+  get() = Drawable31.icon_24206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24207: DrawableResource
+  get() = Drawable31.icon_24207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24208: DrawableResource
+  get() = Drawable31.icon_24208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24209: DrawableResource
+  get() = Drawable31.icon_24209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2421: DrawableResource
+  get() = Drawable31.icon_2421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24210: DrawableResource
+  get() = Drawable31.icon_24210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24211: DrawableResource
+  get() = Drawable31.icon_24211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24212: DrawableResource
+  get() = Drawable31.icon_24212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24213: DrawableResource
+  get() = Drawable31.icon_24213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24214: DrawableResource
+  get() = Drawable31.icon_24214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24215: DrawableResource
+  get() = Drawable31.icon_24215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24216: DrawableResource
+  get() = Drawable31.icon_24216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24217: DrawableResource
+  get() = Drawable31.icon_24217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24218: DrawableResource
+  get() = Drawable31.icon_24218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24219: DrawableResource
+  get() = Drawable31.icon_24219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2422: DrawableResource
+  get() = Drawable31.icon_2422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24220: DrawableResource
+  get() = Drawable31.icon_24220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24221: DrawableResource
+  get() = Drawable31.icon_24221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24222: DrawableResource
+  get() = Drawable31.icon_24222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24223: DrawableResource
+  get() = Drawable31.icon_24223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24224: DrawableResource
+  get() = Drawable31.icon_24224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24225: DrawableResource
+  get() = Drawable31.icon_24225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24226: DrawableResource
+  get() = Drawable31.icon_24226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24227: DrawableResource
+  get() = Drawable31.icon_24227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24228: DrawableResource
+  get() = Drawable31.icon_24228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24229: DrawableResource
+  get() = Drawable31.icon_24229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2423: DrawableResource
+  get() = Drawable31.icon_2423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24230: DrawableResource
+  get() = Drawable31.icon_24230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24231: DrawableResource
+  get() = Drawable31.icon_24231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24232: DrawableResource
+  get() = Drawable31.icon_24232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24233: DrawableResource
+  get() = Drawable31.icon_24233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24234: DrawableResource
+  get() = Drawable31.icon_24234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24235: DrawableResource
+  get() = Drawable31.icon_24235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24236: DrawableResource
+  get() = Drawable31.icon_24236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24237: DrawableResource
+  get() = Drawable31.icon_24237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24238: DrawableResource
+  get() = Drawable31.icon_24238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24239: DrawableResource
+  get() = Drawable31.icon_24239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2424: DrawableResource
+  get() = Drawable31.icon_2424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24240: DrawableResource
+  get() = Drawable31.icon_24240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24241: DrawableResource
+  get() = Drawable31.icon_24241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24242: DrawableResource
+  get() = Drawable31.icon_24242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24243: DrawableResource
+  get() = Drawable31.icon_24243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24244: DrawableResource
+  get() = Drawable31.icon_24244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24245: DrawableResource
+  get() = Drawable31.icon_24245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24246: DrawableResource
+  get() = Drawable31.icon_24246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24247: DrawableResource
+  get() = Drawable31.icon_24247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24248: DrawableResource
+  get() = Drawable31.icon_24248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24249: DrawableResource
+  get() = Drawable31.icon_24249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2425: DrawableResource
+  get() = Drawable31.icon_2425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24250: DrawableResource
+  get() = Drawable31.icon_24250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24251: DrawableResource
+  get() = Drawable31.icon_24251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24252: DrawableResource
+  get() = Drawable31.icon_24252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24253: DrawableResource
+  get() = Drawable31.icon_24253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24254: DrawableResource
+  get() = Drawable31.icon_24254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24255: DrawableResource
+  get() = Drawable31.icon_24255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24256: DrawableResource
+  get() = Drawable31.icon_24256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24257: DrawableResource
+  get() = Drawable31.icon_24257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24258: DrawableResource
+  get() = Drawable31.icon_24258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24259: DrawableResource
+  get() = Drawable31.icon_24259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2426: DrawableResource
+  get() = Drawable31.icon_2426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24260: DrawableResource
+  get() = Drawable31.icon_24260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24261: DrawableResource
+  get() = Drawable31.icon_24261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24262: DrawableResource
+  get() = Drawable31.icon_24262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24263: DrawableResource
+  get() = Drawable31.icon_24263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24264: DrawableResource
+  get() = Drawable31.icon_24264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24265: DrawableResource
+  get() = Drawable31.icon_24265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24266: DrawableResource
+  get() = Drawable31.icon_24266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24267: DrawableResource
+  get() = Drawable31.icon_24267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24268: DrawableResource
+  get() = Drawable31.icon_24268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24269: DrawableResource
+  get() = Drawable31.icon_24269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2427: DrawableResource
+  get() = Drawable31.icon_2427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24270: DrawableResource
+  get() = Drawable31.icon_24270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24271: DrawableResource
+  get() = Drawable31.icon_24271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24272: DrawableResource
+  get() = Drawable31.icon_24272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24273: DrawableResource
+  get() = Drawable31.icon_24273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24274: DrawableResource
+  get() = Drawable31.icon_24274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24275: DrawableResource
+  get() = Drawable31.icon_24275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24276: DrawableResource
+  get() = Drawable31.icon_24276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24277: DrawableResource
+  get() = Drawable31.icon_24277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24278: DrawableResource
+  get() = Drawable31.icon_24278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24279: DrawableResource
+  get() = Drawable31.icon_24279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2428: DrawableResource
+  get() = Drawable31.icon_2428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24280: DrawableResource
+  get() = Drawable31.icon_24280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24281: DrawableResource
+  get() = Drawable31.icon_24281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24282: DrawableResource
+  get() = Drawable31.icon_24282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24283: DrawableResource
+  get() = Drawable31.icon_24283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24284: DrawableResource
+  get() = Drawable31.icon_24284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24285: DrawableResource
+  get() = Drawable31.icon_24285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24286: DrawableResource
+  get() = Drawable31.icon_24286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24287: DrawableResource
+  get() = Drawable31.icon_24287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24288: DrawableResource
+  get() = Drawable31.icon_24288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24289: DrawableResource
+  get() = Drawable31.icon_24289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2429: DrawableResource
+  get() = Drawable31.icon_2429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24290: DrawableResource
+  get() = Drawable31.icon_24290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24291: DrawableResource
+  get() = Drawable31.icon_24291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24292: DrawableResource
+  get() = Drawable31.icon_24292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24293: DrawableResource
+  get() = Drawable31.icon_24293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24294: DrawableResource
+  get() = Drawable31.icon_24294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24295: DrawableResource
+  get() = Drawable31.icon_24295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24296: DrawableResource
+  get() = Drawable31.icon_24296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24297: DrawableResource
+  get() = Drawable31.icon_24297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24298: DrawableResource
+  get() = Drawable31.icon_24298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24299: DrawableResource
+  get() = Drawable31.icon_24299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_243: DrawableResource
+  get() = Drawable31.icon_243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2430: DrawableResource
+  get() = Drawable31.icon_2430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24300: DrawableResource
+  get() = Drawable31.icon_24300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24301: DrawableResource
+  get() = Drawable31.icon_24301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24302: DrawableResource
+  get() = Drawable31.icon_24302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24303: DrawableResource
+  get() = Drawable31.icon_24303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24304: DrawableResource
+  get() = Drawable31.icon_24304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24305: DrawableResource
+  get() = Drawable31.icon_24305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24306: DrawableResource
+  get() = Drawable31.icon_24306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24307: DrawableResource
+  get() = Drawable31.icon_24307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24308: DrawableResource
+  get() = Drawable31.icon_24308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24309: DrawableResource
+  get() = Drawable31.icon_24309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2431: DrawableResource
+  get() = Drawable31.icon_2431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24310: DrawableResource
+  get() = Drawable31.icon_24310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24311: DrawableResource
+  get() = Drawable31.icon_24311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24312: DrawableResource
+  get() = Drawable31.icon_24312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24313: DrawableResource
+  get() = Drawable31.icon_24313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24314: DrawableResource
+  get() = Drawable31.icon_24314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24315: DrawableResource
+  get() = Drawable31.icon_24315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24316: DrawableResource
+  get() = Drawable31.icon_24316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24317: DrawableResource
+  get() = Drawable31.icon_24317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24318: DrawableResource
+  get() = Drawable31.icon_24318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24319: DrawableResource
+  get() = Drawable31.icon_24319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2432: DrawableResource
+  get() = Drawable31.icon_2432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24320: DrawableResource
+  get() = Drawable31.icon_24320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24321: DrawableResource
+  get() = Drawable31.icon_24321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24322: DrawableResource
+  get() = Drawable31.icon_24322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24323: DrawableResource
+  get() = Drawable31.icon_24323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24324: DrawableResource
+  get() = Drawable31.icon_24324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24325: DrawableResource
+  get() = Drawable31.icon_24325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24326: DrawableResource
+  get() = Drawable31.icon_24326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24327: DrawableResource
+  get() = Drawable31.icon_24327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24328: DrawableResource
+  get() = Drawable31.icon_24328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24329: DrawableResource
+  get() = Drawable31.icon_24329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2433: DrawableResource
+  get() = Drawable31.icon_2433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24330: DrawableResource
+  get() = Drawable31.icon_24330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24331: DrawableResource
+  get() = Drawable31.icon_24331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24332: DrawableResource
+  get() = Drawable31.icon_24332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24333: DrawableResource
+  get() = Drawable31.icon_24333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24334: DrawableResource
+  get() = Drawable31.icon_24334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24335: DrawableResource
+  get() = Drawable31.icon_24335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24336: DrawableResource
+  get() = Drawable31.icon_24336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24337: DrawableResource
+  get() = Drawable31.icon_24337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24338: DrawableResource
+  get() = Drawable31.icon_24338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24339: DrawableResource
+  get() = Drawable31.icon_24339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2434: DrawableResource
+  get() = Drawable31.icon_2434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24340: DrawableResource
+  get() = Drawable31.icon_24340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24341: DrawableResource
+  get() = Drawable31.icon_24341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24342: DrawableResource
+  get() = Drawable31.icon_24342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24343: DrawableResource
+  get() = Drawable31.icon_24343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24344: DrawableResource
+  get() = Drawable31.icon_24344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24345: DrawableResource
+  get() = Drawable31.icon_24345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24346: DrawableResource
+  get() = Drawable31.icon_24346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24347: DrawableResource
+  get() = Drawable31.icon_24347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24348: DrawableResource
+  get() = Drawable31.icon_24348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24349: DrawableResource
+  get() = Drawable31.icon_24349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2435: DrawableResource
+  get() = Drawable31.icon_2435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24350: DrawableResource
+  get() = Drawable31.icon_24350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24351: DrawableResource
+  get() = Drawable31.icon_24351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24352: DrawableResource
+  get() = Drawable31.icon_24352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24353: DrawableResource
+  get() = Drawable31.icon_24353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24354: DrawableResource
+  get() = Drawable31.icon_24354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24355: DrawableResource
+  get() = Drawable31.icon_24355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24356: DrawableResource
+  get() = Drawable31.icon_24356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24357: DrawableResource
+  get() = Drawable31.icon_24357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24358: DrawableResource
+  get() = Drawable31.icon_24358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24359: DrawableResource
+  get() = Drawable31.icon_24359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2436: DrawableResource
+  get() = Drawable31.icon_2436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24360: DrawableResource
+  get() = Drawable31.icon_24360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24361: DrawableResource
+  get() = Drawable31.icon_24361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24362: DrawableResource
+  get() = Drawable31.icon_24362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24363: DrawableResource
+  get() = Drawable31.icon_24363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24364: DrawableResource
+  get() = Drawable31.icon_24364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24365: DrawableResource
+  get() = Drawable31.icon_24365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24366: DrawableResource
+  get() = Drawable31.icon_24366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24367: DrawableResource
+  get() = Drawable31.icon_24367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24368: DrawableResource
+  get() = Drawable31.icon_24368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24369: DrawableResource
+  get() = Drawable31.icon_24369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2437: DrawableResource
+  get() = Drawable31.icon_2437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24370: DrawableResource
+  get() = Drawable31.icon_24370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24371: DrawableResource
+  get() = Drawable31.icon_24371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24372: DrawableResource
+  get() = Drawable31.icon_24372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24373: DrawableResource
+  get() = Drawable31.icon_24373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24374: DrawableResource
+  get() = Drawable31.icon_24374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24375: DrawableResource
+  get() = Drawable31.icon_24375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24376: DrawableResource
+  get() = Drawable31.icon_24376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24377: DrawableResource
+  get() = Drawable31.icon_24377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24378: DrawableResource
+  get() = Drawable31.icon_24378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24379: DrawableResource
+  get() = Drawable31.icon_24379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2438: DrawableResource
+  get() = Drawable31.icon_2438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24380: DrawableResource
+  get() = Drawable31.icon_24380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24381: DrawableResource
+  get() = Drawable31.icon_24381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24382: DrawableResource
+  get() = Drawable31.icon_24382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24383: DrawableResource
+  get() = Drawable31.icon_24383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24384: DrawableResource
+  get() = Drawable31.icon_24384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24385: DrawableResource
+  get() = Drawable31.icon_24385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24386: DrawableResource
+  get() = Drawable31.icon_24386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24387: DrawableResource
+  get() = Drawable31.icon_24387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24388: DrawableResource
+  get() = Drawable31.icon_24388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24389: DrawableResource
+  get() = Drawable31.icon_24389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2439: DrawableResource
+  get() = Drawable31.icon_2439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24390: DrawableResource
+  get() = Drawable31.icon_24390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24391: DrawableResource
+  get() = Drawable31.icon_24391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24392: DrawableResource
+  get() = Drawable31.icon_24392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24393: DrawableResource
+  get() = Drawable31.icon_24393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24394: DrawableResource
+  get() = Drawable31.icon_24394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24395: DrawableResource
+  get() = Drawable31.icon_24395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24396: DrawableResource
+  get() = Drawable31.icon_24396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24397: DrawableResource
+  get() = Drawable31.icon_24397

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable32.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable32.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable32 {
+  public val icon_24398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24398.xml"),
+          )
+      )
+
+  public val icon_24399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24399.xml"),
+          )
+      )
+
+  public val icon_244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_244.xml"),
+          )
+      )
+
+  public val icon_2440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2440.xml"),
+          )
+      )
+
+  public val icon_24400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24400.xml"),
+          )
+      )
+
+  public val icon_24401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24401.xml"),
+          )
+      )
+
+  public val icon_24402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24402.xml"),
+          )
+      )
+
+  public val icon_24403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24403.xml"),
+          )
+      )
+
+  public val icon_24404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24404.xml"),
+          )
+      )
+
+  public val icon_24405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24405.xml"),
+          )
+      )
+
+  public val icon_24406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24406.xml"),
+          )
+      )
+
+  public val icon_24407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24407.xml"),
+          )
+      )
+
+  public val icon_24408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24408.xml"),
+          )
+      )
+
+  public val icon_24409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24409.xml"),
+          )
+      )
+
+  public val icon_2441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2441.xml"),
+          )
+      )
+
+  public val icon_24410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24410.xml"),
+          )
+      )
+
+  public val icon_24411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24411.xml"),
+          )
+      )
+
+  public val icon_24412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24412.xml"),
+          )
+      )
+
+  public val icon_24413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24413.xml"),
+          )
+      )
+
+  public val icon_24414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24414.xml"),
+          )
+      )
+
+  public val icon_24415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24415.xml"),
+          )
+      )
+
+  public val icon_24416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24416.xml"),
+          )
+      )
+
+  public val icon_24417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24417.xml"),
+          )
+      )
+
+  public val icon_24418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24418.xml"),
+          )
+      )
+
+  public val icon_24419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24419.xml"),
+          )
+      )
+
+  public val icon_2442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2442.xml"),
+          )
+      )
+
+  public val icon_24420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24420.xml"),
+          )
+      )
+
+  public val icon_24421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24421.xml"),
+          )
+      )
+
+  public val icon_24422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24422.xml"),
+          )
+      )
+
+  public val icon_24423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24423.xml"),
+          )
+      )
+
+  public val icon_24424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24424.xml"),
+          )
+      )
+
+  public val icon_24425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24425.xml"),
+          )
+      )
+
+  public val icon_24426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24426.xml"),
+          )
+      )
+
+  public val icon_24427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24427.xml"),
+          )
+      )
+
+  public val icon_24428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24428.xml"),
+          )
+      )
+
+  public val icon_24429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24429.xml"),
+          )
+      )
+
+  public val icon_2443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2443.xml"),
+          )
+      )
+
+  public val icon_24430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24430.xml"),
+          )
+      )
+
+  public val icon_24431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24431.xml"),
+          )
+      )
+
+  public val icon_24432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24432.xml"),
+          )
+      )
+
+  public val icon_24433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24433.xml"),
+          )
+      )
+
+  public val icon_24434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24434.xml"),
+          )
+      )
+
+  public val icon_24435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24435.xml"),
+          )
+      )
+
+  public val icon_24436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24436.xml"),
+          )
+      )
+
+  public val icon_24437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24437.xml"),
+          )
+      )
+
+  public val icon_24438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24438.xml"),
+          )
+      )
+
+  public val icon_24439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24439.xml"),
+          )
+      )
+
+  public val icon_2444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2444.xml"),
+          )
+      )
+
+  public val icon_24440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24440.xml"),
+          )
+      )
+
+  public val icon_24441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24441.xml"),
+          )
+      )
+
+  public val icon_24442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24442.xml"),
+          )
+      )
+
+  public val icon_24443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24443.xml"),
+          )
+      )
+
+  public val icon_24444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24444.xml"),
+          )
+      )
+
+  public val icon_24445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24445.xml"),
+          )
+      )
+
+  public val icon_24446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24446.xml"),
+          )
+      )
+
+  public val icon_24447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24447.xml"),
+          )
+      )
+
+  public val icon_24448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24448.xml"),
+          )
+      )
+
+  public val icon_24449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24449.xml"),
+          )
+      )
+
+  public val icon_2445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2445.xml"),
+          )
+      )
+
+  public val icon_24450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24450.xml"),
+          )
+      )
+
+  public val icon_24451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24451.xml"),
+          )
+      )
+
+  public val icon_24452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24452.xml"),
+          )
+      )
+
+  public val icon_24453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24453.xml"),
+          )
+      )
+
+  public val icon_24454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24454.xml"),
+          )
+      )
+
+  public val icon_24455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24455.xml"),
+          )
+      )
+
+  public val icon_24456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24456.xml"),
+          )
+      )
+
+  public val icon_24457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24457.xml"),
+          )
+      )
+
+  public val icon_24458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24458.xml"),
+          )
+      )
+
+  public val icon_24459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24459.xml"),
+          )
+      )
+
+  public val icon_2446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2446.xml"),
+          )
+      )
+
+  public val icon_24460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24460.xml"),
+          )
+      )
+
+  public val icon_24461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24461.xml"),
+          )
+      )
+
+  public val icon_24462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24462.xml"),
+          )
+      )
+
+  public val icon_24463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24463.xml"),
+          )
+      )
+
+  public val icon_24464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24464.xml"),
+          )
+      )
+
+  public val icon_24465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24465.xml"),
+          )
+      )
+
+  public val icon_24466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24466.xml"),
+          )
+      )
+
+  public val icon_24467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24467.xml"),
+          )
+      )
+
+  public val icon_24468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24468.xml"),
+          )
+      )
+
+  public val icon_24469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24469.xml"),
+          )
+      )
+
+  public val icon_2447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2447.xml"),
+          )
+      )
+
+  public val icon_24470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24470.xml"),
+          )
+      )
+
+  public val icon_24471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24471.xml"),
+          )
+      )
+
+  public val icon_24472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24472.xml"),
+          )
+      )
+
+  public val icon_24473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24473.xml"),
+          )
+      )
+
+  public val icon_24474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24474.xml"),
+          )
+      )
+
+  public val icon_24475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24475.xml"),
+          )
+      )
+
+  public val icon_24476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24476.xml"),
+          )
+      )
+
+  public val icon_24477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24477.xml"),
+          )
+      )
+
+  public val icon_24478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24478.xml"),
+          )
+      )
+
+  public val icon_24479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24479.xml"),
+          )
+      )
+
+  public val icon_2448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2448.xml"),
+          )
+      )
+
+  public val icon_24480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24480.xml"),
+          )
+      )
+
+  public val icon_24481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24481.xml"),
+          )
+      )
+
+  public val icon_24482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24482.xml"),
+          )
+      )
+
+  public val icon_24483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24483.xml"),
+          )
+      )
+
+  public val icon_24484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24484.xml"),
+          )
+      )
+
+  public val icon_24485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24485.xml"),
+          )
+      )
+
+  public val icon_24486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24486.xml"),
+          )
+      )
+
+  public val icon_24487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24487.xml"),
+          )
+      )
+
+  public val icon_24488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24488.xml"),
+          )
+      )
+
+  public val icon_24489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24489.xml"),
+          )
+      )
+
+  public val icon_2449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2449.xml"),
+          )
+      )
+
+  public val icon_24490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24490.xml"),
+          )
+      )
+
+  public val icon_24491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24491.xml"),
+          )
+      )
+
+  public val icon_24492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24492.xml"),
+          )
+      )
+
+  public val icon_24493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24493.xml"),
+          )
+      )
+
+  public val icon_24494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24494.xml"),
+          )
+      )
+
+  public val icon_24495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24495.xml"),
+          )
+      )
+
+  public val icon_24496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24496.xml"),
+          )
+      )
+
+  public val icon_24497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24497.xml"),
+          )
+      )
+
+  public val icon_24498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24498.xml"),
+          )
+      )
+
+  public val icon_24499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24499.xml"),
+          )
+      )
+
+  public val icon_245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_245.xml"),
+          )
+      )
+
+  public val icon_2450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2450.xml"),
+          )
+      )
+
+  public val icon_24500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24500.xml"),
+          )
+      )
+
+  public val icon_24501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24501.xml"),
+          )
+      )
+
+  public val icon_24502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24502.xml"),
+          )
+      )
+
+  public val icon_24503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24503.xml"),
+          )
+      )
+
+  public val icon_24504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24504.xml"),
+          )
+      )
+
+  public val icon_24505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24505.xml"),
+          )
+      )
+
+  public val icon_24506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24506.xml"),
+          )
+      )
+
+  public val icon_24507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24507.xml"),
+          )
+      )
+
+  public val icon_24508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24508.xml"),
+          )
+      )
+
+  public val icon_24509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24509.xml"),
+          )
+      )
+
+  public val icon_2451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2451.xml"),
+          )
+      )
+
+  public val icon_24510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24510.xml"),
+          )
+      )
+
+  public val icon_24511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24511.xml"),
+          )
+      )
+
+  public val icon_24512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24512.xml"),
+          )
+      )
+
+  public val icon_24513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24513.xml"),
+          )
+      )
+
+  public val icon_24514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24514.xml"),
+          )
+      )
+
+  public val icon_24515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24515.xml"),
+          )
+      )
+
+  public val icon_24516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24516.xml"),
+          )
+      )
+
+  public val icon_24517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24517.xml"),
+          )
+      )
+
+  public val icon_24518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24518.xml"),
+          )
+      )
+
+  public val icon_24519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24519.xml"),
+          )
+      )
+
+  public val icon_2452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2452.xml"),
+          )
+      )
+
+  public val icon_24520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24520.xml"),
+          )
+      )
+
+  public val icon_24521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24521.xml"),
+          )
+      )
+
+  public val icon_24522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24522.xml"),
+          )
+      )
+
+  public val icon_24523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24523.xml"),
+          )
+      )
+
+  public val icon_24524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24524.xml"),
+          )
+      )
+
+  public val icon_24525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24525.xml"),
+          )
+      )
+
+  public val icon_24526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24526.xml"),
+          )
+      )
+
+  public val icon_24527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24527.xml"),
+          )
+      )
+
+  public val icon_24528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24528.xml"),
+          )
+      )
+
+  public val icon_24529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24529.xml"),
+          )
+      )
+
+  public val icon_2453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2453.xml"),
+          )
+      )
+
+  public val icon_24530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24530.xml"),
+          )
+      )
+
+  public val icon_24531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24531.xml"),
+          )
+      )
+
+  public val icon_24532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24532.xml"),
+          )
+      )
+
+  public val icon_24533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24533.xml"),
+          )
+      )
+
+  public val icon_24534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24534.xml"),
+          )
+      )
+
+  public val icon_24535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24535.xml"),
+          )
+      )
+
+  public val icon_24536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24536.xml"),
+          )
+      )
+
+  public val icon_24537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24537.xml"),
+          )
+      )
+
+  public val icon_24538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24538.xml"),
+          )
+      )
+
+  public val icon_24539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24539.xml"),
+          )
+      )
+
+  public val icon_2454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2454.xml"),
+          )
+      )
+
+  public val icon_24540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24540.xml"),
+          )
+      )
+
+  public val icon_24541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24541.xml"),
+          )
+      )
+
+  public val icon_24542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24542.xml"),
+          )
+      )
+
+  public val icon_24543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24543.xml"),
+          )
+      )
+
+  public val icon_24544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24544.xml"),
+          )
+      )
+
+  public val icon_24545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24545.xml"),
+          )
+      )
+
+  public val icon_24546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24546.xml"),
+          )
+      )
+
+  public val icon_24547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24547.xml"),
+          )
+      )
+
+  public val icon_24548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24548.xml"),
+          )
+      )
+
+  public val icon_24549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24549.xml"),
+          )
+      )
+
+  public val icon_2455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2455.xml"),
+          )
+      )
+
+  public val icon_24550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24550.xml"),
+          )
+      )
+
+  public val icon_24551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24551.xml"),
+          )
+      )
+
+  public val icon_24552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24552.xml"),
+          )
+      )
+
+  public val icon_24553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24553.xml"),
+          )
+      )
+
+  public val icon_24554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24554.xml"),
+          )
+      )
+
+  public val icon_24555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24555.xml"),
+          )
+      )
+
+  public val icon_24556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24556.xml"),
+          )
+      )
+
+  public val icon_24557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24557.xml"),
+          )
+      )
+
+  public val icon_24558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24558.xml"),
+          )
+      )
+
+  public val icon_24559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24559.xml"),
+          )
+      )
+
+  public val icon_2456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2456.xml"),
+          )
+      )
+
+  public val icon_24560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24560.xml"),
+          )
+      )
+
+  public val icon_24561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24561.xml"),
+          )
+      )
+
+  public val icon_24562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24562.xml"),
+          )
+      )
+
+  public val icon_24563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24563.xml"),
+          )
+      )
+
+  public val icon_24564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24564.xml"),
+          )
+      )
+
+  public val icon_24565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24565.xml"),
+          )
+      )
+
+  public val icon_24566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24566.xml"),
+          )
+      )
+
+  public val icon_24567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24567.xml"),
+          )
+      )
+
+  public val icon_24568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24568.xml"),
+          )
+      )
+
+  public val icon_24569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24569.xml"),
+          )
+      )
+
+  public val icon_2457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2457.xml"),
+          )
+      )
+
+  public val icon_24570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24570.xml"),
+          )
+      )
+
+  public val icon_24571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24571.xml"),
+          )
+      )
+
+  public val icon_24572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24572.xml"),
+          )
+      )
+
+  public val icon_24573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24573.xml"),
+          )
+      )
+
+  public val icon_24574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24574.xml"),
+          )
+      )
+
+  public val icon_24575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24575.xml"),
+          )
+      )
+
+  public val icon_24576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24576.xml"),
+          )
+      )
+
+  public val icon_24577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24577.xml"),
+          )
+      )
+
+  public val icon_24578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24578.xml"),
+          )
+      )
+
+  public val icon_24579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24579.xml"),
+          )
+      )
+
+  public val icon_2458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2458.xml"),
+          )
+      )
+
+  public val icon_24580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24580.xml"),
+          )
+      )
+
+  public val icon_24581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24581.xml"),
+          )
+      )
+
+  public val icon_24582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24582.xml"),
+          )
+      )
+
+  public val icon_24583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24583.xml"),
+          )
+      )
+
+  public val icon_24584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24584.xml"),
+          )
+      )
+
+  public val icon_24585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24585.xml"),
+          )
+      )
+
+  public val icon_24586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24586.xml"),
+          )
+      )
+
+  public val icon_24587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24587.xml"),
+          )
+      )
+
+  public val icon_24588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24588.xml"),
+          )
+      )
+
+  public val icon_24589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24589.xml"),
+          )
+      )
+
+  public val icon_2459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2459.xml"),
+          )
+      )
+
+  public val icon_24590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24590.xml"),
+          )
+      )
+
+  public val icon_24591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24591.xml"),
+          )
+      )
+
+  public val icon_24592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24592.xml"),
+          )
+      )
+
+  public val icon_24593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24593.xml"),
+          )
+      )
+
+  public val icon_24594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24594.xml"),
+          )
+      )
+
+  public val icon_24595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24595.xml"),
+          )
+      )
+
+  public val icon_24596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24596.xml"),
+          )
+      )
+
+  public val icon_24597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24597.xml"),
+          )
+      )
+
+  public val icon_24598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24598.xml"),
+          )
+      )
+
+  public val icon_24599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24599.xml"),
+          )
+      )
+
+  public val icon_246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_246.xml"),
+          )
+      )
+
+  public val icon_2460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2460.xml"),
+          )
+      )
+
+  public val icon_24600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24600.xml"),
+          )
+      )
+
+  public val icon_24601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24601.xml"),
+          )
+      )
+
+  public val icon_24602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24602.xml"),
+          )
+      )
+
+  public val icon_24603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24603.xml"),
+          )
+      )
+
+  public val icon_24604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24604.xml"),
+          )
+      )
+
+  public val icon_24605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24605.xml"),
+          )
+      )
+
+  public val icon_24606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24606.xml"),
+          )
+      )
+
+  public val icon_24607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24607.xml"),
+          )
+      )
+
+  public val icon_24608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24608.xml"),
+          )
+      )
+
+  public val icon_24609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24609.xml"),
+          )
+      )
+
+  public val icon_2461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2461.xml"),
+          )
+      )
+
+  public val icon_24610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24610.xml"),
+          )
+      )
+
+  public val icon_24611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24611.xml"),
+          )
+      )
+
+  public val icon_24612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24612.xml"),
+          )
+      )
+
+  public val icon_24613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24613.xml"),
+          )
+      )
+
+  public val icon_24614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24614.xml"),
+          )
+      )
+
+  public val icon_24615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24615.xml"),
+          )
+      )
+
+  public val icon_24616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24616.xml"),
+          )
+      )
+
+  public val icon_24617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24617.xml"),
+          )
+      )
+
+  public val icon_24618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24618.xml"),
+          )
+      )
+
+  public val icon_24619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24619.xml"),
+          )
+      )
+
+  public val icon_2462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2462.xml"),
+          )
+      )
+
+  public val icon_24620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24620.xml"),
+          )
+      )
+
+  public val icon_24621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24621.xml"),
+          )
+      )
+
+  public val icon_24622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24622.xml"),
+          )
+      )
+
+  public val icon_24623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24623.xml"),
+          )
+      )
+
+  public val icon_24624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24624.xml"),
+          )
+      )
+
+  public val icon_24625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24625.xml"),
+          )
+      )
+
+  public val icon_24626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24626.xml"),
+          )
+      )
+
+  public val icon_24627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24627.xml"),
+          )
+      )
+
+  public val icon_24628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24628.xml"),
+          )
+      )
+
+  public val icon_24629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24629.xml"),
+          )
+      )
+
+  public val icon_2463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2463.xml"),
+          )
+      )
+
+  public val icon_24630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24630.xml"),
+          )
+      )
+
+  public val icon_24631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24631.xml"),
+          )
+      )
+
+  public val icon_24632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24632.xml"),
+          )
+      )
+
+  public val icon_24633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24633.xml"),
+          )
+      )
+
+  public val icon_24634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24634.xml"),
+          )
+      )
+
+  public val icon_24635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24635.xml"),
+          )
+      )
+
+  public val icon_24636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24636.xml"),
+          )
+      )
+
+  public val icon_24637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24637.xml"),
+          )
+      )
+
+  public val icon_24638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24638.xml"),
+          )
+      )
+
+  public val icon_24639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24639.xml"),
+          )
+      )
+
+  public val icon_2464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2464.xml"),
+          )
+      )
+
+  public val icon_24640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24640.xml"),
+          )
+      )
+
+  public val icon_24641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24641.xml"),
+          )
+      )
+
+  public val icon_24642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24642.xml"),
+          )
+      )
+
+  public val icon_24643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24643.xml"),
+          )
+      )
+
+  public val icon_24644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24644.xml"),
+          )
+      )
+
+  public val icon_24645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24645.xml"),
+          )
+      )
+
+  public val icon_24646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24646.xml"),
+          )
+      )
+
+  public val icon_24647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24647.xml"),
+          )
+      )
+
+  public val icon_24648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24648.xml"),
+          )
+      )
+
+  public val icon_24649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24649.xml"),
+          )
+      )
+
+  public val icon_2465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2465.xml"),
+          )
+      )
+
+  public val icon_24650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24650.xml"),
+          )
+      )
+
+  public val icon_24651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24651.xml"),
+          )
+      )
+
+  public val icon_24652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24652.xml"),
+          )
+      )
+
+  public val icon_24653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24653.xml"),
+          )
+      )
+
+  public val icon_24654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24654.xml"),
+          )
+      )
+
+  public val icon_24655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24655.xml"),
+          )
+      )
+
+  public val icon_24656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24656.xml"),
+          )
+      )
+
+  public val icon_24657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24657.xml"),
+          )
+      )
+
+  public val icon_24658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24658.xml"),
+          )
+      )
+
+  public val icon_24659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24659.xml"),
+          )
+      )
+
+  public val icon_2466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2466.xml"),
+          )
+      )
+
+  public val icon_24660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24660.xml"),
+          )
+      )
+
+  public val icon_24661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24661.xml"),
+          )
+      )
+
+  public val icon_24662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24662.xml"),
+          )
+      )
+
+  public val icon_24663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24663.xml"),
+          )
+      )
+
+  public val icon_24664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24664.xml"),
+          )
+      )
+
+  public val icon_24665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24665.xml"),
+          )
+      )
+
+  public val icon_24666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24666.xml"),
+          )
+      )
+
+  public val icon_24667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24667.xml"),
+          )
+      )
+
+  public val icon_24668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24668.xml"),
+          )
+      )
+
+  public val icon_24669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24669.xml"),
+          )
+      )
+
+  public val icon_2467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2467.xml"),
+          )
+      )
+
+  public val icon_24670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24670.xml"),
+          )
+      )
+
+  public val icon_24671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24671.xml"),
+          )
+      )
+
+  public val icon_24672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24672.xml"),
+          )
+      )
+
+  public val icon_24673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24673.xml"),
+          )
+      )
+
+  public val icon_24674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24674.xml"),
+          )
+      )
+
+  public val icon_24675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24675.xml"),
+          )
+      )
+
+  public val icon_24676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24676.xml"),
+          )
+      )
+
+  public val icon_24677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24677.xml"),
+          )
+      )
+
+  public val icon_24678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24678.xml"),
+          )
+      )
+
+  public val icon_24679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24679.xml"),
+          )
+      )
+
+  public val icon_2468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2468.xml"),
+          )
+      )
+
+  public val icon_24680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24680.xml"),
+          )
+      )
+
+  public val icon_24681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24681.xml"),
+          )
+      )
+
+  public val icon_24682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24682.xml"),
+          )
+      )
+
+  public val icon_24683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24683.xml"),
+          )
+      )
+
+  public val icon_24684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24684.xml"),
+          )
+      )
+
+  public val icon_24685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24685.xml"),
+          )
+      )
+
+  public val icon_24686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24686.xml"),
+          )
+      )
+
+  public val icon_24687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24687.xml"),
+          )
+      )
+
+  public val icon_24688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24688.xml"),
+          )
+      )
+
+  public val icon_24689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24689.xml"),
+          )
+      )
+
+  public val icon_2469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2469.xml"),
+          )
+      )
+
+  public val icon_24690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24690.xml"),
+          )
+      )
+
+  public val icon_24691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24691.xml"),
+          )
+      )
+
+  public val icon_24692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24692.xml"),
+          )
+      )
+
+  public val icon_24693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24693.xml"),
+          )
+      )
+
+  public val icon_24694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24694.xml"),
+          )
+      )
+
+  public val icon_24695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24695.xml"),
+          )
+      )
+
+  public val icon_24696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24696.xml"),
+          )
+      )
+
+  public val icon_24697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24697.xml"),
+          )
+      )
+
+  public val icon_24698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24698.xml"),
+          )
+      )
+
+  public val icon_24699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24699.xml"),
+          )
+      )
+
+  public val icon_247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_247.xml"),
+          )
+      )
+
+  public val icon_2470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2470.xml"),
+          )
+      )
+
+  public val icon_24700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24700.xml"),
+          )
+      )
+
+  public val icon_24701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24701.xml"),
+          )
+      )
+
+  public val icon_24702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24702.xml"),
+          )
+      )
+
+  public val icon_24703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24703.xml"),
+          )
+      )
+
+  public val icon_24704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24704.xml"),
+          )
+      )
+
+  public val icon_24705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24705.xml"),
+          )
+      )
+
+  public val icon_24706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24706.xml"),
+          )
+      )
+
+  public val icon_24707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24707.xml"),
+          )
+      )
+
+  public val icon_24708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24708.xml"),
+          )
+      )
+
+  public val icon_24709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24709.xml"),
+          )
+      )
+
+  public val icon_2471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2471.xml"),
+          )
+      )
+
+  public val icon_24710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24710.xml"),
+          )
+      )
+
+  public val icon_24711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24711.xml"),
+          )
+      )
+
+  public val icon_24712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24712.xml"),
+          )
+      )
+
+  public val icon_24713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24713.xml"),
+          )
+      )
+
+  public val icon_24714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24714.xml"),
+          )
+      )
+
+  public val icon_24715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24715.xml"),
+          )
+      )
+
+  public val icon_24716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24716.xml"),
+          )
+      )
+
+  public val icon_24717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24717.xml"),
+          )
+      )
+
+  public val icon_24718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24718.xml"),
+          )
+      )
+
+  public val icon_24719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24719.xml"),
+          )
+      )
+
+  public val icon_2472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2472.xml"),
+          )
+      )
+
+  public val icon_24720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24720.xml"),
+          )
+      )
+
+  public val icon_24721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24721.xml"),
+          )
+      )
+
+  public val icon_24722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24722.xml"),
+          )
+      )
+
+  public val icon_24723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24723.xml"),
+          )
+      )
+
+  public val icon_24724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24724.xml"),
+          )
+      )
+
+  public val icon_24725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24725.xml"),
+          )
+      )
+
+  public val icon_24726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24726.xml"),
+          )
+      )
+
+  public val icon_24727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24727.xml"),
+          )
+      )
+
+  public val icon_24728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24728.xml"),
+          )
+      )
+
+  public val icon_24729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24729.xml"),
+          )
+      )
+
+  public val icon_2473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2473.xml"),
+          )
+      )
+
+  public val icon_24730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24730.xml"),
+          )
+      )
+
+  public val icon_24731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24731.xml"),
+          )
+      )
+
+  public val icon_24732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24732.xml"),
+          )
+      )
+
+  public val icon_24733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24733.xml"),
+          )
+      )
+
+  public val icon_24734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24734.xml"),
+          )
+      )
+
+  public val icon_24735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24735.xml"),
+          )
+      )
+
+  public val icon_24736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24736.xml"),
+          )
+      )
+
+  public val icon_24737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24737.xml"),
+          )
+      )
+
+  public val icon_24738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24738.xml"),
+          )
+      )
+
+  public val icon_24739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24739.xml"),
+          )
+      )
+
+  public val icon_2474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2474.xml"),
+          )
+      )
+
+  public val icon_24740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24740.xml"),
+          )
+      )
+
+  public val icon_24741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24741.xml"),
+          )
+      )
+
+  public val icon_24742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24742.xml"),
+          )
+      )
+
+  public val icon_24743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24743.xml"),
+          )
+      )
+
+  public val icon_24744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24744.xml"),
+          )
+      )
+
+  public val icon_24745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24745.xml"),
+          )
+      )
+
+  public val icon_24746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24746.xml"),
+          )
+      )
+
+  public val icon_24747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24747.xml"),
+          )
+      )
+
+  public val icon_24748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24748.xml"),
+          )
+      )
+
+  public val icon_24749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24749.xml"),
+          )
+      )
+
+  public val icon_2475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2475.xml"),
+          )
+      )
+
+  public val icon_24750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24750.xml"),
+          )
+      )
+
+  public val icon_24751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24751.xml"),
+          )
+      )
+
+  public val icon_24752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24752.xml"),
+          )
+      )
+
+  public val icon_24753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24753.xml"),
+          )
+      )
+
+  public val icon_24754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24754.xml"),
+          )
+      )
+
+  public val icon_24755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24755.xml"),
+          )
+      )
+
+  public val icon_24756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24756.xml"),
+          )
+      )
+
+  public val icon_24757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24757.xml"),
+          )
+      )
+
+  public val icon_24758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24758.xml"),
+          )
+      )
+
+  public val icon_24759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24759.xml"),
+          )
+      )
+
+  public val icon_2476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2476.xml"),
+          )
+      )
+
+  public val icon_24760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24760.xml"),
+          )
+      )
+
+  public val icon_24761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24761.xml"),
+          )
+      )
+
+  public val icon_24762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24762.xml"),
+          )
+      )
+
+  public val icon_24763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24763.xml"),
+          )
+      )
+
+  public val icon_24764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24764.xml"),
+          )
+      )
+
+  public val icon_24765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24765.xml"),
+          )
+      )
+
+  public val icon_24766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24766.xml"),
+          )
+      )
+
+  public val icon_24767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24767.xml"),
+          )
+      )
+
+  public val icon_24768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24768.xml"),
+          )
+      )
+
+  public val icon_24769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24769.xml"),
+          )
+      )
+
+  public val icon_2477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2477.xml"),
+          )
+      )
+
+  public val icon_24770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24770.xml"),
+          )
+      )
+
+  public val icon_24771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24771.xml"),
+          )
+      )
+
+  public val icon_24772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24772.xml"),
+          )
+      )
+
+  public val icon_24773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24773.xml"),
+          )
+      )
+
+  public val icon_24774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24774.xml"),
+          )
+      )
+
+  public val icon_24775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24775.xml"),
+          )
+      )
+
+  public val icon_24776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24776.xml"),
+          )
+      )
+
+  public val icon_24777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24777.xml"),
+          )
+      )
+
+  public val icon_24778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24778.xml"),
+          )
+      )
+
+  public val icon_24779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24779.xml"),
+          )
+      )
+
+  public val icon_2478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2478.xml"),
+          )
+      )
+
+  public val icon_24780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24780.xml"),
+          )
+      )
+
+  public val icon_24781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24781.xml"),
+          )
+      )
+
+  public val icon_24782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24782.xml"),
+          )
+      )
+
+  public val icon_24783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24783.xml"),
+          )
+      )
+
+  public val icon_24784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24784.xml"),
+          )
+      )
+
+  public val icon_24785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24785.xml"),
+          )
+      )
+
+  public val icon_24786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24786.xml"),
+          )
+      )
+
+  public val icon_24787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24787.xml"),
+          )
+      )
+
+  public val icon_24788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24788.xml"),
+          )
+      )
+
+  public val icon_24789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24789.xml"),
+          )
+      )
+
+  public val icon_2479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2479.xml"),
+          )
+      )
+
+  public val icon_24790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24790.xml"),
+          )
+      )
+
+  public val icon_24791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24791.xml"),
+          )
+      )
+
+  public val icon_24792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24792.xml"),
+          )
+      )
+
+  public val icon_24793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24793.xml"),
+          )
+      )
+
+  public val icon_24794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24794.xml"),
+          )
+      )
+
+  public val icon_24795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24795.xml"),
+          )
+      )
+
+  public val icon_24796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24796.xml"),
+          )
+      )
+
+  public val icon_24797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24797.xml"),
+          )
+      )
+
+  public val icon_24798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24798.xml"),
+          )
+      )
+
+  public val icon_24799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24799.xml"),
+          )
+      )
+
+  public val icon_248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_248.xml"),
+          )
+      )
+
+  public val icon_2480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2480.xml"),
+          )
+      )
+
+  public val icon_24800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24800.xml"),
+          )
+      )
+
+  public val icon_24801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24801.xml"),
+          )
+      )
+
+  public val icon_24802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24802.xml"),
+          )
+      )
+
+  public val icon_24803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24803.xml"),
+          )
+      )
+
+  public val icon_24804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24804.xml"),
+          )
+      )
+
+  public val icon_24805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24805.xml"),
+          )
+      )
+
+  public val icon_24806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24806.xml"),
+          )
+      )
+
+  public val icon_24807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24807.xml"),
+          )
+      )
+
+  public val icon_24808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24808.xml"),
+          )
+      )
+
+  public val icon_24809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24809.xml"),
+          )
+      )
+
+  public val icon_2481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2481.xml"),
+          )
+      )
+
+  public val icon_24810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24810.xml"),
+          )
+      )
+
+  public val icon_24811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24811.xml"),
+          )
+      )
+
+  public val icon_24812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24812.xml"),
+          )
+      )
+
+  public val icon_24813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24813.xml"),
+          )
+      )
+
+  public val icon_24814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24814.xml"),
+          )
+      )
+
+  public val icon_24815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24815.xml"),
+          )
+      )
+
+  public val icon_24816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24816.xml"),
+          )
+      )
+
+  public val icon_24817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24817.xml"),
+          )
+      )
+
+  public val icon_24818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24818.xml"),
+          )
+      )
+
+  public val icon_24819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24819.xml"),
+          )
+      )
+
+  public val icon_2482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2482.xml"),
+          )
+      )
+
+  public val icon_24820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24820.xml"),
+          )
+      )
+
+  public val icon_24821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24821.xml"),
+          )
+      )
+
+  public val icon_24822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24822.xml"),
+          )
+      )
+
+  public val icon_24823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24823.xml"),
+          )
+      )
+
+  public val icon_24824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24824.xml"),
+          )
+      )
+
+  public val icon_24825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24825.xml"),
+          )
+      )
+
+  public val icon_24826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24826.xml"),
+          )
+      )
+
+  public val icon_24827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24827.xml"),
+          )
+      )
+
+  public val icon_24828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24828.xml"),
+          )
+      )
+
+  public val icon_24829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24829.xml"),
+          )
+      )
+
+  public val icon_2483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2483.xml"),
+          )
+      )
+
+  public val icon_24830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24830.xml"),
+          )
+      )
+
+  public val icon_24831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24831.xml"),
+          )
+      )
+
+  public val icon_24832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24832.xml"),
+          )
+      )
+
+  public val icon_24833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24833.xml"),
+          )
+      )
+
+  public val icon_24834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24834.xml"),
+          )
+      )
+
+  public val icon_24835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24835.xml"),
+          )
+      )
+
+  public val icon_24836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24836.xml"),
+          )
+      )
+
+  public val icon_24837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24837.xml"),
+          )
+      )
+
+  public val icon_24838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24838.xml"),
+          )
+      )
+
+  public val icon_24839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24839.xml"),
+          )
+      )
+
+  public val icon_2484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2484.xml"),
+          )
+      )
+
+  public val icon_24840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24840.xml"),
+          )
+      )
+
+  public val icon_24841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24841.xml"),
+          )
+      )
+
+  public val icon_24842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24842.xml"),
+          )
+      )
+
+  public val icon_24843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24843.xml"),
+          )
+      )
+
+  public val icon_24844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24844.xml"),
+          )
+      )
+
+  public val icon_24845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24845.xml"),
+          )
+      )
+
+  public val icon_24846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24846.xml"),
+          )
+      )
+
+  public val icon_24847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24847.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24398: DrawableResource
+  get() = Drawable32.icon_24398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24399: DrawableResource
+  get() = Drawable32.icon_24399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_244: DrawableResource
+  get() = Drawable32.icon_244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2440: DrawableResource
+  get() = Drawable32.icon_2440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24400: DrawableResource
+  get() = Drawable32.icon_24400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24401: DrawableResource
+  get() = Drawable32.icon_24401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24402: DrawableResource
+  get() = Drawable32.icon_24402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24403: DrawableResource
+  get() = Drawable32.icon_24403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24404: DrawableResource
+  get() = Drawable32.icon_24404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24405: DrawableResource
+  get() = Drawable32.icon_24405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24406: DrawableResource
+  get() = Drawable32.icon_24406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24407: DrawableResource
+  get() = Drawable32.icon_24407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24408: DrawableResource
+  get() = Drawable32.icon_24408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24409: DrawableResource
+  get() = Drawable32.icon_24409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2441: DrawableResource
+  get() = Drawable32.icon_2441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24410: DrawableResource
+  get() = Drawable32.icon_24410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24411: DrawableResource
+  get() = Drawable32.icon_24411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24412: DrawableResource
+  get() = Drawable32.icon_24412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24413: DrawableResource
+  get() = Drawable32.icon_24413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24414: DrawableResource
+  get() = Drawable32.icon_24414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24415: DrawableResource
+  get() = Drawable32.icon_24415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24416: DrawableResource
+  get() = Drawable32.icon_24416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24417: DrawableResource
+  get() = Drawable32.icon_24417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24418: DrawableResource
+  get() = Drawable32.icon_24418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24419: DrawableResource
+  get() = Drawable32.icon_24419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2442: DrawableResource
+  get() = Drawable32.icon_2442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24420: DrawableResource
+  get() = Drawable32.icon_24420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24421: DrawableResource
+  get() = Drawable32.icon_24421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24422: DrawableResource
+  get() = Drawable32.icon_24422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24423: DrawableResource
+  get() = Drawable32.icon_24423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24424: DrawableResource
+  get() = Drawable32.icon_24424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24425: DrawableResource
+  get() = Drawable32.icon_24425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24426: DrawableResource
+  get() = Drawable32.icon_24426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24427: DrawableResource
+  get() = Drawable32.icon_24427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24428: DrawableResource
+  get() = Drawable32.icon_24428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24429: DrawableResource
+  get() = Drawable32.icon_24429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2443: DrawableResource
+  get() = Drawable32.icon_2443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24430: DrawableResource
+  get() = Drawable32.icon_24430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24431: DrawableResource
+  get() = Drawable32.icon_24431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24432: DrawableResource
+  get() = Drawable32.icon_24432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24433: DrawableResource
+  get() = Drawable32.icon_24433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24434: DrawableResource
+  get() = Drawable32.icon_24434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24435: DrawableResource
+  get() = Drawable32.icon_24435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24436: DrawableResource
+  get() = Drawable32.icon_24436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24437: DrawableResource
+  get() = Drawable32.icon_24437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24438: DrawableResource
+  get() = Drawable32.icon_24438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24439: DrawableResource
+  get() = Drawable32.icon_24439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2444: DrawableResource
+  get() = Drawable32.icon_2444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24440: DrawableResource
+  get() = Drawable32.icon_24440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24441: DrawableResource
+  get() = Drawable32.icon_24441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24442: DrawableResource
+  get() = Drawable32.icon_24442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24443: DrawableResource
+  get() = Drawable32.icon_24443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24444: DrawableResource
+  get() = Drawable32.icon_24444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24445: DrawableResource
+  get() = Drawable32.icon_24445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24446: DrawableResource
+  get() = Drawable32.icon_24446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24447: DrawableResource
+  get() = Drawable32.icon_24447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24448: DrawableResource
+  get() = Drawable32.icon_24448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24449: DrawableResource
+  get() = Drawable32.icon_24449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2445: DrawableResource
+  get() = Drawable32.icon_2445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24450: DrawableResource
+  get() = Drawable32.icon_24450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24451: DrawableResource
+  get() = Drawable32.icon_24451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24452: DrawableResource
+  get() = Drawable32.icon_24452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24453: DrawableResource
+  get() = Drawable32.icon_24453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24454: DrawableResource
+  get() = Drawable32.icon_24454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24455: DrawableResource
+  get() = Drawable32.icon_24455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24456: DrawableResource
+  get() = Drawable32.icon_24456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24457: DrawableResource
+  get() = Drawable32.icon_24457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24458: DrawableResource
+  get() = Drawable32.icon_24458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24459: DrawableResource
+  get() = Drawable32.icon_24459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2446: DrawableResource
+  get() = Drawable32.icon_2446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24460: DrawableResource
+  get() = Drawable32.icon_24460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24461: DrawableResource
+  get() = Drawable32.icon_24461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24462: DrawableResource
+  get() = Drawable32.icon_24462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24463: DrawableResource
+  get() = Drawable32.icon_24463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24464: DrawableResource
+  get() = Drawable32.icon_24464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24465: DrawableResource
+  get() = Drawable32.icon_24465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24466: DrawableResource
+  get() = Drawable32.icon_24466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24467: DrawableResource
+  get() = Drawable32.icon_24467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24468: DrawableResource
+  get() = Drawable32.icon_24468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24469: DrawableResource
+  get() = Drawable32.icon_24469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2447: DrawableResource
+  get() = Drawable32.icon_2447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24470: DrawableResource
+  get() = Drawable32.icon_24470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24471: DrawableResource
+  get() = Drawable32.icon_24471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24472: DrawableResource
+  get() = Drawable32.icon_24472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24473: DrawableResource
+  get() = Drawable32.icon_24473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24474: DrawableResource
+  get() = Drawable32.icon_24474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24475: DrawableResource
+  get() = Drawable32.icon_24475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24476: DrawableResource
+  get() = Drawable32.icon_24476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24477: DrawableResource
+  get() = Drawable32.icon_24477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24478: DrawableResource
+  get() = Drawable32.icon_24478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24479: DrawableResource
+  get() = Drawable32.icon_24479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2448: DrawableResource
+  get() = Drawable32.icon_2448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24480: DrawableResource
+  get() = Drawable32.icon_24480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24481: DrawableResource
+  get() = Drawable32.icon_24481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24482: DrawableResource
+  get() = Drawable32.icon_24482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24483: DrawableResource
+  get() = Drawable32.icon_24483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24484: DrawableResource
+  get() = Drawable32.icon_24484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24485: DrawableResource
+  get() = Drawable32.icon_24485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24486: DrawableResource
+  get() = Drawable32.icon_24486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24487: DrawableResource
+  get() = Drawable32.icon_24487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24488: DrawableResource
+  get() = Drawable32.icon_24488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24489: DrawableResource
+  get() = Drawable32.icon_24489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2449: DrawableResource
+  get() = Drawable32.icon_2449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24490: DrawableResource
+  get() = Drawable32.icon_24490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24491: DrawableResource
+  get() = Drawable32.icon_24491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24492: DrawableResource
+  get() = Drawable32.icon_24492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24493: DrawableResource
+  get() = Drawable32.icon_24493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24494: DrawableResource
+  get() = Drawable32.icon_24494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24495: DrawableResource
+  get() = Drawable32.icon_24495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24496: DrawableResource
+  get() = Drawable32.icon_24496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24497: DrawableResource
+  get() = Drawable32.icon_24497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24498: DrawableResource
+  get() = Drawable32.icon_24498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24499: DrawableResource
+  get() = Drawable32.icon_24499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_245: DrawableResource
+  get() = Drawable32.icon_245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2450: DrawableResource
+  get() = Drawable32.icon_2450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24500: DrawableResource
+  get() = Drawable32.icon_24500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24501: DrawableResource
+  get() = Drawable32.icon_24501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24502: DrawableResource
+  get() = Drawable32.icon_24502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24503: DrawableResource
+  get() = Drawable32.icon_24503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24504: DrawableResource
+  get() = Drawable32.icon_24504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24505: DrawableResource
+  get() = Drawable32.icon_24505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24506: DrawableResource
+  get() = Drawable32.icon_24506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24507: DrawableResource
+  get() = Drawable32.icon_24507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24508: DrawableResource
+  get() = Drawable32.icon_24508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24509: DrawableResource
+  get() = Drawable32.icon_24509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2451: DrawableResource
+  get() = Drawable32.icon_2451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24510: DrawableResource
+  get() = Drawable32.icon_24510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24511: DrawableResource
+  get() = Drawable32.icon_24511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24512: DrawableResource
+  get() = Drawable32.icon_24512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24513: DrawableResource
+  get() = Drawable32.icon_24513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24514: DrawableResource
+  get() = Drawable32.icon_24514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24515: DrawableResource
+  get() = Drawable32.icon_24515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24516: DrawableResource
+  get() = Drawable32.icon_24516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24517: DrawableResource
+  get() = Drawable32.icon_24517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24518: DrawableResource
+  get() = Drawable32.icon_24518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24519: DrawableResource
+  get() = Drawable32.icon_24519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2452: DrawableResource
+  get() = Drawable32.icon_2452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24520: DrawableResource
+  get() = Drawable32.icon_24520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24521: DrawableResource
+  get() = Drawable32.icon_24521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24522: DrawableResource
+  get() = Drawable32.icon_24522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24523: DrawableResource
+  get() = Drawable32.icon_24523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24524: DrawableResource
+  get() = Drawable32.icon_24524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24525: DrawableResource
+  get() = Drawable32.icon_24525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24526: DrawableResource
+  get() = Drawable32.icon_24526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24527: DrawableResource
+  get() = Drawable32.icon_24527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24528: DrawableResource
+  get() = Drawable32.icon_24528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24529: DrawableResource
+  get() = Drawable32.icon_24529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2453: DrawableResource
+  get() = Drawable32.icon_2453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24530: DrawableResource
+  get() = Drawable32.icon_24530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24531: DrawableResource
+  get() = Drawable32.icon_24531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24532: DrawableResource
+  get() = Drawable32.icon_24532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24533: DrawableResource
+  get() = Drawable32.icon_24533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24534: DrawableResource
+  get() = Drawable32.icon_24534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24535: DrawableResource
+  get() = Drawable32.icon_24535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24536: DrawableResource
+  get() = Drawable32.icon_24536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24537: DrawableResource
+  get() = Drawable32.icon_24537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24538: DrawableResource
+  get() = Drawable32.icon_24538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24539: DrawableResource
+  get() = Drawable32.icon_24539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2454: DrawableResource
+  get() = Drawable32.icon_2454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24540: DrawableResource
+  get() = Drawable32.icon_24540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24541: DrawableResource
+  get() = Drawable32.icon_24541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24542: DrawableResource
+  get() = Drawable32.icon_24542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24543: DrawableResource
+  get() = Drawable32.icon_24543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24544: DrawableResource
+  get() = Drawable32.icon_24544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24545: DrawableResource
+  get() = Drawable32.icon_24545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24546: DrawableResource
+  get() = Drawable32.icon_24546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24547: DrawableResource
+  get() = Drawable32.icon_24547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24548: DrawableResource
+  get() = Drawable32.icon_24548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24549: DrawableResource
+  get() = Drawable32.icon_24549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2455: DrawableResource
+  get() = Drawable32.icon_2455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24550: DrawableResource
+  get() = Drawable32.icon_24550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24551: DrawableResource
+  get() = Drawable32.icon_24551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24552: DrawableResource
+  get() = Drawable32.icon_24552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24553: DrawableResource
+  get() = Drawable32.icon_24553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24554: DrawableResource
+  get() = Drawable32.icon_24554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24555: DrawableResource
+  get() = Drawable32.icon_24555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24556: DrawableResource
+  get() = Drawable32.icon_24556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24557: DrawableResource
+  get() = Drawable32.icon_24557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24558: DrawableResource
+  get() = Drawable32.icon_24558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24559: DrawableResource
+  get() = Drawable32.icon_24559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2456: DrawableResource
+  get() = Drawable32.icon_2456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24560: DrawableResource
+  get() = Drawable32.icon_24560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24561: DrawableResource
+  get() = Drawable32.icon_24561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24562: DrawableResource
+  get() = Drawable32.icon_24562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24563: DrawableResource
+  get() = Drawable32.icon_24563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24564: DrawableResource
+  get() = Drawable32.icon_24564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24565: DrawableResource
+  get() = Drawable32.icon_24565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24566: DrawableResource
+  get() = Drawable32.icon_24566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24567: DrawableResource
+  get() = Drawable32.icon_24567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24568: DrawableResource
+  get() = Drawable32.icon_24568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24569: DrawableResource
+  get() = Drawable32.icon_24569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2457: DrawableResource
+  get() = Drawable32.icon_2457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24570: DrawableResource
+  get() = Drawable32.icon_24570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24571: DrawableResource
+  get() = Drawable32.icon_24571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24572: DrawableResource
+  get() = Drawable32.icon_24572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24573: DrawableResource
+  get() = Drawable32.icon_24573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24574: DrawableResource
+  get() = Drawable32.icon_24574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24575: DrawableResource
+  get() = Drawable32.icon_24575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24576: DrawableResource
+  get() = Drawable32.icon_24576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24577: DrawableResource
+  get() = Drawable32.icon_24577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24578: DrawableResource
+  get() = Drawable32.icon_24578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24579: DrawableResource
+  get() = Drawable32.icon_24579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2458: DrawableResource
+  get() = Drawable32.icon_2458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24580: DrawableResource
+  get() = Drawable32.icon_24580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24581: DrawableResource
+  get() = Drawable32.icon_24581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24582: DrawableResource
+  get() = Drawable32.icon_24582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24583: DrawableResource
+  get() = Drawable32.icon_24583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24584: DrawableResource
+  get() = Drawable32.icon_24584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24585: DrawableResource
+  get() = Drawable32.icon_24585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24586: DrawableResource
+  get() = Drawable32.icon_24586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24587: DrawableResource
+  get() = Drawable32.icon_24587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24588: DrawableResource
+  get() = Drawable32.icon_24588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24589: DrawableResource
+  get() = Drawable32.icon_24589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2459: DrawableResource
+  get() = Drawable32.icon_2459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24590: DrawableResource
+  get() = Drawable32.icon_24590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24591: DrawableResource
+  get() = Drawable32.icon_24591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24592: DrawableResource
+  get() = Drawable32.icon_24592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24593: DrawableResource
+  get() = Drawable32.icon_24593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24594: DrawableResource
+  get() = Drawable32.icon_24594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24595: DrawableResource
+  get() = Drawable32.icon_24595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24596: DrawableResource
+  get() = Drawable32.icon_24596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24597: DrawableResource
+  get() = Drawable32.icon_24597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24598: DrawableResource
+  get() = Drawable32.icon_24598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24599: DrawableResource
+  get() = Drawable32.icon_24599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_246: DrawableResource
+  get() = Drawable32.icon_246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2460: DrawableResource
+  get() = Drawable32.icon_2460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24600: DrawableResource
+  get() = Drawable32.icon_24600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24601: DrawableResource
+  get() = Drawable32.icon_24601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24602: DrawableResource
+  get() = Drawable32.icon_24602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24603: DrawableResource
+  get() = Drawable32.icon_24603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24604: DrawableResource
+  get() = Drawable32.icon_24604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24605: DrawableResource
+  get() = Drawable32.icon_24605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24606: DrawableResource
+  get() = Drawable32.icon_24606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24607: DrawableResource
+  get() = Drawable32.icon_24607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24608: DrawableResource
+  get() = Drawable32.icon_24608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24609: DrawableResource
+  get() = Drawable32.icon_24609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2461: DrawableResource
+  get() = Drawable32.icon_2461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24610: DrawableResource
+  get() = Drawable32.icon_24610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24611: DrawableResource
+  get() = Drawable32.icon_24611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24612: DrawableResource
+  get() = Drawable32.icon_24612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24613: DrawableResource
+  get() = Drawable32.icon_24613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24614: DrawableResource
+  get() = Drawable32.icon_24614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24615: DrawableResource
+  get() = Drawable32.icon_24615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24616: DrawableResource
+  get() = Drawable32.icon_24616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24617: DrawableResource
+  get() = Drawable32.icon_24617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24618: DrawableResource
+  get() = Drawable32.icon_24618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24619: DrawableResource
+  get() = Drawable32.icon_24619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2462: DrawableResource
+  get() = Drawable32.icon_2462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24620: DrawableResource
+  get() = Drawable32.icon_24620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24621: DrawableResource
+  get() = Drawable32.icon_24621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24622: DrawableResource
+  get() = Drawable32.icon_24622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24623: DrawableResource
+  get() = Drawable32.icon_24623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24624: DrawableResource
+  get() = Drawable32.icon_24624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24625: DrawableResource
+  get() = Drawable32.icon_24625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24626: DrawableResource
+  get() = Drawable32.icon_24626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24627: DrawableResource
+  get() = Drawable32.icon_24627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24628: DrawableResource
+  get() = Drawable32.icon_24628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24629: DrawableResource
+  get() = Drawable32.icon_24629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2463: DrawableResource
+  get() = Drawable32.icon_2463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24630: DrawableResource
+  get() = Drawable32.icon_24630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24631: DrawableResource
+  get() = Drawable32.icon_24631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24632: DrawableResource
+  get() = Drawable32.icon_24632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24633: DrawableResource
+  get() = Drawable32.icon_24633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24634: DrawableResource
+  get() = Drawable32.icon_24634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24635: DrawableResource
+  get() = Drawable32.icon_24635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24636: DrawableResource
+  get() = Drawable32.icon_24636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24637: DrawableResource
+  get() = Drawable32.icon_24637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24638: DrawableResource
+  get() = Drawable32.icon_24638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24639: DrawableResource
+  get() = Drawable32.icon_24639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2464: DrawableResource
+  get() = Drawable32.icon_2464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24640: DrawableResource
+  get() = Drawable32.icon_24640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24641: DrawableResource
+  get() = Drawable32.icon_24641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24642: DrawableResource
+  get() = Drawable32.icon_24642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24643: DrawableResource
+  get() = Drawable32.icon_24643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24644: DrawableResource
+  get() = Drawable32.icon_24644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24645: DrawableResource
+  get() = Drawable32.icon_24645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24646: DrawableResource
+  get() = Drawable32.icon_24646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24647: DrawableResource
+  get() = Drawable32.icon_24647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24648: DrawableResource
+  get() = Drawable32.icon_24648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24649: DrawableResource
+  get() = Drawable32.icon_24649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2465: DrawableResource
+  get() = Drawable32.icon_2465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24650: DrawableResource
+  get() = Drawable32.icon_24650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24651: DrawableResource
+  get() = Drawable32.icon_24651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24652: DrawableResource
+  get() = Drawable32.icon_24652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24653: DrawableResource
+  get() = Drawable32.icon_24653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24654: DrawableResource
+  get() = Drawable32.icon_24654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24655: DrawableResource
+  get() = Drawable32.icon_24655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24656: DrawableResource
+  get() = Drawable32.icon_24656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24657: DrawableResource
+  get() = Drawable32.icon_24657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24658: DrawableResource
+  get() = Drawable32.icon_24658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24659: DrawableResource
+  get() = Drawable32.icon_24659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2466: DrawableResource
+  get() = Drawable32.icon_2466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24660: DrawableResource
+  get() = Drawable32.icon_24660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24661: DrawableResource
+  get() = Drawable32.icon_24661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24662: DrawableResource
+  get() = Drawable32.icon_24662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24663: DrawableResource
+  get() = Drawable32.icon_24663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24664: DrawableResource
+  get() = Drawable32.icon_24664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24665: DrawableResource
+  get() = Drawable32.icon_24665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24666: DrawableResource
+  get() = Drawable32.icon_24666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24667: DrawableResource
+  get() = Drawable32.icon_24667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24668: DrawableResource
+  get() = Drawable32.icon_24668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24669: DrawableResource
+  get() = Drawable32.icon_24669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2467: DrawableResource
+  get() = Drawable32.icon_2467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24670: DrawableResource
+  get() = Drawable32.icon_24670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24671: DrawableResource
+  get() = Drawable32.icon_24671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24672: DrawableResource
+  get() = Drawable32.icon_24672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24673: DrawableResource
+  get() = Drawable32.icon_24673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24674: DrawableResource
+  get() = Drawable32.icon_24674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24675: DrawableResource
+  get() = Drawable32.icon_24675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24676: DrawableResource
+  get() = Drawable32.icon_24676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24677: DrawableResource
+  get() = Drawable32.icon_24677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24678: DrawableResource
+  get() = Drawable32.icon_24678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24679: DrawableResource
+  get() = Drawable32.icon_24679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2468: DrawableResource
+  get() = Drawable32.icon_2468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24680: DrawableResource
+  get() = Drawable32.icon_24680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24681: DrawableResource
+  get() = Drawable32.icon_24681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24682: DrawableResource
+  get() = Drawable32.icon_24682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24683: DrawableResource
+  get() = Drawable32.icon_24683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24684: DrawableResource
+  get() = Drawable32.icon_24684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24685: DrawableResource
+  get() = Drawable32.icon_24685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24686: DrawableResource
+  get() = Drawable32.icon_24686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24687: DrawableResource
+  get() = Drawable32.icon_24687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24688: DrawableResource
+  get() = Drawable32.icon_24688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24689: DrawableResource
+  get() = Drawable32.icon_24689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2469: DrawableResource
+  get() = Drawable32.icon_2469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24690: DrawableResource
+  get() = Drawable32.icon_24690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24691: DrawableResource
+  get() = Drawable32.icon_24691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24692: DrawableResource
+  get() = Drawable32.icon_24692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24693: DrawableResource
+  get() = Drawable32.icon_24693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24694: DrawableResource
+  get() = Drawable32.icon_24694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24695: DrawableResource
+  get() = Drawable32.icon_24695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24696: DrawableResource
+  get() = Drawable32.icon_24696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24697: DrawableResource
+  get() = Drawable32.icon_24697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24698: DrawableResource
+  get() = Drawable32.icon_24698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24699: DrawableResource
+  get() = Drawable32.icon_24699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_247: DrawableResource
+  get() = Drawable32.icon_247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2470: DrawableResource
+  get() = Drawable32.icon_2470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24700: DrawableResource
+  get() = Drawable32.icon_24700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24701: DrawableResource
+  get() = Drawable32.icon_24701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24702: DrawableResource
+  get() = Drawable32.icon_24702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24703: DrawableResource
+  get() = Drawable32.icon_24703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24704: DrawableResource
+  get() = Drawable32.icon_24704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24705: DrawableResource
+  get() = Drawable32.icon_24705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24706: DrawableResource
+  get() = Drawable32.icon_24706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24707: DrawableResource
+  get() = Drawable32.icon_24707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24708: DrawableResource
+  get() = Drawable32.icon_24708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24709: DrawableResource
+  get() = Drawable32.icon_24709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2471: DrawableResource
+  get() = Drawable32.icon_2471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24710: DrawableResource
+  get() = Drawable32.icon_24710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24711: DrawableResource
+  get() = Drawable32.icon_24711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24712: DrawableResource
+  get() = Drawable32.icon_24712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24713: DrawableResource
+  get() = Drawable32.icon_24713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24714: DrawableResource
+  get() = Drawable32.icon_24714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24715: DrawableResource
+  get() = Drawable32.icon_24715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24716: DrawableResource
+  get() = Drawable32.icon_24716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24717: DrawableResource
+  get() = Drawable32.icon_24717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24718: DrawableResource
+  get() = Drawable32.icon_24718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24719: DrawableResource
+  get() = Drawable32.icon_24719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2472: DrawableResource
+  get() = Drawable32.icon_2472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24720: DrawableResource
+  get() = Drawable32.icon_24720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24721: DrawableResource
+  get() = Drawable32.icon_24721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24722: DrawableResource
+  get() = Drawable32.icon_24722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24723: DrawableResource
+  get() = Drawable32.icon_24723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24724: DrawableResource
+  get() = Drawable32.icon_24724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24725: DrawableResource
+  get() = Drawable32.icon_24725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24726: DrawableResource
+  get() = Drawable32.icon_24726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24727: DrawableResource
+  get() = Drawable32.icon_24727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24728: DrawableResource
+  get() = Drawable32.icon_24728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24729: DrawableResource
+  get() = Drawable32.icon_24729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2473: DrawableResource
+  get() = Drawable32.icon_2473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24730: DrawableResource
+  get() = Drawable32.icon_24730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24731: DrawableResource
+  get() = Drawable32.icon_24731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24732: DrawableResource
+  get() = Drawable32.icon_24732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24733: DrawableResource
+  get() = Drawable32.icon_24733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24734: DrawableResource
+  get() = Drawable32.icon_24734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24735: DrawableResource
+  get() = Drawable32.icon_24735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24736: DrawableResource
+  get() = Drawable32.icon_24736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24737: DrawableResource
+  get() = Drawable32.icon_24737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24738: DrawableResource
+  get() = Drawable32.icon_24738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24739: DrawableResource
+  get() = Drawable32.icon_24739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2474: DrawableResource
+  get() = Drawable32.icon_2474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24740: DrawableResource
+  get() = Drawable32.icon_24740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24741: DrawableResource
+  get() = Drawable32.icon_24741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24742: DrawableResource
+  get() = Drawable32.icon_24742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24743: DrawableResource
+  get() = Drawable32.icon_24743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24744: DrawableResource
+  get() = Drawable32.icon_24744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24745: DrawableResource
+  get() = Drawable32.icon_24745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24746: DrawableResource
+  get() = Drawable32.icon_24746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24747: DrawableResource
+  get() = Drawable32.icon_24747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24748: DrawableResource
+  get() = Drawable32.icon_24748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24749: DrawableResource
+  get() = Drawable32.icon_24749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2475: DrawableResource
+  get() = Drawable32.icon_2475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24750: DrawableResource
+  get() = Drawable32.icon_24750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24751: DrawableResource
+  get() = Drawable32.icon_24751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24752: DrawableResource
+  get() = Drawable32.icon_24752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24753: DrawableResource
+  get() = Drawable32.icon_24753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24754: DrawableResource
+  get() = Drawable32.icon_24754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24755: DrawableResource
+  get() = Drawable32.icon_24755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24756: DrawableResource
+  get() = Drawable32.icon_24756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24757: DrawableResource
+  get() = Drawable32.icon_24757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24758: DrawableResource
+  get() = Drawable32.icon_24758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24759: DrawableResource
+  get() = Drawable32.icon_24759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2476: DrawableResource
+  get() = Drawable32.icon_2476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24760: DrawableResource
+  get() = Drawable32.icon_24760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24761: DrawableResource
+  get() = Drawable32.icon_24761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24762: DrawableResource
+  get() = Drawable32.icon_24762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24763: DrawableResource
+  get() = Drawable32.icon_24763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24764: DrawableResource
+  get() = Drawable32.icon_24764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24765: DrawableResource
+  get() = Drawable32.icon_24765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24766: DrawableResource
+  get() = Drawable32.icon_24766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24767: DrawableResource
+  get() = Drawable32.icon_24767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24768: DrawableResource
+  get() = Drawable32.icon_24768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24769: DrawableResource
+  get() = Drawable32.icon_24769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2477: DrawableResource
+  get() = Drawable32.icon_2477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24770: DrawableResource
+  get() = Drawable32.icon_24770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24771: DrawableResource
+  get() = Drawable32.icon_24771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24772: DrawableResource
+  get() = Drawable32.icon_24772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24773: DrawableResource
+  get() = Drawable32.icon_24773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24774: DrawableResource
+  get() = Drawable32.icon_24774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24775: DrawableResource
+  get() = Drawable32.icon_24775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24776: DrawableResource
+  get() = Drawable32.icon_24776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24777: DrawableResource
+  get() = Drawable32.icon_24777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24778: DrawableResource
+  get() = Drawable32.icon_24778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24779: DrawableResource
+  get() = Drawable32.icon_24779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2478: DrawableResource
+  get() = Drawable32.icon_2478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24780: DrawableResource
+  get() = Drawable32.icon_24780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24781: DrawableResource
+  get() = Drawable32.icon_24781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24782: DrawableResource
+  get() = Drawable32.icon_24782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24783: DrawableResource
+  get() = Drawable32.icon_24783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24784: DrawableResource
+  get() = Drawable32.icon_24784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24785: DrawableResource
+  get() = Drawable32.icon_24785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24786: DrawableResource
+  get() = Drawable32.icon_24786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24787: DrawableResource
+  get() = Drawable32.icon_24787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24788: DrawableResource
+  get() = Drawable32.icon_24788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24789: DrawableResource
+  get() = Drawable32.icon_24789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2479: DrawableResource
+  get() = Drawable32.icon_2479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24790: DrawableResource
+  get() = Drawable32.icon_24790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24791: DrawableResource
+  get() = Drawable32.icon_24791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24792: DrawableResource
+  get() = Drawable32.icon_24792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24793: DrawableResource
+  get() = Drawable32.icon_24793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24794: DrawableResource
+  get() = Drawable32.icon_24794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24795: DrawableResource
+  get() = Drawable32.icon_24795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24796: DrawableResource
+  get() = Drawable32.icon_24796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24797: DrawableResource
+  get() = Drawable32.icon_24797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24798: DrawableResource
+  get() = Drawable32.icon_24798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24799: DrawableResource
+  get() = Drawable32.icon_24799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_248: DrawableResource
+  get() = Drawable32.icon_248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2480: DrawableResource
+  get() = Drawable32.icon_2480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24800: DrawableResource
+  get() = Drawable32.icon_24800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24801: DrawableResource
+  get() = Drawable32.icon_24801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24802: DrawableResource
+  get() = Drawable32.icon_24802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24803: DrawableResource
+  get() = Drawable32.icon_24803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24804: DrawableResource
+  get() = Drawable32.icon_24804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24805: DrawableResource
+  get() = Drawable32.icon_24805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24806: DrawableResource
+  get() = Drawable32.icon_24806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24807: DrawableResource
+  get() = Drawable32.icon_24807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24808: DrawableResource
+  get() = Drawable32.icon_24808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24809: DrawableResource
+  get() = Drawable32.icon_24809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2481: DrawableResource
+  get() = Drawable32.icon_2481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24810: DrawableResource
+  get() = Drawable32.icon_24810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24811: DrawableResource
+  get() = Drawable32.icon_24811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24812: DrawableResource
+  get() = Drawable32.icon_24812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24813: DrawableResource
+  get() = Drawable32.icon_24813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24814: DrawableResource
+  get() = Drawable32.icon_24814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24815: DrawableResource
+  get() = Drawable32.icon_24815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24816: DrawableResource
+  get() = Drawable32.icon_24816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24817: DrawableResource
+  get() = Drawable32.icon_24817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24818: DrawableResource
+  get() = Drawable32.icon_24818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24819: DrawableResource
+  get() = Drawable32.icon_24819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2482: DrawableResource
+  get() = Drawable32.icon_2482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24820: DrawableResource
+  get() = Drawable32.icon_24820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24821: DrawableResource
+  get() = Drawable32.icon_24821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24822: DrawableResource
+  get() = Drawable32.icon_24822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24823: DrawableResource
+  get() = Drawable32.icon_24823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24824: DrawableResource
+  get() = Drawable32.icon_24824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24825: DrawableResource
+  get() = Drawable32.icon_24825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24826: DrawableResource
+  get() = Drawable32.icon_24826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24827: DrawableResource
+  get() = Drawable32.icon_24827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24828: DrawableResource
+  get() = Drawable32.icon_24828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24829: DrawableResource
+  get() = Drawable32.icon_24829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2483: DrawableResource
+  get() = Drawable32.icon_2483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24830: DrawableResource
+  get() = Drawable32.icon_24830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24831: DrawableResource
+  get() = Drawable32.icon_24831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24832: DrawableResource
+  get() = Drawable32.icon_24832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24833: DrawableResource
+  get() = Drawable32.icon_24833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24834: DrawableResource
+  get() = Drawable32.icon_24834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24835: DrawableResource
+  get() = Drawable32.icon_24835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24836: DrawableResource
+  get() = Drawable32.icon_24836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24837: DrawableResource
+  get() = Drawable32.icon_24837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24838: DrawableResource
+  get() = Drawable32.icon_24838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24839: DrawableResource
+  get() = Drawable32.icon_24839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2484: DrawableResource
+  get() = Drawable32.icon_2484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24840: DrawableResource
+  get() = Drawable32.icon_24840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24841: DrawableResource
+  get() = Drawable32.icon_24841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24842: DrawableResource
+  get() = Drawable32.icon_24842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24843: DrawableResource
+  get() = Drawable32.icon_24843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24844: DrawableResource
+  get() = Drawable32.icon_24844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24845: DrawableResource
+  get() = Drawable32.icon_24845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24846: DrawableResource
+  get() = Drawable32.icon_24846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24847: DrawableResource
+  get() = Drawable32.icon_24847

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable33.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable33.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable33 {
+  public val icon_24848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24848.xml"),
+          )
+      )
+
+  public val icon_24849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24849.xml"),
+          )
+      )
+
+  public val icon_2485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2485.xml"),
+          )
+      )
+
+  public val icon_24850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24850.xml"),
+          )
+      )
+
+  public val icon_24851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24851.xml"),
+          )
+      )
+
+  public val icon_24852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24852.xml"),
+          )
+      )
+
+  public val icon_24853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24853.xml"),
+          )
+      )
+
+  public val icon_24854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24854.xml"),
+          )
+      )
+
+  public val icon_24855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24855.xml"),
+          )
+      )
+
+  public val icon_24856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24856.xml"),
+          )
+      )
+
+  public val icon_24857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24857.xml"),
+          )
+      )
+
+  public val icon_24858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24858.xml"),
+          )
+      )
+
+  public val icon_24859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24859.xml"),
+          )
+      )
+
+  public val icon_2486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2486.xml"),
+          )
+      )
+
+  public val icon_24860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24860.xml"),
+          )
+      )
+
+  public val icon_24861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24861.xml"),
+          )
+      )
+
+  public val icon_24862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24862.xml"),
+          )
+      )
+
+  public val icon_24863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24863.xml"),
+          )
+      )
+
+  public val icon_24864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24864.xml"),
+          )
+      )
+
+  public val icon_24865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24865.xml"),
+          )
+      )
+
+  public val icon_24866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24866.xml"),
+          )
+      )
+
+  public val icon_24867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24867.xml"),
+          )
+      )
+
+  public val icon_24868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24868.xml"),
+          )
+      )
+
+  public val icon_24869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24869.xml"),
+          )
+      )
+
+  public val icon_2487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2487.xml"),
+          )
+      )
+
+  public val icon_24870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24870.xml"),
+          )
+      )
+
+  public val icon_24871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24871.xml"),
+          )
+      )
+
+  public val icon_24872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24872.xml"),
+          )
+      )
+
+  public val icon_24873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24873.xml"),
+          )
+      )
+
+  public val icon_24874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24874.xml"),
+          )
+      )
+
+  public val icon_24875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24875.xml"),
+          )
+      )
+
+  public val icon_24876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24876.xml"),
+          )
+      )
+
+  public val icon_24877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24877.xml"),
+          )
+      )
+
+  public val icon_24878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24878.xml"),
+          )
+      )
+
+  public val icon_24879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24879.xml"),
+          )
+      )
+
+  public val icon_2488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2488.xml"),
+          )
+      )
+
+  public val icon_24880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24880.xml"),
+          )
+      )
+
+  public val icon_24881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24881.xml"),
+          )
+      )
+
+  public val icon_24882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24882.xml"),
+          )
+      )
+
+  public val icon_24883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24883.xml"),
+          )
+      )
+
+  public val icon_24884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24884.xml"),
+          )
+      )
+
+  public val icon_24885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24885.xml"),
+          )
+      )
+
+  public val icon_24886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24886.xml"),
+          )
+      )
+
+  public val icon_24887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24887.xml"),
+          )
+      )
+
+  public val icon_24888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24888.xml"),
+          )
+      )
+
+  public val icon_24889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24889.xml"),
+          )
+      )
+
+  public val icon_2489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2489.xml"),
+          )
+      )
+
+  public val icon_24890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24890.xml"),
+          )
+      )
+
+  public val icon_24891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24891.xml"),
+          )
+      )
+
+  public val icon_24892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24892.xml"),
+          )
+      )
+
+  public val icon_24893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24893.xml"),
+          )
+      )
+
+  public val icon_24894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24894.xml"),
+          )
+      )
+
+  public val icon_24895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24895.xml"),
+          )
+      )
+
+  public val icon_24896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24896.xml"),
+          )
+      )
+
+  public val icon_24897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24897.xml"),
+          )
+      )
+
+  public val icon_24898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24898.xml"),
+          )
+      )
+
+  public val icon_24899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24899.xml"),
+          )
+      )
+
+  public val icon_249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_249.xml"),
+          )
+      )
+
+  public val icon_2490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2490.xml"),
+          )
+      )
+
+  public val icon_24900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24900.xml"),
+          )
+      )
+
+  public val icon_24901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24901.xml"),
+          )
+      )
+
+  public val icon_24902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24902.xml"),
+          )
+      )
+
+  public val icon_24903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24903.xml"),
+          )
+      )
+
+  public val icon_24904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24904.xml"),
+          )
+      )
+
+  public val icon_24905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24905.xml"),
+          )
+      )
+
+  public val icon_24906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24906.xml"),
+          )
+      )
+
+  public val icon_24907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24907.xml"),
+          )
+      )
+
+  public val icon_24908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24908.xml"),
+          )
+      )
+
+  public val icon_24909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24909.xml"),
+          )
+      )
+
+  public val icon_2491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2491.xml"),
+          )
+      )
+
+  public val icon_24910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24910.xml"),
+          )
+      )
+
+  public val icon_24911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24911.xml"),
+          )
+      )
+
+  public val icon_24912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24912.xml"),
+          )
+      )
+
+  public val icon_24913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24913.xml"),
+          )
+      )
+
+  public val icon_24914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24914.xml"),
+          )
+      )
+
+  public val icon_24915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24915.xml"),
+          )
+      )
+
+  public val icon_24916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24916.xml"),
+          )
+      )
+
+  public val icon_24917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24917.xml"),
+          )
+      )
+
+  public val icon_24918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24918.xml"),
+          )
+      )
+
+  public val icon_24919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24919.xml"),
+          )
+      )
+
+  public val icon_2492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2492.xml"),
+          )
+      )
+
+  public val icon_24920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24920.xml"),
+          )
+      )
+
+  public val icon_24921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24921.xml"),
+          )
+      )
+
+  public val icon_24922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24922.xml"),
+          )
+      )
+
+  public val icon_24923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24923.xml"),
+          )
+      )
+
+  public val icon_24924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24924.xml"),
+          )
+      )
+
+  public val icon_24925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24925.xml"),
+          )
+      )
+
+  public val icon_24926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24926.xml"),
+          )
+      )
+
+  public val icon_24927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24927.xml"),
+          )
+      )
+
+  public val icon_24928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24928.xml"),
+          )
+      )
+
+  public val icon_24929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24929.xml"),
+          )
+      )
+
+  public val icon_2493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2493.xml"),
+          )
+      )
+
+  public val icon_24930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24930.xml"),
+          )
+      )
+
+  public val icon_24931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24931.xml"),
+          )
+      )
+
+  public val icon_24932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24932.xml"),
+          )
+      )
+
+  public val icon_24933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24933.xml"),
+          )
+      )
+
+  public val icon_24934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24934.xml"),
+          )
+      )
+
+  public val icon_24935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24935.xml"),
+          )
+      )
+
+  public val icon_24936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24936.xml"),
+          )
+      )
+
+  public val icon_24937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24937.xml"),
+          )
+      )
+
+  public val icon_24938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24938.xml"),
+          )
+      )
+
+  public val icon_24939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24939.xml"),
+          )
+      )
+
+  public val icon_2494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2494.xml"),
+          )
+      )
+
+  public val icon_24940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24940.xml"),
+          )
+      )
+
+  public val icon_24941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24941.xml"),
+          )
+      )
+
+  public val icon_24942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24942.xml"),
+          )
+      )
+
+  public val icon_24943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24943.xml"),
+          )
+      )
+
+  public val icon_24944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24944.xml"),
+          )
+      )
+
+  public val icon_24945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24945.xml"),
+          )
+      )
+
+  public val icon_24946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24946.xml"),
+          )
+      )
+
+  public val icon_24947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24947.xml"),
+          )
+      )
+
+  public val icon_24948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24948.xml"),
+          )
+      )
+
+  public val icon_24949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24949.xml"),
+          )
+      )
+
+  public val icon_2495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2495.xml"),
+          )
+      )
+
+  public val icon_24950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24950.xml"),
+          )
+      )
+
+  public val icon_24951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24951.xml"),
+          )
+      )
+
+  public val icon_24952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24952.xml"),
+          )
+      )
+
+  public val icon_24953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24953.xml"),
+          )
+      )
+
+  public val icon_24954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24954.xml"),
+          )
+      )
+
+  public val icon_24955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24955.xml"),
+          )
+      )
+
+  public val icon_24956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24956.xml"),
+          )
+      )
+
+  public val icon_24957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24957.xml"),
+          )
+      )
+
+  public val icon_24958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24958.xml"),
+          )
+      )
+
+  public val icon_24959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24959.xml"),
+          )
+      )
+
+  public val icon_2496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2496.xml"),
+          )
+      )
+
+  public val icon_24960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24960.xml"),
+          )
+      )
+
+  public val icon_24961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24961.xml"),
+          )
+      )
+
+  public val icon_24962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24962.xml"),
+          )
+      )
+
+  public val icon_24963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24963.xml"),
+          )
+      )
+
+  public val icon_24964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24964.xml"),
+          )
+      )
+
+  public val icon_24965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24965.xml"),
+          )
+      )
+
+  public val icon_24966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24966.xml"),
+          )
+      )
+
+  public val icon_24967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24967.xml"),
+          )
+      )
+
+  public val icon_24968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24968.xml"),
+          )
+      )
+
+  public val icon_24969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24969.xml"),
+          )
+      )
+
+  public val icon_2497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2497.xml"),
+          )
+      )
+
+  public val icon_24970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24970.xml"),
+          )
+      )
+
+  public val icon_24971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24971.xml"),
+          )
+      )
+
+  public val icon_24972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24972.xml"),
+          )
+      )
+
+  public val icon_24973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24973.xml"),
+          )
+      )
+
+  public val icon_24974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24974.xml"),
+          )
+      )
+
+  public val icon_24975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24975.xml"),
+          )
+      )
+
+  public val icon_24976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24976.xml"),
+          )
+      )
+
+  public val icon_24977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24977.xml"),
+          )
+      )
+
+  public val icon_24978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24978.xml"),
+          )
+      )
+
+  public val icon_24979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24979.xml"),
+          )
+      )
+
+  public val icon_2498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2498.xml"),
+          )
+      )
+
+  public val icon_24980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24980.xml"),
+          )
+      )
+
+  public val icon_24981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24981.xml"),
+          )
+      )
+
+  public val icon_24982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24982.xml"),
+          )
+      )
+
+  public val icon_24983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24983.xml"),
+          )
+      )
+
+  public val icon_24984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24984.xml"),
+          )
+      )
+
+  public val icon_24985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24985.xml"),
+          )
+      )
+
+  public val icon_24986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24986.xml"),
+          )
+      )
+
+  public val icon_24987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24987.xml"),
+          )
+      )
+
+  public val icon_24988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24988.xml"),
+          )
+      )
+
+  public val icon_24989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24989.xml"),
+          )
+      )
+
+  public val icon_2499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2499.xml"),
+          )
+      )
+
+  public val icon_24990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24990.xml"),
+          )
+      )
+
+  public val icon_24991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24991.xml"),
+          )
+      )
+
+  public val icon_24992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24992.xml"),
+          )
+      )
+
+  public val icon_24993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24993.xml"),
+          )
+      )
+
+  public val icon_24994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24994.xml"),
+          )
+      )
+
+  public val icon_24995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24995.xml"),
+          )
+      )
+
+  public val icon_24996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24996.xml"),
+          )
+      )
+
+  public val icon_24997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24997.xml"),
+          )
+      )
+
+  public val icon_24998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24998.xml"),
+          )
+      )
+
+  public val icon_24999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_24999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_24999.xml"),
+          )
+      )
+
+  public val icon_25: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_25",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_25.xml"),
+          )
+      )
+
+  public val icon_250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_250.xml"),
+          )
+      )
+
+  public val icon_2500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2500.xml"),
+          )
+      )
+
+  public val icon_2501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2501.xml"),
+          )
+      )
+
+  public val icon_2502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2502.xml"),
+          )
+      )
+
+  public val icon_2503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2503.xml"),
+          )
+      )
+
+  public val icon_2504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2504.xml"),
+          )
+      )
+
+  public val icon_2505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2505.xml"),
+          )
+      )
+
+  public val icon_2506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2506.xml"),
+          )
+      )
+
+  public val icon_2507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2507.xml"),
+          )
+      )
+
+  public val icon_2508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2508.xml"),
+          )
+      )
+
+  public val icon_2509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2509.xml"),
+          )
+      )
+
+  public val icon_251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_251.xml"),
+          )
+      )
+
+  public val icon_2510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2510.xml"),
+          )
+      )
+
+  public val icon_2511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2511.xml"),
+          )
+      )
+
+  public val icon_2512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2512.xml"),
+          )
+      )
+
+  public val icon_2513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2513.xml"),
+          )
+      )
+
+  public val icon_2514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2514.xml"),
+          )
+      )
+
+  public val icon_2515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2515.xml"),
+          )
+      )
+
+  public val icon_2516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2516.xml"),
+          )
+      )
+
+  public val icon_2517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2517.xml"),
+          )
+      )
+
+  public val icon_2518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2518.xml"),
+          )
+      )
+
+  public val icon_2519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2519.xml"),
+          )
+      )
+
+  public val icon_252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_252.xml"),
+          )
+      )
+
+  public val icon_2520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2520.xml"),
+          )
+      )
+
+  public val icon_2521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2521.xml"),
+          )
+      )
+
+  public val icon_2522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2522.xml"),
+          )
+      )
+
+  public val icon_2523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2523.xml"),
+          )
+      )
+
+  public val icon_2524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2524.xml"),
+          )
+      )
+
+  public val icon_2525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2525.xml"),
+          )
+      )
+
+  public val icon_2526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2526.xml"),
+          )
+      )
+
+  public val icon_2527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2527.xml"),
+          )
+      )
+
+  public val icon_2528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2528.xml"),
+          )
+      )
+
+  public val icon_2529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2529.xml"),
+          )
+      )
+
+  public val icon_253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_253.xml"),
+          )
+      )
+
+  public val icon_2530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2530.xml"),
+          )
+      )
+
+  public val icon_2531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2531.xml"),
+          )
+      )
+
+  public val icon_2532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2532.xml"),
+          )
+      )
+
+  public val icon_2533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2533.xml"),
+          )
+      )
+
+  public val icon_2534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2534.xml"),
+          )
+      )
+
+  public val icon_2535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2535.xml"),
+          )
+      )
+
+  public val icon_2536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2536.xml"),
+          )
+      )
+
+  public val icon_2537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2537.xml"),
+          )
+      )
+
+  public val icon_2538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2538.xml"),
+          )
+      )
+
+  public val icon_2539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2539.xml"),
+          )
+      )
+
+  public val icon_254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_254.xml"),
+          )
+      )
+
+  public val icon_2540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2540.xml"),
+          )
+      )
+
+  public val icon_2541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2541.xml"),
+          )
+      )
+
+  public val icon_2542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2542.xml"),
+          )
+      )
+
+  public val icon_2543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2543.xml"),
+          )
+      )
+
+  public val icon_2544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2544.xml"),
+          )
+      )
+
+  public val icon_2545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2545.xml"),
+          )
+      )
+
+  public val icon_2546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2546.xml"),
+          )
+      )
+
+  public val icon_2547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2547.xml"),
+          )
+      )
+
+  public val icon_2548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2548.xml"),
+          )
+      )
+
+  public val icon_2549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2549.xml"),
+          )
+      )
+
+  public val icon_255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_255.xml"),
+          )
+      )
+
+  public val icon_2550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2550.xml"),
+          )
+      )
+
+  public val icon_2551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2551.xml"),
+          )
+      )
+
+  public val icon_2552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2552.xml"),
+          )
+      )
+
+  public val icon_2553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2553.xml"),
+          )
+      )
+
+  public val icon_2554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2554.xml"),
+          )
+      )
+
+  public val icon_2555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2555.xml"),
+          )
+      )
+
+  public val icon_2556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2556.xml"),
+          )
+      )
+
+  public val icon_2557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2557.xml"),
+          )
+      )
+
+  public val icon_2558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2558.xml"),
+          )
+      )
+
+  public val icon_2559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2559.xml"),
+          )
+      )
+
+  public val icon_256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_256.xml"),
+          )
+      )
+
+  public val icon_2560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2560.xml"),
+          )
+      )
+
+  public val icon_2561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2561.xml"),
+          )
+      )
+
+  public val icon_2562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2562.xml"),
+          )
+      )
+
+  public val icon_2563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2563.xml"),
+          )
+      )
+
+  public val icon_2564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2564.xml"),
+          )
+      )
+
+  public val icon_2565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2565.xml"),
+          )
+      )
+
+  public val icon_2566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2566.xml"),
+          )
+      )
+
+  public val icon_2567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2567.xml"),
+          )
+      )
+
+  public val icon_2568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2568.xml"),
+          )
+      )
+
+  public val icon_2569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2569.xml"),
+          )
+      )
+
+  public val icon_257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_257.xml"),
+          )
+      )
+
+  public val icon_2570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2570.xml"),
+          )
+      )
+
+  public val icon_2571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2571.xml"),
+          )
+      )
+
+  public val icon_2572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2572.xml"),
+          )
+      )
+
+  public val icon_2573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2573.xml"),
+          )
+      )
+
+  public val icon_2574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2574.xml"),
+          )
+      )
+
+  public val icon_2575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2575.xml"),
+          )
+      )
+
+  public val icon_2576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2576.xml"),
+          )
+      )
+
+  public val icon_2577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2577.xml"),
+          )
+      )
+
+  public val icon_2578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2578.xml"),
+          )
+      )
+
+  public val icon_2579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2579.xml"),
+          )
+      )
+
+  public val icon_258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_258.xml"),
+          )
+      )
+
+  public val icon_2580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2580.xml"),
+          )
+      )
+
+  public val icon_2581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2581.xml"),
+          )
+      )
+
+  public val icon_2582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2582.xml"),
+          )
+      )
+
+  public val icon_2583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2583.xml"),
+          )
+      )
+
+  public val icon_2584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2584.xml"),
+          )
+      )
+
+  public val icon_2585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2585.xml"),
+          )
+      )
+
+  public val icon_2586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2586.xml"),
+          )
+      )
+
+  public val icon_2587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2587.xml"),
+          )
+      )
+
+  public val icon_2588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2588.xml"),
+          )
+      )
+
+  public val icon_2589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2589.xml"),
+          )
+      )
+
+  public val icon_259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_259.xml"),
+          )
+      )
+
+  public val icon_2590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2590.xml"),
+          )
+      )
+
+  public val icon_2591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2591.xml"),
+          )
+      )
+
+  public val icon_2592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2592.xml"),
+          )
+      )
+
+  public val icon_2593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2593.xml"),
+          )
+      )
+
+  public val icon_2594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2594.xml"),
+          )
+      )
+
+  public val icon_2595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2595.xml"),
+          )
+      )
+
+  public val icon_2596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2596.xml"),
+          )
+      )
+
+  public val icon_2597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2597.xml"),
+          )
+      )
+
+  public val icon_2598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2598.xml"),
+          )
+      )
+
+  public val icon_2599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2599.xml"),
+          )
+      )
+
+  public val icon_26: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_26",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_26.xml"),
+          )
+      )
+
+  public val icon_260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_260.xml"),
+          )
+      )
+
+  public val icon_2600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2600.xml"),
+          )
+      )
+
+  public val icon_2601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2601.xml"),
+          )
+      )
+
+  public val icon_2602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2602.xml"),
+          )
+      )
+
+  public val icon_2603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2603.xml"),
+          )
+      )
+
+  public val icon_2604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2604.xml"),
+          )
+      )
+
+  public val icon_2605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2605.xml"),
+          )
+      )
+
+  public val icon_2606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2606.xml"),
+          )
+      )
+
+  public val icon_2607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2607.xml"),
+          )
+      )
+
+  public val icon_2608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2608.xml"),
+          )
+      )
+
+  public val icon_2609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2609.xml"),
+          )
+      )
+
+  public val icon_261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_261.xml"),
+          )
+      )
+
+  public val icon_2610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2610.xml"),
+          )
+      )
+
+  public val icon_2611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2611.xml"),
+          )
+      )
+
+  public val icon_2612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2612.xml"),
+          )
+      )
+
+  public val icon_2613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2613.xml"),
+          )
+      )
+
+  public val icon_2614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2614.xml"),
+          )
+      )
+
+  public val icon_2615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2615.xml"),
+          )
+      )
+
+  public val icon_2616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2616.xml"),
+          )
+      )
+
+  public val icon_2617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2617.xml"),
+          )
+      )
+
+  public val icon_2618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2618.xml"),
+          )
+      )
+
+  public val icon_2619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2619.xml"),
+          )
+      )
+
+  public val icon_262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_262.xml"),
+          )
+      )
+
+  public val icon_2620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2620.xml"),
+          )
+      )
+
+  public val icon_2621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2621.xml"),
+          )
+      )
+
+  public val icon_2622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2622.xml"),
+          )
+      )
+
+  public val icon_2623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2623.xml"),
+          )
+      )
+
+  public val icon_2624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2624.xml"),
+          )
+      )
+
+  public val icon_2625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2625.xml"),
+          )
+      )
+
+  public val icon_2626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2626.xml"),
+          )
+      )
+
+  public val icon_2627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2627.xml"),
+          )
+      )
+
+  public val icon_2628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2628.xml"),
+          )
+      )
+
+  public val icon_2629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2629.xml"),
+          )
+      )
+
+  public val icon_263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_263.xml"),
+          )
+      )
+
+  public val icon_2630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2630.xml"),
+          )
+      )
+
+  public val icon_2631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2631.xml"),
+          )
+      )
+
+  public val icon_2632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2632.xml"),
+          )
+      )
+
+  public val icon_2633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2633.xml"),
+          )
+      )
+
+  public val icon_2634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2634.xml"),
+          )
+      )
+
+  public val icon_2635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2635.xml"),
+          )
+      )
+
+  public val icon_2636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2636.xml"),
+          )
+      )
+
+  public val icon_2637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2637.xml"),
+          )
+      )
+
+  public val icon_2638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2638.xml"),
+          )
+      )
+
+  public val icon_2639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2639.xml"),
+          )
+      )
+
+  public val icon_264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_264.xml"),
+          )
+      )
+
+  public val icon_2640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2640.xml"),
+          )
+      )
+
+  public val icon_2641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2641.xml"),
+          )
+      )
+
+  public val icon_2642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2642.xml"),
+          )
+      )
+
+  public val icon_2643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2643.xml"),
+          )
+      )
+
+  public val icon_2644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2644.xml"),
+          )
+      )
+
+  public val icon_2645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2645.xml"),
+          )
+      )
+
+  public val icon_2646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2646.xml"),
+          )
+      )
+
+  public val icon_2647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2647.xml"),
+          )
+      )
+
+  public val icon_2648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2648.xml"),
+          )
+      )
+
+  public val icon_2649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2649.xml"),
+          )
+      )
+
+  public val icon_265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_265.xml"),
+          )
+      )
+
+  public val icon_2650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2650.xml"),
+          )
+      )
+
+  public val icon_2651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2651.xml"),
+          )
+      )
+
+  public val icon_2652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2652.xml"),
+          )
+      )
+
+  public val icon_2653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2653.xml"),
+          )
+      )
+
+  public val icon_2654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2654.xml"),
+          )
+      )
+
+  public val icon_2655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2655.xml"),
+          )
+      )
+
+  public val icon_2656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2656.xml"),
+          )
+      )
+
+  public val icon_2657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2657.xml"),
+          )
+      )
+
+  public val icon_2658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2658.xml"),
+          )
+      )
+
+  public val icon_2659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2659.xml"),
+          )
+      )
+
+  public val icon_266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_266.xml"),
+          )
+      )
+
+  public val icon_2660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2660.xml"),
+          )
+      )
+
+  public val icon_2661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2661.xml"),
+          )
+      )
+
+  public val icon_2662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2662.xml"),
+          )
+      )
+
+  public val icon_2663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2663.xml"),
+          )
+      )
+
+  public val icon_2664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2664.xml"),
+          )
+      )
+
+  public val icon_2665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2665.xml"),
+          )
+      )
+
+  public val icon_2666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2666.xml"),
+          )
+      )
+
+  public val icon_2667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2667.xml"),
+          )
+      )
+
+  public val icon_2668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2668.xml"),
+          )
+      )
+
+  public val icon_2669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2669.xml"),
+          )
+      )
+
+  public val icon_267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_267.xml"),
+          )
+      )
+
+  public val icon_2670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2670.xml"),
+          )
+      )
+
+  public val icon_2671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2671.xml"),
+          )
+      )
+
+  public val icon_2672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2672.xml"),
+          )
+      )
+
+  public val icon_2673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2673.xml"),
+          )
+      )
+
+  public val icon_2674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2674.xml"),
+          )
+      )
+
+  public val icon_2675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2675.xml"),
+          )
+      )
+
+  public val icon_2676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2676.xml"),
+          )
+      )
+
+  public val icon_2677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2677.xml"),
+          )
+      )
+
+  public val icon_2678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2678.xml"),
+          )
+      )
+
+  public val icon_2679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2679.xml"),
+          )
+      )
+
+  public val icon_268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_268.xml"),
+          )
+      )
+
+  public val icon_2680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2680.xml"),
+          )
+      )
+
+  public val icon_2681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2681.xml"),
+          )
+      )
+
+  public val icon_2682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2682.xml"),
+          )
+      )
+
+  public val icon_2683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2683.xml"),
+          )
+      )
+
+  public val icon_2684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2684.xml"),
+          )
+      )
+
+  public val icon_2685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2685.xml"),
+          )
+      )
+
+  public val icon_2686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2686.xml"),
+          )
+      )
+
+  public val icon_2687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2687.xml"),
+          )
+      )
+
+  public val icon_2688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2688.xml"),
+          )
+      )
+
+  public val icon_2689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2689.xml"),
+          )
+      )
+
+  public val icon_269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_269.xml"),
+          )
+      )
+
+  public val icon_2690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2690.xml"),
+          )
+      )
+
+  public val icon_2691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2691.xml"),
+          )
+      )
+
+  public val icon_2692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2692.xml"),
+          )
+      )
+
+  public val icon_2693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2693.xml"),
+          )
+      )
+
+  public val icon_2694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2694.xml"),
+          )
+      )
+
+  public val icon_2695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2695.xml"),
+          )
+      )
+
+  public val icon_2696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2696.xml"),
+          )
+      )
+
+  public val icon_2697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2697.xml"),
+          )
+      )
+
+  public val icon_2698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2698.xml"),
+          )
+      )
+
+  public val icon_2699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2699.xml"),
+          )
+      )
+
+  public val icon_27: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_27",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_27.xml"),
+          )
+      )
+
+  public val icon_270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_270.xml"),
+          )
+      )
+
+  public val icon_2700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2700.xml"),
+          )
+      )
+
+  public val icon_2701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2701.xml"),
+          )
+      )
+
+  public val icon_2702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2702.xml"),
+          )
+      )
+
+  public val icon_2703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2703.xml"),
+          )
+      )
+
+  public val icon_2704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2704.xml"),
+          )
+      )
+
+  public val icon_2705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2705.xml"),
+          )
+      )
+
+  public val icon_2706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2706.xml"),
+          )
+      )
+
+  public val icon_2707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2707.xml"),
+          )
+      )
+
+  public val icon_2708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2708.xml"),
+          )
+      )
+
+  public val icon_2709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2709.xml"),
+          )
+      )
+
+  public val icon_271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_271.xml"),
+          )
+      )
+
+  public val icon_2710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2710.xml"),
+          )
+      )
+
+  public val icon_2711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2711.xml"),
+          )
+      )
+
+  public val icon_2712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2712.xml"),
+          )
+      )
+
+  public val icon_2713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2713.xml"),
+          )
+      )
+
+  public val icon_2714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2714.xml"),
+          )
+      )
+
+  public val icon_2715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2715.xml"),
+          )
+      )
+
+  public val icon_2716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2716.xml"),
+          )
+      )
+
+  public val icon_2717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2717.xml"),
+          )
+      )
+
+  public val icon_2718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2718.xml"),
+          )
+      )
+
+  public val icon_2719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2719.xml"),
+          )
+      )
+
+  public val icon_272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_272.xml"),
+          )
+      )
+
+  public val icon_2720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2720.xml"),
+          )
+      )
+
+  public val icon_2721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2721.xml"),
+          )
+      )
+
+  public val icon_2722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2722.xml"),
+          )
+      )
+
+  public val icon_2723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2723.xml"),
+          )
+      )
+
+  public val icon_2724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2724.xml"),
+          )
+      )
+
+  public val icon_2725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2725.xml"),
+          )
+      )
+
+  public val icon_2726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2726.xml"),
+          )
+      )
+
+  public val icon_2727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2727.xml"),
+          )
+      )
+
+  public val icon_2728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2728.xml"),
+          )
+      )
+
+  public val icon_2729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2729.xml"),
+          )
+      )
+
+  public val icon_273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_273.xml"),
+          )
+      )
+
+  public val icon_2730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2730.xml"),
+          )
+      )
+
+  public val icon_2731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2731.xml"),
+          )
+      )
+
+  public val icon_2732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2732.xml"),
+          )
+      )
+
+  public val icon_2733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2733.xml"),
+          )
+      )
+
+  public val icon_2734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2734.xml"),
+          )
+      )
+
+  public val icon_2735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2735.xml"),
+          )
+      )
+
+  public val icon_2736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2736.xml"),
+          )
+      )
+
+  public val icon_2737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2737.xml"),
+          )
+      )
+
+  public val icon_2738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2738.xml"),
+          )
+      )
+
+  public val icon_2739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2739.xml"),
+          )
+      )
+
+  public val icon_274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_274.xml"),
+          )
+      )
+
+  public val icon_2740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2740.xml"),
+          )
+      )
+
+  public val icon_2741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2741.xml"),
+          )
+      )
+
+  public val icon_2742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2742.xml"),
+          )
+      )
+
+  public val icon_2743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2743.xml"),
+          )
+      )
+
+  public val icon_2744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2744.xml"),
+          )
+      )
+
+  public val icon_2745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2745.xml"),
+          )
+      )
+
+  public val icon_2746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2746.xml"),
+          )
+      )
+
+  public val icon_2747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2747.xml"),
+          )
+      )
+
+  public val icon_2748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2748.xml"),
+          )
+      )
+
+  public val icon_2749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2749.xml"),
+          )
+      )
+
+  public val icon_275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_275.xml"),
+          )
+      )
+
+  public val icon_2750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2750.xml"),
+          )
+      )
+
+  public val icon_2751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2751.xml"),
+          )
+      )
+
+  public val icon_2752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2752.xml"),
+          )
+      )
+
+  public val icon_2753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2753.xml"),
+          )
+      )
+
+  public val icon_2754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2754.xml"),
+          )
+      )
+
+  public val icon_2755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2755.xml"),
+          )
+      )
+
+  public val icon_2756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2756.xml"),
+          )
+      )
+
+  public val icon_2757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2757.xml"),
+          )
+      )
+
+  public val icon_2758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2758.xml"),
+          )
+      )
+
+  public val icon_2759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2759.xml"),
+          )
+      )
+
+  public val icon_276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_276.xml"),
+          )
+      )
+
+  public val icon_2760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2760.xml"),
+          )
+      )
+
+  public val icon_2761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2761.xml"),
+          )
+      )
+
+  public val icon_2762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2762.xml"),
+          )
+      )
+
+  public val icon_2763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2763.xml"),
+          )
+      )
+
+  public val icon_2764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2764.xml"),
+          )
+      )
+
+  public val icon_2765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2765.xml"),
+          )
+      )
+
+  public val icon_2766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2766.xml"),
+          )
+      )
+
+  public val icon_2767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2767.xml"),
+          )
+      )
+
+  public val icon_2768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2768.xml"),
+          )
+      )
+
+  public val icon_2769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2769.xml"),
+          )
+      )
+
+  public val icon_277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_277.xml"),
+          )
+      )
+
+  public val icon_2770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2770.xml"),
+          )
+      )
+
+  public val icon_2771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2771.xml"),
+          )
+      )
+
+  public val icon_2772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2772.xml"),
+          )
+      )
+
+  public val icon_2773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2773.xml"),
+          )
+      )
+
+  public val icon_2774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2774.xml"),
+          )
+      )
+
+  public val icon_2775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2775.xml"),
+          )
+      )
+
+  public val icon_2776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2776.xml"),
+          )
+      )
+
+  public val icon_2777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2777.xml"),
+          )
+      )
+
+  public val icon_2778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2778.xml"),
+          )
+      )
+
+  public val icon_2779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2779.xml"),
+          )
+      )
+
+  public val icon_278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_278.xml"),
+          )
+      )
+
+  public val icon_2780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2780.xml"),
+          )
+      )
+
+  public val icon_2781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2781.xml"),
+          )
+      )
+
+  public val icon_2782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2782.xml"),
+          )
+      )
+
+  public val icon_2783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2783.xml"),
+          )
+      )
+
+  public val icon_2784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2784.xml"),
+          )
+      )
+
+  public val icon_2785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2785.xml"),
+          )
+      )
+
+  public val icon_2786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2786.xml"),
+          )
+      )
+
+  public val icon_2787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2787.xml"),
+          )
+      )
+
+  public val icon_2788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2788.xml"),
+          )
+      )
+
+  public val icon_2789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2789.xml"),
+          )
+      )
+
+  public val icon_279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_279.xml"),
+          )
+      )
+
+  public val icon_2790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2790.xml"),
+          )
+      )
+
+  public val icon_2791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2791.xml"),
+          )
+      )
+
+  public val icon_2792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2792.xml"),
+          )
+      )
+
+  public val icon_2793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2793.xml"),
+          )
+      )
+
+  public val icon_2794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2794.xml"),
+          )
+      )
+
+  public val icon_2795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2795.xml"),
+          )
+      )
+
+  public val icon_2796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2796.xml"),
+          )
+      )
+
+  public val icon_2797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2797.xml"),
+          )
+      )
+
+  public val icon_2798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2798.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24848: DrawableResource
+  get() = Drawable33.icon_24848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24849: DrawableResource
+  get() = Drawable33.icon_24849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2485: DrawableResource
+  get() = Drawable33.icon_2485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24850: DrawableResource
+  get() = Drawable33.icon_24850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24851: DrawableResource
+  get() = Drawable33.icon_24851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24852: DrawableResource
+  get() = Drawable33.icon_24852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24853: DrawableResource
+  get() = Drawable33.icon_24853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24854: DrawableResource
+  get() = Drawable33.icon_24854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24855: DrawableResource
+  get() = Drawable33.icon_24855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24856: DrawableResource
+  get() = Drawable33.icon_24856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24857: DrawableResource
+  get() = Drawable33.icon_24857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24858: DrawableResource
+  get() = Drawable33.icon_24858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24859: DrawableResource
+  get() = Drawable33.icon_24859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2486: DrawableResource
+  get() = Drawable33.icon_2486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24860: DrawableResource
+  get() = Drawable33.icon_24860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24861: DrawableResource
+  get() = Drawable33.icon_24861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24862: DrawableResource
+  get() = Drawable33.icon_24862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24863: DrawableResource
+  get() = Drawable33.icon_24863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24864: DrawableResource
+  get() = Drawable33.icon_24864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24865: DrawableResource
+  get() = Drawable33.icon_24865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24866: DrawableResource
+  get() = Drawable33.icon_24866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24867: DrawableResource
+  get() = Drawable33.icon_24867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24868: DrawableResource
+  get() = Drawable33.icon_24868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24869: DrawableResource
+  get() = Drawable33.icon_24869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2487: DrawableResource
+  get() = Drawable33.icon_2487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24870: DrawableResource
+  get() = Drawable33.icon_24870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24871: DrawableResource
+  get() = Drawable33.icon_24871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24872: DrawableResource
+  get() = Drawable33.icon_24872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24873: DrawableResource
+  get() = Drawable33.icon_24873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24874: DrawableResource
+  get() = Drawable33.icon_24874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24875: DrawableResource
+  get() = Drawable33.icon_24875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24876: DrawableResource
+  get() = Drawable33.icon_24876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24877: DrawableResource
+  get() = Drawable33.icon_24877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24878: DrawableResource
+  get() = Drawable33.icon_24878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24879: DrawableResource
+  get() = Drawable33.icon_24879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2488: DrawableResource
+  get() = Drawable33.icon_2488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24880: DrawableResource
+  get() = Drawable33.icon_24880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24881: DrawableResource
+  get() = Drawable33.icon_24881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24882: DrawableResource
+  get() = Drawable33.icon_24882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24883: DrawableResource
+  get() = Drawable33.icon_24883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24884: DrawableResource
+  get() = Drawable33.icon_24884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24885: DrawableResource
+  get() = Drawable33.icon_24885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24886: DrawableResource
+  get() = Drawable33.icon_24886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24887: DrawableResource
+  get() = Drawable33.icon_24887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24888: DrawableResource
+  get() = Drawable33.icon_24888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24889: DrawableResource
+  get() = Drawable33.icon_24889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2489: DrawableResource
+  get() = Drawable33.icon_2489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24890: DrawableResource
+  get() = Drawable33.icon_24890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24891: DrawableResource
+  get() = Drawable33.icon_24891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24892: DrawableResource
+  get() = Drawable33.icon_24892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24893: DrawableResource
+  get() = Drawable33.icon_24893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24894: DrawableResource
+  get() = Drawable33.icon_24894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24895: DrawableResource
+  get() = Drawable33.icon_24895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24896: DrawableResource
+  get() = Drawable33.icon_24896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24897: DrawableResource
+  get() = Drawable33.icon_24897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24898: DrawableResource
+  get() = Drawable33.icon_24898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24899: DrawableResource
+  get() = Drawable33.icon_24899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_249: DrawableResource
+  get() = Drawable33.icon_249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2490: DrawableResource
+  get() = Drawable33.icon_2490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24900: DrawableResource
+  get() = Drawable33.icon_24900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24901: DrawableResource
+  get() = Drawable33.icon_24901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24902: DrawableResource
+  get() = Drawable33.icon_24902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24903: DrawableResource
+  get() = Drawable33.icon_24903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24904: DrawableResource
+  get() = Drawable33.icon_24904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24905: DrawableResource
+  get() = Drawable33.icon_24905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24906: DrawableResource
+  get() = Drawable33.icon_24906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24907: DrawableResource
+  get() = Drawable33.icon_24907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24908: DrawableResource
+  get() = Drawable33.icon_24908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24909: DrawableResource
+  get() = Drawable33.icon_24909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2491: DrawableResource
+  get() = Drawable33.icon_2491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24910: DrawableResource
+  get() = Drawable33.icon_24910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24911: DrawableResource
+  get() = Drawable33.icon_24911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24912: DrawableResource
+  get() = Drawable33.icon_24912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24913: DrawableResource
+  get() = Drawable33.icon_24913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24914: DrawableResource
+  get() = Drawable33.icon_24914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24915: DrawableResource
+  get() = Drawable33.icon_24915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24916: DrawableResource
+  get() = Drawable33.icon_24916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24917: DrawableResource
+  get() = Drawable33.icon_24917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24918: DrawableResource
+  get() = Drawable33.icon_24918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24919: DrawableResource
+  get() = Drawable33.icon_24919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2492: DrawableResource
+  get() = Drawable33.icon_2492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24920: DrawableResource
+  get() = Drawable33.icon_24920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24921: DrawableResource
+  get() = Drawable33.icon_24921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24922: DrawableResource
+  get() = Drawable33.icon_24922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24923: DrawableResource
+  get() = Drawable33.icon_24923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24924: DrawableResource
+  get() = Drawable33.icon_24924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24925: DrawableResource
+  get() = Drawable33.icon_24925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24926: DrawableResource
+  get() = Drawable33.icon_24926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24927: DrawableResource
+  get() = Drawable33.icon_24927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24928: DrawableResource
+  get() = Drawable33.icon_24928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24929: DrawableResource
+  get() = Drawable33.icon_24929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2493: DrawableResource
+  get() = Drawable33.icon_2493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24930: DrawableResource
+  get() = Drawable33.icon_24930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24931: DrawableResource
+  get() = Drawable33.icon_24931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24932: DrawableResource
+  get() = Drawable33.icon_24932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24933: DrawableResource
+  get() = Drawable33.icon_24933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24934: DrawableResource
+  get() = Drawable33.icon_24934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24935: DrawableResource
+  get() = Drawable33.icon_24935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24936: DrawableResource
+  get() = Drawable33.icon_24936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24937: DrawableResource
+  get() = Drawable33.icon_24937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24938: DrawableResource
+  get() = Drawable33.icon_24938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24939: DrawableResource
+  get() = Drawable33.icon_24939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2494: DrawableResource
+  get() = Drawable33.icon_2494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24940: DrawableResource
+  get() = Drawable33.icon_24940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24941: DrawableResource
+  get() = Drawable33.icon_24941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24942: DrawableResource
+  get() = Drawable33.icon_24942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24943: DrawableResource
+  get() = Drawable33.icon_24943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24944: DrawableResource
+  get() = Drawable33.icon_24944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24945: DrawableResource
+  get() = Drawable33.icon_24945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24946: DrawableResource
+  get() = Drawable33.icon_24946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24947: DrawableResource
+  get() = Drawable33.icon_24947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24948: DrawableResource
+  get() = Drawable33.icon_24948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24949: DrawableResource
+  get() = Drawable33.icon_24949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2495: DrawableResource
+  get() = Drawable33.icon_2495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24950: DrawableResource
+  get() = Drawable33.icon_24950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24951: DrawableResource
+  get() = Drawable33.icon_24951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24952: DrawableResource
+  get() = Drawable33.icon_24952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24953: DrawableResource
+  get() = Drawable33.icon_24953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24954: DrawableResource
+  get() = Drawable33.icon_24954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24955: DrawableResource
+  get() = Drawable33.icon_24955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24956: DrawableResource
+  get() = Drawable33.icon_24956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24957: DrawableResource
+  get() = Drawable33.icon_24957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24958: DrawableResource
+  get() = Drawable33.icon_24958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24959: DrawableResource
+  get() = Drawable33.icon_24959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2496: DrawableResource
+  get() = Drawable33.icon_2496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24960: DrawableResource
+  get() = Drawable33.icon_24960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24961: DrawableResource
+  get() = Drawable33.icon_24961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24962: DrawableResource
+  get() = Drawable33.icon_24962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24963: DrawableResource
+  get() = Drawable33.icon_24963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24964: DrawableResource
+  get() = Drawable33.icon_24964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24965: DrawableResource
+  get() = Drawable33.icon_24965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24966: DrawableResource
+  get() = Drawable33.icon_24966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24967: DrawableResource
+  get() = Drawable33.icon_24967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24968: DrawableResource
+  get() = Drawable33.icon_24968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24969: DrawableResource
+  get() = Drawable33.icon_24969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2497: DrawableResource
+  get() = Drawable33.icon_2497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24970: DrawableResource
+  get() = Drawable33.icon_24970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24971: DrawableResource
+  get() = Drawable33.icon_24971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24972: DrawableResource
+  get() = Drawable33.icon_24972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24973: DrawableResource
+  get() = Drawable33.icon_24973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24974: DrawableResource
+  get() = Drawable33.icon_24974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24975: DrawableResource
+  get() = Drawable33.icon_24975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24976: DrawableResource
+  get() = Drawable33.icon_24976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24977: DrawableResource
+  get() = Drawable33.icon_24977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24978: DrawableResource
+  get() = Drawable33.icon_24978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24979: DrawableResource
+  get() = Drawable33.icon_24979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2498: DrawableResource
+  get() = Drawable33.icon_2498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24980: DrawableResource
+  get() = Drawable33.icon_24980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24981: DrawableResource
+  get() = Drawable33.icon_24981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24982: DrawableResource
+  get() = Drawable33.icon_24982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24983: DrawableResource
+  get() = Drawable33.icon_24983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24984: DrawableResource
+  get() = Drawable33.icon_24984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24985: DrawableResource
+  get() = Drawable33.icon_24985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24986: DrawableResource
+  get() = Drawable33.icon_24986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24987: DrawableResource
+  get() = Drawable33.icon_24987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24988: DrawableResource
+  get() = Drawable33.icon_24988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24989: DrawableResource
+  get() = Drawable33.icon_24989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2499: DrawableResource
+  get() = Drawable33.icon_2499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24990: DrawableResource
+  get() = Drawable33.icon_24990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24991: DrawableResource
+  get() = Drawable33.icon_24991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24992: DrawableResource
+  get() = Drawable33.icon_24992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24993: DrawableResource
+  get() = Drawable33.icon_24993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24994: DrawableResource
+  get() = Drawable33.icon_24994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24995: DrawableResource
+  get() = Drawable33.icon_24995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24996: DrawableResource
+  get() = Drawable33.icon_24996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24997: DrawableResource
+  get() = Drawable33.icon_24997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24998: DrawableResource
+  get() = Drawable33.icon_24998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_24999: DrawableResource
+  get() = Drawable33.icon_24999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_25: DrawableResource
+  get() = Drawable33.icon_25
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_250: DrawableResource
+  get() = Drawable33.icon_250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2500: DrawableResource
+  get() = Drawable33.icon_2500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2501: DrawableResource
+  get() = Drawable33.icon_2501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2502: DrawableResource
+  get() = Drawable33.icon_2502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2503: DrawableResource
+  get() = Drawable33.icon_2503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2504: DrawableResource
+  get() = Drawable33.icon_2504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2505: DrawableResource
+  get() = Drawable33.icon_2505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2506: DrawableResource
+  get() = Drawable33.icon_2506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2507: DrawableResource
+  get() = Drawable33.icon_2507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2508: DrawableResource
+  get() = Drawable33.icon_2508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2509: DrawableResource
+  get() = Drawable33.icon_2509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_251: DrawableResource
+  get() = Drawable33.icon_251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2510: DrawableResource
+  get() = Drawable33.icon_2510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2511: DrawableResource
+  get() = Drawable33.icon_2511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2512: DrawableResource
+  get() = Drawable33.icon_2512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2513: DrawableResource
+  get() = Drawable33.icon_2513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2514: DrawableResource
+  get() = Drawable33.icon_2514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2515: DrawableResource
+  get() = Drawable33.icon_2515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2516: DrawableResource
+  get() = Drawable33.icon_2516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2517: DrawableResource
+  get() = Drawable33.icon_2517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2518: DrawableResource
+  get() = Drawable33.icon_2518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2519: DrawableResource
+  get() = Drawable33.icon_2519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_252: DrawableResource
+  get() = Drawable33.icon_252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2520: DrawableResource
+  get() = Drawable33.icon_2520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2521: DrawableResource
+  get() = Drawable33.icon_2521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2522: DrawableResource
+  get() = Drawable33.icon_2522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2523: DrawableResource
+  get() = Drawable33.icon_2523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2524: DrawableResource
+  get() = Drawable33.icon_2524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2525: DrawableResource
+  get() = Drawable33.icon_2525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2526: DrawableResource
+  get() = Drawable33.icon_2526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2527: DrawableResource
+  get() = Drawable33.icon_2527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2528: DrawableResource
+  get() = Drawable33.icon_2528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2529: DrawableResource
+  get() = Drawable33.icon_2529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_253: DrawableResource
+  get() = Drawable33.icon_253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2530: DrawableResource
+  get() = Drawable33.icon_2530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2531: DrawableResource
+  get() = Drawable33.icon_2531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2532: DrawableResource
+  get() = Drawable33.icon_2532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2533: DrawableResource
+  get() = Drawable33.icon_2533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2534: DrawableResource
+  get() = Drawable33.icon_2534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2535: DrawableResource
+  get() = Drawable33.icon_2535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2536: DrawableResource
+  get() = Drawable33.icon_2536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2537: DrawableResource
+  get() = Drawable33.icon_2537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2538: DrawableResource
+  get() = Drawable33.icon_2538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2539: DrawableResource
+  get() = Drawable33.icon_2539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_254: DrawableResource
+  get() = Drawable33.icon_254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2540: DrawableResource
+  get() = Drawable33.icon_2540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2541: DrawableResource
+  get() = Drawable33.icon_2541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2542: DrawableResource
+  get() = Drawable33.icon_2542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2543: DrawableResource
+  get() = Drawable33.icon_2543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2544: DrawableResource
+  get() = Drawable33.icon_2544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2545: DrawableResource
+  get() = Drawable33.icon_2545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2546: DrawableResource
+  get() = Drawable33.icon_2546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2547: DrawableResource
+  get() = Drawable33.icon_2547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2548: DrawableResource
+  get() = Drawable33.icon_2548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2549: DrawableResource
+  get() = Drawable33.icon_2549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_255: DrawableResource
+  get() = Drawable33.icon_255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2550: DrawableResource
+  get() = Drawable33.icon_2550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2551: DrawableResource
+  get() = Drawable33.icon_2551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2552: DrawableResource
+  get() = Drawable33.icon_2552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2553: DrawableResource
+  get() = Drawable33.icon_2553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2554: DrawableResource
+  get() = Drawable33.icon_2554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2555: DrawableResource
+  get() = Drawable33.icon_2555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2556: DrawableResource
+  get() = Drawable33.icon_2556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2557: DrawableResource
+  get() = Drawable33.icon_2557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2558: DrawableResource
+  get() = Drawable33.icon_2558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2559: DrawableResource
+  get() = Drawable33.icon_2559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_256: DrawableResource
+  get() = Drawable33.icon_256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2560: DrawableResource
+  get() = Drawable33.icon_2560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2561: DrawableResource
+  get() = Drawable33.icon_2561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2562: DrawableResource
+  get() = Drawable33.icon_2562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2563: DrawableResource
+  get() = Drawable33.icon_2563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2564: DrawableResource
+  get() = Drawable33.icon_2564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2565: DrawableResource
+  get() = Drawable33.icon_2565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2566: DrawableResource
+  get() = Drawable33.icon_2566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2567: DrawableResource
+  get() = Drawable33.icon_2567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2568: DrawableResource
+  get() = Drawable33.icon_2568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2569: DrawableResource
+  get() = Drawable33.icon_2569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_257: DrawableResource
+  get() = Drawable33.icon_257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2570: DrawableResource
+  get() = Drawable33.icon_2570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2571: DrawableResource
+  get() = Drawable33.icon_2571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2572: DrawableResource
+  get() = Drawable33.icon_2572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2573: DrawableResource
+  get() = Drawable33.icon_2573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2574: DrawableResource
+  get() = Drawable33.icon_2574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2575: DrawableResource
+  get() = Drawable33.icon_2575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2576: DrawableResource
+  get() = Drawable33.icon_2576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2577: DrawableResource
+  get() = Drawable33.icon_2577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2578: DrawableResource
+  get() = Drawable33.icon_2578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2579: DrawableResource
+  get() = Drawable33.icon_2579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_258: DrawableResource
+  get() = Drawable33.icon_258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2580: DrawableResource
+  get() = Drawable33.icon_2580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2581: DrawableResource
+  get() = Drawable33.icon_2581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2582: DrawableResource
+  get() = Drawable33.icon_2582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2583: DrawableResource
+  get() = Drawable33.icon_2583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2584: DrawableResource
+  get() = Drawable33.icon_2584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2585: DrawableResource
+  get() = Drawable33.icon_2585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2586: DrawableResource
+  get() = Drawable33.icon_2586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2587: DrawableResource
+  get() = Drawable33.icon_2587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2588: DrawableResource
+  get() = Drawable33.icon_2588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2589: DrawableResource
+  get() = Drawable33.icon_2589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_259: DrawableResource
+  get() = Drawable33.icon_259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2590: DrawableResource
+  get() = Drawable33.icon_2590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2591: DrawableResource
+  get() = Drawable33.icon_2591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2592: DrawableResource
+  get() = Drawable33.icon_2592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2593: DrawableResource
+  get() = Drawable33.icon_2593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2594: DrawableResource
+  get() = Drawable33.icon_2594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2595: DrawableResource
+  get() = Drawable33.icon_2595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2596: DrawableResource
+  get() = Drawable33.icon_2596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2597: DrawableResource
+  get() = Drawable33.icon_2597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2598: DrawableResource
+  get() = Drawable33.icon_2598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2599: DrawableResource
+  get() = Drawable33.icon_2599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_26: DrawableResource
+  get() = Drawable33.icon_26
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_260: DrawableResource
+  get() = Drawable33.icon_260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2600: DrawableResource
+  get() = Drawable33.icon_2600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2601: DrawableResource
+  get() = Drawable33.icon_2601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2602: DrawableResource
+  get() = Drawable33.icon_2602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2603: DrawableResource
+  get() = Drawable33.icon_2603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2604: DrawableResource
+  get() = Drawable33.icon_2604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2605: DrawableResource
+  get() = Drawable33.icon_2605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2606: DrawableResource
+  get() = Drawable33.icon_2606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2607: DrawableResource
+  get() = Drawable33.icon_2607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2608: DrawableResource
+  get() = Drawable33.icon_2608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2609: DrawableResource
+  get() = Drawable33.icon_2609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_261: DrawableResource
+  get() = Drawable33.icon_261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2610: DrawableResource
+  get() = Drawable33.icon_2610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2611: DrawableResource
+  get() = Drawable33.icon_2611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2612: DrawableResource
+  get() = Drawable33.icon_2612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2613: DrawableResource
+  get() = Drawable33.icon_2613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2614: DrawableResource
+  get() = Drawable33.icon_2614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2615: DrawableResource
+  get() = Drawable33.icon_2615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2616: DrawableResource
+  get() = Drawable33.icon_2616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2617: DrawableResource
+  get() = Drawable33.icon_2617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2618: DrawableResource
+  get() = Drawable33.icon_2618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2619: DrawableResource
+  get() = Drawable33.icon_2619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_262: DrawableResource
+  get() = Drawable33.icon_262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2620: DrawableResource
+  get() = Drawable33.icon_2620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2621: DrawableResource
+  get() = Drawable33.icon_2621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2622: DrawableResource
+  get() = Drawable33.icon_2622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2623: DrawableResource
+  get() = Drawable33.icon_2623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2624: DrawableResource
+  get() = Drawable33.icon_2624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2625: DrawableResource
+  get() = Drawable33.icon_2625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2626: DrawableResource
+  get() = Drawable33.icon_2626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2627: DrawableResource
+  get() = Drawable33.icon_2627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2628: DrawableResource
+  get() = Drawable33.icon_2628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2629: DrawableResource
+  get() = Drawable33.icon_2629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_263: DrawableResource
+  get() = Drawable33.icon_263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2630: DrawableResource
+  get() = Drawable33.icon_2630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2631: DrawableResource
+  get() = Drawable33.icon_2631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2632: DrawableResource
+  get() = Drawable33.icon_2632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2633: DrawableResource
+  get() = Drawable33.icon_2633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2634: DrawableResource
+  get() = Drawable33.icon_2634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2635: DrawableResource
+  get() = Drawable33.icon_2635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2636: DrawableResource
+  get() = Drawable33.icon_2636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2637: DrawableResource
+  get() = Drawable33.icon_2637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2638: DrawableResource
+  get() = Drawable33.icon_2638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2639: DrawableResource
+  get() = Drawable33.icon_2639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_264: DrawableResource
+  get() = Drawable33.icon_264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2640: DrawableResource
+  get() = Drawable33.icon_2640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2641: DrawableResource
+  get() = Drawable33.icon_2641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2642: DrawableResource
+  get() = Drawable33.icon_2642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2643: DrawableResource
+  get() = Drawable33.icon_2643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2644: DrawableResource
+  get() = Drawable33.icon_2644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2645: DrawableResource
+  get() = Drawable33.icon_2645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2646: DrawableResource
+  get() = Drawable33.icon_2646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2647: DrawableResource
+  get() = Drawable33.icon_2647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2648: DrawableResource
+  get() = Drawable33.icon_2648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2649: DrawableResource
+  get() = Drawable33.icon_2649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_265: DrawableResource
+  get() = Drawable33.icon_265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2650: DrawableResource
+  get() = Drawable33.icon_2650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2651: DrawableResource
+  get() = Drawable33.icon_2651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2652: DrawableResource
+  get() = Drawable33.icon_2652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2653: DrawableResource
+  get() = Drawable33.icon_2653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2654: DrawableResource
+  get() = Drawable33.icon_2654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2655: DrawableResource
+  get() = Drawable33.icon_2655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2656: DrawableResource
+  get() = Drawable33.icon_2656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2657: DrawableResource
+  get() = Drawable33.icon_2657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2658: DrawableResource
+  get() = Drawable33.icon_2658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2659: DrawableResource
+  get() = Drawable33.icon_2659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_266: DrawableResource
+  get() = Drawable33.icon_266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2660: DrawableResource
+  get() = Drawable33.icon_2660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2661: DrawableResource
+  get() = Drawable33.icon_2661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2662: DrawableResource
+  get() = Drawable33.icon_2662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2663: DrawableResource
+  get() = Drawable33.icon_2663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2664: DrawableResource
+  get() = Drawable33.icon_2664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2665: DrawableResource
+  get() = Drawable33.icon_2665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2666: DrawableResource
+  get() = Drawable33.icon_2666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2667: DrawableResource
+  get() = Drawable33.icon_2667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2668: DrawableResource
+  get() = Drawable33.icon_2668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2669: DrawableResource
+  get() = Drawable33.icon_2669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_267: DrawableResource
+  get() = Drawable33.icon_267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2670: DrawableResource
+  get() = Drawable33.icon_2670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2671: DrawableResource
+  get() = Drawable33.icon_2671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2672: DrawableResource
+  get() = Drawable33.icon_2672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2673: DrawableResource
+  get() = Drawable33.icon_2673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2674: DrawableResource
+  get() = Drawable33.icon_2674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2675: DrawableResource
+  get() = Drawable33.icon_2675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2676: DrawableResource
+  get() = Drawable33.icon_2676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2677: DrawableResource
+  get() = Drawable33.icon_2677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2678: DrawableResource
+  get() = Drawable33.icon_2678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2679: DrawableResource
+  get() = Drawable33.icon_2679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_268: DrawableResource
+  get() = Drawable33.icon_268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2680: DrawableResource
+  get() = Drawable33.icon_2680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2681: DrawableResource
+  get() = Drawable33.icon_2681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2682: DrawableResource
+  get() = Drawable33.icon_2682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2683: DrawableResource
+  get() = Drawable33.icon_2683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2684: DrawableResource
+  get() = Drawable33.icon_2684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2685: DrawableResource
+  get() = Drawable33.icon_2685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2686: DrawableResource
+  get() = Drawable33.icon_2686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2687: DrawableResource
+  get() = Drawable33.icon_2687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2688: DrawableResource
+  get() = Drawable33.icon_2688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2689: DrawableResource
+  get() = Drawable33.icon_2689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_269: DrawableResource
+  get() = Drawable33.icon_269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2690: DrawableResource
+  get() = Drawable33.icon_2690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2691: DrawableResource
+  get() = Drawable33.icon_2691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2692: DrawableResource
+  get() = Drawable33.icon_2692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2693: DrawableResource
+  get() = Drawable33.icon_2693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2694: DrawableResource
+  get() = Drawable33.icon_2694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2695: DrawableResource
+  get() = Drawable33.icon_2695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2696: DrawableResource
+  get() = Drawable33.icon_2696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2697: DrawableResource
+  get() = Drawable33.icon_2697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2698: DrawableResource
+  get() = Drawable33.icon_2698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2699: DrawableResource
+  get() = Drawable33.icon_2699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_27: DrawableResource
+  get() = Drawable33.icon_27
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_270: DrawableResource
+  get() = Drawable33.icon_270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2700: DrawableResource
+  get() = Drawable33.icon_2700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2701: DrawableResource
+  get() = Drawable33.icon_2701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2702: DrawableResource
+  get() = Drawable33.icon_2702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2703: DrawableResource
+  get() = Drawable33.icon_2703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2704: DrawableResource
+  get() = Drawable33.icon_2704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2705: DrawableResource
+  get() = Drawable33.icon_2705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2706: DrawableResource
+  get() = Drawable33.icon_2706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2707: DrawableResource
+  get() = Drawable33.icon_2707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2708: DrawableResource
+  get() = Drawable33.icon_2708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2709: DrawableResource
+  get() = Drawable33.icon_2709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_271: DrawableResource
+  get() = Drawable33.icon_271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2710: DrawableResource
+  get() = Drawable33.icon_2710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2711: DrawableResource
+  get() = Drawable33.icon_2711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2712: DrawableResource
+  get() = Drawable33.icon_2712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2713: DrawableResource
+  get() = Drawable33.icon_2713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2714: DrawableResource
+  get() = Drawable33.icon_2714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2715: DrawableResource
+  get() = Drawable33.icon_2715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2716: DrawableResource
+  get() = Drawable33.icon_2716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2717: DrawableResource
+  get() = Drawable33.icon_2717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2718: DrawableResource
+  get() = Drawable33.icon_2718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2719: DrawableResource
+  get() = Drawable33.icon_2719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_272: DrawableResource
+  get() = Drawable33.icon_272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2720: DrawableResource
+  get() = Drawable33.icon_2720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2721: DrawableResource
+  get() = Drawable33.icon_2721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2722: DrawableResource
+  get() = Drawable33.icon_2722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2723: DrawableResource
+  get() = Drawable33.icon_2723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2724: DrawableResource
+  get() = Drawable33.icon_2724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2725: DrawableResource
+  get() = Drawable33.icon_2725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2726: DrawableResource
+  get() = Drawable33.icon_2726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2727: DrawableResource
+  get() = Drawable33.icon_2727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2728: DrawableResource
+  get() = Drawable33.icon_2728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2729: DrawableResource
+  get() = Drawable33.icon_2729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_273: DrawableResource
+  get() = Drawable33.icon_273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2730: DrawableResource
+  get() = Drawable33.icon_2730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2731: DrawableResource
+  get() = Drawable33.icon_2731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2732: DrawableResource
+  get() = Drawable33.icon_2732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2733: DrawableResource
+  get() = Drawable33.icon_2733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2734: DrawableResource
+  get() = Drawable33.icon_2734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2735: DrawableResource
+  get() = Drawable33.icon_2735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2736: DrawableResource
+  get() = Drawable33.icon_2736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2737: DrawableResource
+  get() = Drawable33.icon_2737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2738: DrawableResource
+  get() = Drawable33.icon_2738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2739: DrawableResource
+  get() = Drawable33.icon_2739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_274: DrawableResource
+  get() = Drawable33.icon_274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2740: DrawableResource
+  get() = Drawable33.icon_2740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2741: DrawableResource
+  get() = Drawable33.icon_2741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2742: DrawableResource
+  get() = Drawable33.icon_2742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2743: DrawableResource
+  get() = Drawable33.icon_2743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2744: DrawableResource
+  get() = Drawable33.icon_2744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2745: DrawableResource
+  get() = Drawable33.icon_2745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2746: DrawableResource
+  get() = Drawable33.icon_2746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2747: DrawableResource
+  get() = Drawable33.icon_2747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2748: DrawableResource
+  get() = Drawable33.icon_2748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2749: DrawableResource
+  get() = Drawable33.icon_2749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_275: DrawableResource
+  get() = Drawable33.icon_275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2750: DrawableResource
+  get() = Drawable33.icon_2750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2751: DrawableResource
+  get() = Drawable33.icon_2751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2752: DrawableResource
+  get() = Drawable33.icon_2752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2753: DrawableResource
+  get() = Drawable33.icon_2753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2754: DrawableResource
+  get() = Drawable33.icon_2754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2755: DrawableResource
+  get() = Drawable33.icon_2755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2756: DrawableResource
+  get() = Drawable33.icon_2756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2757: DrawableResource
+  get() = Drawable33.icon_2757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2758: DrawableResource
+  get() = Drawable33.icon_2758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2759: DrawableResource
+  get() = Drawable33.icon_2759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_276: DrawableResource
+  get() = Drawable33.icon_276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2760: DrawableResource
+  get() = Drawable33.icon_2760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2761: DrawableResource
+  get() = Drawable33.icon_2761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2762: DrawableResource
+  get() = Drawable33.icon_2762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2763: DrawableResource
+  get() = Drawable33.icon_2763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2764: DrawableResource
+  get() = Drawable33.icon_2764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2765: DrawableResource
+  get() = Drawable33.icon_2765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2766: DrawableResource
+  get() = Drawable33.icon_2766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2767: DrawableResource
+  get() = Drawable33.icon_2767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2768: DrawableResource
+  get() = Drawable33.icon_2768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2769: DrawableResource
+  get() = Drawable33.icon_2769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_277: DrawableResource
+  get() = Drawable33.icon_277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2770: DrawableResource
+  get() = Drawable33.icon_2770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2771: DrawableResource
+  get() = Drawable33.icon_2771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2772: DrawableResource
+  get() = Drawable33.icon_2772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2773: DrawableResource
+  get() = Drawable33.icon_2773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2774: DrawableResource
+  get() = Drawable33.icon_2774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2775: DrawableResource
+  get() = Drawable33.icon_2775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2776: DrawableResource
+  get() = Drawable33.icon_2776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2777: DrawableResource
+  get() = Drawable33.icon_2777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2778: DrawableResource
+  get() = Drawable33.icon_2778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2779: DrawableResource
+  get() = Drawable33.icon_2779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_278: DrawableResource
+  get() = Drawable33.icon_278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2780: DrawableResource
+  get() = Drawable33.icon_2780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2781: DrawableResource
+  get() = Drawable33.icon_2781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2782: DrawableResource
+  get() = Drawable33.icon_2782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2783: DrawableResource
+  get() = Drawable33.icon_2783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2784: DrawableResource
+  get() = Drawable33.icon_2784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2785: DrawableResource
+  get() = Drawable33.icon_2785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2786: DrawableResource
+  get() = Drawable33.icon_2786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2787: DrawableResource
+  get() = Drawable33.icon_2787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2788: DrawableResource
+  get() = Drawable33.icon_2788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2789: DrawableResource
+  get() = Drawable33.icon_2789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_279: DrawableResource
+  get() = Drawable33.icon_279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2790: DrawableResource
+  get() = Drawable33.icon_2790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2791: DrawableResource
+  get() = Drawable33.icon_2791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2792: DrawableResource
+  get() = Drawable33.icon_2792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2793: DrawableResource
+  get() = Drawable33.icon_2793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2794: DrawableResource
+  get() = Drawable33.icon_2794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2795: DrawableResource
+  get() = Drawable33.icon_2795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2796: DrawableResource
+  get() = Drawable33.icon_2796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2797: DrawableResource
+  get() = Drawable33.icon_2797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2798: DrawableResource
+  get() = Drawable33.icon_2798

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable34.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable34.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable34 {
+  public val icon_2799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2799.xml"),
+          )
+      )
+
+  public val icon_28: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_28",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_28.xml"),
+          )
+      )
+
+  public val icon_280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_280.xml"),
+          )
+      )
+
+  public val icon_2800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2800.xml"),
+          )
+      )
+
+  public val icon_2801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2801.xml"),
+          )
+      )
+
+  public val icon_2802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2802.xml"),
+          )
+      )
+
+  public val icon_2803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2803.xml"),
+          )
+      )
+
+  public val icon_2804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2804.xml"),
+          )
+      )
+
+  public val icon_2805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2805.xml"),
+          )
+      )
+
+  public val icon_2806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2806.xml"),
+          )
+      )
+
+  public val icon_2807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2807.xml"),
+          )
+      )
+
+  public val icon_2808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2808.xml"),
+          )
+      )
+
+  public val icon_2809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2809.xml"),
+          )
+      )
+
+  public val icon_281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_281.xml"),
+          )
+      )
+
+  public val icon_2810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2810.xml"),
+          )
+      )
+
+  public val icon_2811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2811.xml"),
+          )
+      )
+
+  public val icon_2812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2812.xml"),
+          )
+      )
+
+  public val icon_2813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2813.xml"),
+          )
+      )
+
+  public val icon_2814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2814.xml"),
+          )
+      )
+
+  public val icon_2815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2815.xml"),
+          )
+      )
+
+  public val icon_2816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2816.xml"),
+          )
+      )
+
+  public val icon_2817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2817.xml"),
+          )
+      )
+
+  public val icon_2818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2818.xml"),
+          )
+      )
+
+  public val icon_2819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2819.xml"),
+          )
+      )
+
+  public val icon_282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_282.xml"),
+          )
+      )
+
+  public val icon_2820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2820.xml"),
+          )
+      )
+
+  public val icon_2821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2821.xml"),
+          )
+      )
+
+  public val icon_2822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2822.xml"),
+          )
+      )
+
+  public val icon_2823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2823.xml"),
+          )
+      )
+
+  public val icon_2824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2824.xml"),
+          )
+      )
+
+  public val icon_2825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2825.xml"),
+          )
+      )
+
+  public val icon_2826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2826.xml"),
+          )
+      )
+
+  public val icon_2827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2827.xml"),
+          )
+      )
+
+  public val icon_2828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2828.xml"),
+          )
+      )
+
+  public val icon_2829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2829.xml"),
+          )
+      )
+
+  public val icon_283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_283.xml"),
+          )
+      )
+
+  public val icon_2830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2830.xml"),
+          )
+      )
+
+  public val icon_2831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2831.xml"),
+          )
+      )
+
+  public val icon_2832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2832.xml"),
+          )
+      )
+
+  public val icon_2833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2833.xml"),
+          )
+      )
+
+  public val icon_2834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2834.xml"),
+          )
+      )
+
+  public val icon_2835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2835.xml"),
+          )
+      )
+
+  public val icon_2836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2836.xml"),
+          )
+      )
+
+  public val icon_2837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2837.xml"),
+          )
+      )
+
+  public val icon_2838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2838.xml"),
+          )
+      )
+
+  public val icon_2839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2839.xml"),
+          )
+      )
+
+  public val icon_284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_284.xml"),
+          )
+      )
+
+  public val icon_2840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2840.xml"),
+          )
+      )
+
+  public val icon_2841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2841.xml"),
+          )
+      )
+
+  public val icon_2842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2842.xml"),
+          )
+      )
+
+  public val icon_2843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2843.xml"),
+          )
+      )
+
+  public val icon_2844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2844.xml"),
+          )
+      )
+
+  public val icon_2845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2845.xml"),
+          )
+      )
+
+  public val icon_2846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2846.xml"),
+          )
+      )
+
+  public val icon_2847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2847.xml"),
+          )
+      )
+
+  public val icon_2848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2848.xml"),
+          )
+      )
+
+  public val icon_2849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2849.xml"),
+          )
+      )
+
+  public val icon_285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_285.xml"),
+          )
+      )
+
+  public val icon_2850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2850.xml"),
+          )
+      )
+
+  public val icon_2851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2851.xml"),
+          )
+      )
+
+  public val icon_2852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2852.xml"),
+          )
+      )
+
+  public val icon_2853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2853.xml"),
+          )
+      )
+
+  public val icon_2854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2854.xml"),
+          )
+      )
+
+  public val icon_2855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2855.xml"),
+          )
+      )
+
+  public val icon_2856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2856.xml"),
+          )
+      )
+
+  public val icon_2857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2857.xml"),
+          )
+      )
+
+  public val icon_2858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2858.xml"),
+          )
+      )
+
+  public val icon_2859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2859.xml"),
+          )
+      )
+
+  public val icon_286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_286.xml"),
+          )
+      )
+
+  public val icon_2860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2860.xml"),
+          )
+      )
+
+  public val icon_2861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2861.xml"),
+          )
+      )
+
+  public val icon_2862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2862.xml"),
+          )
+      )
+
+  public val icon_2863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2863.xml"),
+          )
+      )
+
+  public val icon_2864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2864.xml"),
+          )
+      )
+
+  public val icon_2865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2865.xml"),
+          )
+      )
+
+  public val icon_2866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2866.xml"),
+          )
+      )
+
+  public val icon_2867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2867.xml"),
+          )
+      )
+
+  public val icon_2868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2868.xml"),
+          )
+      )
+
+  public val icon_2869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2869.xml"),
+          )
+      )
+
+  public val icon_287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_287.xml"),
+          )
+      )
+
+  public val icon_2870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2870.xml"),
+          )
+      )
+
+  public val icon_2871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2871.xml"),
+          )
+      )
+
+  public val icon_2872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2872.xml"),
+          )
+      )
+
+  public val icon_2873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2873.xml"),
+          )
+      )
+
+  public val icon_2874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2874.xml"),
+          )
+      )
+
+  public val icon_2875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2875.xml"),
+          )
+      )
+
+  public val icon_2876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2876.xml"),
+          )
+      )
+
+  public val icon_2877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2877.xml"),
+          )
+      )
+
+  public val icon_2878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2878.xml"),
+          )
+      )
+
+  public val icon_2879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2879.xml"),
+          )
+      )
+
+  public val icon_288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_288.xml"),
+          )
+      )
+
+  public val icon_2880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2880.xml"),
+          )
+      )
+
+  public val icon_2881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2881.xml"),
+          )
+      )
+
+  public val icon_2882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2882.xml"),
+          )
+      )
+
+  public val icon_2883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2883.xml"),
+          )
+      )
+
+  public val icon_2884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2884.xml"),
+          )
+      )
+
+  public val icon_2885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2885.xml"),
+          )
+      )
+
+  public val icon_2886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2886.xml"),
+          )
+      )
+
+  public val icon_2887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2887.xml"),
+          )
+      )
+
+  public val icon_2888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2888.xml"),
+          )
+      )
+
+  public val icon_2889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2889.xml"),
+          )
+      )
+
+  public val icon_289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_289.xml"),
+          )
+      )
+
+  public val icon_2890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2890.xml"),
+          )
+      )
+
+  public val icon_2891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2891.xml"),
+          )
+      )
+
+  public val icon_2892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2892.xml"),
+          )
+      )
+
+  public val icon_2893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2893.xml"),
+          )
+      )
+
+  public val icon_2894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2894.xml"),
+          )
+      )
+
+  public val icon_2895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2895.xml"),
+          )
+      )
+
+  public val icon_2896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2896.xml"),
+          )
+      )
+
+  public val icon_2897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2897.xml"),
+          )
+      )
+
+  public val icon_2898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2898.xml"),
+          )
+      )
+
+  public val icon_2899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2899.xml"),
+          )
+      )
+
+  public val icon_29: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_29",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_29.xml"),
+          )
+      )
+
+  public val icon_290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_290.xml"),
+          )
+      )
+
+  public val icon_2900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2900.xml"),
+          )
+      )
+
+  public val icon_2901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2901.xml"),
+          )
+      )
+
+  public val icon_2902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2902.xml"),
+          )
+      )
+
+  public val icon_2903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2903.xml"),
+          )
+      )
+
+  public val icon_2904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2904.xml"),
+          )
+      )
+
+  public val icon_2905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2905.xml"),
+          )
+      )
+
+  public val icon_2906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2906.xml"),
+          )
+      )
+
+  public val icon_2907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2907.xml"),
+          )
+      )
+
+  public val icon_2908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2908.xml"),
+          )
+      )
+
+  public val icon_2909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2909.xml"),
+          )
+      )
+
+  public val icon_291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_291.xml"),
+          )
+      )
+
+  public val icon_2910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2910.xml"),
+          )
+      )
+
+  public val icon_2911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2911.xml"),
+          )
+      )
+
+  public val icon_2912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2912.xml"),
+          )
+      )
+
+  public val icon_2913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2913.xml"),
+          )
+      )
+
+  public val icon_2914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2914.xml"),
+          )
+      )
+
+  public val icon_2915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2915.xml"),
+          )
+      )
+
+  public val icon_2916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2916.xml"),
+          )
+      )
+
+  public val icon_2917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2917.xml"),
+          )
+      )
+
+  public val icon_2918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2918.xml"),
+          )
+      )
+
+  public val icon_2919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2919.xml"),
+          )
+      )
+
+  public val icon_292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_292.xml"),
+          )
+      )
+
+  public val icon_2920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2920.xml"),
+          )
+      )
+
+  public val icon_2921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2921.xml"),
+          )
+      )
+
+  public val icon_2922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2922.xml"),
+          )
+      )
+
+  public val icon_2923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2923.xml"),
+          )
+      )
+
+  public val icon_2924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2924.xml"),
+          )
+      )
+
+  public val icon_2925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2925.xml"),
+          )
+      )
+
+  public val icon_2926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2926.xml"),
+          )
+      )
+
+  public val icon_2927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2927.xml"),
+          )
+      )
+
+  public val icon_2928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2928.xml"),
+          )
+      )
+
+  public val icon_2929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2929.xml"),
+          )
+      )
+
+  public val icon_293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_293.xml"),
+          )
+      )
+
+  public val icon_2930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2930.xml"),
+          )
+      )
+
+  public val icon_2931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2931.xml"),
+          )
+      )
+
+  public val icon_2932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2932.xml"),
+          )
+      )
+
+  public val icon_2933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2933.xml"),
+          )
+      )
+
+  public val icon_2934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2934.xml"),
+          )
+      )
+
+  public val icon_2935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2935.xml"),
+          )
+      )
+
+  public val icon_2936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2936.xml"),
+          )
+      )
+
+  public val icon_2937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2937.xml"),
+          )
+      )
+
+  public val icon_2938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2938.xml"),
+          )
+      )
+
+  public val icon_2939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2939.xml"),
+          )
+      )
+
+  public val icon_294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_294.xml"),
+          )
+      )
+
+  public val icon_2940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2940.xml"),
+          )
+      )
+
+  public val icon_2941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2941.xml"),
+          )
+      )
+
+  public val icon_2942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2942.xml"),
+          )
+      )
+
+  public val icon_2943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2943.xml"),
+          )
+      )
+
+  public val icon_2944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2944.xml"),
+          )
+      )
+
+  public val icon_2945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2945.xml"),
+          )
+      )
+
+  public val icon_2946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2946.xml"),
+          )
+      )
+
+  public val icon_2947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2947.xml"),
+          )
+      )
+
+  public val icon_2948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2948.xml"),
+          )
+      )
+
+  public val icon_2949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2949.xml"),
+          )
+      )
+
+  public val icon_295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_295.xml"),
+          )
+      )
+
+  public val icon_2950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2950.xml"),
+          )
+      )
+
+  public val icon_2951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2951.xml"),
+          )
+      )
+
+  public val icon_2952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2952.xml"),
+          )
+      )
+
+  public val icon_2953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2953.xml"),
+          )
+      )
+
+  public val icon_2954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2954.xml"),
+          )
+      )
+
+  public val icon_2955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2955.xml"),
+          )
+      )
+
+  public val icon_2956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2956.xml"),
+          )
+      )
+
+  public val icon_2957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2957.xml"),
+          )
+      )
+
+  public val icon_2958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2958.xml"),
+          )
+      )
+
+  public val icon_2959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2959.xml"),
+          )
+      )
+
+  public val icon_296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_296.xml"),
+          )
+      )
+
+  public val icon_2960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2960.xml"),
+          )
+      )
+
+  public val icon_2961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2961.xml"),
+          )
+      )
+
+  public val icon_2962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2962.xml"),
+          )
+      )
+
+  public val icon_2963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2963.xml"),
+          )
+      )
+
+  public val icon_2964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2964.xml"),
+          )
+      )
+
+  public val icon_2965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2965.xml"),
+          )
+      )
+
+  public val icon_2966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2966.xml"),
+          )
+      )
+
+  public val icon_2967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2967.xml"),
+          )
+      )
+
+  public val icon_2968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2968.xml"),
+          )
+      )
+
+  public val icon_2969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2969.xml"),
+          )
+      )
+
+  public val icon_297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_297.xml"),
+          )
+      )
+
+  public val icon_2970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2970.xml"),
+          )
+      )
+
+  public val icon_2971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2971.xml"),
+          )
+      )
+
+  public val icon_2972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2972.xml"),
+          )
+      )
+
+  public val icon_2973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2973.xml"),
+          )
+      )
+
+  public val icon_2974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2974.xml"),
+          )
+      )
+
+  public val icon_2975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2975.xml"),
+          )
+      )
+
+  public val icon_2976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2976.xml"),
+          )
+      )
+
+  public val icon_2977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2977.xml"),
+          )
+      )
+
+  public val icon_2978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2978.xml"),
+          )
+      )
+
+  public val icon_2979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2979.xml"),
+          )
+      )
+
+  public val icon_298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_298.xml"),
+          )
+      )
+
+  public val icon_2980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2980.xml"),
+          )
+      )
+
+  public val icon_2981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2981.xml"),
+          )
+      )
+
+  public val icon_2982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2982.xml"),
+          )
+      )
+
+  public val icon_2983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2983.xml"),
+          )
+      )
+
+  public val icon_2984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2984.xml"),
+          )
+      )
+
+  public val icon_2985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2985.xml"),
+          )
+      )
+
+  public val icon_2986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2986.xml"),
+          )
+      )
+
+  public val icon_2987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2987.xml"),
+          )
+      )
+
+  public val icon_2988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2988.xml"),
+          )
+      )
+
+  public val icon_2989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2989.xml"),
+          )
+      )
+
+  public val icon_299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_299.xml"),
+          )
+      )
+
+  public val icon_2990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2990.xml"),
+          )
+      )
+
+  public val icon_2991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2991.xml"),
+          )
+      )
+
+  public val icon_2992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2992.xml"),
+          )
+      )
+
+  public val icon_2993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2993.xml"),
+          )
+      )
+
+  public val icon_2994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2994.xml"),
+          )
+      )
+
+  public val icon_2995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2995.xml"),
+          )
+      )
+
+  public val icon_2996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2996.xml"),
+          )
+      )
+
+  public val icon_2997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2997.xml"),
+          )
+      )
+
+  public val icon_2998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2998.xml"),
+          )
+      )
+
+  public val icon_2999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_2999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_2999.xml"),
+          )
+      )
+
+  public val icon_3: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3.xml"),
+          )
+      )
+
+  public val icon_30: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_30",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_30.xml"),
+          )
+      )
+
+  public val icon_300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_300.xml"),
+          )
+      )
+
+  public val icon_3000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3000.xml"),
+          )
+      )
+
+  public val icon_3001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3001.xml"),
+          )
+      )
+
+  public val icon_3002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3002.xml"),
+          )
+      )
+
+  public val icon_3003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3003.xml"),
+          )
+      )
+
+  public val icon_3004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3004.xml"),
+          )
+      )
+
+  public val icon_3005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3005.xml"),
+          )
+      )
+
+  public val icon_3006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3006.xml"),
+          )
+      )
+
+  public val icon_3007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3007.xml"),
+          )
+      )
+
+  public val icon_3008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3008.xml"),
+          )
+      )
+
+  public val icon_3009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3009.xml"),
+          )
+      )
+
+  public val icon_301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_301.xml"),
+          )
+      )
+
+  public val icon_3010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3010.xml"),
+          )
+      )
+
+  public val icon_3011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3011.xml"),
+          )
+      )
+
+  public val icon_3012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3012.xml"),
+          )
+      )
+
+  public val icon_3013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3013.xml"),
+          )
+      )
+
+  public val icon_3014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3014.xml"),
+          )
+      )
+
+  public val icon_3015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3015.xml"),
+          )
+      )
+
+  public val icon_3016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3016.xml"),
+          )
+      )
+
+  public val icon_3017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3017.xml"),
+          )
+      )
+
+  public val icon_3018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3018.xml"),
+          )
+      )
+
+  public val icon_3019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3019.xml"),
+          )
+      )
+
+  public val icon_302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_302.xml"),
+          )
+      )
+
+  public val icon_3020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3020.xml"),
+          )
+      )
+
+  public val icon_3021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3021.xml"),
+          )
+      )
+
+  public val icon_3022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3022.xml"),
+          )
+      )
+
+  public val icon_3023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3023.xml"),
+          )
+      )
+
+  public val icon_3024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3024.xml"),
+          )
+      )
+
+  public val icon_3025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3025.xml"),
+          )
+      )
+
+  public val icon_3026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3026.xml"),
+          )
+      )
+
+  public val icon_3027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3027.xml"),
+          )
+      )
+
+  public val icon_3028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3028.xml"),
+          )
+      )
+
+  public val icon_3029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3029.xml"),
+          )
+      )
+
+  public val icon_303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_303.xml"),
+          )
+      )
+
+  public val icon_3030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3030.xml"),
+          )
+      )
+
+  public val icon_3031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3031.xml"),
+          )
+      )
+
+  public val icon_3032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3032.xml"),
+          )
+      )
+
+  public val icon_3033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3033.xml"),
+          )
+      )
+
+  public val icon_3034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3034.xml"),
+          )
+      )
+
+  public val icon_3035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3035.xml"),
+          )
+      )
+
+  public val icon_3036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3036.xml"),
+          )
+      )
+
+  public val icon_3037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3037.xml"),
+          )
+      )
+
+  public val icon_3038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3038.xml"),
+          )
+      )
+
+  public val icon_3039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3039.xml"),
+          )
+      )
+
+  public val icon_304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_304.xml"),
+          )
+      )
+
+  public val icon_3040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3040.xml"),
+          )
+      )
+
+  public val icon_3041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3041.xml"),
+          )
+      )
+
+  public val icon_3042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3042.xml"),
+          )
+      )
+
+  public val icon_3043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3043.xml"),
+          )
+      )
+
+  public val icon_3044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3044.xml"),
+          )
+      )
+
+  public val icon_3045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3045.xml"),
+          )
+      )
+
+  public val icon_3046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3046.xml"),
+          )
+      )
+
+  public val icon_3047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3047.xml"),
+          )
+      )
+
+  public val icon_3048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3048.xml"),
+          )
+      )
+
+  public val icon_3049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3049.xml"),
+          )
+      )
+
+  public val icon_305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_305.xml"),
+          )
+      )
+
+  public val icon_3050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3050.xml"),
+          )
+      )
+
+  public val icon_3051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3051.xml"),
+          )
+      )
+
+  public val icon_3052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3052.xml"),
+          )
+      )
+
+  public val icon_3053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3053.xml"),
+          )
+      )
+
+  public val icon_3054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3054.xml"),
+          )
+      )
+
+  public val icon_3055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3055.xml"),
+          )
+      )
+
+  public val icon_3056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3056.xml"),
+          )
+      )
+
+  public val icon_3057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3057.xml"),
+          )
+      )
+
+  public val icon_3058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3058.xml"),
+          )
+      )
+
+  public val icon_3059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3059.xml"),
+          )
+      )
+
+  public val icon_306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_306.xml"),
+          )
+      )
+
+  public val icon_3060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3060.xml"),
+          )
+      )
+
+  public val icon_3061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3061.xml"),
+          )
+      )
+
+  public val icon_3062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3062.xml"),
+          )
+      )
+
+  public val icon_3063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3063.xml"),
+          )
+      )
+
+  public val icon_3064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3064.xml"),
+          )
+      )
+
+  public val icon_3065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3065.xml"),
+          )
+      )
+
+  public val icon_3066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3066.xml"),
+          )
+      )
+
+  public val icon_3067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3067.xml"),
+          )
+      )
+
+  public val icon_3068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3068.xml"),
+          )
+      )
+
+  public val icon_3069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3069.xml"),
+          )
+      )
+
+  public val icon_307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_307.xml"),
+          )
+      )
+
+  public val icon_3070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3070.xml"),
+          )
+      )
+
+  public val icon_3071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3071.xml"),
+          )
+      )
+
+  public val icon_3072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3072.xml"),
+          )
+      )
+
+  public val icon_3073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3073.xml"),
+          )
+      )
+
+  public val icon_3074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3074.xml"),
+          )
+      )
+
+  public val icon_3075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3075.xml"),
+          )
+      )
+
+  public val icon_3076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3076.xml"),
+          )
+      )
+
+  public val icon_3077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3077.xml"),
+          )
+      )
+
+  public val icon_3078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3078.xml"),
+          )
+      )
+
+  public val icon_3079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3079.xml"),
+          )
+      )
+
+  public val icon_308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_308.xml"),
+          )
+      )
+
+  public val icon_3080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3080.xml"),
+          )
+      )
+
+  public val icon_3081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3081.xml"),
+          )
+      )
+
+  public val icon_3082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3082.xml"),
+          )
+      )
+
+  public val icon_3083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3083.xml"),
+          )
+      )
+
+  public val icon_3084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3084.xml"),
+          )
+      )
+
+  public val icon_3085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3085.xml"),
+          )
+      )
+
+  public val icon_3086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3086.xml"),
+          )
+      )
+
+  public val icon_3087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3087.xml"),
+          )
+      )
+
+  public val icon_3088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3088.xml"),
+          )
+      )
+
+  public val icon_3089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3089.xml"),
+          )
+      )
+
+  public val icon_309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_309.xml"),
+          )
+      )
+
+  public val icon_3090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3090.xml"),
+          )
+      )
+
+  public val icon_3091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3091.xml"),
+          )
+      )
+
+  public val icon_3092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3092.xml"),
+          )
+      )
+
+  public val icon_3093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3093.xml"),
+          )
+      )
+
+  public val icon_3094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3094.xml"),
+          )
+      )
+
+  public val icon_3095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3095.xml"),
+          )
+      )
+
+  public val icon_3096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3096.xml"),
+          )
+      )
+
+  public val icon_3097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3097.xml"),
+          )
+      )
+
+  public val icon_3098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3098.xml"),
+          )
+      )
+
+  public val icon_3099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3099.xml"),
+          )
+      )
+
+  public val icon_31: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_31",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_31.xml"),
+          )
+      )
+
+  public val icon_310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_310.xml"),
+          )
+      )
+
+  public val icon_3100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3100.xml"),
+          )
+      )
+
+  public val icon_3101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3101.xml"),
+          )
+      )
+
+  public val icon_3102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3102.xml"),
+          )
+      )
+
+  public val icon_3103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3103.xml"),
+          )
+      )
+
+  public val icon_3104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3104.xml"),
+          )
+      )
+
+  public val icon_3105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3105.xml"),
+          )
+      )
+
+  public val icon_3106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3106.xml"),
+          )
+      )
+
+  public val icon_3107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3107.xml"),
+          )
+      )
+
+  public val icon_3108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3108.xml"),
+          )
+      )
+
+  public val icon_3109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3109.xml"),
+          )
+      )
+
+  public val icon_311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_311.xml"),
+          )
+      )
+
+  public val icon_3110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3110.xml"),
+          )
+      )
+
+  public val icon_3111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3111.xml"),
+          )
+      )
+
+  public val icon_3112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3112.xml"),
+          )
+      )
+
+  public val icon_3113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3113.xml"),
+          )
+      )
+
+  public val icon_3114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3114.xml"),
+          )
+      )
+
+  public val icon_3115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3115.xml"),
+          )
+      )
+
+  public val icon_3116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3116.xml"),
+          )
+      )
+
+  public val icon_3117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3117.xml"),
+          )
+      )
+
+  public val icon_3118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3118.xml"),
+          )
+      )
+
+  public val icon_3119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3119.xml"),
+          )
+      )
+
+  public val icon_312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_312.xml"),
+          )
+      )
+
+  public val icon_3120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3120.xml"),
+          )
+      )
+
+  public val icon_3121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3121.xml"),
+          )
+      )
+
+  public val icon_3122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3122.xml"),
+          )
+      )
+
+  public val icon_3123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3123.xml"),
+          )
+      )
+
+  public val icon_3124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3124.xml"),
+          )
+      )
+
+  public val icon_3125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3125.xml"),
+          )
+      )
+
+  public val icon_3126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3126.xml"),
+          )
+      )
+
+  public val icon_3127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3127.xml"),
+          )
+      )
+
+  public val icon_3128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3128.xml"),
+          )
+      )
+
+  public val icon_3129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3129.xml"),
+          )
+      )
+
+  public val icon_313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_313.xml"),
+          )
+      )
+
+  public val icon_3130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3130.xml"),
+          )
+      )
+
+  public val icon_3131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3131.xml"),
+          )
+      )
+
+  public val icon_3132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3132.xml"),
+          )
+      )
+
+  public val icon_3133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3133.xml"),
+          )
+      )
+
+  public val icon_3134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3134.xml"),
+          )
+      )
+
+  public val icon_3135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3135.xml"),
+          )
+      )
+
+  public val icon_3136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3136.xml"),
+          )
+      )
+
+  public val icon_3137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3137.xml"),
+          )
+      )
+
+  public val icon_3138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3138.xml"),
+          )
+      )
+
+  public val icon_3139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3139.xml"),
+          )
+      )
+
+  public val icon_314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_314.xml"),
+          )
+      )
+
+  public val icon_3140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3140.xml"),
+          )
+      )
+
+  public val icon_3141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3141.xml"),
+          )
+      )
+
+  public val icon_3142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3142.xml"),
+          )
+      )
+
+  public val icon_3143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3143.xml"),
+          )
+      )
+
+  public val icon_3144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3144.xml"),
+          )
+      )
+
+  public val icon_3145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3145.xml"),
+          )
+      )
+
+  public val icon_3146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3146.xml"),
+          )
+      )
+
+  public val icon_3147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3147.xml"),
+          )
+      )
+
+  public val icon_3148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3148.xml"),
+          )
+      )
+
+  public val icon_3149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3149.xml"),
+          )
+      )
+
+  public val icon_315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_315.xml"),
+          )
+      )
+
+  public val icon_3150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3150.xml"),
+          )
+      )
+
+  public val icon_3151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3151.xml"),
+          )
+      )
+
+  public val icon_3152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3152.xml"),
+          )
+      )
+
+  public val icon_3153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3153.xml"),
+          )
+      )
+
+  public val icon_3154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3154.xml"),
+          )
+      )
+
+  public val icon_3155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3155.xml"),
+          )
+      )
+
+  public val icon_3156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3156.xml"),
+          )
+      )
+
+  public val icon_3157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3157.xml"),
+          )
+      )
+
+  public val icon_3158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3158.xml"),
+          )
+      )
+
+  public val icon_3159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3159.xml"),
+          )
+      )
+
+  public val icon_316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_316.xml"),
+          )
+      )
+
+  public val icon_3160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3160.xml"),
+          )
+      )
+
+  public val icon_3161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3161.xml"),
+          )
+      )
+
+  public val icon_3162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3162.xml"),
+          )
+      )
+
+  public val icon_3163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3163.xml"),
+          )
+      )
+
+  public val icon_3164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3164.xml"),
+          )
+      )
+
+  public val icon_3165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3165.xml"),
+          )
+      )
+
+  public val icon_3166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3166.xml"),
+          )
+      )
+
+  public val icon_3167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3167.xml"),
+          )
+      )
+
+  public val icon_3168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3168.xml"),
+          )
+      )
+
+  public val icon_3169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3169.xml"),
+          )
+      )
+
+  public val icon_317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_317.xml"),
+          )
+      )
+
+  public val icon_3170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3170.xml"),
+          )
+      )
+
+  public val icon_3171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3171.xml"),
+          )
+      )
+
+  public val icon_3172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3172.xml"),
+          )
+      )
+
+  public val icon_3173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3173.xml"),
+          )
+      )
+
+  public val icon_3174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3174.xml"),
+          )
+      )
+
+  public val icon_3175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3175.xml"),
+          )
+      )
+
+  public val icon_3176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3176.xml"),
+          )
+      )
+
+  public val icon_3177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3177.xml"),
+          )
+      )
+
+  public val icon_3178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3178.xml"),
+          )
+      )
+
+  public val icon_3179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3179.xml"),
+          )
+      )
+
+  public val icon_318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_318.xml"),
+          )
+      )
+
+  public val icon_3180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3180.xml"),
+          )
+      )
+
+  public val icon_3181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3181.xml"),
+          )
+      )
+
+  public val icon_3182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3182.xml"),
+          )
+      )
+
+  public val icon_3183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3183.xml"),
+          )
+      )
+
+  public val icon_3184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3184.xml"),
+          )
+      )
+
+  public val icon_3185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3185.xml"),
+          )
+      )
+
+  public val icon_3186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3186.xml"),
+          )
+      )
+
+  public val icon_3187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3187.xml"),
+          )
+      )
+
+  public val icon_3188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3188.xml"),
+          )
+      )
+
+  public val icon_3189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3189.xml"),
+          )
+      )
+
+  public val icon_319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_319.xml"),
+          )
+      )
+
+  public val icon_3190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3190.xml"),
+          )
+      )
+
+  public val icon_3191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3191.xml"),
+          )
+      )
+
+  public val icon_3192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3192.xml"),
+          )
+      )
+
+  public val icon_3193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3193.xml"),
+          )
+      )
+
+  public val icon_3194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3194.xml"),
+          )
+      )
+
+  public val icon_3195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3195.xml"),
+          )
+      )
+
+  public val icon_3196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3196.xml"),
+          )
+      )
+
+  public val icon_3197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3197.xml"),
+          )
+      )
+
+  public val icon_3198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3198.xml"),
+          )
+      )
+
+  public val icon_3199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3199.xml"),
+          )
+      )
+
+  public val icon_32: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_32",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_32.xml"),
+          )
+      )
+
+  public val icon_320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_320.xml"),
+          )
+      )
+
+  public val icon_3200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3200.xml"),
+          )
+      )
+
+  public val icon_3201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3201.xml"),
+          )
+      )
+
+  public val icon_3202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3202.xml"),
+          )
+      )
+
+  public val icon_3203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3203.xml"),
+          )
+      )
+
+  public val icon_3204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3204.xml"),
+          )
+      )
+
+  public val icon_3205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3205.xml"),
+          )
+      )
+
+  public val icon_3206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3206.xml"),
+          )
+      )
+
+  public val icon_3207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3207.xml"),
+          )
+      )
+
+  public val icon_3208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3208.xml"),
+          )
+      )
+
+  public val icon_3209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3209.xml"),
+          )
+      )
+
+  public val icon_321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_321.xml"),
+          )
+      )
+
+  public val icon_3210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3210.xml"),
+          )
+      )
+
+  public val icon_3211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3211.xml"),
+          )
+      )
+
+  public val icon_3212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3212.xml"),
+          )
+      )
+
+  public val icon_3213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3213.xml"),
+          )
+      )
+
+  public val icon_3214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3214.xml"),
+          )
+      )
+
+  public val icon_3215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3215.xml"),
+          )
+      )
+
+  public val icon_3216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3216.xml"),
+          )
+      )
+
+  public val icon_3217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3217.xml"),
+          )
+      )
+
+  public val icon_3218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3218.xml"),
+          )
+      )
+
+  public val icon_3219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3219.xml"),
+          )
+      )
+
+  public val icon_322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_322.xml"),
+          )
+      )
+
+  public val icon_3220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3220.xml"),
+          )
+      )
+
+  public val icon_3221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3221.xml"),
+          )
+      )
+
+  public val icon_3222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3222.xml"),
+          )
+      )
+
+  public val icon_3223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3223.xml"),
+          )
+      )
+
+  public val icon_3224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3224.xml"),
+          )
+      )
+
+  public val icon_3225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3225.xml"),
+          )
+      )
+
+  public val icon_3226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3226.xml"),
+          )
+      )
+
+  public val icon_3227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3227.xml"),
+          )
+      )
+
+  public val icon_3228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3228.xml"),
+          )
+      )
+
+  public val icon_3229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3229.xml"),
+          )
+      )
+
+  public val icon_323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_323.xml"),
+          )
+      )
+
+  public val icon_3230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3230.xml"),
+          )
+      )
+
+  public val icon_3231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3231.xml"),
+          )
+      )
+
+  public val icon_3232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3232.xml"),
+          )
+      )
+
+  public val icon_3233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3233.xml"),
+          )
+      )
+
+  public val icon_3234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3234.xml"),
+          )
+      )
+
+  public val icon_3235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3235.xml"),
+          )
+      )
+
+  public val icon_3236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3236.xml"),
+          )
+      )
+
+  public val icon_3237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3237.xml"),
+          )
+      )
+
+  public val icon_3238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3238.xml"),
+          )
+      )
+
+  public val icon_3239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3239.xml"),
+          )
+      )
+
+  public val icon_324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_324.xml"),
+          )
+      )
+
+  public val icon_3240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3240.xml"),
+          )
+      )
+
+  public val icon_3241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3241.xml"),
+          )
+      )
+
+  public val icon_3242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3242.xml"),
+          )
+      )
+
+  public val icon_3243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3243.xml"),
+          )
+      )
+
+  public val icon_3244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3244.xml"),
+          )
+      )
+
+  public val icon_3245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3245.xml"),
+          )
+      )
+
+  public val icon_3246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3246.xml"),
+          )
+      )
+
+  public val icon_3247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3247.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2799: DrawableResource
+  get() = Drawable34.icon_2799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_28: DrawableResource
+  get() = Drawable34.icon_28
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_280: DrawableResource
+  get() = Drawable34.icon_280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2800: DrawableResource
+  get() = Drawable34.icon_2800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2801: DrawableResource
+  get() = Drawable34.icon_2801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2802: DrawableResource
+  get() = Drawable34.icon_2802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2803: DrawableResource
+  get() = Drawable34.icon_2803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2804: DrawableResource
+  get() = Drawable34.icon_2804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2805: DrawableResource
+  get() = Drawable34.icon_2805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2806: DrawableResource
+  get() = Drawable34.icon_2806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2807: DrawableResource
+  get() = Drawable34.icon_2807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2808: DrawableResource
+  get() = Drawable34.icon_2808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2809: DrawableResource
+  get() = Drawable34.icon_2809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_281: DrawableResource
+  get() = Drawable34.icon_281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2810: DrawableResource
+  get() = Drawable34.icon_2810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2811: DrawableResource
+  get() = Drawable34.icon_2811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2812: DrawableResource
+  get() = Drawable34.icon_2812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2813: DrawableResource
+  get() = Drawable34.icon_2813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2814: DrawableResource
+  get() = Drawable34.icon_2814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2815: DrawableResource
+  get() = Drawable34.icon_2815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2816: DrawableResource
+  get() = Drawable34.icon_2816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2817: DrawableResource
+  get() = Drawable34.icon_2817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2818: DrawableResource
+  get() = Drawable34.icon_2818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2819: DrawableResource
+  get() = Drawable34.icon_2819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_282: DrawableResource
+  get() = Drawable34.icon_282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2820: DrawableResource
+  get() = Drawable34.icon_2820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2821: DrawableResource
+  get() = Drawable34.icon_2821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2822: DrawableResource
+  get() = Drawable34.icon_2822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2823: DrawableResource
+  get() = Drawable34.icon_2823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2824: DrawableResource
+  get() = Drawable34.icon_2824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2825: DrawableResource
+  get() = Drawable34.icon_2825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2826: DrawableResource
+  get() = Drawable34.icon_2826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2827: DrawableResource
+  get() = Drawable34.icon_2827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2828: DrawableResource
+  get() = Drawable34.icon_2828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2829: DrawableResource
+  get() = Drawable34.icon_2829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_283: DrawableResource
+  get() = Drawable34.icon_283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2830: DrawableResource
+  get() = Drawable34.icon_2830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2831: DrawableResource
+  get() = Drawable34.icon_2831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2832: DrawableResource
+  get() = Drawable34.icon_2832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2833: DrawableResource
+  get() = Drawable34.icon_2833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2834: DrawableResource
+  get() = Drawable34.icon_2834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2835: DrawableResource
+  get() = Drawable34.icon_2835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2836: DrawableResource
+  get() = Drawable34.icon_2836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2837: DrawableResource
+  get() = Drawable34.icon_2837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2838: DrawableResource
+  get() = Drawable34.icon_2838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2839: DrawableResource
+  get() = Drawable34.icon_2839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_284: DrawableResource
+  get() = Drawable34.icon_284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2840: DrawableResource
+  get() = Drawable34.icon_2840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2841: DrawableResource
+  get() = Drawable34.icon_2841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2842: DrawableResource
+  get() = Drawable34.icon_2842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2843: DrawableResource
+  get() = Drawable34.icon_2843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2844: DrawableResource
+  get() = Drawable34.icon_2844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2845: DrawableResource
+  get() = Drawable34.icon_2845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2846: DrawableResource
+  get() = Drawable34.icon_2846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2847: DrawableResource
+  get() = Drawable34.icon_2847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2848: DrawableResource
+  get() = Drawable34.icon_2848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2849: DrawableResource
+  get() = Drawable34.icon_2849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_285: DrawableResource
+  get() = Drawable34.icon_285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2850: DrawableResource
+  get() = Drawable34.icon_2850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2851: DrawableResource
+  get() = Drawable34.icon_2851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2852: DrawableResource
+  get() = Drawable34.icon_2852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2853: DrawableResource
+  get() = Drawable34.icon_2853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2854: DrawableResource
+  get() = Drawable34.icon_2854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2855: DrawableResource
+  get() = Drawable34.icon_2855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2856: DrawableResource
+  get() = Drawable34.icon_2856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2857: DrawableResource
+  get() = Drawable34.icon_2857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2858: DrawableResource
+  get() = Drawable34.icon_2858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2859: DrawableResource
+  get() = Drawable34.icon_2859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_286: DrawableResource
+  get() = Drawable34.icon_286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2860: DrawableResource
+  get() = Drawable34.icon_2860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2861: DrawableResource
+  get() = Drawable34.icon_2861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2862: DrawableResource
+  get() = Drawable34.icon_2862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2863: DrawableResource
+  get() = Drawable34.icon_2863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2864: DrawableResource
+  get() = Drawable34.icon_2864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2865: DrawableResource
+  get() = Drawable34.icon_2865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2866: DrawableResource
+  get() = Drawable34.icon_2866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2867: DrawableResource
+  get() = Drawable34.icon_2867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2868: DrawableResource
+  get() = Drawable34.icon_2868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2869: DrawableResource
+  get() = Drawable34.icon_2869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_287: DrawableResource
+  get() = Drawable34.icon_287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2870: DrawableResource
+  get() = Drawable34.icon_2870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2871: DrawableResource
+  get() = Drawable34.icon_2871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2872: DrawableResource
+  get() = Drawable34.icon_2872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2873: DrawableResource
+  get() = Drawable34.icon_2873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2874: DrawableResource
+  get() = Drawable34.icon_2874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2875: DrawableResource
+  get() = Drawable34.icon_2875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2876: DrawableResource
+  get() = Drawable34.icon_2876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2877: DrawableResource
+  get() = Drawable34.icon_2877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2878: DrawableResource
+  get() = Drawable34.icon_2878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2879: DrawableResource
+  get() = Drawable34.icon_2879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_288: DrawableResource
+  get() = Drawable34.icon_288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2880: DrawableResource
+  get() = Drawable34.icon_2880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2881: DrawableResource
+  get() = Drawable34.icon_2881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2882: DrawableResource
+  get() = Drawable34.icon_2882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2883: DrawableResource
+  get() = Drawable34.icon_2883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2884: DrawableResource
+  get() = Drawable34.icon_2884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2885: DrawableResource
+  get() = Drawable34.icon_2885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2886: DrawableResource
+  get() = Drawable34.icon_2886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2887: DrawableResource
+  get() = Drawable34.icon_2887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2888: DrawableResource
+  get() = Drawable34.icon_2888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2889: DrawableResource
+  get() = Drawable34.icon_2889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_289: DrawableResource
+  get() = Drawable34.icon_289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2890: DrawableResource
+  get() = Drawable34.icon_2890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2891: DrawableResource
+  get() = Drawable34.icon_2891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2892: DrawableResource
+  get() = Drawable34.icon_2892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2893: DrawableResource
+  get() = Drawable34.icon_2893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2894: DrawableResource
+  get() = Drawable34.icon_2894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2895: DrawableResource
+  get() = Drawable34.icon_2895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2896: DrawableResource
+  get() = Drawable34.icon_2896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2897: DrawableResource
+  get() = Drawable34.icon_2897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2898: DrawableResource
+  get() = Drawable34.icon_2898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2899: DrawableResource
+  get() = Drawable34.icon_2899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_29: DrawableResource
+  get() = Drawable34.icon_29
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_290: DrawableResource
+  get() = Drawable34.icon_290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2900: DrawableResource
+  get() = Drawable34.icon_2900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2901: DrawableResource
+  get() = Drawable34.icon_2901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2902: DrawableResource
+  get() = Drawable34.icon_2902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2903: DrawableResource
+  get() = Drawable34.icon_2903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2904: DrawableResource
+  get() = Drawable34.icon_2904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2905: DrawableResource
+  get() = Drawable34.icon_2905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2906: DrawableResource
+  get() = Drawable34.icon_2906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2907: DrawableResource
+  get() = Drawable34.icon_2907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2908: DrawableResource
+  get() = Drawable34.icon_2908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2909: DrawableResource
+  get() = Drawable34.icon_2909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_291: DrawableResource
+  get() = Drawable34.icon_291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2910: DrawableResource
+  get() = Drawable34.icon_2910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2911: DrawableResource
+  get() = Drawable34.icon_2911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2912: DrawableResource
+  get() = Drawable34.icon_2912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2913: DrawableResource
+  get() = Drawable34.icon_2913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2914: DrawableResource
+  get() = Drawable34.icon_2914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2915: DrawableResource
+  get() = Drawable34.icon_2915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2916: DrawableResource
+  get() = Drawable34.icon_2916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2917: DrawableResource
+  get() = Drawable34.icon_2917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2918: DrawableResource
+  get() = Drawable34.icon_2918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2919: DrawableResource
+  get() = Drawable34.icon_2919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_292: DrawableResource
+  get() = Drawable34.icon_292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2920: DrawableResource
+  get() = Drawable34.icon_2920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2921: DrawableResource
+  get() = Drawable34.icon_2921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2922: DrawableResource
+  get() = Drawable34.icon_2922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2923: DrawableResource
+  get() = Drawable34.icon_2923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2924: DrawableResource
+  get() = Drawable34.icon_2924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2925: DrawableResource
+  get() = Drawable34.icon_2925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2926: DrawableResource
+  get() = Drawable34.icon_2926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2927: DrawableResource
+  get() = Drawable34.icon_2927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2928: DrawableResource
+  get() = Drawable34.icon_2928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2929: DrawableResource
+  get() = Drawable34.icon_2929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_293: DrawableResource
+  get() = Drawable34.icon_293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2930: DrawableResource
+  get() = Drawable34.icon_2930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2931: DrawableResource
+  get() = Drawable34.icon_2931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2932: DrawableResource
+  get() = Drawable34.icon_2932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2933: DrawableResource
+  get() = Drawable34.icon_2933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2934: DrawableResource
+  get() = Drawable34.icon_2934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2935: DrawableResource
+  get() = Drawable34.icon_2935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2936: DrawableResource
+  get() = Drawable34.icon_2936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2937: DrawableResource
+  get() = Drawable34.icon_2937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2938: DrawableResource
+  get() = Drawable34.icon_2938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2939: DrawableResource
+  get() = Drawable34.icon_2939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_294: DrawableResource
+  get() = Drawable34.icon_294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2940: DrawableResource
+  get() = Drawable34.icon_2940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2941: DrawableResource
+  get() = Drawable34.icon_2941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2942: DrawableResource
+  get() = Drawable34.icon_2942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2943: DrawableResource
+  get() = Drawable34.icon_2943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2944: DrawableResource
+  get() = Drawable34.icon_2944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2945: DrawableResource
+  get() = Drawable34.icon_2945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2946: DrawableResource
+  get() = Drawable34.icon_2946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2947: DrawableResource
+  get() = Drawable34.icon_2947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2948: DrawableResource
+  get() = Drawable34.icon_2948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2949: DrawableResource
+  get() = Drawable34.icon_2949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_295: DrawableResource
+  get() = Drawable34.icon_295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2950: DrawableResource
+  get() = Drawable34.icon_2950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2951: DrawableResource
+  get() = Drawable34.icon_2951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2952: DrawableResource
+  get() = Drawable34.icon_2952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2953: DrawableResource
+  get() = Drawable34.icon_2953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2954: DrawableResource
+  get() = Drawable34.icon_2954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2955: DrawableResource
+  get() = Drawable34.icon_2955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2956: DrawableResource
+  get() = Drawable34.icon_2956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2957: DrawableResource
+  get() = Drawable34.icon_2957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2958: DrawableResource
+  get() = Drawable34.icon_2958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2959: DrawableResource
+  get() = Drawable34.icon_2959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_296: DrawableResource
+  get() = Drawable34.icon_296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2960: DrawableResource
+  get() = Drawable34.icon_2960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2961: DrawableResource
+  get() = Drawable34.icon_2961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2962: DrawableResource
+  get() = Drawable34.icon_2962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2963: DrawableResource
+  get() = Drawable34.icon_2963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2964: DrawableResource
+  get() = Drawable34.icon_2964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2965: DrawableResource
+  get() = Drawable34.icon_2965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2966: DrawableResource
+  get() = Drawable34.icon_2966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2967: DrawableResource
+  get() = Drawable34.icon_2967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2968: DrawableResource
+  get() = Drawable34.icon_2968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2969: DrawableResource
+  get() = Drawable34.icon_2969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_297: DrawableResource
+  get() = Drawable34.icon_297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2970: DrawableResource
+  get() = Drawable34.icon_2970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2971: DrawableResource
+  get() = Drawable34.icon_2971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2972: DrawableResource
+  get() = Drawable34.icon_2972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2973: DrawableResource
+  get() = Drawable34.icon_2973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2974: DrawableResource
+  get() = Drawable34.icon_2974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2975: DrawableResource
+  get() = Drawable34.icon_2975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2976: DrawableResource
+  get() = Drawable34.icon_2976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2977: DrawableResource
+  get() = Drawable34.icon_2977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2978: DrawableResource
+  get() = Drawable34.icon_2978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2979: DrawableResource
+  get() = Drawable34.icon_2979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_298: DrawableResource
+  get() = Drawable34.icon_298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2980: DrawableResource
+  get() = Drawable34.icon_2980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2981: DrawableResource
+  get() = Drawable34.icon_2981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2982: DrawableResource
+  get() = Drawable34.icon_2982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2983: DrawableResource
+  get() = Drawable34.icon_2983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2984: DrawableResource
+  get() = Drawable34.icon_2984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2985: DrawableResource
+  get() = Drawable34.icon_2985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2986: DrawableResource
+  get() = Drawable34.icon_2986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2987: DrawableResource
+  get() = Drawable34.icon_2987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2988: DrawableResource
+  get() = Drawable34.icon_2988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2989: DrawableResource
+  get() = Drawable34.icon_2989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_299: DrawableResource
+  get() = Drawable34.icon_299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2990: DrawableResource
+  get() = Drawable34.icon_2990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2991: DrawableResource
+  get() = Drawable34.icon_2991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2992: DrawableResource
+  get() = Drawable34.icon_2992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2993: DrawableResource
+  get() = Drawable34.icon_2993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2994: DrawableResource
+  get() = Drawable34.icon_2994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2995: DrawableResource
+  get() = Drawable34.icon_2995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2996: DrawableResource
+  get() = Drawable34.icon_2996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2997: DrawableResource
+  get() = Drawable34.icon_2997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2998: DrawableResource
+  get() = Drawable34.icon_2998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_2999: DrawableResource
+  get() = Drawable34.icon_2999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3: DrawableResource
+  get() = Drawable34.icon_3
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_30: DrawableResource
+  get() = Drawable34.icon_30
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_300: DrawableResource
+  get() = Drawable34.icon_300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3000: DrawableResource
+  get() = Drawable34.icon_3000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3001: DrawableResource
+  get() = Drawable34.icon_3001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3002: DrawableResource
+  get() = Drawable34.icon_3002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3003: DrawableResource
+  get() = Drawable34.icon_3003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3004: DrawableResource
+  get() = Drawable34.icon_3004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3005: DrawableResource
+  get() = Drawable34.icon_3005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3006: DrawableResource
+  get() = Drawable34.icon_3006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3007: DrawableResource
+  get() = Drawable34.icon_3007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3008: DrawableResource
+  get() = Drawable34.icon_3008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3009: DrawableResource
+  get() = Drawable34.icon_3009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_301: DrawableResource
+  get() = Drawable34.icon_301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3010: DrawableResource
+  get() = Drawable34.icon_3010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3011: DrawableResource
+  get() = Drawable34.icon_3011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3012: DrawableResource
+  get() = Drawable34.icon_3012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3013: DrawableResource
+  get() = Drawable34.icon_3013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3014: DrawableResource
+  get() = Drawable34.icon_3014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3015: DrawableResource
+  get() = Drawable34.icon_3015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3016: DrawableResource
+  get() = Drawable34.icon_3016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3017: DrawableResource
+  get() = Drawable34.icon_3017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3018: DrawableResource
+  get() = Drawable34.icon_3018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3019: DrawableResource
+  get() = Drawable34.icon_3019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_302: DrawableResource
+  get() = Drawable34.icon_302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3020: DrawableResource
+  get() = Drawable34.icon_3020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3021: DrawableResource
+  get() = Drawable34.icon_3021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3022: DrawableResource
+  get() = Drawable34.icon_3022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3023: DrawableResource
+  get() = Drawable34.icon_3023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3024: DrawableResource
+  get() = Drawable34.icon_3024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3025: DrawableResource
+  get() = Drawable34.icon_3025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3026: DrawableResource
+  get() = Drawable34.icon_3026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3027: DrawableResource
+  get() = Drawable34.icon_3027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3028: DrawableResource
+  get() = Drawable34.icon_3028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3029: DrawableResource
+  get() = Drawable34.icon_3029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_303: DrawableResource
+  get() = Drawable34.icon_303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3030: DrawableResource
+  get() = Drawable34.icon_3030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3031: DrawableResource
+  get() = Drawable34.icon_3031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3032: DrawableResource
+  get() = Drawable34.icon_3032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3033: DrawableResource
+  get() = Drawable34.icon_3033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3034: DrawableResource
+  get() = Drawable34.icon_3034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3035: DrawableResource
+  get() = Drawable34.icon_3035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3036: DrawableResource
+  get() = Drawable34.icon_3036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3037: DrawableResource
+  get() = Drawable34.icon_3037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3038: DrawableResource
+  get() = Drawable34.icon_3038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3039: DrawableResource
+  get() = Drawable34.icon_3039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_304: DrawableResource
+  get() = Drawable34.icon_304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3040: DrawableResource
+  get() = Drawable34.icon_3040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3041: DrawableResource
+  get() = Drawable34.icon_3041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3042: DrawableResource
+  get() = Drawable34.icon_3042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3043: DrawableResource
+  get() = Drawable34.icon_3043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3044: DrawableResource
+  get() = Drawable34.icon_3044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3045: DrawableResource
+  get() = Drawable34.icon_3045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3046: DrawableResource
+  get() = Drawable34.icon_3046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3047: DrawableResource
+  get() = Drawable34.icon_3047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3048: DrawableResource
+  get() = Drawable34.icon_3048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3049: DrawableResource
+  get() = Drawable34.icon_3049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_305: DrawableResource
+  get() = Drawable34.icon_305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3050: DrawableResource
+  get() = Drawable34.icon_3050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3051: DrawableResource
+  get() = Drawable34.icon_3051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3052: DrawableResource
+  get() = Drawable34.icon_3052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3053: DrawableResource
+  get() = Drawable34.icon_3053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3054: DrawableResource
+  get() = Drawable34.icon_3054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3055: DrawableResource
+  get() = Drawable34.icon_3055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3056: DrawableResource
+  get() = Drawable34.icon_3056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3057: DrawableResource
+  get() = Drawable34.icon_3057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3058: DrawableResource
+  get() = Drawable34.icon_3058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3059: DrawableResource
+  get() = Drawable34.icon_3059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_306: DrawableResource
+  get() = Drawable34.icon_306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3060: DrawableResource
+  get() = Drawable34.icon_3060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3061: DrawableResource
+  get() = Drawable34.icon_3061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3062: DrawableResource
+  get() = Drawable34.icon_3062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3063: DrawableResource
+  get() = Drawable34.icon_3063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3064: DrawableResource
+  get() = Drawable34.icon_3064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3065: DrawableResource
+  get() = Drawable34.icon_3065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3066: DrawableResource
+  get() = Drawable34.icon_3066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3067: DrawableResource
+  get() = Drawable34.icon_3067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3068: DrawableResource
+  get() = Drawable34.icon_3068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3069: DrawableResource
+  get() = Drawable34.icon_3069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_307: DrawableResource
+  get() = Drawable34.icon_307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3070: DrawableResource
+  get() = Drawable34.icon_3070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3071: DrawableResource
+  get() = Drawable34.icon_3071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3072: DrawableResource
+  get() = Drawable34.icon_3072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3073: DrawableResource
+  get() = Drawable34.icon_3073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3074: DrawableResource
+  get() = Drawable34.icon_3074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3075: DrawableResource
+  get() = Drawable34.icon_3075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3076: DrawableResource
+  get() = Drawable34.icon_3076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3077: DrawableResource
+  get() = Drawable34.icon_3077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3078: DrawableResource
+  get() = Drawable34.icon_3078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3079: DrawableResource
+  get() = Drawable34.icon_3079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_308: DrawableResource
+  get() = Drawable34.icon_308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3080: DrawableResource
+  get() = Drawable34.icon_3080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3081: DrawableResource
+  get() = Drawable34.icon_3081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3082: DrawableResource
+  get() = Drawable34.icon_3082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3083: DrawableResource
+  get() = Drawable34.icon_3083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3084: DrawableResource
+  get() = Drawable34.icon_3084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3085: DrawableResource
+  get() = Drawable34.icon_3085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3086: DrawableResource
+  get() = Drawable34.icon_3086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3087: DrawableResource
+  get() = Drawable34.icon_3087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3088: DrawableResource
+  get() = Drawable34.icon_3088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3089: DrawableResource
+  get() = Drawable34.icon_3089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_309: DrawableResource
+  get() = Drawable34.icon_309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3090: DrawableResource
+  get() = Drawable34.icon_3090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3091: DrawableResource
+  get() = Drawable34.icon_3091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3092: DrawableResource
+  get() = Drawable34.icon_3092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3093: DrawableResource
+  get() = Drawable34.icon_3093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3094: DrawableResource
+  get() = Drawable34.icon_3094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3095: DrawableResource
+  get() = Drawable34.icon_3095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3096: DrawableResource
+  get() = Drawable34.icon_3096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3097: DrawableResource
+  get() = Drawable34.icon_3097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3098: DrawableResource
+  get() = Drawable34.icon_3098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3099: DrawableResource
+  get() = Drawable34.icon_3099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_31: DrawableResource
+  get() = Drawable34.icon_31
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_310: DrawableResource
+  get() = Drawable34.icon_310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3100: DrawableResource
+  get() = Drawable34.icon_3100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3101: DrawableResource
+  get() = Drawable34.icon_3101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3102: DrawableResource
+  get() = Drawable34.icon_3102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3103: DrawableResource
+  get() = Drawable34.icon_3103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3104: DrawableResource
+  get() = Drawable34.icon_3104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3105: DrawableResource
+  get() = Drawable34.icon_3105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3106: DrawableResource
+  get() = Drawable34.icon_3106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3107: DrawableResource
+  get() = Drawable34.icon_3107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3108: DrawableResource
+  get() = Drawable34.icon_3108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3109: DrawableResource
+  get() = Drawable34.icon_3109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_311: DrawableResource
+  get() = Drawable34.icon_311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3110: DrawableResource
+  get() = Drawable34.icon_3110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3111: DrawableResource
+  get() = Drawable34.icon_3111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3112: DrawableResource
+  get() = Drawable34.icon_3112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3113: DrawableResource
+  get() = Drawable34.icon_3113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3114: DrawableResource
+  get() = Drawable34.icon_3114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3115: DrawableResource
+  get() = Drawable34.icon_3115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3116: DrawableResource
+  get() = Drawable34.icon_3116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3117: DrawableResource
+  get() = Drawable34.icon_3117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3118: DrawableResource
+  get() = Drawable34.icon_3118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3119: DrawableResource
+  get() = Drawable34.icon_3119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_312: DrawableResource
+  get() = Drawable34.icon_312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3120: DrawableResource
+  get() = Drawable34.icon_3120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3121: DrawableResource
+  get() = Drawable34.icon_3121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3122: DrawableResource
+  get() = Drawable34.icon_3122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3123: DrawableResource
+  get() = Drawable34.icon_3123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3124: DrawableResource
+  get() = Drawable34.icon_3124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3125: DrawableResource
+  get() = Drawable34.icon_3125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3126: DrawableResource
+  get() = Drawable34.icon_3126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3127: DrawableResource
+  get() = Drawable34.icon_3127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3128: DrawableResource
+  get() = Drawable34.icon_3128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3129: DrawableResource
+  get() = Drawable34.icon_3129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_313: DrawableResource
+  get() = Drawable34.icon_313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3130: DrawableResource
+  get() = Drawable34.icon_3130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3131: DrawableResource
+  get() = Drawable34.icon_3131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3132: DrawableResource
+  get() = Drawable34.icon_3132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3133: DrawableResource
+  get() = Drawable34.icon_3133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3134: DrawableResource
+  get() = Drawable34.icon_3134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3135: DrawableResource
+  get() = Drawable34.icon_3135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3136: DrawableResource
+  get() = Drawable34.icon_3136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3137: DrawableResource
+  get() = Drawable34.icon_3137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3138: DrawableResource
+  get() = Drawable34.icon_3138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3139: DrawableResource
+  get() = Drawable34.icon_3139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_314: DrawableResource
+  get() = Drawable34.icon_314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3140: DrawableResource
+  get() = Drawable34.icon_3140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3141: DrawableResource
+  get() = Drawable34.icon_3141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3142: DrawableResource
+  get() = Drawable34.icon_3142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3143: DrawableResource
+  get() = Drawable34.icon_3143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3144: DrawableResource
+  get() = Drawable34.icon_3144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3145: DrawableResource
+  get() = Drawable34.icon_3145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3146: DrawableResource
+  get() = Drawable34.icon_3146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3147: DrawableResource
+  get() = Drawable34.icon_3147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3148: DrawableResource
+  get() = Drawable34.icon_3148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3149: DrawableResource
+  get() = Drawable34.icon_3149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_315: DrawableResource
+  get() = Drawable34.icon_315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3150: DrawableResource
+  get() = Drawable34.icon_3150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3151: DrawableResource
+  get() = Drawable34.icon_3151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3152: DrawableResource
+  get() = Drawable34.icon_3152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3153: DrawableResource
+  get() = Drawable34.icon_3153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3154: DrawableResource
+  get() = Drawable34.icon_3154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3155: DrawableResource
+  get() = Drawable34.icon_3155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3156: DrawableResource
+  get() = Drawable34.icon_3156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3157: DrawableResource
+  get() = Drawable34.icon_3157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3158: DrawableResource
+  get() = Drawable34.icon_3158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3159: DrawableResource
+  get() = Drawable34.icon_3159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_316: DrawableResource
+  get() = Drawable34.icon_316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3160: DrawableResource
+  get() = Drawable34.icon_3160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3161: DrawableResource
+  get() = Drawable34.icon_3161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3162: DrawableResource
+  get() = Drawable34.icon_3162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3163: DrawableResource
+  get() = Drawable34.icon_3163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3164: DrawableResource
+  get() = Drawable34.icon_3164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3165: DrawableResource
+  get() = Drawable34.icon_3165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3166: DrawableResource
+  get() = Drawable34.icon_3166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3167: DrawableResource
+  get() = Drawable34.icon_3167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3168: DrawableResource
+  get() = Drawable34.icon_3168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3169: DrawableResource
+  get() = Drawable34.icon_3169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_317: DrawableResource
+  get() = Drawable34.icon_317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3170: DrawableResource
+  get() = Drawable34.icon_3170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3171: DrawableResource
+  get() = Drawable34.icon_3171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3172: DrawableResource
+  get() = Drawable34.icon_3172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3173: DrawableResource
+  get() = Drawable34.icon_3173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3174: DrawableResource
+  get() = Drawable34.icon_3174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3175: DrawableResource
+  get() = Drawable34.icon_3175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3176: DrawableResource
+  get() = Drawable34.icon_3176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3177: DrawableResource
+  get() = Drawable34.icon_3177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3178: DrawableResource
+  get() = Drawable34.icon_3178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3179: DrawableResource
+  get() = Drawable34.icon_3179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_318: DrawableResource
+  get() = Drawable34.icon_318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3180: DrawableResource
+  get() = Drawable34.icon_3180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3181: DrawableResource
+  get() = Drawable34.icon_3181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3182: DrawableResource
+  get() = Drawable34.icon_3182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3183: DrawableResource
+  get() = Drawable34.icon_3183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3184: DrawableResource
+  get() = Drawable34.icon_3184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3185: DrawableResource
+  get() = Drawable34.icon_3185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3186: DrawableResource
+  get() = Drawable34.icon_3186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3187: DrawableResource
+  get() = Drawable34.icon_3187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3188: DrawableResource
+  get() = Drawable34.icon_3188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3189: DrawableResource
+  get() = Drawable34.icon_3189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_319: DrawableResource
+  get() = Drawable34.icon_319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3190: DrawableResource
+  get() = Drawable34.icon_3190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3191: DrawableResource
+  get() = Drawable34.icon_3191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3192: DrawableResource
+  get() = Drawable34.icon_3192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3193: DrawableResource
+  get() = Drawable34.icon_3193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3194: DrawableResource
+  get() = Drawable34.icon_3194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3195: DrawableResource
+  get() = Drawable34.icon_3195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3196: DrawableResource
+  get() = Drawable34.icon_3196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3197: DrawableResource
+  get() = Drawable34.icon_3197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3198: DrawableResource
+  get() = Drawable34.icon_3198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3199: DrawableResource
+  get() = Drawable34.icon_3199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_32: DrawableResource
+  get() = Drawable34.icon_32
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_320: DrawableResource
+  get() = Drawable34.icon_320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3200: DrawableResource
+  get() = Drawable34.icon_3200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3201: DrawableResource
+  get() = Drawable34.icon_3201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3202: DrawableResource
+  get() = Drawable34.icon_3202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3203: DrawableResource
+  get() = Drawable34.icon_3203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3204: DrawableResource
+  get() = Drawable34.icon_3204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3205: DrawableResource
+  get() = Drawable34.icon_3205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3206: DrawableResource
+  get() = Drawable34.icon_3206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3207: DrawableResource
+  get() = Drawable34.icon_3207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3208: DrawableResource
+  get() = Drawable34.icon_3208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3209: DrawableResource
+  get() = Drawable34.icon_3209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_321: DrawableResource
+  get() = Drawable34.icon_321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3210: DrawableResource
+  get() = Drawable34.icon_3210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3211: DrawableResource
+  get() = Drawable34.icon_3211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3212: DrawableResource
+  get() = Drawable34.icon_3212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3213: DrawableResource
+  get() = Drawable34.icon_3213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3214: DrawableResource
+  get() = Drawable34.icon_3214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3215: DrawableResource
+  get() = Drawable34.icon_3215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3216: DrawableResource
+  get() = Drawable34.icon_3216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3217: DrawableResource
+  get() = Drawable34.icon_3217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3218: DrawableResource
+  get() = Drawable34.icon_3218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3219: DrawableResource
+  get() = Drawable34.icon_3219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_322: DrawableResource
+  get() = Drawable34.icon_322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3220: DrawableResource
+  get() = Drawable34.icon_3220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3221: DrawableResource
+  get() = Drawable34.icon_3221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3222: DrawableResource
+  get() = Drawable34.icon_3222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3223: DrawableResource
+  get() = Drawable34.icon_3223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3224: DrawableResource
+  get() = Drawable34.icon_3224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3225: DrawableResource
+  get() = Drawable34.icon_3225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3226: DrawableResource
+  get() = Drawable34.icon_3226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3227: DrawableResource
+  get() = Drawable34.icon_3227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3228: DrawableResource
+  get() = Drawable34.icon_3228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3229: DrawableResource
+  get() = Drawable34.icon_3229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_323: DrawableResource
+  get() = Drawable34.icon_323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3230: DrawableResource
+  get() = Drawable34.icon_3230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3231: DrawableResource
+  get() = Drawable34.icon_3231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3232: DrawableResource
+  get() = Drawable34.icon_3232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3233: DrawableResource
+  get() = Drawable34.icon_3233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3234: DrawableResource
+  get() = Drawable34.icon_3234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3235: DrawableResource
+  get() = Drawable34.icon_3235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3236: DrawableResource
+  get() = Drawable34.icon_3236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3237: DrawableResource
+  get() = Drawable34.icon_3237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3238: DrawableResource
+  get() = Drawable34.icon_3238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3239: DrawableResource
+  get() = Drawable34.icon_3239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_324: DrawableResource
+  get() = Drawable34.icon_324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3240: DrawableResource
+  get() = Drawable34.icon_3240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3241: DrawableResource
+  get() = Drawable34.icon_3241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3242: DrawableResource
+  get() = Drawable34.icon_3242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3243: DrawableResource
+  get() = Drawable34.icon_3243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3244: DrawableResource
+  get() = Drawable34.icon_3244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3245: DrawableResource
+  get() = Drawable34.icon_3245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3246: DrawableResource
+  get() = Drawable34.icon_3246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3247: DrawableResource
+  get() = Drawable34.icon_3247

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable35.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable35.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable35 {
+  public val icon_3248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3248.xml"),
+          )
+      )
+
+  public val icon_3249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3249.xml"),
+          )
+      )
+
+  public val icon_325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_325.xml"),
+          )
+      )
+
+  public val icon_3250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3250.xml"),
+          )
+      )
+
+  public val icon_3251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3251.xml"),
+          )
+      )
+
+  public val icon_3252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3252.xml"),
+          )
+      )
+
+  public val icon_3253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3253.xml"),
+          )
+      )
+
+  public val icon_3254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3254.xml"),
+          )
+      )
+
+  public val icon_3255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3255.xml"),
+          )
+      )
+
+  public val icon_3256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3256.xml"),
+          )
+      )
+
+  public val icon_3257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3257.xml"),
+          )
+      )
+
+  public val icon_3258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3258.xml"),
+          )
+      )
+
+  public val icon_3259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3259.xml"),
+          )
+      )
+
+  public val icon_326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_326.xml"),
+          )
+      )
+
+  public val icon_3260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3260.xml"),
+          )
+      )
+
+  public val icon_3261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3261.xml"),
+          )
+      )
+
+  public val icon_3262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3262.xml"),
+          )
+      )
+
+  public val icon_3263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3263.xml"),
+          )
+      )
+
+  public val icon_3264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3264.xml"),
+          )
+      )
+
+  public val icon_3265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3265.xml"),
+          )
+      )
+
+  public val icon_3266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3266.xml"),
+          )
+      )
+
+  public val icon_3267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3267.xml"),
+          )
+      )
+
+  public val icon_3268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3268.xml"),
+          )
+      )
+
+  public val icon_3269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3269.xml"),
+          )
+      )
+
+  public val icon_327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_327.xml"),
+          )
+      )
+
+  public val icon_3270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3270.xml"),
+          )
+      )
+
+  public val icon_3271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3271.xml"),
+          )
+      )
+
+  public val icon_3272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3272.xml"),
+          )
+      )
+
+  public val icon_3273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3273.xml"),
+          )
+      )
+
+  public val icon_3274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3274.xml"),
+          )
+      )
+
+  public val icon_3275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3275.xml"),
+          )
+      )
+
+  public val icon_3276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3276.xml"),
+          )
+      )
+
+  public val icon_3277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3277.xml"),
+          )
+      )
+
+  public val icon_3278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3278.xml"),
+          )
+      )
+
+  public val icon_3279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3279.xml"),
+          )
+      )
+
+  public val icon_328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_328.xml"),
+          )
+      )
+
+  public val icon_3280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3280.xml"),
+          )
+      )
+
+  public val icon_3281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3281.xml"),
+          )
+      )
+
+  public val icon_3282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3282.xml"),
+          )
+      )
+
+  public val icon_3283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3283.xml"),
+          )
+      )
+
+  public val icon_3284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3284.xml"),
+          )
+      )
+
+  public val icon_3285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3285.xml"),
+          )
+      )
+
+  public val icon_3286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3286.xml"),
+          )
+      )
+
+  public val icon_3287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3287.xml"),
+          )
+      )
+
+  public val icon_3288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3288.xml"),
+          )
+      )
+
+  public val icon_3289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3289.xml"),
+          )
+      )
+
+  public val icon_329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_329.xml"),
+          )
+      )
+
+  public val icon_3290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3290.xml"),
+          )
+      )
+
+  public val icon_3291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3291.xml"),
+          )
+      )
+
+  public val icon_3292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3292.xml"),
+          )
+      )
+
+  public val icon_3293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3293.xml"),
+          )
+      )
+
+  public val icon_3294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3294.xml"),
+          )
+      )
+
+  public val icon_3295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3295.xml"),
+          )
+      )
+
+  public val icon_3296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3296.xml"),
+          )
+      )
+
+  public val icon_3297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3297.xml"),
+          )
+      )
+
+  public val icon_3298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3298.xml"),
+          )
+      )
+
+  public val icon_3299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3299.xml"),
+          )
+      )
+
+  public val icon_33: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_33",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_33.xml"),
+          )
+      )
+
+  public val icon_330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_330.xml"),
+          )
+      )
+
+  public val icon_3300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3300.xml"),
+          )
+      )
+
+  public val icon_3301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3301.xml"),
+          )
+      )
+
+  public val icon_3302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3302.xml"),
+          )
+      )
+
+  public val icon_3303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3303.xml"),
+          )
+      )
+
+  public val icon_3304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3304.xml"),
+          )
+      )
+
+  public val icon_3305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3305.xml"),
+          )
+      )
+
+  public val icon_3306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3306.xml"),
+          )
+      )
+
+  public val icon_3307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3307.xml"),
+          )
+      )
+
+  public val icon_3308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3308.xml"),
+          )
+      )
+
+  public val icon_3309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3309.xml"),
+          )
+      )
+
+  public val icon_331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_331.xml"),
+          )
+      )
+
+  public val icon_3310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3310.xml"),
+          )
+      )
+
+  public val icon_3311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3311.xml"),
+          )
+      )
+
+  public val icon_3312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3312.xml"),
+          )
+      )
+
+  public val icon_3313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3313.xml"),
+          )
+      )
+
+  public val icon_3314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3314.xml"),
+          )
+      )
+
+  public val icon_3315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3315.xml"),
+          )
+      )
+
+  public val icon_3316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3316.xml"),
+          )
+      )
+
+  public val icon_3317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3317.xml"),
+          )
+      )
+
+  public val icon_3318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3318.xml"),
+          )
+      )
+
+  public val icon_3319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3319.xml"),
+          )
+      )
+
+  public val icon_332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_332.xml"),
+          )
+      )
+
+  public val icon_3320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3320.xml"),
+          )
+      )
+
+  public val icon_3321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3321.xml"),
+          )
+      )
+
+  public val icon_3322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3322.xml"),
+          )
+      )
+
+  public val icon_3323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3323.xml"),
+          )
+      )
+
+  public val icon_3324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3324.xml"),
+          )
+      )
+
+  public val icon_3325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3325.xml"),
+          )
+      )
+
+  public val icon_3326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3326.xml"),
+          )
+      )
+
+  public val icon_3327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3327.xml"),
+          )
+      )
+
+  public val icon_3328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3328.xml"),
+          )
+      )
+
+  public val icon_3329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3329.xml"),
+          )
+      )
+
+  public val icon_333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_333.xml"),
+          )
+      )
+
+  public val icon_3330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3330.xml"),
+          )
+      )
+
+  public val icon_3331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3331.xml"),
+          )
+      )
+
+  public val icon_3332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3332.xml"),
+          )
+      )
+
+  public val icon_3333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3333.xml"),
+          )
+      )
+
+  public val icon_3334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3334.xml"),
+          )
+      )
+
+  public val icon_3335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3335.xml"),
+          )
+      )
+
+  public val icon_3336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3336.xml"),
+          )
+      )
+
+  public val icon_3337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3337.xml"),
+          )
+      )
+
+  public val icon_3338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3338.xml"),
+          )
+      )
+
+  public val icon_3339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3339.xml"),
+          )
+      )
+
+  public val icon_334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_334.xml"),
+          )
+      )
+
+  public val icon_3340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3340.xml"),
+          )
+      )
+
+  public val icon_3341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3341.xml"),
+          )
+      )
+
+  public val icon_3342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3342.xml"),
+          )
+      )
+
+  public val icon_3343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3343.xml"),
+          )
+      )
+
+  public val icon_3344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3344.xml"),
+          )
+      )
+
+  public val icon_3345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3345.xml"),
+          )
+      )
+
+  public val icon_3346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3346.xml"),
+          )
+      )
+
+  public val icon_3347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3347.xml"),
+          )
+      )
+
+  public val icon_3348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3348.xml"),
+          )
+      )
+
+  public val icon_3349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3349.xml"),
+          )
+      )
+
+  public val icon_335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_335.xml"),
+          )
+      )
+
+  public val icon_3350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3350.xml"),
+          )
+      )
+
+  public val icon_3351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3351.xml"),
+          )
+      )
+
+  public val icon_3352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3352.xml"),
+          )
+      )
+
+  public val icon_3353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3353.xml"),
+          )
+      )
+
+  public val icon_3354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3354.xml"),
+          )
+      )
+
+  public val icon_3355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3355.xml"),
+          )
+      )
+
+  public val icon_3356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3356.xml"),
+          )
+      )
+
+  public val icon_3357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3357.xml"),
+          )
+      )
+
+  public val icon_3358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3358.xml"),
+          )
+      )
+
+  public val icon_3359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3359.xml"),
+          )
+      )
+
+  public val icon_336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_336.xml"),
+          )
+      )
+
+  public val icon_3360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3360.xml"),
+          )
+      )
+
+  public val icon_3361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3361.xml"),
+          )
+      )
+
+  public val icon_3362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3362.xml"),
+          )
+      )
+
+  public val icon_3363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3363.xml"),
+          )
+      )
+
+  public val icon_3364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3364.xml"),
+          )
+      )
+
+  public val icon_3365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3365.xml"),
+          )
+      )
+
+  public val icon_3366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3366.xml"),
+          )
+      )
+
+  public val icon_3367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3367.xml"),
+          )
+      )
+
+  public val icon_3368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3368.xml"),
+          )
+      )
+
+  public val icon_3369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3369.xml"),
+          )
+      )
+
+  public val icon_337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_337.xml"),
+          )
+      )
+
+  public val icon_3370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3370.xml"),
+          )
+      )
+
+  public val icon_3371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3371.xml"),
+          )
+      )
+
+  public val icon_3372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3372.xml"),
+          )
+      )
+
+  public val icon_3373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3373.xml"),
+          )
+      )
+
+  public val icon_3374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3374.xml"),
+          )
+      )
+
+  public val icon_3375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3375.xml"),
+          )
+      )
+
+  public val icon_3376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3376.xml"),
+          )
+      )
+
+  public val icon_3377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3377.xml"),
+          )
+      )
+
+  public val icon_3378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3378.xml"),
+          )
+      )
+
+  public val icon_3379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3379.xml"),
+          )
+      )
+
+  public val icon_338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_338.xml"),
+          )
+      )
+
+  public val icon_3380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3380.xml"),
+          )
+      )
+
+  public val icon_3381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3381.xml"),
+          )
+      )
+
+  public val icon_3382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3382.xml"),
+          )
+      )
+
+  public val icon_3383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3383.xml"),
+          )
+      )
+
+  public val icon_3384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3384.xml"),
+          )
+      )
+
+  public val icon_3385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3385.xml"),
+          )
+      )
+
+  public val icon_3386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3386.xml"),
+          )
+      )
+
+  public val icon_3387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3387.xml"),
+          )
+      )
+
+  public val icon_3388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3388.xml"),
+          )
+      )
+
+  public val icon_3389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3389.xml"),
+          )
+      )
+
+  public val icon_339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_339.xml"),
+          )
+      )
+
+  public val icon_3390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3390.xml"),
+          )
+      )
+
+  public val icon_3391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3391.xml"),
+          )
+      )
+
+  public val icon_3392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3392.xml"),
+          )
+      )
+
+  public val icon_3393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3393.xml"),
+          )
+      )
+
+  public val icon_3394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3394.xml"),
+          )
+      )
+
+  public val icon_3395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3395.xml"),
+          )
+      )
+
+  public val icon_3396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3396.xml"),
+          )
+      )
+
+  public val icon_3397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3397.xml"),
+          )
+      )
+
+  public val icon_3398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3398.xml"),
+          )
+      )
+
+  public val icon_3399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3399.xml"),
+          )
+      )
+
+  public val icon_34: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_34",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_34.xml"),
+          )
+      )
+
+  public val icon_340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_340.xml"),
+          )
+      )
+
+  public val icon_3400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3400.xml"),
+          )
+      )
+
+  public val icon_3401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3401.xml"),
+          )
+      )
+
+  public val icon_3402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3402.xml"),
+          )
+      )
+
+  public val icon_3403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3403.xml"),
+          )
+      )
+
+  public val icon_3404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3404.xml"),
+          )
+      )
+
+  public val icon_3405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3405.xml"),
+          )
+      )
+
+  public val icon_3406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3406.xml"),
+          )
+      )
+
+  public val icon_3407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3407.xml"),
+          )
+      )
+
+  public val icon_3408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3408.xml"),
+          )
+      )
+
+  public val icon_3409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3409.xml"),
+          )
+      )
+
+  public val icon_341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_341.xml"),
+          )
+      )
+
+  public val icon_3410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3410.xml"),
+          )
+      )
+
+  public val icon_3411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3411.xml"),
+          )
+      )
+
+  public val icon_3412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3412.xml"),
+          )
+      )
+
+  public val icon_3413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3413.xml"),
+          )
+      )
+
+  public val icon_3414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3414.xml"),
+          )
+      )
+
+  public val icon_3415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3415.xml"),
+          )
+      )
+
+  public val icon_3416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3416.xml"),
+          )
+      )
+
+  public val icon_3417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3417.xml"),
+          )
+      )
+
+  public val icon_3418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3418.xml"),
+          )
+      )
+
+  public val icon_3419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3419.xml"),
+          )
+      )
+
+  public val icon_342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_342.xml"),
+          )
+      )
+
+  public val icon_3420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3420.xml"),
+          )
+      )
+
+  public val icon_3421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3421.xml"),
+          )
+      )
+
+  public val icon_3422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3422.xml"),
+          )
+      )
+
+  public val icon_3423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3423.xml"),
+          )
+      )
+
+  public val icon_3424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3424.xml"),
+          )
+      )
+
+  public val icon_3425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3425.xml"),
+          )
+      )
+
+  public val icon_3426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3426.xml"),
+          )
+      )
+
+  public val icon_3427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3427.xml"),
+          )
+      )
+
+  public val icon_3428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3428.xml"),
+          )
+      )
+
+  public val icon_3429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3429.xml"),
+          )
+      )
+
+  public val icon_343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_343.xml"),
+          )
+      )
+
+  public val icon_3430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3430.xml"),
+          )
+      )
+
+  public val icon_3431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3431.xml"),
+          )
+      )
+
+  public val icon_3432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3432.xml"),
+          )
+      )
+
+  public val icon_3433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3433.xml"),
+          )
+      )
+
+  public val icon_3434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3434.xml"),
+          )
+      )
+
+  public val icon_3435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3435.xml"),
+          )
+      )
+
+  public val icon_3436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3436.xml"),
+          )
+      )
+
+  public val icon_3437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3437.xml"),
+          )
+      )
+
+  public val icon_3438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3438.xml"),
+          )
+      )
+
+  public val icon_3439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3439.xml"),
+          )
+      )
+
+  public val icon_344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_344.xml"),
+          )
+      )
+
+  public val icon_3440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3440.xml"),
+          )
+      )
+
+  public val icon_3441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3441.xml"),
+          )
+      )
+
+  public val icon_3442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3442.xml"),
+          )
+      )
+
+  public val icon_3443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3443.xml"),
+          )
+      )
+
+  public val icon_3444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3444.xml"),
+          )
+      )
+
+  public val icon_3445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3445.xml"),
+          )
+      )
+
+  public val icon_3446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3446.xml"),
+          )
+      )
+
+  public val icon_3447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3447.xml"),
+          )
+      )
+
+  public val icon_3448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3448.xml"),
+          )
+      )
+
+  public val icon_3449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3449.xml"),
+          )
+      )
+
+  public val icon_345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_345.xml"),
+          )
+      )
+
+  public val icon_3450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3450.xml"),
+          )
+      )
+
+  public val icon_3451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3451.xml"),
+          )
+      )
+
+  public val icon_3452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3452.xml"),
+          )
+      )
+
+  public val icon_3453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3453.xml"),
+          )
+      )
+
+  public val icon_3454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3454.xml"),
+          )
+      )
+
+  public val icon_3455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3455.xml"),
+          )
+      )
+
+  public val icon_3456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3456.xml"),
+          )
+      )
+
+  public val icon_3457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3457.xml"),
+          )
+      )
+
+  public val icon_3458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3458.xml"),
+          )
+      )
+
+  public val icon_3459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3459.xml"),
+          )
+      )
+
+  public val icon_346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_346.xml"),
+          )
+      )
+
+  public val icon_3460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3460.xml"),
+          )
+      )
+
+  public val icon_3461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3461.xml"),
+          )
+      )
+
+  public val icon_3462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3462.xml"),
+          )
+      )
+
+  public val icon_3463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3463.xml"),
+          )
+      )
+
+  public val icon_3464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3464.xml"),
+          )
+      )
+
+  public val icon_3465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3465.xml"),
+          )
+      )
+
+  public val icon_3466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3466.xml"),
+          )
+      )
+
+  public val icon_3467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3467.xml"),
+          )
+      )
+
+  public val icon_3468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3468.xml"),
+          )
+      )
+
+  public val icon_3469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3469.xml"),
+          )
+      )
+
+  public val icon_347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_347.xml"),
+          )
+      )
+
+  public val icon_3470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3470.xml"),
+          )
+      )
+
+  public val icon_3471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3471.xml"),
+          )
+      )
+
+  public val icon_3472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3472.xml"),
+          )
+      )
+
+  public val icon_3473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3473.xml"),
+          )
+      )
+
+  public val icon_3474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3474.xml"),
+          )
+      )
+
+  public val icon_3475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3475.xml"),
+          )
+      )
+
+  public val icon_3476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3476.xml"),
+          )
+      )
+
+  public val icon_3477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3477.xml"),
+          )
+      )
+
+  public val icon_3478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3478.xml"),
+          )
+      )
+
+  public val icon_3479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3479.xml"),
+          )
+      )
+
+  public val icon_348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_348.xml"),
+          )
+      )
+
+  public val icon_3480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3480.xml"),
+          )
+      )
+
+  public val icon_3481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3481.xml"),
+          )
+      )
+
+  public val icon_3482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3482.xml"),
+          )
+      )
+
+  public val icon_3483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3483.xml"),
+          )
+      )
+
+  public val icon_3484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3484.xml"),
+          )
+      )
+
+  public val icon_3485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3485.xml"),
+          )
+      )
+
+  public val icon_3486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3486.xml"),
+          )
+      )
+
+  public val icon_3487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3487.xml"),
+          )
+      )
+
+  public val icon_3488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3488.xml"),
+          )
+      )
+
+  public val icon_3489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3489.xml"),
+          )
+      )
+
+  public val icon_349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_349.xml"),
+          )
+      )
+
+  public val icon_3490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3490.xml"),
+          )
+      )
+
+  public val icon_3491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3491.xml"),
+          )
+      )
+
+  public val icon_3492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3492.xml"),
+          )
+      )
+
+  public val icon_3493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3493.xml"),
+          )
+      )
+
+  public val icon_3494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3494.xml"),
+          )
+      )
+
+  public val icon_3495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3495.xml"),
+          )
+      )
+
+  public val icon_3496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3496.xml"),
+          )
+      )
+
+  public val icon_3497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3497.xml"),
+          )
+      )
+
+  public val icon_3498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3498.xml"),
+          )
+      )
+
+  public val icon_3499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3499.xml"),
+          )
+      )
+
+  public val icon_35: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_35",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_35.xml"),
+          )
+      )
+
+  public val icon_350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_350.xml"),
+          )
+      )
+
+  public val icon_3500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3500.xml"),
+          )
+      )
+
+  public val icon_3501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3501.xml"),
+          )
+      )
+
+  public val icon_3502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3502.xml"),
+          )
+      )
+
+  public val icon_3503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3503.xml"),
+          )
+      )
+
+  public val icon_3504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3504.xml"),
+          )
+      )
+
+  public val icon_3505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3505.xml"),
+          )
+      )
+
+  public val icon_3506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3506.xml"),
+          )
+      )
+
+  public val icon_3507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3507.xml"),
+          )
+      )
+
+  public val icon_3508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3508.xml"),
+          )
+      )
+
+  public val icon_3509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3509.xml"),
+          )
+      )
+
+  public val icon_351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_351.xml"),
+          )
+      )
+
+  public val icon_3510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3510.xml"),
+          )
+      )
+
+  public val icon_3511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3511.xml"),
+          )
+      )
+
+  public val icon_3512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3512.xml"),
+          )
+      )
+
+  public val icon_3513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3513.xml"),
+          )
+      )
+
+  public val icon_3514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3514.xml"),
+          )
+      )
+
+  public val icon_3515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3515.xml"),
+          )
+      )
+
+  public val icon_3516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3516.xml"),
+          )
+      )
+
+  public val icon_3517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3517.xml"),
+          )
+      )
+
+  public val icon_3518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3518.xml"),
+          )
+      )
+
+  public val icon_3519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3519.xml"),
+          )
+      )
+
+  public val icon_352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_352.xml"),
+          )
+      )
+
+  public val icon_3520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3520.xml"),
+          )
+      )
+
+  public val icon_3521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3521.xml"),
+          )
+      )
+
+  public val icon_3522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3522.xml"),
+          )
+      )
+
+  public val icon_3523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3523.xml"),
+          )
+      )
+
+  public val icon_3524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3524.xml"),
+          )
+      )
+
+  public val icon_3525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3525.xml"),
+          )
+      )
+
+  public val icon_3526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3526.xml"),
+          )
+      )
+
+  public val icon_3527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3527.xml"),
+          )
+      )
+
+  public val icon_3528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3528.xml"),
+          )
+      )
+
+  public val icon_3529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3529.xml"),
+          )
+      )
+
+  public val icon_353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_353.xml"),
+          )
+      )
+
+  public val icon_3530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3530.xml"),
+          )
+      )
+
+  public val icon_3531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3531.xml"),
+          )
+      )
+
+  public val icon_3532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3532.xml"),
+          )
+      )
+
+  public val icon_3533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3533.xml"),
+          )
+      )
+
+  public val icon_3534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3534.xml"),
+          )
+      )
+
+  public val icon_3535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3535.xml"),
+          )
+      )
+
+  public val icon_3536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3536.xml"),
+          )
+      )
+
+  public val icon_3537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3537.xml"),
+          )
+      )
+
+  public val icon_3538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3538.xml"),
+          )
+      )
+
+  public val icon_3539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3539.xml"),
+          )
+      )
+
+  public val icon_354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_354.xml"),
+          )
+      )
+
+  public val icon_3540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3540.xml"),
+          )
+      )
+
+  public val icon_3541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3541.xml"),
+          )
+      )
+
+  public val icon_3542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3542.xml"),
+          )
+      )
+
+  public val icon_3543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3543.xml"),
+          )
+      )
+
+  public val icon_3544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3544.xml"),
+          )
+      )
+
+  public val icon_3545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3545.xml"),
+          )
+      )
+
+  public val icon_3546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3546.xml"),
+          )
+      )
+
+  public val icon_3547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3547.xml"),
+          )
+      )
+
+  public val icon_3548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3548.xml"),
+          )
+      )
+
+  public val icon_3549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3549.xml"),
+          )
+      )
+
+  public val icon_355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_355.xml"),
+          )
+      )
+
+  public val icon_3550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3550.xml"),
+          )
+      )
+
+  public val icon_3551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3551.xml"),
+          )
+      )
+
+  public val icon_3552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3552.xml"),
+          )
+      )
+
+  public val icon_3553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3553.xml"),
+          )
+      )
+
+  public val icon_3554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3554.xml"),
+          )
+      )
+
+  public val icon_3555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3555.xml"),
+          )
+      )
+
+  public val icon_3556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3556.xml"),
+          )
+      )
+
+  public val icon_3557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3557.xml"),
+          )
+      )
+
+  public val icon_3558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3558.xml"),
+          )
+      )
+
+  public val icon_3559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3559.xml"),
+          )
+      )
+
+  public val icon_356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_356.xml"),
+          )
+      )
+
+  public val icon_3560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3560.xml"),
+          )
+      )
+
+  public val icon_3561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3561.xml"),
+          )
+      )
+
+  public val icon_3562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3562.xml"),
+          )
+      )
+
+  public val icon_3563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3563.xml"),
+          )
+      )
+
+  public val icon_3564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3564.xml"),
+          )
+      )
+
+  public val icon_3565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3565.xml"),
+          )
+      )
+
+  public val icon_3566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3566.xml"),
+          )
+      )
+
+  public val icon_3567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3567.xml"),
+          )
+      )
+
+  public val icon_3568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3568.xml"),
+          )
+      )
+
+  public val icon_3569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3569.xml"),
+          )
+      )
+
+  public val icon_357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_357.xml"),
+          )
+      )
+
+  public val icon_3570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3570.xml"),
+          )
+      )
+
+  public val icon_3571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3571.xml"),
+          )
+      )
+
+  public val icon_3572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3572.xml"),
+          )
+      )
+
+  public val icon_3573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3573.xml"),
+          )
+      )
+
+  public val icon_3574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3574.xml"),
+          )
+      )
+
+  public val icon_3575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3575.xml"),
+          )
+      )
+
+  public val icon_3576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3576.xml"),
+          )
+      )
+
+  public val icon_3577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3577.xml"),
+          )
+      )
+
+  public val icon_3578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3578.xml"),
+          )
+      )
+
+  public val icon_3579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3579.xml"),
+          )
+      )
+
+  public val icon_358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_358.xml"),
+          )
+      )
+
+  public val icon_3580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3580.xml"),
+          )
+      )
+
+  public val icon_3581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3581.xml"),
+          )
+      )
+
+  public val icon_3582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3582.xml"),
+          )
+      )
+
+  public val icon_3583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3583.xml"),
+          )
+      )
+
+  public val icon_3584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3584.xml"),
+          )
+      )
+
+  public val icon_3585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3585.xml"),
+          )
+      )
+
+  public val icon_3586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3586.xml"),
+          )
+      )
+
+  public val icon_3587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3587.xml"),
+          )
+      )
+
+  public val icon_3588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3588.xml"),
+          )
+      )
+
+  public val icon_3589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3589.xml"),
+          )
+      )
+
+  public val icon_359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_359.xml"),
+          )
+      )
+
+  public val icon_3590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3590.xml"),
+          )
+      )
+
+  public val icon_3591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3591.xml"),
+          )
+      )
+
+  public val icon_3592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3592.xml"),
+          )
+      )
+
+  public val icon_3593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3593.xml"),
+          )
+      )
+
+  public val icon_3594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3594.xml"),
+          )
+      )
+
+  public val icon_3595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3595.xml"),
+          )
+      )
+
+  public val icon_3596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3596.xml"),
+          )
+      )
+
+  public val icon_3597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3597.xml"),
+          )
+      )
+
+  public val icon_3598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3598.xml"),
+          )
+      )
+
+  public val icon_3599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3599.xml"),
+          )
+      )
+
+  public val icon_36: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_36",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_36.xml"),
+          )
+      )
+
+  public val icon_360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_360.xml"),
+          )
+      )
+
+  public val icon_3600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3600.xml"),
+          )
+      )
+
+  public val icon_3601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3601.xml"),
+          )
+      )
+
+  public val icon_3602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3602.xml"),
+          )
+      )
+
+  public val icon_3603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3603.xml"),
+          )
+      )
+
+  public val icon_3604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3604.xml"),
+          )
+      )
+
+  public val icon_3605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3605.xml"),
+          )
+      )
+
+  public val icon_3606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3606.xml"),
+          )
+      )
+
+  public val icon_3607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3607.xml"),
+          )
+      )
+
+  public val icon_3608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3608.xml"),
+          )
+      )
+
+  public val icon_3609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3609.xml"),
+          )
+      )
+
+  public val icon_361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_361.xml"),
+          )
+      )
+
+  public val icon_3610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3610.xml"),
+          )
+      )
+
+  public val icon_3611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3611.xml"),
+          )
+      )
+
+  public val icon_3612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3612.xml"),
+          )
+      )
+
+  public val icon_3613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3613.xml"),
+          )
+      )
+
+  public val icon_3614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3614.xml"),
+          )
+      )
+
+  public val icon_3615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3615.xml"),
+          )
+      )
+
+  public val icon_3616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3616.xml"),
+          )
+      )
+
+  public val icon_3617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3617.xml"),
+          )
+      )
+
+  public val icon_3618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3618.xml"),
+          )
+      )
+
+  public val icon_3619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3619.xml"),
+          )
+      )
+
+  public val icon_362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_362.xml"),
+          )
+      )
+
+  public val icon_3620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3620.xml"),
+          )
+      )
+
+  public val icon_3621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3621.xml"),
+          )
+      )
+
+  public val icon_3622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3622.xml"),
+          )
+      )
+
+  public val icon_3623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3623.xml"),
+          )
+      )
+
+  public val icon_3624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3624.xml"),
+          )
+      )
+
+  public val icon_3625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3625.xml"),
+          )
+      )
+
+  public val icon_3626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3626.xml"),
+          )
+      )
+
+  public val icon_3627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3627.xml"),
+          )
+      )
+
+  public val icon_3628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3628.xml"),
+          )
+      )
+
+  public val icon_3629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3629.xml"),
+          )
+      )
+
+  public val icon_363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_363.xml"),
+          )
+      )
+
+  public val icon_3630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3630.xml"),
+          )
+      )
+
+  public val icon_3631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3631.xml"),
+          )
+      )
+
+  public val icon_3632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3632.xml"),
+          )
+      )
+
+  public val icon_3633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3633.xml"),
+          )
+      )
+
+  public val icon_3634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3634.xml"),
+          )
+      )
+
+  public val icon_3635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3635.xml"),
+          )
+      )
+
+  public val icon_3636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3636.xml"),
+          )
+      )
+
+  public val icon_3637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3637.xml"),
+          )
+      )
+
+  public val icon_3638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3638.xml"),
+          )
+      )
+
+  public val icon_3639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3639.xml"),
+          )
+      )
+
+  public val icon_364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_364.xml"),
+          )
+      )
+
+  public val icon_3640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3640.xml"),
+          )
+      )
+
+  public val icon_3641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3641.xml"),
+          )
+      )
+
+  public val icon_3642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3642.xml"),
+          )
+      )
+
+  public val icon_3643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3643.xml"),
+          )
+      )
+
+  public val icon_3644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3644.xml"),
+          )
+      )
+
+  public val icon_3645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3645.xml"),
+          )
+      )
+
+  public val icon_3646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3646.xml"),
+          )
+      )
+
+  public val icon_3647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3647.xml"),
+          )
+      )
+
+  public val icon_3648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3648.xml"),
+          )
+      )
+
+  public val icon_3649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3649.xml"),
+          )
+      )
+
+  public val icon_365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_365.xml"),
+          )
+      )
+
+  public val icon_3650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3650.xml"),
+          )
+      )
+
+  public val icon_3651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3651.xml"),
+          )
+      )
+
+  public val icon_3652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3652.xml"),
+          )
+      )
+
+  public val icon_3653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3653.xml"),
+          )
+      )
+
+  public val icon_3654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3654.xml"),
+          )
+      )
+
+  public val icon_3655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3655.xml"),
+          )
+      )
+
+  public val icon_3656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3656.xml"),
+          )
+      )
+
+  public val icon_3657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3657.xml"),
+          )
+      )
+
+  public val icon_3658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3658.xml"),
+          )
+      )
+
+  public val icon_3659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3659.xml"),
+          )
+      )
+
+  public val icon_366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_366.xml"),
+          )
+      )
+
+  public val icon_3660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3660.xml"),
+          )
+      )
+
+  public val icon_3661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3661.xml"),
+          )
+      )
+
+  public val icon_3662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3662.xml"),
+          )
+      )
+
+  public val icon_3663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3663.xml"),
+          )
+      )
+
+  public val icon_3664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3664.xml"),
+          )
+      )
+
+  public val icon_3665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3665.xml"),
+          )
+      )
+
+  public val icon_3666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3666.xml"),
+          )
+      )
+
+  public val icon_3667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3667.xml"),
+          )
+      )
+
+  public val icon_3668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3668.xml"),
+          )
+      )
+
+  public val icon_3669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3669.xml"),
+          )
+      )
+
+  public val icon_367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_367.xml"),
+          )
+      )
+
+  public val icon_3670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3670.xml"),
+          )
+      )
+
+  public val icon_3671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3671.xml"),
+          )
+      )
+
+  public val icon_3672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3672.xml"),
+          )
+      )
+
+  public val icon_3673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3673.xml"),
+          )
+      )
+
+  public val icon_3674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3674.xml"),
+          )
+      )
+
+  public val icon_3675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3675.xml"),
+          )
+      )
+
+  public val icon_3676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3676.xml"),
+          )
+      )
+
+  public val icon_3677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3677.xml"),
+          )
+      )
+
+  public val icon_3678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3678.xml"),
+          )
+      )
+
+  public val icon_3679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3679.xml"),
+          )
+      )
+
+  public val icon_368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_368.xml"),
+          )
+      )
+
+  public val icon_3680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3680.xml"),
+          )
+      )
+
+  public val icon_3681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3681.xml"),
+          )
+      )
+
+  public val icon_3682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3682.xml"),
+          )
+      )
+
+  public val icon_3683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3683.xml"),
+          )
+      )
+
+  public val icon_3684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3684.xml"),
+          )
+      )
+
+  public val icon_3685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3685.xml"),
+          )
+      )
+
+  public val icon_3686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3686.xml"),
+          )
+      )
+
+  public val icon_3687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3687.xml"),
+          )
+      )
+
+  public val icon_3688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3688.xml"),
+          )
+      )
+
+  public val icon_3689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3689.xml"),
+          )
+      )
+
+  public val icon_369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_369.xml"),
+          )
+      )
+
+  public val icon_3690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3690.xml"),
+          )
+      )
+
+  public val icon_3691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3691.xml"),
+          )
+      )
+
+  public val icon_3692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3692.xml"),
+          )
+      )
+
+  public val icon_3693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3693.xml"),
+          )
+      )
+
+  public val icon_3694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3694.xml"),
+          )
+      )
+
+  public val icon_3695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3695.xml"),
+          )
+      )
+
+  public val icon_3696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3696.xml"),
+          )
+      )
+
+  public val icon_3697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3697.xml"),
+          )
+      )
+
+  public val icon_3698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3698.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3248: DrawableResource
+  get() = Drawable35.icon_3248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3249: DrawableResource
+  get() = Drawable35.icon_3249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_325: DrawableResource
+  get() = Drawable35.icon_325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3250: DrawableResource
+  get() = Drawable35.icon_3250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3251: DrawableResource
+  get() = Drawable35.icon_3251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3252: DrawableResource
+  get() = Drawable35.icon_3252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3253: DrawableResource
+  get() = Drawable35.icon_3253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3254: DrawableResource
+  get() = Drawable35.icon_3254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3255: DrawableResource
+  get() = Drawable35.icon_3255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3256: DrawableResource
+  get() = Drawable35.icon_3256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3257: DrawableResource
+  get() = Drawable35.icon_3257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3258: DrawableResource
+  get() = Drawable35.icon_3258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3259: DrawableResource
+  get() = Drawable35.icon_3259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_326: DrawableResource
+  get() = Drawable35.icon_326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3260: DrawableResource
+  get() = Drawable35.icon_3260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3261: DrawableResource
+  get() = Drawable35.icon_3261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3262: DrawableResource
+  get() = Drawable35.icon_3262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3263: DrawableResource
+  get() = Drawable35.icon_3263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3264: DrawableResource
+  get() = Drawable35.icon_3264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3265: DrawableResource
+  get() = Drawable35.icon_3265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3266: DrawableResource
+  get() = Drawable35.icon_3266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3267: DrawableResource
+  get() = Drawable35.icon_3267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3268: DrawableResource
+  get() = Drawable35.icon_3268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3269: DrawableResource
+  get() = Drawable35.icon_3269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_327: DrawableResource
+  get() = Drawable35.icon_327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3270: DrawableResource
+  get() = Drawable35.icon_3270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3271: DrawableResource
+  get() = Drawable35.icon_3271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3272: DrawableResource
+  get() = Drawable35.icon_3272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3273: DrawableResource
+  get() = Drawable35.icon_3273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3274: DrawableResource
+  get() = Drawable35.icon_3274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3275: DrawableResource
+  get() = Drawable35.icon_3275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3276: DrawableResource
+  get() = Drawable35.icon_3276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3277: DrawableResource
+  get() = Drawable35.icon_3277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3278: DrawableResource
+  get() = Drawable35.icon_3278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3279: DrawableResource
+  get() = Drawable35.icon_3279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_328: DrawableResource
+  get() = Drawable35.icon_328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3280: DrawableResource
+  get() = Drawable35.icon_3280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3281: DrawableResource
+  get() = Drawable35.icon_3281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3282: DrawableResource
+  get() = Drawable35.icon_3282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3283: DrawableResource
+  get() = Drawable35.icon_3283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3284: DrawableResource
+  get() = Drawable35.icon_3284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3285: DrawableResource
+  get() = Drawable35.icon_3285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3286: DrawableResource
+  get() = Drawable35.icon_3286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3287: DrawableResource
+  get() = Drawable35.icon_3287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3288: DrawableResource
+  get() = Drawable35.icon_3288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3289: DrawableResource
+  get() = Drawable35.icon_3289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_329: DrawableResource
+  get() = Drawable35.icon_329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3290: DrawableResource
+  get() = Drawable35.icon_3290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3291: DrawableResource
+  get() = Drawable35.icon_3291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3292: DrawableResource
+  get() = Drawable35.icon_3292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3293: DrawableResource
+  get() = Drawable35.icon_3293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3294: DrawableResource
+  get() = Drawable35.icon_3294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3295: DrawableResource
+  get() = Drawable35.icon_3295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3296: DrawableResource
+  get() = Drawable35.icon_3296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3297: DrawableResource
+  get() = Drawable35.icon_3297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3298: DrawableResource
+  get() = Drawable35.icon_3298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3299: DrawableResource
+  get() = Drawable35.icon_3299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_33: DrawableResource
+  get() = Drawable35.icon_33
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_330: DrawableResource
+  get() = Drawable35.icon_330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3300: DrawableResource
+  get() = Drawable35.icon_3300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3301: DrawableResource
+  get() = Drawable35.icon_3301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3302: DrawableResource
+  get() = Drawable35.icon_3302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3303: DrawableResource
+  get() = Drawable35.icon_3303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3304: DrawableResource
+  get() = Drawable35.icon_3304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3305: DrawableResource
+  get() = Drawable35.icon_3305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3306: DrawableResource
+  get() = Drawable35.icon_3306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3307: DrawableResource
+  get() = Drawable35.icon_3307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3308: DrawableResource
+  get() = Drawable35.icon_3308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3309: DrawableResource
+  get() = Drawable35.icon_3309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_331: DrawableResource
+  get() = Drawable35.icon_331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3310: DrawableResource
+  get() = Drawable35.icon_3310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3311: DrawableResource
+  get() = Drawable35.icon_3311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3312: DrawableResource
+  get() = Drawable35.icon_3312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3313: DrawableResource
+  get() = Drawable35.icon_3313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3314: DrawableResource
+  get() = Drawable35.icon_3314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3315: DrawableResource
+  get() = Drawable35.icon_3315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3316: DrawableResource
+  get() = Drawable35.icon_3316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3317: DrawableResource
+  get() = Drawable35.icon_3317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3318: DrawableResource
+  get() = Drawable35.icon_3318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3319: DrawableResource
+  get() = Drawable35.icon_3319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_332: DrawableResource
+  get() = Drawable35.icon_332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3320: DrawableResource
+  get() = Drawable35.icon_3320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3321: DrawableResource
+  get() = Drawable35.icon_3321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3322: DrawableResource
+  get() = Drawable35.icon_3322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3323: DrawableResource
+  get() = Drawable35.icon_3323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3324: DrawableResource
+  get() = Drawable35.icon_3324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3325: DrawableResource
+  get() = Drawable35.icon_3325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3326: DrawableResource
+  get() = Drawable35.icon_3326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3327: DrawableResource
+  get() = Drawable35.icon_3327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3328: DrawableResource
+  get() = Drawable35.icon_3328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3329: DrawableResource
+  get() = Drawable35.icon_3329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_333: DrawableResource
+  get() = Drawable35.icon_333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3330: DrawableResource
+  get() = Drawable35.icon_3330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3331: DrawableResource
+  get() = Drawable35.icon_3331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3332: DrawableResource
+  get() = Drawable35.icon_3332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3333: DrawableResource
+  get() = Drawable35.icon_3333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3334: DrawableResource
+  get() = Drawable35.icon_3334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3335: DrawableResource
+  get() = Drawable35.icon_3335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3336: DrawableResource
+  get() = Drawable35.icon_3336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3337: DrawableResource
+  get() = Drawable35.icon_3337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3338: DrawableResource
+  get() = Drawable35.icon_3338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3339: DrawableResource
+  get() = Drawable35.icon_3339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_334: DrawableResource
+  get() = Drawable35.icon_334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3340: DrawableResource
+  get() = Drawable35.icon_3340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3341: DrawableResource
+  get() = Drawable35.icon_3341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3342: DrawableResource
+  get() = Drawable35.icon_3342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3343: DrawableResource
+  get() = Drawable35.icon_3343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3344: DrawableResource
+  get() = Drawable35.icon_3344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3345: DrawableResource
+  get() = Drawable35.icon_3345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3346: DrawableResource
+  get() = Drawable35.icon_3346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3347: DrawableResource
+  get() = Drawable35.icon_3347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3348: DrawableResource
+  get() = Drawable35.icon_3348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3349: DrawableResource
+  get() = Drawable35.icon_3349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_335: DrawableResource
+  get() = Drawable35.icon_335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3350: DrawableResource
+  get() = Drawable35.icon_3350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3351: DrawableResource
+  get() = Drawable35.icon_3351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3352: DrawableResource
+  get() = Drawable35.icon_3352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3353: DrawableResource
+  get() = Drawable35.icon_3353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3354: DrawableResource
+  get() = Drawable35.icon_3354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3355: DrawableResource
+  get() = Drawable35.icon_3355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3356: DrawableResource
+  get() = Drawable35.icon_3356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3357: DrawableResource
+  get() = Drawable35.icon_3357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3358: DrawableResource
+  get() = Drawable35.icon_3358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3359: DrawableResource
+  get() = Drawable35.icon_3359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_336: DrawableResource
+  get() = Drawable35.icon_336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3360: DrawableResource
+  get() = Drawable35.icon_3360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3361: DrawableResource
+  get() = Drawable35.icon_3361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3362: DrawableResource
+  get() = Drawable35.icon_3362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3363: DrawableResource
+  get() = Drawable35.icon_3363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3364: DrawableResource
+  get() = Drawable35.icon_3364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3365: DrawableResource
+  get() = Drawable35.icon_3365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3366: DrawableResource
+  get() = Drawable35.icon_3366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3367: DrawableResource
+  get() = Drawable35.icon_3367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3368: DrawableResource
+  get() = Drawable35.icon_3368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3369: DrawableResource
+  get() = Drawable35.icon_3369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_337: DrawableResource
+  get() = Drawable35.icon_337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3370: DrawableResource
+  get() = Drawable35.icon_3370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3371: DrawableResource
+  get() = Drawable35.icon_3371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3372: DrawableResource
+  get() = Drawable35.icon_3372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3373: DrawableResource
+  get() = Drawable35.icon_3373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3374: DrawableResource
+  get() = Drawable35.icon_3374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3375: DrawableResource
+  get() = Drawable35.icon_3375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3376: DrawableResource
+  get() = Drawable35.icon_3376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3377: DrawableResource
+  get() = Drawable35.icon_3377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3378: DrawableResource
+  get() = Drawable35.icon_3378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3379: DrawableResource
+  get() = Drawable35.icon_3379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_338: DrawableResource
+  get() = Drawable35.icon_338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3380: DrawableResource
+  get() = Drawable35.icon_3380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3381: DrawableResource
+  get() = Drawable35.icon_3381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3382: DrawableResource
+  get() = Drawable35.icon_3382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3383: DrawableResource
+  get() = Drawable35.icon_3383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3384: DrawableResource
+  get() = Drawable35.icon_3384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3385: DrawableResource
+  get() = Drawable35.icon_3385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3386: DrawableResource
+  get() = Drawable35.icon_3386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3387: DrawableResource
+  get() = Drawable35.icon_3387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3388: DrawableResource
+  get() = Drawable35.icon_3388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3389: DrawableResource
+  get() = Drawable35.icon_3389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_339: DrawableResource
+  get() = Drawable35.icon_339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3390: DrawableResource
+  get() = Drawable35.icon_3390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3391: DrawableResource
+  get() = Drawable35.icon_3391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3392: DrawableResource
+  get() = Drawable35.icon_3392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3393: DrawableResource
+  get() = Drawable35.icon_3393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3394: DrawableResource
+  get() = Drawable35.icon_3394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3395: DrawableResource
+  get() = Drawable35.icon_3395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3396: DrawableResource
+  get() = Drawable35.icon_3396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3397: DrawableResource
+  get() = Drawable35.icon_3397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3398: DrawableResource
+  get() = Drawable35.icon_3398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3399: DrawableResource
+  get() = Drawable35.icon_3399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_34: DrawableResource
+  get() = Drawable35.icon_34
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_340: DrawableResource
+  get() = Drawable35.icon_340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3400: DrawableResource
+  get() = Drawable35.icon_3400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3401: DrawableResource
+  get() = Drawable35.icon_3401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3402: DrawableResource
+  get() = Drawable35.icon_3402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3403: DrawableResource
+  get() = Drawable35.icon_3403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3404: DrawableResource
+  get() = Drawable35.icon_3404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3405: DrawableResource
+  get() = Drawable35.icon_3405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3406: DrawableResource
+  get() = Drawable35.icon_3406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3407: DrawableResource
+  get() = Drawable35.icon_3407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3408: DrawableResource
+  get() = Drawable35.icon_3408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3409: DrawableResource
+  get() = Drawable35.icon_3409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_341: DrawableResource
+  get() = Drawable35.icon_341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3410: DrawableResource
+  get() = Drawable35.icon_3410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3411: DrawableResource
+  get() = Drawable35.icon_3411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3412: DrawableResource
+  get() = Drawable35.icon_3412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3413: DrawableResource
+  get() = Drawable35.icon_3413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3414: DrawableResource
+  get() = Drawable35.icon_3414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3415: DrawableResource
+  get() = Drawable35.icon_3415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3416: DrawableResource
+  get() = Drawable35.icon_3416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3417: DrawableResource
+  get() = Drawable35.icon_3417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3418: DrawableResource
+  get() = Drawable35.icon_3418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3419: DrawableResource
+  get() = Drawable35.icon_3419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_342: DrawableResource
+  get() = Drawable35.icon_342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3420: DrawableResource
+  get() = Drawable35.icon_3420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3421: DrawableResource
+  get() = Drawable35.icon_3421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3422: DrawableResource
+  get() = Drawable35.icon_3422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3423: DrawableResource
+  get() = Drawable35.icon_3423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3424: DrawableResource
+  get() = Drawable35.icon_3424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3425: DrawableResource
+  get() = Drawable35.icon_3425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3426: DrawableResource
+  get() = Drawable35.icon_3426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3427: DrawableResource
+  get() = Drawable35.icon_3427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3428: DrawableResource
+  get() = Drawable35.icon_3428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3429: DrawableResource
+  get() = Drawable35.icon_3429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_343: DrawableResource
+  get() = Drawable35.icon_343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3430: DrawableResource
+  get() = Drawable35.icon_3430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3431: DrawableResource
+  get() = Drawable35.icon_3431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3432: DrawableResource
+  get() = Drawable35.icon_3432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3433: DrawableResource
+  get() = Drawable35.icon_3433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3434: DrawableResource
+  get() = Drawable35.icon_3434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3435: DrawableResource
+  get() = Drawable35.icon_3435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3436: DrawableResource
+  get() = Drawable35.icon_3436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3437: DrawableResource
+  get() = Drawable35.icon_3437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3438: DrawableResource
+  get() = Drawable35.icon_3438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3439: DrawableResource
+  get() = Drawable35.icon_3439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_344: DrawableResource
+  get() = Drawable35.icon_344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3440: DrawableResource
+  get() = Drawable35.icon_3440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3441: DrawableResource
+  get() = Drawable35.icon_3441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3442: DrawableResource
+  get() = Drawable35.icon_3442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3443: DrawableResource
+  get() = Drawable35.icon_3443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3444: DrawableResource
+  get() = Drawable35.icon_3444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3445: DrawableResource
+  get() = Drawable35.icon_3445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3446: DrawableResource
+  get() = Drawable35.icon_3446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3447: DrawableResource
+  get() = Drawable35.icon_3447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3448: DrawableResource
+  get() = Drawable35.icon_3448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3449: DrawableResource
+  get() = Drawable35.icon_3449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_345: DrawableResource
+  get() = Drawable35.icon_345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3450: DrawableResource
+  get() = Drawable35.icon_3450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3451: DrawableResource
+  get() = Drawable35.icon_3451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3452: DrawableResource
+  get() = Drawable35.icon_3452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3453: DrawableResource
+  get() = Drawable35.icon_3453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3454: DrawableResource
+  get() = Drawable35.icon_3454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3455: DrawableResource
+  get() = Drawable35.icon_3455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3456: DrawableResource
+  get() = Drawable35.icon_3456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3457: DrawableResource
+  get() = Drawable35.icon_3457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3458: DrawableResource
+  get() = Drawable35.icon_3458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3459: DrawableResource
+  get() = Drawable35.icon_3459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_346: DrawableResource
+  get() = Drawable35.icon_346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3460: DrawableResource
+  get() = Drawable35.icon_3460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3461: DrawableResource
+  get() = Drawable35.icon_3461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3462: DrawableResource
+  get() = Drawable35.icon_3462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3463: DrawableResource
+  get() = Drawable35.icon_3463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3464: DrawableResource
+  get() = Drawable35.icon_3464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3465: DrawableResource
+  get() = Drawable35.icon_3465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3466: DrawableResource
+  get() = Drawable35.icon_3466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3467: DrawableResource
+  get() = Drawable35.icon_3467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3468: DrawableResource
+  get() = Drawable35.icon_3468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3469: DrawableResource
+  get() = Drawable35.icon_3469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_347: DrawableResource
+  get() = Drawable35.icon_347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3470: DrawableResource
+  get() = Drawable35.icon_3470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3471: DrawableResource
+  get() = Drawable35.icon_3471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3472: DrawableResource
+  get() = Drawable35.icon_3472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3473: DrawableResource
+  get() = Drawable35.icon_3473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3474: DrawableResource
+  get() = Drawable35.icon_3474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3475: DrawableResource
+  get() = Drawable35.icon_3475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3476: DrawableResource
+  get() = Drawable35.icon_3476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3477: DrawableResource
+  get() = Drawable35.icon_3477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3478: DrawableResource
+  get() = Drawable35.icon_3478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3479: DrawableResource
+  get() = Drawable35.icon_3479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_348: DrawableResource
+  get() = Drawable35.icon_348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3480: DrawableResource
+  get() = Drawable35.icon_3480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3481: DrawableResource
+  get() = Drawable35.icon_3481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3482: DrawableResource
+  get() = Drawable35.icon_3482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3483: DrawableResource
+  get() = Drawable35.icon_3483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3484: DrawableResource
+  get() = Drawable35.icon_3484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3485: DrawableResource
+  get() = Drawable35.icon_3485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3486: DrawableResource
+  get() = Drawable35.icon_3486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3487: DrawableResource
+  get() = Drawable35.icon_3487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3488: DrawableResource
+  get() = Drawable35.icon_3488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3489: DrawableResource
+  get() = Drawable35.icon_3489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_349: DrawableResource
+  get() = Drawable35.icon_349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3490: DrawableResource
+  get() = Drawable35.icon_3490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3491: DrawableResource
+  get() = Drawable35.icon_3491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3492: DrawableResource
+  get() = Drawable35.icon_3492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3493: DrawableResource
+  get() = Drawable35.icon_3493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3494: DrawableResource
+  get() = Drawable35.icon_3494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3495: DrawableResource
+  get() = Drawable35.icon_3495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3496: DrawableResource
+  get() = Drawable35.icon_3496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3497: DrawableResource
+  get() = Drawable35.icon_3497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3498: DrawableResource
+  get() = Drawable35.icon_3498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3499: DrawableResource
+  get() = Drawable35.icon_3499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_35: DrawableResource
+  get() = Drawable35.icon_35
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_350: DrawableResource
+  get() = Drawable35.icon_350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3500: DrawableResource
+  get() = Drawable35.icon_3500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3501: DrawableResource
+  get() = Drawable35.icon_3501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3502: DrawableResource
+  get() = Drawable35.icon_3502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3503: DrawableResource
+  get() = Drawable35.icon_3503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3504: DrawableResource
+  get() = Drawable35.icon_3504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3505: DrawableResource
+  get() = Drawable35.icon_3505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3506: DrawableResource
+  get() = Drawable35.icon_3506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3507: DrawableResource
+  get() = Drawable35.icon_3507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3508: DrawableResource
+  get() = Drawable35.icon_3508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3509: DrawableResource
+  get() = Drawable35.icon_3509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_351: DrawableResource
+  get() = Drawable35.icon_351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3510: DrawableResource
+  get() = Drawable35.icon_3510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3511: DrawableResource
+  get() = Drawable35.icon_3511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3512: DrawableResource
+  get() = Drawable35.icon_3512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3513: DrawableResource
+  get() = Drawable35.icon_3513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3514: DrawableResource
+  get() = Drawable35.icon_3514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3515: DrawableResource
+  get() = Drawable35.icon_3515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3516: DrawableResource
+  get() = Drawable35.icon_3516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3517: DrawableResource
+  get() = Drawable35.icon_3517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3518: DrawableResource
+  get() = Drawable35.icon_3518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3519: DrawableResource
+  get() = Drawable35.icon_3519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_352: DrawableResource
+  get() = Drawable35.icon_352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3520: DrawableResource
+  get() = Drawable35.icon_3520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3521: DrawableResource
+  get() = Drawable35.icon_3521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3522: DrawableResource
+  get() = Drawable35.icon_3522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3523: DrawableResource
+  get() = Drawable35.icon_3523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3524: DrawableResource
+  get() = Drawable35.icon_3524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3525: DrawableResource
+  get() = Drawable35.icon_3525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3526: DrawableResource
+  get() = Drawable35.icon_3526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3527: DrawableResource
+  get() = Drawable35.icon_3527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3528: DrawableResource
+  get() = Drawable35.icon_3528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3529: DrawableResource
+  get() = Drawable35.icon_3529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_353: DrawableResource
+  get() = Drawable35.icon_353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3530: DrawableResource
+  get() = Drawable35.icon_3530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3531: DrawableResource
+  get() = Drawable35.icon_3531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3532: DrawableResource
+  get() = Drawable35.icon_3532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3533: DrawableResource
+  get() = Drawable35.icon_3533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3534: DrawableResource
+  get() = Drawable35.icon_3534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3535: DrawableResource
+  get() = Drawable35.icon_3535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3536: DrawableResource
+  get() = Drawable35.icon_3536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3537: DrawableResource
+  get() = Drawable35.icon_3537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3538: DrawableResource
+  get() = Drawable35.icon_3538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3539: DrawableResource
+  get() = Drawable35.icon_3539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_354: DrawableResource
+  get() = Drawable35.icon_354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3540: DrawableResource
+  get() = Drawable35.icon_3540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3541: DrawableResource
+  get() = Drawable35.icon_3541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3542: DrawableResource
+  get() = Drawable35.icon_3542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3543: DrawableResource
+  get() = Drawable35.icon_3543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3544: DrawableResource
+  get() = Drawable35.icon_3544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3545: DrawableResource
+  get() = Drawable35.icon_3545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3546: DrawableResource
+  get() = Drawable35.icon_3546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3547: DrawableResource
+  get() = Drawable35.icon_3547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3548: DrawableResource
+  get() = Drawable35.icon_3548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3549: DrawableResource
+  get() = Drawable35.icon_3549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_355: DrawableResource
+  get() = Drawable35.icon_355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3550: DrawableResource
+  get() = Drawable35.icon_3550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3551: DrawableResource
+  get() = Drawable35.icon_3551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3552: DrawableResource
+  get() = Drawable35.icon_3552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3553: DrawableResource
+  get() = Drawable35.icon_3553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3554: DrawableResource
+  get() = Drawable35.icon_3554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3555: DrawableResource
+  get() = Drawable35.icon_3555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3556: DrawableResource
+  get() = Drawable35.icon_3556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3557: DrawableResource
+  get() = Drawable35.icon_3557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3558: DrawableResource
+  get() = Drawable35.icon_3558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3559: DrawableResource
+  get() = Drawable35.icon_3559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_356: DrawableResource
+  get() = Drawable35.icon_356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3560: DrawableResource
+  get() = Drawable35.icon_3560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3561: DrawableResource
+  get() = Drawable35.icon_3561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3562: DrawableResource
+  get() = Drawable35.icon_3562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3563: DrawableResource
+  get() = Drawable35.icon_3563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3564: DrawableResource
+  get() = Drawable35.icon_3564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3565: DrawableResource
+  get() = Drawable35.icon_3565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3566: DrawableResource
+  get() = Drawable35.icon_3566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3567: DrawableResource
+  get() = Drawable35.icon_3567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3568: DrawableResource
+  get() = Drawable35.icon_3568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3569: DrawableResource
+  get() = Drawable35.icon_3569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_357: DrawableResource
+  get() = Drawable35.icon_357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3570: DrawableResource
+  get() = Drawable35.icon_3570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3571: DrawableResource
+  get() = Drawable35.icon_3571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3572: DrawableResource
+  get() = Drawable35.icon_3572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3573: DrawableResource
+  get() = Drawable35.icon_3573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3574: DrawableResource
+  get() = Drawable35.icon_3574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3575: DrawableResource
+  get() = Drawable35.icon_3575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3576: DrawableResource
+  get() = Drawable35.icon_3576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3577: DrawableResource
+  get() = Drawable35.icon_3577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3578: DrawableResource
+  get() = Drawable35.icon_3578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3579: DrawableResource
+  get() = Drawable35.icon_3579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_358: DrawableResource
+  get() = Drawable35.icon_358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3580: DrawableResource
+  get() = Drawable35.icon_3580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3581: DrawableResource
+  get() = Drawable35.icon_3581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3582: DrawableResource
+  get() = Drawable35.icon_3582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3583: DrawableResource
+  get() = Drawable35.icon_3583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3584: DrawableResource
+  get() = Drawable35.icon_3584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3585: DrawableResource
+  get() = Drawable35.icon_3585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3586: DrawableResource
+  get() = Drawable35.icon_3586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3587: DrawableResource
+  get() = Drawable35.icon_3587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3588: DrawableResource
+  get() = Drawable35.icon_3588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3589: DrawableResource
+  get() = Drawable35.icon_3589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_359: DrawableResource
+  get() = Drawable35.icon_359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3590: DrawableResource
+  get() = Drawable35.icon_3590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3591: DrawableResource
+  get() = Drawable35.icon_3591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3592: DrawableResource
+  get() = Drawable35.icon_3592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3593: DrawableResource
+  get() = Drawable35.icon_3593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3594: DrawableResource
+  get() = Drawable35.icon_3594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3595: DrawableResource
+  get() = Drawable35.icon_3595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3596: DrawableResource
+  get() = Drawable35.icon_3596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3597: DrawableResource
+  get() = Drawable35.icon_3597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3598: DrawableResource
+  get() = Drawable35.icon_3598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3599: DrawableResource
+  get() = Drawable35.icon_3599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_36: DrawableResource
+  get() = Drawable35.icon_36
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_360: DrawableResource
+  get() = Drawable35.icon_360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3600: DrawableResource
+  get() = Drawable35.icon_3600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3601: DrawableResource
+  get() = Drawable35.icon_3601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3602: DrawableResource
+  get() = Drawable35.icon_3602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3603: DrawableResource
+  get() = Drawable35.icon_3603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3604: DrawableResource
+  get() = Drawable35.icon_3604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3605: DrawableResource
+  get() = Drawable35.icon_3605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3606: DrawableResource
+  get() = Drawable35.icon_3606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3607: DrawableResource
+  get() = Drawable35.icon_3607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3608: DrawableResource
+  get() = Drawable35.icon_3608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3609: DrawableResource
+  get() = Drawable35.icon_3609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_361: DrawableResource
+  get() = Drawable35.icon_361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3610: DrawableResource
+  get() = Drawable35.icon_3610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3611: DrawableResource
+  get() = Drawable35.icon_3611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3612: DrawableResource
+  get() = Drawable35.icon_3612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3613: DrawableResource
+  get() = Drawable35.icon_3613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3614: DrawableResource
+  get() = Drawable35.icon_3614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3615: DrawableResource
+  get() = Drawable35.icon_3615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3616: DrawableResource
+  get() = Drawable35.icon_3616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3617: DrawableResource
+  get() = Drawable35.icon_3617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3618: DrawableResource
+  get() = Drawable35.icon_3618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3619: DrawableResource
+  get() = Drawable35.icon_3619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_362: DrawableResource
+  get() = Drawable35.icon_362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3620: DrawableResource
+  get() = Drawable35.icon_3620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3621: DrawableResource
+  get() = Drawable35.icon_3621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3622: DrawableResource
+  get() = Drawable35.icon_3622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3623: DrawableResource
+  get() = Drawable35.icon_3623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3624: DrawableResource
+  get() = Drawable35.icon_3624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3625: DrawableResource
+  get() = Drawable35.icon_3625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3626: DrawableResource
+  get() = Drawable35.icon_3626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3627: DrawableResource
+  get() = Drawable35.icon_3627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3628: DrawableResource
+  get() = Drawable35.icon_3628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3629: DrawableResource
+  get() = Drawable35.icon_3629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_363: DrawableResource
+  get() = Drawable35.icon_363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3630: DrawableResource
+  get() = Drawable35.icon_3630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3631: DrawableResource
+  get() = Drawable35.icon_3631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3632: DrawableResource
+  get() = Drawable35.icon_3632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3633: DrawableResource
+  get() = Drawable35.icon_3633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3634: DrawableResource
+  get() = Drawable35.icon_3634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3635: DrawableResource
+  get() = Drawable35.icon_3635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3636: DrawableResource
+  get() = Drawable35.icon_3636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3637: DrawableResource
+  get() = Drawable35.icon_3637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3638: DrawableResource
+  get() = Drawable35.icon_3638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3639: DrawableResource
+  get() = Drawable35.icon_3639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_364: DrawableResource
+  get() = Drawable35.icon_364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3640: DrawableResource
+  get() = Drawable35.icon_3640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3641: DrawableResource
+  get() = Drawable35.icon_3641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3642: DrawableResource
+  get() = Drawable35.icon_3642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3643: DrawableResource
+  get() = Drawable35.icon_3643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3644: DrawableResource
+  get() = Drawable35.icon_3644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3645: DrawableResource
+  get() = Drawable35.icon_3645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3646: DrawableResource
+  get() = Drawable35.icon_3646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3647: DrawableResource
+  get() = Drawable35.icon_3647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3648: DrawableResource
+  get() = Drawable35.icon_3648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3649: DrawableResource
+  get() = Drawable35.icon_3649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_365: DrawableResource
+  get() = Drawable35.icon_365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3650: DrawableResource
+  get() = Drawable35.icon_3650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3651: DrawableResource
+  get() = Drawable35.icon_3651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3652: DrawableResource
+  get() = Drawable35.icon_3652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3653: DrawableResource
+  get() = Drawable35.icon_3653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3654: DrawableResource
+  get() = Drawable35.icon_3654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3655: DrawableResource
+  get() = Drawable35.icon_3655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3656: DrawableResource
+  get() = Drawable35.icon_3656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3657: DrawableResource
+  get() = Drawable35.icon_3657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3658: DrawableResource
+  get() = Drawable35.icon_3658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3659: DrawableResource
+  get() = Drawable35.icon_3659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_366: DrawableResource
+  get() = Drawable35.icon_366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3660: DrawableResource
+  get() = Drawable35.icon_3660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3661: DrawableResource
+  get() = Drawable35.icon_3661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3662: DrawableResource
+  get() = Drawable35.icon_3662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3663: DrawableResource
+  get() = Drawable35.icon_3663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3664: DrawableResource
+  get() = Drawable35.icon_3664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3665: DrawableResource
+  get() = Drawable35.icon_3665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3666: DrawableResource
+  get() = Drawable35.icon_3666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3667: DrawableResource
+  get() = Drawable35.icon_3667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3668: DrawableResource
+  get() = Drawable35.icon_3668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3669: DrawableResource
+  get() = Drawable35.icon_3669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_367: DrawableResource
+  get() = Drawable35.icon_367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3670: DrawableResource
+  get() = Drawable35.icon_3670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3671: DrawableResource
+  get() = Drawable35.icon_3671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3672: DrawableResource
+  get() = Drawable35.icon_3672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3673: DrawableResource
+  get() = Drawable35.icon_3673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3674: DrawableResource
+  get() = Drawable35.icon_3674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3675: DrawableResource
+  get() = Drawable35.icon_3675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3676: DrawableResource
+  get() = Drawable35.icon_3676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3677: DrawableResource
+  get() = Drawable35.icon_3677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3678: DrawableResource
+  get() = Drawable35.icon_3678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3679: DrawableResource
+  get() = Drawable35.icon_3679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_368: DrawableResource
+  get() = Drawable35.icon_368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3680: DrawableResource
+  get() = Drawable35.icon_3680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3681: DrawableResource
+  get() = Drawable35.icon_3681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3682: DrawableResource
+  get() = Drawable35.icon_3682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3683: DrawableResource
+  get() = Drawable35.icon_3683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3684: DrawableResource
+  get() = Drawable35.icon_3684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3685: DrawableResource
+  get() = Drawable35.icon_3685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3686: DrawableResource
+  get() = Drawable35.icon_3686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3687: DrawableResource
+  get() = Drawable35.icon_3687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3688: DrawableResource
+  get() = Drawable35.icon_3688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3689: DrawableResource
+  get() = Drawable35.icon_3689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_369: DrawableResource
+  get() = Drawable35.icon_369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3690: DrawableResource
+  get() = Drawable35.icon_3690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3691: DrawableResource
+  get() = Drawable35.icon_3691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3692: DrawableResource
+  get() = Drawable35.icon_3692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3693: DrawableResource
+  get() = Drawable35.icon_3693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3694: DrawableResource
+  get() = Drawable35.icon_3694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3695: DrawableResource
+  get() = Drawable35.icon_3695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3696: DrawableResource
+  get() = Drawable35.icon_3696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3697: DrawableResource
+  get() = Drawable35.icon_3697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3698: DrawableResource
+  get() = Drawable35.icon_3698

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable36.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable36.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable36 {
+  public val icon_3699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3699.xml"),
+          )
+      )
+
+  public val icon_37: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_37",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_37.xml"),
+          )
+      )
+
+  public val icon_370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_370.xml"),
+          )
+      )
+
+  public val icon_3700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3700.xml"),
+          )
+      )
+
+  public val icon_3701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3701.xml"),
+          )
+      )
+
+  public val icon_3702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3702.xml"),
+          )
+      )
+
+  public val icon_3703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3703.xml"),
+          )
+      )
+
+  public val icon_3704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3704.xml"),
+          )
+      )
+
+  public val icon_3705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3705.xml"),
+          )
+      )
+
+  public val icon_3706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3706.xml"),
+          )
+      )
+
+  public val icon_3707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3707.xml"),
+          )
+      )
+
+  public val icon_3708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3708.xml"),
+          )
+      )
+
+  public val icon_3709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3709.xml"),
+          )
+      )
+
+  public val icon_371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_371.xml"),
+          )
+      )
+
+  public val icon_3710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3710.xml"),
+          )
+      )
+
+  public val icon_3711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3711.xml"),
+          )
+      )
+
+  public val icon_3712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3712.xml"),
+          )
+      )
+
+  public val icon_3713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3713.xml"),
+          )
+      )
+
+  public val icon_3714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3714.xml"),
+          )
+      )
+
+  public val icon_3715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3715.xml"),
+          )
+      )
+
+  public val icon_3716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3716.xml"),
+          )
+      )
+
+  public val icon_3717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3717.xml"),
+          )
+      )
+
+  public val icon_3718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3718.xml"),
+          )
+      )
+
+  public val icon_3719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3719.xml"),
+          )
+      )
+
+  public val icon_372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_372.xml"),
+          )
+      )
+
+  public val icon_3720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3720.xml"),
+          )
+      )
+
+  public val icon_3721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3721.xml"),
+          )
+      )
+
+  public val icon_3722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3722.xml"),
+          )
+      )
+
+  public val icon_3723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3723.xml"),
+          )
+      )
+
+  public val icon_3724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3724.xml"),
+          )
+      )
+
+  public val icon_3725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3725.xml"),
+          )
+      )
+
+  public val icon_3726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3726.xml"),
+          )
+      )
+
+  public val icon_3727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3727.xml"),
+          )
+      )
+
+  public val icon_3728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3728.xml"),
+          )
+      )
+
+  public val icon_3729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3729.xml"),
+          )
+      )
+
+  public val icon_373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_373.xml"),
+          )
+      )
+
+  public val icon_3730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3730.xml"),
+          )
+      )
+
+  public val icon_3731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3731.xml"),
+          )
+      )
+
+  public val icon_3732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3732.xml"),
+          )
+      )
+
+  public val icon_3733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3733.xml"),
+          )
+      )
+
+  public val icon_3734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3734.xml"),
+          )
+      )
+
+  public val icon_3735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3735.xml"),
+          )
+      )
+
+  public val icon_3736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3736.xml"),
+          )
+      )
+
+  public val icon_3737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3737.xml"),
+          )
+      )
+
+  public val icon_3738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3738.xml"),
+          )
+      )
+
+  public val icon_3739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3739.xml"),
+          )
+      )
+
+  public val icon_374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_374.xml"),
+          )
+      )
+
+  public val icon_3740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3740.xml"),
+          )
+      )
+
+  public val icon_3741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3741.xml"),
+          )
+      )
+
+  public val icon_3742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3742.xml"),
+          )
+      )
+
+  public val icon_3743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3743.xml"),
+          )
+      )
+
+  public val icon_3744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3744.xml"),
+          )
+      )
+
+  public val icon_3745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3745.xml"),
+          )
+      )
+
+  public val icon_3746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3746.xml"),
+          )
+      )
+
+  public val icon_3747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3747.xml"),
+          )
+      )
+
+  public val icon_3748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3748.xml"),
+          )
+      )
+
+  public val icon_3749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3749.xml"),
+          )
+      )
+
+  public val icon_375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_375.xml"),
+          )
+      )
+
+  public val icon_3750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3750.xml"),
+          )
+      )
+
+  public val icon_3751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3751.xml"),
+          )
+      )
+
+  public val icon_3752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3752.xml"),
+          )
+      )
+
+  public val icon_3753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3753.xml"),
+          )
+      )
+
+  public val icon_3754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3754.xml"),
+          )
+      )
+
+  public val icon_3755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3755.xml"),
+          )
+      )
+
+  public val icon_3756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3756.xml"),
+          )
+      )
+
+  public val icon_3757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3757.xml"),
+          )
+      )
+
+  public val icon_3758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3758.xml"),
+          )
+      )
+
+  public val icon_3759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3759.xml"),
+          )
+      )
+
+  public val icon_376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_376.xml"),
+          )
+      )
+
+  public val icon_3760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3760.xml"),
+          )
+      )
+
+  public val icon_3761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3761.xml"),
+          )
+      )
+
+  public val icon_3762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3762.xml"),
+          )
+      )
+
+  public val icon_3763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3763.xml"),
+          )
+      )
+
+  public val icon_3764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3764.xml"),
+          )
+      )
+
+  public val icon_3765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3765.xml"),
+          )
+      )
+
+  public val icon_3766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3766.xml"),
+          )
+      )
+
+  public val icon_3767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3767.xml"),
+          )
+      )
+
+  public val icon_3768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3768.xml"),
+          )
+      )
+
+  public val icon_3769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3769.xml"),
+          )
+      )
+
+  public val icon_377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_377.xml"),
+          )
+      )
+
+  public val icon_3770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3770.xml"),
+          )
+      )
+
+  public val icon_3771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3771.xml"),
+          )
+      )
+
+  public val icon_3772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3772.xml"),
+          )
+      )
+
+  public val icon_3773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3773.xml"),
+          )
+      )
+
+  public val icon_3774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3774.xml"),
+          )
+      )
+
+  public val icon_3775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3775.xml"),
+          )
+      )
+
+  public val icon_3776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3776.xml"),
+          )
+      )
+
+  public val icon_3777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3777.xml"),
+          )
+      )
+
+  public val icon_3778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3778.xml"),
+          )
+      )
+
+  public val icon_3779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3779.xml"),
+          )
+      )
+
+  public val icon_378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_378.xml"),
+          )
+      )
+
+  public val icon_3780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3780.xml"),
+          )
+      )
+
+  public val icon_3781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3781.xml"),
+          )
+      )
+
+  public val icon_3782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3782.xml"),
+          )
+      )
+
+  public val icon_3783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3783.xml"),
+          )
+      )
+
+  public val icon_3784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3784.xml"),
+          )
+      )
+
+  public val icon_3785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3785.xml"),
+          )
+      )
+
+  public val icon_3786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3786.xml"),
+          )
+      )
+
+  public val icon_3787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3787.xml"),
+          )
+      )
+
+  public val icon_3788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3788.xml"),
+          )
+      )
+
+  public val icon_3789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3789.xml"),
+          )
+      )
+
+  public val icon_379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_379.xml"),
+          )
+      )
+
+  public val icon_3790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3790.xml"),
+          )
+      )
+
+  public val icon_3791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3791.xml"),
+          )
+      )
+
+  public val icon_3792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3792.xml"),
+          )
+      )
+
+  public val icon_3793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3793.xml"),
+          )
+      )
+
+  public val icon_3794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3794.xml"),
+          )
+      )
+
+  public val icon_3795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3795.xml"),
+          )
+      )
+
+  public val icon_3796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3796.xml"),
+          )
+      )
+
+  public val icon_3797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3797.xml"),
+          )
+      )
+
+  public val icon_3798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3798.xml"),
+          )
+      )
+
+  public val icon_3799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3799.xml"),
+          )
+      )
+
+  public val icon_38: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_38",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_38.xml"),
+          )
+      )
+
+  public val icon_380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_380.xml"),
+          )
+      )
+
+  public val icon_3800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3800.xml"),
+          )
+      )
+
+  public val icon_3801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3801.xml"),
+          )
+      )
+
+  public val icon_3802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3802.xml"),
+          )
+      )
+
+  public val icon_3803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3803.xml"),
+          )
+      )
+
+  public val icon_3804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3804.xml"),
+          )
+      )
+
+  public val icon_3805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3805.xml"),
+          )
+      )
+
+  public val icon_3806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3806.xml"),
+          )
+      )
+
+  public val icon_3807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3807.xml"),
+          )
+      )
+
+  public val icon_3808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3808.xml"),
+          )
+      )
+
+  public val icon_3809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3809.xml"),
+          )
+      )
+
+  public val icon_381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_381.xml"),
+          )
+      )
+
+  public val icon_3810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3810.xml"),
+          )
+      )
+
+  public val icon_3811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3811.xml"),
+          )
+      )
+
+  public val icon_3812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3812.xml"),
+          )
+      )
+
+  public val icon_3813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3813.xml"),
+          )
+      )
+
+  public val icon_3814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3814.xml"),
+          )
+      )
+
+  public val icon_3815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3815.xml"),
+          )
+      )
+
+  public val icon_3816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3816.xml"),
+          )
+      )
+
+  public val icon_3817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3817.xml"),
+          )
+      )
+
+  public val icon_3818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3818.xml"),
+          )
+      )
+
+  public val icon_3819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3819.xml"),
+          )
+      )
+
+  public val icon_382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_382.xml"),
+          )
+      )
+
+  public val icon_3820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3820.xml"),
+          )
+      )
+
+  public val icon_3821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3821.xml"),
+          )
+      )
+
+  public val icon_3822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3822.xml"),
+          )
+      )
+
+  public val icon_3823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3823.xml"),
+          )
+      )
+
+  public val icon_3824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3824.xml"),
+          )
+      )
+
+  public val icon_3825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3825.xml"),
+          )
+      )
+
+  public val icon_3826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3826.xml"),
+          )
+      )
+
+  public val icon_3827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3827.xml"),
+          )
+      )
+
+  public val icon_3828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3828.xml"),
+          )
+      )
+
+  public val icon_3829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3829.xml"),
+          )
+      )
+
+  public val icon_383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_383.xml"),
+          )
+      )
+
+  public val icon_3830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3830.xml"),
+          )
+      )
+
+  public val icon_3831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3831.xml"),
+          )
+      )
+
+  public val icon_3832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3832.xml"),
+          )
+      )
+
+  public val icon_3833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3833.xml"),
+          )
+      )
+
+  public val icon_3834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3834.xml"),
+          )
+      )
+
+  public val icon_3835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3835.xml"),
+          )
+      )
+
+  public val icon_3836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3836.xml"),
+          )
+      )
+
+  public val icon_3837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3837.xml"),
+          )
+      )
+
+  public val icon_3838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3838.xml"),
+          )
+      )
+
+  public val icon_3839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3839.xml"),
+          )
+      )
+
+  public val icon_384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_384.xml"),
+          )
+      )
+
+  public val icon_3840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3840.xml"),
+          )
+      )
+
+  public val icon_3841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3841.xml"),
+          )
+      )
+
+  public val icon_3842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3842.xml"),
+          )
+      )
+
+  public val icon_3843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3843.xml"),
+          )
+      )
+
+  public val icon_3844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3844.xml"),
+          )
+      )
+
+  public val icon_3845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3845.xml"),
+          )
+      )
+
+  public val icon_3846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3846.xml"),
+          )
+      )
+
+  public val icon_3847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3847.xml"),
+          )
+      )
+
+  public val icon_3848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3848.xml"),
+          )
+      )
+
+  public val icon_3849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3849.xml"),
+          )
+      )
+
+  public val icon_385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_385.xml"),
+          )
+      )
+
+  public val icon_3850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3850.xml"),
+          )
+      )
+
+  public val icon_3851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3851.xml"),
+          )
+      )
+
+  public val icon_3852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3852.xml"),
+          )
+      )
+
+  public val icon_3853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3853.xml"),
+          )
+      )
+
+  public val icon_3854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3854.xml"),
+          )
+      )
+
+  public val icon_3855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3855.xml"),
+          )
+      )
+
+  public val icon_3856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3856.xml"),
+          )
+      )
+
+  public val icon_3857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3857.xml"),
+          )
+      )
+
+  public val icon_3858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3858.xml"),
+          )
+      )
+
+  public val icon_3859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3859.xml"),
+          )
+      )
+
+  public val icon_386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_386.xml"),
+          )
+      )
+
+  public val icon_3860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3860.xml"),
+          )
+      )
+
+  public val icon_3861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3861.xml"),
+          )
+      )
+
+  public val icon_3862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3862.xml"),
+          )
+      )
+
+  public val icon_3863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3863.xml"),
+          )
+      )
+
+  public val icon_3864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3864.xml"),
+          )
+      )
+
+  public val icon_3865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3865.xml"),
+          )
+      )
+
+  public val icon_3866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3866.xml"),
+          )
+      )
+
+  public val icon_3867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3867.xml"),
+          )
+      )
+
+  public val icon_3868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3868.xml"),
+          )
+      )
+
+  public val icon_3869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3869.xml"),
+          )
+      )
+
+  public val icon_387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_387.xml"),
+          )
+      )
+
+  public val icon_3870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3870.xml"),
+          )
+      )
+
+  public val icon_3871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3871.xml"),
+          )
+      )
+
+  public val icon_3872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3872.xml"),
+          )
+      )
+
+  public val icon_3873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3873.xml"),
+          )
+      )
+
+  public val icon_3874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3874.xml"),
+          )
+      )
+
+  public val icon_3875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3875.xml"),
+          )
+      )
+
+  public val icon_3876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3876.xml"),
+          )
+      )
+
+  public val icon_3877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3877.xml"),
+          )
+      )
+
+  public val icon_3878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3878.xml"),
+          )
+      )
+
+  public val icon_3879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3879.xml"),
+          )
+      )
+
+  public val icon_388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_388.xml"),
+          )
+      )
+
+  public val icon_3880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3880.xml"),
+          )
+      )
+
+  public val icon_3881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3881.xml"),
+          )
+      )
+
+  public val icon_3882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3882.xml"),
+          )
+      )
+
+  public val icon_3883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3883.xml"),
+          )
+      )
+
+  public val icon_3884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3884.xml"),
+          )
+      )
+
+  public val icon_3885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3885.xml"),
+          )
+      )
+
+  public val icon_3886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3886.xml"),
+          )
+      )
+
+  public val icon_3887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3887.xml"),
+          )
+      )
+
+  public val icon_3888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3888.xml"),
+          )
+      )
+
+  public val icon_3889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3889.xml"),
+          )
+      )
+
+  public val icon_389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_389.xml"),
+          )
+      )
+
+  public val icon_3890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3890.xml"),
+          )
+      )
+
+  public val icon_3891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3891.xml"),
+          )
+      )
+
+  public val icon_3892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3892.xml"),
+          )
+      )
+
+  public val icon_3893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3893.xml"),
+          )
+      )
+
+  public val icon_3894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3894.xml"),
+          )
+      )
+
+  public val icon_3895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3895.xml"),
+          )
+      )
+
+  public val icon_3896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3896.xml"),
+          )
+      )
+
+  public val icon_3897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3897.xml"),
+          )
+      )
+
+  public val icon_3898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3898.xml"),
+          )
+      )
+
+  public val icon_3899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3899.xml"),
+          )
+      )
+
+  public val icon_39: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_39",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_39.xml"),
+          )
+      )
+
+  public val icon_390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_390.xml"),
+          )
+      )
+
+  public val icon_3900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3900.xml"),
+          )
+      )
+
+  public val icon_3901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3901.xml"),
+          )
+      )
+
+  public val icon_3902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3902.xml"),
+          )
+      )
+
+  public val icon_3903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3903.xml"),
+          )
+      )
+
+  public val icon_3904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3904.xml"),
+          )
+      )
+
+  public val icon_3905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3905.xml"),
+          )
+      )
+
+  public val icon_3906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3906.xml"),
+          )
+      )
+
+  public val icon_3907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3907.xml"),
+          )
+      )
+
+  public val icon_3908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3908.xml"),
+          )
+      )
+
+  public val icon_3909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3909.xml"),
+          )
+      )
+
+  public val icon_391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_391.xml"),
+          )
+      )
+
+  public val icon_3910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3910.xml"),
+          )
+      )
+
+  public val icon_3911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3911.xml"),
+          )
+      )
+
+  public val icon_3912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3912.xml"),
+          )
+      )
+
+  public val icon_3913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3913.xml"),
+          )
+      )
+
+  public val icon_3914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3914.xml"),
+          )
+      )
+
+  public val icon_3915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3915.xml"),
+          )
+      )
+
+  public val icon_3916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3916.xml"),
+          )
+      )
+
+  public val icon_3917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3917.xml"),
+          )
+      )
+
+  public val icon_3918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3918.xml"),
+          )
+      )
+
+  public val icon_3919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3919.xml"),
+          )
+      )
+
+  public val icon_392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_392.xml"),
+          )
+      )
+
+  public val icon_3920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3920.xml"),
+          )
+      )
+
+  public val icon_3921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3921.xml"),
+          )
+      )
+
+  public val icon_3922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3922.xml"),
+          )
+      )
+
+  public val icon_3923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3923.xml"),
+          )
+      )
+
+  public val icon_3924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3924.xml"),
+          )
+      )
+
+  public val icon_3925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3925.xml"),
+          )
+      )
+
+  public val icon_3926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3926.xml"),
+          )
+      )
+
+  public val icon_3927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3927.xml"),
+          )
+      )
+
+  public val icon_3928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3928.xml"),
+          )
+      )
+
+  public val icon_3929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3929.xml"),
+          )
+      )
+
+  public val icon_393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_393.xml"),
+          )
+      )
+
+  public val icon_3930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3930.xml"),
+          )
+      )
+
+  public val icon_3931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3931.xml"),
+          )
+      )
+
+  public val icon_3932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3932.xml"),
+          )
+      )
+
+  public val icon_3933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3933.xml"),
+          )
+      )
+
+  public val icon_3934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3934.xml"),
+          )
+      )
+
+  public val icon_3935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3935.xml"),
+          )
+      )
+
+  public val icon_3936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3936.xml"),
+          )
+      )
+
+  public val icon_3937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3937.xml"),
+          )
+      )
+
+  public val icon_3938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3938.xml"),
+          )
+      )
+
+  public val icon_3939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3939.xml"),
+          )
+      )
+
+  public val icon_394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_394.xml"),
+          )
+      )
+
+  public val icon_3940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3940.xml"),
+          )
+      )
+
+  public val icon_3941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3941.xml"),
+          )
+      )
+
+  public val icon_3942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3942.xml"),
+          )
+      )
+
+  public val icon_3943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3943.xml"),
+          )
+      )
+
+  public val icon_3944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3944.xml"),
+          )
+      )
+
+  public val icon_3945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3945.xml"),
+          )
+      )
+
+  public val icon_3946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3946.xml"),
+          )
+      )
+
+  public val icon_3947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3947.xml"),
+          )
+      )
+
+  public val icon_3948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3948.xml"),
+          )
+      )
+
+  public val icon_3949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3949.xml"),
+          )
+      )
+
+  public val icon_395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_395.xml"),
+          )
+      )
+
+  public val icon_3950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3950.xml"),
+          )
+      )
+
+  public val icon_3951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3951.xml"),
+          )
+      )
+
+  public val icon_3952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3952.xml"),
+          )
+      )
+
+  public val icon_3953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3953.xml"),
+          )
+      )
+
+  public val icon_3954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3954.xml"),
+          )
+      )
+
+  public val icon_3955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3955.xml"),
+          )
+      )
+
+  public val icon_3956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3956.xml"),
+          )
+      )
+
+  public val icon_3957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3957.xml"),
+          )
+      )
+
+  public val icon_3958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3958.xml"),
+          )
+      )
+
+  public val icon_3959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3959.xml"),
+          )
+      )
+
+  public val icon_396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_396.xml"),
+          )
+      )
+
+  public val icon_3960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3960.xml"),
+          )
+      )
+
+  public val icon_3961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3961.xml"),
+          )
+      )
+
+  public val icon_3962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3962.xml"),
+          )
+      )
+
+  public val icon_3963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3963.xml"),
+          )
+      )
+
+  public val icon_3964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3964.xml"),
+          )
+      )
+
+  public val icon_3965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3965.xml"),
+          )
+      )
+
+  public val icon_3966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3966.xml"),
+          )
+      )
+
+  public val icon_3967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3967.xml"),
+          )
+      )
+
+  public val icon_3968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3968.xml"),
+          )
+      )
+
+  public val icon_3969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3969.xml"),
+          )
+      )
+
+  public val icon_397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_397.xml"),
+          )
+      )
+
+  public val icon_3970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3970.xml"),
+          )
+      )
+
+  public val icon_3971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3971.xml"),
+          )
+      )
+
+  public val icon_3972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3972.xml"),
+          )
+      )
+
+  public val icon_3973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3973.xml"),
+          )
+      )
+
+  public val icon_3974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3974.xml"),
+          )
+      )
+
+  public val icon_3975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3975.xml"),
+          )
+      )
+
+  public val icon_3976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3976.xml"),
+          )
+      )
+
+  public val icon_3977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3977.xml"),
+          )
+      )
+
+  public val icon_3978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3978.xml"),
+          )
+      )
+
+  public val icon_3979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3979.xml"),
+          )
+      )
+
+  public val icon_398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_398.xml"),
+          )
+      )
+
+  public val icon_3980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3980.xml"),
+          )
+      )
+
+  public val icon_3981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3981.xml"),
+          )
+      )
+
+  public val icon_3982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3982.xml"),
+          )
+      )
+
+  public val icon_3983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3983.xml"),
+          )
+      )
+
+  public val icon_3984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3984.xml"),
+          )
+      )
+
+  public val icon_3985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3985.xml"),
+          )
+      )
+
+  public val icon_3986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3986.xml"),
+          )
+      )
+
+  public val icon_3987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3987.xml"),
+          )
+      )
+
+  public val icon_3988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3988.xml"),
+          )
+      )
+
+  public val icon_3989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3989.xml"),
+          )
+      )
+
+  public val icon_399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_399.xml"),
+          )
+      )
+
+  public val icon_3990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3990.xml"),
+          )
+      )
+
+  public val icon_3991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3991.xml"),
+          )
+      )
+
+  public val icon_3992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3992.xml"),
+          )
+      )
+
+  public val icon_3993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3993.xml"),
+          )
+      )
+
+  public val icon_3994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3994.xml"),
+          )
+      )
+
+  public val icon_3995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3995.xml"),
+          )
+      )
+
+  public val icon_3996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3996.xml"),
+          )
+      )
+
+  public val icon_3997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3997.xml"),
+          )
+      )
+
+  public val icon_3998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3998.xml"),
+          )
+      )
+
+  public val icon_3999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_3999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_3999.xml"),
+          )
+      )
+
+  public val icon_4: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4.xml"),
+          )
+      )
+
+  public val icon_40: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_40",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_40.xml"),
+          )
+      )
+
+  public val icon_400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_400.xml"),
+          )
+      )
+
+  public val icon_4000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4000.xml"),
+          )
+      )
+
+  public val icon_4001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4001.xml"),
+          )
+      )
+
+  public val icon_4002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4002.xml"),
+          )
+      )
+
+  public val icon_4003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4003.xml"),
+          )
+      )
+
+  public val icon_4004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4004.xml"),
+          )
+      )
+
+  public val icon_4005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4005.xml"),
+          )
+      )
+
+  public val icon_4006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4006.xml"),
+          )
+      )
+
+  public val icon_4007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4007.xml"),
+          )
+      )
+
+  public val icon_4008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4008.xml"),
+          )
+      )
+
+  public val icon_4009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4009.xml"),
+          )
+      )
+
+  public val icon_401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_401.xml"),
+          )
+      )
+
+  public val icon_4010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4010.xml"),
+          )
+      )
+
+  public val icon_4011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4011.xml"),
+          )
+      )
+
+  public val icon_4012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4012.xml"),
+          )
+      )
+
+  public val icon_4013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4013.xml"),
+          )
+      )
+
+  public val icon_4014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4014.xml"),
+          )
+      )
+
+  public val icon_4015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4015.xml"),
+          )
+      )
+
+  public val icon_4016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4016.xml"),
+          )
+      )
+
+  public val icon_4017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4017.xml"),
+          )
+      )
+
+  public val icon_4018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4018.xml"),
+          )
+      )
+
+  public val icon_4019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4019.xml"),
+          )
+      )
+
+  public val icon_402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_402.xml"),
+          )
+      )
+
+  public val icon_4020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4020.xml"),
+          )
+      )
+
+  public val icon_4021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4021.xml"),
+          )
+      )
+
+  public val icon_4022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4022.xml"),
+          )
+      )
+
+  public val icon_4023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4023.xml"),
+          )
+      )
+
+  public val icon_4024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4024.xml"),
+          )
+      )
+
+  public val icon_4025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4025.xml"),
+          )
+      )
+
+  public val icon_4026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4026.xml"),
+          )
+      )
+
+  public val icon_4027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4027.xml"),
+          )
+      )
+
+  public val icon_4028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4028.xml"),
+          )
+      )
+
+  public val icon_4029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4029.xml"),
+          )
+      )
+
+  public val icon_403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_403.xml"),
+          )
+      )
+
+  public val icon_4030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4030.xml"),
+          )
+      )
+
+  public val icon_4031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4031.xml"),
+          )
+      )
+
+  public val icon_4032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4032.xml"),
+          )
+      )
+
+  public val icon_4033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4033.xml"),
+          )
+      )
+
+  public val icon_4034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4034.xml"),
+          )
+      )
+
+  public val icon_4035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4035.xml"),
+          )
+      )
+
+  public val icon_4036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4036.xml"),
+          )
+      )
+
+  public val icon_4037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4037.xml"),
+          )
+      )
+
+  public val icon_4038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4038.xml"),
+          )
+      )
+
+  public val icon_4039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4039.xml"),
+          )
+      )
+
+  public val icon_404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_404.xml"),
+          )
+      )
+
+  public val icon_4040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4040.xml"),
+          )
+      )
+
+  public val icon_4041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4041.xml"),
+          )
+      )
+
+  public val icon_4042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4042.xml"),
+          )
+      )
+
+  public val icon_4043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4043.xml"),
+          )
+      )
+
+  public val icon_4044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4044.xml"),
+          )
+      )
+
+  public val icon_4045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4045.xml"),
+          )
+      )
+
+  public val icon_4046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4046.xml"),
+          )
+      )
+
+  public val icon_4047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4047.xml"),
+          )
+      )
+
+  public val icon_4048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4048.xml"),
+          )
+      )
+
+  public val icon_4049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4049.xml"),
+          )
+      )
+
+  public val icon_405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_405.xml"),
+          )
+      )
+
+  public val icon_4050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4050.xml"),
+          )
+      )
+
+  public val icon_4051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4051.xml"),
+          )
+      )
+
+  public val icon_4052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4052.xml"),
+          )
+      )
+
+  public val icon_4053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4053.xml"),
+          )
+      )
+
+  public val icon_4054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4054.xml"),
+          )
+      )
+
+  public val icon_4055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4055.xml"),
+          )
+      )
+
+  public val icon_4056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4056.xml"),
+          )
+      )
+
+  public val icon_4057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4057.xml"),
+          )
+      )
+
+  public val icon_4058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4058.xml"),
+          )
+      )
+
+  public val icon_4059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4059.xml"),
+          )
+      )
+
+  public val icon_406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_406.xml"),
+          )
+      )
+
+  public val icon_4060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4060.xml"),
+          )
+      )
+
+  public val icon_4061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4061.xml"),
+          )
+      )
+
+  public val icon_4062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4062.xml"),
+          )
+      )
+
+  public val icon_4063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4063.xml"),
+          )
+      )
+
+  public val icon_4064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4064.xml"),
+          )
+      )
+
+  public val icon_4065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4065.xml"),
+          )
+      )
+
+  public val icon_4066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4066.xml"),
+          )
+      )
+
+  public val icon_4067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4067.xml"),
+          )
+      )
+
+  public val icon_4068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4068.xml"),
+          )
+      )
+
+  public val icon_4069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4069.xml"),
+          )
+      )
+
+  public val icon_407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_407.xml"),
+          )
+      )
+
+  public val icon_4070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4070.xml"),
+          )
+      )
+
+  public val icon_4071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4071.xml"),
+          )
+      )
+
+  public val icon_4072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4072.xml"),
+          )
+      )
+
+  public val icon_4073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4073.xml"),
+          )
+      )
+
+  public val icon_4074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4074.xml"),
+          )
+      )
+
+  public val icon_4075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4075.xml"),
+          )
+      )
+
+  public val icon_4076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4076.xml"),
+          )
+      )
+
+  public val icon_4077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4077.xml"),
+          )
+      )
+
+  public val icon_4078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4078.xml"),
+          )
+      )
+
+  public val icon_4079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4079.xml"),
+          )
+      )
+
+  public val icon_408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_408.xml"),
+          )
+      )
+
+  public val icon_4080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4080.xml"),
+          )
+      )
+
+  public val icon_4081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4081.xml"),
+          )
+      )
+
+  public val icon_4082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4082.xml"),
+          )
+      )
+
+  public val icon_4083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4083.xml"),
+          )
+      )
+
+  public val icon_4084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4084.xml"),
+          )
+      )
+
+  public val icon_4085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4085.xml"),
+          )
+      )
+
+  public val icon_4086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4086.xml"),
+          )
+      )
+
+  public val icon_4087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4087.xml"),
+          )
+      )
+
+  public val icon_4088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4088.xml"),
+          )
+      )
+
+  public val icon_4089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4089.xml"),
+          )
+      )
+
+  public val icon_409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_409.xml"),
+          )
+      )
+
+  public val icon_4090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4090.xml"),
+          )
+      )
+
+  public val icon_4091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4091.xml"),
+          )
+      )
+
+  public val icon_4092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4092.xml"),
+          )
+      )
+
+  public val icon_4093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4093.xml"),
+          )
+      )
+
+  public val icon_4094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4094.xml"),
+          )
+      )
+
+  public val icon_4095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4095.xml"),
+          )
+      )
+
+  public val icon_4096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4096.xml"),
+          )
+      )
+
+  public val icon_4097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4097.xml"),
+          )
+      )
+
+  public val icon_4098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4098.xml"),
+          )
+      )
+
+  public val icon_4099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4099.xml"),
+          )
+      )
+
+  public val icon_41: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_41",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_41.xml"),
+          )
+      )
+
+  public val icon_410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_410.xml"),
+          )
+      )
+
+  public val icon_4100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4100.xml"),
+          )
+      )
+
+  public val icon_4101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4101.xml"),
+          )
+      )
+
+  public val icon_4102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4102.xml"),
+          )
+      )
+
+  public val icon_4103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4103.xml"),
+          )
+      )
+
+  public val icon_4104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4104.xml"),
+          )
+      )
+
+  public val icon_4105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4105.xml"),
+          )
+      )
+
+  public val icon_4106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4106.xml"),
+          )
+      )
+
+  public val icon_4107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4107.xml"),
+          )
+      )
+
+  public val icon_4108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4108.xml"),
+          )
+      )
+
+  public val icon_4109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4109.xml"),
+          )
+      )
+
+  public val icon_411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_411.xml"),
+          )
+      )
+
+  public val icon_4110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4110.xml"),
+          )
+      )
+
+  public val icon_4111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4111.xml"),
+          )
+      )
+
+  public val icon_4112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4112.xml"),
+          )
+      )
+
+  public val icon_4113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4113.xml"),
+          )
+      )
+
+  public val icon_4114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4114.xml"),
+          )
+      )
+
+  public val icon_4115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4115.xml"),
+          )
+      )
+
+  public val icon_4116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4116.xml"),
+          )
+      )
+
+  public val icon_4117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4117.xml"),
+          )
+      )
+
+  public val icon_4118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4118.xml"),
+          )
+      )
+
+  public val icon_4119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4119.xml"),
+          )
+      )
+
+  public val icon_412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_412.xml"),
+          )
+      )
+
+  public val icon_4120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4120.xml"),
+          )
+      )
+
+  public val icon_4121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4121.xml"),
+          )
+      )
+
+  public val icon_4122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4122.xml"),
+          )
+      )
+
+  public val icon_4123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4123.xml"),
+          )
+      )
+
+  public val icon_4124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4124.xml"),
+          )
+      )
+
+  public val icon_4125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4125.xml"),
+          )
+      )
+
+  public val icon_4126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4126.xml"),
+          )
+      )
+
+  public val icon_4127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4127.xml"),
+          )
+      )
+
+  public val icon_4128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4128.xml"),
+          )
+      )
+
+  public val icon_4129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4129.xml"),
+          )
+      )
+
+  public val icon_413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_413.xml"),
+          )
+      )
+
+  public val icon_4130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4130.xml"),
+          )
+      )
+
+  public val icon_4131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4131.xml"),
+          )
+      )
+
+  public val icon_4132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4132.xml"),
+          )
+      )
+
+  public val icon_4133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4133.xml"),
+          )
+      )
+
+  public val icon_4134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4134.xml"),
+          )
+      )
+
+  public val icon_4135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4135.xml"),
+          )
+      )
+
+  public val icon_4136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4136.xml"),
+          )
+      )
+
+  public val icon_4137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4137.xml"),
+          )
+      )
+
+  public val icon_4138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4138.xml"),
+          )
+      )
+
+  public val icon_4139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4139.xml"),
+          )
+      )
+
+  public val icon_414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_414.xml"),
+          )
+      )
+
+  public val icon_4140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4140.xml"),
+          )
+      )
+
+  public val icon_4141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4141.xml"),
+          )
+      )
+
+  public val icon_4142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4142.xml"),
+          )
+      )
+
+  public val icon_4143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4143.xml"),
+          )
+      )
+
+  public val icon_4144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4144.xml"),
+          )
+      )
+
+  public val icon_4145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4145.xml"),
+          )
+      )
+
+  public val icon_4146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4146.xml"),
+          )
+      )
+
+  public val icon_4147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4147.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3699: DrawableResource
+  get() = Drawable36.icon_3699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_37: DrawableResource
+  get() = Drawable36.icon_37
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_370: DrawableResource
+  get() = Drawable36.icon_370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3700: DrawableResource
+  get() = Drawable36.icon_3700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3701: DrawableResource
+  get() = Drawable36.icon_3701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3702: DrawableResource
+  get() = Drawable36.icon_3702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3703: DrawableResource
+  get() = Drawable36.icon_3703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3704: DrawableResource
+  get() = Drawable36.icon_3704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3705: DrawableResource
+  get() = Drawable36.icon_3705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3706: DrawableResource
+  get() = Drawable36.icon_3706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3707: DrawableResource
+  get() = Drawable36.icon_3707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3708: DrawableResource
+  get() = Drawable36.icon_3708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3709: DrawableResource
+  get() = Drawable36.icon_3709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_371: DrawableResource
+  get() = Drawable36.icon_371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3710: DrawableResource
+  get() = Drawable36.icon_3710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3711: DrawableResource
+  get() = Drawable36.icon_3711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3712: DrawableResource
+  get() = Drawable36.icon_3712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3713: DrawableResource
+  get() = Drawable36.icon_3713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3714: DrawableResource
+  get() = Drawable36.icon_3714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3715: DrawableResource
+  get() = Drawable36.icon_3715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3716: DrawableResource
+  get() = Drawable36.icon_3716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3717: DrawableResource
+  get() = Drawable36.icon_3717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3718: DrawableResource
+  get() = Drawable36.icon_3718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3719: DrawableResource
+  get() = Drawable36.icon_3719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_372: DrawableResource
+  get() = Drawable36.icon_372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3720: DrawableResource
+  get() = Drawable36.icon_3720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3721: DrawableResource
+  get() = Drawable36.icon_3721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3722: DrawableResource
+  get() = Drawable36.icon_3722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3723: DrawableResource
+  get() = Drawable36.icon_3723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3724: DrawableResource
+  get() = Drawable36.icon_3724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3725: DrawableResource
+  get() = Drawable36.icon_3725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3726: DrawableResource
+  get() = Drawable36.icon_3726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3727: DrawableResource
+  get() = Drawable36.icon_3727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3728: DrawableResource
+  get() = Drawable36.icon_3728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3729: DrawableResource
+  get() = Drawable36.icon_3729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_373: DrawableResource
+  get() = Drawable36.icon_373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3730: DrawableResource
+  get() = Drawable36.icon_3730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3731: DrawableResource
+  get() = Drawable36.icon_3731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3732: DrawableResource
+  get() = Drawable36.icon_3732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3733: DrawableResource
+  get() = Drawable36.icon_3733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3734: DrawableResource
+  get() = Drawable36.icon_3734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3735: DrawableResource
+  get() = Drawable36.icon_3735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3736: DrawableResource
+  get() = Drawable36.icon_3736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3737: DrawableResource
+  get() = Drawable36.icon_3737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3738: DrawableResource
+  get() = Drawable36.icon_3738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3739: DrawableResource
+  get() = Drawable36.icon_3739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_374: DrawableResource
+  get() = Drawable36.icon_374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3740: DrawableResource
+  get() = Drawable36.icon_3740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3741: DrawableResource
+  get() = Drawable36.icon_3741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3742: DrawableResource
+  get() = Drawable36.icon_3742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3743: DrawableResource
+  get() = Drawable36.icon_3743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3744: DrawableResource
+  get() = Drawable36.icon_3744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3745: DrawableResource
+  get() = Drawable36.icon_3745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3746: DrawableResource
+  get() = Drawable36.icon_3746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3747: DrawableResource
+  get() = Drawable36.icon_3747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3748: DrawableResource
+  get() = Drawable36.icon_3748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3749: DrawableResource
+  get() = Drawable36.icon_3749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_375: DrawableResource
+  get() = Drawable36.icon_375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3750: DrawableResource
+  get() = Drawable36.icon_3750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3751: DrawableResource
+  get() = Drawable36.icon_3751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3752: DrawableResource
+  get() = Drawable36.icon_3752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3753: DrawableResource
+  get() = Drawable36.icon_3753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3754: DrawableResource
+  get() = Drawable36.icon_3754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3755: DrawableResource
+  get() = Drawable36.icon_3755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3756: DrawableResource
+  get() = Drawable36.icon_3756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3757: DrawableResource
+  get() = Drawable36.icon_3757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3758: DrawableResource
+  get() = Drawable36.icon_3758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3759: DrawableResource
+  get() = Drawable36.icon_3759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_376: DrawableResource
+  get() = Drawable36.icon_376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3760: DrawableResource
+  get() = Drawable36.icon_3760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3761: DrawableResource
+  get() = Drawable36.icon_3761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3762: DrawableResource
+  get() = Drawable36.icon_3762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3763: DrawableResource
+  get() = Drawable36.icon_3763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3764: DrawableResource
+  get() = Drawable36.icon_3764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3765: DrawableResource
+  get() = Drawable36.icon_3765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3766: DrawableResource
+  get() = Drawable36.icon_3766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3767: DrawableResource
+  get() = Drawable36.icon_3767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3768: DrawableResource
+  get() = Drawable36.icon_3768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3769: DrawableResource
+  get() = Drawable36.icon_3769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_377: DrawableResource
+  get() = Drawable36.icon_377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3770: DrawableResource
+  get() = Drawable36.icon_3770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3771: DrawableResource
+  get() = Drawable36.icon_3771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3772: DrawableResource
+  get() = Drawable36.icon_3772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3773: DrawableResource
+  get() = Drawable36.icon_3773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3774: DrawableResource
+  get() = Drawable36.icon_3774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3775: DrawableResource
+  get() = Drawable36.icon_3775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3776: DrawableResource
+  get() = Drawable36.icon_3776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3777: DrawableResource
+  get() = Drawable36.icon_3777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3778: DrawableResource
+  get() = Drawable36.icon_3778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3779: DrawableResource
+  get() = Drawable36.icon_3779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_378: DrawableResource
+  get() = Drawable36.icon_378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3780: DrawableResource
+  get() = Drawable36.icon_3780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3781: DrawableResource
+  get() = Drawable36.icon_3781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3782: DrawableResource
+  get() = Drawable36.icon_3782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3783: DrawableResource
+  get() = Drawable36.icon_3783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3784: DrawableResource
+  get() = Drawable36.icon_3784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3785: DrawableResource
+  get() = Drawable36.icon_3785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3786: DrawableResource
+  get() = Drawable36.icon_3786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3787: DrawableResource
+  get() = Drawable36.icon_3787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3788: DrawableResource
+  get() = Drawable36.icon_3788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3789: DrawableResource
+  get() = Drawable36.icon_3789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_379: DrawableResource
+  get() = Drawable36.icon_379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3790: DrawableResource
+  get() = Drawable36.icon_3790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3791: DrawableResource
+  get() = Drawable36.icon_3791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3792: DrawableResource
+  get() = Drawable36.icon_3792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3793: DrawableResource
+  get() = Drawable36.icon_3793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3794: DrawableResource
+  get() = Drawable36.icon_3794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3795: DrawableResource
+  get() = Drawable36.icon_3795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3796: DrawableResource
+  get() = Drawable36.icon_3796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3797: DrawableResource
+  get() = Drawable36.icon_3797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3798: DrawableResource
+  get() = Drawable36.icon_3798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3799: DrawableResource
+  get() = Drawable36.icon_3799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_38: DrawableResource
+  get() = Drawable36.icon_38
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_380: DrawableResource
+  get() = Drawable36.icon_380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3800: DrawableResource
+  get() = Drawable36.icon_3800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3801: DrawableResource
+  get() = Drawable36.icon_3801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3802: DrawableResource
+  get() = Drawable36.icon_3802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3803: DrawableResource
+  get() = Drawable36.icon_3803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3804: DrawableResource
+  get() = Drawable36.icon_3804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3805: DrawableResource
+  get() = Drawable36.icon_3805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3806: DrawableResource
+  get() = Drawable36.icon_3806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3807: DrawableResource
+  get() = Drawable36.icon_3807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3808: DrawableResource
+  get() = Drawable36.icon_3808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3809: DrawableResource
+  get() = Drawable36.icon_3809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_381: DrawableResource
+  get() = Drawable36.icon_381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3810: DrawableResource
+  get() = Drawable36.icon_3810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3811: DrawableResource
+  get() = Drawable36.icon_3811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3812: DrawableResource
+  get() = Drawable36.icon_3812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3813: DrawableResource
+  get() = Drawable36.icon_3813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3814: DrawableResource
+  get() = Drawable36.icon_3814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3815: DrawableResource
+  get() = Drawable36.icon_3815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3816: DrawableResource
+  get() = Drawable36.icon_3816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3817: DrawableResource
+  get() = Drawable36.icon_3817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3818: DrawableResource
+  get() = Drawable36.icon_3818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3819: DrawableResource
+  get() = Drawable36.icon_3819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_382: DrawableResource
+  get() = Drawable36.icon_382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3820: DrawableResource
+  get() = Drawable36.icon_3820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3821: DrawableResource
+  get() = Drawable36.icon_3821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3822: DrawableResource
+  get() = Drawable36.icon_3822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3823: DrawableResource
+  get() = Drawable36.icon_3823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3824: DrawableResource
+  get() = Drawable36.icon_3824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3825: DrawableResource
+  get() = Drawable36.icon_3825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3826: DrawableResource
+  get() = Drawable36.icon_3826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3827: DrawableResource
+  get() = Drawable36.icon_3827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3828: DrawableResource
+  get() = Drawable36.icon_3828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3829: DrawableResource
+  get() = Drawable36.icon_3829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_383: DrawableResource
+  get() = Drawable36.icon_383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3830: DrawableResource
+  get() = Drawable36.icon_3830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3831: DrawableResource
+  get() = Drawable36.icon_3831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3832: DrawableResource
+  get() = Drawable36.icon_3832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3833: DrawableResource
+  get() = Drawable36.icon_3833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3834: DrawableResource
+  get() = Drawable36.icon_3834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3835: DrawableResource
+  get() = Drawable36.icon_3835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3836: DrawableResource
+  get() = Drawable36.icon_3836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3837: DrawableResource
+  get() = Drawable36.icon_3837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3838: DrawableResource
+  get() = Drawable36.icon_3838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3839: DrawableResource
+  get() = Drawable36.icon_3839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_384: DrawableResource
+  get() = Drawable36.icon_384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3840: DrawableResource
+  get() = Drawable36.icon_3840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3841: DrawableResource
+  get() = Drawable36.icon_3841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3842: DrawableResource
+  get() = Drawable36.icon_3842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3843: DrawableResource
+  get() = Drawable36.icon_3843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3844: DrawableResource
+  get() = Drawable36.icon_3844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3845: DrawableResource
+  get() = Drawable36.icon_3845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3846: DrawableResource
+  get() = Drawable36.icon_3846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3847: DrawableResource
+  get() = Drawable36.icon_3847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3848: DrawableResource
+  get() = Drawable36.icon_3848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3849: DrawableResource
+  get() = Drawable36.icon_3849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_385: DrawableResource
+  get() = Drawable36.icon_385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3850: DrawableResource
+  get() = Drawable36.icon_3850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3851: DrawableResource
+  get() = Drawable36.icon_3851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3852: DrawableResource
+  get() = Drawable36.icon_3852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3853: DrawableResource
+  get() = Drawable36.icon_3853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3854: DrawableResource
+  get() = Drawable36.icon_3854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3855: DrawableResource
+  get() = Drawable36.icon_3855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3856: DrawableResource
+  get() = Drawable36.icon_3856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3857: DrawableResource
+  get() = Drawable36.icon_3857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3858: DrawableResource
+  get() = Drawable36.icon_3858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3859: DrawableResource
+  get() = Drawable36.icon_3859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_386: DrawableResource
+  get() = Drawable36.icon_386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3860: DrawableResource
+  get() = Drawable36.icon_3860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3861: DrawableResource
+  get() = Drawable36.icon_3861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3862: DrawableResource
+  get() = Drawable36.icon_3862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3863: DrawableResource
+  get() = Drawable36.icon_3863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3864: DrawableResource
+  get() = Drawable36.icon_3864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3865: DrawableResource
+  get() = Drawable36.icon_3865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3866: DrawableResource
+  get() = Drawable36.icon_3866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3867: DrawableResource
+  get() = Drawable36.icon_3867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3868: DrawableResource
+  get() = Drawable36.icon_3868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3869: DrawableResource
+  get() = Drawable36.icon_3869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_387: DrawableResource
+  get() = Drawable36.icon_387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3870: DrawableResource
+  get() = Drawable36.icon_3870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3871: DrawableResource
+  get() = Drawable36.icon_3871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3872: DrawableResource
+  get() = Drawable36.icon_3872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3873: DrawableResource
+  get() = Drawable36.icon_3873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3874: DrawableResource
+  get() = Drawable36.icon_3874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3875: DrawableResource
+  get() = Drawable36.icon_3875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3876: DrawableResource
+  get() = Drawable36.icon_3876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3877: DrawableResource
+  get() = Drawable36.icon_3877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3878: DrawableResource
+  get() = Drawable36.icon_3878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3879: DrawableResource
+  get() = Drawable36.icon_3879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_388: DrawableResource
+  get() = Drawable36.icon_388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3880: DrawableResource
+  get() = Drawable36.icon_3880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3881: DrawableResource
+  get() = Drawable36.icon_3881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3882: DrawableResource
+  get() = Drawable36.icon_3882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3883: DrawableResource
+  get() = Drawable36.icon_3883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3884: DrawableResource
+  get() = Drawable36.icon_3884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3885: DrawableResource
+  get() = Drawable36.icon_3885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3886: DrawableResource
+  get() = Drawable36.icon_3886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3887: DrawableResource
+  get() = Drawable36.icon_3887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3888: DrawableResource
+  get() = Drawable36.icon_3888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3889: DrawableResource
+  get() = Drawable36.icon_3889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_389: DrawableResource
+  get() = Drawable36.icon_389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3890: DrawableResource
+  get() = Drawable36.icon_3890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3891: DrawableResource
+  get() = Drawable36.icon_3891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3892: DrawableResource
+  get() = Drawable36.icon_3892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3893: DrawableResource
+  get() = Drawable36.icon_3893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3894: DrawableResource
+  get() = Drawable36.icon_3894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3895: DrawableResource
+  get() = Drawable36.icon_3895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3896: DrawableResource
+  get() = Drawable36.icon_3896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3897: DrawableResource
+  get() = Drawable36.icon_3897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3898: DrawableResource
+  get() = Drawable36.icon_3898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3899: DrawableResource
+  get() = Drawable36.icon_3899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_39: DrawableResource
+  get() = Drawable36.icon_39
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_390: DrawableResource
+  get() = Drawable36.icon_390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3900: DrawableResource
+  get() = Drawable36.icon_3900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3901: DrawableResource
+  get() = Drawable36.icon_3901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3902: DrawableResource
+  get() = Drawable36.icon_3902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3903: DrawableResource
+  get() = Drawable36.icon_3903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3904: DrawableResource
+  get() = Drawable36.icon_3904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3905: DrawableResource
+  get() = Drawable36.icon_3905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3906: DrawableResource
+  get() = Drawable36.icon_3906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3907: DrawableResource
+  get() = Drawable36.icon_3907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3908: DrawableResource
+  get() = Drawable36.icon_3908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3909: DrawableResource
+  get() = Drawable36.icon_3909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_391: DrawableResource
+  get() = Drawable36.icon_391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3910: DrawableResource
+  get() = Drawable36.icon_3910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3911: DrawableResource
+  get() = Drawable36.icon_3911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3912: DrawableResource
+  get() = Drawable36.icon_3912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3913: DrawableResource
+  get() = Drawable36.icon_3913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3914: DrawableResource
+  get() = Drawable36.icon_3914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3915: DrawableResource
+  get() = Drawable36.icon_3915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3916: DrawableResource
+  get() = Drawable36.icon_3916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3917: DrawableResource
+  get() = Drawable36.icon_3917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3918: DrawableResource
+  get() = Drawable36.icon_3918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3919: DrawableResource
+  get() = Drawable36.icon_3919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_392: DrawableResource
+  get() = Drawable36.icon_392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3920: DrawableResource
+  get() = Drawable36.icon_3920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3921: DrawableResource
+  get() = Drawable36.icon_3921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3922: DrawableResource
+  get() = Drawable36.icon_3922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3923: DrawableResource
+  get() = Drawable36.icon_3923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3924: DrawableResource
+  get() = Drawable36.icon_3924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3925: DrawableResource
+  get() = Drawable36.icon_3925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3926: DrawableResource
+  get() = Drawable36.icon_3926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3927: DrawableResource
+  get() = Drawable36.icon_3927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3928: DrawableResource
+  get() = Drawable36.icon_3928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3929: DrawableResource
+  get() = Drawable36.icon_3929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_393: DrawableResource
+  get() = Drawable36.icon_393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3930: DrawableResource
+  get() = Drawable36.icon_3930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3931: DrawableResource
+  get() = Drawable36.icon_3931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3932: DrawableResource
+  get() = Drawable36.icon_3932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3933: DrawableResource
+  get() = Drawable36.icon_3933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3934: DrawableResource
+  get() = Drawable36.icon_3934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3935: DrawableResource
+  get() = Drawable36.icon_3935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3936: DrawableResource
+  get() = Drawable36.icon_3936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3937: DrawableResource
+  get() = Drawable36.icon_3937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3938: DrawableResource
+  get() = Drawable36.icon_3938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3939: DrawableResource
+  get() = Drawable36.icon_3939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_394: DrawableResource
+  get() = Drawable36.icon_394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3940: DrawableResource
+  get() = Drawable36.icon_3940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3941: DrawableResource
+  get() = Drawable36.icon_3941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3942: DrawableResource
+  get() = Drawable36.icon_3942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3943: DrawableResource
+  get() = Drawable36.icon_3943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3944: DrawableResource
+  get() = Drawable36.icon_3944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3945: DrawableResource
+  get() = Drawable36.icon_3945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3946: DrawableResource
+  get() = Drawable36.icon_3946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3947: DrawableResource
+  get() = Drawable36.icon_3947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3948: DrawableResource
+  get() = Drawable36.icon_3948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3949: DrawableResource
+  get() = Drawable36.icon_3949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_395: DrawableResource
+  get() = Drawable36.icon_395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3950: DrawableResource
+  get() = Drawable36.icon_3950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3951: DrawableResource
+  get() = Drawable36.icon_3951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3952: DrawableResource
+  get() = Drawable36.icon_3952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3953: DrawableResource
+  get() = Drawable36.icon_3953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3954: DrawableResource
+  get() = Drawable36.icon_3954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3955: DrawableResource
+  get() = Drawable36.icon_3955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3956: DrawableResource
+  get() = Drawable36.icon_3956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3957: DrawableResource
+  get() = Drawable36.icon_3957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3958: DrawableResource
+  get() = Drawable36.icon_3958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3959: DrawableResource
+  get() = Drawable36.icon_3959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_396: DrawableResource
+  get() = Drawable36.icon_396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3960: DrawableResource
+  get() = Drawable36.icon_3960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3961: DrawableResource
+  get() = Drawable36.icon_3961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3962: DrawableResource
+  get() = Drawable36.icon_3962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3963: DrawableResource
+  get() = Drawable36.icon_3963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3964: DrawableResource
+  get() = Drawable36.icon_3964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3965: DrawableResource
+  get() = Drawable36.icon_3965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3966: DrawableResource
+  get() = Drawable36.icon_3966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3967: DrawableResource
+  get() = Drawable36.icon_3967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3968: DrawableResource
+  get() = Drawable36.icon_3968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3969: DrawableResource
+  get() = Drawable36.icon_3969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_397: DrawableResource
+  get() = Drawable36.icon_397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3970: DrawableResource
+  get() = Drawable36.icon_3970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3971: DrawableResource
+  get() = Drawable36.icon_3971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3972: DrawableResource
+  get() = Drawable36.icon_3972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3973: DrawableResource
+  get() = Drawable36.icon_3973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3974: DrawableResource
+  get() = Drawable36.icon_3974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3975: DrawableResource
+  get() = Drawable36.icon_3975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3976: DrawableResource
+  get() = Drawable36.icon_3976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3977: DrawableResource
+  get() = Drawable36.icon_3977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3978: DrawableResource
+  get() = Drawable36.icon_3978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3979: DrawableResource
+  get() = Drawable36.icon_3979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_398: DrawableResource
+  get() = Drawable36.icon_398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3980: DrawableResource
+  get() = Drawable36.icon_3980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3981: DrawableResource
+  get() = Drawable36.icon_3981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3982: DrawableResource
+  get() = Drawable36.icon_3982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3983: DrawableResource
+  get() = Drawable36.icon_3983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3984: DrawableResource
+  get() = Drawable36.icon_3984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3985: DrawableResource
+  get() = Drawable36.icon_3985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3986: DrawableResource
+  get() = Drawable36.icon_3986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3987: DrawableResource
+  get() = Drawable36.icon_3987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3988: DrawableResource
+  get() = Drawable36.icon_3988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3989: DrawableResource
+  get() = Drawable36.icon_3989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_399: DrawableResource
+  get() = Drawable36.icon_399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3990: DrawableResource
+  get() = Drawable36.icon_3990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3991: DrawableResource
+  get() = Drawable36.icon_3991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3992: DrawableResource
+  get() = Drawable36.icon_3992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3993: DrawableResource
+  get() = Drawable36.icon_3993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3994: DrawableResource
+  get() = Drawable36.icon_3994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3995: DrawableResource
+  get() = Drawable36.icon_3995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3996: DrawableResource
+  get() = Drawable36.icon_3996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3997: DrawableResource
+  get() = Drawable36.icon_3997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3998: DrawableResource
+  get() = Drawable36.icon_3998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_3999: DrawableResource
+  get() = Drawable36.icon_3999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4: DrawableResource
+  get() = Drawable36.icon_4
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_40: DrawableResource
+  get() = Drawable36.icon_40
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_400: DrawableResource
+  get() = Drawable36.icon_400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4000: DrawableResource
+  get() = Drawable36.icon_4000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4001: DrawableResource
+  get() = Drawable36.icon_4001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4002: DrawableResource
+  get() = Drawable36.icon_4002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4003: DrawableResource
+  get() = Drawable36.icon_4003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4004: DrawableResource
+  get() = Drawable36.icon_4004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4005: DrawableResource
+  get() = Drawable36.icon_4005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4006: DrawableResource
+  get() = Drawable36.icon_4006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4007: DrawableResource
+  get() = Drawable36.icon_4007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4008: DrawableResource
+  get() = Drawable36.icon_4008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4009: DrawableResource
+  get() = Drawable36.icon_4009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_401: DrawableResource
+  get() = Drawable36.icon_401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4010: DrawableResource
+  get() = Drawable36.icon_4010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4011: DrawableResource
+  get() = Drawable36.icon_4011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4012: DrawableResource
+  get() = Drawable36.icon_4012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4013: DrawableResource
+  get() = Drawable36.icon_4013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4014: DrawableResource
+  get() = Drawable36.icon_4014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4015: DrawableResource
+  get() = Drawable36.icon_4015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4016: DrawableResource
+  get() = Drawable36.icon_4016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4017: DrawableResource
+  get() = Drawable36.icon_4017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4018: DrawableResource
+  get() = Drawable36.icon_4018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4019: DrawableResource
+  get() = Drawable36.icon_4019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_402: DrawableResource
+  get() = Drawable36.icon_402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4020: DrawableResource
+  get() = Drawable36.icon_4020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4021: DrawableResource
+  get() = Drawable36.icon_4021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4022: DrawableResource
+  get() = Drawable36.icon_4022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4023: DrawableResource
+  get() = Drawable36.icon_4023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4024: DrawableResource
+  get() = Drawable36.icon_4024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4025: DrawableResource
+  get() = Drawable36.icon_4025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4026: DrawableResource
+  get() = Drawable36.icon_4026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4027: DrawableResource
+  get() = Drawable36.icon_4027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4028: DrawableResource
+  get() = Drawable36.icon_4028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4029: DrawableResource
+  get() = Drawable36.icon_4029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_403: DrawableResource
+  get() = Drawable36.icon_403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4030: DrawableResource
+  get() = Drawable36.icon_4030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4031: DrawableResource
+  get() = Drawable36.icon_4031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4032: DrawableResource
+  get() = Drawable36.icon_4032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4033: DrawableResource
+  get() = Drawable36.icon_4033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4034: DrawableResource
+  get() = Drawable36.icon_4034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4035: DrawableResource
+  get() = Drawable36.icon_4035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4036: DrawableResource
+  get() = Drawable36.icon_4036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4037: DrawableResource
+  get() = Drawable36.icon_4037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4038: DrawableResource
+  get() = Drawable36.icon_4038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4039: DrawableResource
+  get() = Drawable36.icon_4039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_404: DrawableResource
+  get() = Drawable36.icon_404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4040: DrawableResource
+  get() = Drawable36.icon_4040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4041: DrawableResource
+  get() = Drawable36.icon_4041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4042: DrawableResource
+  get() = Drawable36.icon_4042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4043: DrawableResource
+  get() = Drawable36.icon_4043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4044: DrawableResource
+  get() = Drawable36.icon_4044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4045: DrawableResource
+  get() = Drawable36.icon_4045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4046: DrawableResource
+  get() = Drawable36.icon_4046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4047: DrawableResource
+  get() = Drawable36.icon_4047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4048: DrawableResource
+  get() = Drawable36.icon_4048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4049: DrawableResource
+  get() = Drawable36.icon_4049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_405: DrawableResource
+  get() = Drawable36.icon_405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4050: DrawableResource
+  get() = Drawable36.icon_4050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4051: DrawableResource
+  get() = Drawable36.icon_4051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4052: DrawableResource
+  get() = Drawable36.icon_4052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4053: DrawableResource
+  get() = Drawable36.icon_4053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4054: DrawableResource
+  get() = Drawable36.icon_4054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4055: DrawableResource
+  get() = Drawable36.icon_4055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4056: DrawableResource
+  get() = Drawable36.icon_4056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4057: DrawableResource
+  get() = Drawable36.icon_4057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4058: DrawableResource
+  get() = Drawable36.icon_4058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4059: DrawableResource
+  get() = Drawable36.icon_4059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_406: DrawableResource
+  get() = Drawable36.icon_406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4060: DrawableResource
+  get() = Drawable36.icon_4060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4061: DrawableResource
+  get() = Drawable36.icon_4061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4062: DrawableResource
+  get() = Drawable36.icon_4062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4063: DrawableResource
+  get() = Drawable36.icon_4063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4064: DrawableResource
+  get() = Drawable36.icon_4064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4065: DrawableResource
+  get() = Drawable36.icon_4065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4066: DrawableResource
+  get() = Drawable36.icon_4066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4067: DrawableResource
+  get() = Drawable36.icon_4067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4068: DrawableResource
+  get() = Drawable36.icon_4068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4069: DrawableResource
+  get() = Drawable36.icon_4069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_407: DrawableResource
+  get() = Drawable36.icon_407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4070: DrawableResource
+  get() = Drawable36.icon_4070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4071: DrawableResource
+  get() = Drawable36.icon_4071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4072: DrawableResource
+  get() = Drawable36.icon_4072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4073: DrawableResource
+  get() = Drawable36.icon_4073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4074: DrawableResource
+  get() = Drawable36.icon_4074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4075: DrawableResource
+  get() = Drawable36.icon_4075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4076: DrawableResource
+  get() = Drawable36.icon_4076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4077: DrawableResource
+  get() = Drawable36.icon_4077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4078: DrawableResource
+  get() = Drawable36.icon_4078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4079: DrawableResource
+  get() = Drawable36.icon_4079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_408: DrawableResource
+  get() = Drawable36.icon_408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4080: DrawableResource
+  get() = Drawable36.icon_4080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4081: DrawableResource
+  get() = Drawable36.icon_4081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4082: DrawableResource
+  get() = Drawable36.icon_4082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4083: DrawableResource
+  get() = Drawable36.icon_4083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4084: DrawableResource
+  get() = Drawable36.icon_4084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4085: DrawableResource
+  get() = Drawable36.icon_4085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4086: DrawableResource
+  get() = Drawable36.icon_4086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4087: DrawableResource
+  get() = Drawable36.icon_4087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4088: DrawableResource
+  get() = Drawable36.icon_4088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4089: DrawableResource
+  get() = Drawable36.icon_4089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_409: DrawableResource
+  get() = Drawable36.icon_409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4090: DrawableResource
+  get() = Drawable36.icon_4090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4091: DrawableResource
+  get() = Drawable36.icon_4091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4092: DrawableResource
+  get() = Drawable36.icon_4092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4093: DrawableResource
+  get() = Drawable36.icon_4093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4094: DrawableResource
+  get() = Drawable36.icon_4094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4095: DrawableResource
+  get() = Drawable36.icon_4095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4096: DrawableResource
+  get() = Drawable36.icon_4096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4097: DrawableResource
+  get() = Drawable36.icon_4097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4098: DrawableResource
+  get() = Drawable36.icon_4098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4099: DrawableResource
+  get() = Drawable36.icon_4099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_41: DrawableResource
+  get() = Drawable36.icon_41
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_410: DrawableResource
+  get() = Drawable36.icon_410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4100: DrawableResource
+  get() = Drawable36.icon_4100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4101: DrawableResource
+  get() = Drawable36.icon_4101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4102: DrawableResource
+  get() = Drawable36.icon_4102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4103: DrawableResource
+  get() = Drawable36.icon_4103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4104: DrawableResource
+  get() = Drawable36.icon_4104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4105: DrawableResource
+  get() = Drawable36.icon_4105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4106: DrawableResource
+  get() = Drawable36.icon_4106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4107: DrawableResource
+  get() = Drawable36.icon_4107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4108: DrawableResource
+  get() = Drawable36.icon_4108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4109: DrawableResource
+  get() = Drawable36.icon_4109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_411: DrawableResource
+  get() = Drawable36.icon_411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4110: DrawableResource
+  get() = Drawable36.icon_4110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4111: DrawableResource
+  get() = Drawable36.icon_4111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4112: DrawableResource
+  get() = Drawable36.icon_4112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4113: DrawableResource
+  get() = Drawable36.icon_4113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4114: DrawableResource
+  get() = Drawable36.icon_4114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4115: DrawableResource
+  get() = Drawable36.icon_4115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4116: DrawableResource
+  get() = Drawable36.icon_4116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4117: DrawableResource
+  get() = Drawable36.icon_4117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4118: DrawableResource
+  get() = Drawable36.icon_4118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4119: DrawableResource
+  get() = Drawable36.icon_4119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_412: DrawableResource
+  get() = Drawable36.icon_412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4120: DrawableResource
+  get() = Drawable36.icon_4120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4121: DrawableResource
+  get() = Drawable36.icon_4121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4122: DrawableResource
+  get() = Drawable36.icon_4122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4123: DrawableResource
+  get() = Drawable36.icon_4123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4124: DrawableResource
+  get() = Drawable36.icon_4124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4125: DrawableResource
+  get() = Drawable36.icon_4125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4126: DrawableResource
+  get() = Drawable36.icon_4126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4127: DrawableResource
+  get() = Drawable36.icon_4127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4128: DrawableResource
+  get() = Drawable36.icon_4128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4129: DrawableResource
+  get() = Drawable36.icon_4129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_413: DrawableResource
+  get() = Drawable36.icon_413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4130: DrawableResource
+  get() = Drawable36.icon_4130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4131: DrawableResource
+  get() = Drawable36.icon_4131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4132: DrawableResource
+  get() = Drawable36.icon_4132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4133: DrawableResource
+  get() = Drawable36.icon_4133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4134: DrawableResource
+  get() = Drawable36.icon_4134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4135: DrawableResource
+  get() = Drawable36.icon_4135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4136: DrawableResource
+  get() = Drawable36.icon_4136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4137: DrawableResource
+  get() = Drawable36.icon_4137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4138: DrawableResource
+  get() = Drawable36.icon_4138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4139: DrawableResource
+  get() = Drawable36.icon_4139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_414: DrawableResource
+  get() = Drawable36.icon_414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4140: DrawableResource
+  get() = Drawable36.icon_4140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4141: DrawableResource
+  get() = Drawable36.icon_4141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4142: DrawableResource
+  get() = Drawable36.icon_4142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4143: DrawableResource
+  get() = Drawable36.icon_4143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4144: DrawableResource
+  get() = Drawable36.icon_4144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4145: DrawableResource
+  get() = Drawable36.icon_4145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4146: DrawableResource
+  get() = Drawable36.icon_4146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4147: DrawableResource
+  get() = Drawable36.icon_4147

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable37.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable37.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable37 {
+  public val icon_4148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4148.xml"),
+          )
+      )
+
+  public val icon_4149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4149.xml"),
+          )
+      )
+
+  public val icon_415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_415.xml"),
+          )
+      )
+
+  public val icon_4150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4150.xml"),
+          )
+      )
+
+  public val icon_4151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4151.xml"),
+          )
+      )
+
+  public val icon_4152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4152.xml"),
+          )
+      )
+
+  public val icon_4153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4153.xml"),
+          )
+      )
+
+  public val icon_4154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4154.xml"),
+          )
+      )
+
+  public val icon_4155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4155.xml"),
+          )
+      )
+
+  public val icon_4156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4156.xml"),
+          )
+      )
+
+  public val icon_4157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4157.xml"),
+          )
+      )
+
+  public val icon_4158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4158.xml"),
+          )
+      )
+
+  public val icon_4159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4159.xml"),
+          )
+      )
+
+  public val icon_416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_416.xml"),
+          )
+      )
+
+  public val icon_4160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4160.xml"),
+          )
+      )
+
+  public val icon_4161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4161.xml"),
+          )
+      )
+
+  public val icon_4162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4162.xml"),
+          )
+      )
+
+  public val icon_4163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4163.xml"),
+          )
+      )
+
+  public val icon_4164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4164.xml"),
+          )
+      )
+
+  public val icon_4165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4165.xml"),
+          )
+      )
+
+  public val icon_4166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4166.xml"),
+          )
+      )
+
+  public val icon_4167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4167.xml"),
+          )
+      )
+
+  public val icon_4168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4168.xml"),
+          )
+      )
+
+  public val icon_4169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4169.xml"),
+          )
+      )
+
+  public val icon_417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_417.xml"),
+          )
+      )
+
+  public val icon_4170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4170.xml"),
+          )
+      )
+
+  public val icon_4171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4171.xml"),
+          )
+      )
+
+  public val icon_4172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4172.xml"),
+          )
+      )
+
+  public val icon_4173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4173.xml"),
+          )
+      )
+
+  public val icon_4174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4174.xml"),
+          )
+      )
+
+  public val icon_4175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4175.xml"),
+          )
+      )
+
+  public val icon_4176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4176.xml"),
+          )
+      )
+
+  public val icon_4177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4177.xml"),
+          )
+      )
+
+  public val icon_4178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4178.xml"),
+          )
+      )
+
+  public val icon_4179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4179.xml"),
+          )
+      )
+
+  public val icon_418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_418.xml"),
+          )
+      )
+
+  public val icon_4180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4180.xml"),
+          )
+      )
+
+  public val icon_4181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4181.xml"),
+          )
+      )
+
+  public val icon_4182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4182.xml"),
+          )
+      )
+
+  public val icon_4183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4183.xml"),
+          )
+      )
+
+  public val icon_4184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4184.xml"),
+          )
+      )
+
+  public val icon_4185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4185.xml"),
+          )
+      )
+
+  public val icon_4186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4186.xml"),
+          )
+      )
+
+  public val icon_4187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4187.xml"),
+          )
+      )
+
+  public val icon_4188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4188.xml"),
+          )
+      )
+
+  public val icon_4189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4189.xml"),
+          )
+      )
+
+  public val icon_419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_419.xml"),
+          )
+      )
+
+  public val icon_4190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4190.xml"),
+          )
+      )
+
+  public val icon_4191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4191.xml"),
+          )
+      )
+
+  public val icon_4192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4192.xml"),
+          )
+      )
+
+  public val icon_4193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4193.xml"),
+          )
+      )
+
+  public val icon_4194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4194.xml"),
+          )
+      )
+
+  public val icon_4195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4195.xml"),
+          )
+      )
+
+  public val icon_4196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4196.xml"),
+          )
+      )
+
+  public val icon_4197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4197.xml"),
+          )
+      )
+
+  public val icon_4198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4198.xml"),
+          )
+      )
+
+  public val icon_4199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4199.xml"),
+          )
+      )
+
+  public val icon_42: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_42",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_42.xml"),
+          )
+      )
+
+  public val icon_420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_420.xml"),
+          )
+      )
+
+  public val icon_4200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4200.xml"),
+          )
+      )
+
+  public val icon_4201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4201.xml"),
+          )
+      )
+
+  public val icon_4202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4202.xml"),
+          )
+      )
+
+  public val icon_4203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4203.xml"),
+          )
+      )
+
+  public val icon_4204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4204.xml"),
+          )
+      )
+
+  public val icon_4205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4205.xml"),
+          )
+      )
+
+  public val icon_4206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4206.xml"),
+          )
+      )
+
+  public val icon_4207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4207.xml"),
+          )
+      )
+
+  public val icon_4208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4208.xml"),
+          )
+      )
+
+  public val icon_4209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4209.xml"),
+          )
+      )
+
+  public val icon_421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_421.xml"),
+          )
+      )
+
+  public val icon_4210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4210.xml"),
+          )
+      )
+
+  public val icon_4211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4211.xml"),
+          )
+      )
+
+  public val icon_4212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4212.xml"),
+          )
+      )
+
+  public val icon_4213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4213.xml"),
+          )
+      )
+
+  public val icon_4214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4214.xml"),
+          )
+      )
+
+  public val icon_4215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4215.xml"),
+          )
+      )
+
+  public val icon_4216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4216.xml"),
+          )
+      )
+
+  public val icon_4217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4217.xml"),
+          )
+      )
+
+  public val icon_4218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4218.xml"),
+          )
+      )
+
+  public val icon_4219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4219.xml"),
+          )
+      )
+
+  public val icon_422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_422.xml"),
+          )
+      )
+
+  public val icon_4220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4220.xml"),
+          )
+      )
+
+  public val icon_4221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4221.xml"),
+          )
+      )
+
+  public val icon_4222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4222.xml"),
+          )
+      )
+
+  public val icon_4223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4223.xml"),
+          )
+      )
+
+  public val icon_4224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4224.xml"),
+          )
+      )
+
+  public val icon_4225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4225.xml"),
+          )
+      )
+
+  public val icon_4226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4226.xml"),
+          )
+      )
+
+  public val icon_4227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4227.xml"),
+          )
+      )
+
+  public val icon_4228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4228.xml"),
+          )
+      )
+
+  public val icon_4229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4229.xml"),
+          )
+      )
+
+  public val icon_423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_423.xml"),
+          )
+      )
+
+  public val icon_4230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4230.xml"),
+          )
+      )
+
+  public val icon_4231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4231.xml"),
+          )
+      )
+
+  public val icon_4232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4232.xml"),
+          )
+      )
+
+  public val icon_4233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4233.xml"),
+          )
+      )
+
+  public val icon_4234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4234.xml"),
+          )
+      )
+
+  public val icon_4235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4235.xml"),
+          )
+      )
+
+  public val icon_4236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4236.xml"),
+          )
+      )
+
+  public val icon_4237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4237.xml"),
+          )
+      )
+
+  public val icon_4238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4238.xml"),
+          )
+      )
+
+  public val icon_4239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4239.xml"),
+          )
+      )
+
+  public val icon_424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_424.xml"),
+          )
+      )
+
+  public val icon_4240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4240.xml"),
+          )
+      )
+
+  public val icon_4241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4241.xml"),
+          )
+      )
+
+  public val icon_4242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4242.xml"),
+          )
+      )
+
+  public val icon_4243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4243.xml"),
+          )
+      )
+
+  public val icon_4244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4244.xml"),
+          )
+      )
+
+  public val icon_4245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4245.xml"),
+          )
+      )
+
+  public val icon_4246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4246.xml"),
+          )
+      )
+
+  public val icon_4247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4247.xml"),
+          )
+      )
+
+  public val icon_4248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4248.xml"),
+          )
+      )
+
+  public val icon_4249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4249.xml"),
+          )
+      )
+
+  public val icon_425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_425.xml"),
+          )
+      )
+
+  public val icon_4250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4250.xml"),
+          )
+      )
+
+  public val icon_4251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4251.xml"),
+          )
+      )
+
+  public val icon_4252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4252.xml"),
+          )
+      )
+
+  public val icon_4253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4253.xml"),
+          )
+      )
+
+  public val icon_4254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4254.xml"),
+          )
+      )
+
+  public val icon_4255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4255.xml"),
+          )
+      )
+
+  public val icon_4256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4256.xml"),
+          )
+      )
+
+  public val icon_4257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4257.xml"),
+          )
+      )
+
+  public val icon_4258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4258.xml"),
+          )
+      )
+
+  public val icon_4259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4259.xml"),
+          )
+      )
+
+  public val icon_426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_426.xml"),
+          )
+      )
+
+  public val icon_4260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4260.xml"),
+          )
+      )
+
+  public val icon_4261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4261.xml"),
+          )
+      )
+
+  public val icon_4262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4262.xml"),
+          )
+      )
+
+  public val icon_4263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4263.xml"),
+          )
+      )
+
+  public val icon_4264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4264.xml"),
+          )
+      )
+
+  public val icon_4265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4265.xml"),
+          )
+      )
+
+  public val icon_4266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4266.xml"),
+          )
+      )
+
+  public val icon_4267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4267.xml"),
+          )
+      )
+
+  public val icon_4268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4268.xml"),
+          )
+      )
+
+  public val icon_4269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4269.xml"),
+          )
+      )
+
+  public val icon_427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_427.xml"),
+          )
+      )
+
+  public val icon_4270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4270.xml"),
+          )
+      )
+
+  public val icon_4271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4271.xml"),
+          )
+      )
+
+  public val icon_4272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4272.xml"),
+          )
+      )
+
+  public val icon_4273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4273.xml"),
+          )
+      )
+
+  public val icon_4274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4274.xml"),
+          )
+      )
+
+  public val icon_4275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4275.xml"),
+          )
+      )
+
+  public val icon_4276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4276.xml"),
+          )
+      )
+
+  public val icon_4277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4277.xml"),
+          )
+      )
+
+  public val icon_4278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4278.xml"),
+          )
+      )
+
+  public val icon_4279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4279.xml"),
+          )
+      )
+
+  public val icon_428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_428.xml"),
+          )
+      )
+
+  public val icon_4280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4280.xml"),
+          )
+      )
+
+  public val icon_4281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4281.xml"),
+          )
+      )
+
+  public val icon_4282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4282.xml"),
+          )
+      )
+
+  public val icon_4283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4283.xml"),
+          )
+      )
+
+  public val icon_4284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4284.xml"),
+          )
+      )
+
+  public val icon_4285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4285.xml"),
+          )
+      )
+
+  public val icon_4286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4286.xml"),
+          )
+      )
+
+  public val icon_4287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4287.xml"),
+          )
+      )
+
+  public val icon_4288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4288.xml"),
+          )
+      )
+
+  public val icon_4289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4289.xml"),
+          )
+      )
+
+  public val icon_429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_429.xml"),
+          )
+      )
+
+  public val icon_4290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4290.xml"),
+          )
+      )
+
+  public val icon_4291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4291.xml"),
+          )
+      )
+
+  public val icon_4292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4292.xml"),
+          )
+      )
+
+  public val icon_4293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4293.xml"),
+          )
+      )
+
+  public val icon_4294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4294.xml"),
+          )
+      )
+
+  public val icon_4295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4295.xml"),
+          )
+      )
+
+  public val icon_4296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4296.xml"),
+          )
+      )
+
+  public val icon_4297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4297.xml"),
+          )
+      )
+
+  public val icon_4298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4298.xml"),
+          )
+      )
+
+  public val icon_4299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4299.xml"),
+          )
+      )
+
+  public val icon_43: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_43",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_43.xml"),
+          )
+      )
+
+  public val icon_430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_430.xml"),
+          )
+      )
+
+  public val icon_4300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4300.xml"),
+          )
+      )
+
+  public val icon_4301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4301.xml"),
+          )
+      )
+
+  public val icon_4302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4302.xml"),
+          )
+      )
+
+  public val icon_4303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4303.xml"),
+          )
+      )
+
+  public val icon_4304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4304.xml"),
+          )
+      )
+
+  public val icon_4305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4305.xml"),
+          )
+      )
+
+  public val icon_4306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4306.xml"),
+          )
+      )
+
+  public val icon_4307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4307.xml"),
+          )
+      )
+
+  public val icon_4308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4308.xml"),
+          )
+      )
+
+  public val icon_4309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4309.xml"),
+          )
+      )
+
+  public val icon_431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_431.xml"),
+          )
+      )
+
+  public val icon_4310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4310.xml"),
+          )
+      )
+
+  public val icon_4311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4311.xml"),
+          )
+      )
+
+  public val icon_4312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4312.xml"),
+          )
+      )
+
+  public val icon_4313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4313.xml"),
+          )
+      )
+
+  public val icon_4314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4314.xml"),
+          )
+      )
+
+  public val icon_4315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4315.xml"),
+          )
+      )
+
+  public val icon_4316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4316.xml"),
+          )
+      )
+
+  public val icon_4317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4317.xml"),
+          )
+      )
+
+  public val icon_4318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4318.xml"),
+          )
+      )
+
+  public val icon_4319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4319.xml"),
+          )
+      )
+
+  public val icon_432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_432.xml"),
+          )
+      )
+
+  public val icon_4320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4320.xml"),
+          )
+      )
+
+  public val icon_4321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4321.xml"),
+          )
+      )
+
+  public val icon_4322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4322.xml"),
+          )
+      )
+
+  public val icon_4323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4323.xml"),
+          )
+      )
+
+  public val icon_4324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4324.xml"),
+          )
+      )
+
+  public val icon_4325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4325.xml"),
+          )
+      )
+
+  public val icon_4326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4326.xml"),
+          )
+      )
+
+  public val icon_4327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4327.xml"),
+          )
+      )
+
+  public val icon_4328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4328.xml"),
+          )
+      )
+
+  public val icon_4329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4329.xml"),
+          )
+      )
+
+  public val icon_433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_433.xml"),
+          )
+      )
+
+  public val icon_4330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4330.xml"),
+          )
+      )
+
+  public val icon_4331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4331.xml"),
+          )
+      )
+
+  public val icon_4332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4332.xml"),
+          )
+      )
+
+  public val icon_4333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4333.xml"),
+          )
+      )
+
+  public val icon_4334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4334.xml"),
+          )
+      )
+
+  public val icon_4335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4335.xml"),
+          )
+      )
+
+  public val icon_4336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4336.xml"),
+          )
+      )
+
+  public val icon_4337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4337.xml"),
+          )
+      )
+
+  public val icon_4338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4338.xml"),
+          )
+      )
+
+  public val icon_4339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4339.xml"),
+          )
+      )
+
+  public val icon_434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_434.xml"),
+          )
+      )
+
+  public val icon_4340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4340.xml"),
+          )
+      )
+
+  public val icon_4341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4341.xml"),
+          )
+      )
+
+  public val icon_4342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4342.xml"),
+          )
+      )
+
+  public val icon_4343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4343.xml"),
+          )
+      )
+
+  public val icon_4344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4344.xml"),
+          )
+      )
+
+  public val icon_4345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4345.xml"),
+          )
+      )
+
+  public val icon_4346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4346.xml"),
+          )
+      )
+
+  public val icon_4347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4347.xml"),
+          )
+      )
+
+  public val icon_4348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4348.xml"),
+          )
+      )
+
+  public val icon_4349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4349.xml"),
+          )
+      )
+
+  public val icon_435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_435.xml"),
+          )
+      )
+
+  public val icon_4350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4350.xml"),
+          )
+      )
+
+  public val icon_4351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4351.xml"),
+          )
+      )
+
+  public val icon_4352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4352.xml"),
+          )
+      )
+
+  public val icon_4353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4353.xml"),
+          )
+      )
+
+  public val icon_4354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4354.xml"),
+          )
+      )
+
+  public val icon_4355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4355.xml"),
+          )
+      )
+
+  public val icon_4356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4356.xml"),
+          )
+      )
+
+  public val icon_4357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4357.xml"),
+          )
+      )
+
+  public val icon_4358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4358.xml"),
+          )
+      )
+
+  public val icon_4359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4359.xml"),
+          )
+      )
+
+  public val icon_436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_436.xml"),
+          )
+      )
+
+  public val icon_4360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4360.xml"),
+          )
+      )
+
+  public val icon_4361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4361.xml"),
+          )
+      )
+
+  public val icon_4362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4362.xml"),
+          )
+      )
+
+  public val icon_4363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4363.xml"),
+          )
+      )
+
+  public val icon_4364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4364.xml"),
+          )
+      )
+
+  public val icon_4365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4365.xml"),
+          )
+      )
+
+  public val icon_4366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4366.xml"),
+          )
+      )
+
+  public val icon_4367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4367.xml"),
+          )
+      )
+
+  public val icon_4368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4368.xml"),
+          )
+      )
+
+  public val icon_4369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4369.xml"),
+          )
+      )
+
+  public val icon_437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_437.xml"),
+          )
+      )
+
+  public val icon_4370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4370.xml"),
+          )
+      )
+
+  public val icon_4371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4371.xml"),
+          )
+      )
+
+  public val icon_4372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4372.xml"),
+          )
+      )
+
+  public val icon_4373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4373.xml"),
+          )
+      )
+
+  public val icon_4374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4374.xml"),
+          )
+      )
+
+  public val icon_4375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4375.xml"),
+          )
+      )
+
+  public val icon_4376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4376.xml"),
+          )
+      )
+
+  public val icon_4377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4377.xml"),
+          )
+      )
+
+  public val icon_4378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4378.xml"),
+          )
+      )
+
+  public val icon_4379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4379.xml"),
+          )
+      )
+
+  public val icon_438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_438.xml"),
+          )
+      )
+
+  public val icon_4380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4380.xml"),
+          )
+      )
+
+  public val icon_4381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4381.xml"),
+          )
+      )
+
+  public val icon_4382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4382.xml"),
+          )
+      )
+
+  public val icon_4383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4383.xml"),
+          )
+      )
+
+  public val icon_4384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4384.xml"),
+          )
+      )
+
+  public val icon_4385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4385.xml"),
+          )
+      )
+
+  public val icon_4386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4386.xml"),
+          )
+      )
+
+  public val icon_4387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4387.xml"),
+          )
+      )
+
+  public val icon_4388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4388.xml"),
+          )
+      )
+
+  public val icon_4389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4389.xml"),
+          )
+      )
+
+  public val icon_439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_439.xml"),
+          )
+      )
+
+  public val icon_4390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4390.xml"),
+          )
+      )
+
+  public val icon_4391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4391.xml"),
+          )
+      )
+
+  public val icon_4392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4392.xml"),
+          )
+      )
+
+  public val icon_4393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4393.xml"),
+          )
+      )
+
+  public val icon_4394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4394.xml"),
+          )
+      )
+
+  public val icon_4395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4395.xml"),
+          )
+      )
+
+  public val icon_4396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4396.xml"),
+          )
+      )
+
+  public val icon_4397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4397.xml"),
+          )
+      )
+
+  public val icon_4398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4398.xml"),
+          )
+      )
+
+  public val icon_4399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4399.xml"),
+          )
+      )
+
+  public val icon_44: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_44",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_44.xml"),
+          )
+      )
+
+  public val icon_440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_440.xml"),
+          )
+      )
+
+  public val icon_4400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4400.xml"),
+          )
+      )
+
+  public val icon_4401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4401.xml"),
+          )
+      )
+
+  public val icon_4402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4402.xml"),
+          )
+      )
+
+  public val icon_4403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4403.xml"),
+          )
+      )
+
+  public val icon_4404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4404.xml"),
+          )
+      )
+
+  public val icon_4405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4405.xml"),
+          )
+      )
+
+  public val icon_4406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4406.xml"),
+          )
+      )
+
+  public val icon_4407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4407.xml"),
+          )
+      )
+
+  public val icon_4408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4408.xml"),
+          )
+      )
+
+  public val icon_4409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4409.xml"),
+          )
+      )
+
+  public val icon_441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_441.xml"),
+          )
+      )
+
+  public val icon_4410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4410.xml"),
+          )
+      )
+
+  public val icon_4411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4411.xml"),
+          )
+      )
+
+  public val icon_4412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4412.xml"),
+          )
+      )
+
+  public val icon_4413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4413.xml"),
+          )
+      )
+
+  public val icon_4414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4414.xml"),
+          )
+      )
+
+  public val icon_4415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4415.xml"),
+          )
+      )
+
+  public val icon_4416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4416.xml"),
+          )
+      )
+
+  public val icon_4417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4417.xml"),
+          )
+      )
+
+  public val icon_4418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4418.xml"),
+          )
+      )
+
+  public val icon_4419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4419.xml"),
+          )
+      )
+
+  public val icon_442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_442.xml"),
+          )
+      )
+
+  public val icon_4420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4420.xml"),
+          )
+      )
+
+  public val icon_4421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4421.xml"),
+          )
+      )
+
+  public val icon_4422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4422.xml"),
+          )
+      )
+
+  public val icon_4423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4423.xml"),
+          )
+      )
+
+  public val icon_4424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4424.xml"),
+          )
+      )
+
+  public val icon_4425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4425.xml"),
+          )
+      )
+
+  public val icon_4426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4426.xml"),
+          )
+      )
+
+  public val icon_4427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4427.xml"),
+          )
+      )
+
+  public val icon_4428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4428.xml"),
+          )
+      )
+
+  public val icon_4429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4429.xml"),
+          )
+      )
+
+  public val icon_443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_443.xml"),
+          )
+      )
+
+  public val icon_4430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4430.xml"),
+          )
+      )
+
+  public val icon_4431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4431.xml"),
+          )
+      )
+
+  public val icon_4432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4432.xml"),
+          )
+      )
+
+  public val icon_4433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4433.xml"),
+          )
+      )
+
+  public val icon_4434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4434.xml"),
+          )
+      )
+
+  public val icon_4435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4435.xml"),
+          )
+      )
+
+  public val icon_4436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4436.xml"),
+          )
+      )
+
+  public val icon_4437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4437.xml"),
+          )
+      )
+
+  public val icon_4438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4438.xml"),
+          )
+      )
+
+  public val icon_4439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4439.xml"),
+          )
+      )
+
+  public val icon_444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_444.xml"),
+          )
+      )
+
+  public val icon_4440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4440.xml"),
+          )
+      )
+
+  public val icon_4441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4441.xml"),
+          )
+      )
+
+  public val icon_4442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4442.xml"),
+          )
+      )
+
+  public val icon_4443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4443.xml"),
+          )
+      )
+
+  public val icon_4444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4444.xml"),
+          )
+      )
+
+  public val icon_4445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4445.xml"),
+          )
+      )
+
+  public val icon_4446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4446.xml"),
+          )
+      )
+
+  public val icon_4447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4447.xml"),
+          )
+      )
+
+  public val icon_4448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4448.xml"),
+          )
+      )
+
+  public val icon_4449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4449.xml"),
+          )
+      )
+
+  public val icon_445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_445.xml"),
+          )
+      )
+
+  public val icon_4450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4450.xml"),
+          )
+      )
+
+  public val icon_4451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4451.xml"),
+          )
+      )
+
+  public val icon_4452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4452.xml"),
+          )
+      )
+
+  public val icon_4453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4453.xml"),
+          )
+      )
+
+  public val icon_4454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4454.xml"),
+          )
+      )
+
+  public val icon_4455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4455.xml"),
+          )
+      )
+
+  public val icon_4456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4456.xml"),
+          )
+      )
+
+  public val icon_4457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4457.xml"),
+          )
+      )
+
+  public val icon_4458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4458.xml"),
+          )
+      )
+
+  public val icon_4459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4459.xml"),
+          )
+      )
+
+  public val icon_446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_446.xml"),
+          )
+      )
+
+  public val icon_4460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4460.xml"),
+          )
+      )
+
+  public val icon_4461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4461.xml"),
+          )
+      )
+
+  public val icon_4462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4462.xml"),
+          )
+      )
+
+  public val icon_4463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4463.xml"),
+          )
+      )
+
+  public val icon_4464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4464.xml"),
+          )
+      )
+
+  public val icon_4465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4465.xml"),
+          )
+      )
+
+  public val icon_4466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4466.xml"),
+          )
+      )
+
+  public val icon_4467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4467.xml"),
+          )
+      )
+
+  public val icon_4468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4468.xml"),
+          )
+      )
+
+  public val icon_4469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4469.xml"),
+          )
+      )
+
+  public val icon_447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_447.xml"),
+          )
+      )
+
+  public val icon_4470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4470.xml"),
+          )
+      )
+
+  public val icon_4471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4471.xml"),
+          )
+      )
+
+  public val icon_4472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4472.xml"),
+          )
+      )
+
+  public val icon_4473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4473.xml"),
+          )
+      )
+
+  public val icon_4474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4474.xml"),
+          )
+      )
+
+  public val icon_4475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4475.xml"),
+          )
+      )
+
+  public val icon_4476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4476.xml"),
+          )
+      )
+
+  public val icon_4477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4477.xml"),
+          )
+      )
+
+  public val icon_4478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4478.xml"),
+          )
+      )
+
+  public val icon_4479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4479.xml"),
+          )
+      )
+
+  public val icon_448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_448.xml"),
+          )
+      )
+
+  public val icon_4480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4480.xml"),
+          )
+      )
+
+  public val icon_4481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4481.xml"),
+          )
+      )
+
+  public val icon_4482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4482.xml"),
+          )
+      )
+
+  public val icon_4483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4483.xml"),
+          )
+      )
+
+  public val icon_4484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4484.xml"),
+          )
+      )
+
+  public val icon_4485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4485.xml"),
+          )
+      )
+
+  public val icon_4486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4486.xml"),
+          )
+      )
+
+  public val icon_4487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4487.xml"),
+          )
+      )
+
+  public val icon_4488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4488.xml"),
+          )
+      )
+
+  public val icon_4489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4489.xml"),
+          )
+      )
+
+  public val icon_449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_449.xml"),
+          )
+      )
+
+  public val icon_4490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4490.xml"),
+          )
+      )
+
+  public val icon_4491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4491.xml"),
+          )
+      )
+
+  public val icon_4492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4492.xml"),
+          )
+      )
+
+  public val icon_4493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4493.xml"),
+          )
+      )
+
+  public val icon_4494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4494.xml"),
+          )
+      )
+
+  public val icon_4495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4495.xml"),
+          )
+      )
+
+  public val icon_4496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4496.xml"),
+          )
+      )
+
+  public val icon_4497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4497.xml"),
+          )
+      )
+
+  public val icon_4498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4498.xml"),
+          )
+      )
+
+  public val icon_4499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4499.xml"),
+          )
+      )
+
+  public val icon_45: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_45",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_45.xml"),
+          )
+      )
+
+  public val icon_450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_450.xml"),
+          )
+      )
+
+  public val icon_4500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4500.xml"),
+          )
+      )
+
+  public val icon_4501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4501.xml"),
+          )
+      )
+
+  public val icon_4502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4502.xml"),
+          )
+      )
+
+  public val icon_4503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4503.xml"),
+          )
+      )
+
+  public val icon_4504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4504.xml"),
+          )
+      )
+
+  public val icon_4505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4505.xml"),
+          )
+      )
+
+  public val icon_4506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4506.xml"),
+          )
+      )
+
+  public val icon_4507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4507.xml"),
+          )
+      )
+
+  public val icon_4508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4508.xml"),
+          )
+      )
+
+  public val icon_4509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4509.xml"),
+          )
+      )
+
+  public val icon_451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_451.xml"),
+          )
+      )
+
+  public val icon_4510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4510.xml"),
+          )
+      )
+
+  public val icon_4511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4511.xml"),
+          )
+      )
+
+  public val icon_4512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4512.xml"),
+          )
+      )
+
+  public val icon_4513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4513.xml"),
+          )
+      )
+
+  public val icon_4514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4514.xml"),
+          )
+      )
+
+  public val icon_4515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4515.xml"),
+          )
+      )
+
+  public val icon_4516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4516.xml"),
+          )
+      )
+
+  public val icon_4517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4517.xml"),
+          )
+      )
+
+  public val icon_4518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4518.xml"),
+          )
+      )
+
+  public val icon_4519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4519.xml"),
+          )
+      )
+
+  public val icon_452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_452.xml"),
+          )
+      )
+
+  public val icon_4520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4520.xml"),
+          )
+      )
+
+  public val icon_4521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4521.xml"),
+          )
+      )
+
+  public val icon_4522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4522.xml"),
+          )
+      )
+
+  public val icon_4523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4523.xml"),
+          )
+      )
+
+  public val icon_4524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4524.xml"),
+          )
+      )
+
+  public val icon_4525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4525.xml"),
+          )
+      )
+
+  public val icon_4526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4526.xml"),
+          )
+      )
+
+  public val icon_4527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4527.xml"),
+          )
+      )
+
+  public val icon_4528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4528.xml"),
+          )
+      )
+
+  public val icon_4529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4529.xml"),
+          )
+      )
+
+  public val icon_453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_453.xml"),
+          )
+      )
+
+  public val icon_4530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4530.xml"),
+          )
+      )
+
+  public val icon_4531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4531.xml"),
+          )
+      )
+
+  public val icon_4532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4532.xml"),
+          )
+      )
+
+  public val icon_4533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4533.xml"),
+          )
+      )
+
+  public val icon_4534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4534.xml"),
+          )
+      )
+
+  public val icon_4535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4535.xml"),
+          )
+      )
+
+  public val icon_4536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4536.xml"),
+          )
+      )
+
+  public val icon_4537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4537.xml"),
+          )
+      )
+
+  public val icon_4538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4538.xml"),
+          )
+      )
+
+  public val icon_4539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4539.xml"),
+          )
+      )
+
+  public val icon_454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_454.xml"),
+          )
+      )
+
+  public val icon_4540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4540.xml"),
+          )
+      )
+
+  public val icon_4541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4541.xml"),
+          )
+      )
+
+  public val icon_4542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4542.xml"),
+          )
+      )
+
+  public val icon_4543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4543.xml"),
+          )
+      )
+
+  public val icon_4544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4544.xml"),
+          )
+      )
+
+  public val icon_4545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4545.xml"),
+          )
+      )
+
+  public val icon_4546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4546.xml"),
+          )
+      )
+
+  public val icon_4547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4547.xml"),
+          )
+      )
+
+  public val icon_4548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4548.xml"),
+          )
+      )
+
+  public val icon_4549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4549.xml"),
+          )
+      )
+
+  public val icon_455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_455.xml"),
+          )
+      )
+
+  public val icon_4550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4550.xml"),
+          )
+      )
+
+  public val icon_4551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4551.xml"),
+          )
+      )
+
+  public val icon_4552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4552.xml"),
+          )
+      )
+
+  public val icon_4553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4553.xml"),
+          )
+      )
+
+  public val icon_4554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4554.xml"),
+          )
+      )
+
+  public val icon_4555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4555.xml"),
+          )
+      )
+
+  public val icon_4556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4556.xml"),
+          )
+      )
+
+  public val icon_4557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4557.xml"),
+          )
+      )
+
+  public val icon_4558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4558.xml"),
+          )
+      )
+
+  public val icon_4559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4559.xml"),
+          )
+      )
+
+  public val icon_456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_456.xml"),
+          )
+      )
+
+  public val icon_4560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4560.xml"),
+          )
+      )
+
+  public val icon_4561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4561.xml"),
+          )
+      )
+
+  public val icon_4562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4562.xml"),
+          )
+      )
+
+  public val icon_4563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4563.xml"),
+          )
+      )
+
+  public val icon_4564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4564.xml"),
+          )
+      )
+
+  public val icon_4565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4565.xml"),
+          )
+      )
+
+  public val icon_4566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4566.xml"),
+          )
+      )
+
+  public val icon_4567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4567.xml"),
+          )
+      )
+
+  public val icon_4568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4568.xml"),
+          )
+      )
+
+  public val icon_4569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4569.xml"),
+          )
+      )
+
+  public val icon_457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_457.xml"),
+          )
+      )
+
+  public val icon_4570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4570.xml"),
+          )
+      )
+
+  public val icon_4571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4571.xml"),
+          )
+      )
+
+  public val icon_4572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4572.xml"),
+          )
+      )
+
+  public val icon_4573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4573.xml"),
+          )
+      )
+
+  public val icon_4574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4574.xml"),
+          )
+      )
+
+  public val icon_4575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4575.xml"),
+          )
+      )
+
+  public val icon_4576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4576.xml"),
+          )
+      )
+
+  public val icon_4577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4577.xml"),
+          )
+      )
+
+  public val icon_4578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4578.xml"),
+          )
+      )
+
+  public val icon_4579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4579.xml"),
+          )
+      )
+
+  public val icon_458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_458.xml"),
+          )
+      )
+
+  public val icon_4580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4580.xml"),
+          )
+      )
+
+  public val icon_4581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4581.xml"),
+          )
+      )
+
+  public val icon_4582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4582.xml"),
+          )
+      )
+
+  public val icon_4583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4583.xml"),
+          )
+      )
+
+  public val icon_4584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4584.xml"),
+          )
+      )
+
+  public val icon_4585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4585.xml"),
+          )
+      )
+
+  public val icon_4586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4586.xml"),
+          )
+      )
+
+  public val icon_4587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4587.xml"),
+          )
+      )
+
+  public val icon_4588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4588.xml"),
+          )
+      )
+
+  public val icon_4589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4589.xml"),
+          )
+      )
+
+  public val icon_459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_459.xml"),
+          )
+      )
+
+  public val icon_4590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4590.xml"),
+          )
+      )
+
+  public val icon_4591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4591.xml"),
+          )
+      )
+
+  public val icon_4592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4592.xml"),
+          )
+      )
+
+  public val icon_4593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4593.xml"),
+          )
+      )
+
+  public val icon_4594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4594.xml"),
+          )
+      )
+
+  public val icon_4595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4595.xml"),
+          )
+      )
+
+  public val icon_4596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4596.xml"),
+          )
+      )
+
+  public val icon_4597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4597.xml"),
+          )
+      )
+
+  public val icon_4598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4598.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4148: DrawableResource
+  get() = Drawable37.icon_4148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4149: DrawableResource
+  get() = Drawable37.icon_4149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_415: DrawableResource
+  get() = Drawable37.icon_415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4150: DrawableResource
+  get() = Drawable37.icon_4150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4151: DrawableResource
+  get() = Drawable37.icon_4151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4152: DrawableResource
+  get() = Drawable37.icon_4152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4153: DrawableResource
+  get() = Drawable37.icon_4153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4154: DrawableResource
+  get() = Drawable37.icon_4154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4155: DrawableResource
+  get() = Drawable37.icon_4155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4156: DrawableResource
+  get() = Drawable37.icon_4156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4157: DrawableResource
+  get() = Drawable37.icon_4157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4158: DrawableResource
+  get() = Drawable37.icon_4158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4159: DrawableResource
+  get() = Drawable37.icon_4159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_416: DrawableResource
+  get() = Drawable37.icon_416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4160: DrawableResource
+  get() = Drawable37.icon_4160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4161: DrawableResource
+  get() = Drawable37.icon_4161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4162: DrawableResource
+  get() = Drawable37.icon_4162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4163: DrawableResource
+  get() = Drawable37.icon_4163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4164: DrawableResource
+  get() = Drawable37.icon_4164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4165: DrawableResource
+  get() = Drawable37.icon_4165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4166: DrawableResource
+  get() = Drawable37.icon_4166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4167: DrawableResource
+  get() = Drawable37.icon_4167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4168: DrawableResource
+  get() = Drawable37.icon_4168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4169: DrawableResource
+  get() = Drawable37.icon_4169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_417: DrawableResource
+  get() = Drawable37.icon_417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4170: DrawableResource
+  get() = Drawable37.icon_4170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4171: DrawableResource
+  get() = Drawable37.icon_4171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4172: DrawableResource
+  get() = Drawable37.icon_4172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4173: DrawableResource
+  get() = Drawable37.icon_4173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4174: DrawableResource
+  get() = Drawable37.icon_4174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4175: DrawableResource
+  get() = Drawable37.icon_4175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4176: DrawableResource
+  get() = Drawable37.icon_4176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4177: DrawableResource
+  get() = Drawable37.icon_4177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4178: DrawableResource
+  get() = Drawable37.icon_4178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4179: DrawableResource
+  get() = Drawable37.icon_4179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_418: DrawableResource
+  get() = Drawable37.icon_418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4180: DrawableResource
+  get() = Drawable37.icon_4180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4181: DrawableResource
+  get() = Drawable37.icon_4181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4182: DrawableResource
+  get() = Drawable37.icon_4182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4183: DrawableResource
+  get() = Drawable37.icon_4183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4184: DrawableResource
+  get() = Drawable37.icon_4184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4185: DrawableResource
+  get() = Drawable37.icon_4185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4186: DrawableResource
+  get() = Drawable37.icon_4186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4187: DrawableResource
+  get() = Drawable37.icon_4187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4188: DrawableResource
+  get() = Drawable37.icon_4188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4189: DrawableResource
+  get() = Drawable37.icon_4189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_419: DrawableResource
+  get() = Drawable37.icon_419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4190: DrawableResource
+  get() = Drawable37.icon_4190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4191: DrawableResource
+  get() = Drawable37.icon_4191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4192: DrawableResource
+  get() = Drawable37.icon_4192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4193: DrawableResource
+  get() = Drawable37.icon_4193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4194: DrawableResource
+  get() = Drawable37.icon_4194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4195: DrawableResource
+  get() = Drawable37.icon_4195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4196: DrawableResource
+  get() = Drawable37.icon_4196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4197: DrawableResource
+  get() = Drawable37.icon_4197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4198: DrawableResource
+  get() = Drawable37.icon_4198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4199: DrawableResource
+  get() = Drawable37.icon_4199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_42: DrawableResource
+  get() = Drawable37.icon_42
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_420: DrawableResource
+  get() = Drawable37.icon_420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4200: DrawableResource
+  get() = Drawable37.icon_4200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4201: DrawableResource
+  get() = Drawable37.icon_4201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4202: DrawableResource
+  get() = Drawable37.icon_4202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4203: DrawableResource
+  get() = Drawable37.icon_4203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4204: DrawableResource
+  get() = Drawable37.icon_4204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4205: DrawableResource
+  get() = Drawable37.icon_4205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4206: DrawableResource
+  get() = Drawable37.icon_4206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4207: DrawableResource
+  get() = Drawable37.icon_4207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4208: DrawableResource
+  get() = Drawable37.icon_4208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4209: DrawableResource
+  get() = Drawable37.icon_4209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_421: DrawableResource
+  get() = Drawable37.icon_421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4210: DrawableResource
+  get() = Drawable37.icon_4210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4211: DrawableResource
+  get() = Drawable37.icon_4211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4212: DrawableResource
+  get() = Drawable37.icon_4212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4213: DrawableResource
+  get() = Drawable37.icon_4213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4214: DrawableResource
+  get() = Drawable37.icon_4214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4215: DrawableResource
+  get() = Drawable37.icon_4215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4216: DrawableResource
+  get() = Drawable37.icon_4216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4217: DrawableResource
+  get() = Drawable37.icon_4217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4218: DrawableResource
+  get() = Drawable37.icon_4218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4219: DrawableResource
+  get() = Drawable37.icon_4219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_422: DrawableResource
+  get() = Drawable37.icon_422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4220: DrawableResource
+  get() = Drawable37.icon_4220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4221: DrawableResource
+  get() = Drawable37.icon_4221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4222: DrawableResource
+  get() = Drawable37.icon_4222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4223: DrawableResource
+  get() = Drawable37.icon_4223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4224: DrawableResource
+  get() = Drawable37.icon_4224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4225: DrawableResource
+  get() = Drawable37.icon_4225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4226: DrawableResource
+  get() = Drawable37.icon_4226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4227: DrawableResource
+  get() = Drawable37.icon_4227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4228: DrawableResource
+  get() = Drawable37.icon_4228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4229: DrawableResource
+  get() = Drawable37.icon_4229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_423: DrawableResource
+  get() = Drawable37.icon_423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4230: DrawableResource
+  get() = Drawable37.icon_4230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4231: DrawableResource
+  get() = Drawable37.icon_4231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4232: DrawableResource
+  get() = Drawable37.icon_4232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4233: DrawableResource
+  get() = Drawable37.icon_4233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4234: DrawableResource
+  get() = Drawable37.icon_4234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4235: DrawableResource
+  get() = Drawable37.icon_4235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4236: DrawableResource
+  get() = Drawable37.icon_4236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4237: DrawableResource
+  get() = Drawable37.icon_4237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4238: DrawableResource
+  get() = Drawable37.icon_4238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4239: DrawableResource
+  get() = Drawable37.icon_4239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_424: DrawableResource
+  get() = Drawable37.icon_424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4240: DrawableResource
+  get() = Drawable37.icon_4240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4241: DrawableResource
+  get() = Drawable37.icon_4241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4242: DrawableResource
+  get() = Drawable37.icon_4242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4243: DrawableResource
+  get() = Drawable37.icon_4243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4244: DrawableResource
+  get() = Drawable37.icon_4244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4245: DrawableResource
+  get() = Drawable37.icon_4245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4246: DrawableResource
+  get() = Drawable37.icon_4246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4247: DrawableResource
+  get() = Drawable37.icon_4247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4248: DrawableResource
+  get() = Drawable37.icon_4248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4249: DrawableResource
+  get() = Drawable37.icon_4249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_425: DrawableResource
+  get() = Drawable37.icon_425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4250: DrawableResource
+  get() = Drawable37.icon_4250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4251: DrawableResource
+  get() = Drawable37.icon_4251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4252: DrawableResource
+  get() = Drawable37.icon_4252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4253: DrawableResource
+  get() = Drawable37.icon_4253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4254: DrawableResource
+  get() = Drawable37.icon_4254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4255: DrawableResource
+  get() = Drawable37.icon_4255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4256: DrawableResource
+  get() = Drawable37.icon_4256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4257: DrawableResource
+  get() = Drawable37.icon_4257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4258: DrawableResource
+  get() = Drawable37.icon_4258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4259: DrawableResource
+  get() = Drawable37.icon_4259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_426: DrawableResource
+  get() = Drawable37.icon_426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4260: DrawableResource
+  get() = Drawable37.icon_4260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4261: DrawableResource
+  get() = Drawable37.icon_4261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4262: DrawableResource
+  get() = Drawable37.icon_4262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4263: DrawableResource
+  get() = Drawable37.icon_4263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4264: DrawableResource
+  get() = Drawable37.icon_4264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4265: DrawableResource
+  get() = Drawable37.icon_4265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4266: DrawableResource
+  get() = Drawable37.icon_4266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4267: DrawableResource
+  get() = Drawable37.icon_4267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4268: DrawableResource
+  get() = Drawable37.icon_4268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4269: DrawableResource
+  get() = Drawable37.icon_4269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_427: DrawableResource
+  get() = Drawable37.icon_427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4270: DrawableResource
+  get() = Drawable37.icon_4270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4271: DrawableResource
+  get() = Drawable37.icon_4271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4272: DrawableResource
+  get() = Drawable37.icon_4272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4273: DrawableResource
+  get() = Drawable37.icon_4273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4274: DrawableResource
+  get() = Drawable37.icon_4274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4275: DrawableResource
+  get() = Drawable37.icon_4275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4276: DrawableResource
+  get() = Drawable37.icon_4276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4277: DrawableResource
+  get() = Drawable37.icon_4277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4278: DrawableResource
+  get() = Drawable37.icon_4278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4279: DrawableResource
+  get() = Drawable37.icon_4279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_428: DrawableResource
+  get() = Drawable37.icon_428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4280: DrawableResource
+  get() = Drawable37.icon_4280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4281: DrawableResource
+  get() = Drawable37.icon_4281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4282: DrawableResource
+  get() = Drawable37.icon_4282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4283: DrawableResource
+  get() = Drawable37.icon_4283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4284: DrawableResource
+  get() = Drawable37.icon_4284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4285: DrawableResource
+  get() = Drawable37.icon_4285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4286: DrawableResource
+  get() = Drawable37.icon_4286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4287: DrawableResource
+  get() = Drawable37.icon_4287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4288: DrawableResource
+  get() = Drawable37.icon_4288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4289: DrawableResource
+  get() = Drawable37.icon_4289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_429: DrawableResource
+  get() = Drawable37.icon_429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4290: DrawableResource
+  get() = Drawable37.icon_4290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4291: DrawableResource
+  get() = Drawable37.icon_4291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4292: DrawableResource
+  get() = Drawable37.icon_4292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4293: DrawableResource
+  get() = Drawable37.icon_4293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4294: DrawableResource
+  get() = Drawable37.icon_4294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4295: DrawableResource
+  get() = Drawable37.icon_4295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4296: DrawableResource
+  get() = Drawable37.icon_4296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4297: DrawableResource
+  get() = Drawable37.icon_4297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4298: DrawableResource
+  get() = Drawable37.icon_4298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4299: DrawableResource
+  get() = Drawable37.icon_4299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_43: DrawableResource
+  get() = Drawable37.icon_43
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_430: DrawableResource
+  get() = Drawable37.icon_430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4300: DrawableResource
+  get() = Drawable37.icon_4300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4301: DrawableResource
+  get() = Drawable37.icon_4301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4302: DrawableResource
+  get() = Drawable37.icon_4302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4303: DrawableResource
+  get() = Drawable37.icon_4303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4304: DrawableResource
+  get() = Drawable37.icon_4304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4305: DrawableResource
+  get() = Drawable37.icon_4305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4306: DrawableResource
+  get() = Drawable37.icon_4306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4307: DrawableResource
+  get() = Drawable37.icon_4307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4308: DrawableResource
+  get() = Drawable37.icon_4308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4309: DrawableResource
+  get() = Drawable37.icon_4309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_431: DrawableResource
+  get() = Drawable37.icon_431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4310: DrawableResource
+  get() = Drawable37.icon_4310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4311: DrawableResource
+  get() = Drawable37.icon_4311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4312: DrawableResource
+  get() = Drawable37.icon_4312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4313: DrawableResource
+  get() = Drawable37.icon_4313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4314: DrawableResource
+  get() = Drawable37.icon_4314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4315: DrawableResource
+  get() = Drawable37.icon_4315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4316: DrawableResource
+  get() = Drawable37.icon_4316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4317: DrawableResource
+  get() = Drawable37.icon_4317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4318: DrawableResource
+  get() = Drawable37.icon_4318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4319: DrawableResource
+  get() = Drawable37.icon_4319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_432: DrawableResource
+  get() = Drawable37.icon_432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4320: DrawableResource
+  get() = Drawable37.icon_4320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4321: DrawableResource
+  get() = Drawable37.icon_4321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4322: DrawableResource
+  get() = Drawable37.icon_4322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4323: DrawableResource
+  get() = Drawable37.icon_4323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4324: DrawableResource
+  get() = Drawable37.icon_4324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4325: DrawableResource
+  get() = Drawable37.icon_4325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4326: DrawableResource
+  get() = Drawable37.icon_4326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4327: DrawableResource
+  get() = Drawable37.icon_4327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4328: DrawableResource
+  get() = Drawable37.icon_4328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4329: DrawableResource
+  get() = Drawable37.icon_4329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_433: DrawableResource
+  get() = Drawable37.icon_433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4330: DrawableResource
+  get() = Drawable37.icon_4330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4331: DrawableResource
+  get() = Drawable37.icon_4331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4332: DrawableResource
+  get() = Drawable37.icon_4332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4333: DrawableResource
+  get() = Drawable37.icon_4333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4334: DrawableResource
+  get() = Drawable37.icon_4334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4335: DrawableResource
+  get() = Drawable37.icon_4335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4336: DrawableResource
+  get() = Drawable37.icon_4336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4337: DrawableResource
+  get() = Drawable37.icon_4337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4338: DrawableResource
+  get() = Drawable37.icon_4338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4339: DrawableResource
+  get() = Drawable37.icon_4339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_434: DrawableResource
+  get() = Drawable37.icon_434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4340: DrawableResource
+  get() = Drawable37.icon_4340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4341: DrawableResource
+  get() = Drawable37.icon_4341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4342: DrawableResource
+  get() = Drawable37.icon_4342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4343: DrawableResource
+  get() = Drawable37.icon_4343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4344: DrawableResource
+  get() = Drawable37.icon_4344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4345: DrawableResource
+  get() = Drawable37.icon_4345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4346: DrawableResource
+  get() = Drawable37.icon_4346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4347: DrawableResource
+  get() = Drawable37.icon_4347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4348: DrawableResource
+  get() = Drawable37.icon_4348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4349: DrawableResource
+  get() = Drawable37.icon_4349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_435: DrawableResource
+  get() = Drawable37.icon_435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4350: DrawableResource
+  get() = Drawable37.icon_4350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4351: DrawableResource
+  get() = Drawable37.icon_4351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4352: DrawableResource
+  get() = Drawable37.icon_4352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4353: DrawableResource
+  get() = Drawable37.icon_4353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4354: DrawableResource
+  get() = Drawable37.icon_4354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4355: DrawableResource
+  get() = Drawable37.icon_4355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4356: DrawableResource
+  get() = Drawable37.icon_4356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4357: DrawableResource
+  get() = Drawable37.icon_4357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4358: DrawableResource
+  get() = Drawable37.icon_4358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4359: DrawableResource
+  get() = Drawable37.icon_4359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_436: DrawableResource
+  get() = Drawable37.icon_436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4360: DrawableResource
+  get() = Drawable37.icon_4360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4361: DrawableResource
+  get() = Drawable37.icon_4361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4362: DrawableResource
+  get() = Drawable37.icon_4362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4363: DrawableResource
+  get() = Drawable37.icon_4363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4364: DrawableResource
+  get() = Drawable37.icon_4364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4365: DrawableResource
+  get() = Drawable37.icon_4365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4366: DrawableResource
+  get() = Drawable37.icon_4366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4367: DrawableResource
+  get() = Drawable37.icon_4367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4368: DrawableResource
+  get() = Drawable37.icon_4368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4369: DrawableResource
+  get() = Drawable37.icon_4369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_437: DrawableResource
+  get() = Drawable37.icon_437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4370: DrawableResource
+  get() = Drawable37.icon_4370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4371: DrawableResource
+  get() = Drawable37.icon_4371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4372: DrawableResource
+  get() = Drawable37.icon_4372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4373: DrawableResource
+  get() = Drawable37.icon_4373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4374: DrawableResource
+  get() = Drawable37.icon_4374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4375: DrawableResource
+  get() = Drawable37.icon_4375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4376: DrawableResource
+  get() = Drawable37.icon_4376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4377: DrawableResource
+  get() = Drawable37.icon_4377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4378: DrawableResource
+  get() = Drawable37.icon_4378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4379: DrawableResource
+  get() = Drawable37.icon_4379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_438: DrawableResource
+  get() = Drawable37.icon_438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4380: DrawableResource
+  get() = Drawable37.icon_4380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4381: DrawableResource
+  get() = Drawable37.icon_4381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4382: DrawableResource
+  get() = Drawable37.icon_4382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4383: DrawableResource
+  get() = Drawable37.icon_4383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4384: DrawableResource
+  get() = Drawable37.icon_4384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4385: DrawableResource
+  get() = Drawable37.icon_4385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4386: DrawableResource
+  get() = Drawable37.icon_4386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4387: DrawableResource
+  get() = Drawable37.icon_4387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4388: DrawableResource
+  get() = Drawable37.icon_4388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4389: DrawableResource
+  get() = Drawable37.icon_4389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_439: DrawableResource
+  get() = Drawable37.icon_439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4390: DrawableResource
+  get() = Drawable37.icon_4390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4391: DrawableResource
+  get() = Drawable37.icon_4391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4392: DrawableResource
+  get() = Drawable37.icon_4392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4393: DrawableResource
+  get() = Drawable37.icon_4393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4394: DrawableResource
+  get() = Drawable37.icon_4394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4395: DrawableResource
+  get() = Drawable37.icon_4395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4396: DrawableResource
+  get() = Drawable37.icon_4396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4397: DrawableResource
+  get() = Drawable37.icon_4397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4398: DrawableResource
+  get() = Drawable37.icon_4398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4399: DrawableResource
+  get() = Drawable37.icon_4399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_44: DrawableResource
+  get() = Drawable37.icon_44
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_440: DrawableResource
+  get() = Drawable37.icon_440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4400: DrawableResource
+  get() = Drawable37.icon_4400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4401: DrawableResource
+  get() = Drawable37.icon_4401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4402: DrawableResource
+  get() = Drawable37.icon_4402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4403: DrawableResource
+  get() = Drawable37.icon_4403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4404: DrawableResource
+  get() = Drawable37.icon_4404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4405: DrawableResource
+  get() = Drawable37.icon_4405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4406: DrawableResource
+  get() = Drawable37.icon_4406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4407: DrawableResource
+  get() = Drawable37.icon_4407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4408: DrawableResource
+  get() = Drawable37.icon_4408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4409: DrawableResource
+  get() = Drawable37.icon_4409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_441: DrawableResource
+  get() = Drawable37.icon_441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4410: DrawableResource
+  get() = Drawable37.icon_4410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4411: DrawableResource
+  get() = Drawable37.icon_4411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4412: DrawableResource
+  get() = Drawable37.icon_4412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4413: DrawableResource
+  get() = Drawable37.icon_4413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4414: DrawableResource
+  get() = Drawable37.icon_4414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4415: DrawableResource
+  get() = Drawable37.icon_4415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4416: DrawableResource
+  get() = Drawable37.icon_4416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4417: DrawableResource
+  get() = Drawable37.icon_4417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4418: DrawableResource
+  get() = Drawable37.icon_4418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4419: DrawableResource
+  get() = Drawable37.icon_4419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_442: DrawableResource
+  get() = Drawable37.icon_442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4420: DrawableResource
+  get() = Drawable37.icon_4420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4421: DrawableResource
+  get() = Drawable37.icon_4421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4422: DrawableResource
+  get() = Drawable37.icon_4422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4423: DrawableResource
+  get() = Drawable37.icon_4423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4424: DrawableResource
+  get() = Drawable37.icon_4424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4425: DrawableResource
+  get() = Drawable37.icon_4425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4426: DrawableResource
+  get() = Drawable37.icon_4426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4427: DrawableResource
+  get() = Drawable37.icon_4427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4428: DrawableResource
+  get() = Drawable37.icon_4428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4429: DrawableResource
+  get() = Drawable37.icon_4429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_443: DrawableResource
+  get() = Drawable37.icon_443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4430: DrawableResource
+  get() = Drawable37.icon_4430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4431: DrawableResource
+  get() = Drawable37.icon_4431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4432: DrawableResource
+  get() = Drawable37.icon_4432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4433: DrawableResource
+  get() = Drawable37.icon_4433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4434: DrawableResource
+  get() = Drawable37.icon_4434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4435: DrawableResource
+  get() = Drawable37.icon_4435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4436: DrawableResource
+  get() = Drawable37.icon_4436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4437: DrawableResource
+  get() = Drawable37.icon_4437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4438: DrawableResource
+  get() = Drawable37.icon_4438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4439: DrawableResource
+  get() = Drawable37.icon_4439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_444: DrawableResource
+  get() = Drawable37.icon_444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4440: DrawableResource
+  get() = Drawable37.icon_4440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4441: DrawableResource
+  get() = Drawable37.icon_4441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4442: DrawableResource
+  get() = Drawable37.icon_4442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4443: DrawableResource
+  get() = Drawable37.icon_4443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4444: DrawableResource
+  get() = Drawable37.icon_4444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4445: DrawableResource
+  get() = Drawable37.icon_4445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4446: DrawableResource
+  get() = Drawable37.icon_4446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4447: DrawableResource
+  get() = Drawable37.icon_4447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4448: DrawableResource
+  get() = Drawable37.icon_4448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4449: DrawableResource
+  get() = Drawable37.icon_4449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_445: DrawableResource
+  get() = Drawable37.icon_445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4450: DrawableResource
+  get() = Drawable37.icon_4450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4451: DrawableResource
+  get() = Drawable37.icon_4451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4452: DrawableResource
+  get() = Drawable37.icon_4452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4453: DrawableResource
+  get() = Drawable37.icon_4453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4454: DrawableResource
+  get() = Drawable37.icon_4454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4455: DrawableResource
+  get() = Drawable37.icon_4455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4456: DrawableResource
+  get() = Drawable37.icon_4456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4457: DrawableResource
+  get() = Drawable37.icon_4457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4458: DrawableResource
+  get() = Drawable37.icon_4458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4459: DrawableResource
+  get() = Drawable37.icon_4459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_446: DrawableResource
+  get() = Drawable37.icon_446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4460: DrawableResource
+  get() = Drawable37.icon_4460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4461: DrawableResource
+  get() = Drawable37.icon_4461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4462: DrawableResource
+  get() = Drawable37.icon_4462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4463: DrawableResource
+  get() = Drawable37.icon_4463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4464: DrawableResource
+  get() = Drawable37.icon_4464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4465: DrawableResource
+  get() = Drawable37.icon_4465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4466: DrawableResource
+  get() = Drawable37.icon_4466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4467: DrawableResource
+  get() = Drawable37.icon_4467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4468: DrawableResource
+  get() = Drawable37.icon_4468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4469: DrawableResource
+  get() = Drawable37.icon_4469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_447: DrawableResource
+  get() = Drawable37.icon_447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4470: DrawableResource
+  get() = Drawable37.icon_4470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4471: DrawableResource
+  get() = Drawable37.icon_4471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4472: DrawableResource
+  get() = Drawable37.icon_4472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4473: DrawableResource
+  get() = Drawable37.icon_4473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4474: DrawableResource
+  get() = Drawable37.icon_4474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4475: DrawableResource
+  get() = Drawable37.icon_4475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4476: DrawableResource
+  get() = Drawable37.icon_4476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4477: DrawableResource
+  get() = Drawable37.icon_4477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4478: DrawableResource
+  get() = Drawable37.icon_4478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4479: DrawableResource
+  get() = Drawable37.icon_4479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_448: DrawableResource
+  get() = Drawable37.icon_448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4480: DrawableResource
+  get() = Drawable37.icon_4480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4481: DrawableResource
+  get() = Drawable37.icon_4481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4482: DrawableResource
+  get() = Drawable37.icon_4482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4483: DrawableResource
+  get() = Drawable37.icon_4483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4484: DrawableResource
+  get() = Drawable37.icon_4484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4485: DrawableResource
+  get() = Drawable37.icon_4485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4486: DrawableResource
+  get() = Drawable37.icon_4486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4487: DrawableResource
+  get() = Drawable37.icon_4487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4488: DrawableResource
+  get() = Drawable37.icon_4488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4489: DrawableResource
+  get() = Drawable37.icon_4489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_449: DrawableResource
+  get() = Drawable37.icon_449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4490: DrawableResource
+  get() = Drawable37.icon_4490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4491: DrawableResource
+  get() = Drawable37.icon_4491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4492: DrawableResource
+  get() = Drawable37.icon_4492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4493: DrawableResource
+  get() = Drawable37.icon_4493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4494: DrawableResource
+  get() = Drawable37.icon_4494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4495: DrawableResource
+  get() = Drawable37.icon_4495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4496: DrawableResource
+  get() = Drawable37.icon_4496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4497: DrawableResource
+  get() = Drawable37.icon_4497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4498: DrawableResource
+  get() = Drawable37.icon_4498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4499: DrawableResource
+  get() = Drawable37.icon_4499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_45: DrawableResource
+  get() = Drawable37.icon_45
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_450: DrawableResource
+  get() = Drawable37.icon_450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4500: DrawableResource
+  get() = Drawable37.icon_4500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4501: DrawableResource
+  get() = Drawable37.icon_4501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4502: DrawableResource
+  get() = Drawable37.icon_4502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4503: DrawableResource
+  get() = Drawable37.icon_4503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4504: DrawableResource
+  get() = Drawable37.icon_4504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4505: DrawableResource
+  get() = Drawable37.icon_4505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4506: DrawableResource
+  get() = Drawable37.icon_4506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4507: DrawableResource
+  get() = Drawable37.icon_4507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4508: DrawableResource
+  get() = Drawable37.icon_4508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4509: DrawableResource
+  get() = Drawable37.icon_4509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_451: DrawableResource
+  get() = Drawable37.icon_451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4510: DrawableResource
+  get() = Drawable37.icon_4510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4511: DrawableResource
+  get() = Drawable37.icon_4511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4512: DrawableResource
+  get() = Drawable37.icon_4512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4513: DrawableResource
+  get() = Drawable37.icon_4513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4514: DrawableResource
+  get() = Drawable37.icon_4514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4515: DrawableResource
+  get() = Drawable37.icon_4515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4516: DrawableResource
+  get() = Drawable37.icon_4516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4517: DrawableResource
+  get() = Drawable37.icon_4517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4518: DrawableResource
+  get() = Drawable37.icon_4518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4519: DrawableResource
+  get() = Drawable37.icon_4519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_452: DrawableResource
+  get() = Drawable37.icon_452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4520: DrawableResource
+  get() = Drawable37.icon_4520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4521: DrawableResource
+  get() = Drawable37.icon_4521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4522: DrawableResource
+  get() = Drawable37.icon_4522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4523: DrawableResource
+  get() = Drawable37.icon_4523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4524: DrawableResource
+  get() = Drawable37.icon_4524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4525: DrawableResource
+  get() = Drawable37.icon_4525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4526: DrawableResource
+  get() = Drawable37.icon_4526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4527: DrawableResource
+  get() = Drawable37.icon_4527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4528: DrawableResource
+  get() = Drawable37.icon_4528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4529: DrawableResource
+  get() = Drawable37.icon_4529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_453: DrawableResource
+  get() = Drawable37.icon_453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4530: DrawableResource
+  get() = Drawable37.icon_4530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4531: DrawableResource
+  get() = Drawable37.icon_4531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4532: DrawableResource
+  get() = Drawable37.icon_4532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4533: DrawableResource
+  get() = Drawable37.icon_4533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4534: DrawableResource
+  get() = Drawable37.icon_4534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4535: DrawableResource
+  get() = Drawable37.icon_4535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4536: DrawableResource
+  get() = Drawable37.icon_4536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4537: DrawableResource
+  get() = Drawable37.icon_4537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4538: DrawableResource
+  get() = Drawable37.icon_4538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4539: DrawableResource
+  get() = Drawable37.icon_4539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_454: DrawableResource
+  get() = Drawable37.icon_454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4540: DrawableResource
+  get() = Drawable37.icon_4540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4541: DrawableResource
+  get() = Drawable37.icon_4541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4542: DrawableResource
+  get() = Drawable37.icon_4542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4543: DrawableResource
+  get() = Drawable37.icon_4543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4544: DrawableResource
+  get() = Drawable37.icon_4544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4545: DrawableResource
+  get() = Drawable37.icon_4545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4546: DrawableResource
+  get() = Drawable37.icon_4546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4547: DrawableResource
+  get() = Drawable37.icon_4547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4548: DrawableResource
+  get() = Drawable37.icon_4548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4549: DrawableResource
+  get() = Drawable37.icon_4549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_455: DrawableResource
+  get() = Drawable37.icon_455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4550: DrawableResource
+  get() = Drawable37.icon_4550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4551: DrawableResource
+  get() = Drawable37.icon_4551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4552: DrawableResource
+  get() = Drawable37.icon_4552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4553: DrawableResource
+  get() = Drawable37.icon_4553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4554: DrawableResource
+  get() = Drawable37.icon_4554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4555: DrawableResource
+  get() = Drawable37.icon_4555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4556: DrawableResource
+  get() = Drawable37.icon_4556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4557: DrawableResource
+  get() = Drawable37.icon_4557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4558: DrawableResource
+  get() = Drawable37.icon_4558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4559: DrawableResource
+  get() = Drawable37.icon_4559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_456: DrawableResource
+  get() = Drawable37.icon_456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4560: DrawableResource
+  get() = Drawable37.icon_4560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4561: DrawableResource
+  get() = Drawable37.icon_4561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4562: DrawableResource
+  get() = Drawable37.icon_4562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4563: DrawableResource
+  get() = Drawable37.icon_4563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4564: DrawableResource
+  get() = Drawable37.icon_4564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4565: DrawableResource
+  get() = Drawable37.icon_4565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4566: DrawableResource
+  get() = Drawable37.icon_4566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4567: DrawableResource
+  get() = Drawable37.icon_4567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4568: DrawableResource
+  get() = Drawable37.icon_4568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4569: DrawableResource
+  get() = Drawable37.icon_4569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_457: DrawableResource
+  get() = Drawable37.icon_457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4570: DrawableResource
+  get() = Drawable37.icon_4570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4571: DrawableResource
+  get() = Drawable37.icon_4571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4572: DrawableResource
+  get() = Drawable37.icon_4572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4573: DrawableResource
+  get() = Drawable37.icon_4573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4574: DrawableResource
+  get() = Drawable37.icon_4574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4575: DrawableResource
+  get() = Drawable37.icon_4575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4576: DrawableResource
+  get() = Drawable37.icon_4576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4577: DrawableResource
+  get() = Drawable37.icon_4577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4578: DrawableResource
+  get() = Drawable37.icon_4578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4579: DrawableResource
+  get() = Drawable37.icon_4579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_458: DrawableResource
+  get() = Drawable37.icon_458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4580: DrawableResource
+  get() = Drawable37.icon_4580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4581: DrawableResource
+  get() = Drawable37.icon_4581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4582: DrawableResource
+  get() = Drawable37.icon_4582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4583: DrawableResource
+  get() = Drawable37.icon_4583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4584: DrawableResource
+  get() = Drawable37.icon_4584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4585: DrawableResource
+  get() = Drawable37.icon_4585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4586: DrawableResource
+  get() = Drawable37.icon_4586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4587: DrawableResource
+  get() = Drawable37.icon_4587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4588: DrawableResource
+  get() = Drawable37.icon_4588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4589: DrawableResource
+  get() = Drawable37.icon_4589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_459: DrawableResource
+  get() = Drawable37.icon_459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4590: DrawableResource
+  get() = Drawable37.icon_4590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4591: DrawableResource
+  get() = Drawable37.icon_4591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4592: DrawableResource
+  get() = Drawable37.icon_4592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4593: DrawableResource
+  get() = Drawable37.icon_4593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4594: DrawableResource
+  get() = Drawable37.icon_4594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4595: DrawableResource
+  get() = Drawable37.icon_4595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4596: DrawableResource
+  get() = Drawable37.icon_4596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4597: DrawableResource
+  get() = Drawable37.icon_4597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4598: DrawableResource
+  get() = Drawable37.icon_4598

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable38.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable38.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable38 {
+  public val icon_4599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4599.xml"),
+          )
+      )
+
+  public val icon_46: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_46",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_46.xml"),
+          )
+      )
+
+  public val icon_460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_460.xml"),
+          )
+      )
+
+  public val icon_4600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4600.xml"),
+          )
+      )
+
+  public val icon_4601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4601.xml"),
+          )
+      )
+
+  public val icon_4602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4602.xml"),
+          )
+      )
+
+  public val icon_4603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4603.xml"),
+          )
+      )
+
+  public val icon_4604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4604.xml"),
+          )
+      )
+
+  public val icon_4605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4605.xml"),
+          )
+      )
+
+  public val icon_4606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4606.xml"),
+          )
+      )
+
+  public val icon_4607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4607.xml"),
+          )
+      )
+
+  public val icon_4608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4608.xml"),
+          )
+      )
+
+  public val icon_4609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4609.xml"),
+          )
+      )
+
+  public val icon_461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_461.xml"),
+          )
+      )
+
+  public val icon_4610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4610.xml"),
+          )
+      )
+
+  public val icon_4611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4611.xml"),
+          )
+      )
+
+  public val icon_4612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4612.xml"),
+          )
+      )
+
+  public val icon_4613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4613.xml"),
+          )
+      )
+
+  public val icon_4614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4614.xml"),
+          )
+      )
+
+  public val icon_4615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4615.xml"),
+          )
+      )
+
+  public val icon_4616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4616.xml"),
+          )
+      )
+
+  public val icon_4617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4617.xml"),
+          )
+      )
+
+  public val icon_4618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4618.xml"),
+          )
+      )
+
+  public val icon_4619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4619.xml"),
+          )
+      )
+
+  public val icon_462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_462.xml"),
+          )
+      )
+
+  public val icon_4620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4620.xml"),
+          )
+      )
+
+  public val icon_4621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4621.xml"),
+          )
+      )
+
+  public val icon_4622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4622.xml"),
+          )
+      )
+
+  public val icon_4623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4623.xml"),
+          )
+      )
+
+  public val icon_4624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4624.xml"),
+          )
+      )
+
+  public val icon_4625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4625.xml"),
+          )
+      )
+
+  public val icon_4626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4626.xml"),
+          )
+      )
+
+  public val icon_4627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4627.xml"),
+          )
+      )
+
+  public val icon_4628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4628.xml"),
+          )
+      )
+
+  public val icon_4629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4629.xml"),
+          )
+      )
+
+  public val icon_463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_463.xml"),
+          )
+      )
+
+  public val icon_4630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4630.xml"),
+          )
+      )
+
+  public val icon_4631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4631.xml"),
+          )
+      )
+
+  public val icon_4632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4632.xml"),
+          )
+      )
+
+  public val icon_4633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4633.xml"),
+          )
+      )
+
+  public val icon_4634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4634.xml"),
+          )
+      )
+
+  public val icon_4635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4635.xml"),
+          )
+      )
+
+  public val icon_4636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4636.xml"),
+          )
+      )
+
+  public val icon_4637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4637.xml"),
+          )
+      )
+
+  public val icon_4638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4638.xml"),
+          )
+      )
+
+  public val icon_4639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4639.xml"),
+          )
+      )
+
+  public val icon_464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_464.xml"),
+          )
+      )
+
+  public val icon_4640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4640.xml"),
+          )
+      )
+
+  public val icon_4641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4641.xml"),
+          )
+      )
+
+  public val icon_4642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4642.xml"),
+          )
+      )
+
+  public val icon_4643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4643.xml"),
+          )
+      )
+
+  public val icon_4644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4644.xml"),
+          )
+      )
+
+  public val icon_4645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4645.xml"),
+          )
+      )
+
+  public val icon_4646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4646.xml"),
+          )
+      )
+
+  public val icon_4647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4647.xml"),
+          )
+      )
+
+  public val icon_4648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4648.xml"),
+          )
+      )
+
+  public val icon_4649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4649.xml"),
+          )
+      )
+
+  public val icon_465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_465.xml"),
+          )
+      )
+
+  public val icon_4650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4650.xml"),
+          )
+      )
+
+  public val icon_4651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4651.xml"),
+          )
+      )
+
+  public val icon_4652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4652.xml"),
+          )
+      )
+
+  public val icon_4653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4653.xml"),
+          )
+      )
+
+  public val icon_4654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4654.xml"),
+          )
+      )
+
+  public val icon_4655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4655.xml"),
+          )
+      )
+
+  public val icon_4656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4656.xml"),
+          )
+      )
+
+  public val icon_4657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4657.xml"),
+          )
+      )
+
+  public val icon_4658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4658.xml"),
+          )
+      )
+
+  public val icon_4659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4659.xml"),
+          )
+      )
+
+  public val icon_466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_466.xml"),
+          )
+      )
+
+  public val icon_4660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4660.xml"),
+          )
+      )
+
+  public val icon_4661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4661.xml"),
+          )
+      )
+
+  public val icon_4662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4662.xml"),
+          )
+      )
+
+  public val icon_4663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4663.xml"),
+          )
+      )
+
+  public val icon_4664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4664.xml"),
+          )
+      )
+
+  public val icon_4665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4665.xml"),
+          )
+      )
+
+  public val icon_4666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4666.xml"),
+          )
+      )
+
+  public val icon_4667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4667.xml"),
+          )
+      )
+
+  public val icon_4668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4668.xml"),
+          )
+      )
+
+  public val icon_4669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4669.xml"),
+          )
+      )
+
+  public val icon_467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_467.xml"),
+          )
+      )
+
+  public val icon_4670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4670.xml"),
+          )
+      )
+
+  public val icon_4671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4671.xml"),
+          )
+      )
+
+  public val icon_4672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4672.xml"),
+          )
+      )
+
+  public val icon_4673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4673.xml"),
+          )
+      )
+
+  public val icon_4674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4674.xml"),
+          )
+      )
+
+  public val icon_4675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4675.xml"),
+          )
+      )
+
+  public val icon_4676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4676.xml"),
+          )
+      )
+
+  public val icon_4677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4677.xml"),
+          )
+      )
+
+  public val icon_4678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4678.xml"),
+          )
+      )
+
+  public val icon_4679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4679.xml"),
+          )
+      )
+
+  public val icon_468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_468.xml"),
+          )
+      )
+
+  public val icon_4680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4680.xml"),
+          )
+      )
+
+  public val icon_4681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4681.xml"),
+          )
+      )
+
+  public val icon_4682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4682.xml"),
+          )
+      )
+
+  public val icon_4683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4683.xml"),
+          )
+      )
+
+  public val icon_4684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4684.xml"),
+          )
+      )
+
+  public val icon_4685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4685.xml"),
+          )
+      )
+
+  public val icon_4686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4686.xml"),
+          )
+      )
+
+  public val icon_4687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4687.xml"),
+          )
+      )
+
+  public val icon_4688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4688.xml"),
+          )
+      )
+
+  public val icon_4689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4689.xml"),
+          )
+      )
+
+  public val icon_469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_469.xml"),
+          )
+      )
+
+  public val icon_4690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4690.xml"),
+          )
+      )
+
+  public val icon_4691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4691.xml"),
+          )
+      )
+
+  public val icon_4692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4692.xml"),
+          )
+      )
+
+  public val icon_4693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4693.xml"),
+          )
+      )
+
+  public val icon_4694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4694.xml"),
+          )
+      )
+
+  public val icon_4695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4695.xml"),
+          )
+      )
+
+  public val icon_4696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4696.xml"),
+          )
+      )
+
+  public val icon_4697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4697.xml"),
+          )
+      )
+
+  public val icon_4698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4698.xml"),
+          )
+      )
+
+  public val icon_4699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4699.xml"),
+          )
+      )
+
+  public val icon_47: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_47",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_47.xml"),
+          )
+      )
+
+  public val icon_470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_470.xml"),
+          )
+      )
+
+  public val icon_4700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4700.xml"),
+          )
+      )
+
+  public val icon_4701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4701.xml"),
+          )
+      )
+
+  public val icon_4702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4702.xml"),
+          )
+      )
+
+  public val icon_4703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4703.xml"),
+          )
+      )
+
+  public val icon_4704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4704.xml"),
+          )
+      )
+
+  public val icon_4705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4705.xml"),
+          )
+      )
+
+  public val icon_4706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4706.xml"),
+          )
+      )
+
+  public val icon_4707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4707.xml"),
+          )
+      )
+
+  public val icon_4708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4708.xml"),
+          )
+      )
+
+  public val icon_4709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4709.xml"),
+          )
+      )
+
+  public val icon_471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_471.xml"),
+          )
+      )
+
+  public val icon_4710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4710.xml"),
+          )
+      )
+
+  public val icon_4711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4711.xml"),
+          )
+      )
+
+  public val icon_4712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4712.xml"),
+          )
+      )
+
+  public val icon_4713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4713.xml"),
+          )
+      )
+
+  public val icon_4714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4714.xml"),
+          )
+      )
+
+  public val icon_4715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4715.xml"),
+          )
+      )
+
+  public val icon_4716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4716.xml"),
+          )
+      )
+
+  public val icon_4717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4717.xml"),
+          )
+      )
+
+  public val icon_4718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4718.xml"),
+          )
+      )
+
+  public val icon_4719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4719.xml"),
+          )
+      )
+
+  public val icon_472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_472.xml"),
+          )
+      )
+
+  public val icon_4720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4720.xml"),
+          )
+      )
+
+  public val icon_4721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4721.xml"),
+          )
+      )
+
+  public val icon_4722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4722.xml"),
+          )
+      )
+
+  public val icon_4723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4723.xml"),
+          )
+      )
+
+  public val icon_4724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4724.xml"),
+          )
+      )
+
+  public val icon_4725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4725.xml"),
+          )
+      )
+
+  public val icon_4726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4726.xml"),
+          )
+      )
+
+  public val icon_4727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4727.xml"),
+          )
+      )
+
+  public val icon_4728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4728.xml"),
+          )
+      )
+
+  public val icon_4729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4729.xml"),
+          )
+      )
+
+  public val icon_473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_473.xml"),
+          )
+      )
+
+  public val icon_4730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4730.xml"),
+          )
+      )
+
+  public val icon_4731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4731.xml"),
+          )
+      )
+
+  public val icon_4732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4732.xml"),
+          )
+      )
+
+  public val icon_4733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4733.xml"),
+          )
+      )
+
+  public val icon_4734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4734.xml"),
+          )
+      )
+
+  public val icon_4735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4735.xml"),
+          )
+      )
+
+  public val icon_4736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4736.xml"),
+          )
+      )
+
+  public val icon_4737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4737.xml"),
+          )
+      )
+
+  public val icon_4738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4738.xml"),
+          )
+      )
+
+  public val icon_4739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4739.xml"),
+          )
+      )
+
+  public val icon_474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_474.xml"),
+          )
+      )
+
+  public val icon_4740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4740.xml"),
+          )
+      )
+
+  public val icon_4741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4741.xml"),
+          )
+      )
+
+  public val icon_4742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4742.xml"),
+          )
+      )
+
+  public val icon_4743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4743.xml"),
+          )
+      )
+
+  public val icon_4744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4744.xml"),
+          )
+      )
+
+  public val icon_4745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4745.xml"),
+          )
+      )
+
+  public val icon_4746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4746.xml"),
+          )
+      )
+
+  public val icon_4747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4747.xml"),
+          )
+      )
+
+  public val icon_4748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4748.xml"),
+          )
+      )
+
+  public val icon_4749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4749.xml"),
+          )
+      )
+
+  public val icon_475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_475.xml"),
+          )
+      )
+
+  public val icon_4750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4750.xml"),
+          )
+      )
+
+  public val icon_4751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4751.xml"),
+          )
+      )
+
+  public val icon_4752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4752.xml"),
+          )
+      )
+
+  public val icon_4753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4753.xml"),
+          )
+      )
+
+  public val icon_4754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4754.xml"),
+          )
+      )
+
+  public val icon_4755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4755.xml"),
+          )
+      )
+
+  public val icon_4756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4756.xml"),
+          )
+      )
+
+  public val icon_4757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4757.xml"),
+          )
+      )
+
+  public val icon_4758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4758.xml"),
+          )
+      )
+
+  public val icon_4759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4759.xml"),
+          )
+      )
+
+  public val icon_476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_476.xml"),
+          )
+      )
+
+  public val icon_4760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4760.xml"),
+          )
+      )
+
+  public val icon_4761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4761.xml"),
+          )
+      )
+
+  public val icon_4762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4762.xml"),
+          )
+      )
+
+  public val icon_4763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4763.xml"),
+          )
+      )
+
+  public val icon_4764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4764.xml"),
+          )
+      )
+
+  public val icon_4765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4765.xml"),
+          )
+      )
+
+  public val icon_4766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4766.xml"),
+          )
+      )
+
+  public val icon_4767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4767.xml"),
+          )
+      )
+
+  public val icon_4768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4768.xml"),
+          )
+      )
+
+  public val icon_4769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4769.xml"),
+          )
+      )
+
+  public val icon_477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_477.xml"),
+          )
+      )
+
+  public val icon_4770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4770.xml"),
+          )
+      )
+
+  public val icon_4771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4771.xml"),
+          )
+      )
+
+  public val icon_4772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4772.xml"),
+          )
+      )
+
+  public val icon_4773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4773.xml"),
+          )
+      )
+
+  public val icon_4774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4774.xml"),
+          )
+      )
+
+  public val icon_4775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4775.xml"),
+          )
+      )
+
+  public val icon_4776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4776.xml"),
+          )
+      )
+
+  public val icon_4777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4777.xml"),
+          )
+      )
+
+  public val icon_4778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4778.xml"),
+          )
+      )
+
+  public val icon_4779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4779.xml"),
+          )
+      )
+
+  public val icon_478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_478.xml"),
+          )
+      )
+
+  public val icon_4780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4780.xml"),
+          )
+      )
+
+  public val icon_4781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4781.xml"),
+          )
+      )
+
+  public val icon_4782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4782.xml"),
+          )
+      )
+
+  public val icon_4783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4783.xml"),
+          )
+      )
+
+  public val icon_4784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4784.xml"),
+          )
+      )
+
+  public val icon_4785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4785.xml"),
+          )
+      )
+
+  public val icon_4786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4786.xml"),
+          )
+      )
+
+  public val icon_4787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4787.xml"),
+          )
+      )
+
+  public val icon_4788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4788.xml"),
+          )
+      )
+
+  public val icon_4789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4789.xml"),
+          )
+      )
+
+  public val icon_479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_479.xml"),
+          )
+      )
+
+  public val icon_4790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4790.xml"),
+          )
+      )
+
+  public val icon_4791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4791.xml"),
+          )
+      )
+
+  public val icon_4792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4792.xml"),
+          )
+      )
+
+  public val icon_4793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4793.xml"),
+          )
+      )
+
+  public val icon_4794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4794.xml"),
+          )
+      )
+
+  public val icon_4795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4795.xml"),
+          )
+      )
+
+  public val icon_4796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4796.xml"),
+          )
+      )
+
+  public val icon_4797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4797.xml"),
+          )
+      )
+
+  public val icon_4798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4798.xml"),
+          )
+      )
+
+  public val icon_4799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4799.xml"),
+          )
+      )
+
+  public val icon_48: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_48",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_48.xml"),
+          )
+      )
+
+  public val icon_480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_480.xml"),
+          )
+      )
+
+  public val icon_4800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4800.xml"),
+          )
+      )
+
+  public val icon_4801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4801.xml"),
+          )
+      )
+
+  public val icon_4802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4802.xml"),
+          )
+      )
+
+  public val icon_4803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4803.xml"),
+          )
+      )
+
+  public val icon_4804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4804.xml"),
+          )
+      )
+
+  public val icon_4805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4805.xml"),
+          )
+      )
+
+  public val icon_4806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4806.xml"),
+          )
+      )
+
+  public val icon_4807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4807.xml"),
+          )
+      )
+
+  public val icon_4808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4808.xml"),
+          )
+      )
+
+  public val icon_4809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4809.xml"),
+          )
+      )
+
+  public val icon_481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_481.xml"),
+          )
+      )
+
+  public val icon_4810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4810.xml"),
+          )
+      )
+
+  public val icon_4811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4811.xml"),
+          )
+      )
+
+  public val icon_4812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4812.xml"),
+          )
+      )
+
+  public val icon_4813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4813.xml"),
+          )
+      )
+
+  public val icon_4814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4814.xml"),
+          )
+      )
+
+  public val icon_4815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4815.xml"),
+          )
+      )
+
+  public val icon_4816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4816.xml"),
+          )
+      )
+
+  public val icon_4817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4817.xml"),
+          )
+      )
+
+  public val icon_4818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4818.xml"),
+          )
+      )
+
+  public val icon_4819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4819.xml"),
+          )
+      )
+
+  public val icon_482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_482.xml"),
+          )
+      )
+
+  public val icon_4820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4820.xml"),
+          )
+      )
+
+  public val icon_4821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4821.xml"),
+          )
+      )
+
+  public val icon_4822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4822.xml"),
+          )
+      )
+
+  public val icon_4823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4823.xml"),
+          )
+      )
+
+  public val icon_4824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4824.xml"),
+          )
+      )
+
+  public val icon_4825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4825.xml"),
+          )
+      )
+
+  public val icon_4826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4826.xml"),
+          )
+      )
+
+  public val icon_4827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4827.xml"),
+          )
+      )
+
+  public val icon_4828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4828.xml"),
+          )
+      )
+
+  public val icon_4829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4829.xml"),
+          )
+      )
+
+  public val icon_483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_483.xml"),
+          )
+      )
+
+  public val icon_4830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4830.xml"),
+          )
+      )
+
+  public val icon_4831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4831.xml"),
+          )
+      )
+
+  public val icon_4832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4832.xml"),
+          )
+      )
+
+  public val icon_4833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4833.xml"),
+          )
+      )
+
+  public val icon_4834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4834.xml"),
+          )
+      )
+
+  public val icon_4835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4835.xml"),
+          )
+      )
+
+  public val icon_4836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4836.xml"),
+          )
+      )
+
+  public val icon_4837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4837.xml"),
+          )
+      )
+
+  public val icon_4838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4838.xml"),
+          )
+      )
+
+  public val icon_4839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4839.xml"),
+          )
+      )
+
+  public val icon_484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_484.xml"),
+          )
+      )
+
+  public val icon_4840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4840.xml"),
+          )
+      )
+
+  public val icon_4841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4841.xml"),
+          )
+      )
+
+  public val icon_4842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4842.xml"),
+          )
+      )
+
+  public val icon_4843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4843.xml"),
+          )
+      )
+
+  public val icon_4844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4844.xml"),
+          )
+      )
+
+  public val icon_4845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4845.xml"),
+          )
+      )
+
+  public val icon_4846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4846.xml"),
+          )
+      )
+
+  public val icon_4847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4847.xml"),
+          )
+      )
+
+  public val icon_4848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4848.xml"),
+          )
+      )
+
+  public val icon_4849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4849.xml"),
+          )
+      )
+
+  public val icon_485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_485.xml"),
+          )
+      )
+
+  public val icon_4850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4850.xml"),
+          )
+      )
+
+  public val icon_4851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4851.xml"),
+          )
+      )
+
+  public val icon_4852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4852.xml"),
+          )
+      )
+
+  public val icon_4853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4853.xml"),
+          )
+      )
+
+  public val icon_4854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4854.xml"),
+          )
+      )
+
+  public val icon_4855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4855.xml"),
+          )
+      )
+
+  public val icon_4856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4856.xml"),
+          )
+      )
+
+  public val icon_4857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4857.xml"),
+          )
+      )
+
+  public val icon_4858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4858.xml"),
+          )
+      )
+
+  public val icon_4859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4859.xml"),
+          )
+      )
+
+  public val icon_486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_486.xml"),
+          )
+      )
+
+  public val icon_4860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4860.xml"),
+          )
+      )
+
+  public val icon_4861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4861.xml"),
+          )
+      )
+
+  public val icon_4862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4862.xml"),
+          )
+      )
+
+  public val icon_4863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4863.xml"),
+          )
+      )
+
+  public val icon_4864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4864.xml"),
+          )
+      )
+
+  public val icon_4865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4865.xml"),
+          )
+      )
+
+  public val icon_4866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4866.xml"),
+          )
+      )
+
+  public val icon_4867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4867.xml"),
+          )
+      )
+
+  public val icon_4868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4868.xml"),
+          )
+      )
+
+  public val icon_4869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4869.xml"),
+          )
+      )
+
+  public val icon_487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_487.xml"),
+          )
+      )
+
+  public val icon_4870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4870.xml"),
+          )
+      )
+
+  public val icon_4871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4871.xml"),
+          )
+      )
+
+  public val icon_4872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4872.xml"),
+          )
+      )
+
+  public val icon_4873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4873.xml"),
+          )
+      )
+
+  public val icon_4874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4874.xml"),
+          )
+      )
+
+  public val icon_4875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4875.xml"),
+          )
+      )
+
+  public val icon_4876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4876.xml"),
+          )
+      )
+
+  public val icon_4877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4877.xml"),
+          )
+      )
+
+  public val icon_4878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4878.xml"),
+          )
+      )
+
+  public val icon_4879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4879.xml"),
+          )
+      )
+
+  public val icon_488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_488.xml"),
+          )
+      )
+
+  public val icon_4880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4880.xml"),
+          )
+      )
+
+  public val icon_4881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4881.xml"),
+          )
+      )
+
+  public val icon_4882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4882.xml"),
+          )
+      )
+
+  public val icon_4883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4883.xml"),
+          )
+      )
+
+  public val icon_4884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4884.xml"),
+          )
+      )
+
+  public val icon_4885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4885.xml"),
+          )
+      )
+
+  public val icon_4886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4886.xml"),
+          )
+      )
+
+  public val icon_4887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4887.xml"),
+          )
+      )
+
+  public val icon_4888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4888.xml"),
+          )
+      )
+
+  public val icon_4889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4889.xml"),
+          )
+      )
+
+  public val icon_489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_489.xml"),
+          )
+      )
+
+  public val icon_4890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4890.xml"),
+          )
+      )
+
+  public val icon_4891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4891.xml"),
+          )
+      )
+
+  public val icon_4892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4892.xml"),
+          )
+      )
+
+  public val icon_4893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4893.xml"),
+          )
+      )
+
+  public val icon_4894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4894.xml"),
+          )
+      )
+
+  public val icon_4895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4895.xml"),
+          )
+      )
+
+  public val icon_4896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4896.xml"),
+          )
+      )
+
+  public val icon_4897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4897.xml"),
+          )
+      )
+
+  public val icon_4898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4898.xml"),
+          )
+      )
+
+  public val icon_4899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4899.xml"),
+          )
+      )
+
+  public val icon_49: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_49",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_49.xml"),
+          )
+      )
+
+  public val icon_490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_490.xml"),
+          )
+      )
+
+  public val icon_4900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4900.xml"),
+          )
+      )
+
+  public val icon_4901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4901.xml"),
+          )
+      )
+
+  public val icon_4902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4902.xml"),
+          )
+      )
+
+  public val icon_4903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4903.xml"),
+          )
+      )
+
+  public val icon_4904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4904.xml"),
+          )
+      )
+
+  public val icon_4905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4905.xml"),
+          )
+      )
+
+  public val icon_4906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4906.xml"),
+          )
+      )
+
+  public val icon_4907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4907.xml"),
+          )
+      )
+
+  public val icon_4908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4908.xml"),
+          )
+      )
+
+  public val icon_4909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4909.xml"),
+          )
+      )
+
+  public val icon_491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_491.xml"),
+          )
+      )
+
+  public val icon_4910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4910.xml"),
+          )
+      )
+
+  public val icon_4911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4911.xml"),
+          )
+      )
+
+  public val icon_4912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4912.xml"),
+          )
+      )
+
+  public val icon_4913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4913.xml"),
+          )
+      )
+
+  public val icon_4914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4914.xml"),
+          )
+      )
+
+  public val icon_4915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4915.xml"),
+          )
+      )
+
+  public val icon_4916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4916.xml"),
+          )
+      )
+
+  public val icon_4917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4917.xml"),
+          )
+      )
+
+  public val icon_4918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4918.xml"),
+          )
+      )
+
+  public val icon_4919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4919.xml"),
+          )
+      )
+
+  public val icon_492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_492.xml"),
+          )
+      )
+
+  public val icon_4920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4920.xml"),
+          )
+      )
+
+  public val icon_4921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4921.xml"),
+          )
+      )
+
+  public val icon_4922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4922.xml"),
+          )
+      )
+
+  public val icon_4923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4923.xml"),
+          )
+      )
+
+  public val icon_4924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4924.xml"),
+          )
+      )
+
+  public val icon_4925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4925.xml"),
+          )
+      )
+
+  public val icon_4926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4926.xml"),
+          )
+      )
+
+  public val icon_4927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4927.xml"),
+          )
+      )
+
+  public val icon_4928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4928.xml"),
+          )
+      )
+
+  public val icon_4929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4929.xml"),
+          )
+      )
+
+  public val icon_493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_493.xml"),
+          )
+      )
+
+  public val icon_4930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4930.xml"),
+          )
+      )
+
+  public val icon_4931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4931.xml"),
+          )
+      )
+
+  public val icon_4932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4932.xml"),
+          )
+      )
+
+  public val icon_4933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4933.xml"),
+          )
+      )
+
+  public val icon_4934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4934.xml"),
+          )
+      )
+
+  public val icon_4935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4935.xml"),
+          )
+      )
+
+  public val icon_4936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4936.xml"),
+          )
+      )
+
+  public val icon_4937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4937.xml"),
+          )
+      )
+
+  public val icon_4938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4938.xml"),
+          )
+      )
+
+  public val icon_4939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4939.xml"),
+          )
+      )
+
+  public val icon_494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_494.xml"),
+          )
+      )
+
+  public val icon_4940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4940.xml"),
+          )
+      )
+
+  public val icon_4941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4941.xml"),
+          )
+      )
+
+  public val icon_4942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4942.xml"),
+          )
+      )
+
+  public val icon_4943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4943.xml"),
+          )
+      )
+
+  public val icon_4944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4944.xml"),
+          )
+      )
+
+  public val icon_4945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4945.xml"),
+          )
+      )
+
+  public val icon_4946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4946.xml"),
+          )
+      )
+
+  public val icon_4947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4947.xml"),
+          )
+      )
+
+  public val icon_4948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4948.xml"),
+          )
+      )
+
+  public val icon_4949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4949.xml"),
+          )
+      )
+
+  public val icon_495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_495.xml"),
+          )
+      )
+
+  public val icon_4950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4950.xml"),
+          )
+      )
+
+  public val icon_4951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4951.xml"),
+          )
+      )
+
+  public val icon_4952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4952.xml"),
+          )
+      )
+
+  public val icon_4953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4953.xml"),
+          )
+      )
+
+  public val icon_4954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4954.xml"),
+          )
+      )
+
+  public val icon_4955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4955.xml"),
+          )
+      )
+
+  public val icon_4956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4956.xml"),
+          )
+      )
+
+  public val icon_4957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4957.xml"),
+          )
+      )
+
+  public val icon_4958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4958.xml"),
+          )
+      )
+
+  public val icon_4959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4959.xml"),
+          )
+      )
+
+  public val icon_496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_496.xml"),
+          )
+      )
+
+  public val icon_4960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4960.xml"),
+          )
+      )
+
+  public val icon_4961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4961.xml"),
+          )
+      )
+
+  public val icon_4962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4962.xml"),
+          )
+      )
+
+  public val icon_4963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4963.xml"),
+          )
+      )
+
+  public val icon_4964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4964.xml"),
+          )
+      )
+
+  public val icon_4965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4965.xml"),
+          )
+      )
+
+  public val icon_4966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4966.xml"),
+          )
+      )
+
+  public val icon_4967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4967.xml"),
+          )
+      )
+
+  public val icon_4968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4968.xml"),
+          )
+      )
+
+  public val icon_4969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4969.xml"),
+          )
+      )
+
+  public val icon_497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_497.xml"),
+          )
+      )
+
+  public val icon_4970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4970.xml"),
+          )
+      )
+
+  public val icon_4971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4971.xml"),
+          )
+      )
+
+  public val icon_4972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4972.xml"),
+          )
+      )
+
+  public val icon_4973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4973.xml"),
+          )
+      )
+
+  public val icon_4974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4974.xml"),
+          )
+      )
+
+  public val icon_4975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4975.xml"),
+          )
+      )
+
+  public val icon_4976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4976.xml"),
+          )
+      )
+
+  public val icon_4977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4977.xml"),
+          )
+      )
+
+  public val icon_4978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4978.xml"),
+          )
+      )
+
+  public val icon_4979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4979.xml"),
+          )
+      )
+
+  public val icon_498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_498.xml"),
+          )
+      )
+
+  public val icon_4980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4980.xml"),
+          )
+      )
+
+  public val icon_4981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4981.xml"),
+          )
+      )
+
+  public val icon_4982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4982.xml"),
+          )
+      )
+
+  public val icon_4983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4983.xml"),
+          )
+      )
+
+  public val icon_4984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4984.xml"),
+          )
+      )
+
+  public val icon_4985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4985.xml"),
+          )
+      )
+
+  public val icon_4986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4986.xml"),
+          )
+      )
+
+  public val icon_4987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4987.xml"),
+          )
+      )
+
+  public val icon_4988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4988.xml"),
+          )
+      )
+
+  public val icon_4989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4989.xml"),
+          )
+      )
+
+  public val icon_499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_499.xml"),
+          )
+      )
+
+  public val icon_4990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4990.xml"),
+          )
+      )
+
+  public val icon_4991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4991.xml"),
+          )
+      )
+
+  public val icon_4992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4992.xml"),
+          )
+      )
+
+  public val icon_4993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4993.xml"),
+          )
+      )
+
+  public val icon_4994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4994.xml"),
+          )
+      )
+
+  public val icon_4995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4995.xml"),
+          )
+      )
+
+  public val icon_4996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4996.xml"),
+          )
+      )
+
+  public val icon_4997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4997.xml"),
+          )
+      )
+
+  public val icon_4998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4998.xml"),
+          )
+      )
+
+  public val icon_4999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_4999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_4999.xml"),
+          )
+      )
+
+  public val icon_5: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5.xml"),
+          )
+      )
+
+  public val icon_50: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_50",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_50.xml"),
+          )
+      )
+
+  public val icon_500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_500.xml"),
+          )
+      )
+
+  public val icon_5000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5000.xml"),
+          )
+      )
+
+  public val icon_5001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5001.xml"),
+          )
+      )
+
+  public val icon_5002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5002.xml"),
+          )
+      )
+
+  public val icon_5003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5003.xml"),
+          )
+      )
+
+  public val icon_5004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5004.xml"),
+          )
+      )
+
+  public val icon_5005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5005.xml"),
+          )
+      )
+
+  public val icon_5006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5006.xml"),
+          )
+      )
+
+  public val icon_5007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5007.xml"),
+          )
+      )
+
+  public val icon_5008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5008.xml"),
+          )
+      )
+
+  public val icon_5009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5009.xml"),
+          )
+      )
+
+  public val icon_501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_501.xml"),
+          )
+      )
+
+  public val icon_5010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5010.xml"),
+          )
+      )
+
+  public val icon_5011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5011.xml"),
+          )
+      )
+
+  public val icon_5012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5012.xml"),
+          )
+      )
+
+  public val icon_5013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5013.xml"),
+          )
+      )
+
+  public val icon_5014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5014.xml"),
+          )
+      )
+
+  public val icon_5015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5015.xml"),
+          )
+      )
+
+  public val icon_5016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5016.xml"),
+          )
+      )
+
+  public val icon_5017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5017.xml"),
+          )
+      )
+
+  public val icon_5018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5018.xml"),
+          )
+      )
+
+  public val icon_5019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5019.xml"),
+          )
+      )
+
+  public val icon_502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_502.xml"),
+          )
+      )
+
+  public val icon_5020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5020.xml"),
+          )
+      )
+
+  public val icon_5021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5021.xml"),
+          )
+      )
+
+  public val icon_5022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5022.xml"),
+          )
+      )
+
+  public val icon_5023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5023.xml"),
+          )
+      )
+
+  public val icon_5024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5024.xml"),
+          )
+      )
+
+  public val icon_5025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5025.xml"),
+          )
+      )
+
+  public val icon_5026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5026.xml"),
+          )
+      )
+
+  public val icon_5027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5027.xml"),
+          )
+      )
+
+  public val icon_5028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5028.xml"),
+          )
+      )
+
+  public val icon_5029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5029.xml"),
+          )
+      )
+
+  public val icon_503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_503.xml"),
+          )
+      )
+
+  public val icon_5030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5030.xml"),
+          )
+      )
+
+  public val icon_5031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5031.xml"),
+          )
+      )
+
+  public val icon_5032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5032.xml"),
+          )
+      )
+
+  public val icon_5033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5033.xml"),
+          )
+      )
+
+  public val icon_5034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5034.xml"),
+          )
+      )
+
+  public val icon_5035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5035.xml"),
+          )
+      )
+
+  public val icon_5036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5036.xml"),
+          )
+      )
+
+  public val icon_5037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5037.xml"),
+          )
+      )
+
+  public val icon_5038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5038.xml"),
+          )
+      )
+
+  public val icon_5039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5039.xml"),
+          )
+      )
+
+  public val icon_504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_504.xml"),
+          )
+      )
+
+  public val icon_5040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5040.xml"),
+          )
+      )
+
+  public val icon_5041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5041.xml"),
+          )
+      )
+
+  public val icon_5042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5042.xml"),
+          )
+      )
+
+  public val icon_5043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5043.xml"),
+          )
+      )
+
+  public val icon_5044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5044.xml"),
+          )
+      )
+
+  public val icon_5045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5045.xml"),
+          )
+      )
+
+  public val icon_5046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5046.xml"),
+          )
+      )
+
+  public val icon_5047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5047.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4599: DrawableResource
+  get() = Drawable38.icon_4599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_46: DrawableResource
+  get() = Drawable38.icon_46
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_460: DrawableResource
+  get() = Drawable38.icon_460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4600: DrawableResource
+  get() = Drawable38.icon_4600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4601: DrawableResource
+  get() = Drawable38.icon_4601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4602: DrawableResource
+  get() = Drawable38.icon_4602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4603: DrawableResource
+  get() = Drawable38.icon_4603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4604: DrawableResource
+  get() = Drawable38.icon_4604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4605: DrawableResource
+  get() = Drawable38.icon_4605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4606: DrawableResource
+  get() = Drawable38.icon_4606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4607: DrawableResource
+  get() = Drawable38.icon_4607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4608: DrawableResource
+  get() = Drawable38.icon_4608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4609: DrawableResource
+  get() = Drawable38.icon_4609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_461: DrawableResource
+  get() = Drawable38.icon_461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4610: DrawableResource
+  get() = Drawable38.icon_4610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4611: DrawableResource
+  get() = Drawable38.icon_4611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4612: DrawableResource
+  get() = Drawable38.icon_4612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4613: DrawableResource
+  get() = Drawable38.icon_4613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4614: DrawableResource
+  get() = Drawable38.icon_4614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4615: DrawableResource
+  get() = Drawable38.icon_4615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4616: DrawableResource
+  get() = Drawable38.icon_4616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4617: DrawableResource
+  get() = Drawable38.icon_4617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4618: DrawableResource
+  get() = Drawable38.icon_4618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4619: DrawableResource
+  get() = Drawable38.icon_4619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_462: DrawableResource
+  get() = Drawable38.icon_462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4620: DrawableResource
+  get() = Drawable38.icon_4620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4621: DrawableResource
+  get() = Drawable38.icon_4621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4622: DrawableResource
+  get() = Drawable38.icon_4622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4623: DrawableResource
+  get() = Drawable38.icon_4623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4624: DrawableResource
+  get() = Drawable38.icon_4624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4625: DrawableResource
+  get() = Drawable38.icon_4625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4626: DrawableResource
+  get() = Drawable38.icon_4626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4627: DrawableResource
+  get() = Drawable38.icon_4627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4628: DrawableResource
+  get() = Drawable38.icon_4628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4629: DrawableResource
+  get() = Drawable38.icon_4629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_463: DrawableResource
+  get() = Drawable38.icon_463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4630: DrawableResource
+  get() = Drawable38.icon_4630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4631: DrawableResource
+  get() = Drawable38.icon_4631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4632: DrawableResource
+  get() = Drawable38.icon_4632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4633: DrawableResource
+  get() = Drawable38.icon_4633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4634: DrawableResource
+  get() = Drawable38.icon_4634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4635: DrawableResource
+  get() = Drawable38.icon_4635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4636: DrawableResource
+  get() = Drawable38.icon_4636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4637: DrawableResource
+  get() = Drawable38.icon_4637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4638: DrawableResource
+  get() = Drawable38.icon_4638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4639: DrawableResource
+  get() = Drawable38.icon_4639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_464: DrawableResource
+  get() = Drawable38.icon_464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4640: DrawableResource
+  get() = Drawable38.icon_4640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4641: DrawableResource
+  get() = Drawable38.icon_4641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4642: DrawableResource
+  get() = Drawable38.icon_4642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4643: DrawableResource
+  get() = Drawable38.icon_4643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4644: DrawableResource
+  get() = Drawable38.icon_4644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4645: DrawableResource
+  get() = Drawable38.icon_4645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4646: DrawableResource
+  get() = Drawable38.icon_4646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4647: DrawableResource
+  get() = Drawable38.icon_4647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4648: DrawableResource
+  get() = Drawable38.icon_4648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4649: DrawableResource
+  get() = Drawable38.icon_4649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_465: DrawableResource
+  get() = Drawable38.icon_465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4650: DrawableResource
+  get() = Drawable38.icon_4650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4651: DrawableResource
+  get() = Drawable38.icon_4651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4652: DrawableResource
+  get() = Drawable38.icon_4652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4653: DrawableResource
+  get() = Drawable38.icon_4653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4654: DrawableResource
+  get() = Drawable38.icon_4654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4655: DrawableResource
+  get() = Drawable38.icon_4655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4656: DrawableResource
+  get() = Drawable38.icon_4656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4657: DrawableResource
+  get() = Drawable38.icon_4657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4658: DrawableResource
+  get() = Drawable38.icon_4658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4659: DrawableResource
+  get() = Drawable38.icon_4659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_466: DrawableResource
+  get() = Drawable38.icon_466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4660: DrawableResource
+  get() = Drawable38.icon_4660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4661: DrawableResource
+  get() = Drawable38.icon_4661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4662: DrawableResource
+  get() = Drawable38.icon_4662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4663: DrawableResource
+  get() = Drawable38.icon_4663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4664: DrawableResource
+  get() = Drawable38.icon_4664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4665: DrawableResource
+  get() = Drawable38.icon_4665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4666: DrawableResource
+  get() = Drawable38.icon_4666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4667: DrawableResource
+  get() = Drawable38.icon_4667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4668: DrawableResource
+  get() = Drawable38.icon_4668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4669: DrawableResource
+  get() = Drawable38.icon_4669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_467: DrawableResource
+  get() = Drawable38.icon_467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4670: DrawableResource
+  get() = Drawable38.icon_4670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4671: DrawableResource
+  get() = Drawable38.icon_4671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4672: DrawableResource
+  get() = Drawable38.icon_4672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4673: DrawableResource
+  get() = Drawable38.icon_4673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4674: DrawableResource
+  get() = Drawable38.icon_4674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4675: DrawableResource
+  get() = Drawable38.icon_4675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4676: DrawableResource
+  get() = Drawable38.icon_4676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4677: DrawableResource
+  get() = Drawable38.icon_4677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4678: DrawableResource
+  get() = Drawable38.icon_4678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4679: DrawableResource
+  get() = Drawable38.icon_4679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_468: DrawableResource
+  get() = Drawable38.icon_468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4680: DrawableResource
+  get() = Drawable38.icon_4680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4681: DrawableResource
+  get() = Drawable38.icon_4681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4682: DrawableResource
+  get() = Drawable38.icon_4682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4683: DrawableResource
+  get() = Drawable38.icon_4683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4684: DrawableResource
+  get() = Drawable38.icon_4684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4685: DrawableResource
+  get() = Drawable38.icon_4685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4686: DrawableResource
+  get() = Drawable38.icon_4686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4687: DrawableResource
+  get() = Drawable38.icon_4687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4688: DrawableResource
+  get() = Drawable38.icon_4688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4689: DrawableResource
+  get() = Drawable38.icon_4689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_469: DrawableResource
+  get() = Drawable38.icon_469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4690: DrawableResource
+  get() = Drawable38.icon_4690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4691: DrawableResource
+  get() = Drawable38.icon_4691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4692: DrawableResource
+  get() = Drawable38.icon_4692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4693: DrawableResource
+  get() = Drawable38.icon_4693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4694: DrawableResource
+  get() = Drawable38.icon_4694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4695: DrawableResource
+  get() = Drawable38.icon_4695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4696: DrawableResource
+  get() = Drawable38.icon_4696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4697: DrawableResource
+  get() = Drawable38.icon_4697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4698: DrawableResource
+  get() = Drawable38.icon_4698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4699: DrawableResource
+  get() = Drawable38.icon_4699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_47: DrawableResource
+  get() = Drawable38.icon_47
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_470: DrawableResource
+  get() = Drawable38.icon_470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4700: DrawableResource
+  get() = Drawable38.icon_4700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4701: DrawableResource
+  get() = Drawable38.icon_4701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4702: DrawableResource
+  get() = Drawable38.icon_4702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4703: DrawableResource
+  get() = Drawable38.icon_4703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4704: DrawableResource
+  get() = Drawable38.icon_4704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4705: DrawableResource
+  get() = Drawable38.icon_4705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4706: DrawableResource
+  get() = Drawable38.icon_4706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4707: DrawableResource
+  get() = Drawable38.icon_4707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4708: DrawableResource
+  get() = Drawable38.icon_4708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4709: DrawableResource
+  get() = Drawable38.icon_4709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_471: DrawableResource
+  get() = Drawable38.icon_471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4710: DrawableResource
+  get() = Drawable38.icon_4710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4711: DrawableResource
+  get() = Drawable38.icon_4711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4712: DrawableResource
+  get() = Drawable38.icon_4712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4713: DrawableResource
+  get() = Drawable38.icon_4713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4714: DrawableResource
+  get() = Drawable38.icon_4714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4715: DrawableResource
+  get() = Drawable38.icon_4715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4716: DrawableResource
+  get() = Drawable38.icon_4716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4717: DrawableResource
+  get() = Drawable38.icon_4717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4718: DrawableResource
+  get() = Drawable38.icon_4718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4719: DrawableResource
+  get() = Drawable38.icon_4719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_472: DrawableResource
+  get() = Drawable38.icon_472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4720: DrawableResource
+  get() = Drawable38.icon_4720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4721: DrawableResource
+  get() = Drawable38.icon_4721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4722: DrawableResource
+  get() = Drawable38.icon_4722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4723: DrawableResource
+  get() = Drawable38.icon_4723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4724: DrawableResource
+  get() = Drawable38.icon_4724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4725: DrawableResource
+  get() = Drawable38.icon_4725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4726: DrawableResource
+  get() = Drawable38.icon_4726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4727: DrawableResource
+  get() = Drawable38.icon_4727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4728: DrawableResource
+  get() = Drawable38.icon_4728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4729: DrawableResource
+  get() = Drawable38.icon_4729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_473: DrawableResource
+  get() = Drawable38.icon_473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4730: DrawableResource
+  get() = Drawable38.icon_4730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4731: DrawableResource
+  get() = Drawable38.icon_4731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4732: DrawableResource
+  get() = Drawable38.icon_4732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4733: DrawableResource
+  get() = Drawable38.icon_4733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4734: DrawableResource
+  get() = Drawable38.icon_4734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4735: DrawableResource
+  get() = Drawable38.icon_4735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4736: DrawableResource
+  get() = Drawable38.icon_4736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4737: DrawableResource
+  get() = Drawable38.icon_4737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4738: DrawableResource
+  get() = Drawable38.icon_4738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4739: DrawableResource
+  get() = Drawable38.icon_4739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_474: DrawableResource
+  get() = Drawable38.icon_474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4740: DrawableResource
+  get() = Drawable38.icon_4740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4741: DrawableResource
+  get() = Drawable38.icon_4741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4742: DrawableResource
+  get() = Drawable38.icon_4742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4743: DrawableResource
+  get() = Drawable38.icon_4743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4744: DrawableResource
+  get() = Drawable38.icon_4744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4745: DrawableResource
+  get() = Drawable38.icon_4745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4746: DrawableResource
+  get() = Drawable38.icon_4746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4747: DrawableResource
+  get() = Drawable38.icon_4747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4748: DrawableResource
+  get() = Drawable38.icon_4748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4749: DrawableResource
+  get() = Drawable38.icon_4749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_475: DrawableResource
+  get() = Drawable38.icon_475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4750: DrawableResource
+  get() = Drawable38.icon_4750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4751: DrawableResource
+  get() = Drawable38.icon_4751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4752: DrawableResource
+  get() = Drawable38.icon_4752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4753: DrawableResource
+  get() = Drawable38.icon_4753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4754: DrawableResource
+  get() = Drawable38.icon_4754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4755: DrawableResource
+  get() = Drawable38.icon_4755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4756: DrawableResource
+  get() = Drawable38.icon_4756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4757: DrawableResource
+  get() = Drawable38.icon_4757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4758: DrawableResource
+  get() = Drawable38.icon_4758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4759: DrawableResource
+  get() = Drawable38.icon_4759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_476: DrawableResource
+  get() = Drawable38.icon_476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4760: DrawableResource
+  get() = Drawable38.icon_4760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4761: DrawableResource
+  get() = Drawable38.icon_4761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4762: DrawableResource
+  get() = Drawable38.icon_4762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4763: DrawableResource
+  get() = Drawable38.icon_4763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4764: DrawableResource
+  get() = Drawable38.icon_4764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4765: DrawableResource
+  get() = Drawable38.icon_4765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4766: DrawableResource
+  get() = Drawable38.icon_4766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4767: DrawableResource
+  get() = Drawable38.icon_4767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4768: DrawableResource
+  get() = Drawable38.icon_4768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4769: DrawableResource
+  get() = Drawable38.icon_4769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_477: DrawableResource
+  get() = Drawable38.icon_477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4770: DrawableResource
+  get() = Drawable38.icon_4770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4771: DrawableResource
+  get() = Drawable38.icon_4771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4772: DrawableResource
+  get() = Drawable38.icon_4772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4773: DrawableResource
+  get() = Drawable38.icon_4773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4774: DrawableResource
+  get() = Drawable38.icon_4774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4775: DrawableResource
+  get() = Drawable38.icon_4775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4776: DrawableResource
+  get() = Drawable38.icon_4776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4777: DrawableResource
+  get() = Drawable38.icon_4777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4778: DrawableResource
+  get() = Drawable38.icon_4778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4779: DrawableResource
+  get() = Drawable38.icon_4779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_478: DrawableResource
+  get() = Drawable38.icon_478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4780: DrawableResource
+  get() = Drawable38.icon_4780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4781: DrawableResource
+  get() = Drawable38.icon_4781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4782: DrawableResource
+  get() = Drawable38.icon_4782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4783: DrawableResource
+  get() = Drawable38.icon_4783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4784: DrawableResource
+  get() = Drawable38.icon_4784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4785: DrawableResource
+  get() = Drawable38.icon_4785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4786: DrawableResource
+  get() = Drawable38.icon_4786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4787: DrawableResource
+  get() = Drawable38.icon_4787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4788: DrawableResource
+  get() = Drawable38.icon_4788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4789: DrawableResource
+  get() = Drawable38.icon_4789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_479: DrawableResource
+  get() = Drawable38.icon_479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4790: DrawableResource
+  get() = Drawable38.icon_4790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4791: DrawableResource
+  get() = Drawable38.icon_4791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4792: DrawableResource
+  get() = Drawable38.icon_4792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4793: DrawableResource
+  get() = Drawable38.icon_4793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4794: DrawableResource
+  get() = Drawable38.icon_4794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4795: DrawableResource
+  get() = Drawable38.icon_4795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4796: DrawableResource
+  get() = Drawable38.icon_4796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4797: DrawableResource
+  get() = Drawable38.icon_4797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4798: DrawableResource
+  get() = Drawable38.icon_4798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4799: DrawableResource
+  get() = Drawable38.icon_4799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_48: DrawableResource
+  get() = Drawable38.icon_48
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_480: DrawableResource
+  get() = Drawable38.icon_480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4800: DrawableResource
+  get() = Drawable38.icon_4800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4801: DrawableResource
+  get() = Drawable38.icon_4801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4802: DrawableResource
+  get() = Drawable38.icon_4802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4803: DrawableResource
+  get() = Drawable38.icon_4803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4804: DrawableResource
+  get() = Drawable38.icon_4804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4805: DrawableResource
+  get() = Drawable38.icon_4805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4806: DrawableResource
+  get() = Drawable38.icon_4806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4807: DrawableResource
+  get() = Drawable38.icon_4807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4808: DrawableResource
+  get() = Drawable38.icon_4808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4809: DrawableResource
+  get() = Drawable38.icon_4809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_481: DrawableResource
+  get() = Drawable38.icon_481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4810: DrawableResource
+  get() = Drawable38.icon_4810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4811: DrawableResource
+  get() = Drawable38.icon_4811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4812: DrawableResource
+  get() = Drawable38.icon_4812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4813: DrawableResource
+  get() = Drawable38.icon_4813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4814: DrawableResource
+  get() = Drawable38.icon_4814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4815: DrawableResource
+  get() = Drawable38.icon_4815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4816: DrawableResource
+  get() = Drawable38.icon_4816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4817: DrawableResource
+  get() = Drawable38.icon_4817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4818: DrawableResource
+  get() = Drawable38.icon_4818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4819: DrawableResource
+  get() = Drawable38.icon_4819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_482: DrawableResource
+  get() = Drawable38.icon_482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4820: DrawableResource
+  get() = Drawable38.icon_4820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4821: DrawableResource
+  get() = Drawable38.icon_4821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4822: DrawableResource
+  get() = Drawable38.icon_4822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4823: DrawableResource
+  get() = Drawable38.icon_4823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4824: DrawableResource
+  get() = Drawable38.icon_4824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4825: DrawableResource
+  get() = Drawable38.icon_4825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4826: DrawableResource
+  get() = Drawable38.icon_4826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4827: DrawableResource
+  get() = Drawable38.icon_4827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4828: DrawableResource
+  get() = Drawable38.icon_4828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4829: DrawableResource
+  get() = Drawable38.icon_4829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_483: DrawableResource
+  get() = Drawable38.icon_483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4830: DrawableResource
+  get() = Drawable38.icon_4830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4831: DrawableResource
+  get() = Drawable38.icon_4831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4832: DrawableResource
+  get() = Drawable38.icon_4832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4833: DrawableResource
+  get() = Drawable38.icon_4833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4834: DrawableResource
+  get() = Drawable38.icon_4834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4835: DrawableResource
+  get() = Drawable38.icon_4835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4836: DrawableResource
+  get() = Drawable38.icon_4836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4837: DrawableResource
+  get() = Drawable38.icon_4837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4838: DrawableResource
+  get() = Drawable38.icon_4838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4839: DrawableResource
+  get() = Drawable38.icon_4839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_484: DrawableResource
+  get() = Drawable38.icon_484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4840: DrawableResource
+  get() = Drawable38.icon_4840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4841: DrawableResource
+  get() = Drawable38.icon_4841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4842: DrawableResource
+  get() = Drawable38.icon_4842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4843: DrawableResource
+  get() = Drawable38.icon_4843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4844: DrawableResource
+  get() = Drawable38.icon_4844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4845: DrawableResource
+  get() = Drawable38.icon_4845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4846: DrawableResource
+  get() = Drawable38.icon_4846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4847: DrawableResource
+  get() = Drawable38.icon_4847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4848: DrawableResource
+  get() = Drawable38.icon_4848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4849: DrawableResource
+  get() = Drawable38.icon_4849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_485: DrawableResource
+  get() = Drawable38.icon_485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4850: DrawableResource
+  get() = Drawable38.icon_4850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4851: DrawableResource
+  get() = Drawable38.icon_4851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4852: DrawableResource
+  get() = Drawable38.icon_4852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4853: DrawableResource
+  get() = Drawable38.icon_4853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4854: DrawableResource
+  get() = Drawable38.icon_4854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4855: DrawableResource
+  get() = Drawable38.icon_4855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4856: DrawableResource
+  get() = Drawable38.icon_4856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4857: DrawableResource
+  get() = Drawable38.icon_4857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4858: DrawableResource
+  get() = Drawable38.icon_4858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4859: DrawableResource
+  get() = Drawable38.icon_4859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_486: DrawableResource
+  get() = Drawable38.icon_486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4860: DrawableResource
+  get() = Drawable38.icon_4860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4861: DrawableResource
+  get() = Drawable38.icon_4861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4862: DrawableResource
+  get() = Drawable38.icon_4862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4863: DrawableResource
+  get() = Drawable38.icon_4863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4864: DrawableResource
+  get() = Drawable38.icon_4864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4865: DrawableResource
+  get() = Drawable38.icon_4865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4866: DrawableResource
+  get() = Drawable38.icon_4866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4867: DrawableResource
+  get() = Drawable38.icon_4867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4868: DrawableResource
+  get() = Drawable38.icon_4868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4869: DrawableResource
+  get() = Drawable38.icon_4869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_487: DrawableResource
+  get() = Drawable38.icon_487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4870: DrawableResource
+  get() = Drawable38.icon_4870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4871: DrawableResource
+  get() = Drawable38.icon_4871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4872: DrawableResource
+  get() = Drawable38.icon_4872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4873: DrawableResource
+  get() = Drawable38.icon_4873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4874: DrawableResource
+  get() = Drawable38.icon_4874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4875: DrawableResource
+  get() = Drawable38.icon_4875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4876: DrawableResource
+  get() = Drawable38.icon_4876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4877: DrawableResource
+  get() = Drawable38.icon_4877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4878: DrawableResource
+  get() = Drawable38.icon_4878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4879: DrawableResource
+  get() = Drawable38.icon_4879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_488: DrawableResource
+  get() = Drawable38.icon_488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4880: DrawableResource
+  get() = Drawable38.icon_4880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4881: DrawableResource
+  get() = Drawable38.icon_4881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4882: DrawableResource
+  get() = Drawable38.icon_4882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4883: DrawableResource
+  get() = Drawable38.icon_4883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4884: DrawableResource
+  get() = Drawable38.icon_4884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4885: DrawableResource
+  get() = Drawable38.icon_4885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4886: DrawableResource
+  get() = Drawable38.icon_4886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4887: DrawableResource
+  get() = Drawable38.icon_4887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4888: DrawableResource
+  get() = Drawable38.icon_4888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4889: DrawableResource
+  get() = Drawable38.icon_4889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_489: DrawableResource
+  get() = Drawable38.icon_489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4890: DrawableResource
+  get() = Drawable38.icon_4890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4891: DrawableResource
+  get() = Drawable38.icon_4891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4892: DrawableResource
+  get() = Drawable38.icon_4892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4893: DrawableResource
+  get() = Drawable38.icon_4893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4894: DrawableResource
+  get() = Drawable38.icon_4894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4895: DrawableResource
+  get() = Drawable38.icon_4895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4896: DrawableResource
+  get() = Drawable38.icon_4896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4897: DrawableResource
+  get() = Drawable38.icon_4897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4898: DrawableResource
+  get() = Drawable38.icon_4898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4899: DrawableResource
+  get() = Drawable38.icon_4899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_49: DrawableResource
+  get() = Drawable38.icon_49
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_490: DrawableResource
+  get() = Drawable38.icon_490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4900: DrawableResource
+  get() = Drawable38.icon_4900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4901: DrawableResource
+  get() = Drawable38.icon_4901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4902: DrawableResource
+  get() = Drawable38.icon_4902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4903: DrawableResource
+  get() = Drawable38.icon_4903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4904: DrawableResource
+  get() = Drawable38.icon_4904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4905: DrawableResource
+  get() = Drawable38.icon_4905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4906: DrawableResource
+  get() = Drawable38.icon_4906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4907: DrawableResource
+  get() = Drawable38.icon_4907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4908: DrawableResource
+  get() = Drawable38.icon_4908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4909: DrawableResource
+  get() = Drawable38.icon_4909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_491: DrawableResource
+  get() = Drawable38.icon_491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4910: DrawableResource
+  get() = Drawable38.icon_4910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4911: DrawableResource
+  get() = Drawable38.icon_4911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4912: DrawableResource
+  get() = Drawable38.icon_4912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4913: DrawableResource
+  get() = Drawable38.icon_4913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4914: DrawableResource
+  get() = Drawable38.icon_4914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4915: DrawableResource
+  get() = Drawable38.icon_4915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4916: DrawableResource
+  get() = Drawable38.icon_4916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4917: DrawableResource
+  get() = Drawable38.icon_4917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4918: DrawableResource
+  get() = Drawable38.icon_4918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4919: DrawableResource
+  get() = Drawable38.icon_4919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_492: DrawableResource
+  get() = Drawable38.icon_492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4920: DrawableResource
+  get() = Drawable38.icon_4920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4921: DrawableResource
+  get() = Drawable38.icon_4921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4922: DrawableResource
+  get() = Drawable38.icon_4922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4923: DrawableResource
+  get() = Drawable38.icon_4923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4924: DrawableResource
+  get() = Drawable38.icon_4924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4925: DrawableResource
+  get() = Drawable38.icon_4925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4926: DrawableResource
+  get() = Drawable38.icon_4926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4927: DrawableResource
+  get() = Drawable38.icon_4927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4928: DrawableResource
+  get() = Drawable38.icon_4928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4929: DrawableResource
+  get() = Drawable38.icon_4929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_493: DrawableResource
+  get() = Drawable38.icon_493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4930: DrawableResource
+  get() = Drawable38.icon_4930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4931: DrawableResource
+  get() = Drawable38.icon_4931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4932: DrawableResource
+  get() = Drawable38.icon_4932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4933: DrawableResource
+  get() = Drawable38.icon_4933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4934: DrawableResource
+  get() = Drawable38.icon_4934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4935: DrawableResource
+  get() = Drawable38.icon_4935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4936: DrawableResource
+  get() = Drawable38.icon_4936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4937: DrawableResource
+  get() = Drawable38.icon_4937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4938: DrawableResource
+  get() = Drawable38.icon_4938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4939: DrawableResource
+  get() = Drawable38.icon_4939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_494: DrawableResource
+  get() = Drawable38.icon_494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4940: DrawableResource
+  get() = Drawable38.icon_4940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4941: DrawableResource
+  get() = Drawable38.icon_4941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4942: DrawableResource
+  get() = Drawable38.icon_4942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4943: DrawableResource
+  get() = Drawable38.icon_4943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4944: DrawableResource
+  get() = Drawable38.icon_4944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4945: DrawableResource
+  get() = Drawable38.icon_4945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4946: DrawableResource
+  get() = Drawable38.icon_4946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4947: DrawableResource
+  get() = Drawable38.icon_4947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4948: DrawableResource
+  get() = Drawable38.icon_4948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4949: DrawableResource
+  get() = Drawable38.icon_4949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_495: DrawableResource
+  get() = Drawable38.icon_495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4950: DrawableResource
+  get() = Drawable38.icon_4950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4951: DrawableResource
+  get() = Drawable38.icon_4951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4952: DrawableResource
+  get() = Drawable38.icon_4952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4953: DrawableResource
+  get() = Drawable38.icon_4953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4954: DrawableResource
+  get() = Drawable38.icon_4954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4955: DrawableResource
+  get() = Drawable38.icon_4955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4956: DrawableResource
+  get() = Drawable38.icon_4956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4957: DrawableResource
+  get() = Drawable38.icon_4957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4958: DrawableResource
+  get() = Drawable38.icon_4958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4959: DrawableResource
+  get() = Drawable38.icon_4959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_496: DrawableResource
+  get() = Drawable38.icon_496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4960: DrawableResource
+  get() = Drawable38.icon_4960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4961: DrawableResource
+  get() = Drawable38.icon_4961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4962: DrawableResource
+  get() = Drawable38.icon_4962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4963: DrawableResource
+  get() = Drawable38.icon_4963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4964: DrawableResource
+  get() = Drawable38.icon_4964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4965: DrawableResource
+  get() = Drawable38.icon_4965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4966: DrawableResource
+  get() = Drawable38.icon_4966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4967: DrawableResource
+  get() = Drawable38.icon_4967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4968: DrawableResource
+  get() = Drawable38.icon_4968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4969: DrawableResource
+  get() = Drawable38.icon_4969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_497: DrawableResource
+  get() = Drawable38.icon_497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4970: DrawableResource
+  get() = Drawable38.icon_4970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4971: DrawableResource
+  get() = Drawable38.icon_4971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4972: DrawableResource
+  get() = Drawable38.icon_4972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4973: DrawableResource
+  get() = Drawable38.icon_4973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4974: DrawableResource
+  get() = Drawable38.icon_4974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4975: DrawableResource
+  get() = Drawable38.icon_4975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4976: DrawableResource
+  get() = Drawable38.icon_4976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4977: DrawableResource
+  get() = Drawable38.icon_4977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4978: DrawableResource
+  get() = Drawable38.icon_4978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4979: DrawableResource
+  get() = Drawable38.icon_4979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_498: DrawableResource
+  get() = Drawable38.icon_498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4980: DrawableResource
+  get() = Drawable38.icon_4980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4981: DrawableResource
+  get() = Drawable38.icon_4981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4982: DrawableResource
+  get() = Drawable38.icon_4982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4983: DrawableResource
+  get() = Drawable38.icon_4983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4984: DrawableResource
+  get() = Drawable38.icon_4984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4985: DrawableResource
+  get() = Drawable38.icon_4985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4986: DrawableResource
+  get() = Drawable38.icon_4986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4987: DrawableResource
+  get() = Drawable38.icon_4987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4988: DrawableResource
+  get() = Drawable38.icon_4988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4989: DrawableResource
+  get() = Drawable38.icon_4989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_499: DrawableResource
+  get() = Drawable38.icon_499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4990: DrawableResource
+  get() = Drawable38.icon_4990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4991: DrawableResource
+  get() = Drawable38.icon_4991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4992: DrawableResource
+  get() = Drawable38.icon_4992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4993: DrawableResource
+  get() = Drawable38.icon_4993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4994: DrawableResource
+  get() = Drawable38.icon_4994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4995: DrawableResource
+  get() = Drawable38.icon_4995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4996: DrawableResource
+  get() = Drawable38.icon_4996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4997: DrawableResource
+  get() = Drawable38.icon_4997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4998: DrawableResource
+  get() = Drawable38.icon_4998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_4999: DrawableResource
+  get() = Drawable38.icon_4999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5: DrawableResource
+  get() = Drawable38.icon_5
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_50: DrawableResource
+  get() = Drawable38.icon_50
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_500: DrawableResource
+  get() = Drawable38.icon_500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5000: DrawableResource
+  get() = Drawable38.icon_5000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5001: DrawableResource
+  get() = Drawable38.icon_5001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5002: DrawableResource
+  get() = Drawable38.icon_5002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5003: DrawableResource
+  get() = Drawable38.icon_5003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5004: DrawableResource
+  get() = Drawable38.icon_5004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5005: DrawableResource
+  get() = Drawable38.icon_5005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5006: DrawableResource
+  get() = Drawable38.icon_5006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5007: DrawableResource
+  get() = Drawable38.icon_5007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5008: DrawableResource
+  get() = Drawable38.icon_5008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5009: DrawableResource
+  get() = Drawable38.icon_5009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_501: DrawableResource
+  get() = Drawable38.icon_501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5010: DrawableResource
+  get() = Drawable38.icon_5010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5011: DrawableResource
+  get() = Drawable38.icon_5011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5012: DrawableResource
+  get() = Drawable38.icon_5012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5013: DrawableResource
+  get() = Drawable38.icon_5013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5014: DrawableResource
+  get() = Drawable38.icon_5014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5015: DrawableResource
+  get() = Drawable38.icon_5015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5016: DrawableResource
+  get() = Drawable38.icon_5016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5017: DrawableResource
+  get() = Drawable38.icon_5017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5018: DrawableResource
+  get() = Drawable38.icon_5018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5019: DrawableResource
+  get() = Drawable38.icon_5019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_502: DrawableResource
+  get() = Drawable38.icon_502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5020: DrawableResource
+  get() = Drawable38.icon_5020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5021: DrawableResource
+  get() = Drawable38.icon_5021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5022: DrawableResource
+  get() = Drawable38.icon_5022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5023: DrawableResource
+  get() = Drawable38.icon_5023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5024: DrawableResource
+  get() = Drawable38.icon_5024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5025: DrawableResource
+  get() = Drawable38.icon_5025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5026: DrawableResource
+  get() = Drawable38.icon_5026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5027: DrawableResource
+  get() = Drawable38.icon_5027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5028: DrawableResource
+  get() = Drawable38.icon_5028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5029: DrawableResource
+  get() = Drawable38.icon_5029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_503: DrawableResource
+  get() = Drawable38.icon_503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5030: DrawableResource
+  get() = Drawable38.icon_5030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5031: DrawableResource
+  get() = Drawable38.icon_5031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5032: DrawableResource
+  get() = Drawable38.icon_5032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5033: DrawableResource
+  get() = Drawable38.icon_5033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5034: DrawableResource
+  get() = Drawable38.icon_5034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5035: DrawableResource
+  get() = Drawable38.icon_5035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5036: DrawableResource
+  get() = Drawable38.icon_5036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5037: DrawableResource
+  get() = Drawable38.icon_5037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5038: DrawableResource
+  get() = Drawable38.icon_5038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5039: DrawableResource
+  get() = Drawable38.icon_5039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_504: DrawableResource
+  get() = Drawable38.icon_504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5040: DrawableResource
+  get() = Drawable38.icon_5040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5041: DrawableResource
+  get() = Drawable38.icon_5041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5042: DrawableResource
+  get() = Drawable38.icon_5042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5043: DrawableResource
+  get() = Drawable38.icon_5043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5044: DrawableResource
+  get() = Drawable38.icon_5044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5045: DrawableResource
+  get() = Drawable38.icon_5045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5046: DrawableResource
+  get() = Drawable38.icon_5046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5047: DrawableResource
+  get() = Drawable38.icon_5047

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable39.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable39.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable39 {
+  public val icon_5048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5048.xml"),
+          )
+      )
+
+  public val icon_5049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5049.xml"),
+          )
+      )
+
+  public val icon_505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_505.xml"),
+          )
+      )
+
+  public val icon_5050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5050.xml"),
+          )
+      )
+
+  public val icon_5051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5051.xml"),
+          )
+      )
+
+  public val icon_5052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5052.xml"),
+          )
+      )
+
+  public val icon_5053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5053.xml"),
+          )
+      )
+
+  public val icon_5054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5054.xml"),
+          )
+      )
+
+  public val icon_5055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5055.xml"),
+          )
+      )
+
+  public val icon_5056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5056.xml"),
+          )
+      )
+
+  public val icon_5057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5057.xml"),
+          )
+      )
+
+  public val icon_5058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5058.xml"),
+          )
+      )
+
+  public val icon_5059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5059.xml"),
+          )
+      )
+
+  public val icon_506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_506.xml"),
+          )
+      )
+
+  public val icon_5060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5060.xml"),
+          )
+      )
+
+  public val icon_5061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5061.xml"),
+          )
+      )
+
+  public val icon_5062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5062.xml"),
+          )
+      )
+
+  public val icon_5063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5063.xml"),
+          )
+      )
+
+  public val icon_5064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5064.xml"),
+          )
+      )
+
+  public val icon_5065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5065.xml"),
+          )
+      )
+
+  public val icon_5066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5066.xml"),
+          )
+      )
+
+  public val icon_5067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5067.xml"),
+          )
+      )
+
+  public val icon_5068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5068.xml"),
+          )
+      )
+
+  public val icon_5069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5069.xml"),
+          )
+      )
+
+  public val icon_507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_507.xml"),
+          )
+      )
+
+  public val icon_5070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5070.xml"),
+          )
+      )
+
+  public val icon_5071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5071.xml"),
+          )
+      )
+
+  public val icon_5072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5072.xml"),
+          )
+      )
+
+  public val icon_5073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5073.xml"),
+          )
+      )
+
+  public val icon_5074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5074.xml"),
+          )
+      )
+
+  public val icon_5075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5075.xml"),
+          )
+      )
+
+  public val icon_5076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5076.xml"),
+          )
+      )
+
+  public val icon_5077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5077.xml"),
+          )
+      )
+
+  public val icon_5078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5078.xml"),
+          )
+      )
+
+  public val icon_5079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5079.xml"),
+          )
+      )
+
+  public val icon_508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_508.xml"),
+          )
+      )
+
+  public val icon_5080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5080.xml"),
+          )
+      )
+
+  public val icon_5081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5081.xml"),
+          )
+      )
+
+  public val icon_5082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5082.xml"),
+          )
+      )
+
+  public val icon_5083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5083.xml"),
+          )
+      )
+
+  public val icon_5084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5084.xml"),
+          )
+      )
+
+  public val icon_5085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5085.xml"),
+          )
+      )
+
+  public val icon_5086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5086.xml"),
+          )
+      )
+
+  public val icon_5087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5087.xml"),
+          )
+      )
+
+  public val icon_5088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5088.xml"),
+          )
+      )
+
+  public val icon_5089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5089.xml"),
+          )
+      )
+
+  public val icon_509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_509.xml"),
+          )
+      )
+
+  public val icon_5090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5090.xml"),
+          )
+      )
+
+  public val icon_5091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5091.xml"),
+          )
+      )
+
+  public val icon_5092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5092.xml"),
+          )
+      )
+
+  public val icon_5093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5093.xml"),
+          )
+      )
+
+  public val icon_5094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5094.xml"),
+          )
+      )
+
+  public val icon_5095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5095.xml"),
+          )
+      )
+
+  public val icon_5096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5096.xml"),
+          )
+      )
+
+  public val icon_5097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5097.xml"),
+          )
+      )
+
+  public val icon_5098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5098.xml"),
+          )
+      )
+
+  public val icon_5099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5099.xml"),
+          )
+      )
+
+  public val icon_51: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_51",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_51.xml"),
+          )
+      )
+
+  public val icon_510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_510.xml"),
+          )
+      )
+
+  public val icon_5100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5100.xml"),
+          )
+      )
+
+  public val icon_5101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5101.xml"),
+          )
+      )
+
+  public val icon_5102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5102.xml"),
+          )
+      )
+
+  public val icon_5103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5103.xml"),
+          )
+      )
+
+  public val icon_5104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5104.xml"),
+          )
+      )
+
+  public val icon_5105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5105.xml"),
+          )
+      )
+
+  public val icon_5106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5106.xml"),
+          )
+      )
+
+  public val icon_5107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5107.xml"),
+          )
+      )
+
+  public val icon_5108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5108.xml"),
+          )
+      )
+
+  public val icon_5109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5109.xml"),
+          )
+      )
+
+  public val icon_511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_511.xml"),
+          )
+      )
+
+  public val icon_5110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5110.xml"),
+          )
+      )
+
+  public val icon_5111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5111.xml"),
+          )
+      )
+
+  public val icon_5112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5112.xml"),
+          )
+      )
+
+  public val icon_5113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5113.xml"),
+          )
+      )
+
+  public val icon_5114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5114.xml"),
+          )
+      )
+
+  public val icon_5115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5115.xml"),
+          )
+      )
+
+  public val icon_5116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5116.xml"),
+          )
+      )
+
+  public val icon_5117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5117.xml"),
+          )
+      )
+
+  public val icon_5118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5118.xml"),
+          )
+      )
+
+  public val icon_5119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5119.xml"),
+          )
+      )
+
+  public val icon_512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_512.xml"),
+          )
+      )
+
+  public val icon_5120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5120.xml"),
+          )
+      )
+
+  public val icon_5121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5121.xml"),
+          )
+      )
+
+  public val icon_5122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5122.xml"),
+          )
+      )
+
+  public val icon_5123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5123.xml"),
+          )
+      )
+
+  public val icon_5124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5124.xml"),
+          )
+      )
+
+  public val icon_5125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5125.xml"),
+          )
+      )
+
+  public val icon_5126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5126.xml"),
+          )
+      )
+
+  public val icon_5127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5127.xml"),
+          )
+      )
+
+  public val icon_5128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5128.xml"),
+          )
+      )
+
+  public val icon_5129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5129.xml"),
+          )
+      )
+
+  public val icon_513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_513.xml"),
+          )
+      )
+
+  public val icon_5130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5130.xml"),
+          )
+      )
+
+  public val icon_5131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5131.xml"),
+          )
+      )
+
+  public val icon_5132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5132.xml"),
+          )
+      )
+
+  public val icon_5133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5133.xml"),
+          )
+      )
+
+  public val icon_5134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5134.xml"),
+          )
+      )
+
+  public val icon_5135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5135.xml"),
+          )
+      )
+
+  public val icon_5136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5136.xml"),
+          )
+      )
+
+  public val icon_5137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5137.xml"),
+          )
+      )
+
+  public val icon_5138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5138.xml"),
+          )
+      )
+
+  public val icon_5139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5139.xml"),
+          )
+      )
+
+  public val icon_514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_514.xml"),
+          )
+      )
+
+  public val icon_5140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5140.xml"),
+          )
+      )
+
+  public val icon_5141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5141.xml"),
+          )
+      )
+
+  public val icon_5142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5142.xml"),
+          )
+      )
+
+  public val icon_5143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5143.xml"),
+          )
+      )
+
+  public val icon_5144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5144.xml"),
+          )
+      )
+
+  public val icon_5145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5145.xml"),
+          )
+      )
+
+  public val icon_5146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5146.xml"),
+          )
+      )
+
+  public val icon_5147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5147.xml"),
+          )
+      )
+
+  public val icon_5148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5148.xml"),
+          )
+      )
+
+  public val icon_5149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5149.xml"),
+          )
+      )
+
+  public val icon_515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_515.xml"),
+          )
+      )
+
+  public val icon_5150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5150.xml"),
+          )
+      )
+
+  public val icon_5151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5151.xml"),
+          )
+      )
+
+  public val icon_5152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5152.xml"),
+          )
+      )
+
+  public val icon_5153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5153.xml"),
+          )
+      )
+
+  public val icon_5154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5154.xml"),
+          )
+      )
+
+  public val icon_5155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5155.xml"),
+          )
+      )
+
+  public val icon_5156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5156.xml"),
+          )
+      )
+
+  public val icon_5157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5157.xml"),
+          )
+      )
+
+  public val icon_5158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5158.xml"),
+          )
+      )
+
+  public val icon_5159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5159.xml"),
+          )
+      )
+
+  public val icon_516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_516.xml"),
+          )
+      )
+
+  public val icon_5160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5160.xml"),
+          )
+      )
+
+  public val icon_5161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5161.xml"),
+          )
+      )
+
+  public val icon_5162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5162.xml"),
+          )
+      )
+
+  public val icon_5163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5163.xml"),
+          )
+      )
+
+  public val icon_5164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5164.xml"),
+          )
+      )
+
+  public val icon_5165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5165.xml"),
+          )
+      )
+
+  public val icon_5166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5166.xml"),
+          )
+      )
+
+  public val icon_5167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5167.xml"),
+          )
+      )
+
+  public val icon_5168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5168.xml"),
+          )
+      )
+
+  public val icon_5169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5169.xml"),
+          )
+      )
+
+  public val icon_517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_517.xml"),
+          )
+      )
+
+  public val icon_5170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5170.xml"),
+          )
+      )
+
+  public val icon_5171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5171.xml"),
+          )
+      )
+
+  public val icon_5172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5172.xml"),
+          )
+      )
+
+  public val icon_5173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5173.xml"),
+          )
+      )
+
+  public val icon_5174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5174.xml"),
+          )
+      )
+
+  public val icon_5175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5175.xml"),
+          )
+      )
+
+  public val icon_5176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5176.xml"),
+          )
+      )
+
+  public val icon_5177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5177.xml"),
+          )
+      )
+
+  public val icon_5178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5178.xml"),
+          )
+      )
+
+  public val icon_5179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5179.xml"),
+          )
+      )
+
+  public val icon_518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_518.xml"),
+          )
+      )
+
+  public val icon_5180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5180.xml"),
+          )
+      )
+
+  public val icon_5181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5181.xml"),
+          )
+      )
+
+  public val icon_5182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5182.xml"),
+          )
+      )
+
+  public val icon_5183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5183.xml"),
+          )
+      )
+
+  public val icon_5184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5184.xml"),
+          )
+      )
+
+  public val icon_5185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5185.xml"),
+          )
+      )
+
+  public val icon_5186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5186.xml"),
+          )
+      )
+
+  public val icon_5187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5187.xml"),
+          )
+      )
+
+  public val icon_5188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5188.xml"),
+          )
+      )
+
+  public val icon_5189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5189.xml"),
+          )
+      )
+
+  public val icon_519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_519.xml"),
+          )
+      )
+
+  public val icon_5190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5190.xml"),
+          )
+      )
+
+  public val icon_5191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5191.xml"),
+          )
+      )
+
+  public val icon_5192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5192.xml"),
+          )
+      )
+
+  public val icon_5193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5193.xml"),
+          )
+      )
+
+  public val icon_5194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5194.xml"),
+          )
+      )
+
+  public val icon_5195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5195.xml"),
+          )
+      )
+
+  public val icon_5196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5196.xml"),
+          )
+      )
+
+  public val icon_5197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5197.xml"),
+          )
+      )
+
+  public val icon_5198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5198.xml"),
+          )
+      )
+
+  public val icon_5199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5199.xml"),
+          )
+      )
+
+  public val icon_52: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_52",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_52.xml"),
+          )
+      )
+
+  public val icon_520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_520.xml"),
+          )
+      )
+
+  public val icon_5200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5200.xml"),
+          )
+      )
+
+  public val icon_5201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5201.xml"),
+          )
+      )
+
+  public val icon_5202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5202.xml"),
+          )
+      )
+
+  public val icon_5203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5203.xml"),
+          )
+      )
+
+  public val icon_5204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5204.xml"),
+          )
+      )
+
+  public val icon_5205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5205.xml"),
+          )
+      )
+
+  public val icon_5206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5206.xml"),
+          )
+      )
+
+  public val icon_5207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5207.xml"),
+          )
+      )
+
+  public val icon_5208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5208.xml"),
+          )
+      )
+
+  public val icon_5209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5209.xml"),
+          )
+      )
+
+  public val icon_521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_521.xml"),
+          )
+      )
+
+  public val icon_5210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5210.xml"),
+          )
+      )
+
+  public val icon_5211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5211.xml"),
+          )
+      )
+
+  public val icon_5212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5212.xml"),
+          )
+      )
+
+  public val icon_5213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5213.xml"),
+          )
+      )
+
+  public val icon_5214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5214.xml"),
+          )
+      )
+
+  public val icon_5215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5215.xml"),
+          )
+      )
+
+  public val icon_5216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5216.xml"),
+          )
+      )
+
+  public val icon_5217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5217.xml"),
+          )
+      )
+
+  public val icon_5218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5218.xml"),
+          )
+      )
+
+  public val icon_5219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5219.xml"),
+          )
+      )
+
+  public val icon_522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_522.xml"),
+          )
+      )
+
+  public val icon_5220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5220.xml"),
+          )
+      )
+
+  public val icon_5221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5221.xml"),
+          )
+      )
+
+  public val icon_5222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5222.xml"),
+          )
+      )
+
+  public val icon_5223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5223.xml"),
+          )
+      )
+
+  public val icon_5224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5224.xml"),
+          )
+      )
+
+  public val icon_5225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5225.xml"),
+          )
+      )
+
+  public val icon_5226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5226.xml"),
+          )
+      )
+
+  public val icon_5227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5227.xml"),
+          )
+      )
+
+  public val icon_5228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5228.xml"),
+          )
+      )
+
+  public val icon_5229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5229.xml"),
+          )
+      )
+
+  public val icon_523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_523.xml"),
+          )
+      )
+
+  public val icon_5230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5230.xml"),
+          )
+      )
+
+  public val icon_5231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5231.xml"),
+          )
+      )
+
+  public val icon_5232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5232.xml"),
+          )
+      )
+
+  public val icon_5233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5233.xml"),
+          )
+      )
+
+  public val icon_5234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5234.xml"),
+          )
+      )
+
+  public val icon_5235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5235.xml"),
+          )
+      )
+
+  public val icon_5236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5236.xml"),
+          )
+      )
+
+  public val icon_5237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5237.xml"),
+          )
+      )
+
+  public val icon_5238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5238.xml"),
+          )
+      )
+
+  public val icon_5239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5239.xml"),
+          )
+      )
+
+  public val icon_524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_524.xml"),
+          )
+      )
+
+  public val icon_5240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5240.xml"),
+          )
+      )
+
+  public val icon_5241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5241.xml"),
+          )
+      )
+
+  public val icon_5242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5242.xml"),
+          )
+      )
+
+  public val icon_5243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5243.xml"),
+          )
+      )
+
+  public val icon_5244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5244.xml"),
+          )
+      )
+
+  public val icon_5245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5245.xml"),
+          )
+      )
+
+  public val icon_5246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5246.xml"),
+          )
+      )
+
+  public val icon_5247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5247.xml"),
+          )
+      )
+
+  public val icon_5248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5248.xml"),
+          )
+      )
+
+  public val icon_5249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5249.xml"),
+          )
+      )
+
+  public val icon_525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_525.xml"),
+          )
+      )
+
+  public val icon_5250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5250.xml"),
+          )
+      )
+
+  public val icon_5251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5251.xml"),
+          )
+      )
+
+  public val icon_5252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5252.xml"),
+          )
+      )
+
+  public val icon_5253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5253.xml"),
+          )
+      )
+
+  public val icon_5254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5254.xml"),
+          )
+      )
+
+  public val icon_5255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5255.xml"),
+          )
+      )
+
+  public val icon_5256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5256.xml"),
+          )
+      )
+
+  public val icon_5257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5257.xml"),
+          )
+      )
+
+  public val icon_5258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5258.xml"),
+          )
+      )
+
+  public val icon_5259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5259.xml"),
+          )
+      )
+
+  public val icon_526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_526.xml"),
+          )
+      )
+
+  public val icon_5260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5260.xml"),
+          )
+      )
+
+  public val icon_5261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5261.xml"),
+          )
+      )
+
+  public val icon_5262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5262.xml"),
+          )
+      )
+
+  public val icon_5263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5263.xml"),
+          )
+      )
+
+  public val icon_5264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5264.xml"),
+          )
+      )
+
+  public val icon_5265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5265.xml"),
+          )
+      )
+
+  public val icon_5266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5266.xml"),
+          )
+      )
+
+  public val icon_5267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5267.xml"),
+          )
+      )
+
+  public val icon_5268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5268.xml"),
+          )
+      )
+
+  public val icon_5269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5269.xml"),
+          )
+      )
+
+  public val icon_527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_527.xml"),
+          )
+      )
+
+  public val icon_5270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5270.xml"),
+          )
+      )
+
+  public val icon_5271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5271.xml"),
+          )
+      )
+
+  public val icon_5272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5272.xml"),
+          )
+      )
+
+  public val icon_5273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5273.xml"),
+          )
+      )
+
+  public val icon_5274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5274.xml"),
+          )
+      )
+
+  public val icon_5275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5275.xml"),
+          )
+      )
+
+  public val icon_5276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5276.xml"),
+          )
+      )
+
+  public val icon_5277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5277.xml"),
+          )
+      )
+
+  public val icon_5278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5278.xml"),
+          )
+      )
+
+  public val icon_5279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5279.xml"),
+          )
+      )
+
+  public val icon_528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_528.xml"),
+          )
+      )
+
+  public val icon_5280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5280.xml"),
+          )
+      )
+
+  public val icon_5281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5281.xml"),
+          )
+      )
+
+  public val icon_5282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5282.xml"),
+          )
+      )
+
+  public val icon_5283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5283.xml"),
+          )
+      )
+
+  public val icon_5284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5284.xml"),
+          )
+      )
+
+  public val icon_5285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5285.xml"),
+          )
+      )
+
+  public val icon_5286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5286.xml"),
+          )
+      )
+
+  public val icon_5287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5287.xml"),
+          )
+      )
+
+  public val icon_5288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5288.xml"),
+          )
+      )
+
+  public val icon_5289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5289.xml"),
+          )
+      )
+
+  public val icon_529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_529.xml"),
+          )
+      )
+
+  public val icon_5290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5290.xml"),
+          )
+      )
+
+  public val icon_5291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5291.xml"),
+          )
+      )
+
+  public val icon_5292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5292.xml"),
+          )
+      )
+
+  public val icon_5293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5293.xml"),
+          )
+      )
+
+  public val icon_5294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5294.xml"),
+          )
+      )
+
+  public val icon_5295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5295.xml"),
+          )
+      )
+
+  public val icon_5296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5296.xml"),
+          )
+      )
+
+  public val icon_5297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5297.xml"),
+          )
+      )
+
+  public val icon_5298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5298.xml"),
+          )
+      )
+
+  public val icon_5299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5299.xml"),
+          )
+      )
+
+  public val icon_53: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_53",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_53.xml"),
+          )
+      )
+
+  public val icon_530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_530.xml"),
+          )
+      )
+
+  public val icon_5300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5300.xml"),
+          )
+      )
+
+  public val icon_5301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5301.xml"),
+          )
+      )
+
+  public val icon_5302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5302.xml"),
+          )
+      )
+
+  public val icon_5303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5303.xml"),
+          )
+      )
+
+  public val icon_5304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5304.xml"),
+          )
+      )
+
+  public val icon_5305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5305.xml"),
+          )
+      )
+
+  public val icon_5306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5306.xml"),
+          )
+      )
+
+  public val icon_5307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5307.xml"),
+          )
+      )
+
+  public val icon_5308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5308.xml"),
+          )
+      )
+
+  public val icon_5309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5309.xml"),
+          )
+      )
+
+  public val icon_531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_531.xml"),
+          )
+      )
+
+  public val icon_5310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5310.xml"),
+          )
+      )
+
+  public val icon_5311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5311.xml"),
+          )
+      )
+
+  public val icon_5312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5312.xml"),
+          )
+      )
+
+  public val icon_5313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5313.xml"),
+          )
+      )
+
+  public val icon_5314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5314.xml"),
+          )
+      )
+
+  public val icon_5315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5315.xml"),
+          )
+      )
+
+  public val icon_5316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5316.xml"),
+          )
+      )
+
+  public val icon_5317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5317.xml"),
+          )
+      )
+
+  public val icon_5318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5318.xml"),
+          )
+      )
+
+  public val icon_5319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5319.xml"),
+          )
+      )
+
+  public val icon_532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_532.xml"),
+          )
+      )
+
+  public val icon_5320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5320.xml"),
+          )
+      )
+
+  public val icon_5321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5321.xml"),
+          )
+      )
+
+  public val icon_5322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5322.xml"),
+          )
+      )
+
+  public val icon_5323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5323.xml"),
+          )
+      )
+
+  public val icon_5324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5324.xml"),
+          )
+      )
+
+  public val icon_5325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5325.xml"),
+          )
+      )
+
+  public val icon_5326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5326.xml"),
+          )
+      )
+
+  public val icon_5327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5327.xml"),
+          )
+      )
+
+  public val icon_5328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5328.xml"),
+          )
+      )
+
+  public val icon_5329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5329.xml"),
+          )
+      )
+
+  public val icon_533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_533.xml"),
+          )
+      )
+
+  public val icon_5330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5330.xml"),
+          )
+      )
+
+  public val icon_5331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5331.xml"),
+          )
+      )
+
+  public val icon_5332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5332.xml"),
+          )
+      )
+
+  public val icon_5333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5333.xml"),
+          )
+      )
+
+  public val icon_5334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5334.xml"),
+          )
+      )
+
+  public val icon_5335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5335.xml"),
+          )
+      )
+
+  public val icon_5336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5336.xml"),
+          )
+      )
+
+  public val icon_5337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5337.xml"),
+          )
+      )
+
+  public val icon_5338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5338.xml"),
+          )
+      )
+
+  public val icon_5339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5339.xml"),
+          )
+      )
+
+  public val icon_534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_534.xml"),
+          )
+      )
+
+  public val icon_5340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5340.xml"),
+          )
+      )
+
+  public val icon_5341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5341.xml"),
+          )
+      )
+
+  public val icon_5342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5342.xml"),
+          )
+      )
+
+  public val icon_5343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5343.xml"),
+          )
+      )
+
+  public val icon_5344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5344.xml"),
+          )
+      )
+
+  public val icon_5345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5345.xml"),
+          )
+      )
+
+  public val icon_5346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5346.xml"),
+          )
+      )
+
+  public val icon_5347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5347.xml"),
+          )
+      )
+
+  public val icon_5348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5348.xml"),
+          )
+      )
+
+  public val icon_5349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5349.xml"),
+          )
+      )
+
+  public val icon_535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_535.xml"),
+          )
+      )
+
+  public val icon_5350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5350.xml"),
+          )
+      )
+
+  public val icon_5351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5351.xml"),
+          )
+      )
+
+  public val icon_5352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5352.xml"),
+          )
+      )
+
+  public val icon_5353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5353.xml"),
+          )
+      )
+
+  public val icon_5354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5354.xml"),
+          )
+      )
+
+  public val icon_5355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5355.xml"),
+          )
+      )
+
+  public val icon_5356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5356.xml"),
+          )
+      )
+
+  public val icon_5357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5357.xml"),
+          )
+      )
+
+  public val icon_5358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5358.xml"),
+          )
+      )
+
+  public val icon_5359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5359.xml"),
+          )
+      )
+
+  public val icon_536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_536.xml"),
+          )
+      )
+
+  public val icon_5360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5360.xml"),
+          )
+      )
+
+  public val icon_5361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5361.xml"),
+          )
+      )
+
+  public val icon_5362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5362.xml"),
+          )
+      )
+
+  public val icon_5363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5363.xml"),
+          )
+      )
+
+  public val icon_5364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5364.xml"),
+          )
+      )
+
+  public val icon_5365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5365.xml"),
+          )
+      )
+
+  public val icon_5366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5366.xml"),
+          )
+      )
+
+  public val icon_5367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5367.xml"),
+          )
+      )
+
+  public val icon_5368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5368.xml"),
+          )
+      )
+
+  public val icon_5369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5369.xml"),
+          )
+      )
+
+  public val icon_537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_537.xml"),
+          )
+      )
+
+  public val icon_5370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5370.xml"),
+          )
+      )
+
+  public val icon_5371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5371.xml"),
+          )
+      )
+
+  public val icon_5372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5372.xml"),
+          )
+      )
+
+  public val icon_5373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5373.xml"),
+          )
+      )
+
+  public val icon_5374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5374.xml"),
+          )
+      )
+
+  public val icon_5375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5375.xml"),
+          )
+      )
+
+  public val icon_5376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5376.xml"),
+          )
+      )
+
+  public val icon_5377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5377.xml"),
+          )
+      )
+
+  public val icon_5378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5378.xml"),
+          )
+      )
+
+  public val icon_5379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5379.xml"),
+          )
+      )
+
+  public val icon_538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_538.xml"),
+          )
+      )
+
+  public val icon_5380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5380.xml"),
+          )
+      )
+
+  public val icon_5381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5381.xml"),
+          )
+      )
+
+  public val icon_5382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5382.xml"),
+          )
+      )
+
+  public val icon_5383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5383.xml"),
+          )
+      )
+
+  public val icon_5384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5384.xml"),
+          )
+      )
+
+  public val icon_5385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5385.xml"),
+          )
+      )
+
+  public val icon_5386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5386.xml"),
+          )
+      )
+
+  public val icon_5387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5387.xml"),
+          )
+      )
+
+  public val icon_5388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5388.xml"),
+          )
+      )
+
+  public val icon_5389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5389.xml"),
+          )
+      )
+
+  public val icon_539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_539.xml"),
+          )
+      )
+
+  public val icon_5390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5390.xml"),
+          )
+      )
+
+  public val icon_5391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5391.xml"),
+          )
+      )
+
+  public val icon_5392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5392.xml"),
+          )
+      )
+
+  public val icon_5393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5393.xml"),
+          )
+      )
+
+  public val icon_5394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5394.xml"),
+          )
+      )
+
+  public val icon_5395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5395.xml"),
+          )
+      )
+
+  public val icon_5396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5396.xml"),
+          )
+      )
+
+  public val icon_5397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5397.xml"),
+          )
+      )
+
+  public val icon_5398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5398.xml"),
+          )
+      )
+
+  public val icon_5399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5399.xml"),
+          )
+      )
+
+  public val icon_54: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_54",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_54.xml"),
+          )
+      )
+
+  public val icon_540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_540.xml"),
+          )
+      )
+
+  public val icon_5400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5400.xml"),
+          )
+      )
+
+  public val icon_5401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5401.xml"),
+          )
+      )
+
+  public val icon_5402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5402.xml"),
+          )
+      )
+
+  public val icon_5403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5403.xml"),
+          )
+      )
+
+  public val icon_5404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5404.xml"),
+          )
+      )
+
+  public val icon_5405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5405.xml"),
+          )
+      )
+
+  public val icon_5406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5406.xml"),
+          )
+      )
+
+  public val icon_5407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5407.xml"),
+          )
+      )
+
+  public val icon_5408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5408.xml"),
+          )
+      )
+
+  public val icon_5409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5409.xml"),
+          )
+      )
+
+  public val icon_541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_541.xml"),
+          )
+      )
+
+  public val icon_5410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5410.xml"),
+          )
+      )
+
+  public val icon_5411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5411.xml"),
+          )
+      )
+
+  public val icon_5412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5412.xml"),
+          )
+      )
+
+  public val icon_5413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5413.xml"),
+          )
+      )
+
+  public val icon_5414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5414.xml"),
+          )
+      )
+
+  public val icon_5415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5415.xml"),
+          )
+      )
+
+  public val icon_5416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5416.xml"),
+          )
+      )
+
+  public val icon_5417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5417.xml"),
+          )
+      )
+
+  public val icon_5418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5418.xml"),
+          )
+      )
+
+  public val icon_5419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5419.xml"),
+          )
+      )
+
+  public val icon_542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_542.xml"),
+          )
+      )
+
+  public val icon_5420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5420.xml"),
+          )
+      )
+
+  public val icon_5421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5421.xml"),
+          )
+      )
+
+  public val icon_5422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5422.xml"),
+          )
+      )
+
+  public val icon_5423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5423.xml"),
+          )
+      )
+
+  public val icon_5424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5424.xml"),
+          )
+      )
+
+  public val icon_5425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5425.xml"),
+          )
+      )
+
+  public val icon_5426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5426.xml"),
+          )
+      )
+
+  public val icon_5427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5427.xml"),
+          )
+      )
+
+  public val icon_5428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5428.xml"),
+          )
+      )
+
+  public val icon_5429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5429.xml"),
+          )
+      )
+
+  public val icon_543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_543.xml"),
+          )
+      )
+
+  public val icon_5430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5430.xml"),
+          )
+      )
+
+  public val icon_5431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5431.xml"),
+          )
+      )
+
+  public val icon_5432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5432.xml"),
+          )
+      )
+
+  public val icon_5433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5433.xml"),
+          )
+      )
+
+  public val icon_5434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5434.xml"),
+          )
+      )
+
+  public val icon_5435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5435.xml"),
+          )
+      )
+
+  public val icon_5436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5436.xml"),
+          )
+      )
+
+  public val icon_5437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5437.xml"),
+          )
+      )
+
+  public val icon_5438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5438.xml"),
+          )
+      )
+
+  public val icon_5439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5439.xml"),
+          )
+      )
+
+  public val icon_544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_544.xml"),
+          )
+      )
+
+  public val icon_5440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5440.xml"),
+          )
+      )
+
+  public val icon_5441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5441.xml"),
+          )
+      )
+
+  public val icon_5442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5442.xml"),
+          )
+      )
+
+  public val icon_5443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5443.xml"),
+          )
+      )
+
+  public val icon_5444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5444.xml"),
+          )
+      )
+
+  public val icon_5445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5445.xml"),
+          )
+      )
+
+  public val icon_5446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5446.xml"),
+          )
+      )
+
+  public val icon_5447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5447.xml"),
+          )
+      )
+
+  public val icon_5448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5448.xml"),
+          )
+      )
+
+  public val icon_5449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5449.xml"),
+          )
+      )
+
+  public val icon_545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_545.xml"),
+          )
+      )
+
+  public val icon_5450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5450.xml"),
+          )
+      )
+
+  public val icon_5451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5451.xml"),
+          )
+      )
+
+  public val icon_5452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5452.xml"),
+          )
+      )
+
+  public val icon_5453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5453.xml"),
+          )
+      )
+
+  public val icon_5454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5454.xml"),
+          )
+      )
+
+  public val icon_5455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5455.xml"),
+          )
+      )
+
+  public val icon_5456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5456.xml"),
+          )
+      )
+
+  public val icon_5457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5457.xml"),
+          )
+      )
+
+  public val icon_5458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5458.xml"),
+          )
+      )
+
+  public val icon_5459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5459.xml"),
+          )
+      )
+
+  public val icon_546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_546.xml"),
+          )
+      )
+
+  public val icon_5460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5460.xml"),
+          )
+      )
+
+  public val icon_5461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5461.xml"),
+          )
+      )
+
+  public val icon_5462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5462.xml"),
+          )
+      )
+
+  public val icon_5463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5463.xml"),
+          )
+      )
+
+  public val icon_5464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5464.xml"),
+          )
+      )
+
+  public val icon_5465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5465.xml"),
+          )
+      )
+
+  public val icon_5466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5466.xml"),
+          )
+      )
+
+  public val icon_5467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5467.xml"),
+          )
+      )
+
+  public val icon_5468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5468.xml"),
+          )
+      )
+
+  public val icon_5469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5469.xml"),
+          )
+      )
+
+  public val icon_547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_547.xml"),
+          )
+      )
+
+  public val icon_5470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5470.xml"),
+          )
+      )
+
+  public val icon_5471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5471.xml"),
+          )
+      )
+
+  public val icon_5472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5472.xml"),
+          )
+      )
+
+  public val icon_5473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5473.xml"),
+          )
+      )
+
+  public val icon_5474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5474.xml"),
+          )
+      )
+
+  public val icon_5475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5475.xml"),
+          )
+      )
+
+  public val icon_5476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5476.xml"),
+          )
+      )
+
+  public val icon_5477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5477.xml"),
+          )
+      )
+
+  public val icon_5478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5478.xml"),
+          )
+      )
+
+  public val icon_5479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5479.xml"),
+          )
+      )
+
+  public val icon_548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_548.xml"),
+          )
+      )
+
+  public val icon_5480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5480.xml"),
+          )
+      )
+
+  public val icon_5481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5481.xml"),
+          )
+      )
+
+  public val icon_5482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5482.xml"),
+          )
+      )
+
+  public val icon_5483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5483.xml"),
+          )
+      )
+
+  public val icon_5484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5484.xml"),
+          )
+      )
+
+  public val icon_5485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5485.xml"),
+          )
+      )
+
+  public val icon_5486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5486.xml"),
+          )
+      )
+
+  public val icon_5487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5487.xml"),
+          )
+      )
+
+  public val icon_5488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5488.xml"),
+          )
+      )
+
+  public val icon_5489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5489.xml"),
+          )
+      )
+
+  public val icon_549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_549.xml"),
+          )
+      )
+
+  public val icon_5490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5490.xml"),
+          )
+      )
+
+  public val icon_5491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5491.xml"),
+          )
+      )
+
+  public val icon_5492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5492.xml"),
+          )
+      )
+
+  public val icon_5493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5493.xml"),
+          )
+      )
+
+  public val icon_5494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5494.xml"),
+          )
+      )
+
+  public val icon_5495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5495.xml"),
+          )
+      )
+
+  public val icon_5496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5496.xml"),
+          )
+      )
+
+  public val icon_5497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5497.xml"),
+          )
+      )
+
+  public val icon_5498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5498.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5048: DrawableResource
+  get() = Drawable39.icon_5048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5049: DrawableResource
+  get() = Drawable39.icon_5049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_505: DrawableResource
+  get() = Drawable39.icon_505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5050: DrawableResource
+  get() = Drawable39.icon_5050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5051: DrawableResource
+  get() = Drawable39.icon_5051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5052: DrawableResource
+  get() = Drawable39.icon_5052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5053: DrawableResource
+  get() = Drawable39.icon_5053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5054: DrawableResource
+  get() = Drawable39.icon_5054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5055: DrawableResource
+  get() = Drawable39.icon_5055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5056: DrawableResource
+  get() = Drawable39.icon_5056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5057: DrawableResource
+  get() = Drawable39.icon_5057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5058: DrawableResource
+  get() = Drawable39.icon_5058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5059: DrawableResource
+  get() = Drawable39.icon_5059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_506: DrawableResource
+  get() = Drawable39.icon_506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5060: DrawableResource
+  get() = Drawable39.icon_5060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5061: DrawableResource
+  get() = Drawable39.icon_5061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5062: DrawableResource
+  get() = Drawable39.icon_5062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5063: DrawableResource
+  get() = Drawable39.icon_5063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5064: DrawableResource
+  get() = Drawable39.icon_5064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5065: DrawableResource
+  get() = Drawable39.icon_5065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5066: DrawableResource
+  get() = Drawable39.icon_5066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5067: DrawableResource
+  get() = Drawable39.icon_5067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5068: DrawableResource
+  get() = Drawable39.icon_5068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5069: DrawableResource
+  get() = Drawable39.icon_5069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_507: DrawableResource
+  get() = Drawable39.icon_507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5070: DrawableResource
+  get() = Drawable39.icon_5070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5071: DrawableResource
+  get() = Drawable39.icon_5071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5072: DrawableResource
+  get() = Drawable39.icon_5072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5073: DrawableResource
+  get() = Drawable39.icon_5073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5074: DrawableResource
+  get() = Drawable39.icon_5074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5075: DrawableResource
+  get() = Drawable39.icon_5075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5076: DrawableResource
+  get() = Drawable39.icon_5076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5077: DrawableResource
+  get() = Drawable39.icon_5077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5078: DrawableResource
+  get() = Drawable39.icon_5078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5079: DrawableResource
+  get() = Drawable39.icon_5079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_508: DrawableResource
+  get() = Drawable39.icon_508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5080: DrawableResource
+  get() = Drawable39.icon_5080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5081: DrawableResource
+  get() = Drawable39.icon_5081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5082: DrawableResource
+  get() = Drawable39.icon_5082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5083: DrawableResource
+  get() = Drawable39.icon_5083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5084: DrawableResource
+  get() = Drawable39.icon_5084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5085: DrawableResource
+  get() = Drawable39.icon_5085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5086: DrawableResource
+  get() = Drawable39.icon_5086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5087: DrawableResource
+  get() = Drawable39.icon_5087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5088: DrawableResource
+  get() = Drawable39.icon_5088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5089: DrawableResource
+  get() = Drawable39.icon_5089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_509: DrawableResource
+  get() = Drawable39.icon_509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5090: DrawableResource
+  get() = Drawable39.icon_5090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5091: DrawableResource
+  get() = Drawable39.icon_5091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5092: DrawableResource
+  get() = Drawable39.icon_5092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5093: DrawableResource
+  get() = Drawable39.icon_5093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5094: DrawableResource
+  get() = Drawable39.icon_5094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5095: DrawableResource
+  get() = Drawable39.icon_5095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5096: DrawableResource
+  get() = Drawable39.icon_5096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5097: DrawableResource
+  get() = Drawable39.icon_5097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5098: DrawableResource
+  get() = Drawable39.icon_5098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5099: DrawableResource
+  get() = Drawable39.icon_5099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_51: DrawableResource
+  get() = Drawable39.icon_51
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_510: DrawableResource
+  get() = Drawable39.icon_510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5100: DrawableResource
+  get() = Drawable39.icon_5100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5101: DrawableResource
+  get() = Drawable39.icon_5101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5102: DrawableResource
+  get() = Drawable39.icon_5102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5103: DrawableResource
+  get() = Drawable39.icon_5103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5104: DrawableResource
+  get() = Drawable39.icon_5104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5105: DrawableResource
+  get() = Drawable39.icon_5105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5106: DrawableResource
+  get() = Drawable39.icon_5106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5107: DrawableResource
+  get() = Drawable39.icon_5107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5108: DrawableResource
+  get() = Drawable39.icon_5108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5109: DrawableResource
+  get() = Drawable39.icon_5109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_511: DrawableResource
+  get() = Drawable39.icon_511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5110: DrawableResource
+  get() = Drawable39.icon_5110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5111: DrawableResource
+  get() = Drawable39.icon_5111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5112: DrawableResource
+  get() = Drawable39.icon_5112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5113: DrawableResource
+  get() = Drawable39.icon_5113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5114: DrawableResource
+  get() = Drawable39.icon_5114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5115: DrawableResource
+  get() = Drawable39.icon_5115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5116: DrawableResource
+  get() = Drawable39.icon_5116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5117: DrawableResource
+  get() = Drawable39.icon_5117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5118: DrawableResource
+  get() = Drawable39.icon_5118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5119: DrawableResource
+  get() = Drawable39.icon_5119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_512: DrawableResource
+  get() = Drawable39.icon_512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5120: DrawableResource
+  get() = Drawable39.icon_5120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5121: DrawableResource
+  get() = Drawable39.icon_5121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5122: DrawableResource
+  get() = Drawable39.icon_5122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5123: DrawableResource
+  get() = Drawable39.icon_5123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5124: DrawableResource
+  get() = Drawable39.icon_5124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5125: DrawableResource
+  get() = Drawable39.icon_5125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5126: DrawableResource
+  get() = Drawable39.icon_5126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5127: DrawableResource
+  get() = Drawable39.icon_5127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5128: DrawableResource
+  get() = Drawable39.icon_5128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5129: DrawableResource
+  get() = Drawable39.icon_5129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_513: DrawableResource
+  get() = Drawable39.icon_513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5130: DrawableResource
+  get() = Drawable39.icon_5130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5131: DrawableResource
+  get() = Drawable39.icon_5131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5132: DrawableResource
+  get() = Drawable39.icon_5132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5133: DrawableResource
+  get() = Drawable39.icon_5133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5134: DrawableResource
+  get() = Drawable39.icon_5134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5135: DrawableResource
+  get() = Drawable39.icon_5135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5136: DrawableResource
+  get() = Drawable39.icon_5136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5137: DrawableResource
+  get() = Drawable39.icon_5137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5138: DrawableResource
+  get() = Drawable39.icon_5138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5139: DrawableResource
+  get() = Drawable39.icon_5139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_514: DrawableResource
+  get() = Drawable39.icon_514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5140: DrawableResource
+  get() = Drawable39.icon_5140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5141: DrawableResource
+  get() = Drawable39.icon_5141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5142: DrawableResource
+  get() = Drawable39.icon_5142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5143: DrawableResource
+  get() = Drawable39.icon_5143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5144: DrawableResource
+  get() = Drawable39.icon_5144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5145: DrawableResource
+  get() = Drawable39.icon_5145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5146: DrawableResource
+  get() = Drawable39.icon_5146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5147: DrawableResource
+  get() = Drawable39.icon_5147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5148: DrawableResource
+  get() = Drawable39.icon_5148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5149: DrawableResource
+  get() = Drawable39.icon_5149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_515: DrawableResource
+  get() = Drawable39.icon_515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5150: DrawableResource
+  get() = Drawable39.icon_5150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5151: DrawableResource
+  get() = Drawable39.icon_5151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5152: DrawableResource
+  get() = Drawable39.icon_5152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5153: DrawableResource
+  get() = Drawable39.icon_5153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5154: DrawableResource
+  get() = Drawable39.icon_5154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5155: DrawableResource
+  get() = Drawable39.icon_5155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5156: DrawableResource
+  get() = Drawable39.icon_5156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5157: DrawableResource
+  get() = Drawable39.icon_5157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5158: DrawableResource
+  get() = Drawable39.icon_5158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5159: DrawableResource
+  get() = Drawable39.icon_5159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_516: DrawableResource
+  get() = Drawable39.icon_516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5160: DrawableResource
+  get() = Drawable39.icon_5160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5161: DrawableResource
+  get() = Drawable39.icon_5161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5162: DrawableResource
+  get() = Drawable39.icon_5162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5163: DrawableResource
+  get() = Drawable39.icon_5163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5164: DrawableResource
+  get() = Drawable39.icon_5164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5165: DrawableResource
+  get() = Drawable39.icon_5165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5166: DrawableResource
+  get() = Drawable39.icon_5166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5167: DrawableResource
+  get() = Drawable39.icon_5167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5168: DrawableResource
+  get() = Drawable39.icon_5168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5169: DrawableResource
+  get() = Drawable39.icon_5169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_517: DrawableResource
+  get() = Drawable39.icon_517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5170: DrawableResource
+  get() = Drawable39.icon_5170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5171: DrawableResource
+  get() = Drawable39.icon_5171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5172: DrawableResource
+  get() = Drawable39.icon_5172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5173: DrawableResource
+  get() = Drawable39.icon_5173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5174: DrawableResource
+  get() = Drawable39.icon_5174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5175: DrawableResource
+  get() = Drawable39.icon_5175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5176: DrawableResource
+  get() = Drawable39.icon_5176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5177: DrawableResource
+  get() = Drawable39.icon_5177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5178: DrawableResource
+  get() = Drawable39.icon_5178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5179: DrawableResource
+  get() = Drawable39.icon_5179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_518: DrawableResource
+  get() = Drawable39.icon_518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5180: DrawableResource
+  get() = Drawable39.icon_5180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5181: DrawableResource
+  get() = Drawable39.icon_5181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5182: DrawableResource
+  get() = Drawable39.icon_5182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5183: DrawableResource
+  get() = Drawable39.icon_5183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5184: DrawableResource
+  get() = Drawable39.icon_5184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5185: DrawableResource
+  get() = Drawable39.icon_5185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5186: DrawableResource
+  get() = Drawable39.icon_5186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5187: DrawableResource
+  get() = Drawable39.icon_5187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5188: DrawableResource
+  get() = Drawable39.icon_5188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5189: DrawableResource
+  get() = Drawable39.icon_5189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_519: DrawableResource
+  get() = Drawable39.icon_519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5190: DrawableResource
+  get() = Drawable39.icon_5190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5191: DrawableResource
+  get() = Drawable39.icon_5191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5192: DrawableResource
+  get() = Drawable39.icon_5192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5193: DrawableResource
+  get() = Drawable39.icon_5193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5194: DrawableResource
+  get() = Drawable39.icon_5194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5195: DrawableResource
+  get() = Drawable39.icon_5195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5196: DrawableResource
+  get() = Drawable39.icon_5196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5197: DrawableResource
+  get() = Drawable39.icon_5197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5198: DrawableResource
+  get() = Drawable39.icon_5198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5199: DrawableResource
+  get() = Drawable39.icon_5199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_52: DrawableResource
+  get() = Drawable39.icon_52
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_520: DrawableResource
+  get() = Drawable39.icon_520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5200: DrawableResource
+  get() = Drawable39.icon_5200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5201: DrawableResource
+  get() = Drawable39.icon_5201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5202: DrawableResource
+  get() = Drawable39.icon_5202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5203: DrawableResource
+  get() = Drawable39.icon_5203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5204: DrawableResource
+  get() = Drawable39.icon_5204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5205: DrawableResource
+  get() = Drawable39.icon_5205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5206: DrawableResource
+  get() = Drawable39.icon_5206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5207: DrawableResource
+  get() = Drawable39.icon_5207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5208: DrawableResource
+  get() = Drawable39.icon_5208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5209: DrawableResource
+  get() = Drawable39.icon_5209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_521: DrawableResource
+  get() = Drawable39.icon_521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5210: DrawableResource
+  get() = Drawable39.icon_5210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5211: DrawableResource
+  get() = Drawable39.icon_5211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5212: DrawableResource
+  get() = Drawable39.icon_5212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5213: DrawableResource
+  get() = Drawable39.icon_5213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5214: DrawableResource
+  get() = Drawable39.icon_5214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5215: DrawableResource
+  get() = Drawable39.icon_5215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5216: DrawableResource
+  get() = Drawable39.icon_5216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5217: DrawableResource
+  get() = Drawable39.icon_5217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5218: DrawableResource
+  get() = Drawable39.icon_5218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5219: DrawableResource
+  get() = Drawable39.icon_5219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_522: DrawableResource
+  get() = Drawable39.icon_522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5220: DrawableResource
+  get() = Drawable39.icon_5220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5221: DrawableResource
+  get() = Drawable39.icon_5221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5222: DrawableResource
+  get() = Drawable39.icon_5222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5223: DrawableResource
+  get() = Drawable39.icon_5223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5224: DrawableResource
+  get() = Drawable39.icon_5224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5225: DrawableResource
+  get() = Drawable39.icon_5225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5226: DrawableResource
+  get() = Drawable39.icon_5226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5227: DrawableResource
+  get() = Drawable39.icon_5227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5228: DrawableResource
+  get() = Drawable39.icon_5228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5229: DrawableResource
+  get() = Drawable39.icon_5229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_523: DrawableResource
+  get() = Drawable39.icon_523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5230: DrawableResource
+  get() = Drawable39.icon_5230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5231: DrawableResource
+  get() = Drawable39.icon_5231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5232: DrawableResource
+  get() = Drawable39.icon_5232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5233: DrawableResource
+  get() = Drawable39.icon_5233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5234: DrawableResource
+  get() = Drawable39.icon_5234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5235: DrawableResource
+  get() = Drawable39.icon_5235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5236: DrawableResource
+  get() = Drawable39.icon_5236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5237: DrawableResource
+  get() = Drawable39.icon_5237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5238: DrawableResource
+  get() = Drawable39.icon_5238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5239: DrawableResource
+  get() = Drawable39.icon_5239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_524: DrawableResource
+  get() = Drawable39.icon_524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5240: DrawableResource
+  get() = Drawable39.icon_5240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5241: DrawableResource
+  get() = Drawable39.icon_5241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5242: DrawableResource
+  get() = Drawable39.icon_5242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5243: DrawableResource
+  get() = Drawable39.icon_5243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5244: DrawableResource
+  get() = Drawable39.icon_5244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5245: DrawableResource
+  get() = Drawable39.icon_5245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5246: DrawableResource
+  get() = Drawable39.icon_5246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5247: DrawableResource
+  get() = Drawable39.icon_5247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5248: DrawableResource
+  get() = Drawable39.icon_5248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5249: DrawableResource
+  get() = Drawable39.icon_5249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_525: DrawableResource
+  get() = Drawable39.icon_525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5250: DrawableResource
+  get() = Drawable39.icon_5250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5251: DrawableResource
+  get() = Drawable39.icon_5251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5252: DrawableResource
+  get() = Drawable39.icon_5252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5253: DrawableResource
+  get() = Drawable39.icon_5253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5254: DrawableResource
+  get() = Drawable39.icon_5254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5255: DrawableResource
+  get() = Drawable39.icon_5255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5256: DrawableResource
+  get() = Drawable39.icon_5256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5257: DrawableResource
+  get() = Drawable39.icon_5257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5258: DrawableResource
+  get() = Drawable39.icon_5258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5259: DrawableResource
+  get() = Drawable39.icon_5259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_526: DrawableResource
+  get() = Drawable39.icon_526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5260: DrawableResource
+  get() = Drawable39.icon_5260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5261: DrawableResource
+  get() = Drawable39.icon_5261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5262: DrawableResource
+  get() = Drawable39.icon_5262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5263: DrawableResource
+  get() = Drawable39.icon_5263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5264: DrawableResource
+  get() = Drawable39.icon_5264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5265: DrawableResource
+  get() = Drawable39.icon_5265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5266: DrawableResource
+  get() = Drawable39.icon_5266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5267: DrawableResource
+  get() = Drawable39.icon_5267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5268: DrawableResource
+  get() = Drawable39.icon_5268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5269: DrawableResource
+  get() = Drawable39.icon_5269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_527: DrawableResource
+  get() = Drawable39.icon_527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5270: DrawableResource
+  get() = Drawable39.icon_5270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5271: DrawableResource
+  get() = Drawable39.icon_5271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5272: DrawableResource
+  get() = Drawable39.icon_5272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5273: DrawableResource
+  get() = Drawable39.icon_5273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5274: DrawableResource
+  get() = Drawable39.icon_5274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5275: DrawableResource
+  get() = Drawable39.icon_5275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5276: DrawableResource
+  get() = Drawable39.icon_5276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5277: DrawableResource
+  get() = Drawable39.icon_5277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5278: DrawableResource
+  get() = Drawable39.icon_5278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5279: DrawableResource
+  get() = Drawable39.icon_5279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_528: DrawableResource
+  get() = Drawable39.icon_528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5280: DrawableResource
+  get() = Drawable39.icon_5280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5281: DrawableResource
+  get() = Drawable39.icon_5281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5282: DrawableResource
+  get() = Drawable39.icon_5282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5283: DrawableResource
+  get() = Drawable39.icon_5283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5284: DrawableResource
+  get() = Drawable39.icon_5284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5285: DrawableResource
+  get() = Drawable39.icon_5285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5286: DrawableResource
+  get() = Drawable39.icon_5286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5287: DrawableResource
+  get() = Drawable39.icon_5287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5288: DrawableResource
+  get() = Drawable39.icon_5288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5289: DrawableResource
+  get() = Drawable39.icon_5289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_529: DrawableResource
+  get() = Drawable39.icon_529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5290: DrawableResource
+  get() = Drawable39.icon_5290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5291: DrawableResource
+  get() = Drawable39.icon_5291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5292: DrawableResource
+  get() = Drawable39.icon_5292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5293: DrawableResource
+  get() = Drawable39.icon_5293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5294: DrawableResource
+  get() = Drawable39.icon_5294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5295: DrawableResource
+  get() = Drawable39.icon_5295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5296: DrawableResource
+  get() = Drawable39.icon_5296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5297: DrawableResource
+  get() = Drawable39.icon_5297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5298: DrawableResource
+  get() = Drawable39.icon_5298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5299: DrawableResource
+  get() = Drawable39.icon_5299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_53: DrawableResource
+  get() = Drawable39.icon_53
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_530: DrawableResource
+  get() = Drawable39.icon_530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5300: DrawableResource
+  get() = Drawable39.icon_5300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5301: DrawableResource
+  get() = Drawable39.icon_5301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5302: DrawableResource
+  get() = Drawable39.icon_5302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5303: DrawableResource
+  get() = Drawable39.icon_5303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5304: DrawableResource
+  get() = Drawable39.icon_5304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5305: DrawableResource
+  get() = Drawable39.icon_5305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5306: DrawableResource
+  get() = Drawable39.icon_5306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5307: DrawableResource
+  get() = Drawable39.icon_5307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5308: DrawableResource
+  get() = Drawable39.icon_5308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5309: DrawableResource
+  get() = Drawable39.icon_5309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_531: DrawableResource
+  get() = Drawable39.icon_531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5310: DrawableResource
+  get() = Drawable39.icon_5310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5311: DrawableResource
+  get() = Drawable39.icon_5311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5312: DrawableResource
+  get() = Drawable39.icon_5312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5313: DrawableResource
+  get() = Drawable39.icon_5313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5314: DrawableResource
+  get() = Drawable39.icon_5314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5315: DrawableResource
+  get() = Drawable39.icon_5315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5316: DrawableResource
+  get() = Drawable39.icon_5316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5317: DrawableResource
+  get() = Drawable39.icon_5317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5318: DrawableResource
+  get() = Drawable39.icon_5318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5319: DrawableResource
+  get() = Drawable39.icon_5319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_532: DrawableResource
+  get() = Drawable39.icon_532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5320: DrawableResource
+  get() = Drawable39.icon_5320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5321: DrawableResource
+  get() = Drawable39.icon_5321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5322: DrawableResource
+  get() = Drawable39.icon_5322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5323: DrawableResource
+  get() = Drawable39.icon_5323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5324: DrawableResource
+  get() = Drawable39.icon_5324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5325: DrawableResource
+  get() = Drawable39.icon_5325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5326: DrawableResource
+  get() = Drawable39.icon_5326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5327: DrawableResource
+  get() = Drawable39.icon_5327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5328: DrawableResource
+  get() = Drawable39.icon_5328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5329: DrawableResource
+  get() = Drawable39.icon_5329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_533: DrawableResource
+  get() = Drawable39.icon_533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5330: DrawableResource
+  get() = Drawable39.icon_5330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5331: DrawableResource
+  get() = Drawable39.icon_5331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5332: DrawableResource
+  get() = Drawable39.icon_5332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5333: DrawableResource
+  get() = Drawable39.icon_5333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5334: DrawableResource
+  get() = Drawable39.icon_5334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5335: DrawableResource
+  get() = Drawable39.icon_5335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5336: DrawableResource
+  get() = Drawable39.icon_5336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5337: DrawableResource
+  get() = Drawable39.icon_5337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5338: DrawableResource
+  get() = Drawable39.icon_5338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5339: DrawableResource
+  get() = Drawable39.icon_5339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_534: DrawableResource
+  get() = Drawable39.icon_534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5340: DrawableResource
+  get() = Drawable39.icon_5340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5341: DrawableResource
+  get() = Drawable39.icon_5341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5342: DrawableResource
+  get() = Drawable39.icon_5342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5343: DrawableResource
+  get() = Drawable39.icon_5343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5344: DrawableResource
+  get() = Drawable39.icon_5344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5345: DrawableResource
+  get() = Drawable39.icon_5345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5346: DrawableResource
+  get() = Drawable39.icon_5346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5347: DrawableResource
+  get() = Drawable39.icon_5347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5348: DrawableResource
+  get() = Drawable39.icon_5348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5349: DrawableResource
+  get() = Drawable39.icon_5349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_535: DrawableResource
+  get() = Drawable39.icon_535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5350: DrawableResource
+  get() = Drawable39.icon_5350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5351: DrawableResource
+  get() = Drawable39.icon_5351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5352: DrawableResource
+  get() = Drawable39.icon_5352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5353: DrawableResource
+  get() = Drawable39.icon_5353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5354: DrawableResource
+  get() = Drawable39.icon_5354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5355: DrawableResource
+  get() = Drawable39.icon_5355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5356: DrawableResource
+  get() = Drawable39.icon_5356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5357: DrawableResource
+  get() = Drawable39.icon_5357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5358: DrawableResource
+  get() = Drawable39.icon_5358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5359: DrawableResource
+  get() = Drawable39.icon_5359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_536: DrawableResource
+  get() = Drawable39.icon_536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5360: DrawableResource
+  get() = Drawable39.icon_5360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5361: DrawableResource
+  get() = Drawable39.icon_5361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5362: DrawableResource
+  get() = Drawable39.icon_5362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5363: DrawableResource
+  get() = Drawable39.icon_5363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5364: DrawableResource
+  get() = Drawable39.icon_5364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5365: DrawableResource
+  get() = Drawable39.icon_5365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5366: DrawableResource
+  get() = Drawable39.icon_5366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5367: DrawableResource
+  get() = Drawable39.icon_5367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5368: DrawableResource
+  get() = Drawable39.icon_5368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5369: DrawableResource
+  get() = Drawable39.icon_5369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_537: DrawableResource
+  get() = Drawable39.icon_537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5370: DrawableResource
+  get() = Drawable39.icon_5370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5371: DrawableResource
+  get() = Drawable39.icon_5371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5372: DrawableResource
+  get() = Drawable39.icon_5372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5373: DrawableResource
+  get() = Drawable39.icon_5373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5374: DrawableResource
+  get() = Drawable39.icon_5374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5375: DrawableResource
+  get() = Drawable39.icon_5375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5376: DrawableResource
+  get() = Drawable39.icon_5376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5377: DrawableResource
+  get() = Drawable39.icon_5377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5378: DrawableResource
+  get() = Drawable39.icon_5378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5379: DrawableResource
+  get() = Drawable39.icon_5379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_538: DrawableResource
+  get() = Drawable39.icon_538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5380: DrawableResource
+  get() = Drawable39.icon_5380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5381: DrawableResource
+  get() = Drawable39.icon_5381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5382: DrawableResource
+  get() = Drawable39.icon_5382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5383: DrawableResource
+  get() = Drawable39.icon_5383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5384: DrawableResource
+  get() = Drawable39.icon_5384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5385: DrawableResource
+  get() = Drawable39.icon_5385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5386: DrawableResource
+  get() = Drawable39.icon_5386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5387: DrawableResource
+  get() = Drawable39.icon_5387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5388: DrawableResource
+  get() = Drawable39.icon_5388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5389: DrawableResource
+  get() = Drawable39.icon_5389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_539: DrawableResource
+  get() = Drawable39.icon_539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5390: DrawableResource
+  get() = Drawable39.icon_5390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5391: DrawableResource
+  get() = Drawable39.icon_5391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5392: DrawableResource
+  get() = Drawable39.icon_5392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5393: DrawableResource
+  get() = Drawable39.icon_5393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5394: DrawableResource
+  get() = Drawable39.icon_5394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5395: DrawableResource
+  get() = Drawable39.icon_5395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5396: DrawableResource
+  get() = Drawable39.icon_5396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5397: DrawableResource
+  get() = Drawable39.icon_5397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5398: DrawableResource
+  get() = Drawable39.icon_5398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5399: DrawableResource
+  get() = Drawable39.icon_5399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_54: DrawableResource
+  get() = Drawable39.icon_54
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_540: DrawableResource
+  get() = Drawable39.icon_540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5400: DrawableResource
+  get() = Drawable39.icon_5400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5401: DrawableResource
+  get() = Drawable39.icon_5401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5402: DrawableResource
+  get() = Drawable39.icon_5402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5403: DrawableResource
+  get() = Drawable39.icon_5403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5404: DrawableResource
+  get() = Drawable39.icon_5404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5405: DrawableResource
+  get() = Drawable39.icon_5405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5406: DrawableResource
+  get() = Drawable39.icon_5406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5407: DrawableResource
+  get() = Drawable39.icon_5407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5408: DrawableResource
+  get() = Drawable39.icon_5408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5409: DrawableResource
+  get() = Drawable39.icon_5409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_541: DrawableResource
+  get() = Drawable39.icon_541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5410: DrawableResource
+  get() = Drawable39.icon_5410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5411: DrawableResource
+  get() = Drawable39.icon_5411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5412: DrawableResource
+  get() = Drawable39.icon_5412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5413: DrawableResource
+  get() = Drawable39.icon_5413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5414: DrawableResource
+  get() = Drawable39.icon_5414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5415: DrawableResource
+  get() = Drawable39.icon_5415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5416: DrawableResource
+  get() = Drawable39.icon_5416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5417: DrawableResource
+  get() = Drawable39.icon_5417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5418: DrawableResource
+  get() = Drawable39.icon_5418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5419: DrawableResource
+  get() = Drawable39.icon_5419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_542: DrawableResource
+  get() = Drawable39.icon_542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5420: DrawableResource
+  get() = Drawable39.icon_5420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5421: DrawableResource
+  get() = Drawable39.icon_5421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5422: DrawableResource
+  get() = Drawable39.icon_5422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5423: DrawableResource
+  get() = Drawable39.icon_5423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5424: DrawableResource
+  get() = Drawable39.icon_5424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5425: DrawableResource
+  get() = Drawable39.icon_5425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5426: DrawableResource
+  get() = Drawable39.icon_5426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5427: DrawableResource
+  get() = Drawable39.icon_5427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5428: DrawableResource
+  get() = Drawable39.icon_5428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5429: DrawableResource
+  get() = Drawable39.icon_5429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_543: DrawableResource
+  get() = Drawable39.icon_543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5430: DrawableResource
+  get() = Drawable39.icon_5430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5431: DrawableResource
+  get() = Drawable39.icon_5431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5432: DrawableResource
+  get() = Drawable39.icon_5432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5433: DrawableResource
+  get() = Drawable39.icon_5433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5434: DrawableResource
+  get() = Drawable39.icon_5434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5435: DrawableResource
+  get() = Drawable39.icon_5435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5436: DrawableResource
+  get() = Drawable39.icon_5436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5437: DrawableResource
+  get() = Drawable39.icon_5437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5438: DrawableResource
+  get() = Drawable39.icon_5438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5439: DrawableResource
+  get() = Drawable39.icon_5439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_544: DrawableResource
+  get() = Drawable39.icon_544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5440: DrawableResource
+  get() = Drawable39.icon_5440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5441: DrawableResource
+  get() = Drawable39.icon_5441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5442: DrawableResource
+  get() = Drawable39.icon_5442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5443: DrawableResource
+  get() = Drawable39.icon_5443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5444: DrawableResource
+  get() = Drawable39.icon_5444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5445: DrawableResource
+  get() = Drawable39.icon_5445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5446: DrawableResource
+  get() = Drawable39.icon_5446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5447: DrawableResource
+  get() = Drawable39.icon_5447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5448: DrawableResource
+  get() = Drawable39.icon_5448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5449: DrawableResource
+  get() = Drawable39.icon_5449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_545: DrawableResource
+  get() = Drawable39.icon_545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5450: DrawableResource
+  get() = Drawable39.icon_5450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5451: DrawableResource
+  get() = Drawable39.icon_5451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5452: DrawableResource
+  get() = Drawable39.icon_5452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5453: DrawableResource
+  get() = Drawable39.icon_5453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5454: DrawableResource
+  get() = Drawable39.icon_5454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5455: DrawableResource
+  get() = Drawable39.icon_5455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5456: DrawableResource
+  get() = Drawable39.icon_5456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5457: DrawableResource
+  get() = Drawable39.icon_5457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5458: DrawableResource
+  get() = Drawable39.icon_5458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5459: DrawableResource
+  get() = Drawable39.icon_5459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_546: DrawableResource
+  get() = Drawable39.icon_546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5460: DrawableResource
+  get() = Drawable39.icon_5460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5461: DrawableResource
+  get() = Drawable39.icon_5461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5462: DrawableResource
+  get() = Drawable39.icon_5462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5463: DrawableResource
+  get() = Drawable39.icon_5463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5464: DrawableResource
+  get() = Drawable39.icon_5464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5465: DrawableResource
+  get() = Drawable39.icon_5465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5466: DrawableResource
+  get() = Drawable39.icon_5466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5467: DrawableResource
+  get() = Drawable39.icon_5467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5468: DrawableResource
+  get() = Drawable39.icon_5468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5469: DrawableResource
+  get() = Drawable39.icon_5469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_547: DrawableResource
+  get() = Drawable39.icon_547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5470: DrawableResource
+  get() = Drawable39.icon_5470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5471: DrawableResource
+  get() = Drawable39.icon_5471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5472: DrawableResource
+  get() = Drawable39.icon_5472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5473: DrawableResource
+  get() = Drawable39.icon_5473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5474: DrawableResource
+  get() = Drawable39.icon_5474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5475: DrawableResource
+  get() = Drawable39.icon_5475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5476: DrawableResource
+  get() = Drawable39.icon_5476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5477: DrawableResource
+  get() = Drawable39.icon_5477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5478: DrawableResource
+  get() = Drawable39.icon_5478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5479: DrawableResource
+  get() = Drawable39.icon_5479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_548: DrawableResource
+  get() = Drawable39.icon_548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5480: DrawableResource
+  get() = Drawable39.icon_5480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5481: DrawableResource
+  get() = Drawable39.icon_5481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5482: DrawableResource
+  get() = Drawable39.icon_5482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5483: DrawableResource
+  get() = Drawable39.icon_5483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5484: DrawableResource
+  get() = Drawable39.icon_5484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5485: DrawableResource
+  get() = Drawable39.icon_5485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5486: DrawableResource
+  get() = Drawable39.icon_5486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5487: DrawableResource
+  get() = Drawable39.icon_5487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5488: DrawableResource
+  get() = Drawable39.icon_5488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5489: DrawableResource
+  get() = Drawable39.icon_5489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_549: DrawableResource
+  get() = Drawable39.icon_549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5490: DrawableResource
+  get() = Drawable39.icon_5490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5491: DrawableResource
+  get() = Drawable39.icon_5491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5492: DrawableResource
+  get() = Drawable39.icon_5492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5493: DrawableResource
+  get() = Drawable39.icon_5493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5494: DrawableResource
+  get() = Drawable39.icon_5494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5495: DrawableResource
+  get() = Drawable39.icon_5495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5496: DrawableResource
+  get() = Drawable39.icon_5496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5497: DrawableResource
+  get() = Drawable39.icon_5497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5498: DrawableResource
+  get() = Drawable39.icon_5498

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable4.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable4.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable4 {
+  public val icon_11798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11798.xml"),
+          )
+      )
+
+  public val icon_11799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11799.xml"),
+          )
+      )
+
+  public val icon_118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_118.xml"),
+          )
+      )
+
+  public val icon_1180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1180.xml"),
+          )
+      )
+
+  public val icon_11800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11800.xml"),
+          )
+      )
+
+  public val icon_11801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11801.xml"),
+          )
+      )
+
+  public val icon_11802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11802.xml"),
+          )
+      )
+
+  public val icon_11803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11803.xml"),
+          )
+      )
+
+  public val icon_11804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11804.xml"),
+          )
+      )
+
+  public val icon_11805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11805.xml"),
+          )
+      )
+
+  public val icon_11806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11806.xml"),
+          )
+      )
+
+  public val icon_11807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11807.xml"),
+          )
+      )
+
+  public val icon_11808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11808.xml"),
+          )
+      )
+
+  public val icon_11809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11809.xml"),
+          )
+      )
+
+  public val icon_1181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1181.xml"),
+          )
+      )
+
+  public val icon_11810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11810.xml"),
+          )
+      )
+
+  public val icon_11811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11811.xml"),
+          )
+      )
+
+  public val icon_11812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11812.xml"),
+          )
+      )
+
+  public val icon_11813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11813.xml"),
+          )
+      )
+
+  public val icon_11814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11814.xml"),
+          )
+      )
+
+  public val icon_11815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11815.xml"),
+          )
+      )
+
+  public val icon_11816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11816.xml"),
+          )
+      )
+
+  public val icon_11817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11817.xml"),
+          )
+      )
+
+  public val icon_11818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11818.xml"),
+          )
+      )
+
+  public val icon_11819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11819.xml"),
+          )
+      )
+
+  public val icon_1182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1182.xml"),
+          )
+      )
+
+  public val icon_11820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11820.xml"),
+          )
+      )
+
+  public val icon_11821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11821.xml"),
+          )
+      )
+
+  public val icon_11822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11822.xml"),
+          )
+      )
+
+  public val icon_11823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11823.xml"),
+          )
+      )
+
+  public val icon_11824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11824.xml"),
+          )
+      )
+
+  public val icon_11825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11825.xml"),
+          )
+      )
+
+  public val icon_11826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11826.xml"),
+          )
+      )
+
+  public val icon_11827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11827.xml"),
+          )
+      )
+
+  public val icon_11828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11828.xml"),
+          )
+      )
+
+  public val icon_11829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11829.xml"),
+          )
+      )
+
+  public val icon_1183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1183.xml"),
+          )
+      )
+
+  public val icon_11830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11830.xml"),
+          )
+      )
+
+  public val icon_11831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11831.xml"),
+          )
+      )
+
+  public val icon_11832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11832.xml"),
+          )
+      )
+
+  public val icon_11833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11833.xml"),
+          )
+      )
+
+  public val icon_11834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11834.xml"),
+          )
+      )
+
+  public val icon_11835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11835.xml"),
+          )
+      )
+
+  public val icon_11836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11836.xml"),
+          )
+      )
+
+  public val icon_11837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11837.xml"),
+          )
+      )
+
+  public val icon_11838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11838.xml"),
+          )
+      )
+
+  public val icon_11839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11839.xml"),
+          )
+      )
+
+  public val icon_1184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1184.xml"),
+          )
+      )
+
+  public val icon_11840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11840.xml"),
+          )
+      )
+
+  public val icon_11841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11841.xml"),
+          )
+      )
+
+  public val icon_11842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11842.xml"),
+          )
+      )
+
+  public val icon_11843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11843.xml"),
+          )
+      )
+
+  public val icon_11844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11844.xml"),
+          )
+      )
+
+  public val icon_11845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11845.xml"),
+          )
+      )
+
+  public val icon_11846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11846.xml"),
+          )
+      )
+
+  public val icon_11847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11847.xml"),
+          )
+      )
+
+  public val icon_11848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11848.xml"),
+          )
+      )
+
+  public val icon_11849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11849.xml"),
+          )
+      )
+
+  public val icon_1185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1185.xml"),
+          )
+      )
+
+  public val icon_11850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11850.xml"),
+          )
+      )
+
+  public val icon_11851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11851.xml"),
+          )
+      )
+
+  public val icon_11852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11852.xml"),
+          )
+      )
+
+  public val icon_11853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11853.xml"),
+          )
+      )
+
+  public val icon_11854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11854.xml"),
+          )
+      )
+
+  public val icon_11855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11855.xml"),
+          )
+      )
+
+  public val icon_11856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11856.xml"),
+          )
+      )
+
+  public val icon_11857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11857.xml"),
+          )
+      )
+
+  public val icon_11858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11858.xml"),
+          )
+      )
+
+  public val icon_11859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11859.xml"),
+          )
+      )
+
+  public val icon_1186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1186.xml"),
+          )
+      )
+
+  public val icon_11860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11860.xml"),
+          )
+      )
+
+  public val icon_11861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11861.xml"),
+          )
+      )
+
+  public val icon_11862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11862.xml"),
+          )
+      )
+
+  public val icon_11863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11863.xml"),
+          )
+      )
+
+  public val icon_11864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11864.xml"),
+          )
+      )
+
+  public val icon_11865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11865.xml"),
+          )
+      )
+
+  public val icon_11866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11866.xml"),
+          )
+      )
+
+  public val icon_11867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11867.xml"),
+          )
+      )
+
+  public val icon_11868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11868.xml"),
+          )
+      )
+
+  public val icon_11869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11869.xml"),
+          )
+      )
+
+  public val icon_1187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1187.xml"),
+          )
+      )
+
+  public val icon_11870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11870.xml"),
+          )
+      )
+
+  public val icon_11871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11871.xml"),
+          )
+      )
+
+  public val icon_11872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11872.xml"),
+          )
+      )
+
+  public val icon_11873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11873.xml"),
+          )
+      )
+
+  public val icon_11874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11874.xml"),
+          )
+      )
+
+  public val icon_11875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11875.xml"),
+          )
+      )
+
+  public val icon_11876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11876.xml"),
+          )
+      )
+
+  public val icon_11877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11877.xml"),
+          )
+      )
+
+  public val icon_11878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11878.xml"),
+          )
+      )
+
+  public val icon_11879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11879.xml"),
+          )
+      )
+
+  public val icon_1188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1188.xml"),
+          )
+      )
+
+  public val icon_11880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11880.xml"),
+          )
+      )
+
+  public val icon_11881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11881.xml"),
+          )
+      )
+
+  public val icon_11882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11882.xml"),
+          )
+      )
+
+  public val icon_11883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11883.xml"),
+          )
+      )
+
+  public val icon_11884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11884.xml"),
+          )
+      )
+
+  public val icon_11885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11885.xml"),
+          )
+      )
+
+  public val icon_11886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11886.xml"),
+          )
+      )
+
+  public val icon_11887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11887.xml"),
+          )
+      )
+
+  public val icon_11888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11888.xml"),
+          )
+      )
+
+  public val icon_11889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11889.xml"),
+          )
+      )
+
+  public val icon_1189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1189.xml"),
+          )
+      )
+
+  public val icon_11890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11890.xml"),
+          )
+      )
+
+  public val icon_11891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11891.xml"),
+          )
+      )
+
+  public val icon_11892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11892.xml"),
+          )
+      )
+
+  public val icon_11893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11893.xml"),
+          )
+      )
+
+  public val icon_11894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11894.xml"),
+          )
+      )
+
+  public val icon_11895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11895.xml"),
+          )
+      )
+
+  public val icon_11896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11896.xml"),
+          )
+      )
+
+  public val icon_11897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11897.xml"),
+          )
+      )
+
+  public val icon_11898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11898.xml"),
+          )
+      )
+
+  public val icon_11899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11899.xml"),
+          )
+      )
+
+  public val icon_119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_119.xml"),
+          )
+      )
+
+  public val icon_1190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1190.xml"),
+          )
+      )
+
+  public val icon_11900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11900.xml"),
+          )
+      )
+
+  public val icon_11901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11901.xml"),
+          )
+      )
+
+  public val icon_11902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11902.xml"),
+          )
+      )
+
+  public val icon_11903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11903.xml"),
+          )
+      )
+
+  public val icon_11904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11904.xml"),
+          )
+      )
+
+  public val icon_11905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11905.xml"),
+          )
+      )
+
+  public val icon_11906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11906.xml"),
+          )
+      )
+
+  public val icon_11907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11907.xml"),
+          )
+      )
+
+  public val icon_11908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11908.xml"),
+          )
+      )
+
+  public val icon_11909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11909.xml"),
+          )
+      )
+
+  public val icon_1191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1191.xml"),
+          )
+      )
+
+  public val icon_11910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11910.xml"),
+          )
+      )
+
+  public val icon_11911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11911.xml"),
+          )
+      )
+
+  public val icon_11912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11912.xml"),
+          )
+      )
+
+  public val icon_11913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11913.xml"),
+          )
+      )
+
+  public val icon_11914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11914.xml"),
+          )
+      )
+
+  public val icon_11915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11915.xml"),
+          )
+      )
+
+  public val icon_11916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11916.xml"),
+          )
+      )
+
+  public val icon_11917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11917.xml"),
+          )
+      )
+
+  public val icon_11918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11918.xml"),
+          )
+      )
+
+  public val icon_11919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11919.xml"),
+          )
+      )
+
+  public val icon_1192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1192.xml"),
+          )
+      )
+
+  public val icon_11920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11920.xml"),
+          )
+      )
+
+  public val icon_11921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11921.xml"),
+          )
+      )
+
+  public val icon_11922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11922.xml"),
+          )
+      )
+
+  public val icon_11923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11923.xml"),
+          )
+      )
+
+  public val icon_11924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11924.xml"),
+          )
+      )
+
+  public val icon_11925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11925.xml"),
+          )
+      )
+
+  public val icon_11926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11926.xml"),
+          )
+      )
+
+  public val icon_11927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11927.xml"),
+          )
+      )
+
+  public val icon_11928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11928.xml"),
+          )
+      )
+
+  public val icon_11929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11929.xml"),
+          )
+      )
+
+  public val icon_1193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1193.xml"),
+          )
+      )
+
+  public val icon_11930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11930.xml"),
+          )
+      )
+
+  public val icon_11931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11931.xml"),
+          )
+      )
+
+  public val icon_11932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11932.xml"),
+          )
+      )
+
+  public val icon_11933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11933.xml"),
+          )
+      )
+
+  public val icon_11934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11934.xml"),
+          )
+      )
+
+  public val icon_11935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11935.xml"),
+          )
+      )
+
+  public val icon_11936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11936.xml"),
+          )
+      )
+
+  public val icon_11937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11937.xml"),
+          )
+      )
+
+  public val icon_11938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11938.xml"),
+          )
+      )
+
+  public val icon_11939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11939.xml"),
+          )
+      )
+
+  public val icon_1194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1194.xml"),
+          )
+      )
+
+  public val icon_11940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11940.xml"),
+          )
+      )
+
+  public val icon_11941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11941.xml"),
+          )
+      )
+
+  public val icon_11942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11942.xml"),
+          )
+      )
+
+  public val icon_11943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11943.xml"),
+          )
+      )
+
+  public val icon_11944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11944.xml"),
+          )
+      )
+
+  public val icon_11945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11945.xml"),
+          )
+      )
+
+  public val icon_11946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11946.xml"),
+          )
+      )
+
+  public val icon_11947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11947.xml"),
+          )
+      )
+
+  public val icon_11948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11948.xml"),
+          )
+      )
+
+  public val icon_11949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11949.xml"),
+          )
+      )
+
+  public val icon_1195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1195.xml"),
+          )
+      )
+
+  public val icon_11950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11950.xml"),
+          )
+      )
+
+  public val icon_11951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11951.xml"),
+          )
+      )
+
+  public val icon_11952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11952.xml"),
+          )
+      )
+
+  public val icon_11953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11953.xml"),
+          )
+      )
+
+  public val icon_11954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11954.xml"),
+          )
+      )
+
+  public val icon_11955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11955.xml"),
+          )
+      )
+
+  public val icon_11956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11956.xml"),
+          )
+      )
+
+  public val icon_11957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11957.xml"),
+          )
+      )
+
+  public val icon_11958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11958.xml"),
+          )
+      )
+
+  public val icon_11959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11959.xml"),
+          )
+      )
+
+  public val icon_1196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1196.xml"),
+          )
+      )
+
+  public val icon_11960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11960.xml"),
+          )
+      )
+
+  public val icon_11961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11961.xml"),
+          )
+      )
+
+  public val icon_11962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11962.xml"),
+          )
+      )
+
+  public val icon_11963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11963.xml"),
+          )
+      )
+
+  public val icon_11964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11964.xml"),
+          )
+      )
+
+  public val icon_11965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11965.xml"),
+          )
+      )
+
+  public val icon_11966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11966.xml"),
+          )
+      )
+
+  public val icon_11967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11967.xml"),
+          )
+      )
+
+  public val icon_11968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11968.xml"),
+          )
+      )
+
+  public val icon_11969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11969.xml"),
+          )
+      )
+
+  public val icon_1197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1197.xml"),
+          )
+      )
+
+  public val icon_11970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11970.xml"),
+          )
+      )
+
+  public val icon_11971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11971.xml"),
+          )
+      )
+
+  public val icon_11972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11972.xml"),
+          )
+      )
+
+  public val icon_11973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11973.xml"),
+          )
+      )
+
+  public val icon_11974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11974.xml"),
+          )
+      )
+
+  public val icon_11975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11975.xml"),
+          )
+      )
+
+  public val icon_11976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11976.xml"),
+          )
+      )
+
+  public val icon_11977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11977.xml"),
+          )
+      )
+
+  public val icon_11978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11978.xml"),
+          )
+      )
+
+  public val icon_11979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11979.xml"),
+          )
+      )
+
+  public val icon_1198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1198.xml"),
+          )
+      )
+
+  public val icon_11980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11980.xml"),
+          )
+      )
+
+  public val icon_11981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11981.xml"),
+          )
+      )
+
+  public val icon_11982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11982.xml"),
+          )
+      )
+
+  public val icon_11983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11983.xml"),
+          )
+      )
+
+  public val icon_11984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11984.xml"),
+          )
+      )
+
+  public val icon_11985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11985.xml"),
+          )
+      )
+
+  public val icon_11986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11986.xml"),
+          )
+      )
+
+  public val icon_11987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11987.xml"),
+          )
+      )
+
+  public val icon_11988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11988.xml"),
+          )
+      )
+
+  public val icon_11989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11989.xml"),
+          )
+      )
+
+  public val icon_1199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1199.xml"),
+          )
+      )
+
+  public val icon_11990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11990.xml"),
+          )
+      )
+
+  public val icon_11991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11991.xml"),
+          )
+      )
+
+  public val icon_11992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11992.xml"),
+          )
+      )
+
+  public val icon_11993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11993.xml"),
+          )
+      )
+
+  public val icon_11994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11994.xml"),
+          )
+      )
+
+  public val icon_11995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11995.xml"),
+          )
+      )
+
+  public val icon_11996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11996.xml"),
+          )
+      )
+
+  public val icon_11997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11997.xml"),
+          )
+      )
+
+  public val icon_11998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11998.xml"),
+          )
+      )
+
+  public val icon_11999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_11999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_11999.xml"),
+          )
+      )
+
+  public val icon_12: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12.xml"),
+          )
+      )
+
+  public val icon_120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_120.xml"),
+          )
+      )
+
+  public val icon_1200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1200.xml"),
+          )
+      )
+
+  public val icon_12000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12000.xml"),
+          )
+      )
+
+  public val icon_12001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12001.xml"),
+          )
+      )
+
+  public val icon_12002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12002.xml"),
+          )
+      )
+
+  public val icon_12003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12003.xml"),
+          )
+      )
+
+  public val icon_12004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12004.xml"),
+          )
+      )
+
+  public val icon_12005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12005.xml"),
+          )
+      )
+
+  public val icon_12006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12006.xml"),
+          )
+      )
+
+  public val icon_12007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12007.xml"),
+          )
+      )
+
+  public val icon_12008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12008.xml"),
+          )
+      )
+
+  public val icon_12009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12009.xml"),
+          )
+      )
+
+  public val icon_1201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1201.xml"),
+          )
+      )
+
+  public val icon_12010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12010.xml"),
+          )
+      )
+
+  public val icon_12011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12011.xml"),
+          )
+      )
+
+  public val icon_12012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12012.xml"),
+          )
+      )
+
+  public val icon_12013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12013.xml"),
+          )
+      )
+
+  public val icon_12014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12014.xml"),
+          )
+      )
+
+  public val icon_12015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12015.xml"),
+          )
+      )
+
+  public val icon_12016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12016.xml"),
+          )
+      )
+
+  public val icon_12017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12017.xml"),
+          )
+      )
+
+  public val icon_12018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12018.xml"),
+          )
+      )
+
+  public val icon_12019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12019.xml"),
+          )
+      )
+
+  public val icon_1202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1202.xml"),
+          )
+      )
+
+  public val icon_12020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12020.xml"),
+          )
+      )
+
+  public val icon_12021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12021.xml"),
+          )
+      )
+
+  public val icon_12022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12022.xml"),
+          )
+      )
+
+  public val icon_12023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12023.xml"),
+          )
+      )
+
+  public val icon_12024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12024.xml"),
+          )
+      )
+
+  public val icon_12025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12025.xml"),
+          )
+      )
+
+  public val icon_12026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12026.xml"),
+          )
+      )
+
+  public val icon_12027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12027.xml"),
+          )
+      )
+
+  public val icon_12028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12028.xml"),
+          )
+      )
+
+  public val icon_12029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12029.xml"),
+          )
+      )
+
+  public val icon_1203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1203.xml"),
+          )
+      )
+
+  public val icon_12030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12030.xml"),
+          )
+      )
+
+  public val icon_12031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12031.xml"),
+          )
+      )
+
+  public val icon_12032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12032.xml"),
+          )
+      )
+
+  public val icon_12033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12033.xml"),
+          )
+      )
+
+  public val icon_12034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12034.xml"),
+          )
+      )
+
+  public val icon_12035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12035.xml"),
+          )
+      )
+
+  public val icon_12036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12036.xml"),
+          )
+      )
+
+  public val icon_12037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12037.xml"),
+          )
+      )
+
+  public val icon_12038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12038.xml"),
+          )
+      )
+
+  public val icon_12039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12039.xml"),
+          )
+      )
+
+  public val icon_1204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1204.xml"),
+          )
+      )
+
+  public val icon_12040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12040.xml"),
+          )
+      )
+
+  public val icon_12041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12041.xml"),
+          )
+      )
+
+  public val icon_12042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12042.xml"),
+          )
+      )
+
+  public val icon_12043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12043.xml"),
+          )
+      )
+
+  public val icon_12044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12044.xml"),
+          )
+      )
+
+  public val icon_12045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12045.xml"),
+          )
+      )
+
+  public val icon_12046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12046.xml"),
+          )
+      )
+
+  public val icon_12047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12047.xml"),
+          )
+      )
+
+  public val icon_12048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12048.xml"),
+          )
+      )
+
+  public val icon_12049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12049.xml"),
+          )
+      )
+
+  public val icon_1205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1205.xml"),
+          )
+      )
+
+  public val icon_12050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12050.xml"),
+          )
+      )
+
+  public val icon_12051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12051.xml"),
+          )
+      )
+
+  public val icon_12052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12052.xml"),
+          )
+      )
+
+  public val icon_12053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12053.xml"),
+          )
+      )
+
+  public val icon_12054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12054.xml"),
+          )
+      )
+
+  public val icon_12055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12055.xml"),
+          )
+      )
+
+  public val icon_12056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12056.xml"),
+          )
+      )
+
+  public val icon_12057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12057.xml"),
+          )
+      )
+
+  public val icon_12058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12058.xml"),
+          )
+      )
+
+  public val icon_12059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12059.xml"),
+          )
+      )
+
+  public val icon_1206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1206.xml"),
+          )
+      )
+
+  public val icon_12060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12060.xml"),
+          )
+      )
+
+  public val icon_12061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12061.xml"),
+          )
+      )
+
+  public val icon_12062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12062.xml"),
+          )
+      )
+
+  public val icon_12063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12063.xml"),
+          )
+      )
+
+  public val icon_12064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12064.xml"),
+          )
+      )
+
+  public val icon_12065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12065.xml"),
+          )
+      )
+
+  public val icon_12066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12066.xml"),
+          )
+      )
+
+  public val icon_12067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12067.xml"),
+          )
+      )
+
+  public val icon_12068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12068.xml"),
+          )
+      )
+
+  public val icon_12069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12069.xml"),
+          )
+      )
+
+  public val icon_1207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1207.xml"),
+          )
+      )
+
+  public val icon_12070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12070.xml"),
+          )
+      )
+
+  public val icon_12071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12071.xml"),
+          )
+      )
+
+  public val icon_12072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12072.xml"),
+          )
+      )
+
+  public val icon_12073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12073.xml"),
+          )
+      )
+
+  public val icon_12074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12074.xml"),
+          )
+      )
+
+  public val icon_12075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12075.xml"),
+          )
+      )
+
+  public val icon_12076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12076.xml"),
+          )
+      )
+
+  public val icon_12077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12077.xml"),
+          )
+      )
+
+  public val icon_12078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12078.xml"),
+          )
+      )
+
+  public val icon_12079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12079.xml"),
+          )
+      )
+
+  public val icon_1208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1208.xml"),
+          )
+      )
+
+  public val icon_12080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12080.xml"),
+          )
+      )
+
+  public val icon_12081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12081.xml"),
+          )
+      )
+
+  public val icon_12082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12082.xml"),
+          )
+      )
+
+  public val icon_12083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12083.xml"),
+          )
+      )
+
+  public val icon_12084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12084.xml"),
+          )
+      )
+
+  public val icon_12085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12085.xml"),
+          )
+      )
+
+  public val icon_12086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12086.xml"),
+          )
+      )
+
+  public val icon_12087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12087.xml"),
+          )
+      )
+
+  public val icon_12088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12088.xml"),
+          )
+      )
+
+  public val icon_12089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12089.xml"),
+          )
+      )
+
+  public val icon_1209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1209.xml"),
+          )
+      )
+
+  public val icon_12090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12090.xml"),
+          )
+      )
+
+  public val icon_12091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12091.xml"),
+          )
+      )
+
+  public val icon_12092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12092.xml"),
+          )
+      )
+
+  public val icon_12093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12093.xml"),
+          )
+      )
+
+  public val icon_12094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12094.xml"),
+          )
+      )
+
+  public val icon_12095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12095.xml"),
+          )
+      )
+
+  public val icon_12096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12096.xml"),
+          )
+      )
+
+  public val icon_12097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12097.xml"),
+          )
+      )
+
+  public val icon_12098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12098.xml"),
+          )
+      )
+
+  public val icon_12099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12099.xml"),
+          )
+      )
+
+  public val icon_121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_121.xml"),
+          )
+      )
+
+  public val icon_1210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1210.xml"),
+          )
+      )
+
+  public val icon_12100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12100.xml"),
+          )
+      )
+
+  public val icon_12101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12101.xml"),
+          )
+      )
+
+  public val icon_12102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12102.xml"),
+          )
+      )
+
+  public val icon_12103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12103.xml"),
+          )
+      )
+
+  public val icon_12104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12104.xml"),
+          )
+      )
+
+  public val icon_12105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12105.xml"),
+          )
+      )
+
+  public val icon_12106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12106.xml"),
+          )
+      )
+
+  public val icon_12107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12107.xml"),
+          )
+      )
+
+  public val icon_12108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12108.xml"),
+          )
+      )
+
+  public val icon_12109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12109.xml"),
+          )
+      )
+
+  public val icon_1211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1211.xml"),
+          )
+      )
+
+  public val icon_12110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12110.xml"),
+          )
+      )
+
+  public val icon_12111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12111.xml"),
+          )
+      )
+
+  public val icon_12112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12112.xml"),
+          )
+      )
+
+  public val icon_12113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12113.xml"),
+          )
+      )
+
+  public val icon_12114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12114.xml"),
+          )
+      )
+
+  public val icon_12115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12115.xml"),
+          )
+      )
+
+  public val icon_12116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12116.xml"),
+          )
+      )
+
+  public val icon_12117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12117.xml"),
+          )
+      )
+
+  public val icon_12118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12118.xml"),
+          )
+      )
+
+  public val icon_12119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12119.xml"),
+          )
+      )
+
+  public val icon_1212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1212.xml"),
+          )
+      )
+
+  public val icon_12120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12120.xml"),
+          )
+      )
+
+  public val icon_12121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12121.xml"),
+          )
+      )
+
+  public val icon_12122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12122.xml"),
+          )
+      )
+
+  public val icon_12123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12123.xml"),
+          )
+      )
+
+  public val icon_12124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12124.xml"),
+          )
+      )
+
+  public val icon_12125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12125.xml"),
+          )
+      )
+
+  public val icon_12126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12126.xml"),
+          )
+      )
+
+  public val icon_12127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12127.xml"),
+          )
+      )
+
+  public val icon_12128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12128.xml"),
+          )
+      )
+
+  public val icon_12129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12129.xml"),
+          )
+      )
+
+  public val icon_1213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1213.xml"),
+          )
+      )
+
+  public val icon_12130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12130.xml"),
+          )
+      )
+
+  public val icon_12131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12131.xml"),
+          )
+      )
+
+  public val icon_12132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12132.xml"),
+          )
+      )
+
+  public val icon_12133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12133.xml"),
+          )
+      )
+
+  public val icon_12134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12134.xml"),
+          )
+      )
+
+  public val icon_12135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12135.xml"),
+          )
+      )
+
+  public val icon_12136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12136.xml"),
+          )
+      )
+
+  public val icon_12137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12137.xml"),
+          )
+      )
+
+  public val icon_12138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12138.xml"),
+          )
+      )
+
+  public val icon_12139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12139.xml"),
+          )
+      )
+
+  public val icon_1214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1214.xml"),
+          )
+      )
+
+  public val icon_12140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12140.xml"),
+          )
+      )
+
+  public val icon_12141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12141.xml"),
+          )
+      )
+
+  public val icon_12142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12142.xml"),
+          )
+      )
+
+  public val icon_12143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12143.xml"),
+          )
+      )
+
+  public val icon_12144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12144.xml"),
+          )
+      )
+
+  public val icon_12145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12145.xml"),
+          )
+      )
+
+  public val icon_12146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12146.xml"),
+          )
+      )
+
+  public val icon_12147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12147.xml"),
+          )
+      )
+
+  public val icon_12148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12148.xml"),
+          )
+      )
+
+  public val icon_12149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12149.xml"),
+          )
+      )
+
+  public val icon_1215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1215.xml"),
+          )
+      )
+
+  public val icon_12150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12150.xml"),
+          )
+      )
+
+  public val icon_12151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12151.xml"),
+          )
+      )
+
+  public val icon_12152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12152.xml"),
+          )
+      )
+
+  public val icon_12153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12153.xml"),
+          )
+      )
+
+  public val icon_12154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12154.xml"),
+          )
+      )
+
+  public val icon_12155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12155.xml"),
+          )
+      )
+
+  public val icon_12156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12156.xml"),
+          )
+      )
+
+  public val icon_12157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12157.xml"),
+          )
+      )
+
+  public val icon_12158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12158.xml"),
+          )
+      )
+
+  public val icon_12159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12159.xml"),
+          )
+      )
+
+  public val icon_1216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1216.xml"),
+          )
+      )
+
+  public val icon_12160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12160.xml"),
+          )
+      )
+
+  public val icon_12161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12161.xml"),
+          )
+      )
+
+  public val icon_12162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12162.xml"),
+          )
+      )
+
+  public val icon_12163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12163.xml"),
+          )
+      )
+
+  public val icon_12164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12164.xml"),
+          )
+      )
+
+  public val icon_12165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12165.xml"),
+          )
+      )
+
+  public val icon_12166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12166.xml"),
+          )
+      )
+
+  public val icon_12167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12167.xml"),
+          )
+      )
+
+  public val icon_12168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12168.xml"),
+          )
+      )
+
+  public val icon_12169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12169.xml"),
+          )
+      )
+
+  public val icon_1217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1217.xml"),
+          )
+      )
+
+  public val icon_12170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12170.xml"),
+          )
+      )
+
+  public val icon_12171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12171.xml"),
+          )
+      )
+
+  public val icon_12172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12172.xml"),
+          )
+      )
+
+  public val icon_12173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12173.xml"),
+          )
+      )
+
+  public val icon_12174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12174.xml"),
+          )
+      )
+
+  public val icon_12175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12175.xml"),
+          )
+      )
+
+  public val icon_12176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12176.xml"),
+          )
+      )
+
+  public val icon_12177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12177.xml"),
+          )
+      )
+
+  public val icon_12178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12178.xml"),
+          )
+      )
+
+  public val icon_12179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12179.xml"),
+          )
+      )
+
+  public val icon_1218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1218.xml"),
+          )
+      )
+
+  public val icon_12180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12180.xml"),
+          )
+      )
+
+  public val icon_12181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12181.xml"),
+          )
+      )
+
+  public val icon_12182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12182.xml"),
+          )
+      )
+
+  public val icon_12183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12183.xml"),
+          )
+      )
+
+  public val icon_12184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12184.xml"),
+          )
+      )
+
+  public val icon_12185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12185.xml"),
+          )
+      )
+
+  public val icon_12186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12186.xml"),
+          )
+      )
+
+  public val icon_12187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12187.xml"),
+          )
+      )
+
+  public val icon_12188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12188.xml"),
+          )
+      )
+
+  public val icon_12189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12189.xml"),
+          )
+      )
+
+  public val icon_1219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1219.xml"),
+          )
+      )
+
+  public val icon_12190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12190.xml"),
+          )
+      )
+
+  public val icon_12191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12191.xml"),
+          )
+      )
+
+  public val icon_12192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12192.xml"),
+          )
+      )
+
+  public val icon_12193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12193.xml"),
+          )
+      )
+
+  public val icon_12194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12194.xml"),
+          )
+      )
+
+  public val icon_12195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12195.xml"),
+          )
+      )
+
+  public val icon_12196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12196.xml"),
+          )
+      )
+
+  public val icon_12197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12197.xml"),
+          )
+      )
+
+  public val icon_12198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12198.xml"),
+          )
+      )
+
+  public val icon_12199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12199.xml"),
+          )
+      )
+
+  public val icon_122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_122.xml"),
+          )
+      )
+
+  public val icon_1220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1220.xml"),
+          )
+      )
+
+  public val icon_12200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12200.xml"),
+          )
+      )
+
+  public val icon_12201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12201.xml"),
+          )
+      )
+
+  public val icon_12202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12202.xml"),
+          )
+      )
+
+  public val icon_12203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12203.xml"),
+          )
+      )
+
+  public val icon_12204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12204.xml"),
+          )
+      )
+
+  public val icon_12205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12205.xml"),
+          )
+      )
+
+  public val icon_12206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12206.xml"),
+          )
+      )
+
+  public val icon_12207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12207.xml"),
+          )
+      )
+
+  public val icon_12208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12208.xml"),
+          )
+      )
+
+  public val icon_12209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12209.xml"),
+          )
+      )
+
+  public val icon_1221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1221.xml"),
+          )
+      )
+
+  public val icon_12210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12210.xml"),
+          )
+      )
+
+  public val icon_12211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12211.xml"),
+          )
+      )
+
+  public val icon_12212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12212.xml"),
+          )
+      )
+
+  public val icon_12213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12213.xml"),
+          )
+      )
+
+  public val icon_12214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12214.xml"),
+          )
+      )
+
+  public val icon_12215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12215.xml"),
+          )
+      )
+
+  public val icon_12216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12216.xml"),
+          )
+      )
+
+  public val icon_12217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12217.xml"),
+          )
+      )
+
+  public val icon_12218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12218.xml"),
+          )
+      )
+
+  public val icon_12219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12219.xml"),
+          )
+      )
+
+  public val icon_1222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1222.xml"),
+          )
+      )
+
+  public val icon_12220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12220.xml"),
+          )
+      )
+
+  public val icon_12221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12221.xml"),
+          )
+      )
+
+  public val icon_12222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12222.xml"),
+          )
+      )
+
+  public val icon_12223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12223.xml"),
+          )
+      )
+
+  public val icon_12224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12224.xml"),
+          )
+      )
+
+  public val icon_12225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12225.xml"),
+          )
+      )
+
+  public val icon_12226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12226.xml"),
+          )
+      )
+
+  public val icon_12227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12227.xml"),
+          )
+      )
+
+  public val icon_12228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12228.xml"),
+          )
+      )
+
+  public val icon_12229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12229.xml"),
+          )
+      )
+
+  public val icon_1223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1223.xml"),
+          )
+      )
+
+  public val icon_12230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12230.xml"),
+          )
+      )
+
+  public val icon_12231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12231.xml"),
+          )
+      )
+
+  public val icon_12232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12232.xml"),
+          )
+      )
+
+  public val icon_12233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12233.xml"),
+          )
+      )
+
+  public val icon_12234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12234.xml"),
+          )
+      )
+
+  public val icon_12235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12235.xml"),
+          )
+      )
+
+  public val icon_12236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12236.xml"),
+          )
+      )
+
+  public val icon_12237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12237.xml"),
+          )
+      )
+
+  public val icon_12238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12238.xml"),
+          )
+      )
+
+  public val icon_12239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12239.xml"),
+          )
+      )
+
+  public val icon_1224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1224.xml"),
+          )
+      )
+
+  public val icon_12240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12240.xml"),
+          )
+      )
+
+  public val icon_12241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12241.xml"),
+          )
+      )
+
+  public val icon_12242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12242.xml"),
+          )
+      )
+
+  public val icon_12243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12243.xml"),
+          )
+      )
+
+  public val icon_12244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12244.xml"),
+          )
+      )
+
+  public val icon_12245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12245.xml"),
+          )
+      )
+
+  public val icon_12246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12246.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11798: DrawableResource
+  get() = Drawable4.icon_11798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11799: DrawableResource
+  get() = Drawable4.icon_11799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_118: DrawableResource
+  get() = Drawable4.icon_118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1180: DrawableResource
+  get() = Drawable4.icon_1180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11800: DrawableResource
+  get() = Drawable4.icon_11800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11801: DrawableResource
+  get() = Drawable4.icon_11801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11802: DrawableResource
+  get() = Drawable4.icon_11802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11803: DrawableResource
+  get() = Drawable4.icon_11803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11804: DrawableResource
+  get() = Drawable4.icon_11804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11805: DrawableResource
+  get() = Drawable4.icon_11805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11806: DrawableResource
+  get() = Drawable4.icon_11806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11807: DrawableResource
+  get() = Drawable4.icon_11807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11808: DrawableResource
+  get() = Drawable4.icon_11808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11809: DrawableResource
+  get() = Drawable4.icon_11809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1181: DrawableResource
+  get() = Drawable4.icon_1181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11810: DrawableResource
+  get() = Drawable4.icon_11810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11811: DrawableResource
+  get() = Drawable4.icon_11811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11812: DrawableResource
+  get() = Drawable4.icon_11812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11813: DrawableResource
+  get() = Drawable4.icon_11813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11814: DrawableResource
+  get() = Drawable4.icon_11814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11815: DrawableResource
+  get() = Drawable4.icon_11815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11816: DrawableResource
+  get() = Drawable4.icon_11816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11817: DrawableResource
+  get() = Drawable4.icon_11817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11818: DrawableResource
+  get() = Drawable4.icon_11818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11819: DrawableResource
+  get() = Drawable4.icon_11819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1182: DrawableResource
+  get() = Drawable4.icon_1182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11820: DrawableResource
+  get() = Drawable4.icon_11820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11821: DrawableResource
+  get() = Drawable4.icon_11821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11822: DrawableResource
+  get() = Drawable4.icon_11822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11823: DrawableResource
+  get() = Drawable4.icon_11823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11824: DrawableResource
+  get() = Drawable4.icon_11824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11825: DrawableResource
+  get() = Drawable4.icon_11825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11826: DrawableResource
+  get() = Drawable4.icon_11826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11827: DrawableResource
+  get() = Drawable4.icon_11827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11828: DrawableResource
+  get() = Drawable4.icon_11828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11829: DrawableResource
+  get() = Drawable4.icon_11829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1183: DrawableResource
+  get() = Drawable4.icon_1183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11830: DrawableResource
+  get() = Drawable4.icon_11830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11831: DrawableResource
+  get() = Drawable4.icon_11831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11832: DrawableResource
+  get() = Drawable4.icon_11832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11833: DrawableResource
+  get() = Drawable4.icon_11833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11834: DrawableResource
+  get() = Drawable4.icon_11834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11835: DrawableResource
+  get() = Drawable4.icon_11835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11836: DrawableResource
+  get() = Drawable4.icon_11836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11837: DrawableResource
+  get() = Drawable4.icon_11837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11838: DrawableResource
+  get() = Drawable4.icon_11838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11839: DrawableResource
+  get() = Drawable4.icon_11839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1184: DrawableResource
+  get() = Drawable4.icon_1184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11840: DrawableResource
+  get() = Drawable4.icon_11840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11841: DrawableResource
+  get() = Drawable4.icon_11841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11842: DrawableResource
+  get() = Drawable4.icon_11842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11843: DrawableResource
+  get() = Drawable4.icon_11843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11844: DrawableResource
+  get() = Drawable4.icon_11844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11845: DrawableResource
+  get() = Drawable4.icon_11845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11846: DrawableResource
+  get() = Drawable4.icon_11846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11847: DrawableResource
+  get() = Drawable4.icon_11847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11848: DrawableResource
+  get() = Drawable4.icon_11848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11849: DrawableResource
+  get() = Drawable4.icon_11849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1185: DrawableResource
+  get() = Drawable4.icon_1185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11850: DrawableResource
+  get() = Drawable4.icon_11850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11851: DrawableResource
+  get() = Drawable4.icon_11851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11852: DrawableResource
+  get() = Drawable4.icon_11852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11853: DrawableResource
+  get() = Drawable4.icon_11853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11854: DrawableResource
+  get() = Drawable4.icon_11854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11855: DrawableResource
+  get() = Drawable4.icon_11855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11856: DrawableResource
+  get() = Drawable4.icon_11856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11857: DrawableResource
+  get() = Drawable4.icon_11857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11858: DrawableResource
+  get() = Drawable4.icon_11858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11859: DrawableResource
+  get() = Drawable4.icon_11859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1186: DrawableResource
+  get() = Drawable4.icon_1186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11860: DrawableResource
+  get() = Drawable4.icon_11860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11861: DrawableResource
+  get() = Drawable4.icon_11861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11862: DrawableResource
+  get() = Drawable4.icon_11862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11863: DrawableResource
+  get() = Drawable4.icon_11863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11864: DrawableResource
+  get() = Drawable4.icon_11864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11865: DrawableResource
+  get() = Drawable4.icon_11865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11866: DrawableResource
+  get() = Drawable4.icon_11866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11867: DrawableResource
+  get() = Drawable4.icon_11867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11868: DrawableResource
+  get() = Drawable4.icon_11868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11869: DrawableResource
+  get() = Drawable4.icon_11869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1187: DrawableResource
+  get() = Drawable4.icon_1187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11870: DrawableResource
+  get() = Drawable4.icon_11870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11871: DrawableResource
+  get() = Drawable4.icon_11871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11872: DrawableResource
+  get() = Drawable4.icon_11872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11873: DrawableResource
+  get() = Drawable4.icon_11873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11874: DrawableResource
+  get() = Drawable4.icon_11874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11875: DrawableResource
+  get() = Drawable4.icon_11875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11876: DrawableResource
+  get() = Drawable4.icon_11876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11877: DrawableResource
+  get() = Drawable4.icon_11877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11878: DrawableResource
+  get() = Drawable4.icon_11878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11879: DrawableResource
+  get() = Drawable4.icon_11879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1188: DrawableResource
+  get() = Drawable4.icon_1188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11880: DrawableResource
+  get() = Drawable4.icon_11880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11881: DrawableResource
+  get() = Drawable4.icon_11881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11882: DrawableResource
+  get() = Drawable4.icon_11882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11883: DrawableResource
+  get() = Drawable4.icon_11883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11884: DrawableResource
+  get() = Drawable4.icon_11884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11885: DrawableResource
+  get() = Drawable4.icon_11885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11886: DrawableResource
+  get() = Drawable4.icon_11886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11887: DrawableResource
+  get() = Drawable4.icon_11887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11888: DrawableResource
+  get() = Drawable4.icon_11888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11889: DrawableResource
+  get() = Drawable4.icon_11889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1189: DrawableResource
+  get() = Drawable4.icon_1189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11890: DrawableResource
+  get() = Drawable4.icon_11890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11891: DrawableResource
+  get() = Drawable4.icon_11891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11892: DrawableResource
+  get() = Drawable4.icon_11892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11893: DrawableResource
+  get() = Drawable4.icon_11893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11894: DrawableResource
+  get() = Drawable4.icon_11894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11895: DrawableResource
+  get() = Drawable4.icon_11895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11896: DrawableResource
+  get() = Drawable4.icon_11896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11897: DrawableResource
+  get() = Drawable4.icon_11897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11898: DrawableResource
+  get() = Drawable4.icon_11898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11899: DrawableResource
+  get() = Drawable4.icon_11899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_119: DrawableResource
+  get() = Drawable4.icon_119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1190: DrawableResource
+  get() = Drawable4.icon_1190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11900: DrawableResource
+  get() = Drawable4.icon_11900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11901: DrawableResource
+  get() = Drawable4.icon_11901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11902: DrawableResource
+  get() = Drawable4.icon_11902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11903: DrawableResource
+  get() = Drawable4.icon_11903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11904: DrawableResource
+  get() = Drawable4.icon_11904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11905: DrawableResource
+  get() = Drawable4.icon_11905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11906: DrawableResource
+  get() = Drawable4.icon_11906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11907: DrawableResource
+  get() = Drawable4.icon_11907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11908: DrawableResource
+  get() = Drawable4.icon_11908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11909: DrawableResource
+  get() = Drawable4.icon_11909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1191: DrawableResource
+  get() = Drawable4.icon_1191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11910: DrawableResource
+  get() = Drawable4.icon_11910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11911: DrawableResource
+  get() = Drawable4.icon_11911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11912: DrawableResource
+  get() = Drawable4.icon_11912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11913: DrawableResource
+  get() = Drawable4.icon_11913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11914: DrawableResource
+  get() = Drawable4.icon_11914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11915: DrawableResource
+  get() = Drawable4.icon_11915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11916: DrawableResource
+  get() = Drawable4.icon_11916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11917: DrawableResource
+  get() = Drawable4.icon_11917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11918: DrawableResource
+  get() = Drawable4.icon_11918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11919: DrawableResource
+  get() = Drawable4.icon_11919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1192: DrawableResource
+  get() = Drawable4.icon_1192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11920: DrawableResource
+  get() = Drawable4.icon_11920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11921: DrawableResource
+  get() = Drawable4.icon_11921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11922: DrawableResource
+  get() = Drawable4.icon_11922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11923: DrawableResource
+  get() = Drawable4.icon_11923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11924: DrawableResource
+  get() = Drawable4.icon_11924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11925: DrawableResource
+  get() = Drawable4.icon_11925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11926: DrawableResource
+  get() = Drawable4.icon_11926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11927: DrawableResource
+  get() = Drawable4.icon_11927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11928: DrawableResource
+  get() = Drawable4.icon_11928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11929: DrawableResource
+  get() = Drawable4.icon_11929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1193: DrawableResource
+  get() = Drawable4.icon_1193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11930: DrawableResource
+  get() = Drawable4.icon_11930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11931: DrawableResource
+  get() = Drawable4.icon_11931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11932: DrawableResource
+  get() = Drawable4.icon_11932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11933: DrawableResource
+  get() = Drawable4.icon_11933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11934: DrawableResource
+  get() = Drawable4.icon_11934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11935: DrawableResource
+  get() = Drawable4.icon_11935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11936: DrawableResource
+  get() = Drawable4.icon_11936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11937: DrawableResource
+  get() = Drawable4.icon_11937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11938: DrawableResource
+  get() = Drawable4.icon_11938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11939: DrawableResource
+  get() = Drawable4.icon_11939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1194: DrawableResource
+  get() = Drawable4.icon_1194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11940: DrawableResource
+  get() = Drawable4.icon_11940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11941: DrawableResource
+  get() = Drawable4.icon_11941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11942: DrawableResource
+  get() = Drawable4.icon_11942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11943: DrawableResource
+  get() = Drawable4.icon_11943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11944: DrawableResource
+  get() = Drawable4.icon_11944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11945: DrawableResource
+  get() = Drawable4.icon_11945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11946: DrawableResource
+  get() = Drawable4.icon_11946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11947: DrawableResource
+  get() = Drawable4.icon_11947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11948: DrawableResource
+  get() = Drawable4.icon_11948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11949: DrawableResource
+  get() = Drawable4.icon_11949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1195: DrawableResource
+  get() = Drawable4.icon_1195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11950: DrawableResource
+  get() = Drawable4.icon_11950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11951: DrawableResource
+  get() = Drawable4.icon_11951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11952: DrawableResource
+  get() = Drawable4.icon_11952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11953: DrawableResource
+  get() = Drawable4.icon_11953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11954: DrawableResource
+  get() = Drawable4.icon_11954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11955: DrawableResource
+  get() = Drawable4.icon_11955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11956: DrawableResource
+  get() = Drawable4.icon_11956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11957: DrawableResource
+  get() = Drawable4.icon_11957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11958: DrawableResource
+  get() = Drawable4.icon_11958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11959: DrawableResource
+  get() = Drawable4.icon_11959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1196: DrawableResource
+  get() = Drawable4.icon_1196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11960: DrawableResource
+  get() = Drawable4.icon_11960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11961: DrawableResource
+  get() = Drawable4.icon_11961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11962: DrawableResource
+  get() = Drawable4.icon_11962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11963: DrawableResource
+  get() = Drawable4.icon_11963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11964: DrawableResource
+  get() = Drawable4.icon_11964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11965: DrawableResource
+  get() = Drawable4.icon_11965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11966: DrawableResource
+  get() = Drawable4.icon_11966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11967: DrawableResource
+  get() = Drawable4.icon_11967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11968: DrawableResource
+  get() = Drawable4.icon_11968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11969: DrawableResource
+  get() = Drawable4.icon_11969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1197: DrawableResource
+  get() = Drawable4.icon_1197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11970: DrawableResource
+  get() = Drawable4.icon_11970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11971: DrawableResource
+  get() = Drawable4.icon_11971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11972: DrawableResource
+  get() = Drawable4.icon_11972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11973: DrawableResource
+  get() = Drawable4.icon_11973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11974: DrawableResource
+  get() = Drawable4.icon_11974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11975: DrawableResource
+  get() = Drawable4.icon_11975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11976: DrawableResource
+  get() = Drawable4.icon_11976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11977: DrawableResource
+  get() = Drawable4.icon_11977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11978: DrawableResource
+  get() = Drawable4.icon_11978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11979: DrawableResource
+  get() = Drawable4.icon_11979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1198: DrawableResource
+  get() = Drawable4.icon_1198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11980: DrawableResource
+  get() = Drawable4.icon_11980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11981: DrawableResource
+  get() = Drawable4.icon_11981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11982: DrawableResource
+  get() = Drawable4.icon_11982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11983: DrawableResource
+  get() = Drawable4.icon_11983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11984: DrawableResource
+  get() = Drawable4.icon_11984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11985: DrawableResource
+  get() = Drawable4.icon_11985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11986: DrawableResource
+  get() = Drawable4.icon_11986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11987: DrawableResource
+  get() = Drawable4.icon_11987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11988: DrawableResource
+  get() = Drawable4.icon_11988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11989: DrawableResource
+  get() = Drawable4.icon_11989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1199: DrawableResource
+  get() = Drawable4.icon_1199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11990: DrawableResource
+  get() = Drawable4.icon_11990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11991: DrawableResource
+  get() = Drawable4.icon_11991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11992: DrawableResource
+  get() = Drawable4.icon_11992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11993: DrawableResource
+  get() = Drawable4.icon_11993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11994: DrawableResource
+  get() = Drawable4.icon_11994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11995: DrawableResource
+  get() = Drawable4.icon_11995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11996: DrawableResource
+  get() = Drawable4.icon_11996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11997: DrawableResource
+  get() = Drawable4.icon_11997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11998: DrawableResource
+  get() = Drawable4.icon_11998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_11999: DrawableResource
+  get() = Drawable4.icon_11999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12: DrawableResource
+  get() = Drawable4.icon_12
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_120: DrawableResource
+  get() = Drawable4.icon_120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1200: DrawableResource
+  get() = Drawable4.icon_1200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12000: DrawableResource
+  get() = Drawable4.icon_12000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12001: DrawableResource
+  get() = Drawable4.icon_12001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12002: DrawableResource
+  get() = Drawable4.icon_12002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12003: DrawableResource
+  get() = Drawable4.icon_12003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12004: DrawableResource
+  get() = Drawable4.icon_12004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12005: DrawableResource
+  get() = Drawable4.icon_12005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12006: DrawableResource
+  get() = Drawable4.icon_12006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12007: DrawableResource
+  get() = Drawable4.icon_12007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12008: DrawableResource
+  get() = Drawable4.icon_12008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12009: DrawableResource
+  get() = Drawable4.icon_12009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1201: DrawableResource
+  get() = Drawable4.icon_1201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12010: DrawableResource
+  get() = Drawable4.icon_12010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12011: DrawableResource
+  get() = Drawable4.icon_12011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12012: DrawableResource
+  get() = Drawable4.icon_12012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12013: DrawableResource
+  get() = Drawable4.icon_12013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12014: DrawableResource
+  get() = Drawable4.icon_12014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12015: DrawableResource
+  get() = Drawable4.icon_12015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12016: DrawableResource
+  get() = Drawable4.icon_12016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12017: DrawableResource
+  get() = Drawable4.icon_12017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12018: DrawableResource
+  get() = Drawable4.icon_12018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12019: DrawableResource
+  get() = Drawable4.icon_12019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1202: DrawableResource
+  get() = Drawable4.icon_1202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12020: DrawableResource
+  get() = Drawable4.icon_12020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12021: DrawableResource
+  get() = Drawable4.icon_12021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12022: DrawableResource
+  get() = Drawable4.icon_12022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12023: DrawableResource
+  get() = Drawable4.icon_12023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12024: DrawableResource
+  get() = Drawable4.icon_12024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12025: DrawableResource
+  get() = Drawable4.icon_12025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12026: DrawableResource
+  get() = Drawable4.icon_12026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12027: DrawableResource
+  get() = Drawable4.icon_12027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12028: DrawableResource
+  get() = Drawable4.icon_12028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12029: DrawableResource
+  get() = Drawable4.icon_12029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1203: DrawableResource
+  get() = Drawable4.icon_1203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12030: DrawableResource
+  get() = Drawable4.icon_12030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12031: DrawableResource
+  get() = Drawable4.icon_12031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12032: DrawableResource
+  get() = Drawable4.icon_12032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12033: DrawableResource
+  get() = Drawable4.icon_12033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12034: DrawableResource
+  get() = Drawable4.icon_12034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12035: DrawableResource
+  get() = Drawable4.icon_12035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12036: DrawableResource
+  get() = Drawable4.icon_12036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12037: DrawableResource
+  get() = Drawable4.icon_12037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12038: DrawableResource
+  get() = Drawable4.icon_12038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12039: DrawableResource
+  get() = Drawable4.icon_12039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1204: DrawableResource
+  get() = Drawable4.icon_1204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12040: DrawableResource
+  get() = Drawable4.icon_12040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12041: DrawableResource
+  get() = Drawable4.icon_12041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12042: DrawableResource
+  get() = Drawable4.icon_12042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12043: DrawableResource
+  get() = Drawable4.icon_12043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12044: DrawableResource
+  get() = Drawable4.icon_12044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12045: DrawableResource
+  get() = Drawable4.icon_12045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12046: DrawableResource
+  get() = Drawable4.icon_12046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12047: DrawableResource
+  get() = Drawable4.icon_12047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12048: DrawableResource
+  get() = Drawable4.icon_12048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12049: DrawableResource
+  get() = Drawable4.icon_12049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1205: DrawableResource
+  get() = Drawable4.icon_1205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12050: DrawableResource
+  get() = Drawable4.icon_12050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12051: DrawableResource
+  get() = Drawable4.icon_12051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12052: DrawableResource
+  get() = Drawable4.icon_12052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12053: DrawableResource
+  get() = Drawable4.icon_12053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12054: DrawableResource
+  get() = Drawable4.icon_12054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12055: DrawableResource
+  get() = Drawable4.icon_12055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12056: DrawableResource
+  get() = Drawable4.icon_12056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12057: DrawableResource
+  get() = Drawable4.icon_12057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12058: DrawableResource
+  get() = Drawable4.icon_12058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12059: DrawableResource
+  get() = Drawable4.icon_12059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1206: DrawableResource
+  get() = Drawable4.icon_1206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12060: DrawableResource
+  get() = Drawable4.icon_12060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12061: DrawableResource
+  get() = Drawable4.icon_12061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12062: DrawableResource
+  get() = Drawable4.icon_12062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12063: DrawableResource
+  get() = Drawable4.icon_12063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12064: DrawableResource
+  get() = Drawable4.icon_12064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12065: DrawableResource
+  get() = Drawable4.icon_12065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12066: DrawableResource
+  get() = Drawable4.icon_12066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12067: DrawableResource
+  get() = Drawable4.icon_12067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12068: DrawableResource
+  get() = Drawable4.icon_12068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12069: DrawableResource
+  get() = Drawable4.icon_12069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1207: DrawableResource
+  get() = Drawable4.icon_1207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12070: DrawableResource
+  get() = Drawable4.icon_12070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12071: DrawableResource
+  get() = Drawable4.icon_12071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12072: DrawableResource
+  get() = Drawable4.icon_12072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12073: DrawableResource
+  get() = Drawable4.icon_12073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12074: DrawableResource
+  get() = Drawable4.icon_12074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12075: DrawableResource
+  get() = Drawable4.icon_12075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12076: DrawableResource
+  get() = Drawable4.icon_12076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12077: DrawableResource
+  get() = Drawable4.icon_12077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12078: DrawableResource
+  get() = Drawable4.icon_12078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12079: DrawableResource
+  get() = Drawable4.icon_12079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1208: DrawableResource
+  get() = Drawable4.icon_1208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12080: DrawableResource
+  get() = Drawable4.icon_12080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12081: DrawableResource
+  get() = Drawable4.icon_12081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12082: DrawableResource
+  get() = Drawable4.icon_12082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12083: DrawableResource
+  get() = Drawable4.icon_12083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12084: DrawableResource
+  get() = Drawable4.icon_12084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12085: DrawableResource
+  get() = Drawable4.icon_12085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12086: DrawableResource
+  get() = Drawable4.icon_12086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12087: DrawableResource
+  get() = Drawable4.icon_12087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12088: DrawableResource
+  get() = Drawable4.icon_12088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12089: DrawableResource
+  get() = Drawable4.icon_12089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1209: DrawableResource
+  get() = Drawable4.icon_1209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12090: DrawableResource
+  get() = Drawable4.icon_12090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12091: DrawableResource
+  get() = Drawable4.icon_12091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12092: DrawableResource
+  get() = Drawable4.icon_12092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12093: DrawableResource
+  get() = Drawable4.icon_12093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12094: DrawableResource
+  get() = Drawable4.icon_12094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12095: DrawableResource
+  get() = Drawable4.icon_12095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12096: DrawableResource
+  get() = Drawable4.icon_12096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12097: DrawableResource
+  get() = Drawable4.icon_12097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12098: DrawableResource
+  get() = Drawable4.icon_12098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12099: DrawableResource
+  get() = Drawable4.icon_12099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_121: DrawableResource
+  get() = Drawable4.icon_121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1210: DrawableResource
+  get() = Drawable4.icon_1210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12100: DrawableResource
+  get() = Drawable4.icon_12100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12101: DrawableResource
+  get() = Drawable4.icon_12101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12102: DrawableResource
+  get() = Drawable4.icon_12102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12103: DrawableResource
+  get() = Drawable4.icon_12103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12104: DrawableResource
+  get() = Drawable4.icon_12104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12105: DrawableResource
+  get() = Drawable4.icon_12105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12106: DrawableResource
+  get() = Drawable4.icon_12106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12107: DrawableResource
+  get() = Drawable4.icon_12107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12108: DrawableResource
+  get() = Drawable4.icon_12108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12109: DrawableResource
+  get() = Drawable4.icon_12109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1211: DrawableResource
+  get() = Drawable4.icon_1211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12110: DrawableResource
+  get() = Drawable4.icon_12110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12111: DrawableResource
+  get() = Drawable4.icon_12111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12112: DrawableResource
+  get() = Drawable4.icon_12112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12113: DrawableResource
+  get() = Drawable4.icon_12113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12114: DrawableResource
+  get() = Drawable4.icon_12114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12115: DrawableResource
+  get() = Drawable4.icon_12115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12116: DrawableResource
+  get() = Drawable4.icon_12116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12117: DrawableResource
+  get() = Drawable4.icon_12117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12118: DrawableResource
+  get() = Drawable4.icon_12118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12119: DrawableResource
+  get() = Drawable4.icon_12119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1212: DrawableResource
+  get() = Drawable4.icon_1212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12120: DrawableResource
+  get() = Drawable4.icon_12120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12121: DrawableResource
+  get() = Drawable4.icon_12121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12122: DrawableResource
+  get() = Drawable4.icon_12122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12123: DrawableResource
+  get() = Drawable4.icon_12123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12124: DrawableResource
+  get() = Drawable4.icon_12124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12125: DrawableResource
+  get() = Drawable4.icon_12125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12126: DrawableResource
+  get() = Drawable4.icon_12126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12127: DrawableResource
+  get() = Drawable4.icon_12127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12128: DrawableResource
+  get() = Drawable4.icon_12128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12129: DrawableResource
+  get() = Drawable4.icon_12129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1213: DrawableResource
+  get() = Drawable4.icon_1213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12130: DrawableResource
+  get() = Drawable4.icon_12130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12131: DrawableResource
+  get() = Drawable4.icon_12131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12132: DrawableResource
+  get() = Drawable4.icon_12132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12133: DrawableResource
+  get() = Drawable4.icon_12133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12134: DrawableResource
+  get() = Drawable4.icon_12134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12135: DrawableResource
+  get() = Drawable4.icon_12135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12136: DrawableResource
+  get() = Drawable4.icon_12136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12137: DrawableResource
+  get() = Drawable4.icon_12137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12138: DrawableResource
+  get() = Drawable4.icon_12138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12139: DrawableResource
+  get() = Drawable4.icon_12139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1214: DrawableResource
+  get() = Drawable4.icon_1214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12140: DrawableResource
+  get() = Drawable4.icon_12140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12141: DrawableResource
+  get() = Drawable4.icon_12141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12142: DrawableResource
+  get() = Drawable4.icon_12142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12143: DrawableResource
+  get() = Drawable4.icon_12143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12144: DrawableResource
+  get() = Drawable4.icon_12144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12145: DrawableResource
+  get() = Drawable4.icon_12145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12146: DrawableResource
+  get() = Drawable4.icon_12146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12147: DrawableResource
+  get() = Drawable4.icon_12147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12148: DrawableResource
+  get() = Drawable4.icon_12148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12149: DrawableResource
+  get() = Drawable4.icon_12149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1215: DrawableResource
+  get() = Drawable4.icon_1215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12150: DrawableResource
+  get() = Drawable4.icon_12150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12151: DrawableResource
+  get() = Drawable4.icon_12151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12152: DrawableResource
+  get() = Drawable4.icon_12152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12153: DrawableResource
+  get() = Drawable4.icon_12153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12154: DrawableResource
+  get() = Drawable4.icon_12154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12155: DrawableResource
+  get() = Drawable4.icon_12155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12156: DrawableResource
+  get() = Drawable4.icon_12156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12157: DrawableResource
+  get() = Drawable4.icon_12157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12158: DrawableResource
+  get() = Drawable4.icon_12158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12159: DrawableResource
+  get() = Drawable4.icon_12159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1216: DrawableResource
+  get() = Drawable4.icon_1216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12160: DrawableResource
+  get() = Drawable4.icon_12160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12161: DrawableResource
+  get() = Drawable4.icon_12161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12162: DrawableResource
+  get() = Drawable4.icon_12162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12163: DrawableResource
+  get() = Drawable4.icon_12163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12164: DrawableResource
+  get() = Drawable4.icon_12164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12165: DrawableResource
+  get() = Drawable4.icon_12165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12166: DrawableResource
+  get() = Drawable4.icon_12166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12167: DrawableResource
+  get() = Drawable4.icon_12167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12168: DrawableResource
+  get() = Drawable4.icon_12168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12169: DrawableResource
+  get() = Drawable4.icon_12169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1217: DrawableResource
+  get() = Drawable4.icon_1217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12170: DrawableResource
+  get() = Drawable4.icon_12170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12171: DrawableResource
+  get() = Drawable4.icon_12171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12172: DrawableResource
+  get() = Drawable4.icon_12172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12173: DrawableResource
+  get() = Drawable4.icon_12173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12174: DrawableResource
+  get() = Drawable4.icon_12174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12175: DrawableResource
+  get() = Drawable4.icon_12175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12176: DrawableResource
+  get() = Drawable4.icon_12176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12177: DrawableResource
+  get() = Drawable4.icon_12177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12178: DrawableResource
+  get() = Drawable4.icon_12178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12179: DrawableResource
+  get() = Drawable4.icon_12179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1218: DrawableResource
+  get() = Drawable4.icon_1218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12180: DrawableResource
+  get() = Drawable4.icon_12180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12181: DrawableResource
+  get() = Drawable4.icon_12181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12182: DrawableResource
+  get() = Drawable4.icon_12182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12183: DrawableResource
+  get() = Drawable4.icon_12183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12184: DrawableResource
+  get() = Drawable4.icon_12184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12185: DrawableResource
+  get() = Drawable4.icon_12185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12186: DrawableResource
+  get() = Drawable4.icon_12186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12187: DrawableResource
+  get() = Drawable4.icon_12187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12188: DrawableResource
+  get() = Drawable4.icon_12188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12189: DrawableResource
+  get() = Drawable4.icon_12189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1219: DrawableResource
+  get() = Drawable4.icon_1219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12190: DrawableResource
+  get() = Drawable4.icon_12190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12191: DrawableResource
+  get() = Drawable4.icon_12191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12192: DrawableResource
+  get() = Drawable4.icon_12192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12193: DrawableResource
+  get() = Drawable4.icon_12193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12194: DrawableResource
+  get() = Drawable4.icon_12194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12195: DrawableResource
+  get() = Drawable4.icon_12195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12196: DrawableResource
+  get() = Drawable4.icon_12196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12197: DrawableResource
+  get() = Drawable4.icon_12197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12198: DrawableResource
+  get() = Drawable4.icon_12198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12199: DrawableResource
+  get() = Drawable4.icon_12199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_122: DrawableResource
+  get() = Drawable4.icon_122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1220: DrawableResource
+  get() = Drawable4.icon_1220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12200: DrawableResource
+  get() = Drawable4.icon_12200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12201: DrawableResource
+  get() = Drawable4.icon_12201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12202: DrawableResource
+  get() = Drawable4.icon_12202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12203: DrawableResource
+  get() = Drawable4.icon_12203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12204: DrawableResource
+  get() = Drawable4.icon_12204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12205: DrawableResource
+  get() = Drawable4.icon_12205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12206: DrawableResource
+  get() = Drawable4.icon_12206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12207: DrawableResource
+  get() = Drawable4.icon_12207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12208: DrawableResource
+  get() = Drawable4.icon_12208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12209: DrawableResource
+  get() = Drawable4.icon_12209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1221: DrawableResource
+  get() = Drawable4.icon_1221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12210: DrawableResource
+  get() = Drawable4.icon_12210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12211: DrawableResource
+  get() = Drawable4.icon_12211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12212: DrawableResource
+  get() = Drawable4.icon_12212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12213: DrawableResource
+  get() = Drawable4.icon_12213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12214: DrawableResource
+  get() = Drawable4.icon_12214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12215: DrawableResource
+  get() = Drawable4.icon_12215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12216: DrawableResource
+  get() = Drawable4.icon_12216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12217: DrawableResource
+  get() = Drawable4.icon_12217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12218: DrawableResource
+  get() = Drawable4.icon_12218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12219: DrawableResource
+  get() = Drawable4.icon_12219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1222: DrawableResource
+  get() = Drawable4.icon_1222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12220: DrawableResource
+  get() = Drawable4.icon_12220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12221: DrawableResource
+  get() = Drawable4.icon_12221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12222: DrawableResource
+  get() = Drawable4.icon_12222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12223: DrawableResource
+  get() = Drawable4.icon_12223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12224: DrawableResource
+  get() = Drawable4.icon_12224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12225: DrawableResource
+  get() = Drawable4.icon_12225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12226: DrawableResource
+  get() = Drawable4.icon_12226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12227: DrawableResource
+  get() = Drawable4.icon_12227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12228: DrawableResource
+  get() = Drawable4.icon_12228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12229: DrawableResource
+  get() = Drawable4.icon_12229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1223: DrawableResource
+  get() = Drawable4.icon_1223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12230: DrawableResource
+  get() = Drawable4.icon_12230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12231: DrawableResource
+  get() = Drawable4.icon_12231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12232: DrawableResource
+  get() = Drawable4.icon_12232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12233: DrawableResource
+  get() = Drawable4.icon_12233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12234: DrawableResource
+  get() = Drawable4.icon_12234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12235: DrawableResource
+  get() = Drawable4.icon_12235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12236: DrawableResource
+  get() = Drawable4.icon_12236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12237: DrawableResource
+  get() = Drawable4.icon_12237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12238: DrawableResource
+  get() = Drawable4.icon_12238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12239: DrawableResource
+  get() = Drawable4.icon_12239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1224: DrawableResource
+  get() = Drawable4.icon_1224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12240: DrawableResource
+  get() = Drawable4.icon_12240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12241: DrawableResource
+  get() = Drawable4.icon_12241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12242: DrawableResource
+  get() = Drawable4.icon_12242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12243: DrawableResource
+  get() = Drawable4.icon_12243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12244: DrawableResource
+  get() = Drawable4.icon_12244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12245: DrawableResource
+  get() = Drawable4.icon_12245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12246: DrawableResource
+  get() = Drawable4.icon_12246

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable40.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable40.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable40 {
+  public val icon_5499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5499.xml"),
+          )
+      )
+
+  public val icon_55: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_55",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_55.xml"),
+          )
+      )
+
+  public val icon_550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_550.xml"),
+          )
+      )
+
+  public val icon_5500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5500.xml"),
+          )
+      )
+
+  public val icon_5501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5501.xml"),
+          )
+      )
+
+  public val icon_5502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5502.xml"),
+          )
+      )
+
+  public val icon_5503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5503.xml"),
+          )
+      )
+
+  public val icon_5504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5504.xml"),
+          )
+      )
+
+  public val icon_5505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5505.xml"),
+          )
+      )
+
+  public val icon_5506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5506.xml"),
+          )
+      )
+
+  public val icon_5507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5507.xml"),
+          )
+      )
+
+  public val icon_5508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5508.xml"),
+          )
+      )
+
+  public val icon_5509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5509.xml"),
+          )
+      )
+
+  public val icon_551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_551.xml"),
+          )
+      )
+
+  public val icon_5510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5510.xml"),
+          )
+      )
+
+  public val icon_5511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5511.xml"),
+          )
+      )
+
+  public val icon_5512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5512.xml"),
+          )
+      )
+
+  public val icon_5513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5513.xml"),
+          )
+      )
+
+  public val icon_5514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5514.xml"),
+          )
+      )
+
+  public val icon_5515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5515.xml"),
+          )
+      )
+
+  public val icon_5516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5516.xml"),
+          )
+      )
+
+  public val icon_5517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5517.xml"),
+          )
+      )
+
+  public val icon_5518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5518.xml"),
+          )
+      )
+
+  public val icon_5519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5519.xml"),
+          )
+      )
+
+  public val icon_552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_552.xml"),
+          )
+      )
+
+  public val icon_5520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5520.xml"),
+          )
+      )
+
+  public val icon_5521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5521.xml"),
+          )
+      )
+
+  public val icon_5522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5522.xml"),
+          )
+      )
+
+  public val icon_5523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5523.xml"),
+          )
+      )
+
+  public val icon_5524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5524.xml"),
+          )
+      )
+
+  public val icon_5525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5525.xml"),
+          )
+      )
+
+  public val icon_5526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5526.xml"),
+          )
+      )
+
+  public val icon_5527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5527.xml"),
+          )
+      )
+
+  public val icon_5528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5528.xml"),
+          )
+      )
+
+  public val icon_5529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5529.xml"),
+          )
+      )
+
+  public val icon_553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_553.xml"),
+          )
+      )
+
+  public val icon_5530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5530.xml"),
+          )
+      )
+
+  public val icon_5531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5531.xml"),
+          )
+      )
+
+  public val icon_5532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5532.xml"),
+          )
+      )
+
+  public val icon_5533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5533.xml"),
+          )
+      )
+
+  public val icon_5534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5534.xml"),
+          )
+      )
+
+  public val icon_5535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5535.xml"),
+          )
+      )
+
+  public val icon_5536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5536.xml"),
+          )
+      )
+
+  public val icon_5537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5537.xml"),
+          )
+      )
+
+  public val icon_5538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5538.xml"),
+          )
+      )
+
+  public val icon_5539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5539.xml"),
+          )
+      )
+
+  public val icon_554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_554.xml"),
+          )
+      )
+
+  public val icon_5540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5540.xml"),
+          )
+      )
+
+  public val icon_5541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5541.xml"),
+          )
+      )
+
+  public val icon_5542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5542.xml"),
+          )
+      )
+
+  public val icon_5543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5543.xml"),
+          )
+      )
+
+  public val icon_5544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5544.xml"),
+          )
+      )
+
+  public val icon_5545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5545.xml"),
+          )
+      )
+
+  public val icon_5546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5546.xml"),
+          )
+      )
+
+  public val icon_5547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5547.xml"),
+          )
+      )
+
+  public val icon_5548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5548.xml"),
+          )
+      )
+
+  public val icon_5549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5549.xml"),
+          )
+      )
+
+  public val icon_555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_555.xml"),
+          )
+      )
+
+  public val icon_5550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5550.xml"),
+          )
+      )
+
+  public val icon_5551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5551.xml"),
+          )
+      )
+
+  public val icon_5552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5552.xml"),
+          )
+      )
+
+  public val icon_5553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5553.xml"),
+          )
+      )
+
+  public val icon_5554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5554.xml"),
+          )
+      )
+
+  public val icon_5555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5555.xml"),
+          )
+      )
+
+  public val icon_5556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5556.xml"),
+          )
+      )
+
+  public val icon_5557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5557.xml"),
+          )
+      )
+
+  public val icon_5558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5558.xml"),
+          )
+      )
+
+  public val icon_5559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5559.xml"),
+          )
+      )
+
+  public val icon_556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_556.xml"),
+          )
+      )
+
+  public val icon_5560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5560.xml"),
+          )
+      )
+
+  public val icon_5561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5561.xml"),
+          )
+      )
+
+  public val icon_5562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5562.xml"),
+          )
+      )
+
+  public val icon_5563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5563.xml"),
+          )
+      )
+
+  public val icon_5564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5564.xml"),
+          )
+      )
+
+  public val icon_5565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5565.xml"),
+          )
+      )
+
+  public val icon_5566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5566.xml"),
+          )
+      )
+
+  public val icon_5567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5567.xml"),
+          )
+      )
+
+  public val icon_5568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5568.xml"),
+          )
+      )
+
+  public val icon_5569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5569.xml"),
+          )
+      )
+
+  public val icon_557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_557.xml"),
+          )
+      )
+
+  public val icon_5570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5570.xml"),
+          )
+      )
+
+  public val icon_5571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5571.xml"),
+          )
+      )
+
+  public val icon_5572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5572.xml"),
+          )
+      )
+
+  public val icon_5573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5573.xml"),
+          )
+      )
+
+  public val icon_5574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5574.xml"),
+          )
+      )
+
+  public val icon_5575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5575.xml"),
+          )
+      )
+
+  public val icon_5576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5576.xml"),
+          )
+      )
+
+  public val icon_5577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5577.xml"),
+          )
+      )
+
+  public val icon_5578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5578.xml"),
+          )
+      )
+
+  public val icon_5579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5579.xml"),
+          )
+      )
+
+  public val icon_558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_558.xml"),
+          )
+      )
+
+  public val icon_5580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5580.xml"),
+          )
+      )
+
+  public val icon_5581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5581.xml"),
+          )
+      )
+
+  public val icon_5582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5582.xml"),
+          )
+      )
+
+  public val icon_5583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5583.xml"),
+          )
+      )
+
+  public val icon_5584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5584.xml"),
+          )
+      )
+
+  public val icon_5585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5585.xml"),
+          )
+      )
+
+  public val icon_5586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5586.xml"),
+          )
+      )
+
+  public val icon_5587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5587.xml"),
+          )
+      )
+
+  public val icon_5588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5588.xml"),
+          )
+      )
+
+  public val icon_5589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5589.xml"),
+          )
+      )
+
+  public val icon_559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_559.xml"),
+          )
+      )
+
+  public val icon_5590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5590.xml"),
+          )
+      )
+
+  public val icon_5591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5591.xml"),
+          )
+      )
+
+  public val icon_5592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5592.xml"),
+          )
+      )
+
+  public val icon_5593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5593.xml"),
+          )
+      )
+
+  public val icon_5594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5594.xml"),
+          )
+      )
+
+  public val icon_5595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5595.xml"),
+          )
+      )
+
+  public val icon_5596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5596.xml"),
+          )
+      )
+
+  public val icon_5597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5597.xml"),
+          )
+      )
+
+  public val icon_5598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5598.xml"),
+          )
+      )
+
+  public val icon_5599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5599.xml"),
+          )
+      )
+
+  public val icon_56: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_56",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_56.xml"),
+          )
+      )
+
+  public val icon_560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_560.xml"),
+          )
+      )
+
+  public val icon_5600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5600.xml"),
+          )
+      )
+
+  public val icon_5601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5601.xml"),
+          )
+      )
+
+  public val icon_5602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5602.xml"),
+          )
+      )
+
+  public val icon_5603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5603.xml"),
+          )
+      )
+
+  public val icon_5604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5604.xml"),
+          )
+      )
+
+  public val icon_5605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5605.xml"),
+          )
+      )
+
+  public val icon_5606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5606.xml"),
+          )
+      )
+
+  public val icon_5607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5607.xml"),
+          )
+      )
+
+  public val icon_5608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5608.xml"),
+          )
+      )
+
+  public val icon_5609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5609.xml"),
+          )
+      )
+
+  public val icon_561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_561.xml"),
+          )
+      )
+
+  public val icon_5610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5610.xml"),
+          )
+      )
+
+  public val icon_5611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5611.xml"),
+          )
+      )
+
+  public val icon_5612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5612.xml"),
+          )
+      )
+
+  public val icon_5613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5613.xml"),
+          )
+      )
+
+  public val icon_5614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5614.xml"),
+          )
+      )
+
+  public val icon_5615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5615.xml"),
+          )
+      )
+
+  public val icon_5616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5616.xml"),
+          )
+      )
+
+  public val icon_5617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5617.xml"),
+          )
+      )
+
+  public val icon_5618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5618.xml"),
+          )
+      )
+
+  public val icon_5619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5619.xml"),
+          )
+      )
+
+  public val icon_562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_562.xml"),
+          )
+      )
+
+  public val icon_5620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5620.xml"),
+          )
+      )
+
+  public val icon_5621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5621.xml"),
+          )
+      )
+
+  public val icon_5622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5622.xml"),
+          )
+      )
+
+  public val icon_5623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5623.xml"),
+          )
+      )
+
+  public val icon_5624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5624.xml"),
+          )
+      )
+
+  public val icon_5625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5625.xml"),
+          )
+      )
+
+  public val icon_5626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5626.xml"),
+          )
+      )
+
+  public val icon_5627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5627.xml"),
+          )
+      )
+
+  public val icon_5628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5628.xml"),
+          )
+      )
+
+  public val icon_5629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5629.xml"),
+          )
+      )
+
+  public val icon_563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_563.xml"),
+          )
+      )
+
+  public val icon_5630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5630.xml"),
+          )
+      )
+
+  public val icon_5631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5631.xml"),
+          )
+      )
+
+  public val icon_5632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5632.xml"),
+          )
+      )
+
+  public val icon_5633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5633.xml"),
+          )
+      )
+
+  public val icon_5634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5634.xml"),
+          )
+      )
+
+  public val icon_5635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5635.xml"),
+          )
+      )
+
+  public val icon_5636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5636.xml"),
+          )
+      )
+
+  public val icon_5637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5637.xml"),
+          )
+      )
+
+  public val icon_5638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5638.xml"),
+          )
+      )
+
+  public val icon_5639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5639.xml"),
+          )
+      )
+
+  public val icon_564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_564.xml"),
+          )
+      )
+
+  public val icon_5640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5640.xml"),
+          )
+      )
+
+  public val icon_5641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5641.xml"),
+          )
+      )
+
+  public val icon_5642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5642.xml"),
+          )
+      )
+
+  public val icon_5643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5643.xml"),
+          )
+      )
+
+  public val icon_5644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5644.xml"),
+          )
+      )
+
+  public val icon_5645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5645.xml"),
+          )
+      )
+
+  public val icon_5646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5646.xml"),
+          )
+      )
+
+  public val icon_5647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5647.xml"),
+          )
+      )
+
+  public val icon_5648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5648.xml"),
+          )
+      )
+
+  public val icon_5649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5649.xml"),
+          )
+      )
+
+  public val icon_565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_565.xml"),
+          )
+      )
+
+  public val icon_5650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5650.xml"),
+          )
+      )
+
+  public val icon_5651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5651.xml"),
+          )
+      )
+
+  public val icon_5652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5652.xml"),
+          )
+      )
+
+  public val icon_5653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5653.xml"),
+          )
+      )
+
+  public val icon_5654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5654.xml"),
+          )
+      )
+
+  public val icon_5655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5655.xml"),
+          )
+      )
+
+  public val icon_5656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5656.xml"),
+          )
+      )
+
+  public val icon_5657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5657.xml"),
+          )
+      )
+
+  public val icon_5658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5658.xml"),
+          )
+      )
+
+  public val icon_5659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5659.xml"),
+          )
+      )
+
+  public val icon_566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_566.xml"),
+          )
+      )
+
+  public val icon_5660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5660.xml"),
+          )
+      )
+
+  public val icon_5661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5661.xml"),
+          )
+      )
+
+  public val icon_5662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5662.xml"),
+          )
+      )
+
+  public val icon_5663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5663.xml"),
+          )
+      )
+
+  public val icon_5664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5664.xml"),
+          )
+      )
+
+  public val icon_5665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5665.xml"),
+          )
+      )
+
+  public val icon_5666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5666.xml"),
+          )
+      )
+
+  public val icon_5667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5667.xml"),
+          )
+      )
+
+  public val icon_5668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5668.xml"),
+          )
+      )
+
+  public val icon_5669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5669.xml"),
+          )
+      )
+
+  public val icon_567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_567.xml"),
+          )
+      )
+
+  public val icon_5670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5670.xml"),
+          )
+      )
+
+  public val icon_5671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5671.xml"),
+          )
+      )
+
+  public val icon_5672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5672.xml"),
+          )
+      )
+
+  public val icon_5673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5673.xml"),
+          )
+      )
+
+  public val icon_5674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5674.xml"),
+          )
+      )
+
+  public val icon_5675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5675.xml"),
+          )
+      )
+
+  public val icon_5676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5676.xml"),
+          )
+      )
+
+  public val icon_5677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5677.xml"),
+          )
+      )
+
+  public val icon_5678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5678.xml"),
+          )
+      )
+
+  public val icon_5679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5679.xml"),
+          )
+      )
+
+  public val icon_568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_568.xml"),
+          )
+      )
+
+  public val icon_5680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5680.xml"),
+          )
+      )
+
+  public val icon_5681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5681.xml"),
+          )
+      )
+
+  public val icon_5682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5682.xml"),
+          )
+      )
+
+  public val icon_5683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5683.xml"),
+          )
+      )
+
+  public val icon_5684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5684.xml"),
+          )
+      )
+
+  public val icon_5685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5685.xml"),
+          )
+      )
+
+  public val icon_5686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5686.xml"),
+          )
+      )
+
+  public val icon_5687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5687.xml"),
+          )
+      )
+
+  public val icon_5688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5688.xml"),
+          )
+      )
+
+  public val icon_5689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5689.xml"),
+          )
+      )
+
+  public val icon_569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_569.xml"),
+          )
+      )
+
+  public val icon_5690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5690.xml"),
+          )
+      )
+
+  public val icon_5691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5691.xml"),
+          )
+      )
+
+  public val icon_5692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5692.xml"),
+          )
+      )
+
+  public val icon_5693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5693.xml"),
+          )
+      )
+
+  public val icon_5694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5694.xml"),
+          )
+      )
+
+  public val icon_5695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5695.xml"),
+          )
+      )
+
+  public val icon_5696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5696.xml"),
+          )
+      )
+
+  public val icon_5697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5697.xml"),
+          )
+      )
+
+  public val icon_5698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5698.xml"),
+          )
+      )
+
+  public val icon_5699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5699.xml"),
+          )
+      )
+
+  public val icon_57: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_57",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_57.xml"),
+          )
+      )
+
+  public val icon_570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_570.xml"),
+          )
+      )
+
+  public val icon_5700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5700.xml"),
+          )
+      )
+
+  public val icon_5701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5701.xml"),
+          )
+      )
+
+  public val icon_5702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5702.xml"),
+          )
+      )
+
+  public val icon_5703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5703.xml"),
+          )
+      )
+
+  public val icon_5704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5704.xml"),
+          )
+      )
+
+  public val icon_5705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5705.xml"),
+          )
+      )
+
+  public val icon_5706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5706.xml"),
+          )
+      )
+
+  public val icon_5707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5707.xml"),
+          )
+      )
+
+  public val icon_5708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5708.xml"),
+          )
+      )
+
+  public val icon_5709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5709.xml"),
+          )
+      )
+
+  public val icon_571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_571.xml"),
+          )
+      )
+
+  public val icon_5710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5710.xml"),
+          )
+      )
+
+  public val icon_5711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5711.xml"),
+          )
+      )
+
+  public val icon_5712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5712.xml"),
+          )
+      )
+
+  public val icon_5713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5713.xml"),
+          )
+      )
+
+  public val icon_5714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5714.xml"),
+          )
+      )
+
+  public val icon_5715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5715.xml"),
+          )
+      )
+
+  public val icon_5716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5716.xml"),
+          )
+      )
+
+  public val icon_5717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5717.xml"),
+          )
+      )
+
+  public val icon_5718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5718.xml"),
+          )
+      )
+
+  public val icon_5719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5719.xml"),
+          )
+      )
+
+  public val icon_572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_572.xml"),
+          )
+      )
+
+  public val icon_5720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5720.xml"),
+          )
+      )
+
+  public val icon_5721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5721.xml"),
+          )
+      )
+
+  public val icon_5722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5722.xml"),
+          )
+      )
+
+  public val icon_5723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5723.xml"),
+          )
+      )
+
+  public val icon_5724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5724.xml"),
+          )
+      )
+
+  public val icon_5725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5725.xml"),
+          )
+      )
+
+  public val icon_5726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5726.xml"),
+          )
+      )
+
+  public val icon_5727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5727.xml"),
+          )
+      )
+
+  public val icon_5728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5728.xml"),
+          )
+      )
+
+  public val icon_5729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5729.xml"),
+          )
+      )
+
+  public val icon_573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_573.xml"),
+          )
+      )
+
+  public val icon_5730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5730.xml"),
+          )
+      )
+
+  public val icon_5731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5731.xml"),
+          )
+      )
+
+  public val icon_5732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5732.xml"),
+          )
+      )
+
+  public val icon_5733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5733.xml"),
+          )
+      )
+
+  public val icon_5734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5734.xml"),
+          )
+      )
+
+  public val icon_5735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5735.xml"),
+          )
+      )
+
+  public val icon_5736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5736.xml"),
+          )
+      )
+
+  public val icon_5737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5737.xml"),
+          )
+      )
+
+  public val icon_5738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5738.xml"),
+          )
+      )
+
+  public val icon_5739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5739.xml"),
+          )
+      )
+
+  public val icon_574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_574.xml"),
+          )
+      )
+
+  public val icon_5740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5740.xml"),
+          )
+      )
+
+  public val icon_5741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5741.xml"),
+          )
+      )
+
+  public val icon_5742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5742.xml"),
+          )
+      )
+
+  public val icon_5743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5743.xml"),
+          )
+      )
+
+  public val icon_5744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5744.xml"),
+          )
+      )
+
+  public val icon_5745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5745.xml"),
+          )
+      )
+
+  public val icon_5746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5746.xml"),
+          )
+      )
+
+  public val icon_5747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5747.xml"),
+          )
+      )
+
+  public val icon_5748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5748.xml"),
+          )
+      )
+
+  public val icon_5749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5749.xml"),
+          )
+      )
+
+  public val icon_575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_575.xml"),
+          )
+      )
+
+  public val icon_5750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5750.xml"),
+          )
+      )
+
+  public val icon_5751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5751.xml"),
+          )
+      )
+
+  public val icon_5752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5752.xml"),
+          )
+      )
+
+  public val icon_5753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5753.xml"),
+          )
+      )
+
+  public val icon_5754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5754.xml"),
+          )
+      )
+
+  public val icon_5755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5755.xml"),
+          )
+      )
+
+  public val icon_5756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5756.xml"),
+          )
+      )
+
+  public val icon_5757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5757.xml"),
+          )
+      )
+
+  public val icon_5758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5758.xml"),
+          )
+      )
+
+  public val icon_5759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5759.xml"),
+          )
+      )
+
+  public val icon_576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_576.xml"),
+          )
+      )
+
+  public val icon_5760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5760.xml"),
+          )
+      )
+
+  public val icon_5761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5761.xml"),
+          )
+      )
+
+  public val icon_5762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5762.xml"),
+          )
+      )
+
+  public val icon_5763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5763.xml"),
+          )
+      )
+
+  public val icon_5764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5764.xml"),
+          )
+      )
+
+  public val icon_5765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5765.xml"),
+          )
+      )
+
+  public val icon_5766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5766.xml"),
+          )
+      )
+
+  public val icon_5767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5767.xml"),
+          )
+      )
+
+  public val icon_5768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5768.xml"),
+          )
+      )
+
+  public val icon_5769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5769.xml"),
+          )
+      )
+
+  public val icon_577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_577.xml"),
+          )
+      )
+
+  public val icon_5770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5770.xml"),
+          )
+      )
+
+  public val icon_5771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5771.xml"),
+          )
+      )
+
+  public val icon_5772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5772.xml"),
+          )
+      )
+
+  public val icon_5773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5773.xml"),
+          )
+      )
+
+  public val icon_5774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5774.xml"),
+          )
+      )
+
+  public val icon_5775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5775.xml"),
+          )
+      )
+
+  public val icon_5776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5776.xml"),
+          )
+      )
+
+  public val icon_5777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5777.xml"),
+          )
+      )
+
+  public val icon_5778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5778.xml"),
+          )
+      )
+
+  public val icon_5779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5779.xml"),
+          )
+      )
+
+  public val icon_578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_578.xml"),
+          )
+      )
+
+  public val icon_5780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5780.xml"),
+          )
+      )
+
+  public val icon_5781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5781.xml"),
+          )
+      )
+
+  public val icon_5782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5782.xml"),
+          )
+      )
+
+  public val icon_5783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5783.xml"),
+          )
+      )
+
+  public val icon_5784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5784.xml"),
+          )
+      )
+
+  public val icon_5785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5785.xml"),
+          )
+      )
+
+  public val icon_5786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5786.xml"),
+          )
+      )
+
+  public val icon_5787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5787.xml"),
+          )
+      )
+
+  public val icon_5788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5788.xml"),
+          )
+      )
+
+  public val icon_5789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5789.xml"),
+          )
+      )
+
+  public val icon_579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_579.xml"),
+          )
+      )
+
+  public val icon_5790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5790.xml"),
+          )
+      )
+
+  public val icon_5791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5791.xml"),
+          )
+      )
+
+  public val icon_5792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5792.xml"),
+          )
+      )
+
+  public val icon_5793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5793.xml"),
+          )
+      )
+
+  public val icon_5794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5794.xml"),
+          )
+      )
+
+  public val icon_5795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5795.xml"),
+          )
+      )
+
+  public val icon_5796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5796.xml"),
+          )
+      )
+
+  public val icon_5797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5797.xml"),
+          )
+      )
+
+  public val icon_5798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5798.xml"),
+          )
+      )
+
+  public val icon_5799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5799.xml"),
+          )
+      )
+
+  public val icon_58: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_58",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_58.xml"),
+          )
+      )
+
+  public val icon_580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_580.xml"),
+          )
+      )
+
+  public val icon_5800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5800.xml"),
+          )
+      )
+
+  public val icon_5801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5801.xml"),
+          )
+      )
+
+  public val icon_5802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5802.xml"),
+          )
+      )
+
+  public val icon_5803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5803.xml"),
+          )
+      )
+
+  public val icon_5804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5804.xml"),
+          )
+      )
+
+  public val icon_5805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5805.xml"),
+          )
+      )
+
+  public val icon_5806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5806.xml"),
+          )
+      )
+
+  public val icon_5807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5807.xml"),
+          )
+      )
+
+  public val icon_5808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5808.xml"),
+          )
+      )
+
+  public val icon_5809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5809.xml"),
+          )
+      )
+
+  public val icon_581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_581.xml"),
+          )
+      )
+
+  public val icon_5810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5810.xml"),
+          )
+      )
+
+  public val icon_5811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5811.xml"),
+          )
+      )
+
+  public val icon_5812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5812.xml"),
+          )
+      )
+
+  public val icon_5813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5813.xml"),
+          )
+      )
+
+  public val icon_5814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5814.xml"),
+          )
+      )
+
+  public val icon_5815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5815.xml"),
+          )
+      )
+
+  public val icon_5816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5816.xml"),
+          )
+      )
+
+  public val icon_5817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5817.xml"),
+          )
+      )
+
+  public val icon_5818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5818.xml"),
+          )
+      )
+
+  public val icon_5819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5819.xml"),
+          )
+      )
+
+  public val icon_582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_582.xml"),
+          )
+      )
+
+  public val icon_5820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5820.xml"),
+          )
+      )
+
+  public val icon_5821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5821.xml"),
+          )
+      )
+
+  public val icon_5822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5822.xml"),
+          )
+      )
+
+  public val icon_5823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5823.xml"),
+          )
+      )
+
+  public val icon_5824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5824.xml"),
+          )
+      )
+
+  public val icon_5825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5825.xml"),
+          )
+      )
+
+  public val icon_5826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5826.xml"),
+          )
+      )
+
+  public val icon_5827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5827.xml"),
+          )
+      )
+
+  public val icon_5828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5828.xml"),
+          )
+      )
+
+  public val icon_5829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5829.xml"),
+          )
+      )
+
+  public val icon_583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_583.xml"),
+          )
+      )
+
+  public val icon_5830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5830.xml"),
+          )
+      )
+
+  public val icon_5831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5831.xml"),
+          )
+      )
+
+  public val icon_5832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5832.xml"),
+          )
+      )
+
+  public val icon_5833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5833.xml"),
+          )
+      )
+
+  public val icon_5834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5834.xml"),
+          )
+      )
+
+  public val icon_5835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5835.xml"),
+          )
+      )
+
+  public val icon_5836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5836.xml"),
+          )
+      )
+
+  public val icon_5837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5837.xml"),
+          )
+      )
+
+  public val icon_5838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5838.xml"),
+          )
+      )
+
+  public val icon_5839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5839.xml"),
+          )
+      )
+
+  public val icon_584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_584.xml"),
+          )
+      )
+
+  public val icon_5840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5840.xml"),
+          )
+      )
+
+  public val icon_5841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5841.xml"),
+          )
+      )
+
+  public val icon_5842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5842.xml"),
+          )
+      )
+
+  public val icon_5843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5843.xml"),
+          )
+      )
+
+  public val icon_5844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5844.xml"),
+          )
+      )
+
+  public val icon_5845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5845.xml"),
+          )
+      )
+
+  public val icon_5846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5846.xml"),
+          )
+      )
+
+  public val icon_5847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5847.xml"),
+          )
+      )
+
+  public val icon_5848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5848.xml"),
+          )
+      )
+
+  public val icon_5849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5849.xml"),
+          )
+      )
+
+  public val icon_585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_585.xml"),
+          )
+      )
+
+  public val icon_5850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5850.xml"),
+          )
+      )
+
+  public val icon_5851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5851.xml"),
+          )
+      )
+
+  public val icon_5852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5852.xml"),
+          )
+      )
+
+  public val icon_5853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5853.xml"),
+          )
+      )
+
+  public val icon_5854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5854.xml"),
+          )
+      )
+
+  public val icon_5855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5855.xml"),
+          )
+      )
+
+  public val icon_5856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5856.xml"),
+          )
+      )
+
+  public val icon_5857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5857.xml"),
+          )
+      )
+
+  public val icon_5858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5858.xml"),
+          )
+      )
+
+  public val icon_5859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5859.xml"),
+          )
+      )
+
+  public val icon_586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_586.xml"),
+          )
+      )
+
+  public val icon_5860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5860.xml"),
+          )
+      )
+
+  public val icon_5861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5861.xml"),
+          )
+      )
+
+  public val icon_5862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5862.xml"),
+          )
+      )
+
+  public val icon_5863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5863.xml"),
+          )
+      )
+
+  public val icon_5864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5864.xml"),
+          )
+      )
+
+  public val icon_5865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5865.xml"),
+          )
+      )
+
+  public val icon_5866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5866.xml"),
+          )
+      )
+
+  public val icon_5867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5867.xml"),
+          )
+      )
+
+  public val icon_5868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5868.xml"),
+          )
+      )
+
+  public val icon_5869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5869.xml"),
+          )
+      )
+
+  public val icon_587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_587.xml"),
+          )
+      )
+
+  public val icon_5870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5870.xml"),
+          )
+      )
+
+  public val icon_5871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5871.xml"),
+          )
+      )
+
+  public val icon_5872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5872.xml"),
+          )
+      )
+
+  public val icon_5873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5873.xml"),
+          )
+      )
+
+  public val icon_5874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5874.xml"),
+          )
+      )
+
+  public val icon_5875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5875.xml"),
+          )
+      )
+
+  public val icon_5876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5876.xml"),
+          )
+      )
+
+  public val icon_5877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5877.xml"),
+          )
+      )
+
+  public val icon_5878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5878.xml"),
+          )
+      )
+
+  public val icon_5879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5879.xml"),
+          )
+      )
+
+  public val icon_588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_588.xml"),
+          )
+      )
+
+  public val icon_5880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5880.xml"),
+          )
+      )
+
+  public val icon_5881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5881.xml"),
+          )
+      )
+
+  public val icon_5882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5882.xml"),
+          )
+      )
+
+  public val icon_5883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5883.xml"),
+          )
+      )
+
+  public val icon_5884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5884.xml"),
+          )
+      )
+
+  public val icon_5885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5885.xml"),
+          )
+      )
+
+  public val icon_5886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5886.xml"),
+          )
+      )
+
+  public val icon_5887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5887.xml"),
+          )
+      )
+
+  public val icon_5888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5888.xml"),
+          )
+      )
+
+  public val icon_5889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5889.xml"),
+          )
+      )
+
+  public val icon_589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_589.xml"),
+          )
+      )
+
+  public val icon_5890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5890.xml"),
+          )
+      )
+
+  public val icon_5891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5891.xml"),
+          )
+      )
+
+  public val icon_5892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5892.xml"),
+          )
+      )
+
+  public val icon_5893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5893.xml"),
+          )
+      )
+
+  public val icon_5894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5894.xml"),
+          )
+      )
+
+  public val icon_5895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5895.xml"),
+          )
+      )
+
+  public val icon_5896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5896.xml"),
+          )
+      )
+
+  public val icon_5897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5897.xml"),
+          )
+      )
+
+  public val icon_5898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5898.xml"),
+          )
+      )
+
+  public val icon_5899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5899.xml"),
+          )
+      )
+
+  public val icon_59: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_59",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_59.xml"),
+          )
+      )
+
+  public val icon_590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_590.xml"),
+          )
+      )
+
+  public val icon_5900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5900.xml"),
+          )
+      )
+
+  public val icon_5901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5901.xml"),
+          )
+      )
+
+  public val icon_5902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5902.xml"),
+          )
+      )
+
+  public val icon_5903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5903.xml"),
+          )
+      )
+
+  public val icon_5904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5904.xml"),
+          )
+      )
+
+  public val icon_5905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5905.xml"),
+          )
+      )
+
+  public val icon_5906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5906.xml"),
+          )
+      )
+
+  public val icon_5907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5907.xml"),
+          )
+      )
+
+  public val icon_5908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5908.xml"),
+          )
+      )
+
+  public val icon_5909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5909.xml"),
+          )
+      )
+
+  public val icon_591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_591.xml"),
+          )
+      )
+
+  public val icon_5910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5910.xml"),
+          )
+      )
+
+  public val icon_5911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5911.xml"),
+          )
+      )
+
+  public val icon_5912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5912.xml"),
+          )
+      )
+
+  public val icon_5913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5913.xml"),
+          )
+      )
+
+  public val icon_5914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5914.xml"),
+          )
+      )
+
+  public val icon_5915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5915.xml"),
+          )
+      )
+
+  public val icon_5916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5916.xml"),
+          )
+      )
+
+  public val icon_5917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5917.xml"),
+          )
+      )
+
+  public val icon_5918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5918.xml"),
+          )
+      )
+
+  public val icon_5919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5919.xml"),
+          )
+      )
+
+  public val icon_592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_592.xml"),
+          )
+      )
+
+  public val icon_5920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5920.xml"),
+          )
+      )
+
+  public val icon_5921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5921.xml"),
+          )
+      )
+
+  public val icon_5922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5922.xml"),
+          )
+      )
+
+  public val icon_5923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5923.xml"),
+          )
+      )
+
+  public val icon_5924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5924.xml"),
+          )
+      )
+
+  public val icon_5925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5925.xml"),
+          )
+      )
+
+  public val icon_5926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5926.xml"),
+          )
+      )
+
+  public val icon_5927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5927.xml"),
+          )
+      )
+
+  public val icon_5928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5928.xml"),
+          )
+      )
+
+  public val icon_5929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5929.xml"),
+          )
+      )
+
+  public val icon_593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_593.xml"),
+          )
+      )
+
+  public val icon_5930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5930.xml"),
+          )
+      )
+
+  public val icon_5931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5931.xml"),
+          )
+      )
+
+  public val icon_5932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5932.xml"),
+          )
+      )
+
+  public val icon_5933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5933.xml"),
+          )
+      )
+
+  public val icon_5934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5934.xml"),
+          )
+      )
+
+  public val icon_5935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5935.xml"),
+          )
+      )
+
+  public val icon_5936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5936.xml"),
+          )
+      )
+
+  public val icon_5937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5937.xml"),
+          )
+      )
+
+  public val icon_5938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5938.xml"),
+          )
+      )
+
+  public val icon_5939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5939.xml"),
+          )
+      )
+
+  public val icon_594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_594.xml"),
+          )
+      )
+
+  public val icon_5940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5940.xml"),
+          )
+      )
+
+  public val icon_5941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5941.xml"),
+          )
+      )
+
+  public val icon_5942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5942.xml"),
+          )
+      )
+
+  public val icon_5943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5943.xml"),
+          )
+      )
+
+  public val icon_5944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5944.xml"),
+          )
+      )
+
+  public val icon_5945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5945.xml"),
+          )
+      )
+
+  public val icon_5946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5946.xml"),
+          )
+      )
+
+  public val icon_5947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5947.xml"),
+          )
+      )
+
+  public val icon_5948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5948.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5499: DrawableResource
+  get() = Drawable40.icon_5499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_55: DrawableResource
+  get() = Drawable40.icon_55
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_550: DrawableResource
+  get() = Drawable40.icon_550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5500: DrawableResource
+  get() = Drawable40.icon_5500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5501: DrawableResource
+  get() = Drawable40.icon_5501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5502: DrawableResource
+  get() = Drawable40.icon_5502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5503: DrawableResource
+  get() = Drawable40.icon_5503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5504: DrawableResource
+  get() = Drawable40.icon_5504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5505: DrawableResource
+  get() = Drawable40.icon_5505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5506: DrawableResource
+  get() = Drawable40.icon_5506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5507: DrawableResource
+  get() = Drawable40.icon_5507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5508: DrawableResource
+  get() = Drawable40.icon_5508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5509: DrawableResource
+  get() = Drawable40.icon_5509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_551: DrawableResource
+  get() = Drawable40.icon_551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5510: DrawableResource
+  get() = Drawable40.icon_5510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5511: DrawableResource
+  get() = Drawable40.icon_5511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5512: DrawableResource
+  get() = Drawable40.icon_5512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5513: DrawableResource
+  get() = Drawable40.icon_5513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5514: DrawableResource
+  get() = Drawable40.icon_5514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5515: DrawableResource
+  get() = Drawable40.icon_5515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5516: DrawableResource
+  get() = Drawable40.icon_5516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5517: DrawableResource
+  get() = Drawable40.icon_5517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5518: DrawableResource
+  get() = Drawable40.icon_5518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5519: DrawableResource
+  get() = Drawable40.icon_5519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_552: DrawableResource
+  get() = Drawable40.icon_552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5520: DrawableResource
+  get() = Drawable40.icon_5520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5521: DrawableResource
+  get() = Drawable40.icon_5521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5522: DrawableResource
+  get() = Drawable40.icon_5522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5523: DrawableResource
+  get() = Drawable40.icon_5523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5524: DrawableResource
+  get() = Drawable40.icon_5524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5525: DrawableResource
+  get() = Drawable40.icon_5525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5526: DrawableResource
+  get() = Drawable40.icon_5526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5527: DrawableResource
+  get() = Drawable40.icon_5527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5528: DrawableResource
+  get() = Drawable40.icon_5528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5529: DrawableResource
+  get() = Drawable40.icon_5529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_553: DrawableResource
+  get() = Drawable40.icon_553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5530: DrawableResource
+  get() = Drawable40.icon_5530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5531: DrawableResource
+  get() = Drawable40.icon_5531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5532: DrawableResource
+  get() = Drawable40.icon_5532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5533: DrawableResource
+  get() = Drawable40.icon_5533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5534: DrawableResource
+  get() = Drawable40.icon_5534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5535: DrawableResource
+  get() = Drawable40.icon_5535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5536: DrawableResource
+  get() = Drawable40.icon_5536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5537: DrawableResource
+  get() = Drawable40.icon_5537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5538: DrawableResource
+  get() = Drawable40.icon_5538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5539: DrawableResource
+  get() = Drawable40.icon_5539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_554: DrawableResource
+  get() = Drawable40.icon_554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5540: DrawableResource
+  get() = Drawable40.icon_5540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5541: DrawableResource
+  get() = Drawable40.icon_5541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5542: DrawableResource
+  get() = Drawable40.icon_5542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5543: DrawableResource
+  get() = Drawable40.icon_5543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5544: DrawableResource
+  get() = Drawable40.icon_5544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5545: DrawableResource
+  get() = Drawable40.icon_5545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5546: DrawableResource
+  get() = Drawable40.icon_5546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5547: DrawableResource
+  get() = Drawable40.icon_5547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5548: DrawableResource
+  get() = Drawable40.icon_5548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5549: DrawableResource
+  get() = Drawable40.icon_5549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_555: DrawableResource
+  get() = Drawable40.icon_555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5550: DrawableResource
+  get() = Drawable40.icon_5550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5551: DrawableResource
+  get() = Drawable40.icon_5551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5552: DrawableResource
+  get() = Drawable40.icon_5552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5553: DrawableResource
+  get() = Drawable40.icon_5553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5554: DrawableResource
+  get() = Drawable40.icon_5554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5555: DrawableResource
+  get() = Drawable40.icon_5555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5556: DrawableResource
+  get() = Drawable40.icon_5556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5557: DrawableResource
+  get() = Drawable40.icon_5557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5558: DrawableResource
+  get() = Drawable40.icon_5558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5559: DrawableResource
+  get() = Drawable40.icon_5559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_556: DrawableResource
+  get() = Drawable40.icon_556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5560: DrawableResource
+  get() = Drawable40.icon_5560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5561: DrawableResource
+  get() = Drawable40.icon_5561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5562: DrawableResource
+  get() = Drawable40.icon_5562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5563: DrawableResource
+  get() = Drawable40.icon_5563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5564: DrawableResource
+  get() = Drawable40.icon_5564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5565: DrawableResource
+  get() = Drawable40.icon_5565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5566: DrawableResource
+  get() = Drawable40.icon_5566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5567: DrawableResource
+  get() = Drawable40.icon_5567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5568: DrawableResource
+  get() = Drawable40.icon_5568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5569: DrawableResource
+  get() = Drawable40.icon_5569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_557: DrawableResource
+  get() = Drawable40.icon_557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5570: DrawableResource
+  get() = Drawable40.icon_5570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5571: DrawableResource
+  get() = Drawable40.icon_5571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5572: DrawableResource
+  get() = Drawable40.icon_5572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5573: DrawableResource
+  get() = Drawable40.icon_5573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5574: DrawableResource
+  get() = Drawable40.icon_5574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5575: DrawableResource
+  get() = Drawable40.icon_5575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5576: DrawableResource
+  get() = Drawable40.icon_5576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5577: DrawableResource
+  get() = Drawable40.icon_5577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5578: DrawableResource
+  get() = Drawable40.icon_5578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5579: DrawableResource
+  get() = Drawable40.icon_5579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_558: DrawableResource
+  get() = Drawable40.icon_558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5580: DrawableResource
+  get() = Drawable40.icon_5580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5581: DrawableResource
+  get() = Drawable40.icon_5581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5582: DrawableResource
+  get() = Drawable40.icon_5582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5583: DrawableResource
+  get() = Drawable40.icon_5583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5584: DrawableResource
+  get() = Drawable40.icon_5584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5585: DrawableResource
+  get() = Drawable40.icon_5585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5586: DrawableResource
+  get() = Drawable40.icon_5586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5587: DrawableResource
+  get() = Drawable40.icon_5587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5588: DrawableResource
+  get() = Drawable40.icon_5588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5589: DrawableResource
+  get() = Drawable40.icon_5589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_559: DrawableResource
+  get() = Drawable40.icon_559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5590: DrawableResource
+  get() = Drawable40.icon_5590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5591: DrawableResource
+  get() = Drawable40.icon_5591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5592: DrawableResource
+  get() = Drawable40.icon_5592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5593: DrawableResource
+  get() = Drawable40.icon_5593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5594: DrawableResource
+  get() = Drawable40.icon_5594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5595: DrawableResource
+  get() = Drawable40.icon_5595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5596: DrawableResource
+  get() = Drawable40.icon_5596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5597: DrawableResource
+  get() = Drawable40.icon_5597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5598: DrawableResource
+  get() = Drawable40.icon_5598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5599: DrawableResource
+  get() = Drawable40.icon_5599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_56: DrawableResource
+  get() = Drawable40.icon_56
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_560: DrawableResource
+  get() = Drawable40.icon_560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5600: DrawableResource
+  get() = Drawable40.icon_5600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5601: DrawableResource
+  get() = Drawable40.icon_5601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5602: DrawableResource
+  get() = Drawable40.icon_5602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5603: DrawableResource
+  get() = Drawable40.icon_5603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5604: DrawableResource
+  get() = Drawable40.icon_5604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5605: DrawableResource
+  get() = Drawable40.icon_5605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5606: DrawableResource
+  get() = Drawable40.icon_5606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5607: DrawableResource
+  get() = Drawable40.icon_5607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5608: DrawableResource
+  get() = Drawable40.icon_5608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5609: DrawableResource
+  get() = Drawable40.icon_5609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_561: DrawableResource
+  get() = Drawable40.icon_561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5610: DrawableResource
+  get() = Drawable40.icon_5610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5611: DrawableResource
+  get() = Drawable40.icon_5611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5612: DrawableResource
+  get() = Drawable40.icon_5612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5613: DrawableResource
+  get() = Drawable40.icon_5613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5614: DrawableResource
+  get() = Drawable40.icon_5614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5615: DrawableResource
+  get() = Drawable40.icon_5615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5616: DrawableResource
+  get() = Drawable40.icon_5616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5617: DrawableResource
+  get() = Drawable40.icon_5617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5618: DrawableResource
+  get() = Drawable40.icon_5618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5619: DrawableResource
+  get() = Drawable40.icon_5619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_562: DrawableResource
+  get() = Drawable40.icon_562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5620: DrawableResource
+  get() = Drawable40.icon_5620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5621: DrawableResource
+  get() = Drawable40.icon_5621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5622: DrawableResource
+  get() = Drawable40.icon_5622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5623: DrawableResource
+  get() = Drawable40.icon_5623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5624: DrawableResource
+  get() = Drawable40.icon_5624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5625: DrawableResource
+  get() = Drawable40.icon_5625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5626: DrawableResource
+  get() = Drawable40.icon_5626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5627: DrawableResource
+  get() = Drawable40.icon_5627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5628: DrawableResource
+  get() = Drawable40.icon_5628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5629: DrawableResource
+  get() = Drawable40.icon_5629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_563: DrawableResource
+  get() = Drawable40.icon_563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5630: DrawableResource
+  get() = Drawable40.icon_5630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5631: DrawableResource
+  get() = Drawable40.icon_5631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5632: DrawableResource
+  get() = Drawable40.icon_5632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5633: DrawableResource
+  get() = Drawable40.icon_5633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5634: DrawableResource
+  get() = Drawable40.icon_5634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5635: DrawableResource
+  get() = Drawable40.icon_5635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5636: DrawableResource
+  get() = Drawable40.icon_5636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5637: DrawableResource
+  get() = Drawable40.icon_5637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5638: DrawableResource
+  get() = Drawable40.icon_5638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5639: DrawableResource
+  get() = Drawable40.icon_5639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_564: DrawableResource
+  get() = Drawable40.icon_564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5640: DrawableResource
+  get() = Drawable40.icon_5640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5641: DrawableResource
+  get() = Drawable40.icon_5641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5642: DrawableResource
+  get() = Drawable40.icon_5642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5643: DrawableResource
+  get() = Drawable40.icon_5643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5644: DrawableResource
+  get() = Drawable40.icon_5644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5645: DrawableResource
+  get() = Drawable40.icon_5645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5646: DrawableResource
+  get() = Drawable40.icon_5646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5647: DrawableResource
+  get() = Drawable40.icon_5647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5648: DrawableResource
+  get() = Drawable40.icon_5648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5649: DrawableResource
+  get() = Drawable40.icon_5649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_565: DrawableResource
+  get() = Drawable40.icon_565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5650: DrawableResource
+  get() = Drawable40.icon_5650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5651: DrawableResource
+  get() = Drawable40.icon_5651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5652: DrawableResource
+  get() = Drawable40.icon_5652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5653: DrawableResource
+  get() = Drawable40.icon_5653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5654: DrawableResource
+  get() = Drawable40.icon_5654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5655: DrawableResource
+  get() = Drawable40.icon_5655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5656: DrawableResource
+  get() = Drawable40.icon_5656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5657: DrawableResource
+  get() = Drawable40.icon_5657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5658: DrawableResource
+  get() = Drawable40.icon_5658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5659: DrawableResource
+  get() = Drawable40.icon_5659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_566: DrawableResource
+  get() = Drawable40.icon_566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5660: DrawableResource
+  get() = Drawable40.icon_5660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5661: DrawableResource
+  get() = Drawable40.icon_5661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5662: DrawableResource
+  get() = Drawable40.icon_5662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5663: DrawableResource
+  get() = Drawable40.icon_5663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5664: DrawableResource
+  get() = Drawable40.icon_5664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5665: DrawableResource
+  get() = Drawable40.icon_5665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5666: DrawableResource
+  get() = Drawable40.icon_5666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5667: DrawableResource
+  get() = Drawable40.icon_5667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5668: DrawableResource
+  get() = Drawable40.icon_5668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5669: DrawableResource
+  get() = Drawable40.icon_5669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_567: DrawableResource
+  get() = Drawable40.icon_567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5670: DrawableResource
+  get() = Drawable40.icon_5670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5671: DrawableResource
+  get() = Drawable40.icon_5671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5672: DrawableResource
+  get() = Drawable40.icon_5672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5673: DrawableResource
+  get() = Drawable40.icon_5673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5674: DrawableResource
+  get() = Drawable40.icon_5674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5675: DrawableResource
+  get() = Drawable40.icon_5675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5676: DrawableResource
+  get() = Drawable40.icon_5676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5677: DrawableResource
+  get() = Drawable40.icon_5677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5678: DrawableResource
+  get() = Drawable40.icon_5678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5679: DrawableResource
+  get() = Drawable40.icon_5679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_568: DrawableResource
+  get() = Drawable40.icon_568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5680: DrawableResource
+  get() = Drawable40.icon_5680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5681: DrawableResource
+  get() = Drawable40.icon_5681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5682: DrawableResource
+  get() = Drawable40.icon_5682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5683: DrawableResource
+  get() = Drawable40.icon_5683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5684: DrawableResource
+  get() = Drawable40.icon_5684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5685: DrawableResource
+  get() = Drawable40.icon_5685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5686: DrawableResource
+  get() = Drawable40.icon_5686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5687: DrawableResource
+  get() = Drawable40.icon_5687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5688: DrawableResource
+  get() = Drawable40.icon_5688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5689: DrawableResource
+  get() = Drawable40.icon_5689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_569: DrawableResource
+  get() = Drawable40.icon_569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5690: DrawableResource
+  get() = Drawable40.icon_5690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5691: DrawableResource
+  get() = Drawable40.icon_5691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5692: DrawableResource
+  get() = Drawable40.icon_5692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5693: DrawableResource
+  get() = Drawable40.icon_5693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5694: DrawableResource
+  get() = Drawable40.icon_5694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5695: DrawableResource
+  get() = Drawable40.icon_5695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5696: DrawableResource
+  get() = Drawable40.icon_5696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5697: DrawableResource
+  get() = Drawable40.icon_5697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5698: DrawableResource
+  get() = Drawable40.icon_5698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5699: DrawableResource
+  get() = Drawable40.icon_5699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_57: DrawableResource
+  get() = Drawable40.icon_57
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_570: DrawableResource
+  get() = Drawable40.icon_570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5700: DrawableResource
+  get() = Drawable40.icon_5700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5701: DrawableResource
+  get() = Drawable40.icon_5701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5702: DrawableResource
+  get() = Drawable40.icon_5702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5703: DrawableResource
+  get() = Drawable40.icon_5703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5704: DrawableResource
+  get() = Drawable40.icon_5704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5705: DrawableResource
+  get() = Drawable40.icon_5705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5706: DrawableResource
+  get() = Drawable40.icon_5706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5707: DrawableResource
+  get() = Drawable40.icon_5707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5708: DrawableResource
+  get() = Drawable40.icon_5708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5709: DrawableResource
+  get() = Drawable40.icon_5709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_571: DrawableResource
+  get() = Drawable40.icon_571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5710: DrawableResource
+  get() = Drawable40.icon_5710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5711: DrawableResource
+  get() = Drawable40.icon_5711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5712: DrawableResource
+  get() = Drawable40.icon_5712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5713: DrawableResource
+  get() = Drawable40.icon_5713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5714: DrawableResource
+  get() = Drawable40.icon_5714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5715: DrawableResource
+  get() = Drawable40.icon_5715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5716: DrawableResource
+  get() = Drawable40.icon_5716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5717: DrawableResource
+  get() = Drawable40.icon_5717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5718: DrawableResource
+  get() = Drawable40.icon_5718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5719: DrawableResource
+  get() = Drawable40.icon_5719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_572: DrawableResource
+  get() = Drawable40.icon_572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5720: DrawableResource
+  get() = Drawable40.icon_5720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5721: DrawableResource
+  get() = Drawable40.icon_5721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5722: DrawableResource
+  get() = Drawable40.icon_5722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5723: DrawableResource
+  get() = Drawable40.icon_5723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5724: DrawableResource
+  get() = Drawable40.icon_5724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5725: DrawableResource
+  get() = Drawable40.icon_5725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5726: DrawableResource
+  get() = Drawable40.icon_5726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5727: DrawableResource
+  get() = Drawable40.icon_5727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5728: DrawableResource
+  get() = Drawable40.icon_5728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5729: DrawableResource
+  get() = Drawable40.icon_5729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_573: DrawableResource
+  get() = Drawable40.icon_573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5730: DrawableResource
+  get() = Drawable40.icon_5730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5731: DrawableResource
+  get() = Drawable40.icon_5731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5732: DrawableResource
+  get() = Drawable40.icon_5732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5733: DrawableResource
+  get() = Drawable40.icon_5733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5734: DrawableResource
+  get() = Drawable40.icon_5734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5735: DrawableResource
+  get() = Drawable40.icon_5735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5736: DrawableResource
+  get() = Drawable40.icon_5736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5737: DrawableResource
+  get() = Drawable40.icon_5737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5738: DrawableResource
+  get() = Drawable40.icon_5738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5739: DrawableResource
+  get() = Drawable40.icon_5739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_574: DrawableResource
+  get() = Drawable40.icon_574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5740: DrawableResource
+  get() = Drawable40.icon_5740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5741: DrawableResource
+  get() = Drawable40.icon_5741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5742: DrawableResource
+  get() = Drawable40.icon_5742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5743: DrawableResource
+  get() = Drawable40.icon_5743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5744: DrawableResource
+  get() = Drawable40.icon_5744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5745: DrawableResource
+  get() = Drawable40.icon_5745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5746: DrawableResource
+  get() = Drawable40.icon_5746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5747: DrawableResource
+  get() = Drawable40.icon_5747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5748: DrawableResource
+  get() = Drawable40.icon_5748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5749: DrawableResource
+  get() = Drawable40.icon_5749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_575: DrawableResource
+  get() = Drawable40.icon_575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5750: DrawableResource
+  get() = Drawable40.icon_5750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5751: DrawableResource
+  get() = Drawable40.icon_5751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5752: DrawableResource
+  get() = Drawable40.icon_5752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5753: DrawableResource
+  get() = Drawable40.icon_5753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5754: DrawableResource
+  get() = Drawable40.icon_5754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5755: DrawableResource
+  get() = Drawable40.icon_5755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5756: DrawableResource
+  get() = Drawable40.icon_5756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5757: DrawableResource
+  get() = Drawable40.icon_5757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5758: DrawableResource
+  get() = Drawable40.icon_5758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5759: DrawableResource
+  get() = Drawable40.icon_5759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_576: DrawableResource
+  get() = Drawable40.icon_576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5760: DrawableResource
+  get() = Drawable40.icon_5760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5761: DrawableResource
+  get() = Drawable40.icon_5761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5762: DrawableResource
+  get() = Drawable40.icon_5762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5763: DrawableResource
+  get() = Drawable40.icon_5763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5764: DrawableResource
+  get() = Drawable40.icon_5764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5765: DrawableResource
+  get() = Drawable40.icon_5765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5766: DrawableResource
+  get() = Drawable40.icon_5766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5767: DrawableResource
+  get() = Drawable40.icon_5767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5768: DrawableResource
+  get() = Drawable40.icon_5768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5769: DrawableResource
+  get() = Drawable40.icon_5769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_577: DrawableResource
+  get() = Drawable40.icon_577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5770: DrawableResource
+  get() = Drawable40.icon_5770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5771: DrawableResource
+  get() = Drawable40.icon_5771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5772: DrawableResource
+  get() = Drawable40.icon_5772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5773: DrawableResource
+  get() = Drawable40.icon_5773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5774: DrawableResource
+  get() = Drawable40.icon_5774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5775: DrawableResource
+  get() = Drawable40.icon_5775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5776: DrawableResource
+  get() = Drawable40.icon_5776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5777: DrawableResource
+  get() = Drawable40.icon_5777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5778: DrawableResource
+  get() = Drawable40.icon_5778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5779: DrawableResource
+  get() = Drawable40.icon_5779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_578: DrawableResource
+  get() = Drawable40.icon_578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5780: DrawableResource
+  get() = Drawable40.icon_5780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5781: DrawableResource
+  get() = Drawable40.icon_5781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5782: DrawableResource
+  get() = Drawable40.icon_5782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5783: DrawableResource
+  get() = Drawable40.icon_5783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5784: DrawableResource
+  get() = Drawable40.icon_5784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5785: DrawableResource
+  get() = Drawable40.icon_5785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5786: DrawableResource
+  get() = Drawable40.icon_5786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5787: DrawableResource
+  get() = Drawable40.icon_5787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5788: DrawableResource
+  get() = Drawable40.icon_5788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5789: DrawableResource
+  get() = Drawable40.icon_5789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_579: DrawableResource
+  get() = Drawable40.icon_579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5790: DrawableResource
+  get() = Drawable40.icon_5790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5791: DrawableResource
+  get() = Drawable40.icon_5791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5792: DrawableResource
+  get() = Drawable40.icon_5792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5793: DrawableResource
+  get() = Drawable40.icon_5793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5794: DrawableResource
+  get() = Drawable40.icon_5794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5795: DrawableResource
+  get() = Drawable40.icon_5795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5796: DrawableResource
+  get() = Drawable40.icon_5796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5797: DrawableResource
+  get() = Drawable40.icon_5797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5798: DrawableResource
+  get() = Drawable40.icon_5798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5799: DrawableResource
+  get() = Drawable40.icon_5799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_58: DrawableResource
+  get() = Drawable40.icon_58
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_580: DrawableResource
+  get() = Drawable40.icon_580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5800: DrawableResource
+  get() = Drawable40.icon_5800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5801: DrawableResource
+  get() = Drawable40.icon_5801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5802: DrawableResource
+  get() = Drawable40.icon_5802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5803: DrawableResource
+  get() = Drawable40.icon_5803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5804: DrawableResource
+  get() = Drawable40.icon_5804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5805: DrawableResource
+  get() = Drawable40.icon_5805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5806: DrawableResource
+  get() = Drawable40.icon_5806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5807: DrawableResource
+  get() = Drawable40.icon_5807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5808: DrawableResource
+  get() = Drawable40.icon_5808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5809: DrawableResource
+  get() = Drawable40.icon_5809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_581: DrawableResource
+  get() = Drawable40.icon_581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5810: DrawableResource
+  get() = Drawable40.icon_5810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5811: DrawableResource
+  get() = Drawable40.icon_5811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5812: DrawableResource
+  get() = Drawable40.icon_5812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5813: DrawableResource
+  get() = Drawable40.icon_5813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5814: DrawableResource
+  get() = Drawable40.icon_5814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5815: DrawableResource
+  get() = Drawable40.icon_5815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5816: DrawableResource
+  get() = Drawable40.icon_5816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5817: DrawableResource
+  get() = Drawable40.icon_5817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5818: DrawableResource
+  get() = Drawable40.icon_5818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5819: DrawableResource
+  get() = Drawable40.icon_5819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_582: DrawableResource
+  get() = Drawable40.icon_582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5820: DrawableResource
+  get() = Drawable40.icon_5820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5821: DrawableResource
+  get() = Drawable40.icon_5821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5822: DrawableResource
+  get() = Drawable40.icon_5822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5823: DrawableResource
+  get() = Drawable40.icon_5823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5824: DrawableResource
+  get() = Drawable40.icon_5824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5825: DrawableResource
+  get() = Drawable40.icon_5825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5826: DrawableResource
+  get() = Drawable40.icon_5826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5827: DrawableResource
+  get() = Drawable40.icon_5827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5828: DrawableResource
+  get() = Drawable40.icon_5828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5829: DrawableResource
+  get() = Drawable40.icon_5829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_583: DrawableResource
+  get() = Drawable40.icon_583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5830: DrawableResource
+  get() = Drawable40.icon_5830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5831: DrawableResource
+  get() = Drawable40.icon_5831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5832: DrawableResource
+  get() = Drawable40.icon_5832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5833: DrawableResource
+  get() = Drawable40.icon_5833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5834: DrawableResource
+  get() = Drawable40.icon_5834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5835: DrawableResource
+  get() = Drawable40.icon_5835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5836: DrawableResource
+  get() = Drawable40.icon_5836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5837: DrawableResource
+  get() = Drawable40.icon_5837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5838: DrawableResource
+  get() = Drawable40.icon_5838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5839: DrawableResource
+  get() = Drawable40.icon_5839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_584: DrawableResource
+  get() = Drawable40.icon_584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5840: DrawableResource
+  get() = Drawable40.icon_5840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5841: DrawableResource
+  get() = Drawable40.icon_5841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5842: DrawableResource
+  get() = Drawable40.icon_5842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5843: DrawableResource
+  get() = Drawable40.icon_5843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5844: DrawableResource
+  get() = Drawable40.icon_5844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5845: DrawableResource
+  get() = Drawable40.icon_5845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5846: DrawableResource
+  get() = Drawable40.icon_5846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5847: DrawableResource
+  get() = Drawable40.icon_5847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5848: DrawableResource
+  get() = Drawable40.icon_5848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5849: DrawableResource
+  get() = Drawable40.icon_5849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_585: DrawableResource
+  get() = Drawable40.icon_585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5850: DrawableResource
+  get() = Drawable40.icon_5850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5851: DrawableResource
+  get() = Drawable40.icon_5851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5852: DrawableResource
+  get() = Drawable40.icon_5852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5853: DrawableResource
+  get() = Drawable40.icon_5853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5854: DrawableResource
+  get() = Drawable40.icon_5854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5855: DrawableResource
+  get() = Drawable40.icon_5855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5856: DrawableResource
+  get() = Drawable40.icon_5856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5857: DrawableResource
+  get() = Drawable40.icon_5857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5858: DrawableResource
+  get() = Drawable40.icon_5858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5859: DrawableResource
+  get() = Drawable40.icon_5859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_586: DrawableResource
+  get() = Drawable40.icon_586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5860: DrawableResource
+  get() = Drawable40.icon_5860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5861: DrawableResource
+  get() = Drawable40.icon_5861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5862: DrawableResource
+  get() = Drawable40.icon_5862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5863: DrawableResource
+  get() = Drawable40.icon_5863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5864: DrawableResource
+  get() = Drawable40.icon_5864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5865: DrawableResource
+  get() = Drawable40.icon_5865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5866: DrawableResource
+  get() = Drawable40.icon_5866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5867: DrawableResource
+  get() = Drawable40.icon_5867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5868: DrawableResource
+  get() = Drawable40.icon_5868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5869: DrawableResource
+  get() = Drawable40.icon_5869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_587: DrawableResource
+  get() = Drawable40.icon_587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5870: DrawableResource
+  get() = Drawable40.icon_5870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5871: DrawableResource
+  get() = Drawable40.icon_5871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5872: DrawableResource
+  get() = Drawable40.icon_5872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5873: DrawableResource
+  get() = Drawable40.icon_5873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5874: DrawableResource
+  get() = Drawable40.icon_5874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5875: DrawableResource
+  get() = Drawable40.icon_5875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5876: DrawableResource
+  get() = Drawable40.icon_5876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5877: DrawableResource
+  get() = Drawable40.icon_5877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5878: DrawableResource
+  get() = Drawable40.icon_5878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5879: DrawableResource
+  get() = Drawable40.icon_5879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_588: DrawableResource
+  get() = Drawable40.icon_588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5880: DrawableResource
+  get() = Drawable40.icon_5880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5881: DrawableResource
+  get() = Drawable40.icon_5881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5882: DrawableResource
+  get() = Drawable40.icon_5882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5883: DrawableResource
+  get() = Drawable40.icon_5883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5884: DrawableResource
+  get() = Drawable40.icon_5884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5885: DrawableResource
+  get() = Drawable40.icon_5885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5886: DrawableResource
+  get() = Drawable40.icon_5886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5887: DrawableResource
+  get() = Drawable40.icon_5887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5888: DrawableResource
+  get() = Drawable40.icon_5888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5889: DrawableResource
+  get() = Drawable40.icon_5889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_589: DrawableResource
+  get() = Drawable40.icon_589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5890: DrawableResource
+  get() = Drawable40.icon_5890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5891: DrawableResource
+  get() = Drawable40.icon_5891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5892: DrawableResource
+  get() = Drawable40.icon_5892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5893: DrawableResource
+  get() = Drawable40.icon_5893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5894: DrawableResource
+  get() = Drawable40.icon_5894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5895: DrawableResource
+  get() = Drawable40.icon_5895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5896: DrawableResource
+  get() = Drawable40.icon_5896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5897: DrawableResource
+  get() = Drawable40.icon_5897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5898: DrawableResource
+  get() = Drawable40.icon_5898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5899: DrawableResource
+  get() = Drawable40.icon_5899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_59: DrawableResource
+  get() = Drawable40.icon_59
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_590: DrawableResource
+  get() = Drawable40.icon_590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5900: DrawableResource
+  get() = Drawable40.icon_5900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5901: DrawableResource
+  get() = Drawable40.icon_5901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5902: DrawableResource
+  get() = Drawable40.icon_5902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5903: DrawableResource
+  get() = Drawable40.icon_5903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5904: DrawableResource
+  get() = Drawable40.icon_5904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5905: DrawableResource
+  get() = Drawable40.icon_5905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5906: DrawableResource
+  get() = Drawable40.icon_5906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5907: DrawableResource
+  get() = Drawable40.icon_5907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5908: DrawableResource
+  get() = Drawable40.icon_5908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5909: DrawableResource
+  get() = Drawable40.icon_5909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_591: DrawableResource
+  get() = Drawable40.icon_591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5910: DrawableResource
+  get() = Drawable40.icon_5910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5911: DrawableResource
+  get() = Drawable40.icon_5911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5912: DrawableResource
+  get() = Drawable40.icon_5912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5913: DrawableResource
+  get() = Drawable40.icon_5913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5914: DrawableResource
+  get() = Drawable40.icon_5914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5915: DrawableResource
+  get() = Drawable40.icon_5915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5916: DrawableResource
+  get() = Drawable40.icon_5916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5917: DrawableResource
+  get() = Drawable40.icon_5917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5918: DrawableResource
+  get() = Drawable40.icon_5918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5919: DrawableResource
+  get() = Drawable40.icon_5919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_592: DrawableResource
+  get() = Drawable40.icon_592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5920: DrawableResource
+  get() = Drawable40.icon_5920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5921: DrawableResource
+  get() = Drawable40.icon_5921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5922: DrawableResource
+  get() = Drawable40.icon_5922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5923: DrawableResource
+  get() = Drawable40.icon_5923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5924: DrawableResource
+  get() = Drawable40.icon_5924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5925: DrawableResource
+  get() = Drawable40.icon_5925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5926: DrawableResource
+  get() = Drawable40.icon_5926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5927: DrawableResource
+  get() = Drawable40.icon_5927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5928: DrawableResource
+  get() = Drawable40.icon_5928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5929: DrawableResource
+  get() = Drawable40.icon_5929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_593: DrawableResource
+  get() = Drawable40.icon_593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5930: DrawableResource
+  get() = Drawable40.icon_5930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5931: DrawableResource
+  get() = Drawable40.icon_5931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5932: DrawableResource
+  get() = Drawable40.icon_5932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5933: DrawableResource
+  get() = Drawable40.icon_5933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5934: DrawableResource
+  get() = Drawable40.icon_5934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5935: DrawableResource
+  get() = Drawable40.icon_5935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5936: DrawableResource
+  get() = Drawable40.icon_5936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5937: DrawableResource
+  get() = Drawable40.icon_5937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5938: DrawableResource
+  get() = Drawable40.icon_5938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5939: DrawableResource
+  get() = Drawable40.icon_5939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_594: DrawableResource
+  get() = Drawable40.icon_594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5940: DrawableResource
+  get() = Drawable40.icon_5940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5941: DrawableResource
+  get() = Drawable40.icon_5941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5942: DrawableResource
+  get() = Drawable40.icon_5942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5943: DrawableResource
+  get() = Drawable40.icon_5943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5944: DrawableResource
+  get() = Drawable40.icon_5944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5945: DrawableResource
+  get() = Drawable40.icon_5945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5946: DrawableResource
+  get() = Drawable40.icon_5946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5947: DrawableResource
+  get() = Drawable40.icon_5947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5948: DrawableResource
+  get() = Drawable40.icon_5948

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable41.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable41.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable41 {
+  public val icon_5949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5949.xml"),
+          )
+      )
+
+  public val icon_595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_595.xml"),
+          )
+      )
+
+  public val icon_5950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5950.xml"),
+          )
+      )
+
+  public val icon_5951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5951.xml"),
+          )
+      )
+
+  public val icon_5952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5952.xml"),
+          )
+      )
+
+  public val icon_5953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5953.xml"),
+          )
+      )
+
+  public val icon_5954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5954.xml"),
+          )
+      )
+
+  public val icon_5955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5955.xml"),
+          )
+      )
+
+  public val icon_5956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5956.xml"),
+          )
+      )
+
+  public val icon_5957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5957.xml"),
+          )
+      )
+
+  public val icon_5958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5958.xml"),
+          )
+      )
+
+  public val icon_5959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5959.xml"),
+          )
+      )
+
+  public val icon_596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_596.xml"),
+          )
+      )
+
+  public val icon_5960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5960.xml"),
+          )
+      )
+
+  public val icon_5961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5961.xml"),
+          )
+      )
+
+  public val icon_5962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5962.xml"),
+          )
+      )
+
+  public val icon_5963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5963.xml"),
+          )
+      )
+
+  public val icon_5964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5964.xml"),
+          )
+      )
+
+  public val icon_5965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5965.xml"),
+          )
+      )
+
+  public val icon_5966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5966.xml"),
+          )
+      )
+
+  public val icon_5967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5967.xml"),
+          )
+      )
+
+  public val icon_5968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5968.xml"),
+          )
+      )
+
+  public val icon_5969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5969.xml"),
+          )
+      )
+
+  public val icon_597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_597.xml"),
+          )
+      )
+
+  public val icon_5970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5970.xml"),
+          )
+      )
+
+  public val icon_5971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5971.xml"),
+          )
+      )
+
+  public val icon_5972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5972.xml"),
+          )
+      )
+
+  public val icon_5973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5973.xml"),
+          )
+      )
+
+  public val icon_5974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5974.xml"),
+          )
+      )
+
+  public val icon_5975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5975.xml"),
+          )
+      )
+
+  public val icon_5976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5976.xml"),
+          )
+      )
+
+  public val icon_5977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5977.xml"),
+          )
+      )
+
+  public val icon_5978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5978.xml"),
+          )
+      )
+
+  public val icon_5979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5979.xml"),
+          )
+      )
+
+  public val icon_598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_598.xml"),
+          )
+      )
+
+  public val icon_5980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5980.xml"),
+          )
+      )
+
+  public val icon_5981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5981.xml"),
+          )
+      )
+
+  public val icon_5982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5982.xml"),
+          )
+      )
+
+  public val icon_5983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5983.xml"),
+          )
+      )
+
+  public val icon_5984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5984.xml"),
+          )
+      )
+
+  public val icon_5985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5985.xml"),
+          )
+      )
+
+  public val icon_5986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5986.xml"),
+          )
+      )
+
+  public val icon_5987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5987.xml"),
+          )
+      )
+
+  public val icon_5988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5988.xml"),
+          )
+      )
+
+  public val icon_5989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5989.xml"),
+          )
+      )
+
+  public val icon_599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_599.xml"),
+          )
+      )
+
+  public val icon_5990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5990.xml"),
+          )
+      )
+
+  public val icon_5991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5991.xml"),
+          )
+      )
+
+  public val icon_5992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5992.xml"),
+          )
+      )
+
+  public val icon_5993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5993.xml"),
+          )
+      )
+
+  public val icon_5994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5994.xml"),
+          )
+      )
+
+  public val icon_5995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5995.xml"),
+          )
+      )
+
+  public val icon_5996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5996.xml"),
+          )
+      )
+
+  public val icon_5997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5997.xml"),
+          )
+      )
+
+  public val icon_5998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5998.xml"),
+          )
+      )
+
+  public val icon_5999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_5999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_5999.xml"),
+          )
+      )
+
+  public val icon_6: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6.xml"),
+          )
+      )
+
+  public val icon_60: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_60",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_60.xml"),
+          )
+      )
+
+  public val icon_600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_600.xml"),
+          )
+      )
+
+  public val icon_6000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6000.xml"),
+          )
+      )
+
+  public val icon_6001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6001.xml"),
+          )
+      )
+
+  public val icon_6002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6002.xml"),
+          )
+      )
+
+  public val icon_6003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6003.xml"),
+          )
+      )
+
+  public val icon_6004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6004.xml"),
+          )
+      )
+
+  public val icon_6005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6005.xml"),
+          )
+      )
+
+  public val icon_6006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6006.xml"),
+          )
+      )
+
+  public val icon_6007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6007.xml"),
+          )
+      )
+
+  public val icon_6008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6008.xml"),
+          )
+      )
+
+  public val icon_6009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6009.xml"),
+          )
+      )
+
+  public val icon_601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_601.xml"),
+          )
+      )
+
+  public val icon_6010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6010.xml"),
+          )
+      )
+
+  public val icon_6011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6011.xml"),
+          )
+      )
+
+  public val icon_6012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6012.xml"),
+          )
+      )
+
+  public val icon_6013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6013.xml"),
+          )
+      )
+
+  public val icon_6014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6014.xml"),
+          )
+      )
+
+  public val icon_6015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6015.xml"),
+          )
+      )
+
+  public val icon_6016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6016.xml"),
+          )
+      )
+
+  public val icon_6017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6017.xml"),
+          )
+      )
+
+  public val icon_6018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6018.xml"),
+          )
+      )
+
+  public val icon_6019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6019.xml"),
+          )
+      )
+
+  public val icon_602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_602.xml"),
+          )
+      )
+
+  public val icon_6020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6020.xml"),
+          )
+      )
+
+  public val icon_6021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6021.xml"),
+          )
+      )
+
+  public val icon_6022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6022.xml"),
+          )
+      )
+
+  public val icon_6023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6023.xml"),
+          )
+      )
+
+  public val icon_6024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6024.xml"),
+          )
+      )
+
+  public val icon_6025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6025.xml"),
+          )
+      )
+
+  public val icon_6026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6026.xml"),
+          )
+      )
+
+  public val icon_6027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6027.xml"),
+          )
+      )
+
+  public val icon_6028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6028.xml"),
+          )
+      )
+
+  public val icon_6029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6029.xml"),
+          )
+      )
+
+  public val icon_603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_603.xml"),
+          )
+      )
+
+  public val icon_6030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6030.xml"),
+          )
+      )
+
+  public val icon_6031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6031.xml"),
+          )
+      )
+
+  public val icon_6032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6032.xml"),
+          )
+      )
+
+  public val icon_6033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6033.xml"),
+          )
+      )
+
+  public val icon_6034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6034.xml"),
+          )
+      )
+
+  public val icon_6035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6035.xml"),
+          )
+      )
+
+  public val icon_6036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6036.xml"),
+          )
+      )
+
+  public val icon_6037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6037.xml"),
+          )
+      )
+
+  public val icon_6038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6038.xml"),
+          )
+      )
+
+  public val icon_6039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6039.xml"),
+          )
+      )
+
+  public val icon_604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_604.xml"),
+          )
+      )
+
+  public val icon_6040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6040.xml"),
+          )
+      )
+
+  public val icon_6041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6041.xml"),
+          )
+      )
+
+  public val icon_6042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6042.xml"),
+          )
+      )
+
+  public val icon_6043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6043.xml"),
+          )
+      )
+
+  public val icon_6044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6044.xml"),
+          )
+      )
+
+  public val icon_6045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6045.xml"),
+          )
+      )
+
+  public val icon_6046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6046.xml"),
+          )
+      )
+
+  public val icon_6047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6047.xml"),
+          )
+      )
+
+  public val icon_6048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6048.xml"),
+          )
+      )
+
+  public val icon_6049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6049.xml"),
+          )
+      )
+
+  public val icon_605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_605.xml"),
+          )
+      )
+
+  public val icon_6050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6050.xml"),
+          )
+      )
+
+  public val icon_6051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6051.xml"),
+          )
+      )
+
+  public val icon_6052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6052.xml"),
+          )
+      )
+
+  public val icon_6053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6053.xml"),
+          )
+      )
+
+  public val icon_6054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6054.xml"),
+          )
+      )
+
+  public val icon_6055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6055.xml"),
+          )
+      )
+
+  public val icon_6056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6056.xml"),
+          )
+      )
+
+  public val icon_6057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6057.xml"),
+          )
+      )
+
+  public val icon_6058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6058.xml"),
+          )
+      )
+
+  public val icon_6059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6059.xml"),
+          )
+      )
+
+  public val icon_606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_606.xml"),
+          )
+      )
+
+  public val icon_6060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6060.xml"),
+          )
+      )
+
+  public val icon_6061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6061.xml"),
+          )
+      )
+
+  public val icon_6062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6062.xml"),
+          )
+      )
+
+  public val icon_6063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6063.xml"),
+          )
+      )
+
+  public val icon_6064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6064.xml"),
+          )
+      )
+
+  public val icon_6065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6065.xml"),
+          )
+      )
+
+  public val icon_6066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6066.xml"),
+          )
+      )
+
+  public val icon_6067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6067.xml"),
+          )
+      )
+
+  public val icon_6068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6068.xml"),
+          )
+      )
+
+  public val icon_6069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6069.xml"),
+          )
+      )
+
+  public val icon_607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_607.xml"),
+          )
+      )
+
+  public val icon_6070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6070.xml"),
+          )
+      )
+
+  public val icon_6071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6071.xml"),
+          )
+      )
+
+  public val icon_6072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6072.xml"),
+          )
+      )
+
+  public val icon_6073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6073.xml"),
+          )
+      )
+
+  public val icon_6074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6074.xml"),
+          )
+      )
+
+  public val icon_6075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6075.xml"),
+          )
+      )
+
+  public val icon_6076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6076.xml"),
+          )
+      )
+
+  public val icon_6077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6077.xml"),
+          )
+      )
+
+  public val icon_6078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6078.xml"),
+          )
+      )
+
+  public val icon_6079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6079.xml"),
+          )
+      )
+
+  public val icon_608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_608.xml"),
+          )
+      )
+
+  public val icon_6080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6080.xml"),
+          )
+      )
+
+  public val icon_6081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6081.xml"),
+          )
+      )
+
+  public val icon_6082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6082.xml"),
+          )
+      )
+
+  public val icon_6083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6083.xml"),
+          )
+      )
+
+  public val icon_6084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6084.xml"),
+          )
+      )
+
+  public val icon_6085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6085.xml"),
+          )
+      )
+
+  public val icon_6086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6086.xml"),
+          )
+      )
+
+  public val icon_6087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6087.xml"),
+          )
+      )
+
+  public val icon_6088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6088.xml"),
+          )
+      )
+
+  public val icon_6089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6089.xml"),
+          )
+      )
+
+  public val icon_609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_609.xml"),
+          )
+      )
+
+  public val icon_6090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6090.xml"),
+          )
+      )
+
+  public val icon_6091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6091.xml"),
+          )
+      )
+
+  public val icon_6092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6092.xml"),
+          )
+      )
+
+  public val icon_6093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6093.xml"),
+          )
+      )
+
+  public val icon_6094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6094.xml"),
+          )
+      )
+
+  public val icon_6095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6095.xml"),
+          )
+      )
+
+  public val icon_6096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6096.xml"),
+          )
+      )
+
+  public val icon_6097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6097.xml"),
+          )
+      )
+
+  public val icon_6098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6098.xml"),
+          )
+      )
+
+  public val icon_6099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6099.xml"),
+          )
+      )
+
+  public val icon_61: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_61",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_61.xml"),
+          )
+      )
+
+  public val icon_610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_610.xml"),
+          )
+      )
+
+  public val icon_6100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6100.xml"),
+          )
+      )
+
+  public val icon_6101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6101.xml"),
+          )
+      )
+
+  public val icon_6102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6102.xml"),
+          )
+      )
+
+  public val icon_6103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6103.xml"),
+          )
+      )
+
+  public val icon_6104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6104.xml"),
+          )
+      )
+
+  public val icon_6105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6105.xml"),
+          )
+      )
+
+  public val icon_6106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6106.xml"),
+          )
+      )
+
+  public val icon_6107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6107.xml"),
+          )
+      )
+
+  public val icon_6108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6108.xml"),
+          )
+      )
+
+  public val icon_6109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6109.xml"),
+          )
+      )
+
+  public val icon_611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_611.xml"),
+          )
+      )
+
+  public val icon_6110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6110.xml"),
+          )
+      )
+
+  public val icon_6111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6111.xml"),
+          )
+      )
+
+  public val icon_6112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6112.xml"),
+          )
+      )
+
+  public val icon_6113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6113.xml"),
+          )
+      )
+
+  public val icon_6114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6114.xml"),
+          )
+      )
+
+  public val icon_6115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6115.xml"),
+          )
+      )
+
+  public val icon_6116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6116.xml"),
+          )
+      )
+
+  public val icon_6117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6117.xml"),
+          )
+      )
+
+  public val icon_6118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6118.xml"),
+          )
+      )
+
+  public val icon_6119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6119.xml"),
+          )
+      )
+
+  public val icon_612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_612.xml"),
+          )
+      )
+
+  public val icon_6120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6120.xml"),
+          )
+      )
+
+  public val icon_6121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6121.xml"),
+          )
+      )
+
+  public val icon_6122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6122.xml"),
+          )
+      )
+
+  public val icon_6123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6123.xml"),
+          )
+      )
+
+  public val icon_6124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6124.xml"),
+          )
+      )
+
+  public val icon_6125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6125.xml"),
+          )
+      )
+
+  public val icon_6126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6126.xml"),
+          )
+      )
+
+  public val icon_6127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6127.xml"),
+          )
+      )
+
+  public val icon_6128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6128.xml"),
+          )
+      )
+
+  public val icon_6129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6129.xml"),
+          )
+      )
+
+  public val icon_613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_613.xml"),
+          )
+      )
+
+  public val icon_6130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6130.xml"),
+          )
+      )
+
+  public val icon_6131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6131.xml"),
+          )
+      )
+
+  public val icon_6132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6132.xml"),
+          )
+      )
+
+  public val icon_6133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6133.xml"),
+          )
+      )
+
+  public val icon_6134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6134.xml"),
+          )
+      )
+
+  public val icon_6135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6135.xml"),
+          )
+      )
+
+  public val icon_6136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6136.xml"),
+          )
+      )
+
+  public val icon_6137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6137.xml"),
+          )
+      )
+
+  public val icon_6138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6138.xml"),
+          )
+      )
+
+  public val icon_6139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6139.xml"),
+          )
+      )
+
+  public val icon_614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_614.xml"),
+          )
+      )
+
+  public val icon_6140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6140.xml"),
+          )
+      )
+
+  public val icon_6141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6141.xml"),
+          )
+      )
+
+  public val icon_6142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6142.xml"),
+          )
+      )
+
+  public val icon_6143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6143.xml"),
+          )
+      )
+
+  public val icon_6144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6144.xml"),
+          )
+      )
+
+  public val icon_6145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6145.xml"),
+          )
+      )
+
+  public val icon_6146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6146.xml"),
+          )
+      )
+
+  public val icon_6147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6147.xml"),
+          )
+      )
+
+  public val icon_6148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6148.xml"),
+          )
+      )
+
+  public val icon_6149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6149.xml"),
+          )
+      )
+
+  public val icon_615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_615.xml"),
+          )
+      )
+
+  public val icon_6150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6150.xml"),
+          )
+      )
+
+  public val icon_6151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6151.xml"),
+          )
+      )
+
+  public val icon_6152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6152.xml"),
+          )
+      )
+
+  public val icon_6153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6153.xml"),
+          )
+      )
+
+  public val icon_6154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6154.xml"),
+          )
+      )
+
+  public val icon_6155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6155.xml"),
+          )
+      )
+
+  public val icon_6156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6156.xml"),
+          )
+      )
+
+  public val icon_6157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6157.xml"),
+          )
+      )
+
+  public val icon_6158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6158.xml"),
+          )
+      )
+
+  public val icon_6159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6159.xml"),
+          )
+      )
+
+  public val icon_616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_616.xml"),
+          )
+      )
+
+  public val icon_6160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6160.xml"),
+          )
+      )
+
+  public val icon_6161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6161.xml"),
+          )
+      )
+
+  public val icon_6162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6162.xml"),
+          )
+      )
+
+  public val icon_6163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6163.xml"),
+          )
+      )
+
+  public val icon_6164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6164.xml"),
+          )
+      )
+
+  public val icon_6165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6165.xml"),
+          )
+      )
+
+  public val icon_6166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6166.xml"),
+          )
+      )
+
+  public val icon_6167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6167.xml"),
+          )
+      )
+
+  public val icon_6168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6168.xml"),
+          )
+      )
+
+  public val icon_6169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6169.xml"),
+          )
+      )
+
+  public val icon_617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_617.xml"),
+          )
+      )
+
+  public val icon_6170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6170.xml"),
+          )
+      )
+
+  public val icon_6171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6171.xml"),
+          )
+      )
+
+  public val icon_6172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6172.xml"),
+          )
+      )
+
+  public val icon_6173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6173.xml"),
+          )
+      )
+
+  public val icon_6174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6174.xml"),
+          )
+      )
+
+  public val icon_6175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6175.xml"),
+          )
+      )
+
+  public val icon_6176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6176.xml"),
+          )
+      )
+
+  public val icon_6177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6177.xml"),
+          )
+      )
+
+  public val icon_6178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6178.xml"),
+          )
+      )
+
+  public val icon_6179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6179.xml"),
+          )
+      )
+
+  public val icon_618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_618.xml"),
+          )
+      )
+
+  public val icon_6180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6180.xml"),
+          )
+      )
+
+  public val icon_6181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6181.xml"),
+          )
+      )
+
+  public val icon_6182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6182.xml"),
+          )
+      )
+
+  public val icon_6183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6183.xml"),
+          )
+      )
+
+  public val icon_6184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6184.xml"),
+          )
+      )
+
+  public val icon_6185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6185.xml"),
+          )
+      )
+
+  public val icon_6186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6186.xml"),
+          )
+      )
+
+  public val icon_6187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6187.xml"),
+          )
+      )
+
+  public val icon_6188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6188.xml"),
+          )
+      )
+
+  public val icon_6189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6189.xml"),
+          )
+      )
+
+  public val icon_619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_619.xml"),
+          )
+      )
+
+  public val icon_6190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6190.xml"),
+          )
+      )
+
+  public val icon_6191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6191.xml"),
+          )
+      )
+
+  public val icon_6192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6192.xml"),
+          )
+      )
+
+  public val icon_6193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6193.xml"),
+          )
+      )
+
+  public val icon_6194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6194.xml"),
+          )
+      )
+
+  public val icon_6195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6195.xml"),
+          )
+      )
+
+  public val icon_6196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6196.xml"),
+          )
+      )
+
+  public val icon_6197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6197.xml"),
+          )
+      )
+
+  public val icon_6198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6198.xml"),
+          )
+      )
+
+  public val icon_6199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6199.xml"),
+          )
+      )
+
+  public val icon_62: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_62",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_62.xml"),
+          )
+      )
+
+  public val icon_620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_620.xml"),
+          )
+      )
+
+  public val icon_6200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6200.xml"),
+          )
+      )
+
+  public val icon_6201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6201.xml"),
+          )
+      )
+
+  public val icon_6202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6202.xml"),
+          )
+      )
+
+  public val icon_6203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6203.xml"),
+          )
+      )
+
+  public val icon_6204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6204.xml"),
+          )
+      )
+
+  public val icon_6205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6205.xml"),
+          )
+      )
+
+  public val icon_6206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6206.xml"),
+          )
+      )
+
+  public val icon_6207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6207.xml"),
+          )
+      )
+
+  public val icon_6208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6208.xml"),
+          )
+      )
+
+  public val icon_6209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6209.xml"),
+          )
+      )
+
+  public val icon_621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_621.xml"),
+          )
+      )
+
+  public val icon_6210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6210.xml"),
+          )
+      )
+
+  public val icon_6211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6211.xml"),
+          )
+      )
+
+  public val icon_6212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6212.xml"),
+          )
+      )
+
+  public val icon_6213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6213.xml"),
+          )
+      )
+
+  public val icon_6214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6214.xml"),
+          )
+      )
+
+  public val icon_6215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6215.xml"),
+          )
+      )
+
+  public val icon_6216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6216.xml"),
+          )
+      )
+
+  public val icon_6217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6217.xml"),
+          )
+      )
+
+  public val icon_6218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6218.xml"),
+          )
+      )
+
+  public val icon_6219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6219.xml"),
+          )
+      )
+
+  public val icon_622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_622.xml"),
+          )
+      )
+
+  public val icon_6220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6220.xml"),
+          )
+      )
+
+  public val icon_6221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6221.xml"),
+          )
+      )
+
+  public val icon_6222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6222.xml"),
+          )
+      )
+
+  public val icon_6223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6223.xml"),
+          )
+      )
+
+  public val icon_6224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6224.xml"),
+          )
+      )
+
+  public val icon_6225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6225.xml"),
+          )
+      )
+
+  public val icon_6226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6226.xml"),
+          )
+      )
+
+  public val icon_6227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6227.xml"),
+          )
+      )
+
+  public val icon_6228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6228.xml"),
+          )
+      )
+
+  public val icon_6229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6229.xml"),
+          )
+      )
+
+  public val icon_623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_623.xml"),
+          )
+      )
+
+  public val icon_6230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6230.xml"),
+          )
+      )
+
+  public val icon_6231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6231.xml"),
+          )
+      )
+
+  public val icon_6232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6232.xml"),
+          )
+      )
+
+  public val icon_6233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6233.xml"),
+          )
+      )
+
+  public val icon_6234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6234.xml"),
+          )
+      )
+
+  public val icon_6235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6235.xml"),
+          )
+      )
+
+  public val icon_6236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6236.xml"),
+          )
+      )
+
+  public val icon_6237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6237.xml"),
+          )
+      )
+
+  public val icon_6238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6238.xml"),
+          )
+      )
+
+  public val icon_6239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6239.xml"),
+          )
+      )
+
+  public val icon_624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_624.xml"),
+          )
+      )
+
+  public val icon_6240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6240.xml"),
+          )
+      )
+
+  public val icon_6241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6241.xml"),
+          )
+      )
+
+  public val icon_6242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6242.xml"),
+          )
+      )
+
+  public val icon_6243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6243.xml"),
+          )
+      )
+
+  public val icon_6244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6244.xml"),
+          )
+      )
+
+  public val icon_6245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6245.xml"),
+          )
+      )
+
+  public val icon_6246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6246.xml"),
+          )
+      )
+
+  public val icon_6247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6247.xml"),
+          )
+      )
+
+  public val icon_6248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6248.xml"),
+          )
+      )
+
+  public val icon_6249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6249.xml"),
+          )
+      )
+
+  public val icon_625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_625.xml"),
+          )
+      )
+
+  public val icon_6250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6250.xml"),
+          )
+      )
+
+  public val icon_6251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6251.xml"),
+          )
+      )
+
+  public val icon_6252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6252.xml"),
+          )
+      )
+
+  public val icon_6253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6253.xml"),
+          )
+      )
+
+  public val icon_6254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6254.xml"),
+          )
+      )
+
+  public val icon_6255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6255.xml"),
+          )
+      )
+
+  public val icon_6256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6256.xml"),
+          )
+      )
+
+  public val icon_6257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6257.xml"),
+          )
+      )
+
+  public val icon_6258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6258.xml"),
+          )
+      )
+
+  public val icon_6259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6259.xml"),
+          )
+      )
+
+  public val icon_626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_626.xml"),
+          )
+      )
+
+  public val icon_6260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6260.xml"),
+          )
+      )
+
+  public val icon_6261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6261.xml"),
+          )
+      )
+
+  public val icon_6262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6262.xml"),
+          )
+      )
+
+  public val icon_6263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6263.xml"),
+          )
+      )
+
+  public val icon_6264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6264.xml"),
+          )
+      )
+
+  public val icon_6265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6265.xml"),
+          )
+      )
+
+  public val icon_6266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6266.xml"),
+          )
+      )
+
+  public val icon_6267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6267.xml"),
+          )
+      )
+
+  public val icon_6268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6268.xml"),
+          )
+      )
+
+  public val icon_6269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6269.xml"),
+          )
+      )
+
+  public val icon_627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_627.xml"),
+          )
+      )
+
+  public val icon_6270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6270.xml"),
+          )
+      )
+
+  public val icon_6271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6271.xml"),
+          )
+      )
+
+  public val icon_6272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6272.xml"),
+          )
+      )
+
+  public val icon_6273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6273.xml"),
+          )
+      )
+
+  public val icon_6274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6274.xml"),
+          )
+      )
+
+  public val icon_6275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6275.xml"),
+          )
+      )
+
+  public val icon_6276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6276.xml"),
+          )
+      )
+
+  public val icon_6277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6277.xml"),
+          )
+      )
+
+  public val icon_6278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6278.xml"),
+          )
+      )
+
+  public val icon_6279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6279.xml"),
+          )
+      )
+
+  public val icon_628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_628.xml"),
+          )
+      )
+
+  public val icon_6280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6280.xml"),
+          )
+      )
+
+  public val icon_6281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6281.xml"),
+          )
+      )
+
+  public val icon_6282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6282.xml"),
+          )
+      )
+
+  public val icon_6283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6283.xml"),
+          )
+      )
+
+  public val icon_6284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6284.xml"),
+          )
+      )
+
+  public val icon_6285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6285.xml"),
+          )
+      )
+
+  public val icon_6286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6286.xml"),
+          )
+      )
+
+  public val icon_6287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6287.xml"),
+          )
+      )
+
+  public val icon_6288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6288.xml"),
+          )
+      )
+
+  public val icon_6289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6289.xml"),
+          )
+      )
+
+  public val icon_629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_629.xml"),
+          )
+      )
+
+  public val icon_6290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6290.xml"),
+          )
+      )
+
+  public val icon_6291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6291.xml"),
+          )
+      )
+
+  public val icon_6292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6292.xml"),
+          )
+      )
+
+  public val icon_6293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6293.xml"),
+          )
+      )
+
+  public val icon_6294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6294.xml"),
+          )
+      )
+
+  public val icon_6295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6295.xml"),
+          )
+      )
+
+  public val icon_6296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6296.xml"),
+          )
+      )
+
+  public val icon_6297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6297.xml"),
+          )
+      )
+
+  public val icon_6298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6298.xml"),
+          )
+      )
+
+  public val icon_6299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6299.xml"),
+          )
+      )
+
+  public val icon_63: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_63",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_63.xml"),
+          )
+      )
+
+  public val icon_630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_630.xml"),
+          )
+      )
+
+  public val icon_6300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6300.xml"),
+          )
+      )
+
+  public val icon_6301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6301.xml"),
+          )
+      )
+
+  public val icon_6302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6302.xml"),
+          )
+      )
+
+  public val icon_6303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6303.xml"),
+          )
+      )
+
+  public val icon_6304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6304.xml"),
+          )
+      )
+
+  public val icon_6305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6305.xml"),
+          )
+      )
+
+  public val icon_6306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6306.xml"),
+          )
+      )
+
+  public val icon_6307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6307.xml"),
+          )
+      )
+
+  public val icon_6308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6308.xml"),
+          )
+      )
+
+  public val icon_6309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6309.xml"),
+          )
+      )
+
+  public val icon_631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_631.xml"),
+          )
+      )
+
+  public val icon_6310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6310.xml"),
+          )
+      )
+
+  public val icon_6311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6311.xml"),
+          )
+      )
+
+  public val icon_6312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6312.xml"),
+          )
+      )
+
+  public val icon_6313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6313.xml"),
+          )
+      )
+
+  public val icon_6314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6314.xml"),
+          )
+      )
+
+  public val icon_6315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6315.xml"),
+          )
+      )
+
+  public val icon_6316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6316.xml"),
+          )
+      )
+
+  public val icon_6317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6317.xml"),
+          )
+      )
+
+  public val icon_6318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6318.xml"),
+          )
+      )
+
+  public val icon_6319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6319.xml"),
+          )
+      )
+
+  public val icon_632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_632.xml"),
+          )
+      )
+
+  public val icon_6320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6320.xml"),
+          )
+      )
+
+  public val icon_6321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6321.xml"),
+          )
+      )
+
+  public val icon_6322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6322.xml"),
+          )
+      )
+
+  public val icon_6323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6323.xml"),
+          )
+      )
+
+  public val icon_6324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6324.xml"),
+          )
+      )
+
+  public val icon_6325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6325.xml"),
+          )
+      )
+
+  public val icon_6326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6326.xml"),
+          )
+      )
+
+  public val icon_6327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6327.xml"),
+          )
+      )
+
+  public val icon_6328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6328.xml"),
+          )
+      )
+
+  public val icon_6329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6329.xml"),
+          )
+      )
+
+  public val icon_633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_633.xml"),
+          )
+      )
+
+  public val icon_6330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6330.xml"),
+          )
+      )
+
+  public val icon_6331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6331.xml"),
+          )
+      )
+
+  public val icon_6332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6332.xml"),
+          )
+      )
+
+  public val icon_6333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6333.xml"),
+          )
+      )
+
+  public val icon_6334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6334.xml"),
+          )
+      )
+
+  public val icon_6335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6335.xml"),
+          )
+      )
+
+  public val icon_6336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6336.xml"),
+          )
+      )
+
+  public val icon_6337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6337.xml"),
+          )
+      )
+
+  public val icon_6338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6338.xml"),
+          )
+      )
+
+  public val icon_6339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6339.xml"),
+          )
+      )
+
+  public val icon_634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_634.xml"),
+          )
+      )
+
+  public val icon_6340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6340.xml"),
+          )
+      )
+
+  public val icon_6341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6341.xml"),
+          )
+      )
+
+  public val icon_6342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6342.xml"),
+          )
+      )
+
+  public val icon_6343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6343.xml"),
+          )
+      )
+
+  public val icon_6344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6344.xml"),
+          )
+      )
+
+  public val icon_6345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6345.xml"),
+          )
+      )
+
+  public val icon_6346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6346.xml"),
+          )
+      )
+
+  public val icon_6347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6347.xml"),
+          )
+      )
+
+  public val icon_6348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6348.xml"),
+          )
+      )
+
+  public val icon_6349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6349.xml"),
+          )
+      )
+
+  public val icon_635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_635.xml"),
+          )
+      )
+
+  public val icon_6350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6350.xml"),
+          )
+      )
+
+  public val icon_6351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6351.xml"),
+          )
+      )
+
+  public val icon_6352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6352.xml"),
+          )
+      )
+
+  public val icon_6353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6353.xml"),
+          )
+      )
+
+  public val icon_6354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6354.xml"),
+          )
+      )
+
+  public val icon_6355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6355.xml"),
+          )
+      )
+
+  public val icon_6356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6356.xml"),
+          )
+      )
+
+  public val icon_6357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6357.xml"),
+          )
+      )
+
+  public val icon_6358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6358.xml"),
+          )
+      )
+
+  public val icon_6359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6359.xml"),
+          )
+      )
+
+  public val icon_636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_636.xml"),
+          )
+      )
+
+  public val icon_6360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6360.xml"),
+          )
+      )
+
+  public val icon_6361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6361.xml"),
+          )
+      )
+
+  public val icon_6362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6362.xml"),
+          )
+      )
+
+  public val icon_6363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6363.xml"),
+          )
+      )
+
+  public val icon_6364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6364.xml"),
+          )
+      )
+
+  public val icon_6365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6365.xml"),
+          )
+      )
+
+  public val icon_6366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6366.xml"),
+          )
+      )
+
+  public val icon_6367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6367.xml"),
+          )
+      )
+
+  public val icon_6368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6368.xml"),
+          )
+      )
+
+  public val icon_6369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6369.xml"),
+          )
+      )
+
+  public val icon_637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_637.xml"),
+          )
+      )
+
+  public val icon_6370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6370.xml"),
+          )
+      )
+
+  public val icon_6371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6371.xml"),
+          )
+      )
+
+  public val icon_6372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6372.xml"),
+          )
+      )
+
+  public val icon_6373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6373.xml"),
+          )
+      )
+
+  public val icon_6374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6374.xml"),
+          )
+      )
+
+  public val icon_6375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6375.xml"),
+          )
+      )
+
+  public val icon_6376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6376.xml"),
+          )
+      )
+
+  public val icon_6377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6377.xml"),
+          )
+      )
+
+  public val icon_6378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6378.xml"),
+          )
+      )
+
+  public val icon_6379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6379.xml"),
+          )
+      )
+
+  public val icon_638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_638.xml"),
+          )
+      )
+
+  public val icon_6380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6380.xml"),
+          )
+      )
+
+  public val icon_6381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6381.xml"),
+          )
+      )
+
+  public val icon_6382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6382.xml"),
+          )
+      )
+
+  public val icon_6383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6383.xml"),
+          )
+      )
+
+  public val icon_6384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6384.xml"),
+          )
+      )
+
+  public val icon_6385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6385.xml"),
+          )
+      )
+
+  public val icon_6386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6386.xml"),
+          )
+      )
+
+  public val icon_6387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6387.xml"),
+          )
+      )
+
+  public val icon_6388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6388.xml"),
+          )
+      )
+
+  public val icon_6389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6389.xml"),
+          )
+      )
+
+  public val icon_639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_639.xml"),
+          )
+      )
+
+  public val icon_6390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6390.xml"),
+          )
+      )
+
+  public val icon_6391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6391.xml"),
+          )
+      )
+
+  public val icon_6392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6392.xml"),
+          )
+      )
+
+  public val icon_6393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6393.xml"),
+          )
+      )
+
+  public val icon_6394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6394.xml"),
+          )
+      )
+
+  public val icon_6395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6395.xml"),
+          )
+      )
+
+  public val icon_6396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6396.xml"),
+          )
+      )
+
+  public val icon_6397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6397.xml"),
+          )
+      )
+
+  public val icon_6398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6398.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5949: DrawableResource
+  get() = Drawable41.icon_5949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_595: DrawableResource
+  get() = Drawable41.icon_595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5950: DrawableResource
+  get() = Drawable41.icon_5950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5951: DrawableResource
+  get() = Drawable41.icon_5951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5952: DrawableResource
+  get() = Drawable41.icon_5952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5953: DrawableResource
+  get() = Drawable41.icon_5953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5954: DrawableResource
+  get() = Drawable41.icon_5954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5955: DrawableResource
+  get() = Drawable41.icon_5955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5956: DrawableResource
+  get() = Drawable41.icon_5956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5957: DrawableResource
+  get() = Drawable41.icon_5957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5958: DrawableResource
+  get() = Drawable41.icon_5958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5959: DrawableResource
+  get() = Drawable41.icon_5959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_596: DrawableResource
+  get() = Drawable41.icon_596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5960: DrawableResource
+  get() = Drawable41.icon_5960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5961: DrawableResource
+  get() = Drawable41.icon_5961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5962: DrawableResource
+  get() = Drawable41.icon_5962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5963: DrawableResource
+  get() = Drawable41.icon_5963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5964: DrawableResource
+  get() = Drawable41.icon_5964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5965: DrawableResource
+  get() = Drawable41.icon_5965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5966: DrawableResource
+  get() = Drawable41.icon_5966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5967: DrawableResource
+  get() = Drawable41.icon_5967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5968: DrawableResource
+  get() = Drawable41.icon_5968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5969: DrawableResource
+  get() = Drawable41.icon_5969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_597: DrawableResource
+  get() = Drawable41.icon_597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5970: DrawableResource
+  get() = Drawable41.icon_5970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5971: DrawableResource
+  get() = Drawable41.icon_5971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5972: DrawableResource
+  get() = Drawable41.icon_5972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5973: DrawableResource
+  get() = Drawable41.icon_5973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5974: DrawableResource
+  get() = Drawable41.icon_5974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5975: DrawableResource
+  get() = Drawable41.icon_5975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5976: DrawableResource
+  get() = Drawable41.icon_5976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5977: DrawableResource
+  get() = Drawable41.icon_5977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5978: DrawableResource
+  get() = Drawable41.icon_5978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5979: DrawableResource
+  get() = Drawable41.icon_5979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_598: DrawableResource
+  get() = Drawable41.icon_598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5980: DrawableResource
+  get() = Drawable41.icon_5980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5981: DrawableResource
+  get() = Drawable41.icon_5981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5982: DrawableResource
+  get() = Drawable41.icon_5982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5983: DrawableResource
+  get() = Drawable41.icon_5983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5984: DrawableResource
+  get() = Drawable41.icon_5984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5985: DrawableResource
+  get() = Drawable41.icon_5985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5986: DrawableResource
+  get() = Drawable41.icon_5986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5987: DrawableResource
+  get() = Drawable41.icon_5987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5988: DrawableResource
+  get() = Drawable41.icon_5988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5989: DrawableResource
+  get() = Drawable41.icon_5989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_599: DrawableResource
+  get() = Drawable41.icon_599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5990: DrawableResource
+  get() = Drawable41.icon_5990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5991: DrawableResource
+  get() = Drawable41.icon_5991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5992: DrawableResource
+  get() = Drawable41.icon_5992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5993: DrawableResource
+  get() = Drawable41.icon_5993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5994: DrawableResource
+  get() = Drawable41.icon_5994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5995: DrawableResource
+  get() = Drawable41.icon_5995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5996: DrawableResource
+  get() = Drawable41.icon_5996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5997: DrawableResource
+  get() = Drawable41.icon_5997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5998: DrawableResource
+  get() = Drawable41.icon_5998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_5999: DrawableResource
+  get() = Drawable41.icon_5999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6: DrawableResource
+  get() = Drawable41.icon_6
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_60: DrawableResource
+  get() = Drawable41.icon_60
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_600: DrawableResource
+  get() = Drawable41.icon_600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6000: DrawableResource
+  get() = Drawable41.icon_6000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6001: DrawableResource
+  get() = Drawable41.icon_6001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6002: DrawableResource
+  get() = Drawable41.icon_6002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6003: DrawableResource
+  get() = Drawable41.icon_6003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6004: DrawableResource
+  get() = Drawable41.icon_6004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6005: DrawableResource
+  get() = Drawable41.icon_6005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6006: DrawableResource
+  get() = Drawable41.icon_6006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6007: DrawableResource
+  get() = Drawable41.icon_6007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6008: DrawableResource
+  get() = Drawable41.icon_6008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6009: DrawableResource
+  get() = Drawable41.icon_6009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_601: DrawableResource
+  get() = Drawable41.icon_601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6010: DrawableResource
+  get() = Drawable41.icon_6010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6011: DrawableResource
+  get() = Drawable41.icon_6011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6012: DrawableResource
+  get() = Drawable41.icon_6012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6013: DrawableResource
+  get() = Drawable41.icon_6013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6014: DrawableResource
+  get() = Drawable41.icon_6014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6015: DrawableResource
+  get() = Drawable41.icon_6015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6016: DrawableResource
+  get() = Drawable41.icon_6016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6017: DrawableResource
+  get() = Drawable41.icon_6017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6018: DrawableResource
+  get() = Drawable41.icon_6018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6019: DrawableResource
+  get() = Drawable41.icon_6019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_602: DrawableResource
+  get() = Drawable41.icon_602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6020: DrawableResource
+  get() = Drawable41.icon_6020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6021: DrawableResource
+  get() = Drawable41.icon_6021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6022: DrawableResource
+  get() = Drawable41.icon_6022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6023: DrawableResource
+  get() = Drawable41.icon_6023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6024: DrawableResource
+  get() = Drawable41.icon_6024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6025: DrawableResource
+  get() = Drawable41.icon_6025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6026: DrawableResource
+  get() = Drawable41.icon_6026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6027: DrawableResource
+  get() = Drawable41.icon_6027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6028: DrawableResource
+  get() = Drawable41.icon_6028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6029: DrawableResource
+  get() = Drawable41.icon_6029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_603: DrawableResource
+  get() = Drawable41.icon_603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6030: DrawableResource
+  get() = Drawable41.icon_6030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6031: DrawableResource
+  get() = Drawable41.icon_6031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6032: DrawableResource
+  get() = Drawable41.icon_6032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6033: DrawableResource
+  get() = Drawable41.icon_6033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6034: DrawableResource
+  get() = Drawable41.icon_6034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6035: DrawableResource
+  get() = Drawable41.icon_6035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6036: DrawableResource
+  get() = Drawable41.icon_6036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6037: DrawableResource
+  get() = Drawable41.icon_6037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6038: DrawableResource
+  get() = Drawable41.icon_6038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6039: DrawableResource
+  get() = Drawable41.icon_6039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_604: DrawableResource
+  get() = Drawable41.icon_604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6040: DrawableResource
+  get() = Drawable41.icon_6040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6041: DrawableResource
+  get() = Drawable41.icon_6041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6042: DrawableResource
+  get() = Drawable41.icon_6042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6043: DrawableResource
+  get() = Drawable41.icon_6043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6044: DrawableResource
+  get() = Drawable41.icon_6044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6045: DrawableResource
+  get() = Drawable41.icon_6045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6046: DrawableResource
+  get() = Drawable41.icon_6046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6047: DrawableResource
+  get() = Drawable41.icon_6047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6048: DrawableResource
+  get() = Drawable41.icon_6048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6049: DrawableResource
+  get() = Drawable41.icon_6049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_605: DrawableResource
+  get() = Drawable41.icon_605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6050: DrawableResource
+  get() = Drawable41.icon_6050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6051: DrawableResource
+  get() = Drawable41.icon_6051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6052: DrawableResource
+  get() = Drawable41.icon_6052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6053: DrawableResource
+  get() = Drawable41.icon_6053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6054: DrawableResource
+  get() = Drawable41.icon_6054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6055: DrawableResource
+  get() = Drawable41.icon_6055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6056: DrawableResource
+  get() = Drawable41.icon_6056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6057: DrawableResource
+  get() = Drawable41.icon_6057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6058: DrawableResource
+  get() = Drawable41.icon_6058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6059: DrawableResource
+  get() = Drawable41.icon_6059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_606: DrawableResource
+  get() = Drawable41.icon_606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6060: DrawableResource
+  get() = Drawable41.icon_6060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6061: DrawableResource
+  get() = Drawable41.icon_6061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6062: DrawableResource
+  get() = Drawable41.icon_6062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6063: DrawableResource
+  get() = Drawable41.icon_6063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6064: DrawableResource
+  get() = Drawable41.icon_6064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6065: DrawableResource
+  get() = Drawable41.icon_6065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6066: DrawableResource
+  get() = Drawable41.icon_6066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6067: DrawableResource
+  get() = Drawable41.icon_6067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6068: DrawableResource
+  get() = Drawable41.icon_6068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6069: DrawableResource
+  get() = Drawable41.icon_6069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_607: DrawableResource
+  get() = Drawable41.icon_607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6070: DrawableResource
+  get() = Drawable41.icon_6070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6071: DrawableResource
+  get() = Drawable41.icon_6071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6072: DrawableResource
+  get() = Drawable41.icon_6072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6073: DrawableResource
+  get() = Drawable41.icon_6073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6074: DrawableResource
+  get() = Drawable41.icon_6074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6075: DrawableResource
+  get() = Drawable41.icon_6075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6076: DrawableResource
+  get() = Drawable41.icon_6076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6077: DrawableResource
+  get() = Drawable41.icon_6077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6078: DrawableResource
+  get() = Drawable41.icon_6078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6079: DrawableResource
+  get() = Drawable41.icon_6079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_608: DrawableResource
+  get() = Drawable41.icon_608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6080: DrawableResource
+  get() = Drawable41.icon_6080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6081: DrawableResource
+  get() = Drawable41.icon_6081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6082: DrawableResource
+  get() = Drawable41.icon_6082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6083: DrawableResource
+  get() = Drawable41.icon_6083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6084: DrawableResource
+  get() = Drawable41.icon_6084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6085: DrawableResource
+  get() = Drawable41.icon_6085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6086: DrawableResource
+  get() = Drawable41.icon_6086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6087: DrawableResource
+  get() = Drawable41.icon_6087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6088: DrawableResource
+  get() = Drawable41.icon_6088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6089: DrawableResource
+  get() = Drawable41.icon_6089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_609: DrawableResource
+  get() = Drawable41.icon_609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6090: DrawableResource
+  get() = Drawable41.icon_6090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6091: DrawableResource
+  get() = Drawable41.icon_6091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6092: DrawableResource
+  get() = Drawable41.icon_6092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6093: DrawableResource
+  get() = Drawable41.icon_6093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6094: DrawableResource
+  get() = Drawable41.icon_6094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6095: DrawableResource
+  get() = Drawable41.icon_6095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6096: DrawableResource
+  get() = Drawable41.icon_6096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6097: DrawableResource
+  get() = Drawable41.icon_6097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6098: DrawableResource
+  get() = Drawable41.icon_6098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6099: DrawableResource
+  get() = Drawable41.icon_6099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_61: DrawableResource
+  get() = Drawable41.icon_61
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_610: DrawableResource
+  get() = Drawable41.icon_610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6100: DrawableResource
+  get() = Drawable41.icon_6100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6101: DrawableResource
+  get() = Drawable41.icon_6101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6102: DrawableResource
+  get() = Drawable41.icon_6102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6103: DrawableResource
+  get() = Drawable41.icon_6103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6104: DrawableResource
+  get() = Drawable41.icon_6104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6105: DrawableResource
+  get() = Drawable41.icon_6105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6106: DrawableResource
+  get() = Drawable41.icon_6106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6107: DrawableResource
+  get() = Drawable41.icon_6107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6108: DrawableResource
+  get() = Drawable41.icon_6108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6109: DrawableResource
+  get() = Drawable41.icon_6109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_611: DrawableResource
+  get() = Drawable41.icon_611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6110: DrawableResource
+  get() = Drawable41.icon_6110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6111: DrawableResource
+  get() = Drawable41.icon_6111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6112: DrawableResource
+  get() = Drawable41.icon_6112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6113: DrawableResource
+  get() = Drawable41.icon_6113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6114: DrawableResource
+  get() = Drawable41.icon_6114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6115: DrawableResource
+  get() = Drawable41.icon_6115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6116: DrawableResource
+  get() = Drawable41.icon_6116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6117: DrawableResource
+  get() = Drawable41.icon_6117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6118: DrawableResource
+  get() = Drawable41.icon_6118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6119: DrawableResource
+  get() = Drawable41.icon_6119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_612: DrawableResource
+  get() = Drawable41.icon_612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6120: DrawableResource
+  get() = Drawable41.icon_6120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6121: DrawableResource
+  get() = Drawable41.icon_6121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6122: DrawableResource
+  get() = Drawable41.icon_6122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6123: DrawableResource
+  get() = Drawable41.icon_6123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6124: DrawableResource
+  get() = Drawable41.icon_6124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6125: DrawableResource
+  get() = Drawable41.icon_6125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6126: DrawableResource
+  get() = Drawable41.icon_6126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6127: DrawableResource
+  get() = Drawable41.icon_6127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6128: DrawableResource
+  get() = Drawable41.icon_6128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6129: DrawableResource
+  get() = Drawable41.icon_6129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_613: DrawableResource
+  get() = Drawable41.icon_613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6130: DrawableResource
+  get() = Drawable41.icon_6130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6131: DrawableResource
+  get() = Drawable41.icon_6131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6132: DrawableResource
+  get() = Drawable41.icon_6132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6133: DrawableResource
+  get() = Drawable41.icon_6133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6134: DrawableResource
+  get() = Drawable41.icon_6134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6135: DrawableResource
+  get() = Drawable41.icon_6135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6136: DrawableResource
+  get() = Drawable41.icon_6136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6137: DrawableResource
+  get() = Drawable41.icon_6137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6138: DrawableResource
+  get() = Drawable41.icon_6138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6139: DrawableResource
+  get() = Drawable41.icon_6139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_614: DrawableResource
+  get() = Drawable41.icon_614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6140: DrawableResource
+  get() = Drawable41.icon_6140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6141: DrawableResource
+  get() = Drawable41.icon_6141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6142: DrawableResource
+  get() = Drawable41.icon_6142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6143: DrawableResource
+  get() = Drawable41.icon_6143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6144: DrawableResource
+  get() = Drawable41.icon_6144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6145: DrawableResource
+  get() = Drawable41.icon_6145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6146: DrawableResource
+  get() = Drawable41.icon_6146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6147: DrawableResource
+  get() = Drawable41.icon_6147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6148: DrawableResource
+  get() = Drawable41.icon_6148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6149: DrawableResource
+  get() = Drawable41.icon_6149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_615: DrawableResource
+  get() = Drawable41.icon_615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6150: DrawableResource
+  get() = Drawable41.icon_6150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6151: DrawableResource
+  get() = Drawable41.icon_6151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6152: DrawableResource
+  get() = Drawable41.icon_6152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6153: DrawableResource
+  get() = Drawable41.icon_6153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6154: DrawableResource
+  get() = Drawable41.icon_6154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6155: DrawableResource
+  get() = Drawable41.icon_6155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6156: DrawableResource
+  get() = Drawable41.icon_6156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6157: DrawableResource
+  get() = Drawable41.icon_6157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6158: DrawableResource
+  get() = Drawable41.icon_6158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6159: DrawableResource
+  get() = Drawable41.icon_6159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_616: DrawableResource
+  get() = Drawable41.icon_616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6160: DrawableResource
+  get() = Drawable41.icon_6160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6161: DrawableResource
+  get() = Drawable41.icon_6161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6162: DrawableResource
+  get() = Drawable41.icon_6162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6163: DrawableResource
+  get() = Drawable41.icon_6163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6164: DrawableResource
+  get() = Drawable41.icon_6164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6165: DrawableResource
+  get() = Drawable41.icon_6165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6166: DrawableResource
+  get() = Drawable41.icon_6166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6167: DrawableResource
+  get() = Drawable41.icon_6167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6168: DrawableResource
+  get() = Drawable41.icon_6168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6169: DrawableResource
+  get() = Drawable41.icon_6169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_617: DrawableResource
+  get() = Drawable41.icon_617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6170: DrawableResource
+  get() = Drawable41.icon_6170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6171: DrawableResource
+  get() = Drawable41.icon_6171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6172: DrawableResource
+  get() = Drawable41.icon_6172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6173: DrawableResource
+  get() = Drawable41.icon_6173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6174: DrawableResource
+  get() = Drawable41.icon_6174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6175: DrawableResource
+  get() = Drawable41.icon_6175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6176: DrawableResource
+  get() = Drawable41.icon_6176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6177: DrawableResource
+  get() = Drawable41.icon_6177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6178: DrawableResource
+  get() = Drawable41.icon_6178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6179: DrawableResource
+  get() = Drawable41.icon_6179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_618: DrawableResource
+  get() = Drawable41.icon_618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6180: DrawableResource
+  get() = Drawable41.icon_6180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6181: DrawableResource
+  get() = Drawable41.icon_6181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6182: DrawableResource
+  get() = Drawable41.icon_6182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6183: DrawableResource
+  get() = Drawable41.icon_6183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6184: DrawableResource
+  get() = Drawable41.icon_6184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6185: DrawableResource
+  get() = Drawable41.icon_6185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6186: DrawableResource
+  get() = Drawable41.icon_6186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6187: DrawableResource
+  get() = Drawable41.icon_6187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6188: DrawableResource
+  get() = Drawable41.icon_6188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6189: DrawableResource
+  get() = Drawable41.icon_6189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_619: DrawableResource
+  get() = Drawable41.icon_619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6190: DrawableResource
+  get() = Drawable41.icon_6190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6191: DrawableResource
+  get() = Drawable41.icon_6191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6192: DrawableResource
+  get() = Drawable41.icon_6192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6193: DrawableResource
+  get() = Drawable41.icon_6193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6194: DrawableResource
+  get() = Drawable41.icon_6194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6195: DrawableResource
+  get() = Drawable41.icon_6195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6196: DrawableResource
+  get() = Drawable41.icon_6196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6197: DrawableResource
+  get() = Drawable41.icon_6197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6198: DrawableResource
+  get() = Drawable41.icon_6198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6199: DrawableResource
+  get() = Drawable41.icon_6199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_62: DrawableResource
+  get() = Drawable41.icon_62
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_620: DrawableResource
+  get() = Drawable41.icon_620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6200: DrawableResource
+  get() = Drawable41.icon_6200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6201: DrawableResource
+  get() = Drawable41.icon_6201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6202: DrawableResource
+  get() = Drawable41.icon_6202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6203: DrawableResource
+  get() = Drawable41.icon_6203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6204: DrawableResource
+  get() = Drawable41.icon_6204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6205: DrawableResource
+  get() = Drawable41.icon_6205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6206: DrawableResource
+  get() = Drawable41.icon_6206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6207: DrawableResource
+  get() = Drawable41.icon_6207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6208: DrawableResource
+  get() = Drawable41.icon_6208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6209: DrawableResource
+  get() = Drawable41.icon_6209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_621: DrawableResource
+  get() = Drawable41.icon_621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6210: DrawableResource
+  get() = Drawable41.icon_6210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6211: DrawableResource
+  get() = Drawable41.icon_6211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6212: DrawableResource
+  get() = Drawable41.icon_6212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6213: DrawableResource
+  get() = Drawable41.icon_6213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6214: DrawableResource
+  get() = Drawable41.icon_6214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6215: DrawableResource
+  get() = Drawable41.icon_6215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6216: DrawableResource
+  get() = Drawable41.icon_6216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6217: DrawableResource
+  get() = Drawable41.icon_6217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6218: DrawableResource
+  get() = Drawable41.icon_6218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6219: DrawableResource
+  get() = Drawable41.icon_6219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_622: DrawableResource
+  get() = Drawable41.icon_622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6220: DrawableResource
+  get() = Drawable41.icon_6220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6221: DrawableResource
+  get() = Drawable41.icon_6221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6222: DrawableResource
+  get() = Drawable41.icon_6222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6223: DrawableResource
+  get() = Drawable41.icon_6223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6224: DrawableResource
+  get() = Drawable41.icon_6224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6225: DrawableResource
+  get() = Drawable41.icon_6225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6226: DrawableResource
+  get() = Drawable41.icon_6226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6227: DrawableResource
+  get() = Drawable41.icon_6227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6228: DrawableResource
+  get() = Drawable41.icon_6228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6229: DrawableResource
+  get() = Drawable41.icon_6229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_623: DrawableResource
+  get() = Drawable41.icon_623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6230: DrawableResource
+  get() = Drawable41.icon_6230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6231: DrawableResource
+  get() = Drawable41.icon_6231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6232: DrawableResource
+  get() = Drawable41.icon_6232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6233: DrawableResource
+  get() = Drawable41.icon_6233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6234: DrawableResource
+  get() = Drawable41.icon_6234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6235: DrawableResource
+  get() = Drawable41.icon_6235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6236: DrawableResource
+  get() = Drawable41.icon_6236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6237: DrawableResource
+  get() = Drawable41.icon_6237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6238: DrawableResource
+  get() = Drawable41.icon_6238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6239: DrawableResource
+  get() = Drawable41.icon_6239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_624: DrawableResource
+  get() = Drawable41.icon_624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6240: DrawableResource
+  get() = Drawable41.icon_6240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6241: DrawableResource
+  get() = Drawable41.icon_6241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6242: DrawableResource
+  get() = Drawable41.icon_6242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6243: DrawableResource
+  get() = Drawable41.icon_6243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6244: DrawableResource
+  get() = Drawable41.icon_6244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6245: DrawableResource
+  get() = Drawable41.icon_6245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6246: DrawableResource
+  get() = Drawable41.icon_6246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6247: DrawableResource
+  get() = Drawable41.icon_6247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6248: DrawableResource
+  get() = Drawable41.icon_6248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6249: DrawableResource
+  get() = Drawable41.icon_6249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_625: DrawableResource
+  get() = Drawable41.icon_625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6250: DrawableResource
+  get() = Drawable41.icon_6250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6251: DrawableResource
+  get() = Drawable41.icon_6251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6252: DrawableResource
+  get() = Drawable41.icon_6252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6253: DrawableResource
+  get() = Drawable41.icon_6253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6254: DrawableResource
+  get() = Drawable41.icon_6254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6255: DrawableResource
+  get() = Drawable41.icon_6255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6256: DrawableResource
+  get() = Drawable41.icon_6256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6257: DrawableResource
+  get() = Drawable41.icon_6257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6258: DrawableResource
+  get() = Drawable41.icon_6258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6259: DrawableResource
+  get() = Drawable41.icon_6259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_626: DrawableResource
+  get() = Drawable41.icon_626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6260: DrawableResource
+  get() = Drawable41.icon_6260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6261: DrawableResource
+  get() = Drawable41.icon_6261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6262: DrawableResource
+  get() = Drawable41.icon_6262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6263: DrawableResource
+  get() = Drawable41.icon_6263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6264: DrawableResource
+  get() = Drawable41.icon_6264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6265: DrawableResource
+  get() = Drawable41.icon_6265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6266: DrawableResource
+  get() = Drawable41.icon_6266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6267: DrawableResource
+  get() = Drawable41.icon_6267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6268: DrawableResource
+  get() = Drawable41.icon_6268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6269: DrawableResource
+  get() = Drawable41.icon_6269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_627: DrawableResource
+  get() = Drawable41.icon_627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6270: DrawableResource
+  get() = Drawable41.icon_6270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6271: DrawableResource
+  get() = Drawable41.icon_6271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6272: DrawableResource
+  get() = Drawable41.icon_6272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6273: DrawableResource
+  get() = Drawable41.icon_6273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6274: DrawableResource
+  get() = Drawable41.icon_6274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6275: DrawableResource
+  get() = Drawable41.icon_6275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6276: DrawableResource
+  get() = Drawable41.icon_6276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6277: DrawableResource
+  get() = Drawable41.icon_6277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6278: DrawableResource
+  get() = Drawable41.icon_6278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6279: DrawableResource
+  get() = Drawable41.icon_6279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_628: DrawableResource
+  get() = Drawable41.icon_628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6280: DrawableResource
+  get() = Drawable41.icon_6280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6281: DrawableResource
+  get() = Drawable41.icon_6281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6282: DrawableResource
+  get() = Drawable41.icon_6282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6283: DrawableResource
+  get() = Drawable41.icon_6283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6284: DrawableResource
+  get() = Drawable41.icon_6284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6285: DrawableResource
+  get() = Drawable41.icon_6285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6286: DrawableResource
+  get() = Drawable41.icon_6286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6287: DrawableResource
+  get() = Drawable41.icon_6287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6288: DrawableResource
+  get() = Drawable41.icon_6288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6289: DrawableResource
+  get() = Drawable41.icon_6289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_629: DrawableResource
+  get() = Drawable41.icon_629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6290: DrawableResource
+  get() = Drawable41.icon_6290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6291: DrawableResource
+  get() = Drawable41.icon_6291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6292: DrawableResource
+  get() = Drawable41.icon_6292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6293: DrawableResource
+  get() = Drawable41.icon_6293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6294: DrawableResource
+  get() = Drawable41.icon_6294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6295: DrawableResource
+  get() = Drawable41.icon_6295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6296: DrawableResource
+  get() = Drawable41.icon_6296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6297: DrawableResource
+  get() = Drawable41.icon_6297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6298: DrawableResource
+  get() = Drawable41.icon_6298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6299: DrawableResource
+  get() = Drawable41.icon_6299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_63: DrawableResource
+  get() = Drawable41.icon_63
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_630: DrawableResource
+  get() = Drawable41.icon_630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6300: DrawableResource
+  get() = Drawable41.icon_6300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6301: DrawableResource
+  get() = Drawable41.icon_6301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6302: DrawableResource
+  get() = Drawable41.icon_6302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6303: DrawableResource
+  get() = Drawable41.icon_6303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6304: DrawableResource
+  get() = Drawable41.icon_6304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6305: DrawableResource
+  get() = Drawable41.icon_6305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6306: DrawableResource
+  get() = Drawable41.icon_6306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6307: DrawableResource
+  get() = Drawable41.icon_6307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6308: DrawableResource
+  get() = Drawable41.icon_6308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6309: DrawableResource
+  get() = Drawable41.icon_6309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_631: DrawableResource
+  get() = Drawable41.icon_631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6310: DrawableResource
+  get() = Drawable41.icon_6310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6311: DrawableResource
+  get() = Drawable41.icon_6311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6312: DrawableResource
+  get() = Drawable41.icon_6312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6313: DrawableResource
+  get() = Drawable41.icon_6313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6314: DrawableResource
+  get() = Drawable41.icon_6314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6315: DrawableResource
+  get() = Drawable41.icon_6315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6316: DrawableResource
+  get() = Drawable41.icon_6316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6317: DrawableResource
+  get() = Drawable41.icon_6317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6318: DrawableResource
+  get() = Drawable41.icon_6318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6319: DrawableResource
+  get() = Drawable41.icon_6319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_632: DrawableResource
+  get() = Drawable41.icon_632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6320: DrawableResource
+  get() = Drawable41.icon_6320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6321: DrawableResource
+  get() = Drawable41.icon_6321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6322: DrawableResource
+  get() = Drawable41.icon_6322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6323: DrawableResource
+  get() = Drawable41.icon_6323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6324: DrawableResource
+  get() = Drawable41.icon_6324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6325: DrawableResource
+  get() = Drawable41.icon_6325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6326: DrawableResource
+  get() = Drawable41.icon_6326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6327: DrawableResource
+  get() = Drawable41.icon_6327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6328: DrawableResource
+  get() = Drawable41.icon_6328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6329: DrawableResource
+  get() = Drawable41.icon_6329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_633: DrawableResource
+  get() = Drawable41.icon_633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6330: DrawableResource
+  get() = Drawable41.icon_6330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6331: DrawableResource
+  get() = Drawable41.icon_6331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6332: DrawableResource
+  get() = Drawable41.icon_6332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6333: DrawableResource
+  get() = Drawable41.icon_6333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6334: DrawableResource
+  get() = Drawable41.icon_6334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6335: DrawableResource
+  get() = Drawable41.icon_6335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6336: DrawableResource
+  get() = Drawable41.icon_6336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6337: DrawableResource
+  get() = Drawable41.icon_6337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6338: DrawableResource
+  get() = Drawable41.icon_6338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6339: DrawableResource
+  get() = Drawable41.icon_6339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_634: DrawableResource
+  get() = Drawable41.icon_634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6340: DrawableResource
+  get() = Drawable41.icon_6340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6341: DrawableResource
+  get() = Drawable41.icon_6341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6342: DrawableResource
+  get() = Drawable41.icon_6342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6343: DrawableResource
+  get() = Drawable41.icon_6343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6344: DrawableResource
+  get() = Drawable41.icon_6344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6345: DrawableResource
+  get() = Drawable41.icon_6345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6346: DrawableResource
+  get() = Drawable41.icon_6346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6347: DrawableResource
+  get() = Drawable41.icon_6347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6348: DrawableResource
+  get() = Drawable41.icon_6348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6349: DrawableResource
+  get() = Drawable41.icon_6349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_635: DrawableResource
+  get() = Drawable41.icon_635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6350: DrawableResource
+  get() = Drawable41.icon_6350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6351: DrawableResource
+  get() = Drawable41.icon_6351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6352: DrawableResource
+  get() = Drawable41.icon_6352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6353: DrawableResource
+  get() = Drawable41.icon_6353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6354: DrawableResource
+  get() = Drawable41.icon_6354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6355: DrawableResource
+  get() = Drawable41.icon_6355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6356: DrawableResource
+  get() = Drawable41.icon_6356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6357: DrawableResource
+  get() = Drawable41.icon_6357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6358: DrawableResource
+  get() = Drawable41.icon_6358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6359: DrawableResource
+  get() = Drawable41.icon_6359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_636: DrawableResource
+  get() = Drawable41.icon_636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6360: DrawableResource
+  get() = Drawable41.icon_6360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6361: DrawableResource
+  get() = Drawable41.icon_6361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6362: DrawableResource
+  get() = Drawable41.icon_6362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6363: DrawableResource
+  get() = Drawable41.icon_6363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6364: DrawableResource
+  get() = Drawable41.icon_6364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6365: DrawableResource
+  get() = Drawable41.icon_6365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6366: DrawableResource
+  get() = Drawable41.icon_6366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6367: DrawableResource
+  get() = Drawable41.icon_6367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6368: DrawableResource
+  get() = Drawable41.icon_6368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6369: DrawableResource
+  get() = Drawable41.icon_6369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_637: DrawableResource
+  get() = Drawable41.icon_637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6370: DrawableResource
+  get() = Drawable41.icon_6370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6371: DrawableResource
+  get() = Drawable41.icon_6371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6372: DrawableResource
+  get() = Drawable41.icon_6372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6373: DrawableResource
+  get() = Drawable41.icon_6373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6374: DrawableResource
+  get() = Drawable41.icon_6374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6375: DrawableResource
+  get() = Drawable41.icon_6375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6376: DrawableResource
+  get() = Drawable41.icon_6376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6377: DrawableResource
+  get() = Drawable41.icon_6377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6378: DrawableResource
+  get() = Drawable41.icon_6378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6379: DrawableResource
+  get() = Drawable41.icon_6379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_638: DrawableResource
+  get() = Drawable41.icon_638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6380: DrawableResource
+  get() = Drawable41.icon_6380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6381: DrawableResource
+  get() = Drawable41.icon_6381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6382: DrawableResource
+  get() = Drawable41.icon_6382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6383: DrawableResource
+  get() = Drawable41.icon_6383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6384: DrawableResource
+  get() = Drawable41.icon_6384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6385: DrawableResource
+  get() = Drawable41.icon_6385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6386: DrawableResource
+  get() = Drawable41.icon_6386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6387: DrawableResource
+  get() = Drawable41.icon_6387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6388: DrawableResource
+  get() = Drawable41.icon_6388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6389: DrawableResource
+  get() = Drawable41.icon_6389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_639: DrawableResource
+  get() = Drawable41.icon_639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6390: DrawableResource
+  get() = Drawable41.icon_6390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6391: DrawableResource
+  get() = Drawable41.icon_6391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6392: DrawableResource
+  get() = Drawable41.icon_6392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6393: DrawableResource
+  get() = Drawable41.icon_6393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6394: DrawableResource
+  get() = Drawable41.icon_6394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6395: DrawableResource
+  get() = Drawable41.icon_6395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6396: DrawableResource
+  get() = Drawable41.icon_6396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6397: DrawableResource
+  get() = Drawable41.icon_6397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6398: DrawableResource
+  get() = Drawable41.icon_6398

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable42.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable42.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable42 {
+  public val icon_6399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6399.xml"),
+          )
+      )
+
+  public val icon_64: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_64",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_64.xml"),
+          )
+      )
+
+  public val icon_640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_640.xml"),
+          )
+      )
+
+  public val icon_6400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6400.xml"),
+          )
+      )
+
+  public val icon_6401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6401.xml"),
+          )
+      )
+
+  public val icon_6402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6402.xml"),
+          )
+      )
+
+  public val icon_6403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6403.xml"),
+          )
+      )
+
+  public val icon_6404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6404.xml"),
+          )
+      )
+
+  public val icon_6405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6405.xml"),
+          )
+      )
+
+  public val icon_6406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6406.xml"),
+          )
+      )
+
+  public val icon_6407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6407.xml"),
+          )
+      )
+
+  public val icon_6408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6408.xml"),
+          )
+      )
+
+  public val icon_6409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6409.xml"),
+          )
+      )
+
+  public val icon_641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_641.xml"),
+          )
+      )
+
+  public val icon_6410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6410.xml"),
+          )
+      )
+
+  public val icon_6411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6411.xml"),
+          )
+      )
+
+  public val icon_6412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6412.xml"),
+          )
+      )
+
+  public val icon_6413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6413.xml"),
+          )
+      )
+
+  public val icon_6414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6414.xml"),
+          )
+      )
+
+  public val icon_6415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6415.xml"),
+          )
+      )
+
+  public val icon_6416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6416.xml"),
+          )
+      )
+
+  public val icon_6417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6417.xml"),
+          )
+      )
+
+  public val icon_6418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6418.xml"),
+          )
+      )
+
+  public val icon_6419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6419.xml"),
+          )
+      )
+
+  public val icon_642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_642.xml"),
+          )
+      )
+
+  public val icon_6420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6420.xml"),
+          )
+      )
+
+  public val icon_6421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6421.xml"),
+          )
+      )
+
+  public val icon_6422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6422.xml"),
+          )
+      )
+
+  public val icon_6423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6423.xml"),
+          )
+      )
+
+  public val icon_6424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6424.xml"),
+          )
+      )
+
+  public val icon_6425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6425.xml"),
+          )
+      )
+
+  public val icon_6426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6426.xml"),
+          )
+      )
+
+  public val icon_6427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6427.xml"),
+          )
+      )
+
+  public val icon_6428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6428.xml"),
+          )
+      )
+
+  public val icon_6429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6429.xml"),
+          )
+      )
+
+  public val icon_643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_643.xml"),
+          )
+      )
+
+  public val icon_6430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6430.xml"),
+          )
+      )
+
+  public val icon_6431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6431.xml"),
+          )
+      )
+
+  public val icon_6432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6432.xml"),
+          )
+      )
+
+  public val icon_6433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6433.xml"),
+          )
+      )
+
+  public val icon_6434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6434.xml"),
+          )
+      )
+
+  public val icon_6435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6435.xml"),
+          )
+      )
+
+  public val icon_6436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6436.xml"),
+          )
+      )
+
+  public val icon_6437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6437.xml"),
+          )
+      )
+
+  public val icon_6438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6438.xml"),
+          )
+      )
+
+  public val icon_6439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6439.xml"),
+          )
+      )
+
+  public val icon_644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_644.xml"),
+          )
+      )
+
+  public val icon_6440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6440.xml"),
+          )
+      )
+
+  public val icon_6441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6441.xml"),
+          )
+      )
+
+  public val icon_6442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6442.xml"),
+          )
+      )
+
+  public val icon_6443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6443.xml"),
+          )
+      )
+
+  public val icon_6444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6444.xml"),
+          )
+      )
+
+  public val icon_6445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6445.xml"),
+          )
+      )
+
+  public val icon_6446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6446.xml"),
+          )
+      )
+
+  public val icon_6447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6447.xml"),
+          )
+      )
+
+  public val icon_6448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6448.xml"),
+          )
+      )
+
+  public val icon_6449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6449.xml"),
+          )
+      )
+
+  public val icon_645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_645.xml"),
+          )
+      )
+
+  public val icon_6450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6450.xml"),
+          )
+      )
+
+  public val icon_6451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6451.xml"),
+          )
+      )
+
+  public val icon_6452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6452.xml"),
+          )
+      )
+
+  public val icon_6453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6453.xml"),
+          )
+      )
+
+  public val icon_6454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6454.xml"),
+          )
+      )
+
+  public val icon_6455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6455.xml"),
+          )
+      )
+
+  public val icon_6456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6456.xml"),
+          )
+      )
+
+  public val icon_6457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6457.xml"),
+          )
+      )
+
+  public val icon_6458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6458.xml"),
+          )
+      )
+
+  public val icon_6459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6459.xml"),
+          )
+      )
+
+  public val icon_646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_646.xml"),
+          )
+      )
+
+  public val icon_6460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6460.xml"),
+          )
+      )
+
+  public val icon_6461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6461.xml"),
+          )
+      )
+
+  public val icon_6462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6462.xml"),
+          )
+      )
+
+  public val icon_6463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6463.xml"),
+          )
+      )
+
+  public val icon_6464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6464.xml"),
+          )
+      )
+
+  public val icon_6465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6465.xml"),
+          )
+      )
+
+  public val icon_6466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6466.xml"),
+          )
+      )
+
+  public val icon_6467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6467.xml"),
+          )
+      )
+
+  public val icon_6468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6468.xml"),
+          )
+      )
+
+  public val icon_6469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6469.xml"),
+          )
+      )
+
+  public val icon_647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_647.xml"),
+          )
+      )
+
+  public val icon_6470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6470.xml"),
+          )
+      )
+
+  public val icon_6471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6471.xml"),
+          )
+      )
+
+  public val icon_6472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6472.xml"),
+          )
+      )
+
+  public val icon_6473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6473.xml"),
+          )
+      )
+
+  public val icon_6474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6474.xml"),
+          )
+      )
+
+  public val icon_6475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6475.xml"),
+          )
+      )
+
+  public val icon_6476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6476.xml"),
+          )
+      )
+
+  public val icon_6477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6477.xml"),
+          )
+      )
+
+  public val icon_6478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6478.xml"),
+          )
+      )
+
+  public val icon_6479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6479.xml"),
+          )
+      )
+
+  public val icon_648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_648.xml"),
+          )
+      )
+
+  public val icon_6480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6480.xml"),
+          )
+      )
+
+  public val icon_6481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6481.xml"),
+          )
+      )
+
+  public val icon_6482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6482.xml"),
+          )
+      )
+
+  public val icon_6483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6483.xml"),
+          )
+      )
+
+  public val icon_6484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6484.xml"),
+          )
+      )
+
+  public val icon_6485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6485.xml"),
+          )
+      )
+
+  public val icon_6486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6486.xml"),
+          )
+      )
+
+  public val icon_6487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6487.xml"),
+          )
+      )
+
+  public val icon_6488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6488.xml"),
+          )
+      )
+
+  public val icon_6489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6489.xml"),
+          )
+      )
+
+  public val icon_649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_649.xml"),
+          )
+      )
+
+  public val icon_6490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6490.xml"),
+          )
+      )
+
+  public val icon_6491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6491.xml"),
+          )
+      )
+
+  public val icon_6492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6492.xml"),
+          )
+      )
+
+  public val icon_6493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6493.xml"),
+          )
+      )
+
+  public val icon_6494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6494.xml"),
+          )
+      )
+
+  public val icon_6495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6495.xml"),
+          )
+      )
+
+  public val icon_6496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6496.xml"),
+          )
+      )
+
+  public val icon_6497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6497.xml"),
+          )
+      )
+
+  public val icon_6498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6498.xml"),
+          )
+      )
+
+  public val icon_6499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6499.xml"),
+          )
+      )
+
+  public val icon_65: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_65",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_65.xml"),
+          )
+      )
+
+  public val icon_650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_650.xml"),
+          )
+      )
+
+  public val icon_6500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6500.xml"),
+          )
+      )
+
+  public val icon_6501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6501.xml"),
+          )
+      )
+
+  public val icon_6502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6502.xml"),
+          )
+      )
+
+  public val icon_6503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6503.xml"),
+          )
+      )
+
+  public val icon_6504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6504.xml"),
+          )
+      )
+
+  public val icon_6505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6505.xml"),
+          )
+      )
+
+  public val icon_6506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6506.xml"),
+          )
+      )
+
+  public val icon_6507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6507.xml"),
+          )
+      )
+
+  public val icon_6508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6508.xml"),
+          )
+      )
+
+  public val icon_6509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6509.xml"),
+          )
+      )
+
+  public val icon_651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_651.xml"),
+          )
+      )
+
+  public val icon_6510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6510.xml"),
+          )
+      )
+
+  public val icon_6511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6511.xml"),
+          )
+      )
+
+  public val icon_6512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6512.xml"),
+          )
+      )
+
+  public val icon_6513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6513.xml"),
+          )
+      )
+
+  public val icon_6514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6514.xml"),
+          )
+      )
+
+  public val icon_6515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6515.xml"),
+          )
+      )
+
+  public val icon_6516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6516.xml"),
+          )
+      )
+
+  public val icon_6517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6517.xml"),
+          )
+      )
+
+  public val icon_6518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6518.xml"),
+          )
+      )
+
+  public val icon_6519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6519.xml"),
+          )
+      )
+
+  public val icon_652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_652.xml"),
+          )
+      )
+
+  public val icon_6520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6520.xml"),
+          )
+      )
+
+  public val icon_6521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6521.xml"),
+          )
+      )
+
+  public val icon_6522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6522.xml"),
+          )
+      )
+
+  public val icon_6523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6523.xml"),
+          )
+      )
+
+  public val icon_6524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6524.xml"),
+          )
+      )
+
+  public val icon_6525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6525.xml"),
+          )
+      )
+
+  public val icon_6526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6526.xml"),
+          )
+      )
+
+  public val icon_6527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6527.xml"),
+          )
+      )
+
+  public val icon_6528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6528.xml"),
+          )
+      )
+
+  public val icon_6529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6529.xml"),
+          )
+      )
+
+  public val icon_653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_653.xml"),
+          )
+      )
+
+  public val icon_6530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6530.xml"),
+          )
+      )
+
+  public val icon_6531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6531.xml"),
+          )
+      )
+
+  public val icon_6532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6532.xml"),
+          )
+      )
+
+  public val icon_6533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6533.xml"),
+          )
+      )
+
+  public val icon_6534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6534.xml"),
+          )
+      )
+
+  public val icon_6535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6535.xml"),
+          )
+      )
+
+  public val icon_6536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6536.xml"),
+          )
+      )
+
+  public val icon_6537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6537.xml"),
+          )
+      )
+
+  public val icon_6538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6538.xml"),
+          )
+      )
+
+  public val icon_6539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6539.xml"),
+          )
+      )
+
+  public val icon_654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_654.xml"),
+          )
+      )
+
+  public val icon_6540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6540.xml"),
+          )
+      )
+
+  public val icon_6541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6541.xml"),
+          )
+      )
+
+  public val icon_6542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6542.xml"),
+          )
+      )
+
+  public val icon_6543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6543.xml"),
+          )
+      )
+
+  public val icon_6544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6544.xml"),
+          )
+      )
+
+  public val icon_6545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6545.xml"),
+          )
+      )
+
+  public val icon_6546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6546.xml"),
+          )
+      )
+
+  public val icon_6547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6547.xml"),
+          )
+      )
+
+  public val icon_6548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6548.xml"),
+          )
+      )
+
+  public val icon_6549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6549.xml"),
+          )
+      )
+
+  public val icon_655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_655.xml"),
+          )
+      )
+
+  public val icon_6550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6550.xml"),
+          )
+      )
+
+  public val icon_6551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6551.xml"),
+          )
+      )
+
+  public val icon_6552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6552.xml"),
+          )
+      )
+
+  public val icon_6553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6553.xml"),
+          )
+      )
+
+  public val icon_6554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6554.xml"),
+          )
+      )
+
+  public val icon_6555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6555.xml"),
+          )
+      )
+
+  public val icon_6556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6556.xml"),
+          )
+      )
+
+  public val icon_6557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6557.xml"),
+          )
+      )
+
+  public val icon_6558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6558.xml"),
+          )
+      )
+
+  public val icon_6559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6559.xml"),
+          )
+      )
+
+  public val icon_656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_656.xml"),
+          )
+      )
+
+  public val icon_6560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6560.xml"),
+          )
+      )
+
+  public val icon_6561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6561.xml"),
+          )
+      )
+
+  public val icon_6562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6562.xml"),
+          )
+      )
+
+  public val icon_6563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6563.xml"),
+          )
+      )
+
+  public val icon_6564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6564.xml"),
+          )
+      )
+
+  public val icon_6565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6565.xml"),
+          )
+      )
+
+  public val icon_6566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6566.xml"),
+          )
+      )
+
+  public val icon_6567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6567.xml"),
+          )
+      )
+
+  public val icon_6568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6568.xml"),
+          )
+      )
+
+  public val icon_6569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6569.xml"),
+          )
+      )
+
+  public val icon_657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_657.xml"),
+          )
+      )
+
+  public val icon_6570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6570.xml"),
+          )
+      )
+
+  public val icon_6571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6571.xml"),
+          )
+      )
+
+  public val icon_6572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6572.xml"),
+          )
+      )
+
+  public val icon_6573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6573.xml"),
+          )
+      )
+
+  public val icon_6574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6574.xml"),
+          )
+      )
+
+  public val icon_6575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6575.xml"),
+          )
+      )
+
+  public val icon_6576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6576.xml"),
+          )
+      )
+
+  public val icon_6577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6577.xml"),
+          )
+      )
+
+  public val icon_6578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6578.xml"),
+          )
+      )
+
+  public val icon_6579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6579.xml"),
+          )
+      )
+
+  public val icon_658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_658.xml"),
+          )
+      )
+
+  public val icon_6580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6580.xml"),
+          )
+      )
+
+  public val icon_6581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6581.xml"),
+          )
+      )
+
+  public val icon_6582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6582.xml"),
+          )
+      )
+
+  public val icon_6583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6583.xml"),
+          )
+      )
+
+  public val icon_6584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6584.xml"),
+          )
+      )
+
+  public val icon_6585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6585.xml"),
+          )
+      )
+
+  public val icon_6586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6586.xml"),
+          )
+      )
+
+  public val icon_6587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6587.xml"),
+          )
+      )
+
+  public val icon_6588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6588.xml"),
+          )
+      )
+
+  public val icon_6589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6589.xml"),
+          )
+      )
+
+  public val icon_659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_659.xml"),
+          )
+      )
+
+  public val icon_6590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6590.xml"),
+          )
+      )
+
+  public val icon_6591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6591.xml"),
+          )
+      )
+
+  public val icon_6592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6592.xml"),
+          )
+      )
+
+  public val icon_6593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6593.xml"),
+          )
+      )
+
+  public val icon_6594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6594.xml"),
+          )
+      )
+
+  public val icon_6595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6595.xml"),
+          )
+      )
+
+  public val icon_6596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6596.xml"),
+          )
+      )
+
+  public val icon_6597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6597.xml"),
+          )
+      )
+
+  public val icon_6598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6598.xml"),
+          )
+      )
+
+  public val icon_6599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6599.xml"),
+          )
+      )
+
+  public val icon_66: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_66",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_66.xml"),
+          )
+      )
+
+  public val icon_660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_660.xml"),
+          )
+      )
+
+  public val icon_6600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6600.xml"),
+          )
+      )
+
+  public val icon_6601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6601.xml"),
+          )
+      )
+
+  public val icon_6602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6602.xml"),
+          )
+      )
+
+  public val icon_6603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6603.xml"),
+          )
+      )
+
+  public val icon_6604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6604.xml"),
+          )
+      )
+
+  public val icon_6605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6605.xml"),
+          )
+      )
+
+  public val icon_6606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6606.xml"),
+          )
+      )
+
+  public val icon_6607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6607.xml"),
+          )
+      )
+
+  public val icon_6608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6608.xml"),
+          )
+      )
+
+  public val icon_6609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6609.xml"),
+          )
+      )
+
+  public val icon_661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_661.xml"),
+          )
+      )
+
+  public val icon_6610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6610.xml"),
+          )
+      )
+
+  public val icon_6611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6611.xml"),
+          )
+      )
+
+  public val icon_6612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6612.xml"),
+          )
+      )
+
+  public val icon_6613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6613.xml"),
+          )
+      )
+
+  public val icon_6614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6614.xml"),
+          )
+      )
+
+  public val icon_6615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6615.xml"),
+          )
+      )
+
+  public val icon_6616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6616.xml"),
+          )
+      )
+
+  public val icon_6617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6617.xml"),
+          )
+      )
+
+  public val icon_6618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6618.xml"),
+          )
+      )
+
+  public val icon_6619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6619.xml"),
+          )
+      )
+
+  public val icon_662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_662.xml"),
+          )
+      )
+
+  public val icon_6620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6620.xml"),
+          )
+      )
+
+  public val icon_6621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6621.xml"),
+          )
+      )
+
+  public val icon_6622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6622.xml"),
+          )
+      )
+
+  public val icon_6623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6623.xml"),
+          )
+      )
+
+  public val icon_6624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6624.xml"),
+          )
+      )
+
+  public val icon_6625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6625.xml"),
+          )
+      )
+
+  public val icon_6626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6626.xml"),
+          )
+      )
+
+  public val icon_6627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6627.xml"),
+          )
+      )
+
+  public val icon_6628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6628.xml"),
+          )
+      )
+
+  public val icon_6629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6629.xml"),
+          )
+      )
+
+  public val icon_663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_663.xml"),
+          )
+      )
+
+  public val icon_6630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6630.xml"),
+          )
+      )
+
+  public val icon_6631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6631.xml"),
+          )
+      )
+
+  public val icon_6632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6632.xml"),
+          )
+      )
+
+  public val icon_6633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6633.xml"),
+          )
+      )
+
+  public val icon_6634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6634.xml"),
+          )
+      )
+
+  public val icon_6635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6635.xml"),
+          )
+      )
+
+  public val icon_6636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6636.xml"),
+          )
+      )
+
+  public val icon_6637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6637.xml"),
+          )
+      )
+
+  public val icon_6638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6638.xml"),
+          )
+      )
+
+  public val icon_6639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6639.xml"),
+          )
+      )
+
+  public val icon_664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_664.xml"),
+          )
+      )
+
+  public val icon_6640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6640.xml"),
+          )
+      )
+
+  public val icon_6641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6641.xml"),
+          )
+      )
+
+  public val icon_6642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6642.xml"),
+          )
+      )
+
+  public val icon_6643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6643.xml"),
+          )
+      )
+
+  public val icon_6644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6644.xml"),
+          )
+      )
+
+  public val icon_6645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6645.xml"),
+          )
+      )
+
+  public val icon_6646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6646.xml"),
+          )
+      )
+
+  public val icon_6647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6647.xml"),
+          )
+      )
+
+  public val icon_6648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6648.xml"),
+          )
+      )
+
+  public val icon_6649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6649.xml"),
+          )
+      )
+
+  public val icon_665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_665.xml"),
+          )
+      )
+
+  public val icon_6650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6650.xml"),
+          )
+      )
+
+  public val icon_6651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6651.xml"),
+          )
+      )
+
+  public val icon_6652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6652.xml"),
+          )
+      )
+
+  public val icon_6653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6653.xml"),
+          )
+      )
+
+  public val icon_6654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6654.xml"),
+          )
+      )
+
+  public val icon_6655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6655.xml"),
+          )
+      )
+
+  public val icon_6656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6656.xml"),
+          )
+      )
+
+  public val icon_6657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6657.xml"),
+          )
+      )
+
+  public val icon_6658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6658.xml"),
+          )
+      )
+
+  public val icon_6659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6659.xml"),
+          )
+      )
+
+  public val icon_666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_666.xml"),
+          )
+      )
+
+  public val icon_6660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6660.xml"),
+          )
+      )
+
+  public val icon_6661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6661.xml"),
+          )
+      )
+
+  public val icon_6662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6662.xml"),
+          )
+      )
+
+  public val icon_6663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6663.xml"),
+          )
+      )
+
+  public val icon_6664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6664.xml"),
+          )
+      )
+
+  public val icon_6665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6665.xml"),
+          )
+      )
+
+  public val icon_6666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6666.xml"),
+          )
+      )
+
+  public val icon_6667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6667.xml"),
+          )
+      )
+
+  public val icon_6668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6668.xml"),
+          )
+      )
+
+  public val icon_6669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6669.xml"),
+          )
+      )
+
+  public val icon_667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_667.xml"),
+          )
+      )
+
+  public val icon_6670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6670.xml"),
+          )
+      )
+
+  public val icon_6671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6671.xml"),
+          )
+      )
+
+  public val icon_6672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6672.xml"),
+          )
+      )
+
+  public val icon_6673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6673.xml"),
+          )
+      )
+
+  public val icon_6674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6674.xml"),
+          )
+      )
+
+  public val icon_6675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6675.xml"),
+          )
+      )
+
+  public val icon_6676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6676.xml"),
+          )
+      )
+
+  public val icon_6677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6677.xml"),
+          )
+      )
+
+  public val icon_6678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6678.xml"),
+          )
+      )
+
+  public val icon_6679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6679.xml"),
+          )
+      )
+
+  public val icon_668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_668.xml"),
+          )
+      )
+
+  public val icon_6680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6680.xml"),
+          )
+      )
+
+  public val icon_6681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6681.xml"),
+          )
+      )
+
+  public val icon_6682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6682.xml"),
+          )
+      )
+
+  public val icon_6683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6683.xml"),
+          )
+      )
+
+  public val icon_6684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6684.xml"),
+          )
+      )
+
+  public val icon_6685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6685.xml"),
+          )
+      )
+
+  public val icon_6686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6686.xml"),
+          )
+      )
+
+  public val icon_6687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6687.xml"),
+          )
+      )
+
+  public val icon_6688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6688.xml"),
+          )
+      )
+
+  public val icon_6689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6689.xml"),
+          )
+      )
+
+  public val icon_669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_669.xml"),
+          )
+      )
+
+  public val icon_6690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6690.xml"),
+          )
+      )
+
+  public val icon_6691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6691.xml"),
+          )
+      )
+
+  public val icon_6692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6692.xml"),
+          )
+      )
+
+  public val icon_6693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6693.xml"),
+          )
+      )
+
+  public val icon_6694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6694.xml"),
+          )
+      )
+
+  public val icon_6695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6695.xml"),
+          )
+      )
+
+  public val icon_6696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6696.xml"),
+          )
+      )
+
+  public val icon_6697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6697.xml"),
+          )
+      )
+
+  public val icon_6698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6698.xml"),
+          )
+      )
+
+  public val icon_6699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6699.xml"),
+          )
+      )
+
+  public val icon_67: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_67",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_67.xml"),
+          )
+      )
+
+  public val icon_670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_670.xml"),
+          )
+      )
+
+  public val icon_6700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6700.xml"),
+          )
+      )
+
+  public val icon_6701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6701.xml"),
+          )
+      )
+
+  public val icon_6702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6702.xml"),
+          )
+      )
+
+  public val icon_6703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6703.xml"),
+          )
+      )
+
+  public val icon_6704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6704.xml"),
+          )
+      )
+
+  public val icon_6705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6705.xml"),
+          )
+      )
+
+  public val icon_6706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6706.xml"),
+          )
+      )
+
+  public val icon_6707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6707.xml"),
+          )
+      )
+
+  public val icon_6708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6708.xml"),
+          )
+      )
+
+  public val icon_6709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6709.xml"),
+          )
+      )
+
+  public val icon_671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_671.xml"),
+          )
+      )
+
+  public val icon_6710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6710.xml"),
+          )
+      )
+
+  public val icon_6711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6711.xml"),
+          )
+      )
+
+  public val icon_6712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6712.xml"),
+          )
+      )
+
+  public val icon_6713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6713.xml"),
+          )
+      )
+
+  public val icon_6714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6714.xml"),
+          )
+      )
+
+  public val icon_6715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6715.xml"),
+          )
+      )
+
+  public val icon_6716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6716.xml"),
+          )
+      )
+
+  public val icon_6717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6717.xml"),
+          )
+      )
+
+  public val icon_6718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6718.xml"),
+          )
+      )
+
+  public val icon_6719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6719.xml"),
+          )
+      )
+
+  public val icon_672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_672.xml"),
+          )
+      )
+
+  public val icon_6720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6720.xml"),
+          )
+      )
+
+  public val icon_6721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6721.xml"),
+          )
+      )
+
+  public val icon_6722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6722.xml"),
+          )
+      )
+
+  public val icon_6723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6723.xml"),
+          )
+      )
+
+  public val icon_6724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6724.xml"),
+          )
+      )
+
+  public val icon_6725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6725.xml"),
+          )
+      )
+
+  public val icon_6726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6726.xml"),
+          )
+      )
+
+  public val icon_6727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6727.xml"),
+          )
+      )
+
+  public val icon_6728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6728.xml"),
+          )
+      )
+
+  public val icon_6729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6729.xml"),
+          )
+      )
+
+  public val icon_673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_673.xml"),
+          )
+      )
+
+  public val icon_6730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6730.xml"),
+          )
+      )
+
+  public val icon_6731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6731.xml"),
+          )
+      )
+
+  public val icon_6732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6732.xml"),
+          )
+      )
+
+  public val icon_6733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6733.xml"),
+          )
+      )
+
+  public val icon_6734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6734.xml"),
+          )
+      )
+
+  public val icon_6735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6735.xml"),
+          )
+      )
+
+  public val icon_6736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6736.xml"),
+          )
+      )
+
+  public val icon_6737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6737.xml"),
+          )
+      )
+
+  public val icon_6738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6738.xml"),
+          )
+      )
+
+  public val icon_6739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6739.xml"),
+          )
+      )
+
+  public val icon_674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_674.xml"),
+          )
+      )
+
+  public val icon_6740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6740.xml"),
+          )
+      )
+
+  public val icon_6741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6741.xml"),
+          )
+      )
+
+  public val icon_6742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6742.xml"),
+          )
+      )
+
+  public val icon_6743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6743.xml"),
+          )
+      )
+
+  public val icon_6744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6744.xml"),
+          )
+      )
+
+  public val icon_6745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6745.xml"),
+          )
+      )
+
+  public val icon_6746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6746.xml"),
+          )
+      )
+
+  public val icon_6747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6747.xml"),
+          )
+      )
+
+  public val icon_6748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6748.xml"),
+          )
+      )
+
+  public val icon_6749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6749.xml"),
+          )
+      )
+
+  public val icon_675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_675.xml"),
+          )
+      )
+
+  public val icon_6750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6750.xml"),
+          )
+      )
+
+  public val icon_6751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6751.xml"),
+          )
+      )
+
+  public val icon_6752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6752.xml"),
+          )
+      )
+
+  public val icon_6753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6753.xml"),
+          )
+      )
+
+  public val icon_6754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6754.xml"),
+          )
+      )
+
+  public val icon_6755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6755.xml"),
+          )
+      )
+
+  public val icon_6756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6756.xml"),
+          )
+      )
+
+  public val icon_6757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6757.xml"),
+          )
+      )
+
+  public val icon_6758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6758.xml"),
+          )
+      )
+
+  public val icon_6759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6759.xml"),
+          )
+      )
+
+  public val icon_676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_676.xml"),
+          )
+      )
+
+  public val icon_6760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6760.xml"),
+          )
+      )
+
+  public val icon_6761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6761.xml"),
+          )
+      )
+
+  public val icon_6762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6762.xml"),
+          )
+      )
+
+  public val icon_6763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6763.xml"),
+          )
+      )
+
+  public val icon_6764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6764.xml"),
+          )
+      )
+
+  public val icon_6765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6765.xml"),
+          )
+      )
+
+  public val icon_6766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6766.xml"),
+          )
+      )
+
+  public val icon_6767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6767.xml"),
+          )
+      )
+
+  public val icon_6768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6768.xml"),
+          )
+      )
+
+  public val icon_6769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6769.xml"),
+          )
+      )
+
+  public val icon_677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_677.xml"),
+          )
+      )
+
+  public val icon_6770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6770.xml"),
+          )
+      )
+
+  public val icon_6771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6771.xml"),
+          )
+      )
+
+  public val icon_6772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6772.xml"),
+          )
+      )
+
+  public val icon_6773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6773.xml"),
+          )
+      )
+
+  public val icon_6774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6774.xml"),
+          )
+      )
+
+  public val icon_6775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6775.xml"),
+          )
+      )
+
+  public val icon_6776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6776.xml"),
+          )
+      )
+
+  public val icon_6777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6777.xml"),
+          )
+      )
+
+  public val icon_6778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6778.xml"),
+          )
+      )
+
+  public val icon_6779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6779.xml"),
+          )
+      )
+
+  public val icon_678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_678.xml"),
+          )
+      )
+
+  public val icon_6780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6780.xml"),
+          )
+      )
+
+  public val icon_6781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6781.xml"),
+          )
+      )
+
+  public val icon_6782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6782.xml"),
+          )
+      )
+
+  public val icon_6783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6783.xml"),
+          )
+      )
+
+  public val icon_6784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6784.xml"),
+          )
+      )
+
+  public val icon_6785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6785.xml"),
+          )
+      )
+
+  public val icon_6786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6786.xml"),
+          )
+      )
+
+  public val icon_6787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6787.xml"),
+          )
+      )
+
+  public val icon_6788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6788.xml"),
+          )
+      )
+
+  public val icon_6789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6789.xml"),
+          )
+      )
+
+  public val icon_679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_679.xml"),
+          )
+      )
+
+  public val icon_6790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6790.xml"),
+          )
+      )
+
+  public val icon_6791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6791.xml"),
+          )
+      )
+
+  public val icon_6792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6792.xml"),
+          )
+      )
+
+  public val icon_6793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6793.xml"),
+          )
+      )
+
+  public val icon_6794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6794.xml"),
+          )
+      )
+
+  public val icon_6795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6795.xml"),
+          )
+      )
+
+  public val icon_6796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6796.xml"),
+          )
+      )
+
+  public val icon_6797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6797.xml"),
+          )
+      )
+
+  public val icon_6798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6798.xml"),
+          )
+      )
+
+  public val icon_6799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6799.xml"),
+          )
+      )
+
+  public val icon_68: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_68",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_68.xml"),
+          )
+      )
+
+  public val icon_680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_680.xml"),
+          )
+      )
+
+  public val icon_6800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6800.xml"),
+          )
+      )
+
+  public val icon_6801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6801.xml"),
+          )
+      )
+
+  public val icon_6802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6802.xml"),
+          )
+      )
+
+  public val icon_6803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6803.xml"),
+          )
+      )
+
+  public val icon_6804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6804.xml"),
+          )
+      )
+
+  public val icon_6805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6805.xml"),
+          )
+      )
+
+  public val icon_6806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6806.xml"),
+          )
+      )
+
+  public val icon_6807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6807.xml"),
+          )
+      )
+
+  public val icon_6808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6808.xml"),
+          )
+      )
+
+  public val icon_6809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6809.xml"),
+          )
+      )
+
+  public val icon_681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_681.xml"),
+          )
+      )
+
+  public val icon_6810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6810.xml"),
+          )
+      )
+
+  public val icon_6811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6811.xml"),
+          )
+      )
+
+  public val icon_6812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6812.xml"),
+          )
+      )
+
+  public val icon_6813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6813.xml"),
+          )
+      )
+
+  public val icon_6814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6814.xml"),
+          )
+      )
+
+  public val icon_6815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6815.xml"),
+          )
+      )
+
+  public val icon_6816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6816.xml"),
+          )
+      )
+
+  public val icon_6817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6817.xml"),
+          )
+      )
+
+  public val icon_6818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6818.xml"),
+          )
+      )
+
+  public val icon_6819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6819.xml"),
+          )
+      )
+
+  public val icon_682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_682.xml"),
+          )
+      )
+
+  public val icon_6820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6820.xml"),
+          )
+      )
+
+  public val icon_6821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6821.xml"),
+          )
+      )
+
+  public val icon_6822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6822.xml"),
+          )
+      )
+
+  public val icon_6823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6823.xml"),
+          )
+      )
+
+  public val icon_6824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6824.xml"),
+          )
+      )
+
+  public val icon_6825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6825.xml"),
+          )
+      )
+
+  public val icon_6826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6826.xml"),
+          )
+      )
+
+  public val icon_6827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6827.xml"),
+          )
+      )
+
+  public val icon_6828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6828.xml"),
+          )
+      )
+
+  public val icon_6829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6829.xml"),
+          )
+      )
+
+  public val icon_683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_683.xml"),
+          )
+      )
+
+  public val icon_6830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6830.xml"),
+          )
+      )
+
+  public val icon_6831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6831.xml"),
+          )
+      )
+
+  public val icon_6832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6832.xml"),
+          )
+      )
+
+  public val icon_6833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6833.xml"),
+          )
+      )
+
+  public val icon_6834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6834.xml"),
+          )
+      )
+
+  public val icon_6835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6835.xml"),
+          )
+      )
+
+  public val icon_6836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6836.xml"),
+          )
+      )
+
+  public val icon_6837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6837.xml"),
+          )
+      )
+
+  public val icon_6838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6838.xml"),
+          )
+      )
+
+  public val icon_6839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6839.xml"),
+          )
+      )
+
+  public val icon_684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_684.xml"),
+          )
+      )
+
+  public val icon_6840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6840.xml"),
+          )
+      )
+
+  public val icon_6841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6841.xml"),
+          )
+      )
+
+  public val icon_6842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6842.xml"),
+          )
+      )
+
+  public val icon_6843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6843.xml"),
+          )
+      )
+
+  public val icon_6844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6844.xml"),
+          )
+      )
+
+  public val icon_6845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6845.xml"),
+          )
+      )
+
+  public val icon_6846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6846.xml"),
+          )
+      )
+
+  public val icon_6847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6847.xml"),
+          )
+      )
+
+  public val icon_6848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6848.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6399: DrawableResource
+  get() = Drawable42.icon_6399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_64: DrawableResource
+  get() = Drawable42.icon_64
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_640: DrawableResource
+  get() = Drawable42.icon_640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6400: DrawableResource
+  get() = Drawable42.icon_6400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6401: DrawableResource
+  get() = Drawable42.icon_6401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6402: DrawableResource
+  get() = Drawable42.icon_6402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6403: DrawableResource
+  get() = Drawable42.icon_6403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6404: DrawableResource
+  get() = Drawable42.icon_6404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6405: DrawableResource
+  get() = Drawable42.icon_6405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6406: DrawableResource
+  get() = Drawable42.icon_6406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6407: DrawableResource
+  get() = Drawable42.icon_6407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6408: DrawableResource
+  get() = Drawable42.icon_6408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6409: DrawableResource
+  get() = Drawable42.icon_6409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_641: DrawableResource
+  get() = Drawable42.icon_641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6410: DrawableResource
+  get() = Drawable42.icon_6410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6411: DrawableResource
+  get() = Drawable42.icon_6411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6412: DrawableResource
+  get() = Drawable42.icon_6412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6413: DrawableResource
+  get() = Drawable42.icon_6413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6414: DrawableResource
+  get() = Drawable42.icon_6414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6415: DrawableResource
+  get() = Drawable42.icon_6415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6416: DrawableResource
+  get() = Drawable42.icon_6416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6417: DrawableResource
+  get() = Drawable42.icon_6417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6418: DrawableResource
+  get() = Drawable42.icon_6418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6419: DrawableResource
+  get() = Drawable42.icon_6419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_642: DrawableResource
+  get() = Drawable42.icon_642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6420: DrawableResource
+  get() = Drawable42.icon_6420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6421: DrawableResource
+  get() = Drawable42.icon_6421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6422: DrawableResource
+  get() = Drawable42.icon_6422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6423: DrawableResource
+  get() = Drawable42.icon_6423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6424: DrawableResource
+  get() = Drawable42.icon_6424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6425: DrawableResource
+  get() = Drawable42.icon_6425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6426: DrawableResource
+  get() = Drawable42.icon_6426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6427: DrawableResource
+  get() = Drawable42.icon_6427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6428: DrawableResource
+  get() = Drawable42.icon_6428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6429: DrawableResource
+  get() = Drawable42.icon_6429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_643: DrawableResource
+  get() = Drawable42.icon_643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6430: DrawableResource
+  get() = Drawable42.icon_6430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6431: DrawableResource
+  get() = Drawable42.icon_6431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6432: DrawableResource
+  get() = Drawable42.icon_6432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6433: DrawableResource
+  get() = Drawable42.icon_6433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6434: DrawableResource
+  get() = Drawable42.icon_6434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6435: DrawableResource
+  get() = Drawable42.icon_6435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6436: DrawableResource
+  get() = Drawable42.icon_6436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6437: DrawableResource
+  get() = Drawable42.icon_6437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6438: DrawableResource
+  get() = Drawable42.icon_6438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6439: DrawableResource
+  get() = Drawable42.icon_6439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_644: DrawableResource
+  get() = Drawable42.icon_644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6440: DrawableResource
+  get() = Drawable42.icon_6440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6441: DrawableResource
+  get() = Drawable42.icon_6441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6442: DrawableResource
+  get() = Drawable42.icon_6442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6443: DrawableResource
+  get() = Drawable42.icon_6443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6444: DrawableResource
+  get() = Drawable42.icon_6444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6445: DrawableResource
+  get() = Drawable42.icon_6445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6446: DrawableResource
+  get() = Drawable42.icon_6446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6447: DrawableResource
+  get() = Drawable42.icon_6447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6448: DrawableResource
+  get() = Drawable42.icon_6448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6449: DrawableResource
+  get() = Drawable42.icon_6449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_645: DrawableResource
+  get() = Drawable42.icon_645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6450: DrawableResource
+  get() = Drawable42.icon_6450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6451: DrawableResource
+  get() = Drawable42.icon_6451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6452: DrawableResource
+  get() = Drawable42.icon_6452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6453: DrawableResource
+  get() = Drawable42.icon_6453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6454: DrawableResource
+  get() = Drawable42.icon_6454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6455: DrawableResource
+  get() = Drawable42.icon_6455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6456: DrawableResource
+  get() = Drawable42.icon_6456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6457: DrawableResource
+  get() = Drawable42.icon_6457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6458: DrawableResource
+  get() = Drawable42.icon_6458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6459: DrawableResource
+  get() = Drawable42.icon_6459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_646: DrawableResource
+  get() = Drawable42.icon_646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6460: DrawableResource
+  get() = Drawable42.icon_6460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6461: DrawableResource
+  get() = Drawable42.icon_6461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6462: DrawableResource
+  get() = Drawable42.icon_6462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6463: DrawableResource
+  get() = Drawable42.icon_6463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6464: DrawableResource
+  get() = Drawable42.icon_6464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6465: DrawableResource
+  get() = Drawable42.icon_6465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6466: DrawableResource
+  get() = Drawable42.icon_6466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6467: DrawableResource
+  get() = Drawable42.icon_6467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6468: DrawableResource
+  get() = Drawable42.icon_6468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6469: DrawableResource
+  get() = Drawable42.icon_6469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_647: DrawableResource
+  get() = Drawable42.icon_647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6470: DrawableResource
+  get() = Drawable42.icon_6470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6471: DrawableResource
+  get() = Drawable42.icon_6471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6472: DrawableResource
+  get() = Drawable42.icon_6472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6473: DrawableResource
+  get() = Drawable42.icon_6473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6474: DrawableResource
+  get() = Drawable42.icon_6474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6475: DrawableResource
+  get() = Drawable42.icon_6475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6476: DrawableResource
+  get() = Drawable42.icon_6476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6477: DrawableResource
+  get() = Drawable42.icon_6477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6478: DrawableResource
+  get() = Drawable42.icon_6478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6479: DrawableResource
+  get() = Drawable42.icon_6479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_648: DrawableResource
+  get() = Drawable42.icon_648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6480: DrawableResource
+  get() = Drawable42.icon_6480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6481: DrawableResource
+  get() = Drawable42.icon_6481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6482: DrawableResource
+  get() = Drawable42.icon_6482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6483: DrawableResource
+  get() = Drawable42.icon_6483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6484: DrawableResource
+  get() = Drawable42.icon_6484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6485: DrawableResource
+  get() = Drawable42.icon_6485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6486: DrawableResource
+  get() = Drawable42.icon_6486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6487: DrawableResource
+  get() = Drawable42.icon_6487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6488: DrawableResource
+  get() = Drawable42.icon_6488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6489: DrawableResource
+  get() = Drawable42.icon_6489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_649: DrawableResource
+  get() = Drawable42.icon_649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6490: DrawableResource
+  get() = Drawable42.icon_6490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6491: DrawableResource
+  get() = Drawable42.icon_6491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6492: DrawableResource
+  get() = Drawable42.icon_6492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6493: DrawableResource
+  get() = Drawable42.icon_6493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6494: DrawableResource
+  get() = Drawable42.icon_6494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6495: DrawableResource
+  get() = Drawable42.icon_6495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6496: DrawableResource
+  get() = Drawable42.icon_6496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6497: DrawableResource
+  get() = Drawable42.icon_6497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6498: DrawableResource
+  get() = Drawable42.icon_6498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6499: DrawableResource
+  get() = Drawable42.icon_6499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_65: DrawableResource
+  get() = Drawable42.icon_65
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_650: DrawableResource
+  get() = Drawable42.icon_650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6500: DrawableResource
+  get() = Drawable42.icon_6500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6501: DrawableResource
+  get() = Drawable42.icon_6501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6502: DrawableResource
+  get() = Drawable42.icon_6502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6503: DrawableResource
+  get() = Drawable42.icon_6503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6504: DrawableResource
+  get() = Drawable42.icon_6504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6505: DrawableResource
+  get() = Drawable42.icon_6505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6506: DrawableResource
+  get() = Drawable42.icon_6506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6507: DrawableResource
+  get() = Drawable42.icon_6507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6508: DrawableResource
+  get() = Drawable42.icon_6508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6509: DrawableResource
+  get() = Drawable42.icon_6509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_651: DrawableResource
+  get() = Drawable42.icon_651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6510: DrawableResource
+  get() = Drawable42.icon_6510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6511: DrawableResource
+  get() = Drawable42.icon_6511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6512: DrawableResource
+  get() = Drawable42.icon_6512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6513: DrawableResource
+  get() = Drawable42.icon_6513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6514: DrawableResource
+  get() = Drawable42.icon_6514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6515: DrawableResource
+  get() = Drawable42.icon_6515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6516: DrawableResource
+  get() = Drawable42.icon_6516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6517: DrawableResource
+  get() = Drawable42.icon_6517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6518: DrawableResource
+  get() = Drawable42.icon_6518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6519: DrawableResource
+  get() = Drawable42.icon_6519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_652: DrawableResource
+  get() = Drawable42.icon_652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6520: DrawableResource
+  get() = Drawable42.icon_6520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6521: DrawableResource
+  get() = Drawable42.icon_6521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6522: DrawableResource
+  get() = Drawable42.icon_6522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6523: DrawableResource
+  get() = Drawable42.icon_6523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6524: DrawableResource
+  get() = Drawable42.icon_6524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6525: DrawableResource
+  get() = Drawable42.icon_6525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6526: DrawableResource
+  get() = Drawable42.icon_6526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6527: DrawableResource
+  get() = Drawable42.icon_6527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6528: DrawableResource
+  get() = Drawable42.icon_6528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6529: DrawableResource
+  get() = Drawable42.icon_6529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_653: DrawableResource
+  get() = Drawable42.icon_653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6530: DrawableResource
+  get() = Drawable42.icon_6530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6531: DrawableResource
+  get() = Drawable42.icon_6531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6532: DrawableResource
+  get() = Drawable42.icon_6532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6533: DrawableResource
+  get() = Drawable42.icon_6533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6534: DrawableResource
+  get() = Drawable42.icon_6534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6535: DrawableResource
+  get() = Drawable42.icon_6535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6536: DrawableResource
+  get() = Drawable42.icon_6536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6537: DrawableResource
+  get() = Drawable42.icon_6537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6538: DrawableResource
+  get() = Drawable42.icon_6538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6539: DrawableResource
+  get() = Drawable42.icon_6539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_654: DrawableResource
+  get() = Drawable42.icon_654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6540: DrawableResource
+  get() = Drawable42.icon_6540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6541: DrawableResource
+  get() = Drawable42.icon_6541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6542: DrawableResource
+  get() = Drawable42.icon_6542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6543: DrawableResource
+  get() = Drawable42.icon_6543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6544: DrawableResource
+  get() = Drawable42.icon_6544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6545: DrawableResource
+  get() = Drawable42.icon_6545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6546: DrawableResource
+  get() = Drawable42.icon_6546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6547: DrawableResource
+  get() = Drawable42.icon_6547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6548: DrawableResource
+  get() = Drawable42.icon_6548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6549: DrawableResource
+  get() = Drawable42.icon_6549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_655: DrawableResource
+  get() = Drawable42.icon_655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6550: DrawableResource
+  get() = Drawable42.icon_6550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6551: DrawableResource
+  get() = Drawable42.icon_6551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6552: DrawableResource
+  get() = Drawable42.icon_6552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6553: DrawableResource
+  get() = Drawable42.icon_6553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6554: DrawableResource
+  get() = Drawable42.icon_6554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6555: DrawableResource
+  get() = Drawable42.icon_6555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6556: DrawableResource
+  get() = Drawable42.icon_6556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6557: DrawableResource
+  get() = Drawable42.icon_6557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6558: DrawableResource
+  get() = Drawable42.icon_6558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6559: DrawableResource
+  get() = Drawable42.icon_6559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_656: DrawableResource
+  get() = Drawable42.icon_656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6560: DrawableResource
+  get() = Drawable42.icon_6560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6561: DrawableResource
+  get() = Drawable42.icon_6561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6562: DrawableResource
+  get() = Drawable42.icon_6562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6563: DrawableResource
+  get() = Drawable42.icon_6563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6564: DrawableResource
+  get() = Drawable42.icon_6564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6565: DrawableResource
+  get() = Drawable42.icon_6565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6566: DrawableResource
+  get() = Drawable42.icon_6566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6567: DrawableResource
+  get() = Drawable42.icon_6567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6568: DrawableResource
+  get() = Drawable42.icon_6568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6569: DrawableResource
+  get() = Drawable42.icon_6569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_657: DrawableResource
+  get() = Drawable42.icon_657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6570: DrawableResource
+  get() = Drawable42.icon_6570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6571: DrawableResource
+  get() = Drawable42.icon_6571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6572: DrawableResource
+  get() = Drawable42.icon_6572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6573: DrawableResource
+  get() = Drawable42.icon_6573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6574: DrawableResource
+  get() = Drawable42.icon_6574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6575: DrawableResource
+  get() = Drawable42.icon_6575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6576: DrawableResource
+  get() = Drawable42.icon_6576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6577: DrawableResource
+  get() = Drawable42.icon_6577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6578: DrawableResource
+  get() = Drawable42.icon_6578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6579: DrawableResource
+  get() = Drawable42.icon_6579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_658: DrawableResource
+  get() = Drawable42.icon_658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6580: DrawableResource
+  get() = Drawable42.icon_6580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6581: DrawableResource
+  get() = Drawable42.icon_6581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6582: DrawableResource
+  get() = Drawable42.icon_6582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6583: DrawableResource
+  get() = Drawable42.icon_6583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6584: DrawableResource
+  get() = Drawable42.icon_6584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6585: DrawableResource
+  get() = Drawable42.icon_6585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6586: DrawableResource
+  get() = Drawable42.icon_6586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6587: DrawableResource
+  get() = Drawable42.icon_6587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6588: DrawableResource
+  get() = Drawable42.icon_6588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6589: DrawableResource
+  get() = Drawable42.icon_6589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_659: DrawableResource
+  get() = Drawable42.icon_659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6590: DrawableResource
+  get() = Drawable42.icon_6590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6591: DrawableResource
+  get() = Drawable42.icon_6591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6592: DrawableResource
+  get() = Drawable42.icon_6592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6593: DrawableResource
+  get() = Drawable42.icon_6593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6594: DrawableResource
+  get() = Drawable42.icon_6594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6595: DrawableResource
+  get() = Drawable42.icon_6595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6596: DrawableResource
+  get() = Drawable42.icon_6596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6597: DrawableResource
+  get() = Drawable42.icon_6597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6598: DrawableResource
+  get() = Drawable42.icon_6598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6599: DrawableResource
+  get() = Drawable42.icon_6599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_66: DrawableResource
+  get() = Drawable42.icon_66
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_660: DrawableResource
+  get() = Drawable42.icon_660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6600: DrawableResource
+  get() = Drawable42.icon_6600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6601: DrawableResource
+  get() = Drawable42.icon_6601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6602: DrawableResource
+  get() = Drawable42.icon_6602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6603: DrawableResource
+  get() = Drawable42.icon_6603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6604: DrawableResource
+  get() = Drawable42.icon_6604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6605: DrawableResource
+  get() = Drawable42.icon_6605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6606: DrawableResource
+  get() = Drawable42.icon_6606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6607: DrawableResource
+  get() = Drawable42.icon_6607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6608: DrawableResource
+  get() = Drawable42.icon_6608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6609: DrawableResource
+  get() = Drawable42.icon_6609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_661: DrawableResource
+  get() = Drawable42.icon_661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6610: DrawableResource
+  get() = Drawable42.icon_6610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6611: DrawableResource
+  get() = Drawable42.icon_6611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6612: DrawableResource
+  get() = Drawable42.icon_6612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6613: DrawableResource
+  get() = Drawable42.icon_6613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6614: DrawableResource
+  get() = Drawable42.icon_6614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6615: DrawableResource
+  get() = Drawable42.icon_6615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6616: DrawableResource
+  get() = Drawable42.icon_6616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6617: DrawableResource
+  get() = Drawable42.icon_6617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6618: DrawableResource
+  get() = Drawable42.icon_6618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6619: DrawableResource
+  get() = Drawable42.icon_6619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_662: DrawableResource
+  get() = Drawable42.icon_662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6620: DrawableResource
+  get() = Drawable42.icon_6620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6621: DrawableResource
+  get() = Drawable42.icon_6621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6622: DrawableResource
+  get() = Drawable42.icon_6622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6623: DrawableResource
+  get() = Drawable42.icon_6623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6624: DrawableResource
+  get() = Drawable42.icon_6624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6625: DrawableResource
+  get() = Drawable42.icon_6625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6626: DrawableResource
+  get() = Drawable42.icon_6626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6627: DrawableResource
+  get() = Drawable42.icon_6627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6628: DrawableResource
+  get() = Drawable42.icon_6628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6629: DrawableResource
+  get() = Drawable42.icon_6629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_663: DrawableResource
+  get() = Drawable42.icon_663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6630: DrawableResource
+  get() = Drawable42.icon_6630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6631: DrawableResource
+  get() = Drawable42.icon_6631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6632: DrawableResource
+  get() = Drawable42.icon_6632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6633: DrawableResource
+  get() = Drawable42.icon_6633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6634: DrawableResource
+  get() = Drawable42.icon_6634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6635: DrawableResource
+  get() = Drawable42.icon_6635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6636: DrawableResource
+  get() = Drawable42.icon_6636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6637: DrawableResource
+  get() = Drawable42.icon_6637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6638: DrawableResource
+  get() = Drawable42.icon_6638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6639: DrawableResource
+  get() = Drawable42.icon_6639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_664: DrawableResource
+  get() = Drawable42.icon_664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6640: DrawableResource
+  get() = Drawable42.icon_6640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6641: DrawableResource
+  get() = Drawable42.icon_6641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6642: DrawableResource
+  get() = Drawable42.icon_6642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6643: DrawableResource
+  get() = Drawable42.icon_6643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6644: DrawableResource
+  get() = Drawable42.icon_6644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6645: DrawableResource
+  get() = Drawable42.icon_6645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6646: DrawableResource
+  get() = Drawable42.icon_6646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6647: DrawableResource
+  get() = Drawable42.icon_6647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6648: DrawableResource
+  get() = Drawable42.icon_6648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6649: DrawableResource
+  get() = Drawable42.icon_6649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_665: DrawableResource
+  get() = Drawable42.icon_665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6650: DrawableResource
+  get() = Drawable42.icon_6650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6651: DrawableResource
+  get() = Drawable42.icon_6651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6652: DrawableResource
+  get() = Drawable42.icon_6652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6653: DrawableResource
+  get() = Drawable42.icon_6653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6654: DrawableResource
+  get() = Drawable42.icon_6654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6655: DrawableResource
+  get() = Drawable42.icon_6655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6656: DrawableResource
+  get() = Drawable42.icon_6656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6657: DrawableResource
+  get() = Drawable42.icon_6657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6658: DrawableResource
+  get() = Drawable42.icon_6658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6659: DrawableResource
+  get() = Drawable42.icon_6659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_666: DrawableResource
+  get() = Drawable42.icon_666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6660: DrawableResource
+  get() = Drawable42.icon_6660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6661: DrawableResource
+  get() = Drawable42.icon_6661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6662: DrawableResource
+  get() = Drawable42.icon_6662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6663: DrawableResource
+  get() = Drawable42.icon_6663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6664: DrawableResource
+  get() = Drawable42.icon_6664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6665: DrawableResource
+  get() = Drawable42.icon_6665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6666: DrawableResource
+  get() = Drawable42.icon_6666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6667: DrawableResource
+  get() = Drawable42.icon_6667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6668: DrawableResource
+  get() = Drawable42.icon_6668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6669: DrawableResource
+  get() = Drawable42.icon_6669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_667: DrawableResource
+  get() = Drawable42.icon_667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6670: DrawableResource
+  get() = Drawable42.icon_6670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6671: DrawableResource
+  get() = Drawable42.icon_6671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6672: DrawableResource
+  get() = Drawable42.icon_6672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6673: DrawableResource
+  get() = Drawable42.icon_6673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6674: DrawableResource
+  get() = Drawable42.icon_6674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6675: DrawableResource
+  get() = Drawable42.icon_6675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6676: DrawableResource
+  get() = Drawable42.icon_6676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6677: DrawableResource
+  get() = Drawable42.icon_6677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6678: DrawableResource
+  get() = Drawable42.icon_6678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6679: DrawableResource
+  get() = Drawable42.icon_6679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_668: DrawableResource
+  get() = Drawable42.icon_668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6680: DrawableResource
+  get() = Drawable42.icon_6680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6681: DrawableResource
+  get() = Drawable42.icon_6681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6682: DrawableResource
+  get() = Drawable42.icon_6682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6683: DrawableResource
+  get() = Drawable42.icon_6683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6684: DrawableResource
+  get() = Drawable42.icon_6684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6685: DrawableResource
+  get() = Drawable42.icon_6685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6686: DrawableResource
+  get() = Drawable42.icon_6686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6687: DrawableResource
+  get() = Drawable42.icon_6687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6688: DrawableResource
+  get() = Drawable42.icon_6688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6689: DrawableResource
+  get() = Drawable42.icon_6689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_669: DrawableResource
+  get() = Drawable42.icon_669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6690: DrawableResource
+  get() = Drawable42.icon_6690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6691: DrawableResource
+  get() = Drawable42.icon_6691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6692: DrawableResource
+  get() = Drawable42.icon_6692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6693: DrawableResource
+  get() = Drawable42.icon_6693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6694: DrawableResource
+  get() = Drawable42.icon_6694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6695: DrawableResource
+  get() = Drawable42.icon_6695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6696: DrawableResource
+  get() = Drawable42.icon_6696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6697: DrawableResource
+  get() = Drawable42.icon_6697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6698: DrawableResource
+  get() = Drawable42.icon_6698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6699: DrawableResource
+  get() = Drawable42.icon_6699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_67: DrawableResource
+  get() = Drawable42.icon_67
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_670: DrawableResource
+  get() = Drawable42.icon_670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6700: DrawableResource
+  get() = Drawable42.icon_6700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6701: DrawableResource
+  get() = Drawable42.icon_6701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6702: DrawableResource
+  get() = Drawable42.icon_6702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6703: DrawableResource
+  get() = Drawable42.icon_6703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6704: DrawableResource
+  get() = Drawable42.icon_6704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6705: DrawableResource
+  get() = Drawable42.icon_6705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6706: DrawableResource
+  get() = Drawable42.icon_6706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6707: DrawableResource
+  get() = Drawable42.icon_6707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6708: DrawableResource
+  get() = Drawable42.icon_6708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6709: DrawableResource
+  get() = Drawable42.icon_6709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_671: DrawableResource
+  get() = Drawable42.icon_671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6710: DrawableResource
+  get() = Drawable42.icon_6710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6711: DrawableResource
+  get() = Drawable42.icon_6711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6712: DrawableResource
+  get() = Drawable42.icon_6712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6713: DrawableResource
+  get() = Drawable42.icon_6713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6714: DrawableResource
+  get() = Drawable42.icon_6714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6715: DrawableResource
+  get() = Drawable42.icon_6715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6716: DrawableResource
+  get() = Drawable42.icon_6716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6717: DrawableResource
+  get() = Drawable42.icon_6717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6718: DrawableResource
+  get() = Drawable42.icon_6718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6719: DrawableResource
+  get() = Drawable42.icon_6719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_672: DrawableResource
+  get() = Drawable42.icon_672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6720: DrawableResource
+  get() = Drawable42.icon_6720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6721: DrawableResource
+  get() = Drawable42.icon_6721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6722: DrawableResource
+  get() = Drawable42.icon_6722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6723: DrawableResource
+  get() = Drawable42.icon_6723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6724: DrawableResource
+  get() = Drawable42.icon_6724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6725: DrawableResource
+  get() = Drawable42.icon_6725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6726: DrawableResource
+  get() = Drawable42.icon_6726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6727: DrawableResource
+  get() = Drawable42.icon_6727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6728: DrawableResource
+  get() = Drawable42.icon_6728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6729: DrawableResource
+  get() = Drawable42.icon_6729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_673: DrawableResource
+  get() = Drawable42.icon_673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6730: DrawableResource
+  get() = Drawable42.icon_6730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6731: DrawableResource
+  get() = Drawable42.icon_6731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6732: DrawableResource
+  get() = Drawable42.icon_6732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6733: DrawableResource
+  get() = Drawable42.icon_6733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6734: DrawableResource
+  get() = Drawable42.icon_6734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6735: DrawableResource
+  get() = Drawable42.icon_6735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6736: DrawableResource
+  get() = Drawable42.icon_6736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6737: DrawableResource
+  get() = Drawable42.icon_6737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6738: DrawableResource
+  get() = Drawable42.icon_6738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6739: DrawableResource
+  get() = Drawable42.icon_6739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_674: DrawableResource
+  get() = Drawable42.icon_674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6740: DrawableResource
+  get() = Drawable42.icon_6740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6741: DrawableResource
+  get() = Drawable42.icon_6741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6742: DrawableResource
+  get() = Drawable42.icon_6742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6743: DrawableResource
+  get() = Drawable42.icon_6743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6744: DrawableResource
+  get() = Drawable42.icon_6744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6745: DrawableResource
+  get() = Drawable42.icon_6745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6746: DrawableResource
+  get() = Drawable42.icon_6746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6747: DrawableResource
+  get() = Drawable42.icon_6747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6748: DrawableResource
+  get() = Drawable42.icon_6748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6749: DrawableResource
+  get() = Drawable42.icon_6749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_675: DrawableResource
+  get() = Drawable42.icon_675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6750: DrawableResource
+  get() = Drawable42.icon_6750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6751: DrawableResource
+  get() = Drawable42.icon_6751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6752: DrawableResource
+  get() = Drawable42.icon_6752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6753: DrawableResource
+  get() = Drawable42.icon_6753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6754: DrawableResource
+  get() = Drawable42.icon_6754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6755: DrawableResource
+  get() = Drawable42.icon_6755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6756: DrawableResource
+  get() = Drawable42.icon_6756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6757: DrawableResource
+  get() = Drawable42.icon_6757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6758: DrawableResource
+  get() = Drawable42.icon_6758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6759: DrawableResource
+  get() = Drawable42.icon_6759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_676: DrawableResource
+  get() = Drawable42.icon_676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6760: DrawableResource
+  get() = Drawable42.icon_6760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6761: DrawableResource
+  get() = Drawable42.icon_6761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6762: DrawableResource
+  get() = Drawable42.icon_6762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6763: DrawableResource
+  get() = Drawable42.icon_6763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6764: DrawableResource
+  get() = Drawable42.icon_6764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6765: DrawableResource
+  get() = Drawable42.icon_6765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6766: DrawableResource
+  get() = Drawable42.icon_6766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6767: DrawableResource
+  get() = Drawable42.icon_6767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6768: DrawableResource
+  get() = Drawable42.icon_6768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6769: DrawableResource
+  get() = Drawable42.icon_6769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_677: DrawableResource
+  get() = Drawable42.icon_677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6770: DrawableResource
+  get() = Drawable42.icon_6770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6771: DrawableResource
+  get() = Drawable42.icon_6771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6772: DrawableResource
+  get() = Drawable42.icon_6772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6773: DrawableResource
+  get() = Drawable42.icon_6773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6774: DrawableResource
+  get() = Drawable42.icon_6774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6775: DrawableResource
+  get() = Drawable42.icon_6775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6776: DrawableResource
+  get() = Drawable42.icon_6776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6777: DrawableResource
+  get() = Drawable42.icon_6777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6778: DrawableResource
+  get() = Drawable42.icon_6778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6779: DrawableResource
+  get() = Drawable42.icon_6779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_678: DrawableResource
+  get() = Drawable42.icon_678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6780: DrawableResource
+  get() = Drawable42.icon_6780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6781: DrawableResource
+  get() = Drawable42.icon_6781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6782: DrawableResource
+  get() = Drawable42.icon_6782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6783: DrawableResource
+  get() = Drawable42.icon_6783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6784: DrawableResource
+  get() = Drawable42.icon_6784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6785: DrawableResource
+  get() = Drawable42.icon_6785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6786: DrawableResource
+  get() = Drawable42.icon_6786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6787: DrawableResource
+  get() = Drawable42.icon_6787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6788: DrawableResource
+  get() = Drawable42.icon_6788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6789: DrawableResource
+  get() = Drawable42.icon_6789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_679: DrawableResource
+  get() = Drawable42.icon_679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6790: DrawableResource
+  get() = Drawable42.icon_6790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6791: DrawableResource
+  get() = Drawable42.icon_6791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6792: DrawableResource
+  get() = Drawable42.icon_6792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6793: DrawableResource
+  get() = Drawable42.icon_6793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6794: DrawableResource
+  get() = Drawable42.icon_6794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6795: DrawableResource
+  get() = Drawable42.icon_6795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6796: DrawableResource
+  get() = Drawable42.icon_6796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6797: DrawableResource
+  get() = Drawable42.icon_6797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6798: DrawableResource
+  get() = Drawable42.icon_6798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6799: DrawableResource
+  get() = Drawable42.icon_6799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_68: DrawableResource
+  get() = Drawable42.icon_68
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_680: DrawableResource
+  get() = Drawable42.icon_680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6800: DrawableResource
+  get() = Drawable42.icon_6800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6801: DrawableResource
+  get() = Drawable42.icon_6801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6802: DrawableResource
+  get() = Drawable42.icon_6802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6803: DrawableResource
+  get() = Drawable42.icon_6803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6804: DrawableResource
+  get() = Drawable42.icon_6804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6805: DrawableResource
+  get() = Drawable42.icon_6805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6806: DrawableResource
+  get() = Drawable42.icon_6806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6807: DrawableResource
+  get() = Drawable42.icon_6807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6808: DrawableResource
+  get() = Drawable42.icon_6808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6809: DrawableResource
+  get() = Drawable42.icon_6809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_681: DrawableResource
+  get() = Drawable42.icon_681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6810: DrawableResource
+  get() = Drawable42.icon_6810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6811: DrawableResource
+  get() = Drawable42.icon_6811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6812: DrawableResource
+  get() = Drawable42.icon_6812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6813: DrawableResource
+  get() = Drawable42.icon_6813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6814: DrawableResource
+  get() = Drawable42.icon_6814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6815: DrawableResource
+  get() = Drawable42.icon_6815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6816: DrawableResource
+  get() = Drawable42.icon_6816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6817: DrawableResource
+  get() = Drawable42.icon_6817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6818: DrawableResource
+  get() = Drawable42.icon_6818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6819: DrawableResource
+  get() = Drawable42.icon_6819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_682: DrawableResource
+  get() = Drawable42.icon_682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6820: DrawableResource
+  get() = Drawable42.icon_6820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6821: DrawableResource
+  get() = Drawable42.icon_6821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6822: DrawableResource
+  get() = Drawable42.icon_6822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6823: DrawableResource
+  get() = Drawable42.icon_6823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6824: DrawableResource
+  get() = Drawable42.icon_6824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6825: DrawableResource
+  get() = Drawable42.icon_6825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6826: DrawableResource
+  get() = Drawable42.icon_6826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6827: DrawableResource
+  get() = Drawable42.icon_6827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6828: DrawableResource
+  get() = Drawable42.icon_6828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6829: DrawableResource
+  get() = Drawable42.icon_6829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_683: DrawableResource
+  get() = Drawable42.icon_683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6830: DrawableResource
+  get() = Drawable42.icon_6830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6831: DrawableResource
+  get() = Drawable42.icon_6831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6832: DrawableResource
+  get() = Drawable42.icon_6832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6833: DrawableResource
+  get() = Drawable42.icon_6833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6834: DrawableResource
+  get() = Drawable42.icon_6834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6835: DrawableResource
+  get() = Drawable42.icon_6835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6836: DrawableResource
+  get() = Drawable42.icon_6836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6837: DrawableResource
+  get() = Drawable42.icon_6837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6838: DrawableResource
+  get() = Drawable42.icon_6838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6839: DrawableResource
+  get() = Drawable42.icon_6839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_684: DrawableResource
+  get() = Drawable42.icon_684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6840: DrawableResource
+  get() = Drawable42.icon_6840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6841: DrawableResource
+  get() = Drawable42.icon_6841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6842: DrawableResource
+  get() = Drawable42.icon_6842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6843: DrawableResource
+  get() = Drawable42.icon_6843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6844: DrawableResource
+  get() = Drawable42.icon_6844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6845: DrawableResource
+  get() = Drawable42.icon_6845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6846: DrawableResource
+  get() = Drawable42.icon_6846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6847: DrawableResource
+  get() = Drawable42.icon_6847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6848: DrawableResource
+  get() = Drawable42.icon_6848

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable43.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable43.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable43 {
+  public val icon_6849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6849.xml"),
+          )
+      )
+
+  public val icon_685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_685.xml"),
+          )
+      )
+
+  public val icon_6850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6850.xml"),
+          )
+      )
+
+  public val icon_6851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6851.xml"),
+          )
+      )
+
+  public val icon_6852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6852.xml"),
+          )
+      )
+
+  public val icon_6853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6853.xml"),
+          )
+      )
+
+  public val icon_6854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6854.xml"),
+          )
+      )
+
+  public val icon_6855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6855.xml"),
+          )
+      )
+
+  public val icon_6856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6856.xml"),
+          )
+      )
+
+  public val icon_6857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6857.xml"),
+          )
+      )
+
+  public val icon_6858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6858.xml"),
+          )
+      )
+
+  public val icon_6859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6859.xml"),
+          )
+      )
+
+  public val icon_686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_686.xml"),
+          )
+      )
+
+  public val icon_6860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6860.xml"),
+          )
+      )
+
+  public val icon_6861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6861.xml"),
+          )
+      )
+
+  public val icon_6862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6862.xml"),
+          )
+      )
+
+  public val icon_6863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6863.xml"),
+          )
+      )
+
+  public val icon_6864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6864.xml"),
+          )
+      )
+
+  public val icon_6865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6865.xml"),
+          )
+      )
+
+  public val icon_6866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6866.xml"),
+          )
+      )
+
+  public val icon_6867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6867.xml"),
+          )
+      )
+
+  public val icon_6868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6868.xml"),
+          )
+      )
+
+  public val icon_6869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6869.xml"),
+          )
+      )
+
+  public val icon_687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_687.xml"),
+          )
+      )
+
+  public val icon_6870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6870.xml"),
+          )
+      )
+
+  public val icon_6871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6871.xml"),
+          )
+      )
+
+  public val icon_6872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6872.xml"),
+          )
+      )
+
+  public val icon_6873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6873.xml"),
+          )
+      )
+
+  public val icon_6874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6874.xml"),
+          )
+      )
+
+  public val icon_6875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6875.xml"),
+          )
+      )
+
+  public val icon_6876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6876.xml"),
+          )
+      )
+
+  public val icon_6877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6877.xml"),
+          )
+      )
+
+  public val icon_6878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6878.xml"),
+          )
+      )
+
+  public val icon_6879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6879.xml"),
+          )
+      )
+
+  public val icon_688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_688.xml"),
+          )
+      )
+
+  public val icon_6880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6880.xml"),
+          )
+      )
+
+  public val icon_6881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6881.xml"),
+          )
+      )
+
+  public val icon_6882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6882.xml"),
+          )
+      )
+
+  public val icon_6883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6883.xml"),
+          )
+      )
+
+  public val icon_6884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6884.xml"),
+          )
+      )
+
+  public val icon_6885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6885.xml"),
+          )
+      )
+
+  public val icon_6886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6886.xml"),
+          )
+      )
+
+  public val icon_6887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6887.xml"),
+          )
+      )
+
+  public val icon_6888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6888.xml"),
+          )
+      )
+
+  public val icon_6889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6889.xml"),
+          )
+      )
+
+  public val icon_689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_689.xml"),
+          )
+      )
+
+  public val icon_6890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6890.xml"),
+          )
+      )
+
+  public val icon_6891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6891.xml"),
+          )
+      )
+
+  public val icon_6892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6892.xml"),
+          )
+      )
+
+  public val icon_6893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6893.xml"),
+          )
+      )
+
+  public val icon_6894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6894.xml"),
+          )
+      )
+
+  public val icon_6895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6895.xml"),
+          )
+      )
+
+  public val icon_6896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6896.xml"),
+          )
+      )
+
+  public val icon_6897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6897.xml"),
+          )
+      )
+
+  public val icon_6898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6898.xml"),
+          )
+      )
+
+  public val icon_6899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6899.xml"),
+          )
+      )
+
+  public val icon_69: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_69",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_69.xml"),
+          )
+      )
+
+  public val icon_690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_690.xml"),
+          )
+      )
+
+  public val icon_6900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6900.xml"),
+          )
+      )
+
+  public val icon_6901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6901.xml"),
+          )
+      )
+
+  public val icon_6902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6902.xml"),
+          )
+      )
+
+  public val icon_6903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6903.xml"),
+          )
+      )
+
+  public val icon_6904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6904.xml"),
+          )
+      )
+
+  public val icon_6905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6905.xml"),
+          )
+      )
+
+  public val icon_6906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6906.xml"),
+          )
+      )
+
+  public val icon_6907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6907.xml"),
+          )
+      )
+
+  public val icon_6908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6908.xml"),
+          )
+      )
+
+  public val icon_6909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6909.xml"),
+          )
+      )
+
+  public val icon_691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_691.xml"),
+          )
+      )
+
+  public val icon_6910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6910.xml"),
+          )
+      )
+
+  public val icon_6911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6911.xml"),
+          )
+      )
+
+  public val icon_6912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6912.xml"),
+          )
+      )
+
+  public val icon_6913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6913.xml"),
+          )
+      )
+
+  public val icon_6914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6914.xml"),
+          )
+      )
+
+  public val icon_6915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6915.xml"),
+          )
+      )
+
+  public val icon_6916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6916.xml"),
+          )
+      )
+
+  public val icon_6917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6917.xml"),
+          )
+      )
+
+  public val icon_6918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6918.xml"),
+          )
+      )
+
+  public val icon_6919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6919.xml"),
+          )
+      )
+
+  public val icon_692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_692.xml"),
+          )
+      )
+
+  public val icon_6920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6920.xml"),
+          )
+      )
+
+  public val icon_6921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6921.xml"),
+          )
+      )
+
+  public val icon_6922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6922.xml"),
+          )
+      )
+
+  public val icon_6923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6923.xml"),
+          )
+      )
+
+  public val icon_6924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6924.xml"),
+          )
+      )
+
+  public val icon_6925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6925.xml"),
+          )
+      )
+
+  public val icon_6926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6926.xml"),
+          )
+      )
+
+  public val icon_6927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6927.xml"),
+          )
+      )
+
+  public val icon_6928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6928.xml"),
+          )
+      )
+
+  public val icon_6929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6929.xml"),
+          )
+      )
+
+  public val icon_693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_693.xml"),
+          )
+      )
+
+  public val icon_6930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6930.xml"),
+          )
+      )
+
+  public val icon_6931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6931.xml"),
+          )
+      )
+
+  public val icon_6932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6932.xml"),
+          )
+      )
+
+  public val icon_6933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6933.xml"),
+          )
+      )
+
+  public val icon_6934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6934.xml"),
+          )
+      )
+
+  public val icon_6935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6935.xml"),
+          )
+      )
+
+  public val icon_6936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6936.xml"),
+          )
+      )
+
+  public val icon_6937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6937.xml"),
+          )
+      )
+
+  public val icon_6938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6938.xml"),
+          )
+      )
+
+  public val icon_6939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6939.xml"),
+          )
+      )
+
+  public val icon_694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_694.xml"),
+          )
+      )
+
+  public val icon_6940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6940.xml"),
+          )
+      )
+
+  public val icon_6941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6941.xml"),
+          )
+      )
+
+  public val icon_6942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6942.xml"),
+          )
+      )
+
+  public val icon_6943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6943.xml"),
+          )
+      )
+
+  public val icon_6944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6944.xml"),
+          )
+      )
+
+  public val icon_6945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6945.xml"),
+          )
+      )
+
+  public val icon_6946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6946.xml"),
+          )
+      )
+
+  public val icon_6947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6947.xml"),
+          )
+      )
+
+  public val icon_6948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6948.xml"),
+          )
+      )
+
+  public val icon_6949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6949.xml"),
+          )
+      )
+
+  public val icon_695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_695.xml"),
+          )
+      )
+
+  public val icon_6950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6950.xml"),
+          )
+      )
+
+  public val icon_6951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6951.xml"),
+          )
+      )
+
+  public val icon_6952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6952.xml"),
+          )
+      )
+
+  public val icon_6953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6953.xml"),
+          )
+      )
+
+  public val icon_6954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6954.xml"),
+          )
+      )
+
+  public val icon_6955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6955.xml"),
+          )
+      )
+
+  public val icon_6956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6956.xml"),
+          )
+      )
+
+  public val icon_6957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6957.xml"),
+          )
+      )
+
+  public val icon_6958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6958.xml"),
+          )
+      )
+
+  public val icon_6959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6959.xml"),
+          )
+      )
+
+  public val icon_696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_696.xml"),
+          )
+      )
+
+  public val icon_6960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6960.xml"),
+          )
+      )
+
+  public val icon_6961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6961.xml"),
+          )
+      )
+
+  public val icon_6962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6962.xml"),
+          )
+      )
+
+  public val icon_6963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6963.xml"),
+          )
+      )
+
+  public val icon_6964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6964.xml"),
+          )
+      )
+
+  public val icon_6965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6965.xml"),
+          )
+      )
+
+  public val icon_6966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6966.xml"),
+          )
+      )
+
+  public val icon_6967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6967.xml"),
+          )
+      )
+
+  public val icon_6968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6968.xml"),
+          )
+      )
+
+  public val icon_6969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6969.xml"),
+          )
+      )
+
+  public val icon_697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_697.xml"),
+          )
+      )
+
+  public val icon_6970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6970.xml"),
+          )
+      )
+
+  public val icon_6971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6971.xml"),
+          )
+      )
+
+  public val icon_6972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6972.xml"),
+          )
+      )
+
+  public val icon_6973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6973.xml"),
+          )
+      )
+
+  public val icon_6974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6974.xml"),
+          )
+      )
+
+  public val icon_6975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6975.xml"),
+          )
+      )
+
+  public val icon_6976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6976.xml"),
+          )
+      )
+
+  public val icon_6977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6977.xml"),
+          )
+      )
+
+  public val icon_6978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6978.xml"),
+          )
+      )
+
+  public val icon_6979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6979.xml"),
+          )
+      )
+
+  public val icon_698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_698.xml"),
+          )
+      )
+
+  public val icon_6980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6980.xml"),
+          )
+      )
+
+  public val icon_6981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6981.xml"),
+          )
+      )
+
+  public val icon_6982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6982.xml"),
+          )
+      )
+
+  public val icon_6983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6983.xml"),
+          )
+      )
+
+  public val icon_6984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6984.xml"),
+          )
+      )
+
+  public val icon_6985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6985.xml"),
+          )
+      )
+
+  public val icon_6986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6986.xml"),
+          )
+      )
+
+  public val icon_6987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6987.xml"),
+          )
+      )
+
+  public val icon_6988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6988.xml"),
+          )
+      )
+
+  public val icon_6989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6989.xml"),
+          )
+      )
+
+  public val icon_699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_699.xml"),
+          )
+      )
+
+  public val icon_6990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6990.xml"),
+          )
+      )
+
+  public val icon_6991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6991.xml"),
+          )
+      )
+
+  public val icon_6992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6992.xml"),
+          )
+      )
+
+  public val icon_6993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6993.xml"),
+          )
+      )
+
+  public val icon_6994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6994.xml"),
+          )
+      )
+
+  public val icon_6995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6995.xml"),
+          )
+      )
+
+  public val icon_6996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6996.xml"),
+          )
+      )
+
+  public val icon_6997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6997.xml"),
+          )
+      )
+
+  public val icon_6998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6998.xml"),
+          )
+      )
+
+  public val icon_6999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_6999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_6999.xml"),
+          )
+      )
+
+  public val icon_7: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7.xml"),
+          )
+      )
+
+  public val icon_70: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_70",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_70.xml"),
+          )
+      )
+
+  public val icon_700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_700.xml"),
+          )
+      )
+
+  public val icon_7000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7000.xml"),
+          )
+      )
+
+  public val icon_7001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7001.xml"),
+          )
+      )
+
+  public val icon_7002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7002.xml"),
+          )
+      )
+
+  public val icon_7003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7003.xml"),
+          )
+      )
+
+  public val icon_7004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7004.xml"),
+          )
+      )
+
+  public val icon_7005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7005.xml"),
+          )
+      )
+
+  public val icon_7006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7006.xml"),
+          )
+      )
+
+  public val icon_7007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7007.xml"),
+          )
+      )
+
+  public val icon_7008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7008.xml"),
+          )
+      )
+
+  public val icon_7009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7009.xml"),
+          )
+      )
+
+  public val icon_701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_701.xml"),
+          )
+      )
+
+  public val icon_7010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7010.xml"),
+          )
+      )
+
+  public val icon_7011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7011.xml"),
+          )
+      )
+
+  public val icon_7012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7012.xml"),
+          )
+      )
+
+  public val icon_7013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7013.xml"),
+          )
+      )
+
+  public val icon_7014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7014.xml"),
+          )
+      )
+
+  public val icon_7015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7015.xml"),
+          )
+      )
+
+  public val icon_7016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7016.xml"),
+          )
+      )
+
+  public val icon_7017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7017.xml"),
+          )
+      )
+
+  public val icon_7018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7018.xml"),
+          )
+      )
+
+  public val icon_7019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7019.xml"),
+          )
+      )
+
+  public val icon_702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_702.xml"),
+          )
+      )
+
+  public val icon_7020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7020.xml"),
+          )
+      )
+
+  public val icon_7021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7021.xml"),
+          )
+      )
+
+  public val icon_7022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7022.xml"),
+          )
+      )
+
+  public val icon_7023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7023.xml"),
+          )
+      )
+
+  public val icon_7024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7024.xml"),
+          )
+      )
+
+  public val icon_7025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7025.xml"),
+          )
+      )
+
+  public val icon_7026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7026.xml"),
+          )
+      )
+
+  public val icon_7027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7027.xml"),
+          )
+      )
+
+  public val icon_7028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7028.xml"),
+          )
+      )
+
+  public val icon_7029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7029.xml"),
+          )
+      )
+
+  public val icon_703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_703.xml"),
+          )
+      )
+
+  public val icon_7030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7030.xml"),
+          )
+      )
+
+  public val icon_7031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7031.xml"),
+          )
+      )
+
+  public val icon_7032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7032.xml"),
+          )
+      )
+
+  public val icon_7033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7033.xml"),
+          )
+      )
+
+  public val icon_7034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7034.xml"),
+          )
+      )
+
+  public val icon_7035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7035.xml"),
+          )
+      )
+
+  public val icon_7036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7036.xml"),
+          )
+      )
+
+  public val icon_7037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7037.xml"),
+          )
+      )
+
+  public val icon_7038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7038.xml"),
+          )
+      )
+
+  public val icon_7039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7039.xml"),
+          )
+      )
+
+  public val icon_704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_704.xml"),
+          )
+      )
+
+  public val icon_7040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7040.xml"),
+          )
+      )
+
+  public val icon_7041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7041.xml"),
+          )
+      )
+
+  public val icon_7042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7042.xml"),
+          )
+      )
+
+  public val icon_7043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7043.xml"),
+          )
+      )
+
+  public val icon_7044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7044.xml"),
+          )
+      )
+
+  public val icon_7045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7045.xml"),
+          )
+      )
+
+  public val icon_7046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7046.xml"),
+          )
+      )
+
+  public val icon_7047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7047.xml"),
+          )
+      )
+
+  public val icon_7048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7048.xml"),
+          )
+      )
+
+  public val icon_7049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7049.xml"),
+          )
+      )
+
+  public val icon_705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_705.xml"),
+          )
+      )
+
+  public val icon_7050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7050.xml"),
+          )
+      )
+
+  public val icon_7051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7051.xml"),
+          )
+      )
+
+  public val icon_7052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7052.xml"),
+          )
+      )
+
+  public val icon_7053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7053.xml"),
+          )
+      )
+
+  public val icon_7054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7054.xml"),
+          )
+      )
+
+  public val icon_7055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7055.xml"),
+          )
+      )
+
+  public val icon_7056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7056.xml"),
+          )
+      )
+
+  public val icon_7057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7057.xml"),
+          )
+      )
+
+  public val icon_7058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7058.xml"),
+          )
+      )
+
+  public val icon_7059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7059.xml"),
+          )
+      )
+
+  public val icon_706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_706.xml"),
+          )
+      )
+
+  public val icon_7060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7060.xml"),
+          )
+      )
+
+  public val icon_7061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7061.xml"),
+          )
+      )
+
+  public val icon_7062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7062.xml"),
+          )
+      )
+
+  public val icon_7063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7063.xml"),
+          )
+      )
+
+  public val icon_7064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7064.xml"),
+          )
+      )
+
+  public val icon_7065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7065.xml"),
+          )
+      )
+
+  public val icon_7066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7066.xml"),
+          )
+      )
+
+  public val icon_7067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7067.xml"),
+          )
+      )
+
+  public val icon_7068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7068.xml"),
+          )
+      )
+
+  public val icon_7069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7069.xml"),
+          )
+      )
+
+  public val icon_707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_707.xml"),
+          )
+      )
+
+  public val icon_7070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7070.xml"),
+          )
+      )
+
+  public val icon_7071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7071.xml"),
+          )
+      )
+
+  public val icon_7072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7072.xml"),
+          )
+      )
+
+  public val icon_7073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7073.xml"),
+          )
+      )
+
+  public val icon_7074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7074.xml"),
+          )
+      )
+
+  public val icon_7075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7075.xml"),
+          )
+      )
+
+  public val icon_7076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7076.xml"),
+          )
+      )
+
+  public val icon_7077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7077.xml"),
+          )
+      )
+
+  public val icon_7078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7078.xml"),
+          )
+      )
+
+  public val icon_7079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7079.xml"),
+          )
+      )
+
+  public val icon_708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_708.xml"),
+          )
+      )
+
+  public val icon_7080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7080.xml"),
+          )
+      )
+
+  public val icon_7081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7081.xml"),
+          )
+      )
+
+  public val icon_7082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7082.xml"),
+          )
+      )
+
+  public val icon_7083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7083.xml"),
+          )
+      )
+
+  public val icon_7084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7084.xml"),
+          )
+      )
+
+  public val icon_7085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7085.xml"),
+          )
+      )
+
+  public val icon_7086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7086.xml"),
+          )
+      )
+
+  public val icon_7087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7087.xml"),
+          )
+      )
+
+  public val icon_7088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7088.xml"),
+          )
+      )
+
+  public val icon_7089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7089.xml"),
+          )
+      )
+
+  public val icon_709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_709.xml"),
+          )
+      )
+
+  public val icon_7090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7090.xml"),
+          )
+      )
+
+  public val icon_7091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7091.xml"),
+          )
+      )
+
+  public val icon_7092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7092.xml"),
+          )
+      )
+
+  public val icon_7093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7093.xml"),
+          )
+      )
+
+  public val icon_7094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7094.xml"),
+          )
+      )
+
+  public val icon_7095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7095.xml"),
+          )
+      )
+
+  public val icon_7096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7096.xml"),
+          )
+      )
+
+  public val icon_7097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7097.xml"),
+          )
+      )
+
+  public val icon_7098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7098.xml"),
+          )
+      )
+
+  public val icon_7099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7099.xml"),
+          )
+      )
+
+  public val icon_71: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_71",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_71.xml"),
+          )
+      )
+
+  public val icon_710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_710.xml"),
+          )
+      )
+
+  public val icon_7100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7100.xml"),
+          )
+      )
+
+  public val icon_7101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7101.xml"),
+          )
+      )
+
+  public val icon_7102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7102.xml"),
+          )
+      )
+
+  public val icon_7103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7103.xml"),
+          )
+      )
+
+  public val icon_7104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7104.xml"),
+          )
+      )
+
+  public val icon_7105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7105.xml"),
+          )
+      )
+
+  public val icon_7106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7106.xml"),
+          )
+      )
+
+  public val icon_7107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7107.xml"),
+          )
+      )
+
+  public val icon_7108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7108.xml"),
+          )
+      )
+
+  public val icon_7109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7109.xml"),
+          )
+      )
+
+  public val icon_711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_711.xml"),
+          )
+      )
+
+  public val icon_7110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7110.xml"),
+          )
+      )
+
+  public val icon_7111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7111.xml"),
+          )
+      )
+
+  public val icon_7112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7112.xml"),
+          )
+      )
+
+  public val icon_7113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7113.xml"),
+          )
+      )
+
+  public val icon_7114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7114.xml"),
+          )
+      )
+
+  public val icon_7115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7115.xml"),
+          )
+      )
+
+  public val icon_7116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7116.xml"),
+          )
+      )
+
+  public val icon_7117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7117.xml"),
+          )
+      )
+
+  public val icon_7118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7118.xml"),
+          )
+      )
+
+  public val icon_7119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7119.xml"),
+          )
+      )
+
+  public val icon_712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_712.xml"),
+          )
+      )
+
+  public val icon_7120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7120.xml"),
+          )
+      )
+
+  public val icon_7121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7121.xml"),
+          )
+      )
+
+  public val icon_7122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7122.xml"),
+          )
+      )
+
+  public val icon_7123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7123.xml"),
+          )
+      )
+
+  public val icon_7124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7124.xml"),
+          )
+      )
+
+  public val icon_7125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7125.xml"),
+          )
+      )
+
+  public val icon_7126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7126.xml"),
+          )
+      )
+
+  public val icon_7127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7127.xml"),
+          )
+      )
+
+  public val icon_7128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7128.xml"),
+          )
+      )
+
+  public val icon_7129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7129.xml"),
+          )
+      )
+
+  public val icon_713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_713.xml"),
+          )
+      )
+
+  public val icon_7130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7130.xml"),
+          )
+      )
+
+  public val icon_7131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7131.xml"),
+          )
+      )
+
+  public val icon_7132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7132.xml"),
+          )
+      )
+
+  public val icon_7133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7133.xml"),
+          )
+      )
+
+  public val icon_7134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7134.xml"),
+          )
+      )
+
+  public val icon_7135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7135.xml"),
+          )
+      )
+
+  public val icon_7136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7136.xml"),
+          )
+      )
+
+  public val icon_7137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7137.xml"),
+          )
+      )
+
+  public val icon_7138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7138.xml"),
+          )
+      )
+
+  public val icon_7139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7139.xml"),
+          )
+      )
+
+  public val icon_714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_714.xml"),
+          )
+      )
+
+  public val icon_7140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7140.xml"),
+          )
+      )
+
+  public val icon_7141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7141.xml"),
+          )
+      )
+
+  public val icon_7142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7142.xml"),
+          )
+      )
+
+  public val icon_7143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7143.xml"),
+          )
+      )
+
+  public val icon_7144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7144.xml"),
+          )
+      )
+
+  public val icon_7145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7145.xml"),
+          )
+      )
+
+  public val icon_7146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7146.xml"),
+          )
+      )
+
+  public val icon_7147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7147.xml"),
+          )
+      )
+
+  public val icon_7148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7148.xml"),
+          )
+      )
+
+  public val icon_7149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7149.xml"),
+          )
+      )
+
+  public val icon_715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_715.xml"),
+          )
+      )
+
+  public val icon_7150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7150.xml"),
+          )
+      )
+
+  public val icon_7151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7151.xml"),
+          )
+      )
+
+  public val icon_7152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7152.xml"),
+          )
+      )
+
+  public val icon_7153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7153.xml"),
+          )
+      )
+
+  public val icon_7154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7154.xml"),
+          )
+      )
+
+  public val icon_7155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7155.xml"),
+          )
+      )
+
+  public val icon_7156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7156.xml"),
+          )
+      )
+
+  public val icon_7157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7157.xml"),
+          )
+      )
+
+  public val icon_7158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7158.xml"),
+          )
+      )
+
+  public val icon_7159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7159.xml"),
+          )
+      )
+
+  public val icon_716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_716.xml"),
+          )
+      )
+
+  public val icon_7160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7160.xml"),
+          )
+      )
+
+  public val icon_7161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7161.xml"),
+          )
+      )
+
+  public val icon_7162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7162.xml"),
+          )
+      )
+
+  public val icon_7163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7163.xml"),
+          )
+      )
+
+  public val icon_7164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7164.xml"),
+          )
+      )
+
+  public val icon_7165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7165.xml"),
+          )
+      )
+
+  public val icon_7166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7166.xml"),
+          )
+      )
+
+  public val icon_7167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7167.xml"),
+          )
+      )
+
+  public val icon_7168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7168.xml"),
+          )
+      )
+
+  public val icon_7169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7169.xml"),
+          )
+      )
+
+  public val icon_717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_717.xml"),
+          )
+      )
+
+  public val icon_7170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7170.xml"),
+          )
+      )
+
+  public val icon_7171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7171.xml"),
+          )
+      )
+
+  public val icon_7172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7172.xml"),
+          )
+      )
+
+  public val icon_7173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7173.xml"),
+          )
+      )
+
+  public val icon_7174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7174.xml"),
+          )
+      )
+
+  public val icon_7175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7175.xml"),
+          )
+      )
+
+  public val icon_7176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7176.xml"),
+          )
+      )
+
+  public val icon_7177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7177.xml"),
+          )
+      )
+
+  public val icon_7178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7178.xml"),
+          )
+      )
+
+  public val icon_7179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7179.xml"),
+          )
+      )
+
+  public val icon_718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_718.xml"),
+          )
+      )
+
+  public val icon_7180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7180.xml"),
+          )
+      )
+
+  public val icon_7181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7181.xml"),
+          )
+      )
+
+  public val icon_7182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7182.xml"),
+          )
+      )
+
+  public val icon_7183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7183.xml"),
+          )
+      )
+
+  public val icon_7184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7184.xml"),
+          )
+      )
+
+  public val icon_7185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7185.xml"),
+          )
+      )
+
+  public val icon_7186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7186.xml"),
+          )
+      )
+
+  public val icon_7187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7187.xml"),
+          )
+      )
+
+  public val icon_7188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7188.xml"),
+          )
+      )
+
+  public val icon_7189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7189.xml"),
+          )
+      )
+
+  public val icon_719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_719.xml"),
+          )
+      )
+
+  public val icon_7190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7190.xml"),
+          )
+      )
+
+  public val icon_7191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7191.xml"),
+          )
+      )
+
+  public val icon_7192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7192.xml"),
+          )
+      )
+
+  public val icon_7193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7193.xml"),
+          )
+      )
+
+  public val icon_7194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7194.xml"),
+          )
+      )
+
+  public val icon_7195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7195.xml"),
+          )
+      )
+
+  public val icon_7196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7196.xml"),
+          )
+      )
+
+  public val icon_7197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7197.xml"),
+          )
+      )
+
+  public val icon_7198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7198.xml"),
+          )
+      )
+
+  public val icon_7199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7199.xml"),
+          )
+      )
+
+  public val icon_72: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_72",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_72.xml"),
+          )
+      )
+
+  public val icon_720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_720.xml"),
+          )
+      )
+
+  public val icon_7200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7200.xml"),
+          )
+      )
+
+  public val icon_7201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7201.xml"),
+          )
+      )
+
+  public val icon_7202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7202.xml"),
+          )
+      )
+
+  public val icon_7203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7203.xml"),
+          )
+      )
+
+  public val icon_7204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7204.xml"),
+          )
+      )
+
+  public val icon_7205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7205.xml"),
+          )
+      )
+
+  public val icon_7206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7206.xml"),
+          )
+      )
+
+  public val icon_7207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7207.xml"),
+          )
+      )
+
+  public val icon_7208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7208.xml"),
+          )
+      )
+
+  public val icon_7209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7209.xml"),
+          )
+      )
+
+  public val icon_721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_721.xml"),
+          )
+      )
+
+  public val icon_7210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7210.xml"),
+          )
+      )
+
+  public val icon_7211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7211.xml"),
+          )
+      )
+
+  public val icon_7212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7212.xml"),
+          )
+      )
+
+  public val icon_7213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7213.xml"),
+          )
+      )
+
+  public val icon_7214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7214.xml"),
+          )
+      )
+
+  public val icon_7215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7215.xml"),
+          )
+      )
+
+  public val icon_7216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7216.xml"),
+          )
+      )
+
+  public val icon_7217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7217.xml"),
+          )
+      )
+
+  public val icon_7218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7218.xml"),
+          )
+      )
+
+  public val icon_7219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7219.xml"),
+          )
+      )
+
+  public val icon_722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_722.xml"),
+          )
+      )
+
+  public val icon_7220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7220.xml"),
+          )
+      )
+
+  public val icon_7221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7221.xml"),
+          )
+      )
+
+  public val icon_7222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7222.xml"),
+          )
+      )
+
+  public val icon_7223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7223.xml"),
+          )
+      )
+
+  public val icon_7224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7224.xml"),
+          )
+      )
+
+  public val icon_7225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7225.xml"),
+          )
+      )
+
+  public val icon_7226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7226.xml"),
+          )
+      )
+
+  public val icon_7227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7227.xml"),
+          )
+      )
+
+  public val icon_7228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7228.xml"),
+          )
+      )
+
+  public val icon_7229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7229.xml"),
+          )
+      )
+
+  public val icon_723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_723.xml"),
+          )
+      )
+
+  public val icon_7230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7230.xml"),
+          )
+      )
+
+  public val icon_7231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7231.xml"),
+          )
+      )
+
+  public val icon_7232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7232.xml"),
+          )
+      )
+
+  public val icon_7233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7233.xml"),
+          )
+      )
+
+  public val icon_7234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7234.xml"),
+          )
+      )
+
+  public val icon_7235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7235.xml"),
+          )
+      )
+
+  public val icon_7236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7236.xml"),
+          )
+      )
+
+  public val icon_7237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7237.xml"),
+          )
+      )
+
+  public val icon_7238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7238.xml"),
+          )
+      )
+
+  public val icon_7239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7239.xml"),
+          )
+      )
+
+  public val icon_724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_724.xml"),
+          )
+      )
+
+  public val icon_7240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7240.xml"),
+          )
+      )
+
+  public val icon_7241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7241.xml"),
+          )
+      )
+
+  public val icon_7242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7242.xml"),
+          )
+      )
+
+  public val icon_7243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7243.xml"),
+          )
+      )
+
+  public val icon_7244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7244.xml"),
+          )
+      )
+
+  public val icon_7245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7245.xml"),
+          )
+      )
+
+  public val icon_7246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7246.xml"),
+          )
+      )
+
+  public val icon_7247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7247.xml"),
+          )
+      )
+
+  public val icon_7248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7248.xml"),
+          )
+      )
+
+  public val icon_7249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7249.xml"),
+          )
+      )
+
+  public val icon_725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_725.xml"),
+          )
+      )
+
+  public val icon_7250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7250.xml"),
+          )
+      )
+
+  public val icon_7251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7251.xml"),
+          )
+      )
+
+  public val icon_7252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7252.xml"),
+          )
+      )
+
+  public val icon_7253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7253.xml"),
+          )
+      )
+
+  public val icon_7254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7254.xml"),
+          )
+      )
+
+  public val icon_7255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7255.xml"),
+          )
+      )
+
+  public val icon_7256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7256.xml"),
+          )
+      )
+
+  public val icon_7257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7257.xml"),
+          )
+      )
+
+  public val icon_7258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7258.xml"),
+          )
+      )
+
+  public val icon_7259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7259.xml"),
+          )
+      )
+
+  public val icon_726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_726.xml"),
+          )
+      )
+
+  public val icon_7260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7260.xml"),
+          )
+      )
+
+  public val icon_7261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7261.xml"),
+          )
+      )
+
+  public val icon_7262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7262.xml"),
+          )
+      )
+
+  public val icon_7263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7263.xml"),
+          )
+      )
+
+  public val icon_7264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7264.xml"),
+          )
+      )
+
+  public val icon_7265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7265.xml"),
+          )
+      )
+
+  public val icon_7266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7266.xml"),
+          )
+      )
+
+  public val icon_7267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7267.xml"),
+          )
+      )
+
+  public val icon_7268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7268.xml"),
+          )
+      )
+
+  public val icon_7269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7269.xml"),
+          )
+      )
+
+  public val icon_727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_727.xml"),
+          )
+      )
+
+  public val icon_7270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7270.xml"),
+          )
+      )
+
+  public val icon_7271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7271.xml"),
+          )
+      )
+
+  public val icon_7272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7272.xml"),
+          )
+      )
+
+  public val icon_7273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7273.xml"),
+          )
+      )
+
+  public val icon_7274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7274.xml"),
+          )
+      )
+
+  public val icon_7275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7275.xml"),
+          )
+      )
+
+  public val icon_7276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7276.xml"),
+          )
+      )
+
+  public val icon_7277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7277.xml"),
+          )
+      )
+
+  public val icon_7278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7278.xml"),
+          )
+      )
+
+  public val icon_7279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7279.xml"),
+          )
+      )
+
+  public val icon_728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_728.xml"),
+          )
+      )
+
+  public val icon_7280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7280.xml"),
+          )
+      )
+
+  public val icon_7281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7281.xml"),
+          )
+      )
+
+  public val icon_7282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7282.xml"),
+          )
+      )
+
+  public val icon_7283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7283.xml"),
+          )
+      )
+
+  public val icon_7284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7284.xml"),
+          )
+      )
+
+  public val icon_7285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7285.xml"),
+          )
+      )
+
+  public val icon_7286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7286.xml"),
+          )
+      )
+
+  public val icon_7287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7287.xml"),
+          )
+      )
+
+  public val icon_7288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7288.xml"),
+          )
+      )
+
+  public val icon_7289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7289.xml"),
+          )
+      )
+
+  public val icon_729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_729.xml"),
+          )
+      )
+
+  public val icon_7290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7290.xml"),
+          )
+      )
+
+  public val icon_7291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7291.xml"),
+          )
+      )
+
+  public val icon_7292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7292.xml"),
+          )
+      )
+
+  public val icon_7293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7293.xml"),
+          )
+      )
+
+  public val icon_7294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7294.xml"),
+          )
+      )
+
+  public val icon_7295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7295.xml"),
+          )
+      )
+
+  public val icon_7296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7296.xml"),
+          )
+      )
+
+  public val icon_7297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7297.xml"),
+          )
+      )
+
+  public val icon_7298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7298.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6849: DrawableResource
+  get() = Drawable43.icon_6849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_685: DrawableResource
+  get() = Drawable43.icon_685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6850: DrawableResource
+  get() = Drawable43.icon_6850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6851: DrawableResource
+  get() = Drawable43.icon_6851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6852: DrawableResource
+  get() = Drawable43.icon_6852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6853: DrawableResource
+  get() = Drawable43.icon_6853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6854: DrawableResource
+  get() = Drawable43.icon_6854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6855: DrawableResource
+  get() = Drawable43.icon_6855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6856: DrawableResource
+  get() = Drawable43.icon_6856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6857: DrawableResource
+  get() = Drawable43.icon_6857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6858: DrawableResource
+  get() = Drawable43.icon_6858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6859: DrawableResource
+  get() = Drawable43.icon_6859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_686: DrawableResource
+  get() = Drawable43.icon_686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6860: DrawableResource
+  get() = Drawable43.icon_6860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6861: DrawableResource
+  get() = Drawable43.icon_6861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6862: DrawableResource
+  get() = Drawable43.icon_6862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6863: DrawableResource
+  get() = Drawable43.icon_6863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6864: DrawableResource
+  get() = Drawable43.icon_6864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6865: DrawableResource
+  get() = Drawable43.icon_6865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6866: DrawableResource
+  get() = Drawable43.icon_6866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6867: DrawableResource
+  get() = Drawable43.icon_6867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6868: DrawableResource
+  get() = Drawable43.icon_6868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6869: DrawableResource
+  get() = Drawable43.icon_6869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_687: DrawableResource
+  get() = Drawable43.icon_687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6870: DrawableResource
+  get() = Drawable43.icon_6870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6871: DrawableResource
+  get() = Drawable43.icon_6871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6872: DrawableResource
+  get() = Drawable43.icon_6872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6873: DrawableResource
+  get() = Drawable43.icon_6873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6874: DrawableResource
+  get() = Drawable43.icon_6874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6875: DrawableResource
+  get() = Drawable43.icon_6875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6876: DrawableResource
+  get() = Drawable43.icon_6876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6877: DrawableResource
+  get() = Drawable43.icon_6877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6878: DrawableResource
+  get() = Drawable43.icon_6878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6879: DrawableResource
+  get() = Drawable43.icon_6879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_688: DrawableResource
+  get() = Drawable43.icon_688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6880: DrawableResource
+  get() = Drawable43.icon_6880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6881: DrawableResource
+  get() = Drawable43.icon_6881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6882: DrawableResource
+  get() = Drawable43.icon_6882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6883: DrawableResource
+  get() = Drawable43.icon_6883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6884: DrawableResource
+  get() = Drawable43.icon_6884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6885: DrawableResource
+  get() = Drawable43.icon_6885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6886: DrawableResource
+  get() = Drawable43.icon_6886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6887: DrawableResource
+  get() = Drawable43.icon_6887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6888: DrawableResource
+  get() = Drawable43.icon_6888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6889: DrawableResource
+  get() = Drawable43.icon_6889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_689: DrawableResource
+  get() = Drawable43.icon_689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6890: DrawableResource
+  get() = Drawable43.icon_6890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6891: DrawableResource
+  get() = Drawable43.icon_6891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6892: DrawableResource
+  get() = Drawable43.icon_6892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6893: DrawableResource
+  get() = Drawable43.icon_6893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6894: DrawableResource
+  get() = Drawable43.icon_6894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6895: DrawableResource
+  get() = Drawable43.icon_6895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6896: DrawableResource
+  get() = Drawable43.icon_6896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6897: DrawableResource
+  get() = Drawable43.icon_6897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6898: DrawableResource
+  get() = Drawable43.icon_6898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6899: DrawableResource
+  get() = Drawable43.icon_6899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_69: DrawableResource
+  get() = Drawable43.icon_69
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_690: DrawableResource
+  get() = Drawable43.icon_690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6900: DrawableResource
+  get() = Drawable43.icon_6900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6901: DrawableResource
+  get() = Drawable43.icon_6901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6902: DrawableResource
+  get() = Drawable43.icon_6902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6903: DrawableResource
+  get() = Drawable43.icon_6903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6904: DrawableResource
+  get() = Drawable43.icon_6904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6905: DrawableResource
+  get() = Drawable43.icon_6905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6906: DrawableResource
+  get() = Drawable43.icon_6906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6907: DrawableResource
+  get() = Drawable43.icon_6907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6908: DrawableResource
+  get() = Drawable43.icon_6908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6909: DrawableResource
+  get() = Drawable43.icon_6909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_691: DrawableResource
+  get() = Drawable43.icon_691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6910: DrawableResource
+  get() = Drawable43.icon_6910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6911: DrawableResource
+  get() = Drawable43.icon_6911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6912: DrawableResource
+  get() = Drawable43.icon_6912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6913: DrawableResource
+  get() = Drawable43.icon_6913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6914: DrawableResource
+  get() = Drawable43.icon_6914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6915: DrawableResource
+  get() = Drawable43.icon_6915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6916: DrawableResource
+  get() = Drawable43.icon_6916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6917: DrawableResource
+  get() = Drawable43.icon_6917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6918: DrawableResource
+  get() = Drawable43.icon_6918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6919: DrawableResource
+  get() = Drawable43.icon_6919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_692: DrawableResource
+  get() = Drawable43.icon_692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6920: DrawableResource
+  get() = Drawable43.icon_6920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6921: DrawableResource
+  get() = Drawable43.icon_6921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6922: DrawableResource
+  get() = Drawable43.icon_6922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6923: DrawableResource
+  get() = Drawable43.icon_6923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6924: DrawableResource
+  get() = Drawable43.icon_6924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6925: DrawableResource
+  get() = Drawable43.icon_6925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6926: DrawableResource
+  get() = Drawable43.icon_6926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6927: DrawableResource
+  get() = Drawable43.icon_6927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6928: DrawableResource
+  get() = Drawable43.icon_6928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6929: DrawableResource
+  get() = Drawable43.icon_6929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_693: DrawableResource
+  get() = Drawable43.icon_693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6930: DrawableResource
+  get() = Drawable43.icon_6930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6931: DrawableResource
+  get() = Drawable43.icon_6931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6932: DrawableResource
+  get() = Drawable43.icon_6932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6933: DrawableResource
+  get() = Drawable43.icon_6933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6934: DrawableResource
+  get() = Drawable43.icon_6934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6935: DrawableResource
+  get() = Drawable43.icon_6935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6936: DrawableResource
+  get() = Drawable43.icon_6936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6937: DrawableResource
+  get() = Drawable43.icon_6937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6938: DrawableResource
+  get() = Drawable43.icon_6938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6939: DrawableResource
+  get() = Drawable43.icon_6939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_694: DrawableResource
+  get() = Drawable43.icon_694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6940: DrawableResource
+  get() = Drawable43.icon_6940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6941: DrawableResource
+  get() = Drawable43.icon_6941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6942: DrawableResource
+  get() = Drawable43.icon_6942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6943: DrawableResource
+  get() = Drawable43.icon_6943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6944: DrawableResource
+  get() = Drawable43.icon_6944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6945: DrawableResource
+  get() = Drawable43.icon_6945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6946: DrawableResource
+  get() = Drawable43.icon_6946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6947: DrawableResource
+  get() = Drawable43.icon_6947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6948: DrawableResource
+  get() = Drawable43.icon_6948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6949: DrawableResource
+  get() = Drawable43.icon_6949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_695: DrawableResource
+  get() = Drawable43.icon_695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6950: DrawableResource
+  get() = Drawable43.icon_6950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6951: DrawableResource
+  get() = Drawable43.icon_6951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6952: DrawableResource
+  get() = Drawable43.icon_6952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6953: DrawableResource
+  get() = Drawable43.icon_6953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6954: DrawableResource
+  get() = Drawable43.icon_6954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6955: DrawableResource
+  get() = Drawable43.icon_6955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6956: DrawableResource
+  get() = Drawable43.icon_6956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6957: DrawableResource
+  get() = Drawable43.icon_6957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6958: DrawableResource
+  get() = Drawable43.icon_6958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6959: DrawableResource
+  get() = Drawable43.icon_6959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_696: DrawableResource
+  get() = Drawable43.icon_696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6960: DrawableResource
+  get() = Drawable43.icon_6960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6961: DrawableResource
+  get() = Drawable43.icon_6961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6962: DrawableResource
+  get() = Drawable43.icon_6962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6963: DrawableResource
+  get() = Drawable43.icon_6963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6964: DrawableResource
+  get() = Drawable43.icon_6964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6965: DrawableResource
+  get() = Drawable43.icon_6965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6966: DrawableResource
+  get() = Drawable43.icon_6966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6967: DrawableResource
+  get() = Drawable43.icon_6967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6968: DrawableResource
+  get() = Drawable43.icon_6968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6969: DrawableResource
+  get() = Drawable43.icon_6969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_697: DrawableResource
+  get() = Drawable43.icon_697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6970: DrawableResource
+  get() = Drawable43.icon_6970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6971: DrawableResource
+  get() = Drawable43.icon_6971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6972: DrawableResource
+  get() = Drawable43.icon_6972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6973: DrawableResource
+  get() = Drawable43.icon_6973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6974: DrawableResource
+  get() = Drawable43.icon_6974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6975: DrawableResource
+  get() = Drawable43.icon_6975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6976: DrawableResource
+  get() = Drawable43.icon_6976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6977: DrawableResource
+  get() = Drawable43.icon_6977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6978: DrawableResource
+  get() = Drawable43.icon_6978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6979: DrawableResource
+  get() = Drawable43.icon_6979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_698: DrawableResource
+  get() = Drawable43.icon_698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6980: DrawableResource
+  get() = Drawable43.icon_6980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6981: DrawableResource
+  get() = Drawable43.icon_6981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6982: DrawableResource
+  get() = Drawable43.icon_6982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6983: DrawableResource
+  get() = Drawable43.icon_6983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6984: DrawableResource
+  get() = Drawable43.icon_6984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6985: DrawableResource
+  get() = Drawable43.icon_6985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6986: DrawableResource
+  get() = Drawable43.icon_6986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6987: DrawableResource
+  get() = Drawable43.icon_6987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6988: DrawableResource
+  get() = Drawable43.icon_6988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6989: DrawableResource
+  get() = Drawable43.icon_6989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_699: DrawableResource
+  get() = Drawable43.icon_699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6990: DrawableResource
+  get() = Drawable43.icon_6990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6991: DrawableResource
+  get() = Drawable43.icon_6991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6992: DrawableResource
+  get() = Drawable43.icon_6992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6993: DrawableResource
+  get() = Drawable43.icon_6993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6994: DrawableResource
+  get() = Drawable43.icon_6994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6995: DrawableResource
+  get() = Drawable43.icon_6995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6996: DrawableResource
+  get() = Drawable43.icon_6996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6997: DrawableResource
+  get() = Drawable43.icon_6997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6998: DrawableResource
+  get() = Drawable43.icon_6998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_6999: DrawableResource
+  get() = Drawable43.icon_6999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7: DrawableResource
+  get() = Drawable43.icon_7
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_70: DrawableResource
+  get() = Drawable43.icon_70
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_700: DrawableResource
+  get() = Drawable43.icon_700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7000: DrawableResource
+  get() = Drawable43.icon_7000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7001: DrawableResource
+  get() = Drawable43.icon_7001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7002: DrawableResource
+  get() = Drawable43.icon_7002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7003: DrawableResource
+  get() = Drawable43.icon_7003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7004: DrawableResource
+  get() = Drawable43.icon_7004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7005: DrawableResource
+  get() = Drawable43.icon_7005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7006: DrawableResource
+  get() = Drawable43.icon_7006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7007: DrawableResource
+  get() = Drawable43.icon_7007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7008: DrawableResource
+  get() = Drawable43.icon_7008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7009: DrawableResource
+  get() = Drawable43.icon_7009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_701: DrawableResource
+  get() = Drawable43.icon_701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7010: DrawableResource
+  get() = Drawable43.icon_7010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7011: DrawableResource
+  get() = Drawable43.icon_7011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7012: DrawableResource
+  get() = Drawable43.icon_7012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7013: DrawableResource
+  get() = Drawable43.icon_7013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7014: DrawableResource
+  get() = Drawable43.icon_7014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7015: DrawableResource
+  get() = Drawable43.icon_7015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7016: DrawableResource
+  get() = Drawable43.icon_7016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7017: DrawableResource
+  get() = Drawable43.icon_7017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7018: DrawableResource
+  get() = Drawable43.icon_7018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7019: DrawableResource
+  get() = Drawable43.icon_7019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_702: DrawableResource
+  get() = Drawable43.icon_702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7020: DrawableResource
+  get() = Drawable43.icon_7020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7021: DrawableResource
+  get() = Drawable43.icon_7021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7022: DrawableResource
+  get() = Drawable43.icon_7022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7023: DrawableResource
+  get() = Drawable43.icon_7023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7024: DrawableResource
+  get() = Drawable43.icon_7024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7025: DrawableResource
+  get() = Drawable43.icon_7025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7026: DrawableResource
+  get() = Drawable43.icon_7026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7027: DrawableResource
+  get() = Drawable43.icon_7027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7028: DrawableResource
+  get() = Drawable43.icon_7028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7029: DrawableResource
+  get() = Drawable43.icon_7029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_703: DrawableResource
+  get() = Drawable43.icon_703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7030: DrawableResource
+  get() = Drawable43.icon_7030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7031: DrawableResource
+  get() = Drawable43.icon_7031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7032: DrawableResource
+  get() = Drawable43.icon_7032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7033: DrawableResource
+  get() = Drawable43.icon_7033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7034: DrawableResource
+  get() = Drawable43.icon_7034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7035: DrawableResource
+  get() = Drawable43.icon_7035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7036: DrawableResource
+  get() = Drawable43.icon_7036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7037: DrawableResource
+  get() = Drawable43.icon_7037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7038: DrawableResource
+  get() = Drawable43.icon_7038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7039: DrawableResource
+  get() = Drawable43.icon_7039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_704: DrawableResource
+  get() = Drawable43.icon_704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7040: DrawableResource
+  get() = Drawable43.icon_7040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7041: DrawableResource
+  get() = Drawable43.icon_7041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7042: DrawableResource
+  get() = Drawable43.icon_7042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7043: DrawableResource
+  get() = Drawable43.icon_7043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7044: DrawableResource
+  get() = Drawable43.icon_7044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7045: DrawableResource
+  get() = Drawable43.icon_7045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7046: DrawableResource
+  get() = Drawable43.icon_7046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7047: DrawableResource
+  get() = Drawable43.icon_7047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7048: DrawableResource
+  get() = Drawable43.icon_7048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7049: DrawableResource
+  get() = Drawable43.icon_7049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_705: DrawableResource
+  get() = Drawable43.icon_705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7050: DrawableResource
+  get() = Drawable43.icon_7050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7051: DrawableResource
+  get() = Drawable43.icon_7051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7052: DrawableResource
+  get() = Drawable43.icon_7052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7053: DrawableResource
+  get() = Drawable43.icon_7053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7054: DrawableResource
+  get() = Drawable43.icon_7054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7055: DrawableResource
+  get() = Drawable43.icon_7055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7056: DrawableResource
+  get() = Drawable43.icon_7056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7057: DrawableResource
+  get() = Drawable43.icon_7057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7058: DrawableResource
+  get() = Drawable43.icon_7058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7059: DrawableResource
+  get() = Drawable43.icon_7059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_706: DrawableResource
+  get() = Drawable43.icon_706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7060: DrawableResource
+  get() = Drawable43.icon_7060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7061: DrawableResource
+  get() = Drawable43.icon_7061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7062: DrawableResource
+  get() = Drawable43.icon_7062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7063: DrawableResource
+  get() = Drawable43.icon_7063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7064: DrawableResource
+  get() = Drawable43.icon_7064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7065: DrawableResource
+  get() = Drawable43.icon_7065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7066: DrawableResource
+  get() = Drawable43.icon_7066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7067: DrawableResource
+  get() = Drawable43.icon_7067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7068: DrawableResource
+  get() = Drawable43.icon_7068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7069: DrawableResource
+  get() = Drawable43.icon_7069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_707: DrawableResource
+  get() = Drawable43.icon_707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7070: DrawableResource
+  get() = Drawable43.icon_7070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7071: DrawableResource
+  get() = Drawable43.icon_7071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7072: DrawableResource
+  get() = Drawable43.icon_7072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7073: DrawableResource
+  get() = Drawable43.icon_7073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7074: DrawableResource
+  get() = Drawable43.icon_7074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7075: DrawableResource
+  get() = Drawable43.icon_7075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7076: DrawableResource
+  get() = Drawable43.icon_7076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7077: DrawableResource
+  get() = Drawable43.icon_7077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7078: DrawableResource
+  get() = Drawable43.icon_7078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7079: DrawableResource
+  get() = Drawable43.icon_7079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_708: DrawableResource
+  get() = Drawable43.icon_708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7080: DrawableResource
+  get() = Drawable43.icon_7080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7081: DrawableResource
+  get() = Drawable43.icon_7081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7082: DrawableResource
+  get() = Drawable43.icon_7082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7083: DrawableResource
+  get() = Drawable43.icon_7083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7084: DrawableResource
+  get() = Drawable43.icon_7084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7085: DrawableResource
+  get() = Drawable43.icon_7085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7086: DrawableResource
+  get() = Drawable43.icon_7086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7087: DrawableResource
+  get() = Drawable43.icon_7087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7088: DrawableResource
+  get() = Drawable43.icon_7088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7089: DrawableResource
+  get() = Drawable43.icon_7089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_709: DrawableResource
+  get() = Drawable43.icon_709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7090: DrawableResource
+  get() = Drawable43.icon_7090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7091: DrawableResource
+  get() = Drawable43.icon_7091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7092: DrawableResource
+  get() = Drawable43.icon_7092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7093: DrawableResource
+  get() = Drawable43.icon_7093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7094: DrawableResource
+  get() = Drawable43.icon_7094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7095: DrawableResource
+  get() = Drawable43.icon_7095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7096: DrawableResource
+  get() = Drawable43.icon_7096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7097: DrawableResource
+  get() = Drawable43.icon_7097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7098: DrawableResource
+  get() = Drawable43.icon_7098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7099: DrawableResource
+  get() = Drawable43.icon_7099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_71: DrawableResource
+  get() = Drawable43.icon_71
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_710: DrawableResource
+  get() = Drawable43.icon_710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7100: DrawableResource
+  get() = Drawable43.icon_7100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7101: DrawableResource
+  get() = Drawable43.icon_7101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7102: DrawableResource
+  get() = Drawable43.icon_7102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7103: DrawableResource
+  get() = Drawable43.icon_7103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7104: DrawableResource
+  get() = Drawable43.icon_7104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7105: DrawableResource
+  get() = Drawable43.icon_7105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7106: DrawableResource
+  get() = Drawable43.icon_7106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7107: DrawableResource
+  get() = Drawable43.icon_7107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7108: DrawableResource
+  get() = Drawable43.icon_7108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7109: DrawableResource
+  get() = Drawable43.icon_7109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_711: DrawableResource
+  get() = Drawable43.icon_711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7110: DrawableResource
+  get() = Drawable43.icon_7110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7111: DrawableResource
+  get() = Drawable43.icon_7111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7112: DrawableResource
+  get() = Drawable43.icon_7112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7113: DrawableResource
+  get() = Drawable43.icon_7113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7114: DrawableResource
+  get() = Drawable43.icon_7114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7115: DrawableResource
+  get() = Drawable43.icon_7115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7116: DrawableResource
+  get() = Drawable43.icon_7116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7117: DrawableResource
+  get() = Drawable43.icon_7117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7118: DrawableResource
+  get() = Drawable43.icon_7118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7119: DrawableResource
+  get() = Drawable43.icon_7119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_712: DrawableResource
+  get() = Drawable43.icon_712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7120: DrawableResource
+  get() = Drawable43.icon_7120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7121: DrawableResource
+  get() = Drawable43.icon_7121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7122: DrawableResource
+  get() = Drawable43.icon_7122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7123: DrawableResource
+  get() = Drawable43.icon_7123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7124: DrawableResource
+  get() = Drawable43.icon_7124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7125: DrawableResource
+  get() = Drawable43.icon_7125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7126: DrawableResource
+  get() = Drawable43.icon_7126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7127: DrawableResource
+  get() = Drawable43.icon_7127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7128: DrawableResource
+  get() = Drawable43.icon_7128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7129: DrawableResource
+  get() = Drawable43.icon_7129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_713: DrawableResource
+  get() = Drawable43.icon_713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7130: DrawableResource
+  get() = Drawable43.icon_7130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7131: DrawableResource
+  get() = Drawable43.icon_7131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7132: DrawableResource
+  get() = Drawable43.icon_7132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7133: DrawableResource
+  get() = Drawable43.icon_7133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7134: DrawableResource
+  get() = Drawable43.icon_7134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7135: DrawableResource
+  get() = Drawable43.icon_7135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7136: DrawableResource
+  get() = Drawable43.icon_7136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7137: DrawableResource
+  get() = Drawable43.icon_7137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7138: DrawableResource
+  get() = Drawable43.icon_7138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7139: DrawableResource
+  get() = Drawable43.icon_7139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_714: DrawableResource
+  get() = Drawable43.icon_714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7140: DrawableResource
+  get() = Drawable43.icon_7140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7141: DrawableResource
+  get() = Drawable43.icon_7141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7142: DrawableResource
+  get() = Drawable43.icon_7142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7143: DrawableResource
+  get() = Drawable43.icon_7143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7144: DrawableResource
+  get() = Drawable43.icon_7144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7145: DrawableResource
+  get() = Drawable43.icon_7145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7146: DrawableResource
+  get() = Drawable43.icon_7146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7147: DrawableResource
+  get() = Drawable43.icon_7147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7148: DrawableResource
+  get() = Drawable43.icon_7148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7149: DrawableResource
+  get() = Drawable43.icon_7149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_715: DrawableResource
+  get() = Drawable43.icon_715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7150: DrawableResource
+  get() = Drawable43.icon_7150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7151: DrawableResource
+  get() = Drawable43.icon_7151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7152: DrawableResource
+  get() = Drawable43.icon_7152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7153: DrawableResource
+  get() = Drawable43.icon_7153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7154: DrawableResource
+  get() = Drawable43.icon_7154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7155: DrawableResource
+  get() = Drawable43.icon_7155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7156: DrawableResource
+  get() = Drawable43.icon_7156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7157: DrawableResource
+  get() = Drawable43.icon_7157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7158: DrawableResource
+  get() = Drawable43.icon_7158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7159: DrawableResource
+  get() = Drawable43.icon_7159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_716: DrawableResource
+  get() = Drawable43.icon_716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7160: DrawableResource
+  get() = Drawable43.icon_7160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7161: DrawableResource
+  get() = Drawable43.icon_7161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7162: DrawableResource
+  get() = Drawable43.icon_7162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7163: DrawableResource
+  get() = Drawable43.icon_7163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7164: DrawableResource
+  get() = Drawable43.icon_7164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7165: DrawableResource
+  get() = Drawable43.icon_7165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7166: DrawableResource
+  get() = Drawable43.icon_7166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7167: DrawableResource
+  get() = Drawable43.icon_7167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7168: DrawableResource
+  get() = Drawable43.icon_7168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7169: DrawableResource
+  get() = Drawable43.icon_7169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_717: DrawableResource
+  get() = Drawable43.icon_717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7170: DrawableResource
+  get() = Drawable43.icon_7170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7171: DrawableResource
+  get() = Drawable43.icon_7171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7172: DrawableResource
+  get() = Drawable43.icon_7172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7173: DrawableResource
+  get() = Drawable43.icon_7173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7174: DrawableResource
+  get() = Drawable43.icon_7174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7175: DrawableResource
+  get() = Drawable43.icon_7175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7176: DrawableResource
+  get() = Drawable43.icon_7176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7177: DrawableResource
+  get() = Drawable43.icon_7177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7178: DrawableResource
+  get() = Drawable43.icon_7178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7179: DrawableResource
+  get() = Drawable43.icon_7179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_718: DrawableResource
+  get() = Drawable43.icon_718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7180: DrawableResource
+  get() = Drawable43.icon_7180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7181: DrawableResource
+  get() = Drawable43.icon_7181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7182: DrawableResource
+  get() = Drawable43.icon_7182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7183: DrawableResource
+  get() = Drawable43.icon_7183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7184: DrawableResource
+  get() = Drawable43.icon_7184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7185: DrawableResource
+  get() = Drawable43.icon_7185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7186: DrawableResource
+  get() = Drawable43.icon_7186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7187: DrawableResource
+  get() = Drawable43.icon_7187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7188: DrawableResource
+  get() = Drawable43.icon_7188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7189: DrawableResource
+  get() = Drawable43.icon_7189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_719: DrawableResource
+  get() = Drawable43.icon_719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7190: DrawableResource
+  get() = Drawable43.icon_7190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7191: DrawableResource
+  get() = Drawable43.icon_7191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7192: DrawableResource
+  get() = Drawable43.icon_7192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7193: DrawableResource
+  get() = Drawable43.icon_7193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7194: DrawableResource
+  get() = Drawable43.icon_7194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7195: DrawableResource
+  get() = Drawable43.icon_7195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7196: DrawableResource
+  get() = Drawable43.icon_7196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7197: DrawableResource
+  get() = Drawable43.icon_7197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7198: DrawableResource
+  get() = Drawable43.icon_7198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7199: DrawableResource
+  get() = Drawable43.icon_7199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_72: DrawableResource
+  get() = Drawable43.icon_72
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_720: DrawableResource
+  get() = Drawable43.icon_720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7200: DrawableResource
+  get() = Drawable43.icon_7200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7201: DrawableResource
+  get() = Drawable43.icon_7201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7202: DrawableResource
+  get() = Drawable43.icon_7202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7203: DrawableResource
+  get() = Drawable43.icon_7203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7204: DrawableResource
+  get() = Drawable43.icon_7204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7205: DrawableResource
+  get() = Drawable43.icon_7205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7206: DrawableResource
+  get() = Drawable43.icon_7206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7207: DrawableResource
+  get() = Drawable43.icon_7207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7208: DrawableResource
+  get() = Drawable43.icon_7208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7209: DrawableResource
+  get() = Drawable43.icon_7209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_721: DrawableResource
+  get() = Drawable43.icon_721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7210: DrawableResource
+  get() = Drawable43.icon_7210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7211: DrawableResource
+  get() = Drawable43.icon_7211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7212: DrawableResource
+  get() = Drawable43.icon_7212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7213: DrawableResource
+  get() = Drawable43.icon_7213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7214: DrawableResource
+  get() = Drawable43.icon_7214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7215: DrawableResource
+  get() = Drawable43.icon_7215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7216: DrawableResource
+  get() = Drawable43.icon_7216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7217: DrawableResource
+  get() = Drawable43.icon_7217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7218: DrawableResource
+  get() = Drawable43.icon_7218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7219: DrawableResource
+  get() = Drawable43.icon_7219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_722: DrawableResource
+  get() = Drawable43.icon_722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7220: DrawableResource
+  get() = Drawable43.icon_7220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7221: DrawableResource
+  get() = Drawable43.icon_7221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7222: DrawableResource
+  get() = Drawable43.icon_7222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7223: DrawableResource
+  get() = Drawable43.icon_7223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7224: DrawableResource
+  get() = Drawable43.icon_7224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7225: DrawableResource
+  get() = Drawable43.icon_7225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7226: DrawableResource
+  get() = Drawable43.icon_7226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7227: DrawableResource
+  get() = Drawable43.icon_7227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7228: DrawableResource
+  get() = Drawable43.icon_7228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7229: DrawableResource
+  get() = Drawable43.icon_7229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_723: DrawableResource
+  get() = Drawable43.icon_723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7230: DrawableResource
+  get() = Drawable43.icon_7230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7231: DrawableResource
+  get() = Drawable43.icon_7231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7232: DrawableResource
+  get() = Drawable43.icon_7232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7233: DrawableResource
+  get() = Drawable43.icon_7233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7234: DrawableResource
+  get() = Drawable43.icon_7234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7235: DrawableResource
+  get() = Drawable43.icon_7235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7236: DrawableResource
+  get() = Drawable43.icon_7236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7237: DrawableResource
+  get() = Drawable43.icon_7237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7238: DrawableResource
+  get() = Drawable43.icon_7238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7239: DrawableResource
+  get() = Drawable43.icon_7239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_724: DrawableResource
+  get() = Drawable43.icon_724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7240: DrawableResource
+  get() = Drawable43.icon_7240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7241: DrawableResource
+  get() = Drawable43.icon_7241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7242: DrawableResource
+  get() = Drawable43.icon_7242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7243: DrawableResource
+  get() = Drawable43.icon_7243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7244: DrawableResource
+  get() = Drawable43.icon_7244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7245: DrawableResource
+  get() = Drawable43.icon_7245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7246: DrawableResource
+  get() = Drawable43.icon_7246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7247: DrawableResource
+  get() = Drawable43.icon_7247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7248: DrawableResource
+  get() = Drawable43.icon_7248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7249: DrawableResource
+  get() = Drawable43.icon_7249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_725: DrawableResource
+  get() = Drawable43.icon_725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7250: DrawableResource
+  get() = Drawable43.icon_7250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7251: DrawableResource
+  get() = Drawable43.icon_7251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7252: DrawableResource
+  get() = Drawable43.icon_7252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7253: DrawableResource
+  get() = Drawable43.icon_7253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7254: DrawableResource
+  get() = Drawable43.icon_7254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7255: DrawableResource
+  get() = Drawable43.icon_7255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7256: DrawableResource
+  get() = Drawable43.icon_7256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7257: DrawableResource
+  get() = Drawable43.icon_7257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7258: DrawableResource
+  get() = Drawable43.icon_7258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7259: DrawableResource
+  get() = Drawable43.icon_7259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_726: DrawableResource
+  get() = Drawable43.icon_726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7260: DrawableResource
+  get() = Drawable43.icon_7260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7261: DrawableResource
+  get() = Drawable43.icon_7261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7262: DrawableResource
+  get() = Drawable43.icon_7262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7263: DrawableResource
+  get() = Drawable43.icon_7263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7264: DrawableResource
+  get() = Drawable43.icon_7264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7265: DrawableResource
+  get() = Drawable43.icon_7265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7266: DrawableResource
+  get() = Drawable43.icon_7266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7267: DrawableResource
+  get() = Drawable43.icon_7267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7268: DrawableResource
+  get() = Drawable43.icon_7268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7269: DrawableResource
+  get() = Drawable43.icon_7269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_727: DrawableResource
+  get() = Drawable43.icon_727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7270: DrawableResource
+  get() = Drawable43.icon_7270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7271: DrawableResource
+  get() = Drawable43.icon_7271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7272: DrawableResource
+  get() = Drawable43.icon_7272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7273: DrawableResource
+  get() = Drawable43.icon_7273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7274: DrawableResource
+  get() = Drawable43.icon_7274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7275: DrawableResource
+  get() = Drawable43.icon_7275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7276: DrawableResource
+  get() = Drawable43.icon_7276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7277: DrawableResource
+  get() = Drawable43.icon_7277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7278: DrawableResource
+  get() = Drawable43.icon_7278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7279: DrawableResource
+  get() = Drawable43.icon_7279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_728: DrawableResource
+  get() = Drawable43.icon_728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7280: DrawableResource
+  get() = Drawable43.icon_7280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7281: DrawableResource
+  get() = Drawable43.icon_7281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7282: DrawableResource
+  get() = Drawable43.icon_7282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7283: DrawableResource
+  get() = Drawable43.icon_7283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7284: DrawableResource
+  get() = Drawable43.icon_7284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7285: DrawableResource
+  get() = Drawable43.icon_7285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7286: DrawableResource
+  get() = Drawable43.icon_7286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7287: DrawableResource
+  get() = Drawable43.icon_7287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7288: DrawableResource
+  get() = Drawable43.icon_7288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7289: DrawableResource
+  get() = Drawable43.icon_7289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_729: DrawableResource
+  get() = Drawable43.icon_729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7290: DrawableResource
+  get() = Drawable43.icon_7290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7291: DrawableResource
+  get() = Drawable43.icon_7291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7292: DrawableResource
+  get() = Drawable43.icon_7292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7293: DrawableResource
+  get() = Drawable43.icon_7293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7294: DrawableResource
+  get() = Drawable43.icon_7294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7295: DrawableResource
+  get() = Drawable43.icon_7295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7296: DrawableResource
+  get() = Drawable43.icon_7296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7297: DrawableResource
+  get() = Drawable43.icon_7297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7298: DrawableResource
+  get() = Drawable43.icon_7298

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable44.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable44.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable44 {
+  public val icon_7299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7299.xml"),
+          )
+      )
+
+  public val icon_73: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_73",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_73.xml"),
+          )
+      )
+
+  public val icon_730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_730.xml"),
+          )
+      )
+
+  public val icon_7300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7300.xml"),
+          )
+      )
+
+  public val icon_7301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7301.xml"),
+          )
+      )
+
+  public val icon_7302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7302.xml"),
+          )
+      )
+
+  public val icon_7303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7303.xml"),
+          )
+      )
+
+  public val icon_7304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7304.xml"),
+          )
+      )
+
+  public val icon_7305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7305.xml"),
+          )
+      )
+
+  public val icon_7306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7306.xml"),
+          )
+      )
+
+  public val icon_7307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7307.xml"),
+          )
+      )
+
+  public val icon_7308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7308.xml"),
+          )
+      )
+
+  public val icon_7309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7309.xml"),
+          )
+      )
+
+  public val icon_731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_731.xml"),
+          )
+      )
+
+  public val icon_7310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7310.xml"),
+          )
+      )
+
+  public val icon_7311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7311.xml"),
+          )
+      )
+
+  public val icon_7312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7312.xml"),
+          )
+      )
+
+  public val icon_7313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7313.xml"),
+          )
+      )
+
+  public val icon_7314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7314.xml"),
+          )
+      )
+
+  public val icon_7315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7315.xml"),
+          )
+      )
+
+  public val icon_7316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7316.xml"),
+          )
+      )
+
+  public val icon_7317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7317.xml"),
+          )
+      )
+
+  public val icon_7318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7318.xml"),
+          )
+      )
+
+  public val icon_7319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7319.xml"),
+          )
+      )
+
+  public val icon_732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_732.xml"),
+          )
+      )
+
+  public val icon_7320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7320.xml"),
+          )
+      )
+
+  public val icon_7321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7321.xml"),
+          )
+      )
+
+  public val icon_7322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7322.xml"),
+          )
+      )
+
+  public val icon_7323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7323.xml"),
+          )
+      )
+
+  public val icon_7324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7324.xml"),
+          )
+      )
+
+  public val icon_7325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7325.xml"),
+          )
+      )
+
+  public val icon_7326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7326.xml"),
+          )
+      )
+
+  public val icon_7327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7327.xml"),
+          )
+      )
+
+  public val icon_7328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7328.xml"),
+          )
+      )
+
+  public val icon_7329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7329.xml"),
+          )
+      )
+
+  public val icon_733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_733.xml"),
+          )
+      )
+
+  public val icon_7330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7330.xml"),
+          )
+      )
+
+  public val icon_7331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7331.xml"),
+          )
+      )
+
+  public val icon_7332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7332.xml"),
+          )
+      )
+
+  public val icon_7333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7333.xml"),
+          )
+      )
+
+  public val icon_7334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7334.xml"),
+          )
+      )
+
+  public val icon_7335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7335.xml"),
+          )
+      )
+
+  public val icon_7336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7336.xml"),
+          )
+      )
+
+  public val icon_7337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7337.xml"),
+          )
+      )
+
+  public val icon_7338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7338.xml"),
+          )
+      )
+
+  public val icon_7339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7339.xml"),
+          )
+      )
+
+  public val icon_734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_734.xml"),
+          )
+      )
+
+  public val icon_7340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7340.xml"),
+          )
+      )
+
+  public val icon_7341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7341.xml"),
+          )
+      )
+
+  public val icon_7342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7342.xml"),
+          )
+      )
+
+  public val icon_7343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7343.xml"),
+          )
+      )
+
+  public val icon_7344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7344.xml"),
+          )
+      )
+
+  public val icon_7345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7345.xml"),
+          )
+      )
+
+  public val icon_7346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7346.xml"),
+          )
+      )
+
+  public val icon_7347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7347.xml"),
+          )
+      )
+
+  public val icon_7348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7348.xml"),
+          )
+      )
+
+  public val icon_7349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7349.xml"),
+          )
+      )
+
+  public val icon_735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_735.xml"),
+          )
+      )
+
+  public val icon_7350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7350.xml"),
+          )
+      )
+
+  public val icon_7351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7351.xml"),
+          )
+      )
+
+  public val icon_7352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7352.xml"),
+          )
+      )
+
+  public val icon_7353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7353.xml"),
+          )
+      )
+
+  public val icon_7354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7354.xml"),
+          )
+      )
+
+  public val icon_7355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7355.xml"),
+          )
+      )
+
+  public val icon_7356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7356.xml"),
+          )
+      )
+
+  public val icon_7357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7357.xml"),
+          )
+      )
+
+  public val icon_7358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7358.xml"),
+          )
+      )
+
+  public val icon_7359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7359.xml"),
+          )
+      )
+
+  public val icon_736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_736.xml"),
+          )
+      )
+
+  public val icon_7360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7360.xml"),
+          )
+      )
+
+  public val icon_7361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7361.xml"),
+          )
+      )
+
+  public val icon_7362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7362.xml"),
+          )
+      )
+
+  public val icon_7363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7363.xml"),
+          )
+      )
+
+  public val icon_7364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7364.xml"),
+          )
+      )
+
+  public val icon_7365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7365.xml"),
+          )
+      )
+
+  public val icon_7366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7366.xml"),
+          )
+      )
+
+  public val icon_7367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7367.xml"),
+          )
+      )
+
+  public val icon_7368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7368.xml"),
+          )
+      )
+
+  public val icon_7369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7369.xml"),
+          )
+      )
+
+  public val icon_737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_737.xml"),
+          )
+      )
+
+  public val icon_7370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7370.xml"),
+          )
+      )
+
+  public val icon_7371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7371.xml"),
+          )
+      )
+
+  public val icon_7372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7372.xml"),
+          )
+      )
+
+  public val icon_7373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7373.xml"),
+          )
+      )
+
+  public val icon_7374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7374.xml"),
+          )
+      )
+
+  public val icon_7375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7375.xml"),
+          )
+      )
+
+  public val icon_7376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7376.xml"),
+          )
+      )
+
+  public val icon_7377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7377.xml"),
+          )
+      )
+
+  public val icon_7378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7378.xml"),
+          )
+      )
+
+  public val icon_7379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7379.xml"),
+          )
+      )
+
+  public val icon_738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_738.xml"),
+          )
+      )
+
+  public val icon_7380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7380.xml"),
+          )
+      )
+
+  public val icon_7381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7381.xml"),
+          )
+      )
+
+  public val icon_7382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7382.xml"),
+          )
+      )
+
+  public val icon_7383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7383.xml"),
+          )
+      )
+
+  public val icon_7384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7384.xml"),
+          )
+      )
+
+  public val icon_7385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7385.xml"),
+          )
+      )
+
+  public val icon_7386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7386.xml"),
+          )
+      )
+
+  public val icon_7387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7387.xml"),
+          )
+      )
+
+  public val icon_7388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7388.xml"),
+          )
+      )
+
+  public val icon_7389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7389.xml"),
+          )
+      )
+
+  public val icon_739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_739.xml"),
+          )
+      )
+
+  public val icon_7390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7390.xml"),
+          )
+      )
+
+  public val icon_7391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7391.xml"),
+          )
+      )
+
+  public val icon_7392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7392.xml"),
+          )
+      )
+
+  public val icon_7393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7393.xml"),
+          )
+      )
+
+  public val icon_7394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7394.xml"),
+          )
+      )
+
+  public val icon_7395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7395.xml"),
+          )
+      )
+
+  public val icon_7396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7396.xml"),
+          )
+      )
+
+  public val icon_7397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7397.xml"),
+          )
+      )
+
+  public val icon_7398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7398.xml"),
+          )
+      )
+
+  public val icon_7399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7399.xml"),
+          )
+      )
+
+  public val icon_74: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_74",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_74.xml"),
+          )
+      )
+
+  public val icon_740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_740.xml"),
+          )
+      )
+
+  public val icon_7400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7400.xml"),
+          )
+      )
+
+  public val icon_7401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7401.xml"),
+          )
+      )
+
+  public val icon_7402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7402.xml"),
+          )
+      )
+
+  public val icon_7403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7403.xml"),
+          )
+      )
+
+  public val icon_7404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7404.xml"),
+          )
+      )
+
+  public val icon_7405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7405.xml"),
+          )
+      )
+
+  public val icon_7406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7406.xml"),
+          )
+      )
+
+  public val icon_7407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7407.xml"),
+          )
+      )
+
+  public val icon_7408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7408.xml"),
+          )
+      )
+
+  public val icon_7409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7409.xml"),
+          )
+      )
+
+  public val icon_741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_741.xml"),
+          )
+      )
+
+  public val icon_7410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7410.xml"),
+          )
+      )
+
+  public val icon_7411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7411.xml"),
+          )
+      )
+
+  public val icon_7412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7412.xml"),
+          )
+      )
+
+  public val icon_7413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7413.xml"),
+          )
+      )
+
+  public val icon_7414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7414.xml"),
+          )
+      )
+
+  public val icon_7415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7415.xml"),
+          )
+      )
+
+  public val icon_7416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7416.xml"),
+          )
+      )
+
+  public val icon_7417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7417.xml"),
+          )
+      )
+
+  public val icon_7418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7418.xml"),
+          )
+      )
+
+  public val icon_7419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7419.xml"),
+          )
+      )
+
+  public val icon_742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_742.xml"),
+          )
+      )
+
+  public val icon_7420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7420.xml"),
+          )
+      )
+
+  public val icon_7421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7421.xml"),
+          )
+      )
+
+  public val icon_7422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7422.xml"),
+          )
+      )
+
+  public val icon_7423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7423.xml"),
+          )
+      )
+
+  public val icon_7424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7424.xml"),
+          )
+      )
+
+  public val icon_7425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7425.xml"),
+          )
+      )
+
+  public val icon_7426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7426.xml"),
+          )
+      )
+
+  public val icon_7427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7427.xml"),
+          )
+      )
+
+  public val icon_7428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7428.xml"),
+          )
+      )
+
+  public val icon_7429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7429.xml"),
+          )
+      )
+
+  public val icon_743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_743.xml"),
+          )
+      )
+
+  public val icon_7430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7430.xml"),
+          )
+      )
+
+  public val icon_7431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7431.xml"),
+          )
+      )
+
+  public val icon_7432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7432.xml"),
+          )
+      )
+
+  public val icon_7433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7433.xml"),
+          )
+      )
+
+  public val icon_7434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7434.xml"),
+          )
+      )
+
+  public val icon_7435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7435.xml"),
+          )
+      )
+
+  public val icon_7436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7436.xml"),
+          )
+      )
+
+  public val icon_7437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7437.xml"),
+          )
+      )
+
+  public val icon_7438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7438.xml"),
+          )
+      )
+
+  public val icon_7439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7439.xml"),
+          )
+      )
+
+  public val icon_744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_744.xml"),
+          )
+      )
+
+  public val icon_7440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7440.xml"),
+          )
+      )
+
+  public val icon_7441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7441.xml"),
+          )
+      )
+
+  public val icon_7442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7442.xml"),
+          )
+      )
+
+  public val icon_7443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7443.xml"),
+          )
+      )
+
+  public val icon_7444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7444.xml"),
+          )
+      )
+
+  public val icon_7445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7445.xml"),
+          )
+      )
+
+  public val icon_7446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7446.xml"),
+          )
+      )
+
+  public val icon_7447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7447.xml"),
+          )
+      )
+
+  public val icon_7448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7448.xml"),
+          )
+      )
+
+  public val icon_7449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7449.xml"),
+          )
+      )
+
+  public val icon_745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_745.xml"),
+          )
+      )
+
+  public val icon_7450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7450.xml"),
+          )
+      )
+
+  public val icon_7451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7451.xml"),
+          )
+      )
+
+  public val icon_7452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7452.xml"),
+          )
+      )
+
+  public val icon_7453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7453.xml"),
+          )
+      )
+
+  public val icon_7454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7454.xml"),
+          )
+      )
+
+  public val icon_7455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7455.xml"),
+          )
+      )
+
+  public val icon_7456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7456.xml"),
+          )
+      )
+
+  public val icon_7457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7457.xml"),
+          )
+      )
+
+  public val icon_7458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7458.xml"),
+          )
+      )
+
+  public val icon_7459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7459.xml"),
+          )
+      )
+
+  public val icon_746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_746.xml"),
+          )
+      )
+
+  public val icon_7460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7460.xml"),
+          )
+      )
+
+  public val icon_7461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7461.xml"),
+          )
+      )
+
+  public val icon_7462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7462.xml"),
+          )
+      )
+
+  public val icon_7463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7463.xml"),
+          )
+      )
+
+  public val icon_7464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7464.xml"),
+          )
+      )
+
+  public val icon_7465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7465.xml"),
+          )
+      )
+
+  public val icon_7466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7466.xml"),
+          )
+      )
+
+  public val icon_7467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7467.xml"),
+          )
+      )
+
+  public val icon_7468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7468.xml"),
+          )
+      )
+
+  public val icon_7469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7469.xml"),
+          )
+      )
+
+  public val icon_747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_747.xml"),
+          )
+      )
+
+  public val icon_7470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7470.xml"),
+          )
+      )
+
+  public val icon_7471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7471.xml"),
+          )
+      )
+
+  public val icon_7472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7472.xml"),
+          )
+      )
+
+  public val icon_7473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7473.xml"),
+          )
+      )
+
+  public val icon_7474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7474.xml"),
+          )
+      )
+
+  public val icon_7475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7475.xml"),
+          )
+      )
+
+  public val icon_7476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7476.xml"),
+          )
+      )
+
+  public val icon_7477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7477.xml"),
+          )
+      )
+
+  public val icon_7478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7478.xml"),
+          )
+      )
+
+  public val icon_7479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7479.xml"),
+          )
+      )
+
+  public val icon_748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_748.xml"),
+          )
+      )
+
+  public val icon_7480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7480.xml"),
+          )
+      )
+
+  public val icon_7481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7481.xml"),
+          )
+      )
+
+  public val icon_7482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7482.xml"),
+          )
+      )
+
+  public val icon_7483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7483.xml"),
+          )
+      )
+
+  public val icon_7484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7484.xml"),
+          )
+      )
+
+  public val icon_7485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7485.xml"),
+          )
+      )
+
+  public val icon_7486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7486.xml"),
+          )
+      )
+
+  public val icon_7487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7487.xml"),
+          )
+      )
+
+  public val icon_7488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7488.xml"),
+          )
+      )
+
+  public val icon_7489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7489.xml"),
+          )
+      )
+
+  public val icon_749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_749.xml"),
+          )
+      )
+
+  public val icon_7490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7490.xml"),
+          )
+      )
+
+  public val icon_7491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7491.xml"),
+          )
+      )
+
+  public val icon_7492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7492.xml"),
+          )
+      )
+
+  public val icon_7493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7493.xml"),
+          )
+      )
+
+  public val icon_7494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7494.xml"),
+          )
+      )
+
+  public val icon_7495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7495.xml"),
+          )
+      )
+
+  public val icon_7496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7496.xml"),
+          )
+      )
+
+  public val icon_7497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7497.xml"),
+          )
+      )
+
+  public val icon_7498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7498.xml"),
+          )
+      )
+
+  public val icon_7499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7499.xml"),
+          )
+      )
+
+  public val icon_75: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_75",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_75.xml"),
+          )
+      )
+
+  public val icon_750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_750.xml"),
+          )
+      )
+
+  public val icon_7500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7500.xml"),
+          )
+      )
+
+  public val icon_7501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7501.xml"),
+          )
+      )
+
+  public val icon_7502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7502.xml"),
+          )
+      )
+
+  public val icon_7503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7503.xml"),
+          )
+      )
+
+  public val icon_7504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7504.xml"),
+          )
+      )
+
+  public val icon_7505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7505.xml"),
+          )
+      )
+
+  public val icon_7506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7506.xml"),
+          )
+      )
+
+  public val icon_7507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7507.xml"),
+          )
+      )
+
+  public val icon_7508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7508.xml"),
+          )
+      )
+
+  public val icon_7509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7509.xml"),
+          )
+      )
+
+  public val icon_751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_751.xml"),
+          )
+      )
+
+  public val icon_7510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7510.xml"),
+          )
+      )
+
+  public val icon_7511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7511.xml"),
+          )
+      )
+
+  public val icon_7512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7512.xml"),
+          )
+      )
+
+  public val icon_7513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7513.xml"),
+          )
+      )
+
+  public val icon_7514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7514.xml"),
+          )
+      )
+
+  public val icon_7515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7515.xml"),
+          )
+      )
+
+  public val icon_7516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7516.xml"),
+          )
+      )
+
+  public val icon_7517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7517.xml"),
+          )
+      )
+
+  public val icon_7518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7518.xml"),
+          )
+      )
+
+  public val icon_7519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7519.xml"),
+          )
+      )
+
+  public val icon_752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_752.xml"),
+          )
+      )
+
+  public val icon_7520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7520.xml"),
+          )
+      )
+
+  public val icon_7521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7521.xml"),
+          )
+      )
+
+  public val icon_7522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7522.xml"),
+          )
+      )
+
+  public val icon_7523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7523.xml"),
+          )
+      )
+
+  public val icon_7524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7524.xml"),
+          )
+      )
+
+  public val icon_7525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7525.xml"),
+          )
+      )
+
+  public val icon_7526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7526.xml"),
+          )
+      )
+
+  public val icon_7527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7527.xml"),
+          )
+      )
+
+  public val icon_7528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7528.xml"),
+          )
+      )
+
+  public val icon_7529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7529.xml"),
+          )
+      )
+
+  public val icon_753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_753.xml"),
+          )
+      )
+
+  public val icon_7530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7530.xml"),
+          )
+      )
+
+  public val icon_7531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7531.xml"),
+          )
+      )
+
+  public val icon_7532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7532.xml"),
+          )
+      )
+
+  public val icon_7533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7533.xml"),
+          )
+      )
+
+  public val icon_7534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7534.xml"),
+          )
+      )
+
+  public val icon_7535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7535.xml"),
+          )
+      )
+
+  public val icon_7536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7536.xml"),
+          )
+      )
+
+  public val icon_7537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7537.xml"),
+          )
+      )
+
+  public val icon_7538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7538.xml"),
+          )
+      )
+
+  public val icon_7539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7539.xml"),
+          )
+      )
+
+  public val icon_754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_754.xml"),
+          )
+      )
+
+  public val icon_7540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7540.xml"),
+          )
+      )
+
+  public val icon_7541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7541.xml"),
+          )
+      )
+
+  public val icon_7542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7542.xml"),
+          )
+      )
+
+  public val icon_7543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7543.xml"),
+          )
+      )
+
+  public val icon_7544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7544.xml"),
+          )
+      )
+
+  public val icon_7545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7545.xml"),
+          )
+      )
+
+  public val icon_7546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7546.xml"),
+          )
+      )
+
+  public val icon_7547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7547.xml"),
+          )
+      )
+
+  public val icon_7548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7548.xml"),
+          )
+      )
+
+  public val icon_7549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7549.xml"),
+          )
+      )
+
+  public val icon_755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_755.xml"),
+          )
+      )
+
+  public val icon_7550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7550.xml"),
+          )
+      )
+
+  public val icon_7551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7551.xml"),
+          )
+      )
+
+  public val icon_7552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7552.xml"),
+          )
+      )
+
+  public val icon_7553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7553.xml"),
+          )
+      )
+
+  public val icon_7554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7554.xml"),
+          )
+      )
+
+  public val icon_7555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7555.xml"),
+          )
+      )
+
+  public val icon_7556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7556.xml"),
+          )
+      )
+
+  public val icon_7557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7557.xml"),
+          )
+      )
+
+  public val icon_7558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7558.xml"),
+          )
+      )
+
+  public val icon_7559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7559.xml"),
+          )
+      )
+
+  public val icon_756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_756.xml"),
+          )
+      )
+
+  public val icon_7560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7560.xml"),
+          )
+      )
+
+  public val icon_7561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7561.xml"),
+          )
+      )
+
+  public val icon_7562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7562.xml"),
+          )
+      )
+
+  public val icon_7563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7563.xml"),
+          )
+      )
+
+  public val icon_7564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7564.xml"),
+          )
+      )
+
+  public val icon_7565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7565.xml"),
+          )
+      )
+
+  public val icon_7566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7566.xml"),
+          )
+      )
+
+  public val icon_7567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7567.xml"),
+          )
+      )
+
+  public val icon_7568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7568.xml"),
+          )
+      )
+
+  public val icon_7569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7569.xml"),
+          )
+      )
+
+  public val icon_757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_757.xml"),
+          )
+      )
+
+  public val icon_7570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7570.xml"),
+          )
+      )
+
+  public val icon_7571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7571.xml"),
+          )
+      )
+
+  public val icon_7572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7572.xml"),
+          )
+      )
+
+  public val icon_7573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7573.xml"),
+          )
+      )
+
+  public val icon_7574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7574.xml"),
+          )
+      )
+
+  public val icon_7575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7575.xml"),
+          )
+      )
+
+  public val icon_7576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7576.xml"),
+          )
+      )
+
+  public val icon_7577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7577.xml"),
+          )
+      )
+
+  public val icon_7578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7578.xml"),
+          )
+      )
+
+  public val icon_7579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7579.xml"),
+          )
+      )
+
+  public val icon_758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_758.xml"),
+          )
+      )
+
+  public val icon_7580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7580.xml"),
+          )
+      )
+
+  public val icon_7581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7581.xml"),
+          )
+      )
+
+  public val icon_7582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7582.xml"),
+          )
+      )
+
+  public val icon_7583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7583.xml"),
+          )
+      )
+
+  public val icon_7584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7584.xml"),
+          )
+      )
+
+  public val icon_7585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7585.xml"),
+          )
+      )
+
+  public val icon_7586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7586.xml"),
+          )
+      )
+
+  public val icon_7587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7587.xml"),
+          )
+      )
+
+  public val icon_7588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7588.xml"),
+          )
+      )
+
+  public val icon_7589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7589.xml"),
+          )
+      )
+
+  public val icon_759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_759.xml"),
+          )
+      )
+
+  public val icon_7590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7590.xml"),
+          )
+      )
+
+  public val icon_7591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7591.xml"),
+          )
+      )
+
+  public val icon_7592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7592.xml"),
+          )
+      )
+
+  public val icon_7593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7593.xml"),
+          )
+      )
+
+  public val icon_7594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7594.xml"),
+          )
+      )
+
+  public val icon_7595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7595.xml"),
+          )
+      )
+
+  public val icon_7596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7596.xml"),
+          )
+      )
+
+  public val icon_7597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7597.xml"),
+          )
+      )
+
+  public val icon_7598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7598.xml"),
+          )
+      )
+
+  public val icon_7599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7599.xml"),
+          )
+      )
+
+  public val icon_76: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_76",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_76.xml"),
+          )
+      )
+
+  public val icon_760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_760.xml"),
+          )
+      )
+
+  public val icon_7600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7600.xml"),
+          )
+      )
+
+  public val icon_7601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7601.xml"),
+          )
+      )
+
+  public val icon_7602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7602.xml"),
+          )
+      )
+
+  public val icon_7603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7603.xml"),
+          )
+      )
+
+  public val icon_7604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7604.xml"),
+          )
+      )
+
+  public val icon_7605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7605.xml"),
+          )
+      )
+
+  public val icon_7606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7606.xml"),
+          )
+      )
+
+  public val icon_7607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7607.xml"),
+          )
+      )
+
+  public val icon_7608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7608.xml"),
+          )
+      )
+
+  public val icon_7609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7609.xml"),
+          )
+      )
+
+  public val icon_761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_761.xml"),
+          )
+      )
+
+  public val icon_7610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7610.xml"),
+          )
+      )
+
+  public val icon_7611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7611.xml"),
+          )
+      )
+
+  public val icon_7612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7612.xml"),
+          )
+      )
+
+  public val icon_7613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7613.xml"),
+          )
+      )
+
+  public val icon_7614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7614.xml"),
+          )
+      )
+
+  public val icon_7615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7615.xml"),
+          )
+      )
+
+  public val icon_7616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7616.xml"),
+          )
+      )
+
+  public val icon_7617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7617.xml"),
+          )
+      )
+
+  public val icon_7618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7618.xml"),
+          )
+      )
+
+  public val icon_7619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7619.xml"),
+          )
+      )
+
+  public val icon_762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_762.xml"),
+          )
+      )
+
+  public val icon_7620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7620.xml"),
+          )
+      )
+
+  public val icon_7621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7621.xml"),
+          )
+      )
+
+  public val icon_7622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7622.xml"),
+          )
+      )
+
+  public val icon_7623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7623.xml"),
+          )
+      )
+
+  public val icon_7624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7624.xml"),
+          )
+      )
+
+  public val icon_7625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7625.xml"),
+          )
+      )
+
+  public val icon_7626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7626.xml"),
+          )
+      )
+
+  public val icon_7627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7627.xml"),
+          )
+      )
+
+  public val icon_7628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7628.xml"),
+          )
+      )
+
+  public val icon_7629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7629.xml"),
+          )
+      )
+
+  public val icon_763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_763.xml"),
+          )
+      )
+
+  public val icon_7630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7630.xml"),
+          )
+      )
+
+  public val icon_7631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7631.xml"),
+          )
+      )
+
+  public val icon_7632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7632.xml"),
+          )
+      )
+
+  public val icon_7633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7633.xml"),
+          )
+      )
+
+  public val icon_7634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7634.xml"),
+          )
+      )
+
+  public val icon_7635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7635.xml"),
+          )
+      )
+
+  public val icon_7636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7636.xml"),
+          )
+      )
+
+  public val icon_7637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7637.xml"),
+          )
+      )
+
+  public val icon_7638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7638.xml"),
+          )
+      )
+
+  public val icon_7639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7639.xml"),
+          )
+      )
+
+  public val icon_764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_764.xml"),
+          )
+      )
+
+  public val icon_7640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7640.xml"),
+          )
+      )
+
+  public val icon_7641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7641.xml"),
+          )
+      )
+
+  public val icon_7642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7642.xml"),
+          )
+      )
+
+  public val icon_7643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7643.xml"),
+          )
+      )
+
+  public val icon_7644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7644.xml"),
+          )
+      )
+
+  public val icon_7645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7645.xml"),
+          )
+      )
+
+  public val icon_7646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7646.xml"),
+          )
+      )
+
+  public val icon_7647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7647.xml"),
+          )
+      )
+
+  public val icon_7648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7648.xml"),
+          )
+      )
+
+  public val icon_7649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7649.xml"),
+          )
+      )
+
+  public val icon_765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_765.xml"),
+          )
+      )
+
+  public val icon_7650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7650.xml"),
+          )
+      )
+
+  public val icon_7651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7651.xml"),
+          )
+      )
+
+  public val icon_7652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7652.xml"),
+          )
+      )
+
+  public val icon_7653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7653.xml"),
+          )
+      )
+
+  public val icon_7654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7654.xml"),
+          )
+      )
+
+  public val icon_7655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7655.xml"),
+          )
+      )
+
+  public val icon_7656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7656.xml"),
+          )
+      )
+
+  public val icon_7657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7657.xml"),
+          )
+      )
+
+  public val icon_7658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7658.xml"),
+          )
+      )
+
+  public val icon_7659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7659.xml"),
+          )
+      )
+
+  public val icon_766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_766.xml"),
+          )
+      )
+
+  public val icon_7660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7660.xml"),
+          )
+      )
+
+  public val icon_7661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7661.xml"),
+          )
+      )
+
+  public val icon_7662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7662.xml"),
+          )
+      )
+
+  public val icon_7663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7663.xml"),
+          )
+      )
+
+  public val icon_7664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7664.xml"),
+          )
+      )
+
+  public val icon_7665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7665.xml"),
+          )
+      )
+
+  public val icon_7666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7666.xml"),
+          )
+      )
+
+  public val icon_7667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7667.xml"),
+          )
+      )
+
+  public val icon_7668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7668.xml"),
+          )
+      )
+
+  public val icon_7669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7669.xml"),
+          )
+      )
+
+  public val icon_767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_767.xml"),
+          )
+      )
+
+  public val icon_7670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7670.xml"),
+          )
+      )
+
+  public val icon_7671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7671.xml"),
+          )
+      )
+
+  public val icon_7672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7672.xml"),
+          )
+      )
+
+  public val icon_7673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7673.xml"),
+          )
+      )
+
+  public val icon_7674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7674.xml"),
+          )
+      )
+
+  public val icon_7675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7675.xml"),
+          )
+      )
+
+  public val icon_7676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7676.xml"),
+          )
+      )
+
+  public val icon_7677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7677.xml"),
+          )
+      )
+
+  public val icon_7678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7678.xml"),
+          )
+      )
+
+  public val icon_7679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7679.xml"),
+          )
+      )
+
+  public val icon_768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_768.xml"),
+          )
+      )
+
+  public val icon_7680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7680.xml"),
+          )
+      )
+
+  public val icon_7681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7681.xml"),
+          )
+      )
+
+  public val icon_7682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7682.xml"),
+          )
+      )
+
+  public val icon_7683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7683.xml"),
+          )
+      )
+
+  public val icon_7684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7684.xml"),
+          )
+      )
+
+  public val icon_7685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7685.xml"),
+          )
+      )
+
+  public val icon_7686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7686.xml"),
+          )
+      )
+
+  public val icon_7687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7687.xml"),
+          )
+      )
+
+  public val icon_7688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7688.xml"),
+          )
+      )
+
+  public val icon_7689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7689.xml"),
+          )
+      )
+
+  public val icon_769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_769.xml"),
+          )
+      )
+
+  public val icon_7690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7690.xml"),
+          )
+      )
+
+  public val icon_7691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7691.xml"),
+          )
+      )
+
+  public val icon_7692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7692.xml"),
+          )
+      )
+
+  public val icon_7693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7693.xml"),
+          )
+      )
+
+  public val icon_7694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7694.xml"),
+          )
+      )
+
+  public val icon_7695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7695.xml"),
+          )
+      )
+
+  public val icon_7696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7696.xml"),
+          )
+      )
+
+  public val icon_7697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7697.xml"),
+          )
+      )
+
+  public val icon_7698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7698.xml"),
+          )
+      )
+
+  public val icon_7699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7699.xml"),
+          )
+      )
+
+  public val icon_77: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_77",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_77.xml"),
+          )
+      )
+
+  public val icon_770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_770.xml"),
+          )
+      )
+
+  public val icon_7700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7700.xml"),
+          )
+      )
+
+  public val icon_7701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7701.xml"),
+          )
+      )
+
+  public val icon_7702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7702.xml"),
+          )
+      )
+
+  public val icon_7703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7703.xml"),
+          )
+      )
+
+  public val icon_7704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7704.xml"),
+          )
+      )
+
+  public val icon_7705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7705.xml"),
+          )
+      )
+
+  public val icon_7706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7706.xml"),
+          )
+      )
+
+  public val icon_7707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7707.xml"),
+          )
+      )
+
+  public val icon_7708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7708.xml"),
+          )
+      )
+
+  public val icon_7709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7709.xml"),
+          )
+      )
+
+  public val icon_771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_771.xml"),
+          )
+      )
+
+  public val icon_7710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7710.xml"),
+          )
+      )
+
+  public val icon_7711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7711.xml"),
+          )
+      )
+
+  public val icon_7712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7712.xml"),
+          )
+      )
+
+  public val icon_7713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7713.xml"),
+          )
+      )
+
+  public val icon_7714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7714.xml"),
+          )
+      )
+
+  public val icon_7715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7715.xml"),
+          )
+      )
+
+  public val icon_7716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7716.xml"),
+          )
+      )
+
+  public val icon_7717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7717.xml"),
+          )
+      )
+
+  public val icon_7718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7718.xml"),
+          )
+      )
+
+  public val icon_7719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7719.xml"),
+          )
+      )
+
+  public val icon_772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_772.xml"),
+          )
+      )
+
+  public val icon_7720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7720.xml"),
+          )
+      )
+
+  public val icon_7721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7721.xml"),
+          )
+      )
+
+  public val icon_7722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7722.xml"),
+          )
+      )
+
+  public val icon_7723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7723.xml"),
+          )
+      )
+
+  public val icon_7724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7724.xml"),
+          )
+      )
+
+  public val icon_7725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7725.xml"),
+          )
+      )
+
+  public val icon_7726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7726.xml"),
+          )
+      )
+
+  public val icon_7727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7727.xml"),
+          )
+      )
+
+  public val icon_7728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7728.xml"),
+          )
+      )
+
+  public val icon_7729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7729.xml"),
+          )
+      )
+
+  public val icon_773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_773.xml"),
+          )
+      )
+
+  public val icon_7730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7730.xml"),
+          )
+      )
+
+  public val icon_7731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7731.xml"),
+          )
+      )
+
+  public val icon_7732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7732.xml"),
+          )
+      )
+
+  public val icon_7733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7733.xml"),
+          )
+      )
+
+  public val icon_7734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7734.xml"),
+          )
+      )
+
+  public val icon_7735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7735.xml"),
+          )
+      )
+
+  public val icon_7736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7736.xml"),
+          )
+      )
+
+  public val icon_7737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7737.xml"),
+          )
+      )
+
+  public val icon_7738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7738.xml"),
+          )
+      )
+
+  public val icon_7739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7739.xml"),
+          )
+      )
+
+  public val icon_774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_774.xml"),
+          )
+      )
+
+  public val icon_7740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7740.xml"),
+          )
+      )
+
+  public val icon_7741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7741.xml"),
+          )
+      )
+
+  public val icon_7742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7742.xml"),
+          )
+      )
+
+  public val icon_7743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7743.xml"),
+          )
+      )
+
+  public val icon_7744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7744.xml"),
+          )
+      )
+
+  public val icon_7745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7745.xml"),
+          )
+      )
+
+  public val icon_7746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7746.xml"),
+          )
+      )
+
+  public val icon_7747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7747.xml"),
+          )
+      )
+
+  public val icon_7748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7748.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7299: DrawableResource
+  get() = Drawable44.icon_7299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_73: DrawableResource
+  get() = Drawable44.icon_73
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_730: DrawableResource
+  get() = Drawable44.icon_730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7300: DrawableResource
+  get() = Drawable44.icon_7300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7301: DrawableResource
+  get() = Drawable44.icon_7301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7302: DrawableResource
+  get() = Drawable44.icon_7302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7303: DrawableResource
+  get() = Drawable44.icon_7303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7304: DrawableResource
+  get() = Drawable44.icon_7304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7305: DrawableResource
+  get() = Drawable44.icon_7305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7306: DrawableResource
+  get() = Drawable44.icon_7306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7307: DrawableResource
+  get() = Drawable44.icon_7307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7308: DrawableResource
+  get() = Drawable44.icon_7308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7309: DrawableResource
+  get() = Drawable44.icon_7309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_731: DrawableResource
+  get() = Drawable44.icon_731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7310: DrawableResource
+  get() = Drawable44.icon_7310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7311: DrawableResource
+  get() = Drawable44.icon_7311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7312: DrawableResource
+  get() = Drawable44.icon_7312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7313: DrawableResource
+  get() = Drawable44.icon_7313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7314: DrawableResource
+  get() = Drawable44.icon_7314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7315: DrawableResource
+  get() = Drawable44.icon_7315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7316: DrawableResource
+  get() = Drawable44.icon_7316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7317: DrawableResource
+  get() = Drawable44.icon_7317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7318: DrawableResource
+  get() = Drawable44.icon_7318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7319: DrawableResource
+  get() = Drawable44.icon_7319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_732: DrawableResource
+  get() = Drawable44.icon_732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7320: DrawableResource
+  get() = Drawable44.icon_7320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7321: DrawableResource
+  get() = Drawable44.icon_7321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7322: DrawableResource
+  get() = Drawable44.icon_7322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7323: DrawableResource
+  get() = Drawable44.icon_7323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7324: DrawableResource
+  get() = Drawable44.icon_7324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7325: DrawableResource
+  get() = Drawable44.icon_7325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7326: DrawableResource
+  get() = Drawable44.icon_7326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7327: DrawableResource
+  get() = Drawable44.icon_7327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7328: DrawableResource
+  get() = Drawable44.icon_7328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7329: DrawableResource
+  get() = Drawable44.icon_7329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_733: DrawableResource
+  get() = Drawable44.icon_733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7330: DrawableResource
+  get() = Drawable44.icon_7330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7331: DrawableResource
+  get() = Drawable44.icon_7331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7332: DrawableResource
+  get() = Drawable44.icon_7332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7333: DrawableResource
+  get() = Drawable44.icon_7333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7334: DrawableResource
+  get() = Drawable44.icon_7334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7335: DrawableResource
+  get() = Drawable44.icon_7335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7336: DrawableResource
+  get() = Drawable44.icon_7336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7337: DrawableResource
+  get() = Drawable44.icon_7337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7338: DrawableResource
+  get() = Drawable44.icon_7338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7339: DrawableResource
+  get() = Drawable44.icon_7339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_734: DrawableResource
+  get() = Drawable44.icon_734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7340: DrawableResource
+  get() = Drawable44.icon_7340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7341: DrawableResource
+  get() = Drawable44.icon_7341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7342: DrawableResource
+  get() = Drawable44.icon_7342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7343: DrawableResource
+  get() = Drawable44.icon_7343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7344: DrawableResource
+  get() = Drawable44.icon_7344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7345: DrawableResource
+  get() = Drawable44.icon_7345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7346: DrawableResource
+  get() = Drawable44.icon_7346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7347: DrawableResource
+  get() = Drawable44.icon_7347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7348: DrawableResource
+  get() = Drawable44.icon_7348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7349: DrawableResource
+  get() = Drawable44.icon_7349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_735: DrawableResource
+  get() = Drawable44.icon_735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7350: DrawableResource
+  get() = Drawable44.icon_7350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7351: DrawableResource
+  get() = Drawable44.icon_7351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7352: DrawableResource
+  get() = Drawable44.icon_7352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7353: DrawableResource
+  get() = Drawable44.icon_7353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7354: DrawableResource
+  get() = Drawable44.icon_7354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7355: DrawableResource
+  get() = Drawable44.icon_7355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7356: DrawableResource
+  get() = Drawable44.icon_7356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7357: DrawableResource
+  get() = Drawable44.icon_7357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7358: DrawableResource
+  get() = Drawable44.icon_7358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7359: DrawableResource
+  get() = Drawable44.icon_7359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_736: DrawableResource
+  get() = Drawable44.icon_736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7360: DrawableResource
+  get() = Drawable44.icon_7360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7361: DrawableResource
+  get() = Drawable44.icon_7361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7362: DrawableResource
+  get() = Drawable44.icon_7362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7363: DrawableResource
+  get() = Drawable44.icon_7363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7364: DrawableResource
+  get() = Drawable44.icon_7364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7365: DrawableResource
+  get() = Drawable44.icon_7365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7366: DrawableResource
+  get() = Drawable44.icon_7366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7367: DrawableResource
+  get() = Drawable44.icon_7367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7368: DrawableResource
+  get() = Drawable44.icon_7368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7369: DrawableResource
+  get() = Drawable44.icon_7369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_737: DrawableResource
+  get() = Drawable44.icon_737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7370: DrawableResource
+  get() = Drawable44.icon_7370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7371: DrawableResource
+  get() = Drawable44.icon_7371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7372: DrawableResource
+  get() = Drawable44.icon_7372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7373: DrawableResource
+  get() = Drawable44.icon_7373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7374: DrawableResource
+  get() = Drawable44.icon_7374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7375: DrawableResource
+  get() = Drawable44.icon_7375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7376: DrawableResource
+  get() = Drawable44.icon_7376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7377: DrawableResource
+  get() = Drawable44.icon_7377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7378: DrawableResource
+  get() = Drawable44.icon_7378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7379: DrawableResource
+  get() = Drawable44.icon_7379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_738: DrawableResource
+  get() = Drawable44.icon_738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7380: DrawableResource
+  get() = Drawable44.icon_7380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7381: DrawableResource
+  get() = Drawable44.icon_7381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7382: DrawableResource
+  get() = Drawable44.icon_7382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7383: DrawableResource
+  get() = Drawable44.icon_7383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7384: DrawableResource
+  get() = Drawable44.icon_7384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7385: DrawableResource
+  get() = Drawable44.icon_7385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7386: DrawableResource
+  get() = Drawable44.icon_7386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7387: DrawableResource
+  get() = Drawable44.icon_7387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7388: DrawableResource
+  get() = Drawable44.icon_7388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7389: DrawableResource
+  get() = Drawable44.icon_7389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_739: DrawableResource
+  get() = Drawable44.icon_739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7390: DrawableResource
+  get() = Drawable44.icon_7390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7391: DrawableResource
+  get() = Drawable44.icon_7391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7392: DrawableResource
+  get() = Drawable44.icon_7392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7393: DrawableResource
+  get() = Drawable44.icon_7393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7394: DrawableResource
+  get() = Drawable44.icon_7394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7395: DrawableResource
+  get() = Drawable44.icon_7395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7396: DrawableResource
+  get() = Drawable44.icon_7396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7397: DrawableResource
+  get() = Drawable44.icon_7397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7398: DrawableResource
+  get() = Drawable44.icon_7398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7399: DrawableResource
+  get() = Drawable44.icon_7399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_74: DrawableResource
+  get() = Drawable44.icon_74
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_740: DrawableResource
+  get() = Drawable44.icon_740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7400: DrawableResource
+  get() = Drawable44.icon_7400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7401: DrawableResource
+  get() = Drawable44.icon_7401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7402: DrawableResource
+  get() = Drawable44.icon_7402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7403: DrawableResource
+  get() = Drawable44.icon_7403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7404: DrawableResource
+  get() = Drawable44.icon_7404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7405: DrawableResource
+  get() = Drawable44.icon_7405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7406: DrawableResource
+  get() = Drawable44.icon_7406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7407: DrawableResource
+  get() = Drawable44.icon_7407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7408: DrawableResource
+  get() = Drawable44.icon_7408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7409: DrawableResource
+  get() = Drawable44.icon_7409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_741: DrawableResource
+  get() = Drawable44.icon_741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7410: DrawableResource
+  get() = Drawable44.icon_7410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7411: DrawableResource
+  get() = Drawable44.icon_7411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7412: DrawableResource
+  get() = Drawable44.icon_7412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7413: DrawableResource
+  get() = Drawable44.icon_7413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7414: DrawableResource
+  get() = Drawable44.icon_7414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7415: DrawableResource
+  get() = Drawable44.icon_7415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7416: DrawableResource
+  get() = Drawable44.icon_7416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7417: DrawableResource
+  get() = Drawable44.icon_7417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7418: DrawableResource
+  get() = Drawable44.icon_7418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7419: DrawableResource
+  get() = Drawable44.icon_7419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_742: DrawableResource
+  get() = Drawable44.icon_742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7420: DrawableResource
+  get() = Drawable44.icon_7420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7421: DrawableResource
+  get() = Drawable44.icon_7421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7422: DrawableResource
+  get() = Drawable44.icon_7422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7423: DrawableResource
+  get() = Drawable44.icon_7423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7424: DrawableResource
+  get() = Drawable44.icon_7424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7425: DrawableResource
+  get() = Drawable44.icon_7425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7426: DrawableResource
+  get() = Drawable44.icon_7426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7427: DrawableResource
+  get() = Drawable44.icon_7427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7428: DrawableResource
+  get() = Drawable44.icon_7428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7429: DrawableResource
+  get() = Drawable44.icon_7429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_743: DrawableResource
+  get() = Drawable44.icon_743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7430: DrawableResource
+  get() = Drawable44.icon_7430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7431: DrawableResource
+  get() = Drawable44.icon_7431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7432: DrawableResource
+  get() = Drawable44.icon_7432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7433: DrawableResource
+  get() = Drawable44.icon_7433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7434: DrawableResource
+  get() = Drawable44.icon_7434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7435: DrawableResource
+  get() = Drawable44.icon_7435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7436: DrawableResource
+  get() = Drawable44.icon_7436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7437: DrawableResource
+  get() = Drawable44.icon_7437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7438: DrawableResource
+  get() = Drawable44.icon_7438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7439: DrawableResource
+  get() = Drawable44.icon_7439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_744: DrawableResource
+  get() = Drawable44.icon_744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7440: DrawableResource
+  get() = Drawable44.icon_7440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7441: DrawableResource
+  get() = Drawable44.icon_7441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7442: DrawableResource
+  get() = Drawable44.icon_7442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7443: DrawableResource
+  get() = Drawable44.icon_7443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7444: DrawableResource
+  get() = Drawable44.icon_7444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7445: DrawableResource
+  get() = Drawable44.icon_7445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7446: DrawableResource
+  get() = Drawable44.icon_7446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7447: DrawableResource
+  get() = Drawable44.icon_7447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7448: DrawableResource
+  get() = Drawable44.icon_7448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7449: DrawableResource
+  get() = Drawable44.icon_7449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_745: DrawableResource
+  get() = Drawable44.icon_745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7450: DrawableResource
+  get() = Drawable44.icon_7450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7451: DrawableResource
+  get() = Drawable44.icon_7451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7452: DrawableResource
+  get() = Drawable44.icon_7452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7453: DrawableResource
+  get() = Drawable44.icon_7453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7454: DrawableResource
+  get() = Drawable44.icon_7454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7455: DrawableResource
+  get() = Drawable44.icon_7455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7456: DrawableResource
+  get() = Drawable44.icon_7456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7457: DrawableResource
+  get() = Drawable44.icon_7457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7458: DrawableResource
+  get() = Drawable44.icon_7458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7459: DrawableResource
+  get() = Drawable44.icon_7459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_746: DrawableResource
+  get() = Drawable44.icon_746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7460: DrawableResource
+  get() = Drawable44.icon_7460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7461: DrawableResource
+  get() = Drawable44.icon_7461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7462: DrawableResource
+  get() = Drawable44.icon_7462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7463: DrawableResource
+  get() = Drawable44.icon_7463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7464: DrawableResource
+  get() = Drawable44.icon_7464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7465: DrawableResource
+  get() = Drawable44.icon_7465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7466: DrawableResource
+  get() = Drawable44.icon_7466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7467: DrawableResource
+  get() = Drawable44.icon_7467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7468: DrawableResource
+  get() = Drawable44.icon_7468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7469: DrawableResource
+  get() = Drawable44.icon_7469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_747: DrawableResource
+  get() = Drawable44.icon_747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7470: DrawableResource
+  get() = Drawable44.icon_7470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7471: DrawableResource
+  get() = Drawable44.icon_7471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7472: DrawableResource
+  get() = Drawable44.icon_7472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7473: DrawableResource
+  get() = Drawable44.icon_7473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7474: DrawableResource
+  get() = Drawable44.icon_7474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7475: DrawableResource
+  get() = Drawable44.icon_7475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7476: DrawableResource
+  get() = Drawable44.icon_7476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7477: DrawableResource
+  get() = Drawable44.icon_7477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7478: DrawableResource
+  get() = Drawable44.icon_7478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7479: DrawableResource
+  get() = Drawable44.icon_7479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_748: DrawableResource
+  get() = Drawable44.icon_748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7480: DrawableResource
+  get() = Drawable44.icon_7480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7481: DrawableResource
+  get() = Drawable44.icon_7481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7482: DrawableResource
+  get() = Drawable44.icon_7482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7483: DrawableResource
+  get() = Drawable44.icon_7483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7484: DrawableResource
+  get() = Drawable44.icon_7484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7485: DrawableResource
+  get() = Drawable44.icon_7485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7486: DrawableResource
+  get() = Drawable44.icon_7486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7487: DrawableResource
+  get() = Drawable44.icon_7487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7488: DrawableResource
+  get() = Drawable44.icon_7488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7489: DrawableResource
+  get() = Drawable44.icon_7489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_749: DrawableResource
+  get() = Drawable44.icon_749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7490: DrawableResource
+  get() = Drawable44.icon_7490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7491: DrawableResource
+  get() = Drawable44.icon_7491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7492: DrawableResource
+  get() = Drawable44.icon_7492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7493: DrawableResource
+  get() = Drawable44.icon_7493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7494: DrawableResource
+  get() = Drawable44.icon_7494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7495: DrawableResource
+  get() = Drawable44.icon_7495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7496: DrawableResource
+  get() = Drawable44.icon_7496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7497: DrawableResource
+  get() = Drawable44.icon_7497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7498: DrawableResource
+  get() = Drawable44.icon_7498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7499: DrawableResource
+  get() = Drawable44.icon_7499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_75: DrawableResource
+  get() = Drawable44.icon_75
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_750: DrawableResource
+  get() = Drawable44.icon_750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7500: DrawableResource
+  get() = Drawable44.icon_7500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7501: DrawableResource
+  get() = Drawable44.icon_7501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7502: DrawableResource
+  get() = Drawable44.icon_7502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7503: DrawableResource
+  get() = Drawable44.icon_7503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7504: DrawableResource
+  get() = Drawable44.icon_7504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7505: DrawableResource
+  get() = Drawable44.icon_7505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7506: DrawableResource
+  get() = Drawable44.icon_7506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7507: DrawableResource
+  get() = Drawable44.icon_7507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7508: DrawableResource
+  get() = Drawable44.icon_7508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7509: DrawableResource
+  get() = Drawable44.icon_7509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_751: DrawableResource
+  get() = Drawable44.icon_751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7510: DrawableResource
+  get() = Drawable44.icon_7510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7511: DrawableResource
+  get() = Drawable44.icon_7511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7512: DrawableResource
+  get() = Drawable44.icon_7512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7513: DrawableResource
+  get() = Drawable44.icon_7513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7514: DrawableResource
+  get() = Drawable44.icon_7514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7515: DrawableResource
+  get() = Drawable44.icon_7515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7516: DrawableResource
+  get() = Drawable44.icon_7516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7517: DrawableResource
+  get() = Drawable44.icon_7517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7518: DrawableResource
+  get() = Drawable44.icon_7518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7519: DrawableResource
+  get() = Drawable44.icon_7519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_752: DrawableResource
+  get() = Drawable44.icon_752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7520: DrawableResource
+  get() = Drawable44.icon_7520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7521: DrawableResource
+  get() = Drawable44.icon_7521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7522: DrawableResource
+  get() = Drawable44.icon_7522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7523: DrawableResource
+  get() = Drawable44.icon_7523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7524: DrawableResource
+  get() = Drawable44.icon_7524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7525: DrawableResource
+  get() = Drawable44.icon_7525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7526: DrawableResource
+  get() = Drawable44.icon_7526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7527: DrawableResource
+  get() = Drawable44.icon_7527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7528: DrawableResource
+  get() = Drawable44.icon_7528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7529: DrawableResource
+  get() = Drawable44.icon_7529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_753: DrawableResource
+  get() = Drawable44.icon_753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7530: DrawableResource
+  get() = Drawable44.icon_7530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7531: DrawableResource
+  get() = Drawable44.icon_7531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7532: DrawableResource
+  get() = Drawable44.icon_7532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7533: DrawableResource
+  get() = Drawable44.icon_7533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7534: DrawableResource
+  get() = Drawable44.icon_7534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7535: DrawableResource
+  get() = Drawable44.icon_7535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7536: DrawableResource
+  get() = Drawable44.icon_7536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7537: DrawableResource
+  get() = Drawable44.icon_7537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7538: DrawableResource
+  get() = Drawable44.icon_7538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7539: DrawableResource
+  get() = Drawable44.icon_7539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_754: DrawableResource
+  get() = Drawable44.icon_754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7540: DrawableResource
+  get() = Drawable44.icon_7540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7541: DrawableResource
+  get() = Drawable44.icon_7541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7542: DrawableResource
+  get() = Drawable44.icon_7542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7543: DrawableResource
+  get() = Drawable44.icon_7543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7544: DrawableResource
+  get() = Drawable44.icon_7544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7545: DrawableResource
+  get() = Drawable44.icon_7545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7546: DrawableResource
+  get() = Drawable44.icon_7546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7547: DrawableResource
+  get() = Drawable44.icon_7547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7548: DrawableResource
+  get() = Drawable44.icon_7548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7549: DrawableResource
+  get() = Drawable44.icon_7549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_755: DrawableResource
+  get() = Drawable44.icon_755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7550: DrawableResource
+  get() = Drawable44.icon_7550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7551: DrawableResource
+  get() = Drawable44.icon_7551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7552: DrawableResource
+  get() = Drawable44.icon_7552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7553: DrawableResource
+  get() = Drawable44.icon_7553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7554: DrawableResource
+  get() = Drawable44.icon_7554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7555: DrawableResource
+  get() = Drawable44.icon_7555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7556: DrawableResource
+  get() = Drawable44.icon_7556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7557: DrawableResource
+  get() = Drawable44.icon_7557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7558: DrawableResource
+  get() = Drawable44.icon_7558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7559: DrawableResource
+  get() = Drawable44.icon_7559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_756: DrawableResource
+  get() = Drawable44.icon_756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7560: DrawableResource
+  get() = Drawable44.icon_7560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7561: DrawableResource
+  get() = Drawable44.icon_7561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7562: DrawableResource
+  get() = Drawable44.icon_7562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7563: DrawableResource
+  get() = Drawable44.icon_7563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7564: DrawableResource
+  get() = Drawable44.icon_7564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7565: DrawableResource
+  get() = Drawable44.icon_7565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7566: DrawableResource
+  get() = Drawable44.icon_7566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7567: DrawableResource
+  get() = Drawable44.icon_7567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7568: DrawableResource
+  get() = Drawable44.icon_7568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7569: DrawableResource
+  get() = Drawable44.icon_7569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_757: DrawableResource
+  get() = Drawable44.icon_757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7570: DrawableResource
+  get() = Drawable44.icon_7570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7571: DrawableResource
+  get() = Drawable44.icon_7571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7572: DrawableResource
+  get() = Drawable44.icon_7572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7573: DrawableResource
+  get() = Drawable44.icon_7573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7574: DrawableResource
+  get() = Drawable44.icon_7574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7575: DrawableResource
+  get() = Drawable44.icon_7575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7576: DrawableResource
+  get() = Drawable44.icon_7576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7577: DrawableResource
+  get() = Drawable44.icon_7577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7578: DrawableResource
+  get() = Drawable44.icon_7578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7579: DrawableResource
+  get() = Drawable44.icon_7579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_758: DrawableResource
+  get() = Drawable44.icon_758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7580: DrawableResource
+  get() = Drawable44.icon_7580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7581: DrawableResource
+  get() = Drawable44.icon_7581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7582: DrawableResource
+  get() = Drawable44.icon_7582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7583: DrawableResource
+  get() = Drawable44.icon_7583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7584: DrawableResource
+  get() = Drawable44.icon_7584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7585: DrawableResource
+  get() = Drawable44.icon_7585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7586: DrawableResource
+  get() = Drawable44.icon_7586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7587: DrawableResource
+  get() = Drawable44.icon_7587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7588: DrawableResource
+  get() = Drawable44.icon_7588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7589: DrawableResource
+  get() = Drawable44.icon_7589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_759: DrawableResource
+  get() = Drawable44.icon_759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7590: DrawableResource
+  get() = Drawable44.icon_7590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7591: DrawableResource
+  get() = Drawable44.icon_7591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7592: DrawableResource
+  get() = Drawable44.icon_7592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7593: DrawableResource
+  get() = Drawable44.icon_7593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7594: DrawableResource
+  get() = Drawable44.icon_7594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7595: DrawableResource
+  get() = Drawable44.icon_7595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7596: DrawableResource
+  get() = Drawable44.icon_7596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7597: DrawableResource
+  get() = Drawable44.icon_7597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7598: DrawableResource
+  get() = Drawable44.icon_7598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7599: DrawableResource
+  get() = Drawable44.icon_7599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_76: DrawableResource
+  get() = Drawable44.icon_76
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_760: DrawableResource
+  get() = Drawable44.icon_760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7600: DrawableResource
+  get() = Drawable44.icon_7600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7601: DrawableResource
+  get() = Drawable44.icon_7601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7602: DrawableResource
+  get() = Drawable44.icon_7602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7603: DrawableResource
+  get() = Drawable44.icon_7603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7604: DrawableResource
+  get() = Drawable44.icon_7604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7605: DrawableResource
+  get() = Drawable44.icon_7605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7606: DrawableResource
+  get() = Drawable44.icon_7606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7607: DrawableResource
+  get() = Drawable44.icon_7607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7608: DrawableResource
+  get() = Drawable44.icon_7608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7609: DrawableResource
+  get() = Drawable44.icon_7609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_761: DrawableResource
+  get() = Drawable44.icon_761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7610: DrawableResource
+  get() = Drawable44.icon_7610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7611: DrawableResource
+  get() = Drawable44.icon_7611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7612: DrawableResource
+  get() = Drawable44.icon_7612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7613: DrawableResource
+  get() = Drawable44.icon_7613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7614: DrawableResource
+  get() = Drawable44.icon_7614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7615: DrawableResource
+  get() = Drawable44.icon_7615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7616: DrawableResource
+  get() = Drawable44.icon_7616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7617: DrawableResource
+  get() = Drawable44.icon_7617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7618: DrawableResource
+  get() = Drawable44.icon_7618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7619: DrawableResource
+  get() = Drawable44.icon_7619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_762: DrawableResource
+  get() = Drawable44.icon_762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7620: DrawableResource
+  get() = Drawable44.icon_7620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7621: DrawableResource
+  get() = Drawable44.icon_7621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7622: DrawableResource
+  get() = Drawable44.icon_7622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7623: DrawableResource
+  get() = Drawable44.icon_7623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7624: DrawableResource
+  get() = Drawable44.icon_7624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7625: DrawableResource
+  get() = Drawable44.icon_7625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7626: DrawableResource
+  get() = Drawable44.icon_7626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7627: DrawableResource
+  get() = Drawable44.icon_7627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7628: DrawableResource
+  get() = Drawable44.icon_7628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7629: DrawableResource
+  get() = Drawable44.icon_7629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_763: DrawableResource
+  get() = Drawable44.icon_763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7630: DrawableResource
+  get() = Drawable44.icon_7630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7631: DrawableResource
+  get() = Drawable44.icon_7631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7632: DrawableResource
+  get() = Drawable44.icon_7632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7633: DrawableResource
+  get() = Drawable44.icon_7633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7634: DrawableResource
+  get() = Drawable44.icon_7634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7635: DrawableResource
+  get() = Drawable44.icon_7635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7636: DrawableResource
+  get() = Drawable44.icon_7636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7637: DrawableResource
+  get() = Drawable44.icon_7637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7638: DrawableResource
+  get() = Drawable44.icon_7638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7639: DrawableResource
+  get() = Drawable44.icon_7639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_764: DrawableResource
+  get() = Drawable44.icon_764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7640: DrawableResource
+  get() = Drawable44.icon_7640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7641: DrawableResource
+  get() = Drawable44.icon_7641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7642: DrawableResource
+  get() = Drawable44.icon_7642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7643: DrawableResource
+  get() = Drawable44.icon_7643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7644: DrawableResource
+  get() = Drawable44.icon_7644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7645: DrawableResource
+  get() = Drawable44.icon_7645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7646: DrawableResource
+  get() = Drawable44.icon_7646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7647: DrawableResource
+  get() = Drawable44.icon_7647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7648: DrawableResource
+  get() = Drawable44.icon_7648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7649: DrawableResource
+  get() = Drawable44.icon_7649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_765: DrawableResource
+  get() = Drawable44.icon_765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7650: DrawableResource
+  get() = Drawable44.icon_7650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7651: DrawableResource
+  get() = Drawable44.icon_7651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7652: DrawableResource
+  get() = Drawable44.icon_7652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7653: DrawableResource
+  get() = Drawable44.icon_7653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7654: DrawableResource
+  get() = Drawable44.icon_7654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7655: DrawableResource
+  get() = Drawable44.icon_7655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7656: DrawableResource
+  get() = Drawable44.icon_7656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7657: DrawableResource
+  get() = Drawable44.icon_7657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7658: DrawableResource
+  get() = Drawable44.icon_7658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7659: DrawableResource
+  get() = Drawable44.icon_7659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_766: DrawableResource
+  get() = Drawable44.icon_766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7660: DrawableResource
+  get() = Drawable44.icon_7660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7661: DrawableResource
+  get() = Drawable44.icon_7661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7662: DrawableResource
+  get() = Drawable44.icon_7662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7663: DrawableResource
+  get() = Drawable44.icon_7663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7664: DrawableResource
+  get() = Drawable44.icon_7664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7665: DrawableResource
+  get() = Drawable44.icon_7665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7666: DrawableResource
+  get() = Drawable44.icon_7666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7667: DrawableResource
+  get() = Drawable44.icon_7667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7668: DrawableResource
+  get() = Drawable44.icon_7668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7669: DrawableResource
+  get() = Drawable44.icon_7669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_767: DrawableResource
+  get() = Drawable44.icon_767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7670: DrawableResource
+  get() = Drawable44.icon_7670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7671: DrawableResource
+  get() = Drawable44.icon_7671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7672: DrawableResource
+  get() = Drawable44.icon_7672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7673: DrawableResource
+  get() = Drawable44.icon_7673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7674: DrawableResource
+  get() = Drawable44.icon_7674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7675: DrawableResource
+  get() = Drawable44.icon_7675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7676: DrawableResource
+  get() = Drawable44.icon_7676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7677: DrawableResource
+  get() = Drawable44.icon_7677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7678: DrawableResource
+  get() = Drawable44.icon_7678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7679: DrawableResource
+  get() = Drawable44.icon_7679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_768: DrawableResource
+  get() = Drawable44.icon_768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7680: DrawableResource
+  get() = Drawable44.icon_7680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7681: DrawableResource
+  get() = Drawable44.icon_7681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7682: DrawableResource
+  get() = Drawable44.icon_7682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7683: DrawableResource
+  get() = Drawable44.icon_7683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7684: DrawableResource
+  get() = Drawable44.icon_7684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7685: DrawableResource
+  get() = Drawable44.icon_7685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7686: DrawableResource
+  get() = Drawable44.icon_7686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7687: DrawableResource
+  get() = Drawable44.icon_7687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7688: DrawableResource
+  get() = Drawable44.icon_7688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7689: DrawableResource
+  get() = Drawable44.icon_7689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_769: DrawableResource
+  get() = Drawable44.icon_769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7690: DrawableResource
+  get() = Drawable44.icon_7690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7691: DrawableResource
+  get() = Drawable44.icon_7691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7692: DrawableResource
+  get() = Drawable44.icon_7692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7693: DrawableResource
+  get() = Drawable44.icon_7693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7694: DrawableResource
+  get() = Drawable44.icon_7694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7695: DrawableResource
+  get() = Drawable44.icon_7695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7696: DrawableResource
+  get() = Drawable44.icon_7696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7697: DrawableResource
+  get() = Drawable44.icon_7697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7698: DrawableResource
+  get() = Drawable44.icon_7698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7699: DrawableResource
+  get() = Drawable44.icon_7699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_77: DrawableResource
+  get() = Drawable44.icon_77
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_770: DrawableResource
+  get() = Drawable44.icon_770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7700: DrawableResource
+  get() = Drawable44.icon_7700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7701: DrawableResource
+  get() = Drawable44.icon_7701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7702: DrawableResource
+  get() = Drawable44.icon_7702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7703: DrawableResource
+  get() = Drawable44.icon_7703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7704: DrawableResource
+  get() = Drawable44.icon_7704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7705: DrawableResource
+  get() = Drawable44.icon_7705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7706: DrawableResource
+  get() = Drawable44.icon_7706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7707: DrawableResource
+  get() = Drawable44.icon_7707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7708: DrawableResource
+  get() = Drawable44.icon_7708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7709: DrawableResource
+  get() = Drawable44.icon_7709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_771: DrawableResource
+  get() = Drawable44.icon_771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7710: DrawableResource
+  get() = Drawable44.icon_7710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7711: DrawableResource
+  get() = Drawable44.icon_7711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7712: DrawableResource
+  get() = Drawable44.icon_7712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7713: DrawableResource
+  get() = Drawable44.icon_7713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7714: DrawableResource
+  get() = Drawable44.icon_7714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7715: DrawableResource
+  get() = Drawable44.icon_7715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7716: DrawableResource
+  get() = Drawable44.icon_7716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7717: DrawableResource
+  get() = Drawable44.icon_7717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7718: DrawableResource
+  get() = Drawable44.icon_7718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7719: DrawableResource
+  get() = Drawable44.icon_7719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_772: DrawableResource
+  get() = Drawable44.icon_772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7720: DrawableResource
+  get() = Drawable44.icon_7720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7721: DrawableResource
+  get() = Drawable44.icon_7721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7722: DrawableResource
+  get() = Drawable44.icon_7722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7723: DrawableResource
+  get() = Drawable44.icon_7723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7724: DrawableResource
+  get() = Drawable44.icon_7724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7725: DrawableResource
+  get() = Drawable44.icon_7725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7726: DrawableResource
+  get() = Drawable44.icon_7726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7727: DrawableResource
+  get() = Drawable44.icon_7727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7728: DrawableResource
+  get() = Drawable44.icon_7728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7729: DrawableResource
+  get() = Drawable44.icon_7729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_773: DrawableResource
+  get() = Drawable44.icon_773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7730: DrawableResource
+  get() = Drawable44.icon_7730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7731: DrawableResource
+  get() = Drawable44.icon_7731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7732: DrawableResource
+  get() = Drawable44.icon_7732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7733: DrawableResource
+  get() = Drawable44.icon_7733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7734: DrawableResource
+  get() = Drawable44.icon_7734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7735: DrawableResource
+  get() = Drawable44.icon_7735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7736: DrawableResource
+  get() = Drawable44.icon_7736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7737: DrawableResource
+  get() = Drawable44.icon_7737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7738: DrawableResource
+  get() = Drawable44.icon_7738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7739: DrawableResource
+  get() = Drawable44.icon_7739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_774: DrawableResource
+  get() = Drawable44.icon_774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7740: DrawableResource
+  get() = Drawable44.icon_7740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7741: DrawableResource
+  get() = Drawable44.icon_7741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7742: DrawableResource
+  get() = Drawable44.icon_7742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7743: DrawableResource
+  get() = Drawable44.icon_7743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7744: DrawableResource
+  get() = Drawable44.icon_7744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7745: DrawableResource
+  get() = Drawable44.icon_7745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7746: DrawableResource
+  get() = Drawable44.icon_7746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7747: DrawableResource
+  get() = Drawable44.icon_7747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7748: DrawableResource
+  get() = Drawable44.icon_7748

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable45.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable45.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable45 {
+  public val icon_7749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7749.xml"),
+          )
+      )
+
+  public val icon_775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_775.xml"),
+          )
+      )
+
+  public val icon_7750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7750.xml"),
+          )
+      )
+
+  public val icon_7751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7751.xml"),
+          )
+      )
+
+  public val icon_7752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7752.xml"),
+          )
+      )
+
+  public val icon_7753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7753.xml"),
+          )
+      )
+
+  public val icon_7754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7754.xml"),
+          )
+      )
+
+  public val icon_7755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7755.xml"),
+          )
+      )
+
+  public val icon_7756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7756.xml"),
+          )
+      )
+
+  public val icon_7757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7757.xml"),
+          )
+      )
+
+  public val icon_7758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7758.xml"),
+          )
+      )
+
+  public val icon_7759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7759.xml"),
+          )
+      )
+
+  public val icon_776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_776.xml"),
+          )
+      )
+
+  public val icon_7760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7760.xml"),
+          )
+      )
+
+  public val icon_7761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7761.xml"),
+          )
+      )
+
+  public val icon_7762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7762.xml"),
+          )
+      )
+
+  public val icon_7763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7763.xml"),
+          )
+      )
+
+  public val icon_7764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7764.xml"),
+          )
+      )
+
+  public val icon_7765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7765.xml"),
+          )
+      )
+
+  public val icon_7766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7766.xml"),
+          )
+      )
+
+  public val icon_7767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7767.xml"),
+          )
+      )
+
+  public val icon_7768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7768.xml"),
+          )
+      )
+
+  public val icon_7769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7769.xml"),
+          )
+      )
+
+  public val icon_777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_777.xml"),
+          )
+      )
+
+  public val icon_7770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7770.xml"),
+          )
+      )
+
+  public val icon_7771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7771.xml"),
+          )
+      )
+
+  public val icon_7772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7772.xml"),
+          )
+      )
+
+  public val icon_7773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7773.xml"),
+          )
+      )
+
+  public val icon_7774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7774.xml"),
+          )
+      )
+
+  public val icon_7775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7775.xml"),
+          )
+      )
+
+  public val icon_7776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7776.xml"),
+          )
+      )
+
+  public val icon_7777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7777.xml"),
+          )
+      )
+
+  public val icon_7778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7778.xml"),
+          )
+      )
+
+  public val icon_7779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7779.xml"),
+          )
+      )
+
+  public val icon_778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_778.xml"),
+          )
+      )
+
+  public val icon_7780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7780.xml"),
+          )
+      )
+
+  public val icon_7781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7781.xml"),
+          )
+      )
+
+  public val icon_7782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7782.xml"),
+          )
+      )
+
+  public val icon_7783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7783.xml"),
+          )
+      )
+
+  public val icon_7784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7784.xml"),
+          )
+      )
+
+  public val icon_7785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7785.xml"),
+          )
+      )
+
+  public val icon_7786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7786.xml"),
+          )
+      )
+
+  public val icon_7787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7787.xml"),
+          )
+      )
+
+  public val icon_7788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7788.xml"),
+          )
+      )
+
+  public val icon_7789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7789.xml"),
+          )
+      )
+
+  public val icon_779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_779.xml"),
+          )
+      )
+
+  public val icon_7790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7790.xml"),
+          )
+      )
+
+  public val icon_7791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7791.xml"),
+          )
+      )
+
+  public val icon_7792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7792.xml"),
+          )
+      )
+
+  public val icon_7793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7793.xml"),
+          )
+      )
+
+  public val icon_7794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7794.xml"),
+          )
+      )
+
+  public val icon_7795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7795.xml"),
+          )
+      )
+
+  public val icon_7796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7796.xml"),
+          )
+      )
+
+  public val icon_7797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7797.xml"),
+          )
+      )
+
+  public val icon_7798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7798.xml"),
+          )
+      )
+
+  public val icon_7799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7799.xml"),
+          )
+      )
+
+  public val icon_78: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_78",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_78.xml"),
+          )
+      )
+
+  public val icon_780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_780.xml"),
+          )
+      )
+
+  public val icon_7800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7800.xml"),
+          )
+      )
+
+  public val icon_7801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7801.xml"),
+          )
+      )
+
+  public val icon_7802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7802.xml"),
+          )
+      )
+
+  public val icon_7803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7803.xml"),
+          )
+      )
+
+  public val icon_7804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7804.xml"),
+          )
+      )
+
+  public val icon_7805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7805.xml"),
+          )
+      )
+
+  public val icon_7806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7806.xml"),
+          )
+      )
+
+  public val icon_7807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7807.xml"),
+          )
+      )
+
+  public val icon_7808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7808.xml"),
+          )
+      )
+
+  public val icon_7809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7809.xml"),
+          )
+      )
+
+  public val icon_781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_781.xml"),
+          )
+      )
+
+  public val icon_7810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7810.xml"),
+          )
+      )
+
+  public val icon_7811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7811.xml"),
+          )
+      )
+
+  public val icon_7812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7812.xml"),
+          )
+      )
+
+  public val icon_7813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7813.xml"),
+          )
+      )
+
+  public val icon_7814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7814.xml"),
+          )
+      )
+
+  public val icon_7815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7815.xml"),
+          )
+      )
+
+  public val icon_7816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7816.xml"),
+          )
+      )
+
+  public val icon_7817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7817.xml"),
+          )
+      )
+
+  public val icon_7818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7818.xml"),
+          )
+      )
+
+  public val icon_7819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7819.xml"),
+          )
+      )
+
+  public val icon_782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_782.xml"),
+          )
+      )
+
+  public val icon_7820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7820.xml"),
+          )
+      )
+
+  public val icon_7821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7821.xml"),
+          )
+      )
+
+  public val icon_7822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7822.xml"),
+          )
+      )
+
+  public val icon_7823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7823.xml"),
+          )
+      )
+
+  public val icon_7824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7824.xml"),
+          )
+      )
+
+  public val icon_7825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7825.xml"),
+          )
+      )
+
+  public val icon_7826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7826.xml"),
+          )
+      )
+
+  public val icon_7827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7827.xml"),
+          )
+      )
+
+  public val icon_7828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7828.xml"),
+          )
+      )
+
+  public val icon_7829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7829.xml"),
+          )
+      )
+
+  public val icon_783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_783.xml"),
+          )
+      )
+
+  public val icon_7830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7830.xml"),
+          )
+      )
+
+  public val icon_7831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7831.xml"),
+          )
+      )
+
+  public val icon_7832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7832.xml"),
+          )
+      )
+
+  public val icon_7833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7833.xml"),
+          )
+      )
+
+  public val icon_7834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7834.xml"),
+          )
+      )
+
+  public val icon_7835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7835.xml"),
+          )
+      )
+
+  public val icon_7836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7836.xml"),
+          )
+      )
+
+  public val icon_7837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7837.xml"),
+          )
+      )
+
+  public val icon_7838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7838.xml"),
+          )
+      )
+
+  public val icon_7839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7839.xml"),
+          )
+      )
+
+  public val icon_784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_784.xml"),
+          )
+      )
+
+  public val icon_7840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7840.xml"),
+          )
+      )
+
+  public val icon_7841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7841.xml"),
+          )
+      )
+
+  public val icon_7842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7842.xml"),
+          )
+      )
+
+  public val icon_7843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7843.xml"),
+          )
+      )
+
+  public val icon_7844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7844.xml"),
+          )
+      )
+
+  public val icon_7845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7845.xml"),
+          )
+      )
+
+  public val icon_7846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7846.xml"),
+          )
+      )
+
+  public val icon_7847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7847.xml"),
+          )
+      )
+
+  public val icon_7848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7848.xml"),
+          )
+      )
+
+  public val icon_7849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7849.xml"),
+          )
+      )
+
+  public val icon_785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_785.xml"),
+          )
+      )
+
+  public val icon_7850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7850.xml"),
+          )
+      )
+
+  public val icon_7851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7851.xml"),
+          )
+      )
+
+  public val icon_7852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7852.xml"),
+          )
+      )
+
+  public val icon_7853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7853.xml"),
+          )
+      )
+
+  public val icon_7854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7854.xml"),
+          )
+      )
+
+  public val icon_7855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7855.xml"),
+          )
+      )
+
+  public val icon_7856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7856.xml"),
+          )
+      )
+
+  public val icon_7857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7857.xml"),
+          )
+      )
+
+  public val icon_7858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7858.xml"),
+          )
+      )
+
+  public val icon_7859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7859.xml"),
+          )
+      )
+
+  public val icon_786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_786.xml"),
+          )
+      )
+
+  public val icon_7860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7860.xml"),
+          )
+      )
+
+  public val icon_7861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7861.xml"),
+          )
+      )
+
+  public val icon_7862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7862.xml"),
+          )
+      )
+
+  public val icon_7863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7863.xml"),
+          )
+      )
+
+  public val icon_7864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7864.xml"),
+          )
+      )
+
+  public val icon_7865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7865.xml"),
+          )
+      )
+
+  public val icon_7866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7866.xml"),
+          )
+      )
+
+  public val icon_7867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7867.xml"),
+          )
+      )
+
+  public val icon_7868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7868.xml"),
+          )
+      )
+
+  public val icon_7869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7869.xml"),
+          )
+      )
+
+  public val icon_787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_787.xml"),
+          )
+      )
+
+  public val icon_7870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7870.xml"),
+          )
+      )
+
+  public val icon_7871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7871.xml"),
+          )
+      )
+
+  public val icon_7872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7872.xml"),
+          )
+      )
+
+  public val icon_7873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7873.xml"),
+          )
+      )
+
+  public val icon_7874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7874.xml"),
+          )
+      )
+
+  public val icon_7875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7875.xml"),
+          )
+      )
+
+  public val icon_7876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7876.xml"),
+          )
+      )
+
+  public val icon_7877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7877.xml"),
+          )
+      )
+
+  public val icon_7878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7878.xml"),
+          )
+      )
+
+  public val icon_7879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7879.xml"),
+          )
+      )
+
+  public val icon_788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_788.xml"),
+          )
+      )
+
+  public val icon_7880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7880.xml"),
+          )
+      )
+
+  public val icon_7881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7881.xml"),
+          )
+      )
+
+  public val icon_7882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7882.xml"),
+          )
+      )
+
+  public val icon_7883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7883.xml"),
+          )
+      )
+
+  public val icon_7884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7884.xml"),
+          )
+      )
+
+  public val icon_7885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7885.xml"),
+          )
+      )
+
+  public val icon_7886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7886.xml"),
+          )
+      )
+
+  public val icon_7887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7887.xml"),
+          )
+      )
+
+  public val icon_7888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7888.xml"),
+          )
+      )
+
+  public val icon_7889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7889.xml"),
+          )
+      )
+
+  public val icon_789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_789.xml"),
+          )
+      )
+
+  public val icon_7890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7890.xml"),
+          )
+      )
+
+  public val icon_7891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7891.xml"),
+          )
+      )
+
+  public val icon_7892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7892.xml"),
+          )
+      )
+
+  public val icon_7893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7893.xml"),
+          )
+      )
+
+  public val icon_7894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7894.xml"),
+          )
+      )
+
+  public val icon_7895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7895.xml"),
+          )
+      )
+
+  public val icon_7896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7896.xml"),
+          )
+      )
+
+  public val icon_7897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7897.xml"),
+          )
+      )
+
+  public val icon_7898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7898.xml"),
+          )
+      )
+
+  public val icon_7899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7899.xml"),
+          )
+      )
+
+  public val icon_79: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_79",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_79.xml"),
+          )
+      )
+
+  public val icon_790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_790.xml"),
+          )
+      )
+
+  public val icon_7900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7900.xml"),
+          )
+      )
+
+  public val icon_7901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7901.xml"),
+          )
+      )
+
+  public val icon_7902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7902.xml"),
+          )
+      )
+
+  public val icon_7903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7903.xml"),
+          )
+      )
+
+  public val icon_7904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7904.xml"),
+          )
+      )
+
+  public val icon_7905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7905.xml"),
+          )
+      )
+
+  public val icon_7906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7906.xml"),
+          )
+      )
+
+  public val icon_7907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7907.xml"),
+          )
+      )
+
+  public val icon_7908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7908.xml"),
+          )
+      )
+
+  public val icon_7909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7909.xml"),
+          )
+      )
+
+  public val icon_791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_791.xml"),
+          )
+      )
+
+  public val icon_7910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7910.xml"),
+          )
+      )
+
+  public val icon_7911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7911.xml"),
+          )
+      )
+
+  public val icon_7912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7912.xml"),
+          )
+      )
+
+  public val icon_7913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7913.xml"),
+          )
+      )
+
+  public val icon_7914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7914.xml"),
+          )
+      )
+
+  public val icon_7915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7915.xml"),
+          )
+      )
+
+  public val icon_7916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7916.xml"),
+          )
+      )
+
+  public val icon_7917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7917.xml"),
+          )
+      )
+
+  public val icon_7918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7918.xml"),
+          )
+      )
+
+  public val icon_7919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7919.xml"),
+          )
+      )
+
+  public val icon_792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_792.xml"),
+          )
+      )
+
+  public val icon_7920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7920.xml"),
+          )
+      )
+
+  public val icon_7921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7921.xml"),
+          )
+      )
+
+  public val icon_7922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7922.xml"),
+          )
+      )
+
+  public val icon_7923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7923.xml"),
+          )
+      )
+
+  public val icon_7924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7924.xml"),
+          )
+      )
+
+  public val icon_7925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7925.xml"),
+          )
+      )
+
+  public val icon_7926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7926.xml"),
+          )
+      )
+
+  public val icon_7927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7927.xml"),
+          )
+      )
+
+  public val icon_7928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7928.xml"),
+          )
+      )
+
+  public val icon_7929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7929.xml"),
+          )
+      )
+
+  public val icon_793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_793.xml"),
+          )
+      )
+
+  public val icon_7930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7930.xml"),
+          )
+      )
+
+  public val icon_7931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7931.xml"),
+          )
+      )
+
+  public val icon_7932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7932.xml"),
+          )
+      )
+
+  public val icon_7933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7933.xml"),
+          )
+      )
+
+  public val icon_7934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7934.xml"),
+          )
+      )
+
+  public val icon_7935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7935.xml"),
+          )
+      )
+
+  public val icon_7936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7936.xml"),
+          )
+      )
+
+  public val icon_7937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7937.xml"),
+          )
+      )
+
+  public val icon_7938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7938.xml"),
+          )
+      )
+
+  public val icon_7939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7939.xml"),
+          )
+      )
+
+  public val icon_794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_794.xml"),
+          )
+      )
+
+  public val icon_7940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7940.xml"),
+          )
+      )
+
+  public val icon_7941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7941.xml"),
+          )
+      )
+
+  public val icon_7942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7942.xml"),
+          )
+      )
+
+  public val icon_7943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7943.xml"),
+          )
+      )
+
+  public val icon_7944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7944.xml"),
+          )
+      )
+
+  public val icon_7945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7945.xml"),
+          )
+      )
+
+  public val icon_7946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7946.xml"),
+          )
+      )
+
+  public val icon_7947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7947.xml"),
+          )
+      )
+
+  public val icon_7948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7948.xml"),
+          )
+      )
+
+  public val icon_7949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7949.xml"),
+          )
+      )
+
+  public val icon_795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_795.xml"),
+          )
+      )
+
+  public val icon_7950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7950.xml"),
+          )
+      )
+
+  public val icon_7951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7951.xml"),
+          )
+      )
+
+  public val icon_7952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7952.xml"),
+          )
+      )
+
+  public val icon_7953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7953.xml"),
+          )
+      )
+
+  public val icon_7954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7954.xml"),
+          )
+      )
+
+  public val icon_7955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7955.xml"),
+          )
+      )
+
+  public val icon_7956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7956.xml"),
+          )
+      )
+
+  public val icon_7957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7957.xml"),
+          )
+      )
+
+  public val icon_7958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7958.xml"),
+          )
+      )
+
+  public val icon_7959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7959.xml"),
+          )
+      )
+
+  public val icon_796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_796.xml"),
+          )
+      )
+
+  public val icon_7960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7960.xml"),
+          )
+      )
+
+  public val icon_7961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7961.xml"),
+          )
+      )
+
+  public val icon_7962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7962.xml"),
+          )
+      )
+
+  public val icon_7963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7963.xml"),
+          )
+      )
+
+  public val icon_7964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7964.xml"),
+          )
+      )
+
+  public val icon_7965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7965.xml"),
+          )
+      )
+
+  public val icon_7966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7966.xml"),
+          )
+      )
+
+  public val icon_7967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7967.xml"),
+          )
+      )
+
+  public val icon_7968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7968.xml"),
+          )
+      )
+
+  public val icon_7969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7969.xml"),
+          )
+      )
+
+  public val icon_797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_797.xml"),
+          )
+      )
+
+  public val icon_7970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7970.xml"),
+          )
+      )
+
+  public val icon_7971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7971.xml"),
+          )
+      )
+
+  public val icon_7972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7972.xml"),
+          )
+      )
+
+  public val icon_7973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7973.xml"),
+          )
+      )
+
+  public val icon_7974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7974.xml"),
+          )
+      )
+
+  public val icon_7975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7975.xml"),
+          )
+      )
+
+  public val icon_7976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7976.xml"),
+          )
+      )
+
+  public val icon_7977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7977.xml"),
+          )
+      )
+
+  public val icon_7978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7978.xml"),
+          )
+      )
+
+  public val icon_7979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7979.xml"),
+          )
+      )
+
+  public val icon_798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_798.xml"),
+          )
+      )
+
+  public val icon_7980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7980.xml"),
+          )
+      )
+
+  public val icon_7981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7981.xml"),
+          )
+      )
+
+  public val icon_7982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7982.xml"),
+          )
+      )
+
+  public val icon_7983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7983.xml"),
+          )
+      )
+
+  public val icon_7984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7984.xml"),
+          )
+      )
+
+  public val icon_7985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7985.xml"),
+          )
+      )
+
+  public val icon_7986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7986.xml"),
+          )
+      )
+
+  public val icon_7987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7987.xml"),
+          )
+      )
+
+  public val icon_7988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7988.xml"),
+          )
+      )
+
+  public val icon_7989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7989.xml"),
+          )
+      )
+
+  public val icon_799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_799.xml"),
+          )
+      )
+
+  public val icon_7990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7990.xml"),
+          )
+      )
+
+  public val icon_7991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7991.xml"),
+          )
+      )
+
+  public val icon_7992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7992.xml"),
+          )
+      )
+
+  public val icon_7993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7993.xml"),
+          )
+      )
+
+  public val icon_7994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7994.xml"),
+          )
+      )
+
+  public val icon_7995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7995.xml"),
+          )
+      )
+
+  public val icon_7996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7996.xml"),
+          )
+      )
+
+  public val icon_7997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7997.xml"),
+          )
+      )
+
+  public val icon_7998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7998.xml"),
+          )
+      )
+
+  public val icon_7999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_7999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_7999.xml"),
+          )
+      )
+
+  public val icon_8: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8.xml"),
+          )
+      )
+
+  public val icon_80: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_80",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_80.xml"),
+          )
+      )
+
+  public val icon_800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_800.xml"),
+          )
+      )
+
+  public val icon_8000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8000.xml"),
+          )
+      )
+
+  public val icon_8001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8001.xml"),
+          )
+      )
+
+  public val icon_8002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8002.xml"),
+          )
+      )
+
+  public val icon_8003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8003.xml"),
+          )
+      )
+
+  public val icon_8004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8004.xml"),
+          )
+      )
+
+  public val icon_8005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8005.xml"),
+          )
+      )
+
+  public val icon_8006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8006.xml"),
+          )
+      )
+
+  public val icon_8007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8007.xml"),
+          )
+      )
+
+  public val icon_8008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8008.xml"),
+          )
+      )
+
+  public val icon_8009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8009.xml"),
+          )
+      )
+
+  public val icon_801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_801.xml"),
+          )
+      )
+
+  public val icon_8010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8010.xml"),
+          )
+      )
+
+  public val icon_8011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8011.xml"),
+          )
+      )
+
+  public val icon_8012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8012.xml"),
+          )
+      )
+
+  public val icon_8013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8013.xml"),
+          )
+      )
+
+  public val icon_8014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8014.xml"),
+          )
+      )
+
+  public val icon_8015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8015.xml"),
+          )
+      )
+
+  public val icon_8016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8016.xml"),
+          )
+      )
+
+  public val icon_8017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8017.xml"),
+          )
+      )
+
+  public val icon_8018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8018.xml"),
+          )
+      )
+
+  public val icon_8019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8019.xml"),
+          )
+      )
+
+  public val icon_802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_802.xml"),
+          )
+      )
+
+  public val icon_8020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8020.xml"),
+          )
+      )
+
+  public val icon_8021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8021.xml"),
+          )
+      )
+
+  public val icon_8022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8022.xml"),
+          )
+      )
+
+  public val icon_8023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8023.xml"),
+          )
+      )
+
+  public val icon_8024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8024.xml"),
+          )
+      )
+
+  public val icon_8025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8025.xml"),
+          )
+      )
+
+  public val icon_8026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8026.xml"),
+          )
+      )
+
+  public val icon_8027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8027.xml"),
+          )
+      )
+
+  public val icon_8028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8028.xml"),
+          )
+      )
+
+  public val icon_8029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8029.xml"),
+          )
+      )
+
+  public val icon_803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_803.xml"),
+          )
+      )
+
+  public val icon_8030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8030.xml"),
+          )
+      )
+
+  public val icon_8031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8031.xml"),
+          )
+      )
+
+  public val icon_8032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8032.xml"),
+          )
+      )
+
+  public val icon_8033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8033.xml"),
+          )
+      )
+
+  public val icon_8034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8034.xml"),
+          )
+      )
+
+  public val icon_8035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8035.xml"),
+          )
+      )
+
+  public val icon_8036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8036.xml"),
+          )
+      )
+
+  public val icon_8037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8037.xml"),
+          )
+      )
+
+  public val icon_8038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8038.xml"),
+          )
+      )
+
+  public val icon_8039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8039.xml"),
+          )
+      )
+
+  public val icon_804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_804.xml"),
+          )
+      )
+
+  public val icon_8040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8040.xml"),
+          )
+      )
+
+  public val icon_8041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8041.xml"),
+          )
+      )
+
+  public val icon_8042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8042.xml"),
+          )
+      )
+
+  public val icon_8043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8043.xml"),
+          )
+      )
+
+  public val icon_8044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8044.xml"),
+          )
+      )
+
+  public val icon_8045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8045.xml"),
+          )
+      )
+
+  public val icon_8046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8046.xml"),
+          )
+      )
+
+  public val icon_8047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8047.xml"),
+          )
+      )
+
+  public val icon_8048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8048.xml"),
+          )
+      )
+
+  public val icon_8049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8049.xml"),
+          )
+      )
+
+  public val icon_805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_805.xml"),
+          )
+      )
+
+  public val icon_8050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8050.xml"),
+          )
+      )
+
+  public val icon_8051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8051.xml"),
+          )
+      )
+
+  public val icon_8052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8052.xml"),
+          )
+      )
+
+  public val icon_8053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8053.xml"),
+          )
+      )
+
+  public val icon_8054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8054.xml"),
+          )
+      )
+
+  public val icon_8055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8055.xml"),
+          )
+      )
+
+  public val icon_8056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8056.xml"),
+          )
+      )
+
+  public val icon_8057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8057.xml"),
+          )
+      )
+
+  public val icon_8058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8058.xml"),
+          )
+      )
+
+  public val icon_8059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8059.xml"),
+          )
+      )
+
+  public val icon_806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_806.xml"),
+          )
+      )
+
+  public val icon_8060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8060.xml"),
+          )
+      )
+
+  public val icon_8061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8061.xml"),
+          )
+      )
+
+  public val icon_8062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8062.xml"),
+          )
+      )
+
+  public val icon_8063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8063.xml"),
+          )
+      )
+
+  public val icon_8064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8064.xml"),
+          )
+      )
+
+  public val icon_8065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8065.xml"),
+          )
+      )
+
+  public val icon_8066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8066.xml"),
+          )
+      )
+
+  public val icon_8067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8067.xml"),
+          )
+      )
+
+  public val icon_8068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8068.xml"),
+          )
+      )
+
+  public val icon_8069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8069.xml"),
+          )
+      )
+
+  public val icon_807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_807.xml"),
+          )
+      )
+
+  public val icon_8070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8070.xml"),
+          )
+      )
+
+  public val icon_8071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8071.xml"),
+          )
+      )
+
+  public val icon_8072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8072.xml"),
+          )
+      )
+
+  public val icon_8073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8073.xml"),
+          )
+      )
+
+  public val icon_8074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8074.xml"),
+          )
+      )
+
+  public val icon_8075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8075.xml"),
+          )
+      )
+
+  public val icon_8076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8076.xml"),
+          )
+      )
+
+  public val icon_8077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8077.xml"),
+          )
+      )
+
+  public val icon_8078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8078.xml"),
+          )
+      )
+
+  public val icon_8079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8079.xml"),
+          )
+      )
+
+  public val icon_808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_808.xml"),
+          )
+      )
+
+  public val icon_8080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8080.xml"),
+          )
+      )
+
+  public val icon_8081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8081.xml"),
+          )
+      )
+
+  public val icon_8082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8082.xml"),
+          )
+      )
+
+  public val icon_8083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8083.xml"),
+          )
+      )
+
+  public val icon_8084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8084.xml"),
+          )
+      )
+
+  public val icon_8085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8085.xml"),
+          )
+      )
+
+  public val icon_8086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8086.xml"),
+          )
+      )
+
+  public val icon_8087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8087.xml"),
+          )
+      )
+
+  public val icon_8088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8088.xml"),
+          )
+      )
+
+  public val icon_8089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8089.xml"),
+          )
+      )
+
+  public val icon_809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_809.xml"),
+          )
+      )
+
+  public val icon_8090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8090.xml"),
+          )
+      )
+
+  public val icon_8091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8091.xml"),
+          )
+      )
+
+  public val icon_8092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8092.xml"),
+          )
+      )
+
+  public val icon_8093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8093.xml"),
+          )
+      )
+
+  public val icon_8094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8094.xml"),
+          )
+      )
+
+  public val icon_8095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8095.xml"),
+          )
+      )
+
+  public val icon_8096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8096.xml"),
+          )
+      )
+
+  public val icon_8097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8097.xml"),
+          )
+      )
+
+  public val icon_8098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8098.xml"),
+          )
+      )
+
+  public val icon_8099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8099.xml"),
+          )
+      )
+
+  public val icon_81: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_81",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_81.xml"),
+          )
+      )
+
+  public val icon_810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_810.xml"),
+          )
+      )
+
+  public val icon_8100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8100.xml"),
+          )
+      )
+
+  public val icon_8101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8101.xml"),
+          )
+      )
+
+  public val icon_8102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8102.xml"),
+          )
+      )
+
+  public val icon_8103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8103.xml"),
+          )
+      )
+
+  public val icon_8104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8104.xml"),
+          )
+      )
+
+  public val icon_8105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8105.xml"),
+          )
+      )
+
+  public val icon_8106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8106.xml"),
+          )
+      )
+
+  public val icon_8107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8107.xml"),
+          )
+      )
+
+  public val icon_8108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8108.xml"),
+          )
+      )
+
+  public val icon_8109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8109.xml"),
+          )
+      )
+
+  public val icon_811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_811.xml"),
+          )
+      )
+
+  public val icon_8110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8110.xml"),
+          )
+      )
+
+  public val icon_8111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8111.xml"),
+          )
+      )
+
+  public val icon_8112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8112.xml"),
+          )
+      )
+
+  public val icon_8113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8113.xml"),
+          )
+      )
+
+  public val icon_8114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8114.xml"),
+          )
+      )
+
+  public val icon_8115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8115.xml"),
+          )
+      )
+
+  public val icon_8116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8116.xml"),
+          )
+      )
+
+  public val icon_8117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8117.xml"),
+          )
+      )
+
+  public val icon_8118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8118.xml"),
+          )
+      )
+
+  public val icon_8119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8119.xml"),
+          )
+      )
+
+  public val icon_812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_812.xml"),
+          )
+      )
+
+  public val icon_8120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8120.xml"),
+          )
+      )
+
+  public val icon_8121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8121.xml"),
+          )
+      )
+
+  public val icon_8122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8122.xml"),
+          )
+      )
+
+  public val icon_8123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8123.xml"),
+          )
+      )
+
+  public val icon_8124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8124.xml"),
+          )
+      )
+
+  public val icon_8125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8125.xml"),
+          )
+      )
+
+  public val icon_8126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8126.xml"),
+          )
+      )
+
+  public val icon_8127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8127.xml"),
+          )
+      )
+
+  public val icon_8128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8128.xml"),
+          )
+      )
+
+  public val icon_8129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8129.xml"),
+          )
+      )
+
+  public val icon_813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_813.xml"),
+          )
+      )
+
+  public val icon_8130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8130.xml"),
+          )
+      )
+
+  public val icon_8131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8131.xml"),
+          )
+      )
+
+  public val icon_8132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8132.xml"),
+          )
+      )
+
+  public val icon_8133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8133.xml"),
+          )
+      )
+
+  public val icon_8134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8134.xml"),
+          )
+      )
+
+  public val icon_8135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8135.xml"),
+          )
+      )
+
+  public val icon_8136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8136.xml"),
+          )
+      )
+
+  public val icon_8137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8137.xml"),
+          )
+      )
+
+  public val icon_8138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8138.xml"),
+          )
+      )
+
+  public val icon_8139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8139.xml"),
+          )
+      )
+
+  public val icon_814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_814.xml"),
+          )
+      )
+
+  public val icon_8140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8140.xml"),
+          )
+      )
+
+  public val icon_8141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8141.xml"),
+          )
+      )
+
+  public val icon_8142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8142.xml"),
+          )
+      )
+
+  public val icon_8143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8143.xml"),
+          )
+      )
+
+  public val icon_8144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8144.xml"),
+          )
+      )
+
+  public val icon_8145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8145.xml"),
+          )
+      )
+
+  public val icon_8146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8146.xml"),
+          )
+      )
+
+  public val icon_8147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8147.xml"),
+          )
+      )
+
+  public val icon_8148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8148.xml"),
+          )
+      )
+
+  public val icon_8149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8149.xml"),
+          )
+      )
+
+  public val icon_815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_815.xml"),
+          )
+      )
+
+  public val icon_8150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8150.xml"),
+          )
+      )
+
+  public val icon_8151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8151.xml"),
+          )
+      )
+
+  public val icon_8152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8152.xml"),
+          )
+      )
+
+  public val icon_8153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8153.xml"),
+          )
+      )
+
+  public val icon_8154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8154.xml"),
+          )
+      )
+
+  public val icon_8155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8155.xml"),
+          )
+      )
+
+  public val icon_8156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8156.xml"),
+          )
+      )
+
+  public val icon_8157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8157.xml"),
+          )
+      )
+
+  public val icon_8158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8158.xml"),
+          )
+      )
+
+  public val icon_8159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8159.xml"),
+          )
+      )
+
+  public val icon_816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_816.xml"),
+          )
+      )
+
+  public val icon_8160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8160.xml"),
+          )
+      )
+
+  public val icon_8161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8161.xml"),
+          )
+      )
+
+  public val icon_8162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8162.xml"),
+          )
+      )
+
+  public val icon_8163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8163.xml"),
+          )
+      )
+
+  public val icon_8164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8164.xml"),
+          )
+      )
+
+  public val icon_8165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8165.xml"),
+          )
+      )
+
+  public val icon_8166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8166.xml"),
+          )
+      )
+
+  public val icon_8167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8167.xml"),
+          )
+      )
+
+  public val icon_8168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8168.xml"),
+          )
+      )
+
+  public val icon_8169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8169.xml"),
+          )
+      )
+
+  public val icon_817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_817.xml"),
+          )
+      )
+
+  public val icon_8170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8170.xml"),
+          )
+      )
+
+  public val icon_8171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8171.xml"),
+          )
+      )
+
+  public val icon_8172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8172.xml"),
+          )
+      )
+
+  public val icon_8173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8173.xml"),
+          )
+      )
+
+  public val icon_8174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8174.xml"),
+          )
+      )
+
+  public val icon_8175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8175.xml"),
+          )
+      )
+
+  public val icon_8176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8176.xml"),
+          )
+      )
+
+  public val icon_8177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8177.xml"),
+          )
+      )
+
+  public val icon_8178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8178.xml"),
+          )
+      )
+
+  public val icon_8179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8179.xml"),
+          )
+      )
+
+  public val icon_818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_818.xml"),
+          )
+      )
+
+  public val icon_8180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8180.xml"),
+          )
+      )
+
+  public val icon_8181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8181.xml"),
+          )
+      )
+
+  public val icon_8182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8182.xml"),
+          )
+      )
+
+  public val icon_8183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8183.xml"),
+          )
+      )
+
+  public val icon_8184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8184.xml"),
+          )
+      )
+
+  public val icon_8185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8185.xml"),
+          )
+      )
+
+  public val icon_8186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8186.xml"),
+          )
+      )
+
+  public val icon_8187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8187.xml"),
+          )
+      )
+
+  public val icon_8188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8188.xml"),
+          )
+      )
+
+  public val icon_8189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8189.xml"),
+          )
+      )
+
+  public val icon_819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_819.xml"),
+          )
+      )
+
+  public val icon_8190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8190.xml"),
+          )
+      )
+
+  public val icon_8191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8191.xml"),
+          )
+      )
+
+  public val icon_8192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8192.xml"),
+          )
+      )
+
+  public val icon_8193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8193.xml"),
+          )
+      )
+
+  public val icon_8194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8194.xml"),
+          )
+      )
+
+  public val icon_8195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8195.xml"),
+          )
+      )
+
+  public val icon_8196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8196.xml"),
+          )
+      )
+
+  public val icon_8197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8197.xml"),
+          )
+      )
+
+  public val icon_8198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8198.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7749: DrawableResource
+  get() = Drawable45.icon_7749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_775: DrawableResource
+  get() = Drawable45.icon_775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7750: DrawableResource
+  get() = Drawable45.icon_7750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7751: DrawableResource
+  get() = Drawable45.icon_7751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7752: DrawableResource
+  get() = Drawable45.icon_7752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7753: DrawableResource
+  get() = Drawable45.icon_7753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7754: DrawableResource
+  get() = Drawable45.icon_7754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7755: DrawableResource
+  get() = Drawable45.icon_7755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7756: DrawableResource
+  get() = Drawable45.icon_7756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7757: DrawableResource
+  get() = Drawable45.icon_7757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7758: DrawableResource
+  get() = Drawable45.icon_7758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7759: DrawableResource
+  get() = Drawable45.icon_7759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_776: DrawableResource
+  get() = Drawable45.icon_776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7760: DrawableResource
+  get() = Drawable45.icon_7760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7761: DrawableResource
+  get() = Drawable45.icon_7761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7762: DrawableResource
+  get() = Drawable45.icon_7762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7763: DrawableResource
+  get() = Drawable45.icon_7763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7764: DrawableResource
+  get() = Drawable45.icon_7764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7765: DrawableResource
+  get() = Drawable45.icon_7765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7766: DrawableResource
+  get() = Drawable45.icon_7766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7767: DrawableResource
+  get() = Drawable45.icon_7767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7768: DrawableResource
+  get() = Drawable45.icon_7768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7769: DrawableResource
+  get() = Drawable45.icon_7769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_777: DrawableResource
+  get() = Drawable45.icon_777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7770: DrawableResource
+  get() = Drawable45.icon_7770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7771: DrawableResource
+  get() = Drawable45.icon_7771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7772: DrawableResource
+  get() = Drawable45.icon_7772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7773: DrawableResource
+  get() = Drawable45.icon_7773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7774: DrawableResource
+  get() = Drawable45.icon_7774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7775: DrawableResource
+  get() = Drawable45.icon_7775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7776: DrawableResource
+  get() = Drawable45.icon_7776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7777: DrawableResource
+  get() = Drawable45.icon_7777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7778: DrawableResource
+  get() = Drawable45.icon_7778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7779: DrawableResource
+  get() = Drawable45.icon_7779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_778: DrawableResource
+  get() = Drawable45.icon_778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7780: DrawableResource
+  get() = Drawable45.icon_7780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7781: DrawableResource
+  get() = Drawable45.icon_7781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7782: DrawableResource
+  get() = Drawable45.icon_7782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7783: DrawableResource
+  get() = Drawable45.icon_7783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7784: DrawableResource
+  get() = Drawable45.icon_7784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7785: DrawableResource
+  get() = Drawable45.icon_7785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7786: DrawableResource
+  get() = Drawable45.icon_7786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7787: DrawableResource
+  get() = Drawable45.icon_7787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7788: DrawableResource
+  get() = Drawable45.icon_7788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7789: DrawableResource
+  get() = Drawable45.icon_7789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_779: DrawableResource
+  get() = Drawable45.icon_779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7790: DrawableResource
+  get() = Drawable45.icon_7790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7791: DrawableResource
+  get() = Drawable45.icon_7791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7792: DrawableResource
+  get() = Drawable45.icon_7792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7793: DrawableResource
+  get() = Drawable45.icon_7793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7794: DrawableResource
+  get() = Drawable45.icon_7794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7795: DrawableResource
+  get() = Drawable45.icon_7795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7796: DrawableResource
+  get() = Drawable45.icon_7796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7797: DrawableResource
+  get() = Drawable45.icon_7797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7798: DrawableResource
+  get() = Drawable45.icon_7798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7799: DrawableResource
+  get() = Drawable45.icon_7799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_78: DrawableResource
+  get() = Drawable45.icon_78
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_780: DrawableResource
+  get() = Drawable45.icon_780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7800: DrawableResource
+  get() = Drawable45.icon_7800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7801: DrawableResource
+  get() = Drawable45.icon_7801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7802: DrawableResource
+  get() = Drawable45.icon_7802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7803: DrawableResource
+  get() = Drawable45.icon_7803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7804: DrawableResource
+  get() = Drawable45.icon_7804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7805: DrawableResource
+  get() = Drawable45.icon_7805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7806: DrawableResource
+  get() = Drawable45.icon_7806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7807: DrawableResource
+  get() = Drawable45.icon_7807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7808: DrawableResource
+  get() = Drawable45.icon_7808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7809: DrawableResource
+  get() = Drawable45.icon_7809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_781: DrawableResource
+  get() = Drawable45.icon_781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7810: DrawableResource
+  get() = Drawable45.icon_7810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7811: DrawableResource
+  get() = Drawable45.icon_7811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7812: DrawableResource
+  get() = Drawable45.icon_7812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7813: DrawableResource
+  get() = Drawable45.icon_7813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7814: DrawableResource
+  get() = Drawable45.icon_7814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7815: DrawableResource
+  get() = Drawable45.icon_7815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7816: DrawableResource
+  get() = Drawable45.icon_7816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7817: DrawableResource
+  get() = Drawable45.icon_7817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7818: DrawableResource
+  get() = Drawable45.icon_7818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7819: DrawableResource
+  get() = Drawable45.icon_7819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_782: DrawableResource
+  get() = Drawable45.icon_782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7820: DrawableResource
+  get() = Drawable45.icon_7820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7821: DrawableResource
+  get() = Drawable45.icon_7821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7822: DrawableResource
+  get() = Drawable45.icon_7822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7823: DrawableResource
+  get() = Drawable45.icon_7823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7824: DrawableResource
+  get() = Drawable45.icon_7824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7825: DrawableResource
+  get() = Drawable45.icon_7825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7826: DrawableResource
+  get() = Drawable45.icon_7826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7827: DrawableResource
+  get() = Drawable45.icon_7827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7828: DrawableResource
+  get() = Drawable45.icon_7828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7829: DrawableResource
+  get() = Drawable45.icon_7829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_783: DrawableResource
+  get() = Drawable45.icon_783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7830: DrawableResource
+  get() = Drawable45.icon_7830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7831: DrawableResource
+  get() = Drawable45.icon_7831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7832: DrawableResource
+  get() = Drawable45.icon_7832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7833: DrawableResource
+  get() = Drawable45.icon_7833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7834: DrawableResource
+  get() = Drawable45.icon_7834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7835: DrawableResource
+  get() = Drawable45.icon_7835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7836: DrawableResource
+  get() = Drawable45.icon_7836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7837: DrawableResource
+  get() = Drawable45.icon_7837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7838: DrawableResource
+  get() = Drawable45.icon_7838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7839: DrawableResource
+  get() = Drawable45.icon_7839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_784: DrawableResource
+  get() = Drawable45.icon_784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7840: DrawableResource
+  get() = Drawable45.icon_7840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7841: DrawableResource
+  get() = Drawable45.icon_7841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7842: DrawableResource
+  get() = Drawable45.icon_7842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7843: DrawableResource
+  get() = Drawable45.icon_7843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7844: DrawableResource
+  get() = Drawable45.icon_7844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7845: DrawableResource
+  get() = Drawable45.icon_7845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7846: DrawableResource
+  get() = Drawable45.icon_7846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7847: DrawableResource
+  get() = Drawable45.icon_7847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7848: DrawableResource
+  get() = Drawable45.icon_7848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7849: DrawableResource
+  get() = Drawable45.icon_7849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_785: DrawableResource
+  get() = Drawable45.icon_785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7850: DrawableResource
+  get() = Drawable45.icon_7850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7851: DrawableResource
+  get() = Drawable45.icon_7851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7852: DrawableResource
+  get() = Drawable45.icon_7852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7853: DrawableResource
+  get() = Drawable45.icon_7853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7854: DrawableResource
+  get() = Drawable45.icon_7854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7855: DrawableResource
+  get() = Drawable45.icon_7855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7856: DrawableResource
+  get() = Drawable45.icon_7856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7857: DrawableResource
+  get() = Drawable45.icon_7857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7858: DrawableResource
+  get() = Drawable45.icon_7858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7859: DrawableResource
+  get() = Drawable45.icon_7859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_786: DrawableResource
+  get() = Drawable45.icon_786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7860: DrawableResource
+  get() = Drawable45.icon_7860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7861: DrawableResource
+  get() = Drawable45.icon_7861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7862: DrawableResource
+  get() = Drawable45.icon_7862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7863: DrawableResource
+  get() = Drawable45.icon_7863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7864: DrawableResource
+  get() = Drawable45.icon_7864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7865: DrawableResource
+  get() = Drawable45.icon_7865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7866: DrawableResource
+  get() = Drawable45.icon_7866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7867: DrawableResource
+  get() = Drawable45.icon_7867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7868: DrawableResource
+  get() = Drawable45.icon_7868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7869: DrawableResource
+  get() = Drawable45.icon_7869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_787: DrawableResource
+  get() = Drawable45.icon_787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7870: DrawableResource
+  get() = Drawable45.icon_7870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7871: DrawableResource
+  get() = Drawable45.icon_7871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7872: DrawableResource
+  get() = Drawable45.icon_7872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7873: DrawableResource
+  get() = Drawable45.icon_7873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7874: DrawableResource
+  get() = Drawable45.icon_7874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7875: DrawableResource
+  get() = Drawable45.icon_7875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7876: DrawableResource
+  get() = Drawable45.icon_7876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7877: DrawableResource
+  get() = Drawable45.icon_7877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7878: DrawableResource
+  get() = Drawable45.icon_7878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7879: DrawableResource
+  get() = Drawable45.icon_7879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_788: DrawableResource
+  get() = Drawable45.icon_788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7880: DrawableResource
+  get() = Drawable45.icon_7880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7881: DrawableResource
+  get() = Drawable45.icon_7881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7882: DrawableResource
+  get() = Drawable45.icon_7882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7883: DrawableResource
+  get() = Drawable45.icon_7883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7884: DrawableResource
+  get() = Drawable45.icon_7884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7885: DrawableResource
+  get() = Drawable45.icon_7885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7886: DrawableResource
+  get() = Drawable45.icon_7886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7887: DrawableResource
+  get() = Drawable45.icon_7887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7888: DrawableResource
+  get() = Drawable45.icon_7888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7889: DrawableResource
+  get() = Drawable45.icon_7889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_789: DrawableResource
+  get() = Drawable45.icon_789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7890: DrawableResource
+  get() = Drawable45.icon_7890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7891: DrawableResource
+  get() = Drawable45.icon_7891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7892: DrawableResource
+  get() = Drawable45.icon_7892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7893: DrawableResource
+  get() = Drawable45.icon_7893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7894: DrawableResource
+  get() = Drawable45.icon_7894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7895: DrawableResource
+  get() = Drawable45.icon_7895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7896: DrawableResource
+  get() = Drawable45.icon_7896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7897: DrawableResource
+  get() = Drawable45.icon_7897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7898: DrawableResource
+  get() = Drawable45.icon_7898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7899: DrawableResource
+  get() = Drawable45.icon_7899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_79: DrawableResource
+  get() = Drawable45.icon_79
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_790: DrawableResource
+  get() = Drawable45.icon_790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7900: DrawableResource
+  get() = Drawable45.icon_7900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7901: DrawableResource
+  get() = Drawable45.icon_7901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7902: DrawableResource
+  get() = Drawable45.icon_7902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7903: DrawableResource
+  get() = Drawable45.icon_7903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7904: DrawableResource
+  get() = Drawable45.icon_7904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7905: DrawableResource
+  get() = Drawable45.icon_7905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7906: DrawableResource
+  get() = Drawable45.icon_7906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7907: DrawableResource
+  get() = Drawable45.icon_7907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7908: DrawableResource
+  get() = Drawable45.icon_7908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7909: DrawableResource
+  get() = Drawable45.icon_7909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_791: DrawableResource
+  get() = Drawable45.icon_791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7910: DrawableResource
+  get() = Drawable45.icon_7910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7911: DrawableResource
+  get() = Drawable45.icon_7911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7912: DrawableResource
+  get() = Drawable45.icon_7912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7913: DrawableResource
+  get() = Drawable45.icon_7913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7914: DrawableResource
+  get() = Drawable45.icon_7914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7915: DrawableResource
+  get() = Drawable45.icon_7915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7916: DrawableResource
+  get() = Drawable45.icon_7916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7917: DrawableResource
+  get() = Drawable45.icon_7917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7918: DrawableResource
+  get() = Drawable45.icon_7918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7919: DrawableResource
+  get() = Drawable45.icon_7919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_792: DrawableResource
+  get() = Drawable45.icon_792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7920: DrawableResource
+  get() = Drawable45.icon_7920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7921: DrawableResource
+  get() = Drawable45.icon_7921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7922: DrawableResource
+  get() = Drawable45.icon_7922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7923: DrawableResource
+  get() = Drawable45.icon_7923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7924: DrawableResource
+  get() = Drawable45.icon_7924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7925: DrawableResource
+  get() = Drawable45.icon_7925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7926: DrawableResource
+  get() = Drawable45.icon_7926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7927: DrawableResource
+  get() = Drawable45.icon_7927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7928: DrawableResource
+  get() = Drawable45.icon_7928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7929: DrawableResource
+  get() = Drawable45.icon_7929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_793: DrawableResource
+  get() = Drawable45.icon_793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7930: DrawableResource
+  get() = Drawable45.icon_7930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7931: DrawableResource
+  get() = Drawable45.icon_7931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7932: DrawableResource
+  get() = Drawable45.icon_7932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7933: DrawableResource
+  get() = Drawable45.icon_7933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7934: DrawableResource
+  get() = Drawable45.icon_7934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7935: DrawableResource
+  get() = Drawable45.icon_7935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7936: DrawableResource
+  get() = Drawable45.icon_7936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7937: DrawableResource
+  get() = Drawable45.icon_7937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7938: DrawableResource
+  get() = Drawable45.icon_7938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7939: DrawableResource
+  get() = Drawable45.icon_7939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_794: DrawableResource
+  get() = Drawable45.icon_794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7940: DrawableResource
+  get() = Drawable45.icon_7940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7941: DrawableResource
+  get() = Drawable45.icon_7941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7942: DrawableResource
+  get() = Drawable45.icon_7942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7943: DrawableResource
+  get() = Drawable45.icon_7943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7944: DrawableResource
+  get() = Drawable45.icon_7944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7945: DrawableResource
+  get() = Drawable45.icon_7945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7946: DrawableResource
+  get() = Drawable45.icon_7946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7947: DrawableResource
+  get() = Drawable45.icon_7947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7948: DrawableResource
+  get() = Drawable45.icon_7948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7949: DrawableResource
+  get() = Drawable45.icon_7949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_795: DrawableResource
+  get() = Drawable45.icon_795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7950: DrawableResource
+  get() = Drawable45.icon_7950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7951: DrawableResource
+  get() = Drawable45.icon_7951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7952: DrawableResource
+  get() = Drawable45.icon_7952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7953: DrawableResource
+  get() = Drawable45.icon_7953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7954: DrawableResource
+  get() = Drawable45.icon_7954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7955: DrawableResource
+  get() = Drawable45.icon_7955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7956: DrawableResource
+  get() = Drawable45.icon_7956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7957: DrawableResource
+  get() = Drawable45.icon_7957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7958: DrawableResource
+  get() = Drawable45.icon_7958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7959: DrawableResource
+  get() = Drawable45.icon_7959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_796: DrawableResource
+  get() = Drawable45.icon_796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7960: DrawableResource
+  get() = Drawable45.icon_7960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7961: DrawableResource
+  get() = Drawable45.icon_7961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7962: DrawableResource
+  get() = Drawable45.icon_7962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7963: DrawableResource
+  get() = Drawable45.icon_7963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7964: DrawableResource
+  get() = Drawable45.icon_7964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7965: DrawableResource
+  get() = Drawable45.icon_7965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7966: DrawableResource
+  get() = Drawable45.icon_7966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7967: DrawableResource
+  get() = Drawable45.icon_7967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7968: DrawableResource
+  get() = Drawable45.icon_7968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7969: DrawableResource
+  get() = Drawable45.icon_7969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_797: DrawableResource
+  get() = Drawable45.icon_797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7970: DrawableResource
+  get() = Drawable45.icon_7970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7971: DrawableResource
+  get() = Drawable45.icon_7971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7972: DrawableResource
+  get() = Drawable45.icon_7972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7973: DrawableResource
+  get() = Drawable45.icon_7973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7974: DrawableResource
+  get() = Drawable45.icon_7974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7975: DrawableResource
+  get() = Drawable45.icon_7975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7976: DrawableResource
+  get() = Drawable45.icon_7976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7977: DrawableResource
+  get() = Drawable45.icon_7977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7978: DrawableResource
+  get() = Drawable45.icon_7978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7979: DrawableResource
+  get() = Drawable45.icon_7979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_798: DrawableResource
+  get() = Drawable45.icon_798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7980: DrawableResource
+  get() = Drawable45.icon_7980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7981: DrawableResource
+  get() = Drawable45.icon_7981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7982: DrawableResource
+  get() = Drawable45.icon_7982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7983: DrawableResource
+  get() = Drawable45.icon_7983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7984: DrawableResource
+  get() = Drawable45.icon_7984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7985: DrawableResource
+  get() = Drawable45.icon_7985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7986: DrawableResource
+  get() = Drawable45.icon_7986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7987: DrawableResource
+  get() = Drawable45.icon_7987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7988: DrawableResource
+  get() = Drawable45.icon_7988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7989: DrawableResource
+  get() = Drawable45.icon_7989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_799: DrawableResource
+  get() = Drawable45.icon_799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7990: DrawableResource
+  get() = Drawable45.icon_7990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7991: DrawableResource
+  get() = Drawable45.icon_7991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7992: DrawableResource
+  get() = Drawable45.icon_7992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7993: DrawableResource
+  get() = Drawable45.icon_7993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7994: DrawableResource
+  get() = Drawable45.icon_7994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7995: DrawableResource
+  get() = Drawable45.icon_7995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7996: DrawableResource
+  get() = Drawable45.icon_7996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7997: DrawableResource
+  get() = Drawable45.icon_7997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7998: DrawableResource
+  get() = Drawable45.icon_7998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_7999: DrawableResource
+  get() = Drawable45.icon_7999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8: DrawableResource
+  get() = Drawable45.icon_8
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_80: DrawableResource
+  get() = Drawable45.icon_80
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_800: DrawableResource
+  get() = Drawable45.icon_800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8000: DrawableResource
+  get() = Drawable45.icon_8000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8001: DrawableResource
+  get() = Drawable45.icon_8001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8002: DrawableResource
+  get() = Drawable45.icon_8002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8003: DrawableResource
+  get() = Drawable45.icon_8003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8004: DrawableResource
+  get() = Drawable45.icon_8004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8005: DrawableResource
+  get() = Drawable45.icon_8005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8006: DrawableResource
+  get() = Drawable45.icon_8006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8007: DrawableResource
+  get() = Drawable45.icon_8007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8008: DrawableResource
+  get() = Drawable45.icon_8008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8009: DrawableResource
+  get() = Drawable45.icon_8009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_801: DrawableResource
+  get() = Drawable45.icon_801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8010: DrawableResource
+  get() = Drawable45.icon_8010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8011: DrawableResource
+  get() = Drawable45.icon_8011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8012: DrawableResource
+  get() = Drawable45.icon_8012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8013: DrawableResource
+  get() = Drawable45.icon_8013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8014: DrawableResource
+  get() = Drawable45.icon_8014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8015: DrawableResource
+  get() = Drawable45.icon_8015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8016: DrawableResource
+  get() = Drawable45.icon_8016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8017: DrawableResource
+  get() = Drawable45.icon_8017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8018: DrawableResource
+  get() = Drawable45.icon_8018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8019: DrawableResource
+  get() = Drawable45.icon_8019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_802: DrawableResource
+  get() = Drawable45.icon_802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8020: DrawableResource
+  get() = Drawable45.icon_8020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8021: DrawableResource
+  get() = Drawable45.icon_8021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8022: DrawableResource
+  get() = Drawable45.icon_8022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8023: DrawableResource
+  get() = Drawable45.icon_8023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8024: DrawableResource
+  get() = Drawable45.icon_8024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8025: DrawableResource
+  get() = Drawable45.icon_8025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8026: DrawableResource
+  get() = Drawable45.icon_8026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8027: DrawableResource
+  get() = Drawable45.icon_8027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8028: DrawableResource
+  get() = Drawable45.icon_8028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8029: DrawableResource
+  get() = Drawable45.icon_8029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_803: DrawableResource
+  get() = Drawable45.icon_803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8030: DrawableResource
+  get() = Drawable45.icon_8030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8031: DrawableResource
+  get() = Drawable45.icon_8031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8032: DrawableResource
+  get() = Drawable45.icon_8032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8033: DrawableResource
+  get() = Drawable45.icon_8033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8034: DrawableResource
+  get() = Drawable45.icon_8034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8035: DrawableResource
+  get() = Drawable45.icon_8035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8036: DrawableResource
+  get() = Drawable45.icon_8036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8037: DrawableResource
+  get() = Drawable45.icon_8037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8038: DrawableResource
+  get() = Drawable45.icon_8038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8039: DrawableResource
+  get() = Drawable45.icon_8039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_804: DrawableResource
+  get() = Drawable45.icon_804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8040: DrawableResource
+  get() = Drawable45.icon_8040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8041: DrawableResource
+  get() = Drawable45.icon_8041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8042: DrawableResource
+  get() = Drawable45.icon_8042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8043: DrawableResource
+  get() = Drawable45.icon_8043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8044: DrawableResource
+  get() = Drawable45.icon_8044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8045: DrawableResource
+  get() = Drawable45.icon_8045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8046: DrawableResource
+  get() = Drawable45.icon_8046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8047: DrawableResource
+  get() = Drawable45.icon_8047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8048: DrawableResource
+  get() = Drawable45.icon_8048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8049: DrawableResource
+  get() = Drawable45.icon_8049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_805: DrawableResource
+  get() = Drawable45.icon_805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8050: DrawableResource
+  get() = Drawable45.icon_8050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8051: DrawableResource
+  get() = Drawable45.icon_8051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8052: DrawableResource
+  get() = Drawable45.icon_8052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8053: DrawableResource
+  get() = Drawable45.icon_8053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8054: DrawableResource
+  get() = Drawable45.icon_8054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8055: DrawableResource
+  get() = Drawable45.icon_8055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8056: DrawableResource
+  get() = Drawable45.icon_8056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8057: DrawableResource
+  get() = Drawable45.icon_8057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8058: DrawableResource
+  get() = Drawable45.icon_8058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8059: DrawableResource
+  get() = Drawable45.icon_8059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_806: DrawableResource
+  get() = Drawable45.icon_806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8060: DrawableResource
+  get() = Drawable45.icon_8060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8061: DrawableResource
+  get() = Drawable45.icon_8061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8062: DrawableResource
+  get() = Drawable45.icon_8062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8063: DrawableResource
+  get() = Drawable45.icon_8063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8064: DrawableResource
+  get() = Drawable45.icon_8064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8065: DrawableResource
+  get() = Drawable45.icon_8065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8066: DrawableResource
+  get() = Drawable45.icon_8066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8067: DrawableResource
+  get() = Drawable45.icon_8067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8068: DrawableResource
+  get() = Drawable45.icon_8068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8069: DrawableResource
+  get() = Drawable45.icon_8069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_807: DrawableResource
+  get() = Drawable45.icon_807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8070: DrawableResource
+  get() = Drawable45.icon_8070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8071: DrawableResource
+  get() = Drawable45.icon_8071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8072: DrawableResource
+  get() = Drawable45.icon_8072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8073: DrawableResource
+  get() = Drawable45.icon_8073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8074: DrawableResource
+  get() = Drawable45.icon_8074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8075: DrawableResource
+  get() = Drawable45.icon_8075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8076: DrawableResource
+  get() = Drawable45.icon_8076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8077: DrawableResource
+  get() = Drawable45.icon_8077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8078: DrawableResource
+  get() = Drawable45.icon_8078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8079: DrawableResource
+  get() = Drawable45.icon_8079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_808: DrawableResource
+  get() = Drawable45.icon_808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8080: DrawableResource
+  get() = Drawable45.icon_8080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8081: DrawableResource
+  get() = Drawable45.icon_8081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8082: DrawableResource
+  get() = Drawable45.icon_8082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8083: DrawableResource
+  get() = Drawable45.icon_8083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8084: DrawableResource
+  get() = Drawable45.icon_8084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8085: DrawableResource
+  get() = Drawable45.icon_8085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8086: DrawableResource
+  get() = Drawable45.icon_8086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8087: DrawableResource
+  get() = Drawable45.icon_8087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8088: DrawableResource
+  get() = Drawable45.icon_8088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8089: DrawableResource
+  get() = Drawable45.icon_8089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_809: DrawableResource
+  get() = Drawable45.icon_809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8090: DrawableResource
+  get() = Drawable45.icon_8090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8091: DrawableResource
+  get() = Drawable45.icon_8091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8092: DrawableResource
+  get() = Drawable45.icon_8092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8093: DrawableResource
+  get() = Drawable45.icon_8093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8094: DrawableResource
+  get() = Drawable45.icon_8094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8095: DrawableResource
+  get() = Drawable45.icon_8095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8096: DrawableResource
+  get() = Drawable45.icon_8096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8097: DrawableResource
+  get() = Drawable45.icon_8097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8098: DrawableResource
+  get() = Drawable45.icon_8098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8099: DrawableResource
+  get() = Drawable45.icon_8099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_81: DrawableResource
+  get() = Drawable45.icon_81
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_810: DrawableResource
+  get() = Drawable45.icon_810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8100: DrawableResource
+  get() = Drawable45.icon_8100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8101: DrawableResource
+  get() = Drawable45.icon_8101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8102: DrawableResource
+  get() = Drawable45.icon_8102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8103: DrawableResource
+  get() = Drawable45.icon_8103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8104: DrawableResource
+  get() = Drawable45.icon_8104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8105: DrawableResource
+  get() = Drawable45.icon_8105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8106: DrawableResource
+  get() = Drawable45.icon_8106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8107: DrawableResource
+  get() = Drawable45.icon_8107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8108: DrawableResource
+  get() = Drawable45.icon_8108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8109: DrawableResource
+  get() = Drawable45.icon_8109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_811: DrawableResource
+  get() = Drawable45.icon_811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8110: DrawableResource
+  get() = Drawable45.icon_8110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8111: DrawableResource
+  get() = Drawable45.icon_8111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8112: DrawableResource
+  get() = Drawable45.icon_8112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8113: DrawableResource
+  get() = Drawable45.icon_8113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8114: DrawableResource
+  get() = Drawable45.icon_8114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8115: DrawableResource
+  get() = Drawable45.icon_8115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8116: DrawableResource
+  get() = Drawable45.icon_8116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8117: DrawableResource
+  get() = Drawable45.icon_8117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8118: DrawableResource
+  get() = Drawable45.icon_8118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8119: DrawableResource
+  get() = Drawable45.icon_8119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_812: DrawableResource
+  get() = Drawable45.icon_812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8120: DrawableResource
+  get() = Drawable45.icon_8120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8121: DrawableResource
+  get() = Drawable45.icon_8121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8122: DrawableResource
+  get() = Drawable45.icon_8122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8123: DrawableResource
+  get() = Drawable45.icon_8123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8124: DrawableResource
+  get() = Drawable45.icon_8124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8125: DrawableResource
+  get() = Drawable45.icon_8125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8126: DrawableResource
+  get() = Drawable45.icon_8126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8127: DrawableResource
+  get() = Drawable45.icon_8127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8128: DrawableResource
+  get() = Drawable45.icon_8128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8129: DrawableResource
+  get() = Drawable45.icon_8129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_813: DrawableResource
+  get() = Drawable45.icon_813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8130: DrawableResource
+  get() = Drawable45.icon_8130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8131: DrawableResource
+  get() = Drawable45.icon_8131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8132: DrawableResource
+  get() = Drawable45.icon_8132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8133: DrawableResource
+  get() = Drawable45.icon_8133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8134: DrawableResource
+  get() = Drawable45.icon_8134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8135: DrawableResource
+  get() = Drawable45.icon_8135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8136: DrawableResource
+  get() = Drawable45.icon_8136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8137: DrawableResource
+  get() = Drawable45.icon_8137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8138: DrawableResource
+  get() = Drawable45.icon_8138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8139: DrawableResource
+  get() = Drawable45.icon_8139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_814: DrawableResource
+  get() = Drawable45.icon_814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8140: DrawableResource
+  get() = Drawable45.icon_8140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8141: DrawableResource
+  get() = Drawable45.icon_8141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8142: DrawableResource
+  get() = Drawable45.icon_8142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8143: DrawableResource
+  get() = Drawable45.icon_8143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8144: DrawableResource
+  get() = Drawable45.icon_8144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8145: DrawableResource
+  get() = Drawable45.icon_8145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8146: DrawableResource
+  get() = Drawable45.icon_8146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8147: DrawableResource
+  get() = Drawable45.icon_8147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8148: DrawableResource
+  get() = Drawable45.icon_8148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8149: DrawableResource
+  get() = Drawable45.icon_8149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_815: DrawableResource
+  get() = Drawable45.icon_815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8150: DrawableResource
+  get() = Drawable45.icon_8150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8151: DrawableResource
+  get() = Drawable45.icon_8151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8152: DrawableResource
+  get() = Drawable45.icon_8152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8153: DrawableResource
+  get() = Drawable45.icon_8153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8154: DrawableResource
+  get() = Drawable45.icon_8154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8155: DrawableResource
+  get() = Drawable45.icon_8155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8156: DrawableResource
+  get() = Drawable45.icon_8156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8157: DrawableResource
+  get() = Drawable45.icon_8157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8158: DrawableResource
+  get() = Drawable45.icon_8158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8159: DrawableResource
+  get() = Drawable45.icon_8159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_816: DrawableResource
+  get() = Drawable45.icon_816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8160: DrawableResource
+  get() = Drawable45.icon_8160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8161: DrawableResource
+  get() = Drawable45.icon_8161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8162: DrawableResource
+  get() = Drawable45.icon_8162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8163: DrawableResource
+  get() = Drawable45.icon_8163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8164: DrawableResource
+  get() = Drawable45.icon_8164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8165: DrawableResource
+  get() = Drawable45.icon_8165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8166: DrawableResource
+  get() = Drawable45.icon_8166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8167: DrawableResource
+  get() = Drawable45.icon_8167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8168: DrawableResource
+  get() = Drawable45.icon_8168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8169: DrawableResource
+  get() = Drawable45.icon_8169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_817: DrawableResource
+  get() = Drawable45.icon_817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8170: DrawableResource
+  get() = Drawable45.icon_8170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8171: DrawableResource
+  get() = Drawable45.icon_8171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8172: DrawableResource
+  get() = Drawable45.icon_8172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8173: DrawableResource
+  get() = Drawable45.icon_8173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8174: DrawableResource
+  get() = Drawable45.icon_8174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8175: DrawableResource
+  get() = Drawable45.icon_8175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8176: DrawableResource
+  get() = Drawable45.icon_8176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8177: DrawableResource
+  get() = Drawable45.icon_8177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8178: DrawableResource
+  get() = Drawable45.icon_8178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8179: DrawableResource
+  get() = Drawable45.icon_8179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_818: DrawableResource
+  get() = Drawable45.icon_818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8180: DrawableResource
+  get() = Drawable45.icon_8180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8181: DrawableResource
+  get() = Drawable45.icon_8181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8182: DrawableResource
+  get() = Drawable45.icon_8182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8183: DrawableResource
+  get() = Drawable45.icon_8183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8184: DrawableResource
+  get() = Drawable45.icon_8184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8185: DrawableResource
+  get() = Drawable45.icon_8185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8186: DrawableResource
+  get() = Drawable45.icon_8186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8187: DrawableResource
+  get() = Drawable45.icon_8187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8188: DrawableResource
+  get() = Drawable45.icon_8188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8189: DrawableResource
+  get() = Drawable45.icon_8189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_819: DrawableResource
+  get() = Drawable45.icon_819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8190: DrawableResource
+  get() = Drawable45.icon_8190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8191: DrawableResource
+  get() = Drawable45.icon_8191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8192: DrawableResource
+  get() = Drawable45.icon_8192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8193: DrawableResource
+  get() = Drawable45.icon_8193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8194: DrawableResource
+  get() = Drawable45.icon_8194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8195: DrawableResource
+  get() = Drawable45.icon_8195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8196: DrawableResource
+  get() = Drawable45.icon_8196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8197: DrawableResource
+  get() = Drawable45.icon_8197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8198: DrawableResource
+  get() = Drawable45.icon_8198

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable46.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable46.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable46 {
+  public val icon_8199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8199.xml"),
+          )
+      )
+
+  public val icon_82: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_82",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_82.xml"),
+          )
+      )
+
+  public val icon_820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_820.xml"),
+          )
+      )
+
+  public val icon_8200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8200.xml"),
+          )
+      )
+
+  public val icon_8201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8201.xml"),
+          )
+      )
+
+  public val icon_8202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8202.xml"),
+          )
+      )
+
+  public val icon_8203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8203.xml"),
+          )
+      )
+
+  public val icon_8204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8204.xml"),
+          )
+      )
+
+  public val icon_8205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8205.xml"),
+          )
+      )
+
+  public val icon_8206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8206.xml"),
+          )
+      )
+
+  public val icon_8207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8207.xml"),
+          )
+      )
+
+  public val icon_8208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8208.xml"),
+          )
+      )
+
+  public val icon_8209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8209.xml"),
+          )
+      )
+
+  public val icon_821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_821.xml"),
+          )
+      )
+
+  public val icon_8210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8210.xml"),
+          )
+      )
+
+  public val icon_8211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8211.xml"),
+          )
+      )
+
+  public val icon_8212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8212.xml"),
+          )
+      )
+
+  public val icon_8213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8213.xml"),
+          )
+      )
+
+  public val icon_8214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8214.xml"),
+          )
+      )
+
+  public val icon_8215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8215.xml"),
+          )
+      )
+
+  public val icon_8216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8216.xml"),
+          )
+      )
+
+  public val icon_8217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8217.xml"),
+          )
+      )
+
+  public val icon_8218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8218.xml"),
+          )
+      )
+
+  public val icon_8219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8219.xml"),
+          )
+      )
+
+  public val icon_822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_822.xml"),
+          )
+      )
+
+  public val icon_8220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8220.xml"),
+          )
+      )
+
+  public val icon_8221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8221.xml"),
+          )
+      )
+
+  public val icon_8222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8222.xml"),
+          )
+      )
+
+  public val icon_8223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8223.xml"),
+          )
+      )
+
+  public val icon_8224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8224.xml"),
+          )
+      )
+
+  public val icon_8225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8225.xml"),
+          )
+      )
+
+  public val icon_8226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8226.xml"),
+          )
+      )
+
+  public val icon_8227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8227.xml"),
+          )
+      )
+
+  public val icon_8228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8228.xml"),
+          )
+      )
+
+  public val icon_8229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8229.xml"),
+          )
+      )
+
+  public val icon_823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_823.xml"),
+          )
+      )
+
+  public val icon_8230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8230.xml"),
+          )
+      )
+
+  public val icon_8231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8231.xml"),
+          )
+      )
+
+  public val icon_8232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8232.xml"),
+          )
+      )
+
+  public val icon_8233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8233.xml"),
+          )
+      )
+
+  public val icon_8234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8234.xml"),
+          )
+      )
+
+  public val icon_8235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8235.xml"),
+          )
+      )
+
+  public val icon_8236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8236.xml"),
+          )
+      )
+
+  public val icon_8237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8237.xml"),
+          )
+      )
+
+  public val icon_8238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8238.xml"),
+          )
+      )
+
+  public val icon_8239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8239.xml"),
+          )
+      )
+
+  public val icon_824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_824.xml"),
+          )
+      )
+
+  public val icon_8240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8240.xml"),
+          )
+      )
+
+  public val icon_8241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8241.xml"),
+          )
+      )
+
+  public val icon_8242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8242.xml"),
+          )
+      )
+
+  public val icon_8243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8243.xml"),
+          )
+      )
+
+  public val icon_8244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8244.xml"),
+          )
+      )
+
+  public val icon_8245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8245.xml"),
+          )
+      )
+
+  public val icon_8246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8246.xml"),
+          )
+      )
+
+  public val icon_8247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8247.xml"),
+          )
+      )
+
+  public val icon_8248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8248.xml"),
+          )
+      )
+
+  public val icon_8249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8249.xml"),
+          )
+      )
+
+  public val icon_825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_825.xml"),
+          )
+      )
+
+  public val icon_8250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8250.xml"),
+          )
+      )
+
+  public val icon_8251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8251.xml"),
+          )
+      )
+
+  public val icon_8252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8252.xml"),
+          )
+      )
+
+  public val icon_8253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8253.xml"),
+          )
+      )
+
+  public val icon_8254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8254.xml"),
+          )
+      )
+
+  public val icon_8255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8255.xml"),
+          )
+      )
+
+  public val icon_8256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8256.xml"),
+          )
+      )
+
+  public val icon_8257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8257.xml"),
+          )
+      )
+
+  public val icon_8258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8258.xml"),
+          )
+      )
+
+  public val icon_8259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8259.xml"),
+          )
+      )
+
+  public val icon_826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_826.xml"),
+          )
+      )
+
+  public val icon_8260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8260.xml"),
+          )
+      )
+
+  public val icon_8261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8261.xml"),
+          )
+      )
+
+  public val icon_8262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8262.xml"),
+          )
+      )
+
+  public val icon_8263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8263.xml"),
+          )
+      )
+
+  public val icon_8264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8264.xml"),
+          )
+      )
+
+  public val icon_8265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8265.xml"),
+          )
+      )
+
+  public val icon_8266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8266.xml"),
+          )
+      )
+
+  public val icon_8267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8267.xml"),
+          )
+      )
+
+  public val icon_8268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8268.xml"),
+          )
+      )
+
+  public val icon_8269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8269.xml"),
+          )
+      )
+
+  public val icon_827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_827.xml"),
+          )
+      )
+
+  public val icon_8270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8270.xml"),
+          )
+      )
+
+  public val icon_8271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8271.xml"),
+          )
+      )
+
+  public val icon_8272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8272.xml"),
+          )
+      )
+
+  public val icon_8273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8273.xml"),
+          )
+      )
+
+  public val icon_8274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8274.xml"),
+          )
+      )
+
+  public val icon_8275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8275.xml"),
+          )
+      )
+
+  public val icon_8276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8276.xml"),
+          )
+      )
+
+  public val icon_8277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8277.xml"),
+          )
+      )
+
+  public val icon_8278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8278.xml"),
+          )
+      )
+
+  public val icon_8279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8279.xml"),
+          )
+      )
+
+  public val icon_828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_828.xml"),
+          )
+      )
+
+  public val icon_8280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8280.xml"),
+          )
+      )
+
+  public val icon_8281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8281.xml"),
+          )
+      )
+
+  public val icon_8282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8282.xml"),
+          )
+      )
+
+  public val icon_8283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8283.xml"),
+          )
+      )
+
+  public val icon_8284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8284.xml"),
+          )
+      )
+
+  public val icon_8285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8285.xml"),
+          )
+      )
+
+  public val icon_8286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8286.xml"),
+          )
+      )
+
+  public val icon_8287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8287.xml"),
+          )
+      )
+
+  public val icon_8288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8288.xml"),
+          )
+      )
+
+  public val icon_8289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8289.xml"),
+          )
+      )
+
+  public val icon_829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_829.xml"),
+          )
+      )
+
+  public val icon_8290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8290.xml"),
+          )
+      )
+
+  public val icon_8291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8291.xml"),
+          )
+      )
+
+  public val icon_8292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8292.xml"),
+          )
+      )
+
+  public val icon_8293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8293.xml"),
+          )
+      )
+
+  public val icon_8294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8294.xml"),
+          )
+      )
+
+  public val icon_8295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8295.xml"),
+          )
+      )
+
+  public val icon_8296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8296.xml"),
+          )
+      )
+
+  public val icon_8297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8297.xml"),
+          )
+      )
+
+  public val icon_8298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8298.xml"),
+          )
+      )
+
+  public val icon_8299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8299.xml"),
+          )
+      )
+
+  public val icon_83: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_83",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_83.xml"),
+          )
+      )
+
+  public val icon_830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_830.xml"),
+          )
+      )
+
+  public val icon_8300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8300.xml"),
+          )
+      )
+
+  public val icon_8301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8301.xml"),
+          )
+      )
+
+  public val icon_8302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8302.xml"),
+          )
+      )
+
+  public val icon_8303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8303.xml"),
+          )
+      )
+
+  public val icon_8304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8304.xml"),
+          )
+      )
+
+  public val icon_8305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8305.xml"),
+          )
+      )
+
+  public val icon_8306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8306.xml"),
+          )
+      )
+
+  public val icon_8307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8307.xml"),
+          )
+      )
+
+  public val icon_8308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8308.xml"),
+          )
+      )
+
+  public val icon_8309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8309.xml"),
+          )
+      )
+
+  public val icon_831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_831.xml"),
+          )
+      )
+
+  public val icon_8310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8310.xml"),
+          )
+      )
+
+  public val icon_8311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8311.xml"),
+          )
+      )
+
+  public val icon_8312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8312.xml"),
+          )
+      )
+
+  public val icon_8313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8313.xml"),
+          )
+      )
+
+  public val icon_8314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8314.xml"),
+          )
+      )
+
+  public val icon_8315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8315.xml"),
+          )
+      )
+
+  public val icon_8316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8316.xml"),
+          )
+      )
+
+  public val icon_8317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8317.xml"),
+          )
+      )
+
+  public val icon_8318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8318.xml"),
+          )
+      )
+
+  public val icon_8319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8319.xml"),
+          )
+      )
+
+  public val icon_832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_832.xml"),
+          )
+      )
+
+  public val icon_8320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8320.xml"),
+          )
+      )
+
+  public val icon_8321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8321.xml"),
+          )
+      )
+
+  public val icon_8322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8322.xml"),
+          )
+      )
+
+  public val icon_8323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8323.xml"),
+          )
+      )
+
+  public val icon_8324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8324.xml"),
+          )
+      )
+
+  public val icon_8325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8325.xml"),
+          )
+      )
+
+  public val icon_8326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8326.xml"),
+          )
+      )
+
+  public val icon_8327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8327.xml"),
+          )
+      )
+
+  public val icon_8328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8328.xml"),
+          )
+      )
+
+  public val icon_8329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8329.xml"),
+          )
+      )
+
+  public val icon_833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_833.xml"),
+          )
+      )
+
+  public val icon_8330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8330.xml"),
+          )
+      )
+
+  public val icon_8331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8331.xml"),
+          )
+      )
+
+  public val icon_8332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8332.xml"),
+          )
+      )
+
+  public val icon_8333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8333.xml"),
+          )
+      )
+
+  public val icon_8334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8334.xml"),
+          )
+      )
+
+  public val icon_8335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8335.xml"),
+          )
+      )
+
+  public val icon_8336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8336.xml"),
+          )
+      )
+
+  public val icon_8337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8337.xml"),
+          )
+      )
+
+  public val icon_8338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8338.xml"),
+          )
+      )
+
+  public val icon_8339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8339.xml"),
+          )
+      )
+
+  public val icon_834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_834.xml"),
+          )
+      )
+
+  public val icon_8340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8340.xml"),
+          )
+      )
+
+  public val icon_8341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8341.xml"),
+          )
+      )
+
+  public val icon_8342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8342.xml"),
+          )
+      )
+
+  public val icon_8343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8343.xml"),
+          )
+      )
+
+  public val icon_8344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8344.xml"),
+          )
+      )
+
+  public val icon_8345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8345.xml"),
+          )
+      )
+
+  public val icon_8346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8346.xml"),
+          )
+      )
+
+  public val icon_8347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8347.xml"),
+          )
+      )
+
+  public val icon_8348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8348.xml"),
+          )
+      )
+
+  public val icon_8349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8349.xml"),
+          )
+      )
+
+  public val icon_835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_835.xml"),
+          )
+      )
+
+  public val icon_8350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8350.xml"),
+          )
+      )
+
+  public val icon_8351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8351.xml"),
+          )
+      )
+
+  public val icon_8352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8352.xml"),
+          )
+      )
+
+  public val icon_8353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8353.xml"),
+          )
+      )
+
+  public val icon_8354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8354.xml"),
+          )
+      )
+
+  public val icon_8355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8355.xml"),
+          )
+      )
+
+  public val icon_8356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8356.xml"),
+          )
+      )
+
+  public val icon_8357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8357.xml"),
+          )
+      )
+
+  public val icon_8358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8358.xml"),
+          )
+      )
+
+  public val icon_8359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8359.xml"),
+          )
+      )
+
+  public val icon_836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_836.xml"),
+          )
+      )
+
+  public val icon_8360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8360.xml"),
+          )
+      )
+
+  public val icon_8361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8361.xml"),
+          )
+      )
+
+  public val icon_8362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8362.xml"),
+          )
+      )
+
+  public val icon_8363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8363.xml"),
+          )
+      )
+
+  public val icon_8364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8364.xml"),
+          )
+      )
+
+  public val icon_8365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8365.xml"),
+          )
+      )
+
+  public val icon_8366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8366.xml"),
+          )
+      )
+
+  public val icon_8367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8367.xml"),
+          )
+      )
+
+  public val icon_8368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8368.xml"),
+          )
+      )
+
+  public val icon_8369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8369.xml"),
+          )
+      )
+
+  public val icon_837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_837.xml"),
+          )
+      )
+
+  public val icon_8370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8370.xml"),
+          )
+      )
+
+  public val icon_8371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8371.xml"),
+          )
+      )
+
+  public val icon_8372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8372.xml"),
+          )
+      )
+
+  public val icon_8373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8373.xml"),
+          )
+      )
+
+  public val icon_8374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8374.xml"),
+          )
+      )
+
+  public val icon_8375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8375.xml"),
+          )
+      )
+
+  public val icon_8376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8376.xml"),
+          )
+      )
+
+  public val icon_8377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8377.xml"),
+          )
+      )
+
+  public val icon_8378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8378.xml"),
+          )
+      )
+
+  public val icon_8379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8379.xml"),
+          )
+      )
+
+  public val icon_838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_838.xml"),
+          )
+      )
+
+  public val icon_8380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8380.xml"),
+          )
+      )
+
+  public val icon_8381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8381.xml"),
+          )
+      )
+
+  public val icon_8382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8382.xml"),
+          )
+      )
+
+  public val icon_8383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8383.xml"),
+          )
+      )
+
+  public val icon_8384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8384.xml"),
+          )
+      )
+
+  public val icon_8385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8385.xml"),
+          )
+      )
+
+  public val icon_8386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8386.xml"),
+          )
+      )
+
+  public val icon_8387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8387.xml"),
+          )
+      )
+
+  public val icon_8388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8388.xml"),
+          )
+      )
+
+  public val icon_8389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8389.xml"),
+          )
+      )
+
+  public val icon_839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_839.xml"),
+          )
+      )
+
+  public val icon_8390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8390.xml"),
+          )
+      )
+
+  public val icon_8391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8391.xml"),
+          )
+      )
+
+  public val icon_8392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8392.xml"),
+          )
+      )
+
+  public val icon_8393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8393.xml"),
+          )
+      )
+
+  public val icon_8394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8394.xml"),
+          )
+      )
+
+  public val icon_8395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8395.xml"),
+          )
+      )
+
+  public val icon_8396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8396.xml"),
+          )
+      )
+
+  public val icon_8397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8397.xml"),
+          )
+      )
+
+  public val icon_8398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8398.xml"),
+          )
+      )
+
+  public val icon_8399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8399.xml"),
+          )
+      )
+
+  public val icon_84: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_84",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_84.xml"),
+          )
+      )
+
+  public val icon_840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_840.xml"),
+          )
+      )
+
+  public val icon_8400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8400.xml"),
+          )
+      )
+
+  public val icon_8401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8401.xml"),
+          )
+      )
+
+  public val icon_8402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8402.xml"),
+          )
+      )
+
+  public val icon_8403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8403.xml"),
+          )
+      )
+
+  public val icon_8404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8404.xml"),
+          )
+      )
+
+  public val icon_8405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8405.xml"),
+          )
+      )
+
+  public val icon_8406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8406.xml"),
+          )
+      )
+
+  public val icon_8407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8407.xml"),
+          )
+      )
+
+  public val icon_8408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8408.xml"),
+          )
+      )
+
+  public val icon_8409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8409.xml"),
+          )
+      )
+
+  public val icon_841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_841.xml"),
+          )
+      )
+
+  public val icon_8410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8410.xml"),
+          )
+      )
+
+  public val icon_8411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8411.xml"),
+          )
+      )
+
+  public val icon_8412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8412.xml"),
+          )
+      )
+
+  public val icon_8413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8413.xml"),
+          )
+      )
+
+  public val icon_8414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8414.xml"),
+          )
+      )
+
+  public val icon_8415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8415.xml"),
+          )
+      )
+
+  public val icon_8416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8416.xml"),
+          )
+      )
+
+  public val icon_8417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8417.xml"),
+          )
+      )
+
+  public val icon_8418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8418.xml"),
+          )
+      )
+
+  public val icon_8419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8419.xml"),
+          )
+      )
+
+  public val icon_842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_842.xml"),
+          )
+      )
+
+  public val icon_8420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8420.xml"),
+          )
+      )
+
+  public val icon_8421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8421.xml"),
+          )
+      )
+
+  public val icon_8422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8422.xml"),
+          )
+      )
+
+  public val icon_8423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8423.xml"),
+          )
+      )
+
+  public val icon_8424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8424.xml"),
+          )
+      )
+
+  public val icon_8425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8425.xml"),
+          )
+      )
+
+  public val icon_8426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8426.xml"),
+          )
+      )
+
+  public val icon_8427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8427.xml"),
+          )
+      )
+
+  public val icon_8428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8428.xml"),
+          )
+      )
+
+  public val icon_8429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8429.xml"),
+          )
+      )
+
+  public val icon_843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_843.xml"),
+          )
+      )
+
+  public val icon_8430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8430.xml"),
+          )
+      )
+
+  public val icon_8431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8431.xml"),
+          )
+      )
+
+  public val icon_8432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8432.xml"),
+          )
+      )
+
+  public val icon_8433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8433.xml"),
+          )
+      )
+
+  public val icon_8434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8434.xml"),
+          )
+      )
+
+  public val icon_8435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8435.xml"),
+          )
+      )
+
+  public val icon_8436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8436.xml"),
+          )
+      )
+
+  public val icon_8437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8437.xml"),
+          )
+      )
+
+  public val icon_8438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8438.xml"),
+          )
+      )
+
+  public val icon_8439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8439.xml"),
+          )
+      )
+
+  public val icon_844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_844.xml"),
+          )
+      )
+
+  public val icon_8440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8440.xml"),
+          )
+      )
+
+  public val icon_8441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8441.xml"),
+          )
+      )
+
+  public val icon_8442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8442.xml"),
+          )
+      )
+
+  public val icon_8443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8443.xml"),
+          )
+      )
+
+  public val icon_8444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8444.xml"),
+          )
+      )
+
+  public val icon_8445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8445.xml"),
+          )
+      )
+
+  public val icon_8446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8446.xml"),
+          )
+      )
+
+  public val icon_8447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8447.xml"),
+          )
+      )
+
+  public val icon_8448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8448.xml"),
+          )
+      )
+
+  public val icon_8449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8449.xml"),
+          )
+      )
+
+  public val icon_845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_845.xml"),
+          )
+      )
+
+  public val icon_8450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8450.xml"),
+          )
+      )
+
+  public val icon_8451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8451.xml"),
+          )
+      )
+
+  public val icon_8452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8452.xml"),
+          )
+      )
+
+  public val icon_8453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8453.xml"),
+          )
+      )
+
+  public val icon_8454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8454.xml"),
+          )
+      )
+
+  public val icon_8455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8455.xml"),
+          )
+      )
+
+  public val icon_8456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8456.xml"),
+          )
+      )
+
+  public val icon_8457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8457.xml"),
+          )
+      )
+
+  public val icon_8458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8458.xml"),
+          )
+      )
+
+  public val icon_8459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8459.xml"),
+          )
+      )
+
+  public val icon_846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_846.xml"),
+          )
+      )
+
+  public val icon_8460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8460.xml"),
+          )
+      )
+
+  public val icon_8461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8461.xml"),
+          )
+      )
+
+  public val icon_8462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8462.xml"),
+          )
+      )
+
+  public val icon_8463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8463.xml"),
+          )
+      )
+
+  public val icon_8464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8464.xml"),
+          )
+      )
+
+  public val icon_8465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8465.xml"),
+          )
+      )
+
+  public val icon_8466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8466.xml"),
+          )
+      )
+
+  public val icon_8467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8467.xml"),
+          )
+      )
+
+  public val icon_8468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8468.xml"),
+          )
+      )
+
+  public val icon_8469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8469.xml"),
+          )
+      )
+
+  public val icon_847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_847.xml"),
+          )
+      )
+
+  public val icon_8470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8470.xml"),
+          )
+      )
+
+  public val icon_8471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8471.xml"),
+          )
+      )
+
+  public val icon_8472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8472.xml"),
+          )
+      )
+
+  public val icon_8473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8473.xml"),
+          )
+      )
+
+  public val icon_8474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8474.xml"),
+          )
+      )
+
+  public val icon_8475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8475.xml"),
+          )
+      )
+
+  public val icon_8476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8476.xml"),
+          )
+      )
+
+  public val icon_8477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8477.xml"),
+          )
+      )
+
+  public val icon_8478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8478.xml"),
+          )
+      )
+
+  public val icon_8479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8479.xml"),
+          )
+      )
+
+  public val icon_848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_848.xml"),
+          )
+      )
+
+  public val icon_8480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8480.xml"),
+          )
+      )
+
+  public val icon_8481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8481.xml"),
+          )
+      )
+
+  public val icon_8482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8482.xml"),
+          )
+      )
+
+  public val icon_8483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8483.xml"),
+          )
+      )
+
+  public val icon_8484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8484.xml"),
+          )
+      )
+
+  public val icon_8485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8485.xml"),
+          )
+      )
+
+  public val icon_8486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8486.xml"),
+          )
+      )
+
+  public val icon_8487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8487.xml"),
+          )
+      )
+
+  public val icon_8488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8488.xml"),
+          )
+      )
+
+  public val icon_8489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8489.xml"),
+          )
+      )
+
+  public val icon_849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_849.xml"),
+          )
+      )
+
+  public val icon_8490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8490.xml"),
+          )
+      )
+
+  public val icon_8491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8491.xml"),
+          )
+      )
+
+  public val icon_8492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8492.xml"),
+          )
+      )
+
+  public val icon_8493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8493.xml"),
+          )
+      )
+
+  public val icon_8494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8494.xml"),
+          )
+      )
+
+  public val icon_8495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8495.xml"),
+          )
+      )
+
+  public val icon_8496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8496.xml"),
+          )
+      )
+
+  public val icon_8497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8497.xml"),
+          )
+      )
+
+  public val icon_8498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8498.xml"),
+          )
+      )
+
+  public val icon_8499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8499.xml"),
+          )
+      )
+
+  public val icon_85: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_85",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_85.xml"),
+          )
+      )
+
+  public val icon_850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_850.xml"),
+          )
+      )
+
+  public val icon_8500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8500.xml"),
+          )
+      )
+
+  public val icon_8501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8501.xml"),
+          )
+      )
+
+  public val icon_8502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8502.xml"),
+          )
+      )
+
+  public val icon_8503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8503.xml"),
+          )
+      )
+
+  public val icon_8504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8504.xml"),
+          )
+      )
+
+  public val icon_8505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8505.xml"),
+          )
+      )
+
+  public val icon_8506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8506.xml"),
+          )
+      )
+
+  public val icon_8507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8507.xml"),
+          )
+      )
+
+  public val icon_8508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8508.xml"),
+          )
+      )
+
+  public val icon_8509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8509.xml"),
+          )
+      )
+
+  public val icon_851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_851.xml"),
+          )
+      )
+
+  public val icon_8510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8510.xml"),
+          )
+      )
+
+  public val icon_8511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8511.xml"),
+          )
+      )
+
+  public val icon_8512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8512.xml"),
+          )
+      )
+
+  public val icon_8513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8513.xml"),
+          )
+      )
+
+  public val icon_8514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8514.xml"),
+          )
+      )
+
+  public val icon_8515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8515.xml"),
+          )
+      )
+
+  public val icon_8516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8516.xml"),
+          )
+      )
+
+  public val icon_8517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8517.xml"),
+          )
+      )
+
+  public val icon_8518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8518.xml"),
+          )
+      )
+
+  public val icon_8519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8519.xml"),
+          )
+      )
+
+  public val icon_852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_852.xml"),
+          )
+      )
+
+  public val icon_8520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8520.xml"),
+          )
+      )
+
+  public val icon_8521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8521.xml"),
+          )
+      )
+
+  public val icon_8522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8522.xml"),
+          )
+      )
+
+  public val icon_8523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8523.xml"),
+          )
+      )
+
+  public val icon_8524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8524.xml"),
+          )
+      )
+
+  public val icon_8525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8525.xml"),
+          )
+      )
+
+  public val icon_8526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8526.xml"),
+          )
+      )
+
+  public val icon_8527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8527.xml"),
+          )
+      )
+
+  public val icon_8528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8528.xml"),
+          )
+      )
+
+  public val icon_8529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8529.xml"),
+          )
+      )
+
+  public val icon_853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_853.xml"),
+          )
+      )
+
+  public val icon_8530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8530.xml"),
+          )
+      )
+
+  public val icon_8531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8531.xml"),
+          )
+      )
+
+  public val icon_8532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8532.xml"),
+          )
+      )
+
+  public val icon_8533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8533.xml"),
+          )
+      )
+
+  public val icon_8534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8534.xml"),
+          )
+      )
+
+  public val icon_8535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8535.xml"),
+          )
+      )
+
+  public val icon_8536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8536.xml"),
+          )
+      )
+
+  public val icon_8537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8537.xml"),
+          )
+      )
+
+  public val icon_8538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8538.xml"),
+          )
+      )
+
+  public val icon_8539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8539.xml"),
+          )
+      )
+
+  public val icon_854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_854.xml"),
+          )
+      )
+
+  public val icon_8540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8540.xml"),
+          )
+      )
+
+  public val icon_8541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8541.xml"),
+          )
+      )
+
+  public val icon_8542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8542.xml"),
+          )
+      )
+
+  public val icon_8543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8543.xml"),
+          )
+      )
+
+  public val icon_8544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8544.xml"),
+          )
+      )
+
+  public val icon_8545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8545.xml"),
+          )
+      )
+
+  public val icon_8546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8546.xml"),
+          )
+      )
+
+  public val icon_8547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8547.xml"),
+          )
+      )
+
+  public val icon_8548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8548.xml"),
+          )
+      )
+
+  public val icon_8549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8549.xml"),
+          )
+      )
+
+  public val icon_855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_855.xml"),
+          )
+      )
+
+  public val icon_8550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8550.xml"),
+          )
+      )
+
+  public val icon_8551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8551.xml"),
+          )
+      )
+
+  public val icon_8552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8552.xml"),
+          )
+      )
+
+  public val icon_8553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8553.xml"),
+          )
+      )
+
+  public val icon_8554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8554.xml"),
+          )
+      )
+
+  public val icon_8555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8555.xml"),
+          )
+      )
+
+  public val icon_8556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8556.xml"),
+          )
+      )
+
+  public val icon_8557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8557.xml"),
+          )
+      )
+
+  public val icon_8558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8558.xml"),
+          )
+      )
+
+  public val icon_8559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8559.xml"),
+          )
+      )
+
+  public val icon_856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_856.xml"),
+          )
+      )
+
+  public val icon_8560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8560.xml"),
+          )
+      )
+
+  public val icon_8561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8561.xml"),
+          )
+      )
+
+  public val icon_8562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8562.xml"),
+          )
+      )
+
+  public val icon_8563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8563.xml"),
+          )
+      )
+
+  public val icon_8564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8564.xml"),
+          )
+      )
+
+  public val icon_8565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8565.xml"),
+          )
+      )
+
+  public val icon_8566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8566.xml"),
+          )
+      )
+
+  public val icon_8567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8567.xml"),
+          )
+      )
+
+  public val icon_8568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8568.xml"),
+          )
+      )
+
+  public val icon_8569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8569.xml"),
+          )
+      )
+
+  public val icon_857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_857.xml"),
+          )
+      )
+
+  public val icon_8570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8570.xml"),
+          )
+      )
+
+  public val icon_8571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8571.xml"),
+          )
+      )
+
+  public val icon_8572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8572.xml"),
+          )
+      )
+
+  public val icon_8573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8573.xml"),
+          )
+      )
+
+  public val icon_8574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8574.xml"),
+          )
+      )
+
+  public val icon_8575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8575.xml"),
+          )
+      )
+
+  public val icon_8576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8576.xml"),
+          )
+      )
+
+  public val icon_8577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8577.xml"),
+          )
+      )
+
+  public val icon_8578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8578.xml"),
+          )
+      )
+
+  public val icon_8579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8579.xml"),
+          )
+      )
+
+  public val icon_858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_858.xml"),
+          )
+      )
+
+  public val icon_8580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8580.xml"),
+          )
+      )
+
+  public val icon_8581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8581.xml"),
+          )
+      )
+
+  public val icon_8582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8582.xml"),
+          )
+      )
+
+  public val icon_8583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8583.xml"),
+          )
+      )
+
+  public val icon_8584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8584.xml"),
+          )
+      )
+
+  public val icon_8585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8585.xml"),
+          )
+      )
+
+  public val icon_8586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8586.xml"),
+          )
+      )
+
+  public val icon_8587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8587.xml"),
+          )
+      )
+
+  public val icon_8588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8588.xml"),
+          )
+      )
+
+  public val icon_8589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8589.xml"),
+          )
+      )
+
+  public val icon_859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_859.xml"),
+          )
+      )
+
+  public val icon_8590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8590.xml"),
+          )
+      )
+
+  public val icon_8591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8591.xml"),
+          )
+      )
+
+  public val icon_8592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8592.xml"),
+          )
+      )
+
+  public val icon_8593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8593.xml"),
+          )
+      )
+
+  public val icon_8594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8594.xml"),
+          )
+      )
+
+  public val icon_8595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8595.xml"),
+          )
+      )
+
+  public val icon_8596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8596.xml"),
+          )
+      )
+
+  public val icon_8597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8597.xml"),
+          )
+      )
+
+  public val icon_8598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8598.xml"),
+          )
+      )
+
+  public val icon_8599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8599.xml"),
+          )
+      )
+
+  public val icon_86: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_86",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_86.xml"),
+          )
+      )
+
+  public val icon_860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_860.xml"),
+          )
+      )
+
+  public val icon_8600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8600.xml"),
+          )
+      )
+
+  public val icon_8601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8601.xml"),
+          )
+      )
+
+  public val icon_8602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8602.xml"),
+          )
+      )
+
+  public val icon_8603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8603.xml"),
+          )
+      )
+
+  public val icon_8604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8604.xml"),
+          )
+      )
+
+  public val icon_8605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8605.xml"),
+          )
+      )
+
+  public val icon_8606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8606.xml"),
+          )
+      )
+
+  public val icon_8607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8607.xml"),
+          )
+      )
+
+  public val icon_8608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8608.xml"),
+          )
+      )
+
+  public val icon_8609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8609.xml"),
+          )
+      )
+
+  public val icon_861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_861.xml"),
+          )
+      )
+
+  public val icon_8610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8610.xml"),
+          )
+      )
+
+  public val icon_8611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8611.xml"),
+          )
+      )
+
+  public val icon_8612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8612.xml"),
+          )
+      )
+
+  public val icon_8613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8613.xml"),
+          )
+      )
+
+  public val icon_8614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8614.xml"),
+          )
+      )
+
+  public val icon_8615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8615.xml"),
+          )
+      )
+
+  public val icon_8616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8616.xml"),
+          )
+      )
+
+  public val icon_8617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8617.xml"),
+          )
+      )
+
+  public val icon_8618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8618.xml"),
+          )
+      )
+
+  public val icon_8619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8619.xml"),
+          )
+      )
+
+  public val icon_862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_862.xml"),
+          )
+      )
+
+  public val icon_8620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8620.xml"),
+          )
+      )
+
+  public val icon_8621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8621.xml"),
+          )
+      )
+
+  public val icon_8622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8622.xml"),
+          )
+      )
+
+  public val icon_8623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8623.xml"),
+          )
+      )
+
+  public val icon_8624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8624.xml"),
+          )
+      )
+
+  public val icon_8625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8625.xml"),
+          )
+      )
+
+  public val icon_8626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8626.xml"),
+          )
+      )
+
+  public val icon_8627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8627.xml"),
+          )
+      )
+
+  public val icon_8628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8628.xml"),
+          )
+      )
+
+  public val icon_8629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8629.xml"),
+          )
+      )
+
+  public val icon_863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_863.xml"),
+          )
+      )
+
+  public val icon_8630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8630.xml"),
+          )
+      )
+
+  public val icon_8631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8631.xml"),
+          )
+      )
+
+  public val icon_8632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8632.xml"),
+          )
+      )
+
+  public val icon_8633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8633.xml"),
+          )
+      )
+
+  public val icon_8634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8634.xml"),
+          )
+      )
+
+  public val icon_8635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8635.xml"),
+          )
+      )
+
+  public val icon_8636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8636.xml"),
+          )
+      )
+
+  public val icon_8637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8637.xml"),
+          )
+      )
+
+  public val icon_8638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8638.xml"),
+          )
+      )
+
+  public val icon_8639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8639.xml"),
+          )
+      )
+
+  public val icon_864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_864.xml"),
+          )
+      )
+
+  public val icon_8640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8640.xml"),
+          )
+      )
+
+  public val icon_8641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8641.xml"),
+          )
+      )
+
+  public val icon_8642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8642.xml"),
+          )
+      )
+
+  public val icon_8643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8643.xml"),
+          )
+      )
+
+  public val icon_8644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8644.xml"),
+          )
+      )
+
+  public val icon_8645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8645.xml"),
+          )
+      )
+
+  public val icon_8646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8646.xml"),
+          )
+      )
+
+  public val icon_8647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8647.xml"),
+          )
+      )
+
+  public val icon_8648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8648.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8199: DrawableResource
+  get() = Drawable46.icon_8199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_82: DrawableResource
+  get() = Drawable46.icon_82
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_820: DrawableResource
+  get() = Drawable46.icon_820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8200: DrawableResource
+  get() = Drawable46.icon_8200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8201: DrawableResource
+  get() = Drawable46.icon_8201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8202: DrawableResource
+  get() = Drawable46.icon_8202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8203: DrawableResource
+  get() = Drawable46.icon_8203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8204: DrawableResource
+  get() = Drawable46.icon_8204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8205: DrawableResource
+  get() = Drawable46.icon_8205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8206: DrawableResource
+  get() = Drawable46.icon_8206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8207: DrawableResource
+  get() = Drawable46.icon_8207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8208: DrawableResource
+  get() = Drawable46.icon_8208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8209: DrawableResource
+  get() = Drawable46.icon_8209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_821: DrawableResource
+  get() = Drawable46.icon_821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8210: DrawableResource
+  get() = Drawable46.icon_8210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8211: DrawableResource
+  get() = Drawable46.icon_8211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8212: DrawableResource
+  get() = Drawable46.icon_8212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8213: DrawableResource
+  get() = Drawable46.icon_8213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8214: DrawableResource
+  get() = Drawable46.icon_8214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8215: DrawableResource
+  get() = Drawable46.icon_8215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8216: DrawableResource
+  get() = Drawable46.icon_8216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8217: DrawableResource
+  get() = Drawable46.icon_8217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8218: DrawableResource
+  get() = Drawable46.icon_8218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8219: DrawableResource
+  get() = Drawable46.icon_8219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_822: DrawableResource
+  get() = Drawable46.icon_822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8220: DrawableResource
+  get() = Drawable46.icon_8220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8221: DrawableResource
+  get() = Drawable46.icon_8221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8222: DrawableResource
+  get() = Drawable46.icon_8222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8223: DrawableResource
+  get() = Drawable46.icon_8223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8224: DrawableResource
+  get() = Drawable46.icon_8224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8225: DrawableResource
+  get() = Drawable46.icon_8225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8226: DrawableResource
+  get() = Drawable46.icon_8226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8227: DrawableResource
+  get() = Drawable46.icon_8227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8228: DrawableResource
+  get() = Drawable46.icon_8228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8229: DrawableResource
+  get() = Drawable46.icon_8229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_823: DrawableResource
+  get() = Drawable46.icon_823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8230: DrawableResource
+  get() = Drawable46.icon_8230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8231: DrawableResource
+  get() = Drawable46.icon_8231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8232: DrawableResource
+  get() = Drawable46.icon_8232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8233: DrawableResource
+  get() = Drawable46.icon_8233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8234: DrawableResource
+  get() = Drawable46.icon_8234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8235: DrawableResource
+  get() = Drawable46.icon_8235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8236: DrawableResource
+  get() = Drawable46.icon_8236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8237: DrawableResource
+  get() = Drawable46.icon_8237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8238: DrawableResource
+  get() = Drawable46.icon_8238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8239: DrawableResource
+  get() = Drawable46.icon_8239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_824: DrawableResource
+  get() = Drawable46.icon_824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8240: DrawableResource
+  get() = Drawable46.icon_8240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8241: DrawableResource
+  get() = Drawable46.icon_8241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8242: DrawableResource
+  get() = Drawable46.icon_8242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8243: DrawableResource
+  get() = Drawable46.icon_8243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8244: DrawableResource
+  get() = Drawable46.icon_8244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8245: DrawableResource
+  get() = Drawable46.icon_8245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8246: DrawableResource
+  get() = Drawable46.icon_8246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8247: DrawableResource
+  get() = Drawable46.icon_8247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8248: DrawableResource
+  get() = Drawable46.icon_8248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8249: DrawableResource
+  get() = Drawable46.icon_8249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_825: DrawableResource
+  get() = Drawable46.icon_825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8250: DrawableResource
+  get() = Drawable46.icon_8250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8251: DrawableResource
+  get() = Drawable46.icon_8251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8252: DrawableResource
+  get() = Drawable46.icon_8252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8253: DrawableResource
+  get() = Drawable46.icon_8253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8254: DrawableResource
+  get() = Drawable46.icon_8254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8255: DrawableResource
+  get() = Drawable46.icon_8255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8256: DrawableResource
+  get() = Drawable46.icon_8256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8257: DrawableResource
+  get() = Drawable46.icon_8257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8258: DrawableResource
+  get() = Drawable46.icon_8258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8259: DrawableResource
+  get() = Drawable46.icon_8259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_826: DrawableResource
+  get() = Drawable46.icon_826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8260: DrawableResource
+  get() = Drawable46.icon_8260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8261: DrawableResource
+  get() = Drawable46.icon_8261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8262: DrawableResource
+  get() = Drawable46.icon_8262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8263: DrawableResource
+  get() = Drawable46.icon_8263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8264: DrawableResource
+  get() = Drawable46.icon_8264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8265: DrawableResource
+  get() = Drawable46.icon_8265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8266: DrawableResource
+  get() = Drawable46.icon_8266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8267: DrawableResource
+  get() = Drawable46.icon_8267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8268: DrawableResource
+  get() = Drawable46.icon_8268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8269: DrawableResource
+  get() = Drawable46.icon_8269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_827: DrawableResource
+  get() = Drawable46.icon_827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8270: DrawableResource
+  get() = Drawable46.icon_8270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8271: DrawableResource
+  get() = Drawable46.icon_8271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8272: DrawableResource
+  get() = Drawable46.icon_8272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8273: DrawableResource
+  get() = Drawable46.icon_8273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8274: DrawableResource
+  get() = Drawable46.icon_8274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8275: DrawableResource
+  get() = Drawable46.icon_8275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8276: DrawableResource
+  get() = Drawable46.icon_8276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8277: DrawableResource
+  get() = Drawable46.icon_8277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8278: DrawableResource
+  get() = Drawable46.icon_8278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8279: DrawableResource
+  get() = Drawable46.icon_8279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_828: DrawableResource
+  get() = Drawable46.icon_828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8280: DrawableResource
+  get() = Drawable46.icon_8280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8281: DrawableResource
+  get() = Drawable46.icon_8281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8282: DrawableResource
+  get() = Drawable46.icon_8282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8283: DrawableResource
+  get() = Drawable46.icon_8283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8284: DrawableResource
+  get() = Drawable46.icon_8284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8285: DrawableResource
+  get() = Drawable46.icon_8285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8286: DrawableResource
+  get() = Drawable46.icon_8286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8287: DrawableResource
+  get() = Drawable46.icon_8287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8288: DrawableResource
+  get() = Drawable46.icon_8288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8289: DrawableResource
+  get() = Drawable46.icon_8289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_829: DrawableResource
+  get() = Drawable46.icon_829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8290: DrawableResource
+  get() = Drawable46.icon_8290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8291: DrawableResource
+  get() = Drawable46.icon_8291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8292: DrawableResource
+  get() = Drawable46.icon_8292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8293: DrawableResource
+  get() = Drawable46.icon_8293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8294: DrawableResource
+  get() = Drawable46.icon_8294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8295: DrawableResource
+  get() = Drawable46.icon_8295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8296: DrawableResource
+  get() = Drawable46.icon_8296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8297: DrawableResource
+  get() = Drawable46.icon_8297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8298: DrawableResource
+  get() = Drawable46.icon_8298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8299: DrawableResource
+  get() = Drawable46.icon_8299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_83: DrawableResource
+  get() = Drawable46.icon_83
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_830: DrawableResource
+  get() = Drawable46.icon_830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8300: DrawableResource
+  get() = Drawable46.icon_8300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8301: DrawableResource
+  get() = Drawable46.icon_8301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8302: DrawableResource
+  get() = Drawable46.icon_8302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8303: DrawableResource
+  get() = Drawable46.icon_8303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8304: DrawableResource
+  get() = Drawable46.icon_8304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8305: DrawableResource
+  get() = Drawable46.icon_8305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8306: DrawableResource
+  get() = Drawable46.icon_8306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8307: DrawableResource
+  get() = Drawable46.icon_8307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8308: DrawableResource
+  get() = Drawable46.icon_8308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8309: DrawableResource
+  get() = Drawable46.icon_8309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_831: DrawableResource
+  get() = Drawable46.icon_831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8310: DrawableResource
+  get() = Drawable46.icon_8310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8311: DrawableResource
+  get() = Drawable46.icon_8311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8312: DrawableResource
+  get() = Drawable46.icon_8312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8313: DrawableResource
+  get() = Drawable46.icon_8313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8314: DrawableResource
+  get() = Drawable46.icon_8314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8315: DrawableResource
+  get() = Drawable46.icon_8315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8316: DrawableResource
+  get() = Drawable46.icon_8316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8317: DrawableResource
+  get() = Drawable46.icon_8317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8318: DrawableResource
+  get() = Drawable46.icon_8318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8319: DrawableResource
+  get() = Drawable46.icon_8319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_832: DrawableResource
+  get() = Drawable46.icon_832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8320: DrawableResource
+  get() = Drawable46.icon_8320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8321: DrawableResource
+  get() = Drawable46.icon_8321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8322: DrawableResource
+  get() = Drawable46.icon_8322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8323: DrawableResource
+  get() = Drawable46.icon_8323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8324: DrawableResource
+  get() = Drawable46.icon_8324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8325: DrawableResource
+  get() = Drawable46.icon_8325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8326: DrawableResource
+  get() = Drawable46.icon_8326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8327: DrawableResource
+  get() = Drawable46.icon_8327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8328: DrawableResource
+  get() = Drawable46.icon_8328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8329: DrawableResource
+  get() = Drawable46.icon_8329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_833: DrawableResource
+  get() = Drawable46.icon_833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8330: DrawableResource
+  get() = Drawable46.icon_8330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8331: DrawableResource
+  get() = Drawable46.icon_8331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8332: DrawableResource
+  get() = Drawable46.icon_8332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8333: DrawableResource
+  get() = Drawable46.icon_8333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8334: DrawableResource
+  get() = Drawable46.icon_8334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8335: DrawableResource
+  get() = Drawable46.icon_8335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8336: DrawableResource
+  get() = Drawable46.icon_8336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8337: DrawableResource
+  get() = Drawable46.icon_8337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8338: DrawableResource
+  get() = Drawable46.icon_8338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8339: DrawableResource
+  get() = Drawable46.icon_8339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_834: DrawableResource
+  get() = Drawable46.icon_834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8340: DrawableResource
+  get() = Drawable46.icon_8340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8341: DrawableResource
+  get() = Drawable46.icon_8341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8342: DrawableResource
+  get() = Drawable46.icon_8342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8343: DrawableResource
+  get() = Drawable46.icon_8343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8344: DrawableResource
+  get() = Drawable46.icon_8344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8345: DrawableResource
+  get() = Drawable46.icon_8345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8346: DrawableResource
+  get() = Drawable46.icon_8346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8347: DrawableResource
+  get() = Drawable46.icon_8347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8348: DrawableResource
+  get() = Drawable46.icon_8348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8349: DrawableResource
+  get() = Drawable46.icon_8349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_835: DrawableResource
+  get() = Drawable46.icon_835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8350: DrawableResource
+  get() = Drawable46.icon_8350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8351: DrawableResource
+  get() = Drawable46.icon_8351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8352: DrawableResource
+  get() = Drawable46.icon_8352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8353: DrawableResource
+  get() = Drawable46.icon_8353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8354: DrawableResource
+  get() = Drawable46.icon_8354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8355: DrawableResource
+  get() = Drawable46.icon_8355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8356: DrawableResource
+  get() = Drawable46.icon_8356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8357: DrawableResource
+  get() = Drawable46.icon_8357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8358: DrawableResource
+  get() = Drawable46.icon_8358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8359: DrawableResource
+  get() = Drawable46.icon_8359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_836: DrawableResource
+  get() = Drawable46.icon_836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8360: DrawableResource
+  get() = Drawable46.icon_8360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8361: DrawableResource
+  get() = Drawable46.icon_8361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8362: DrawableResource
+  get() = Drawable46.icon_8362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8363: DrawableResource
+  get() = Drawable46.icon_8363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8364: DrawableResource
+  get() = Drawable46.icon_8364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8365: DrawableResource
+  get() = Drawable46.icon_8365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8366: DrawableResource
+  get() = Drawable46.icon_8366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8367: DrawableResource
+  get() = Drawable46.icon_8367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8368: DrawableResource
+  get() = Drawable46.icon_8368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8369: DrawableResource
+  get() = Drawable46.icon_8369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_837: DrawableResource
+  get() = Drawable46.icon_837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8370: DrawableResource
+  get() = Drawable46.icon_8370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8371: DrawableResource
+  get() = Drawable46.icon_8371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8372: DrawableResource
+  get() = Drawable46.icon_8372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8373: DrawableResource
+  get() = Drawable46.icon_8373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8374: DrawableResource
+  get() = Drawable46.icon_8374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8375: DrawableResource
+  get() = Drawable46.icon_8375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8376: DrawableResource
+  get() = Drawable46.icon_8376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8377: DrawableResource
+  get() = Drawable46.icon_8377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8378: DrawableResource
+  get() = Drawable46.icon_8378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8379: DrawableResource
+  get() = Drawable46.icon_8379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_838: DrawableResource
+  get() = Drawable46.icon_838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8380: DrawableResource
+  get() = Drawable46.icon_8380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8381: DrawableResource
+  get() = Drawable46.icon_8381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8382: DrawableResource
+  get() = Drawable46.icon_8382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8383: DrawableResource
+  get() = Drawable46.icon_8383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8384: DrawableResource
+  get() = Drawable46.icon_8384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8385: DrawableResource
+  get() = Drawable46.icon_8385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8386: DrawableResource
+  get() = Drawable46.icon_8386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8387: DrawableResource
+  get() = Drawable46.icon_8387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8388: DrawableResource
+  get() = Drawable46.icon_8388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8389: DrawableResource
+  get() = Drawable46.icon_8389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_839: DrawableResource
+  get() = Drawable46.icon_839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8390: DrawableResource
+  get() = Drawable46.icon_8390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8391: DrawableResource
+  get() = Drawable46.icon_8391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8392: DrawableResource
+  get() = Drawable46.icon_8392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8393: DrawableResource
+  get() = Drawable46.icon_8393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8394: DrawableResource
+  get() = Drawable46.icon_8394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8395: DrawableResource
+  get() = Drawable46.icon_8395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8396: DrawableResource
+  get() = Drawable46.icon_8396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8397: DrawableResource
+  get() = Drawable46.icon_8397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8398: DrawableResource
+  get() = Drawable46.icon_8398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8399: DrawableResource
+  get() = Drawable46.icon_8399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_84: DrawableResource
+  get() = Drawable46.icon_84
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_840: DrawableResource
+  get() = Drawable46.icon_840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8400: DrawableResource
+  get() = Drawable46.icon_8400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8401: DrawableResource
+  get() = Drawable46.icon_8401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8402: DrawableResource
+  get() = Drawable46.icon_8402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8403: DrawableResource
+  get() = Drawable46.icon_8403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8404: DrawableResource
+  get() = Drawable46.icon_8404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8405: DrawableResource
+  get() = Drawable46.icon_8405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8406: DrawableResource
+  get() = Drawable46.icon_8406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8407: DrawableResource
+  get() = Drawable46.icon_8407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8408: DrawableResource
+  get() = Drawable46.icon_8408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8409: DrawableResource
+  get() = Drawable46.icon_8409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_841: DrawableResource
+  get() = Drawable46.icon_841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8410: DrawableResource
+  get() = Drawable46.icon_8410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8411: DrawableResource
+  get() = Drawable46.icon_8411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8412: DrawableResource
+  get() = Drawable46.icon_8412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8413: DrawableResource
+  get() = Drawable46.icon_8413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8414: DrawableResource
+  get() = Drawable46.icon_8414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8415: DrawableResource
+  get() = Drawable46.icon_8415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8416: DrawableResource
+  get() = Drawable46.icon_8416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8417: DrawableResource
+  get() = Drawable46.icon_8417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8418: DrawableResource
+  get() = Drawable46.icon_8418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8419: DrawableResource
+  get() = Drawable46.icon_8419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_842: DrawableResource
+  get() = Drawable46.icon_842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8420: DrawableResource
+  get() = Drawable46.icon_8420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8421: DrawableResource
+  get() = Drawable46.icon_8421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8422: DrawableResource
+  get() = Drawable46.icon_8422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8423: DrawableResource
+  get() = Drawable46.icon_8423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8424: DrawableResource
+  get() = Drawable46.icon_8424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8425: DrawableResource
+  get() = Drawable46.icon_8425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8426: DrawableResource
+  get() = Drawable46.icon_8426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8427: DrawableResource
+  get() = Drawable46.icon_8427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8428: DrawableResource
+  get() = Drawable46.icon_8428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8429: DrawableResource
+  get() = Drawable46.icon_8429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_843: DrawableResource
+  get() = Drawable46.icon_843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8430: DrawableResource
+  get() = Drawable46.icon_8430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8431: DrawableResource
+  get() = Drawable46.icon_8431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8432: DrawableResource
+  get() = Drawable46.icon_8432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8433: DrawableResource
+  get() = Drawable46.icon_8433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8434: DrawableResource
+  get() = Drawable46.icon_8434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8435: DrawableResource
+  get() = Drawable46.icon_8435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8436: DrawableResource
+  get() = Drawable46.icon_8436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8437: DrawableResource
+  get() = Drawable46.icon_8437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8438: DrawableResource
+  get() = Drawable46.icon_8438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8439: DrawableResource
+  get() = Drawable46.icon_8439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_844: DrawableResource
+  get() = Drawable46.icon_844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8440: DrawableResource
+  get() = Drawable46.icon_8440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8441: DrawableResource
+  get() = Drawable46.icon_8441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8442: DrawableResource
+  get() = Drawable46.icon_8442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8443: DrawableResource
+  get() = Drawable46.icon_8443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8444: DrawableResource
+  get() = Drawable46.icon_8444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8445: DrawableResource
+  get() = Drawable46.icon_8445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8446: DrawableResource
+  get() = Drawable46.icon_8446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8447: DrawableResource
+  get() = Drawable46.icon_8447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8448: DrawableResource
+  get() = Drawable46.icon_8448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8449: DrawableResource
+  get() = Drawable46.icon_8449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_845: DrawableResource
+  get() = Drawable46.icon_845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8450: DrawableResource
+  get() = Drawable46.icon_8450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8451: DrawableResource
+  get() = Drawable46.icon_8451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8452: DrawableResource
+  get() = Drawable46.icon_8452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8453: DrawableResource
+  get() = Drawable46.icon_8453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8454: DrawableResource
+  get() = Drawable46.icon_8454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8455: DrawableResource
+  get() = Drawable46.icon_8455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8456: DrawableResource
+  get() = Drawable46.icon_8456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8457: DrawableResource
+  get() = Drawable46.icon_8457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8458: DrawableResource
+  get() = Drawable46.icon_8458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8459: DrawableResource
+  get() = Drawable46.icon_8459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_846: DrawableResource
+  get() = Drawable46.icon_846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8460: DrawableResource
+  get() = Drawable46.icon_8460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8461: DrawableResource
+  get() = Drawable46.icon_8461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8462: DrawableResource
+  get() = Drawable46.icon_8462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8463: DrawableResource
+  get() = Drawable46.icon_8463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8464: DrawableResource
+  get() = Drawable46.icon_8464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8465: DrawableResource
+  get() = Drawable46.icon_8465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8466: DrawableResource
+  get() = Drawable46.icon_8466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8467: DrawableResource
+  get() = Drawable46.icon_8467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8468: DrawableResource
+  get() = Drawable46.icon_8468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8469: DrawableResource
+  get() = Drawable46.icon_8469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_847: DrawableResource
+  get() = Drawable46.icon_847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8470: DrawableResource
+  get() = Drawable46.icon_8470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8471: DrawableResource
+  get() = Drawable46.icon_8471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8472: DrawableResource
+  get() = Drawable46.icon_8472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8473: DrawableResource
+  get() = Drawable46.icon_8473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8474: DrawableResource
+  get() = Drawable46.icon_8474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8475: DrawableResource
+  get() = Drawable46.icon_8475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8476: DrawableResource
+  get() = Drawable46.icon_8476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8477: DrawableResource
+  get() = Drawable46.icon_8477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8478: DrawableResource
+  get() = Drawable46.icon_8478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8479: DrawableResource
+  get() = Drawable46.icon_8479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_848: DrawableResource
+  get() = Drawable46.icon_848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8480: DrawableResource
+  get() = Drawable46.icon_8480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8481: DrawableResource
+  get() = Drawable46.icon_8481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8482: DrawableResource
+  get() = Drawable46.icon_8482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8483: DrawableResource
+  get() = Drawable46.icon_8483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8484: DrawableResource
+  get() = Drawable46.icon_8484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8485: DrawableResource
+  get() = Drawable46.icon_8485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8486: DrawableResource
+  get() = Drawable46.icon_8486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8487: DrawableResource
+  get() = Drawable46.icon_8487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8488: DrawableResource
+  get() = Drawable46.icon_8488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8489: DrawableResource
+  get() = Drawable46.icon_8489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_849: DrawableResource
+  get() = Drawable46.icon_849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8490: DrawableResource
+  get() = Drawable46.icon_8490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8491: DrawableResource
+  get() = Drawable46.icon_8491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8492: DrawableResource
+  get() = Drawable46.icon_8492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8493: DrawableResource
+  get() = Drawable46.icon_8493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8494: DrawableResource
+  get() = Drawable46.icon_8494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8495: DrawableResource
+  get() = Drawable46.icon_8495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8496: DrawableResource
+  get() = Drawable46.icon_8496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8497: DrawableResource
+  get() = Drawable46.icon_8497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8498: DrawableResource
+  get() = Drawable46.icon_8498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8499: DrawableResource
+  get() = Drawable46.icon_8499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_85: DrawableResource
+  get() = Drawable46.icon_85
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_850: DrawableResource
+  get() = Drawable46.icon_850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8500: DrawableResource
+  get() = Drawable46.icon_8500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8501: DrawableResource
+  get() = Drawable46.icon_8501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8502: DrawableResource
+  get() = Drawable46.icon_8502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8503: DrawableResource
+  get() = Drawable46.icon_8503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8504: DrawableResource
+  get() = Drawable46.icon_8504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8505: DrawableResource
+  get() = Drawable46.icon_8505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8506: DrawableResource
+  get() = Drawable46.icon_8506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8507: DrawableResource
+  get() = Drawable46.icon_8507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8508: DrawableResource
+  get() = Drawable46.icon_8508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8509: DrawableResource
+  get() = Drawable46.icon_8509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_851: DrawableResource
+  get() = Drawable46.icon_851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8510: DrawableResource
+  get() = Drawable46.icon_8510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8511: DrawableResource
+  get() = Drawable46.icon_8511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8512: DrawableResource
+  get() = Drawable46.icon_8512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8513: DrawableResource
+  get() = Drawable46.icon_8513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8514: DrawableResource
+  get() = Drawable46.icon_8514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8515: DrawableResource
+  get() = Drawable46.icon_8515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8516: DrawableResource
+  get() = Drawable46.icon_8516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8517: DrawableResource
+  get() = Drawable46.icon_8517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8518: DrawableResource
+  get() = Drawable46.icon_8518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8519: DrawableResource
+  get() = Drawable46.icon_8519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_852: DrawableResource
+  get() = Drawable46.icon_852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8520: DrawableResource
+  get() = Drawable46.icon_8520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8521: DrawableResource
+  get() = Drawable46.icon_8521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8522: DrawableResource
+  get() = Drawable46.icon_8522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8523: DrawableResource
+  get() = Drawable46.icon_8523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8524: DrawableResource
+  get() = Drawable46.icon_8524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8525: DrawableResource
+  get() = Drawable46.icon_8525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8526: DrawableResource
+  get() = Drawable46.icon_8526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8527: DrawableResource
+  get() = Drawable46.icon_8527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8528: DrawableResource
+  get() = Drawable46.icon_8528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8529: DrawableResource
+  get() = Drawable46.icon_8529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_853: DrawableResource
+  get() = Drawable46.icon_853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8530: DrawableResource
+  get() = Drawable46.icon_8530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8531: DrawableResource
+  get() = Drawable46.icon_8531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8532: DrawableResource
+  get() = Drawable46.icon_8532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8533: DrawableResource
+  get() = Drawable46.icon_8533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8534: DrawableResource
+  get() = Drawable46.icon_8534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8535: DrawableResource
+  get() = Drawable46.icon_8535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8536: DrawableResource
+  get() = Drawable46.icon_8536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8537: DrawableResource
+  get() = Drawable46.icon_8537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8538: DrawableResource
+  get() = Drawable46.icon_8538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8539: DrawableResource
+  get() = Drawable46.icon_8539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_854: DrawableResource
+  get() = Drawable46.icon_854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8540: DrawableResource
+  get() = Drawable46.icon_8540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8541: DrawableResource
+  get() = Drawable46.icon_8541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8542: DrawableResource
+  get() = Drawable46.icon_8542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8543: DrawableResource
+  get() = Drawable46.icon_8543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8544: DrawableResource
+  get() = Drawable46.icon_8544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8545: DrawableResource
+  get() = Drawable46.icon_8545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8546: DrawableResource
+  get() = Drawable46.icon_8546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8547: DrawableResource
+  get() = Drawable46.icon_8547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8548: DrawableResource
+  get() = Drawable46.icon_8548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8549: DrawableResource
+  get() = Drawable46.icon_8549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_855: DrawableResource
+  get() = Drawable46.icon_855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8550: DrawableResource
+  get() = Drawable46.icon_8550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8551: DrawableResource
+  get() = Drawable46.icon_8551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8552: DrawableResource
+  get() = Drawable46.icon_8552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8553: DrawableResource
+  get() = Drawable46.icon_8553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8554: DrawableResource
+  get() = Drawable46.icon_8554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8555: DrawableResource
+  get() = Drawable46.icon_8555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8556: DrawableResource
+  get() = Drawable46.icon_8556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8557: DrawableResource
+  get() = Drawable46.icon_8557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8558: DrawableResource
+  get() = Drawable46.icon_8558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8559: DrawableResource
+  get() = Drawable46.icon_8559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_856: DrawableResource
+  get() = Drawable46.icon_856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8560: DrawableResource
+  get() = Drawable46.icon_8560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8561: DrawableResource
+  get() = Drawable46.icon_8561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8562: DrawableResource
+  get() = Drawable46.icon_8562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8563: DrawableResource
+  get() = Drawable46.icon_8563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8564: DrawableResource
+  get() = Drawable46.icon_8564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8565: DrawableResource
+  get() = Drawable46.icon_8565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8566: DrawableResource
+  get() = Drawable46.icon_8566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8567: DrawableResource
+  get() = Drawable46.icon_8567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8568: DrawableResource
+  get() = Drawable46.icon_8568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8569: DrawableResource
+  get() = Drawable46.icon_8569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_857: DrawableResource
+  get() = Drawable46.icon_857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8570: DrawableResource
+  get() = Drawable46.icon_8570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8571: DrawableResource
+  get() = Drawable46.icon_8571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8572: DrawableResource
+  get() = Drawable46.icon_8572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8573: DrawableResource
+  get() = Drawable46.icon_8573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8574: DrawableResource
+  get() = Drawable46.icon_8574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8575: DrawableResource
+  get() = Drawable46.icon_8575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8576: DrawableResource
+  get() = Drawable46.icon_8576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8577: DrawableResource
+  get() = Drawable46.icon_8577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8578: DrawableResource
+  get() = Drawable46.icon_8578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8579: DrawableResource
+  get() = Drawable46.icon_8579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_858: DrawableResource
+  get() = Drawable46.icon_858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8580: DrawableResource
+  get() = Drawable46.icon_8580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8581: DrawableResource
+  get() = Drawable46.icon_8581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8582: DrawableResource
+  get() = Drawable46.icon_8582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8583: DrawableResource
+  get() = Drawable46.icon_8583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8584: DrawableResource
+  get() = Drawable46.icon_8584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8585: DrawableResource
+  get() = Drawable46.icon_8585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8586: DrawableResource
+  get() = Drawable46.icon_8586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8587: DrawableResource
+  get() = Drawable46.icon_8587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8588: DrawableResource
+  get() = Drawable46.icon_8588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8589: DrawableResource
+  get() = Drawable46.icon_8589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_859: DrawableResource
+  get() = Drawable46.icon_859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8590: DrawableResource
+  get() = Drawable46.icon_8590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8591: DrawableResource
+  get() = Drawable46.icon_8591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8592: DrawableResource
+  get() = Drawable46.icon_8592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8593: DrawableResource
+  get() = Drawable46.icon_8593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8594: DrawableResource
+  get() = Drawable46.icon_8594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8595: DrawableResource
+  get() = Drawable46.icon_8595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8596: DrawableResource
+  get() = Drawable46.icon_8596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8597: DrawableResource
+  get() = Drawable46.icon_8597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8598: DrawableResource
+  get() = Drawable46.icon_8598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8599: DrawableResource
+  get() = Drawable46.icon_8599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_86: DrawableResource
+  get() = Drawable46.icon_86
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_860: DrawableResource
+  get() = Drawable46.icon_860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8600: DrawableResource
+  get() = Drawable46.icon_8600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8601: DrawableResource
+  get() = Drawable46.icon_8601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8602: DrawableResource
+  get() = Drawable46.icon_8602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8603: DrawableResource
+  get() = Drawable46.icon_8603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8604: DrawableResource
+  get() = Drawable46.icon_8604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8605: DrawableResource
+  get() = Drawable46.icon_8605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8606: DrawableResource
+  get() = Drawable46.icon_8606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8607: DrawableResource
+  get() = Drawable46.icon_8607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8608: DrawableResource
+  get() = Drawable46.icon_8608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8609: DrawableResource
+  get() = Drawable46.icon_8609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_861: DrawableResource
+  get() = Drawable46.icon_861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8610: DrawableResource
+  get() = Drawable46.icon_8610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8611: DrawableResource
+  get() = Drawable46.icon_8611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8612: DrawableResource
+  get() = Drawable46.icon_8612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8613: DrawableResource
+  get() = Drawable46.icon_8613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8614: DrawableResource
+  get() = Drawable46.icon_8614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8615: DrawableResource
+  get() = Drawable46.icon_8615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8616: DrawableResource
+  get() = Drawable46.icon_8616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8617: DrawableResource
+  get() = Drawable46.icon_8617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8618: DrawableResource
+  get() = Drawable46.icon_8618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8619: DrawableResource
+  get() = Drawable46.icon_8619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_862: DrawableResource
+  get() = Drawable46.icon_862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8620: DrawableResource
+  get() = Drawable46.icon_8620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8621: DrawableResource
+  get() = Drawable46.icon_8621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8622: DrawableResource
+  get() = Drawable46.icon_8622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8623: DrawableResource
+  get() = Drawable46.icon_8623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8624: DrawableResource
+  get() = Drawable46.icon_8624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8625: DrawableResource
+  get() = Drawable46.icon_8625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8626: DrawableResource
+  get() = Drawable46.icon_8626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8627: DrawableResource
+  get() = Drawable46.icon_8627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8628: DrawableResource
+  get() = Drawable46.icon_8628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8629: DrawableResource
+  get() = Drawable46.icon_8629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_863: DrawableResource
+  get() = Drawable46.icon_863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8630: DrawableResource
+  get() = Drawable46.icon_8630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8631: DrawableResource
+  get() = Drawable46.icon_8631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8632: DrawableResource
+  get() = Drawable46.icon_8632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8633: DrawableResource
+  get() = Drawable46.icon_8633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8634: DrawableResource
+  get() = Drawable46.icon_8634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8635: DrawableResource
+  get() = Drawable46.icon_8635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8636: DrawableResource
+  get() = Drawable46.icon_8636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8637: DrawableResource
+  get() = Drawable46.icon_8637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8638: DrawableResource
+  get() = Drawable46.icon_8638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8639: DrawableResource
+  get() = Drawable46.icon_8639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_864: DrawableResource
+  get() = Drawable46.icon_864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8640: DrawableResource
+  get() = Drawable46.icon_8640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8641: DrawableResource
+  get() = Drawable46.icon_8641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8642: DrawableResource
+  get() = Drawable46.icon_8642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8643: DrawableResource
+  get() = Drawable46.icon_8643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8644: DrawableResource
+  get() = Drawable46.icon_8644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8645: DrawableResource
+  get() = Drawable46.icon_8645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8646: DrawableResource
+  get() = Drawable46.icon_8646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8647: DrawableResource
+  get() = Drawable46.icon_8647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8648: DrawableResource
+  get() = Drawable46.icon_8648

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable47.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable47.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable47 {
+  public val icon_8649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8649.xml"),
+          )
+      )
+
+  public val icon_865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_865.xml"),
+          )
+      )
+
+  public val icon_8650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8650.xml"),
+          )
+      )
+
+  public val icon_8651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8651.xml"),
+          )
+      )
+
+  public val icon_8652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8652.xml"),
+          )
+      )
+
+  public val icon_8653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8653.xml"),
+          )
+      )
+
+  public val icon_8654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8654.xml"),
+          )
+      )
+
+  public val icon_8655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8655.xml"),
+          )
+      )
+
+  public val icon_8656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8656.xml"),
+          )
+      )
+
+  public val icon_8657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8657.xml"),
+          )
+      )
+
+  public val icon_8658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8658.xml"),
+          )
+      )
+
+  public val icon_8659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8659.xml"),
+          )
+      )
+
+  public val icon_866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_866.xml"),
+          )
+      )
+
+  public val icon_8660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8660.xml"),
+          )
+      )
+
+  public val icon_8661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8661.xml"),
+          )
+      )
+
+  public val icon_8662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8662.xml"),
+          )
+      )
+
+  public val icon_8663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8663.xml"),
+          )
+      )
+
+  public val icon_8664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8664.xml"),
+          )
+      )
+
+  public val icon_8665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8665.xml"),
+          )
+      )
+
+  public val icon_8666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8666.xml"),
+          )
+      )
+
+  public val icon_8667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8667.xml"),
+          )
+      )
+
+  public val icon_8668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8668.xml"),
+          )
+      )
+
+  public val icon_8669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8669.xml"),
+          )
+      )
+
+  public val icon_867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_867.xml"),
+          )
+      )
+
+  public val icon_8670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8670.xml"),
+          )
+      )
+
+  public val icon_8671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8671.xml"),
+          )
+      )
+
+  public val icon_8672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8672.xml"),
+          )
+      )
+
+  public val icon_8673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8673.xml"),
+          )
+      )
+
+  public val icon_8674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8674.xml"),
+          )
+      )
+
+  public val icon_8675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8675.xml"),
+          )
+      )
+
+  public val icon_8676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8676.xml"),
+          )
+      )
+
+  public val icon_8677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8677.xml"),
+          )
+      )
+
+  public val icon_8678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8678.xml"),
+          )
+      )
+
+  public val icon_8679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8679.xml"),
+          )
+      )
+
+  public val icon_868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_868.xml"),
+          )
+      )
+
+  public val icon_8680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8680.xml"),
+          )
+      )
+
+  public val icon_8681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8681.xml"),
+          )
+      )
+
+  public val icon_8682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8682.xml"),
+          )
+      )
+
+  public val icon_8683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8683.xml"),
+          )
+      )
+
+  public val icon_8684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8684.xml"),
+          )
+      )
+
+  public val icon_8685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8685.xml"),
+          )
+      )
+
+  public val icon_8686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8686.xml"),
+          )
+      )
+
+  public val icon_8687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8687.xml"),
+          )
+      )
+
+  public val icon_8688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8688.xml"),
+          )
+      )
+
+  public val icon_8689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8689.xml"),
+          )
+      )
+
+  public val icon_869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_869.xml"),
+          )
+      )
+
+  public val icon_8690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8690.xml"),
+          )
+      )
+
+  public val icon_8691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8691.xml"),
+          )
+      )
+
+  public val icon_8692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8692.xml"),
+          )
+      )
+
+  public val icon_8693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8693.xml"),
+          )
+      )
+
+  public val icon_8694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8694.xml"),
+          )
+      )
+
+  public val icon_8695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8695.xml"),
+          )
+      )
+
+  public val icon_8696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8696.xml"),
+          )
+      )
+
+  public val icon_8697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8697.xml"),
+          )
+      )
+
+  public val icon_8698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8698.xml"),
+          )
+      )
+
+  public val icon_8699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8699.xml"),
+          )
+      )
+
+  public val icon_87: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_87",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_87.xml"),
+          )
+      )
+
+  public val icon_870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_870.xml"),
+          )
+      )
+
+  public val icon_8700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8700.xml"),
+          )
+      )
+
+  public val icon_8701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8701.xml"),
+          )
+      )
+
+  public val icon_8702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8702.xml"),
+          )
+      )
+
+  public val icon_8703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8703.xml"),
+          )
+      )
+
+  public val icon_8704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8704.xml"),
+          )
+      )
+
+  public val icon_8705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8705.xml"),
+          )
+      )
+
+  public val icon_8706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8706.xml"),
+          )
+      )
+
+  public val icon_8707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8707.xml"),
+          )
+      )
+
+  public val icon_8708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8708.xml"),
+          )
+      )
+
+  public val icon_8709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8709.xml"),
+          )
+      )
+
+  public val icon_871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_871.xml"),
+          )
+      )
+
+  public val icon_8710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8710.xml"),
+          )
+      )
+
+  public val icon_8711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8711.xml"),
+          )
+      )
+
+  public val icon_8712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8712.xml"),
+          )
+      )
+
+  public val icon_8713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8713.xml"),
+          )
+      )
+
+  public val icon_8714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8714.xml"),
+          )
+      )
+
+  public val icon_8715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8715.xml"),
+          )
+      )
+
+  public val icon_8716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8716.xml"),
+          )
+      )
+
+  public val icon_8717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8717.xml"),
+          )
+      )
+
+  public val icon_8718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8718.xml"),
+          )
+      )
+
+  public val icon_8719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8719.xml"),
+          )
+      )
+
+  public val icon_872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_872.xml"),
+          )
+      )
+
+  public val icon_8720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8720.xml"),
+          )
+      )
+
+  public val icon_8721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8721.xml"),
+          )
+      )
+
+  public val icon_8722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8722.xml"),
+          )
+      )
+
+  public val icon_8723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8723.xml"),
+          )
+      )
+
+  public val icon_8724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8724.xml"),
+          )
+      )
+
+  public val icon_8725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8725.xml"),
+          )
+      )
+
+  public val icon_8726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8726.xml"),
+          )
+      )
+
+  public val icon_8727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8727.xml"),
+          )
+      )
+
+  public val icon_8728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8728.xml"),
+          )
+      )
+
+  public val icon_8729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8729.xml"),
+          )
+      )
+
+  public val icon_873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_873.xml"),
+          )
+      )
+
+  public val icon_8730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8730.xml"),
+          )
+      )
+
+  public val icon_8731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8731.xml"),
+          )
+      )
+
+  public val icon_8732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8732.xml"),
+          )
+      )
+
+  public val icon_8733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8733.xml"),
+          )
+      )
+
+  public val icon_8734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8734.xml"),
+          )
+      )
+
+  public val icon_8735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8735.xml"),
+          )
+      )
+
+  public val icon_8736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8736.xml"),
+          )
+      )
+
+  public val icon_8737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8737.xml"),
+          )
+      )
+
+  public val icon_8738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8738.xml"),
+          )
+      )
+
+  public val icon_8739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8739.xml"),
+          )
+      )
+
+  public val icon_874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_874.xml"),
+          )
+      )
+
+  public val icon_8740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8740.xml"),
+          )
+      )
+
+  public val icon_8741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8741.xml"),
+          )
+      )
+
+  public val icon_8742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8742.xml"),
+          )
+      )
+
+  public val icon_8743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8743.xml"),
+          )
+      )
+
+  public val icon_8744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8744.xml"),
+          )
+      )
+
+  public val icon_8745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8745.xml"),
+          )
+      )
+
+  public val icon_8746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8746.xml"),
+          )
+      )
+
+  public val icon_8747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8747.xml"),
+          )
+      )
+
+  public val icon_8748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8748.xml"),
+          )
+      )
+
+  public val icon_8749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8749.xml"),
+          )
+      )
+
+  public val icon_875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_875.xml"),
+          )
+      )
+
+  public val icon_8750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8750.xml"),
+          )
+      )
+
+  public val icon_8751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8751.xml"),
+          )
+      )
+
+  public val icon_8752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8752.xml"),
+          )
+      )
+
+  public val icon_8753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8753.xml"),
+          )
+      )
+
+  public val icon_8754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8754.xml"),
+          )
+      )
+
+  public val icon_8755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8755.xml"),
+          )
+      )
+
+  public val icon_8756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8756.xml"),
+          )
+      )
+
+  public val icon_8757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8757.xml"),
+          )
+      )
+
+  public val icon_8758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8758.xml"),
+          )
+      )
+
+  public val icon_8759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8759.xml"),
+          )
+      )
+
+  public val icon_876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_876.xml"),
+          )
+      )
+
+  public val icon_8760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8760.xml"),
+          )
+      )
+
+  public val icon_8761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8761.xml"),
+          )
+      )
+
+  public val icon_8762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8762.xml"),
+          )
+      )
+
+  public val icon_8763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8763.xml"),
+          )
+      )
+
+  public val icon_8764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8764.xml"),
+          )
+      )
+
+  public val icon_8765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8765.xml"),
+          )
+      )
+
+  public val icon_8766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8766.xml"),
+          )
+      )
+
+  public val icon_8767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8767.xml"),
+          )
+      )
+
+  public val icon_8768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8768.xml"),
+          )
+      )
+
+  public val icon_8769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8769.xml"),
+          )
+      )
+
+  public val icon_877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_877.xml"),
+          )
+      )
+
+  public val icon_8770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8770.xml"),
+          )
+      )
+
+  public val icon_8771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8771.xml"),
+          )
+      )
+
+  public val icon_8772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8772.xml"),
+          )
+      )
+
+  public val icon_8773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8773.xml"),
+          )
+      )
+
+  public val icon_8774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8774.xml"),
+          )
+      )
+
+  public val icon_8775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8775.xml"),
+          )
+      )
+
+  public val icon_8776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8776.xml"),
+          )
+      )
+
+  public val icon_8777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8777.xml"),
+          )
+      )
+
+  public val icon_8778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8778.xml"),
+          )
+      )
+
+  public val icon_8779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8779.xml"),
+          )
+      )
+
+  public val icon_878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_878.xml"),
+          )
+      )
+
+  public val icon_8780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8780.xml"),
+          )
+      )
+
+  public val icon_8781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8781.xml"),
+          )
+      )
+
+  public val icon_8782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8782.xml"),
+          )
+      )
+
+  public val icon_8783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8783.xml"),
+          )
+      )
+
+  public val icon_8784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8784.xml"),
+          )
+      )
+
+  public val icon_8785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8785.xml"),
+          )
+      )
+
+  public val icon_8786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8786.xml"),
+          )
+      )
+
+  public val icon_8787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8787.xml"),
+          )
+      )
+
+  public val icon_8788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8788.xml"),
+          )
+      )
+
+  public val icon_8789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8789.xml"),
+          )
+      )
+
+  public val icon_879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_879.xml"),
+          )
+      )
+
+  public val icon_8790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8790.xml"),
+          )
+      )
+
+  public val icon_8791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8791.xml"),
+          )
+      )
+
+  public val icon_8792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8792.xml"),
+          )
+      )
+
+  public val icon_8793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8793.xml"),
+          )
+      )
+
+  public val icon_8794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8794.xml"),
+          )
+      )
+
+  public val icon_8795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8795.xml"),
+          )
+      )
+
+  public val icon_8796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8796.xml"),
+          )
+      )
+
+  public val icon_8797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8797.xml"),
+          )
+      )
+
+  public val icon_8798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8798.xml"),
+          )
+      )
+
+  public val icon_8799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8799.xml"),
+          )
+      )
+
+  public val icon_88: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_88",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_88.xml"),
+          )
+      )
+
+  public val icon_880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_880.xml"),
+          )
+      )
+
+  public val icon_8800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8800.xml"),
+          )
+      )
+
+  public val icon_8801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8801.xml"),
+          )
+      )
+
+  public val icon_8802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8802.xml"),
+          )
+      )
+
+  public val icon_8803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8803.xml"),
+          )
+      )
+
+  public val icon_8804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8804.xml"),
+          )
+      )
+
+  public val icon_8805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8805.xml"),
+          )
+      )
+
+  public val icon_8806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8806.xml"),
+          )
+      )
+
+  public val icon_8807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8807.xml"),
+          )
+      )
+
+  public val icon_8808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8808.xml"),
+          )
+      )
+
+  public val icon_8809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8809.xml"),
+          )
+      )
+
+  public val icon_881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_881.xml"),
+          )
+      )
+
+  public val icon_8810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8810.xml"),
+          )
+      )
+
+  public val icon_8811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8811.xml"),
+          )
+      )
+
+  public val icon_8812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8812.xml"),
+          )
+      )
+
+  public val icon_8813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8813.xml"),
+          )
+      )
+
+  public val icon_8814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8814.xml"),
+          )
+      )
+
+  public val icon_8815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8815.xml"),
+          )
+      )
+
+  public val icon_8816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8816.xml"),
+          )
+      )
+
+  public val icon_8817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8817.xml"),
+          )
+      )
+
+  public val icon_8818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8818.xml"),
+          )
+      )
+
+  public val icon_8819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8819.xml"),
+          )
+      )
+
+  public val icon_882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_882.xml"),
+          )
+      )
+
+  public val icon_8820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8820.xml"),
+          )
+      )
+
+  public val icon_8821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8821.xml"),
+          )
+      )
+
+  public val icon_8822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8822.xml"),
+          )
+      )
+
+  public val icon_8823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8823.xml"),
+          )
+      )
+
+  public val icon_8824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8824.xml"),
+          )
+      )
+
+  public val icon_8825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8825.xml"),
+          )
+      )
+
+  public val icon_8826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8826.xml"),
+          )
+      )
+
+  public val icon_8827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8827.xml"),
+          )
+      )
+
+  public val icon_8828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8828.xml"),
+          )
+      )
+
+  public val icon_8829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8829.xml"),
+          )
+      )
+
+  public val icon_883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_883.xml"),
+          )
+      )
+
+  public val icon_8830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8830.xml"),
+          )
+      )
+
+  public val icon_8831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8831.xml"),
+          )
+      )
+
+  public val icon_8832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8832.xml"),
+          )
+      )
+
+  public val icon_8833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8833.xml"),
+          )
+      )
+
+  public val icon_8834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8834.xml"),
+          )
+      )
+
+  public val icon_8835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8835.xml"),
+          )
+      )
+
+  public val icon_8836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8836.xml"),
+          )
+      )
+
+  public val icon_8837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8837.xml"),
+          )
+      )
+
+  public val icon_8838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8838.xml"),
+          )
+      )
+
+  public val icon_8839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8839.xml"),
+          )
+      )
+
+  public val icon_884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_884.xml"),
+          )
+      )
+
+  public val icon_8840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8840.xml"),
+          )
+      )
+
+  public val icon_8841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8841.xml"),
+          )
+      )
+
+  public val icon_8842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8842.xml"),
+          )
+      )
+
+  public val icon_8843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8843.xml"),
+          )
+      )
+
+  public val icon_8844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8844.xml"),
+          )
+      )
+
+  public val icon_8845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8845.xml"),
+          )
+      )
+
+  public val icon_8846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8846.xml"),
+          )
+      )
+
+  public val icon_8847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8847.xml"),
+          )
+      )
+
+  public val icon_8848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8848.xml"),
+          )
+      )
+
+  public val icon_8849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8849.xml"),
+          )
+      )
+
+  public val icon_885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_885.xml"),
+          )
+      )
+
+  public val icon_8850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8850.xml"),
+          )
+      )
+
+  public val icon_8851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8851.xml"),
+          )
+      )
+
+  public val icon_8852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8852.xml"),
+          )
+      )
+
+  public val icon_8853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8853.xml"),
+          )
+      )
+
+  public val icon_8854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8854.xml"),
+          )
+      )
+
+  public val icon_8855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8855.xml"),
+          )
+      )
+
+  public val icon_8856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8856.xml"),
+          )
+      )
+
+  public val icon_8857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8857.xml"),
+          )
+      )
+
+  public val icon_8858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8858.xml"),
+          )
+      )
+
+  public val icon_8859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8859.xml"),
+          )
+      )
+
+  public val icon_886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_886.xml"),
+          )
+      )
+
+  public val icon_8860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8860.xml"),
+          )
+      )
+
+  public val icon_8861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8861.xml"),
+          )
+      )
+
+  public val icon_8862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8862.xml"),
+          )
+      )
+
+  public val icon_8863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8863.xml"),
+          )
+      )
+
+  public val icon_8864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8864.xml"),
+          )
+      )
+
+  public val icon_8865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8865.xml"),
+          )
+      )
+
+  public val icon_8866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8866.xml"),
+          )
+      )
+
+  public val icon_8867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8867.xml"),
+          )
+      )
+
+  public val icon_8868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8868.xml"),
+          )
+      )
+
+  public val icon_8869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8869.xml"),
+          )
+      )
+
+  public val icon_887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_887.xml"),
+          )
+      )
+
+  public val icon_8870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8870.xml"),
+          )
+      )
+
+  public val icon_8871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8871.xml"),
+          )
+      )
+
+  public val icon_8872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8872.xml"),
+          )
+      )
+
+  public val icon_8873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8873.xml"),
+          )
+      )
+
+  public val icon_8874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8874.xml"),
+          )
+      )
+
+  public val icon_8875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8875.xml"),
+          )
+      )
+
+  public val icon_8876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8876.xml"),
+          )
+      )
+
+  public val icon_8877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8877.xml"),
+          )
+      )
+
+  public val icon_8878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8878.xml"),
+          )
+      )
+
+  public val icon_8879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8879.xml"),
+          )
+      )
+
+  public val icon_888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_888.xml"),
+          )
+      )
+
+  public val icon_8880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8880.xml"),
+          )
+      )
+
+  public val icon_8881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8881.xml"),
+          )
+      )
+
+  public val icon_8882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8882.xml"),
+          )
+      )
+
+  public val icon_8883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8883.xml"),
+          )
+      )
+
+  public val icon_8884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8884.xml"),
+          )
+      )
+
+  public val icon_8885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8885.xml"),
+          )
+      )
+
+  public val icon_8886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8886.xml"),
+          )
+      )
+
+  public val icon_8887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8887.xml"),
+          )
+      )
+
+  public val icon_8888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8888.xml"),
+          )
+      )
+
+  public val icon_8889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8889.xml"),
+          )
+      )
+
+  public val icon_889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_889.xml"),
+          )
+      )
+
+  public val icon_8890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8890.xml"),
+          )
+      )
+
+  public val icon_8891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8891.xml"),
+          )
+      )
+
+  public val icon_8892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8892.xml"),
+          )
+      )
+
+  public val icon_8893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8893.xml"),
+          )
+      )
+
+  public val icon_8894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8894.xml"),
+          )
+      )
+
+  public val icon_8895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8895.xml"),
+          )
+      )
+
+  public val icon_8896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8896.xml"),
+          )
+      )
+
+  public val icon_8897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8897.xml"),
+          )
+      )
+
+  public val icon_8898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8898.xml"),
+          )
+      )
+
+  public val icon_8899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8899.xml"),
+          )
+      )
+
+  public val icon_89: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_89",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_89.xml"),
+          )
+      )
+
+  public val icon_890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_890.xml"),
+          )
+      )
+
+  public val icon_8900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8900.xml"),
+          )
+      )
+
+  public val icon_8901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8901.xml"),
+          )
+      )
+
+  public val icon_8902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8902.xml"),
+          )
+      )
+
+  public val icon_8903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8903.xml"),
+          )
+      )
+
+  public val icon_8904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8904.xml"),
+          )
+      )
+
+  public val icon_8905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8905.xml"),
+          )
+      )
+
+  public val icon_8906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8906.xml"),
+          )
+      )
+
+  public val icon_8907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8907.xml"),
+          )
+      )
+
+  public val icon_8908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8908.xml"),
+          )
+      )
+
+  public val icon_8909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8909.xml"),
+          )
+      )
+
+  public val icon_891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_891.xml"),
+          )
+      )
+
+  public val icon_8910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8910.xml"),
+          )
+      )
+
+  public val icon_8911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8911.xml"),
+          )
+      )
+
+  public val icon_8912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8912.xml"),
+          )
+      )
+
+  public val icon_8913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8913.xml"),
+          )
+      )
+
+  public val icon_8914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8914.xml"),
+          )
+      )
+
+  public val icon_8915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8915.xml"),
+          )
+      )
+
+  public val icon_8916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8916.xml"),
+          )
+      )
+
+  public val icon_8917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8917.xml"),
+          )
+      )
+
+  public val icon_8918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8918.xml"),
+          )
+      )
+
+  public val icon_8919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8919.xml"),
+          )
+      )
+
+  public val icon_892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_892.xml"),
+          )
+      )
+
+  public val icon_8920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8920.xml"),
+          )
+      )
+
+  public val icon_8921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8921.xml"),
+          )
+      )
+
+  public val icon_8922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8922.xml"),
+          )
+      )
+
+  public val icon_8923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8923.xml"),
+          )
+      )
+
+  public val icon_8924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8924.xml"),
+          )
+      )
+
+  public val icon_8925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8925.xml"),
+          )
+      )
+
+  public val icon_8926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8926.xml"),
+          )
+      )
+
+  public val icon_8927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8927.xml"),
+          )
+      )
+
+  public val icon_8928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8928.xml"),
+          )
+      )
+
+  public val icon_8929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8929.xml"),
+          )
+      )
+
+  public val icon_893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_893.xml"),
+          )
+      )
+
+  public val icon_8930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8930.xml"),
+          )
+      )
+
+  public val icon_8931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8931.xml"),
+          )
+      )
+
+  public val icon_8932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8932.xml"),
+          )
+      )
+
+  public val icon_8933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8933.xml"),
+          )
+      )
+
+  public val icon_8934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8934.xml"),
+          )
+      )
+
+  public val icon_8935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8935.xml"),
+          )
+      )
+
+  public val icon_8936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8936.xml"),
+          )
+      )
+
+  public val icon_8937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8937.xml"),
+          )
+      )
+
+  public val icon_8938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8938.xml"),
+          )
+      )
+
+  public val icon_8939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8939.xml"),
+          )
+      )
+
+  public val icon_894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_894.xml"),
+          )
+      )
+
+  public val icon_8940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8940.xml"),
+          )
+      )
+
+  public val icon_8941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8941.xml"),
+          )
+      )
+
+  public val icon_8942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8942.xml"),
+          )
+      )
+
+  public val icon_8943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8943.xml"),
+          )
+      )
+
+  public val icon_8944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8944.xml"),
+          )
+      )
+
+  public val icon_8945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8945.xml"),
+          )
+      )
+
+  public val icon_8946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8946.xml"),
+          )
+      )
+
+  public val icon_8947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8947.xml"),
+          )
+      )
+
+  public val icon_8948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8948.xml"),
+          )
+      )
+
+  public val icon_8949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8949.xml"),
+          )
+      )
+
+  public val icon_895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_895.xml"),
+          )
+      )
+
+  public val icon_8950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8950.xml"),
+          )
+      )
+
+  public val icon_8951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8951.xml"),
+          )
+      )
+
+  public val icon_8952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8952.xml"),
+          )
+      )
+
+  public val icon_8953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8953.xml"),
+          )
+      )
+
+  public val icon_8954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8954.xml"),
+          )
+      )
+
+  public val icon_8955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8955.xml"),
+          )
+      )
+
+  public val icon_8956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8956.xml"),
+          )
+      )
+
+  public val icon_8957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8957.xml"),
+          )
+      )
+
+  public val icon_8958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8958.xml"),
+          )
+      )
+
+  public val icon_8959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8959.xml"),
+          )
+      )
+
+  public val icon_896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_896.xml"),
+          )
+      )
+
+  public val icon_8960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8960.xml"),
+          )
+      )
+
+  public val icon_8961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8961.xml"),
+          )
+      )
+
+  public val icon_8962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8962.xml"),
+          )
+      )
+
+  public val icon_8963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8963.xml"),
+          )
+      )
+
+  public val icon_8964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8964.xml"),
+          )
+      )
+
+  public val icon_8965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8965.xml"),
+          )
+      )
+
+  public val icon_8966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8966.xml"),
+          )
+      )
+
+  public val icon_8967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8967.xml"),
+          )
+      )
+
+  public val icon_8968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8968.xml"),
+          )
+      )
+
+  public val icon_8969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8969.xml"),
+          )
+      )
+
+  public val icon_897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_897.xml"),
+          )
+      )
+
+  public val icon_8970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8970.xml"),
+          )
+      )
+
+  public val icon_8971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8971.xml"),
+          )
+      )
+
+  public val icon_8972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8972.xml"),
+          )
+      )
+
+  public val icon_8973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8973.xml"),
+          )
+      )
+
+  public val icon_8974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8974.xml"),
+          )
+      )
+
+  public val icon_8975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8975.xml"),
+          )
+      )
+
+  public val icon_8976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8976.xml"),
+          )
+      )
+
+  public val icon_8977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8977.xml"),
+          )
+      )
+
+  public val icon_8978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8978.xml"),
+          )
+      )
+
+  public val icon_8979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8979.xml"),
+          )
+      )
+
+  public val icon_898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_898.xml"),
+          )
+      )
+
+  public val icon_8980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8980.xml"),
+          )
+      )
+
+  public val icon_8981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8981.xml"),
+          )
+      )
+
+  public val icon_8982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8982.xml"),
+          )
+      )
+
+  public val icon_8983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8983.xml"),
+          )
+      )
+
+  public val icon_8984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8984.xml"),
+          )
+      )
+
+  public val icon_8985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8985.xml"),
+          )
+      )
+
+  public val icon_8986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8986.xml"),
+          )
+      )
+
+  public val icon_8987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8987.xml"),
+          )
+      )
+
+  public val icon_8988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8988.xml"),
+          )
+      )
+
+  public val icon_8989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8989.xml"),
+          )
+      )
+
+  public val icon_899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_899.xml"),
+          )
+      )
+
+  public val icon_8990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8990.xml"),
+          )
+      )
+
+  public val icon_8991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8991.xml"),
+          )
+      )
+
+  public val icon_8992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8992.xml"),
+          )
+      )
+
+  public val icon_8993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8993.xml"),
+          )
+      )
+
+  public val icon_8994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8994.xml"),
+          )
+      )
+
+  public val icon_8995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8995.xml"),
+          )
+      )
+
+  public val icon_8996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8996.xml"),
+          )
+      )
+
+  public val icon_8997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8997.xml"),
+          )
+      )
+
+  public val icon_8998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8998.xml"),
+          )
+      )
+
+  public val icon_8999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_8999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_8999.xml"),
+          )
+      )
+
+  public val icon_9: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9.xml"),
+          )
+      )
+
+  public val icon_90: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_90",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_90.xml"),
+          )
+      )
+
+  public val icon_900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_900.xml"),
+          )
+      )
+
+  public val icon_9000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9000.xml"),
+          )
+      )
+
+  public val icon_9001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9001.xml"),
+          )
+      )
+
+  public val icon_9002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9002.xml"),
+          )
+      )
+
+  public val icon_9003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9003.xml"),
+          )
+      )
+
+  public val icon_9004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9004.xml"),
+          )
+      )
+
+  public val icon_9005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9005.xml"),
+          )
+      )
+
+  public val icon_9006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9006.xml"),
+          )
+      )
+
+  public val icon_9007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9007.xml"),
+          )
+      )
+
+  public val icon_9008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9008.xml"),
+          )
+      )
+
+  public val icon_9009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9009.xml"),
+          )
+      )
+
+  public val icon_901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_901.xml"),
+          )
+      )
+
+  public val icon_9010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9010.xml"),
+          )
+      )
+
+  public val icon_9011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9011.xml"),
+          )
+      )
+
+  public val icon_9012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9012.xml"),
+          )
+      )
+
+  public val icon_9013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9013.xml"),
+          )
+      )
+
+  public val icon_9014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9014.xml"),
+          )
+      )
+
+  public val icon_9015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9015.xml"),
+          )
+      )
+
+  public val icon_9016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9016.xml"),
+          )
+      )
+
+  public val icon_9017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9017.xml"),
+          )
+      )
+
+  public val icon_9018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9018.xml"),
+          )
+      )
+
+  public val icon_9019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9019.xml"),
+          )
+      )
+
+  public val icon_902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_902.xml"),
+          )
+      )
+
+  public val icon_9020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9020.xml"),
+          )
+      )
+
+  public val icon_9021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9021.xml"),
+          )
+      )
+
+  public val icon_9022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9022.xml"),
+          )
+      )
+
+  public val icon_9023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9023.xml"),
+          )
+      )
+
+  public val icon_9024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9024.xml"),
+          )
+      )
+
+  public val icon_9025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9025.xml"),
+          )
+      )
+
+  public val icon_9026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9026.xml"),
+          )
+      )
+
+  public val icon_9027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9027.xml"),
+          )
+      )
+
+  public val icon_9028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9028.xml"),
+          )
+      )
+
+  public val icon_9029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9029.xml"),
+          )
+      )
+
+  public val icon_903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_903.xml"),
+          )
+      )
+
+  public val icon_9030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9030.xml"),
+          )
+      )
+
+  public val icon_9031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9031.xml"),
+          )
+      )
+
+  public val icon_9032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9032.xml"),
+          )
+      )
+
+  public val icon_9033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9033.xml"),
+          )
+      )
+
+  public val icon_9034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9034.xml"),
+          )
+      )
+
+  public val icon_9035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9035.xml"),
+          )
+      )
+
+  public val icon_9036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9036.xml"),
+          )
+      )
+
+  public val icon_9037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9037.xml"),
+          )
+      )
+
+  public val icon_9038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9038.xml"),
+          )
+      )
+
+  public val icon_9039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9039.xml"),
+          )
+      )
+
+  public val icon_904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_904.xml"),
+          )
+      )
+
+  public val icon_9040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9040.xml"),
+          )
+      )
+
+  public val icon_9041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9041.xml"),
+          )
+      )
+
+  public val icon_9042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9042.xml"),
+          )
+      )
+
+  public val icon_9043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9043.xml"),
+          )
+      )
+
+  public val icon_9044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9044.xml"),
+          )
+      )
+
+  public val icon_9045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9045.xml"),
+          )
+      )
+
+  public val icon_9046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9046.xml"),
+          )
+      )
+
+  public val icon_9047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9047.xml"),
+          )
+      )
+
+  public val icon_9048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9048.xml"),
+          )
+      )
+
+  public val icon_9049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9049.xml"),
+          )
+      )
+
+  public val icon_905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_905.xml"),
+          )
+      )
+
+  public val icon_9050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9050.xml"),
+          )
+      )
+
+  public val icon_9051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9051.xml"),
+          )
+      )
+
+  public val icon_9052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9052.xml"),
+          )
+      )
+
+  public val icon_9053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9053.xml"),
+          )
+      )
+
+  public val icon_9054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9054.xml"),
+          )
+      )
+
+  public val icon_9055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9055.xml"),
+          )
+      )
+
+  public val icon_9056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9056.xml"),
+          )
+      )
+
+  public val icon_9057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9057.xml"),
+          )
+      )
+
+  public val icon_9058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9058.xml"),
+          )
+      )
+
+  public val icon_9059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9059.xml"),
+          )
+      )
+
+  public val icon_906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_906.xml"),
+          )
+      )
+
+  public val icon_9060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9060.xml"),
+          )
+      )
+
+  public val icon_9061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9061.xml"),
+          )
+      )
+
+  public val icon_9062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9062.xml"),
+          )
+      )
+
+  public val icon_9063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9063.xml"),
+          )
+      )
+
+  public val icon_9064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9064.xml"),
+          )
+      )
+
+  public val icon_9065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9065.xml"),
+          )
+      )
+
+  public val icon_9066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9066.xml"),
+          )
+      )
+
+  public val icon_9067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9067.xml"),
+          )
+      )
+
+  public val icon_9068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9068.xml"),
+          )
+      )
+
+  public val icon_9069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9069.xml"),
+          )
+      )
+
+  public val icon_907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_907.xml"),
+          )
+      )
+
+  public val icon_9070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9070.xml"),
+          )
+      )
+
+  public val icon_9071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9071.xml"),
+          )
+      )
+
+  public val icon_9072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9072.xml"),
+          )
+      )
+
+  public val icon_9073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9073.xml"),
+          )
+      )
+
+  public val icon_9074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9074.xml"),
+          )
+      )
+
+  public val icon_9075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9075.xml"),
+          )
+      )
+
+  public val icon_9076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9076.xml"),
+          )
+      )
+
+  public val icon_9077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9077.xml"),
+          )
+      )
+
+  public val icon_9078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9078.xml"),
+          )
+      )
+
+  public val icon_9079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9079.xml"),
+          )
+      )
+
+  public val icon_908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_908.xml"),
+          )
+      )
+
+  public val icon_9080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9080.xml"),
+          )
+      )
+
+  public val icon_9081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9081.xml"),
+          )
+      )
+
+  public val icon_9082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9082.xml"),
+          )
+      )
+
+  public val icon_9083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9083.xml"),
+          )
+      )
+
+  public val icon_9084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9084.xml"),
+          )
+      )
+
+  public val icon_9085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9085.xml"),
+          )
+      )
+
+  public val icon_9086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9086.xml"),
+          )
+      )
+
+  public val icon_9087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9087.xml"),
+          )
+      )
+
+  public val icon_9088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9088.xml"),
+          )
+      )
+
+  public val icon_9089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9089.xml"),
+          )
+      )
+
+  public val icon_909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_909.xml"),
+          )
+      )
+
+  public val icon_9090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9090.xml"),
+          )
+      )
+
+  public val icon_9091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9091.xml"),
+          )
+      )
+
+  public val icon_9092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9092.xml"),
+          )
+      )
+
+  public val icon_9093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9093.xml"),
+          )
+      )
+
+  public val icon_9094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9094.xml"),
+          )
+      )
+
+  public val icon_9095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9095.xml"),
+          )
+      )
+
+  public val icon_9096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9096.xml"),
+          )
+      )
+
+  public val icon_9097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9097.xml"),
+          )
+      )
+
+  public val icon_9098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9098.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8649: DrawableResource
+  get() = Drawable47.icon_8649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_865: DrawableResource
+  get() = Drawable47.icon_865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8650: DrawableResource
+  get() = Drawable47.icon_8650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8651: DrawableResource
+  get() = Drawable47.icon_8651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8652: DrawableResource
+  get() = Drawable47.icon_8652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8653: DrawableResource
+  get() = Drawable47.icon_8653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8654: DrawableResource
+  get() = Drawable47.icon_8654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8655: DrawableResource
+  get() = Drawable47.icon_8655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8656: DrawableResource
+  get() = Drawable47.icon_8656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8657: DrawableResource
+  get() = Drawable47.icon_8657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8658: DrawableResource
+  get() = Drawable47.icon_8658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8659: DrawableResource
+  get() = Drawable47.icon_8659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_866: DrawableResource
+  get() = Drawable47.icon_866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8660: DrawableResource
+  get() = Drawable47.icon_8660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8661: DrawableResource
+  get() = Drawable47.icon_8661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8662: DrawableResource
+  get() = Drawable47.icon_8662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8663: DrawableResource
+  get() = Drawable47.icon_8663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8664: DrawableResource
+  get() = Drawable47.icon_8664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8665: DrawableResource
+  get() = Drawable47.icon_8665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8666: DrawableResource
+  get() = Drawable47.icon_8666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8667: DrawableResource
+  get() = Drawable47.icon_8667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8668: DrawableResource
+  get() = Drawable47.icon_8668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8669: DrawableResource
+  get() = Drawable47.icon_8669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_867: DrawableResource
+  get() = Drawable47.icon_867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8670: DrawableResource
+  get() = Drawable47.icon_8670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8671: DrawableResource
+  get() = Drawable47.icon_8671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8672: DrawableResource
+  get() = Drawable47.icon_8672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8673: DrawableResource
+  get() = Drawable47.icon_8673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8674: DrawableResource
+  get() = Drawable47.icon_8674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8675: DrawableResource
+  get() = Drawable47.icon_8675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8676: DrawableResource
+  get() = Drawable47.icon_8676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8677: DrawableResource
+  get() = Drawable47.icon_8677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8678: DrawableResource
+  get() = Drawable47.icon_8678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8679: DrawableResource
+  get() = Drawable47.icon_8679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_868: DrawableResource
+  get() = Drawable47.icon_868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8680: DrawableResource
+  get() = Drawable47.icon_8680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8681: DrawableResource
+  get() = Drawable47.icon_8681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8682: DrawableResource
+  get() = Drawable47.icon_8682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8683: DrawableResource
+  get() = Drawable47.icon_8683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8684: DrawableResource
+  get() = Drawable47.icon_8684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8685: DrawableResource
+  get() = Drawable47.icon_8685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8686: DrawableResource
+  get() = Drawable47.icon_8686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8687: DrawableResource
+  get() = Drawable47.icon_8687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8688: DrawableResource
+  get() = Drawable47.icon_8688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8689: DrawableResource
+  get() = Drawable47.icon_8689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_869: DrawableResource
+  get() = Drawable47.icon_869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8690: DrawableResource
+  get() = Drawable47.icon_8690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8691: DrawableResource
+  get() = Drawable47.icon_8691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8692: DrawableResource
+  get() = Drawable47.icon_8692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8693: DrawableResource
+  get() = Drawable47.icon_8693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8694: DrawableResource
+  get() = Drawable47.icon_8694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8695: DrawableResource
+  get() = Drawable47.icon_8695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8696: DrawableResource
+  get() = Drawable47.icon_8696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8697: DrawableResource
+  get() = Drawable47.icon_8697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8698: DrawableResource
+  get() = Drawable47.icon_8698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8699: DrawableResource
+  get() = Drawable47.icon_8699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_87: DrawableResource
+  get() = Drawable47.icon_87
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_870: DrawableResource
+  get() = Drawable47.icon_870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8700: DrawableResource
+  get() = Drawable47.icon_8700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8701: DrawableResource
+  get() = Drawable47.icon_8701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8702: DrawableResource
+  get() = Drawable47.icon_8702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8703: DrawableResource
+  get() = Drawable47.icon_8703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8704: DrawableResource
+  get() = Drawable47.icon_8704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8705: DrawableResource
+  get() = Drawable47.icon_8705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8706: DrawableResource
+  get() = Drawable47.icon_8706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8707: DrawableResource
+  get() = Drawable47.icon_8707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8708: DrawableResource
+  get() = Drawable47.icon_8708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8709: DrawableResource
+  get() = Drawable47.icon_8709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_871: DrawableResource
+  get() = Drawable47.icon_871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8710: DrawableResource
+  get() = Drawable47.icon_8710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8711: DrawableResource
+  get() = Drawable47.icon_8711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8712: DrawableResource
+  get() = Drawable47.icon_8712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8713: DrawableResource
+  get() = Drawable47.icon_8713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8714: DrawableResource
+  get() = Drawable47.icon_8714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8715: DrawableResource
+  get() = Drawable47.icon_8715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8716: DrawableResource
+  get() = Drawable47.icon_8716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8717: DrawableResource
+  get() = Drawable47.icon_8717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8718: DrawableResource
+  get() = Drawable47.icon_8718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8719: DrawableResource
+  get() = Drawable47.icon_8719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_872: DrawableResource
+  get() = Drawable47.icon_872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8720: DrawableResource
+  get() = Drawable47.icon_8720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8721: DrawableResource
+  get() = Drawable47.icon_8721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8722: DrawableResource
+  get() = Drawable47.icon_8722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8723: DrawableResource
+  get() = Drawable47.icon_8723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8724: DrawableResource
+  get() = Drawable47.icon_8724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8725: DrawableResource
+  get() = Drawable47.icon_8725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8726: DrawableResource
+  get() = Drawable47.icon_8726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8727: DrawableResource
+  get() = Drawable47.icon_8727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8728: DrawableResource
+  get() = Drawable47.icon_8728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8729: DrawableResource
+  get() = Drawable47.icon_8729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_873: DrawableResource
+  get() = Drawable47.icon_873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8730: DrawableResource
+  get() = Drawable47.icon_8730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8731: DrawableResource
+  get() = Drawable47.icon_8731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8732: DrawableResource
+  get() = Drawable47.icon_8732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8733: DrawableResource
+  get() = Drawable47.icon_8733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8734: DrawableResource
+  get() = Drawable47.icon_8734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8735: DrawableResource
+  get() = Drawable47.icon_8735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8736: DrawableResource
+  get() = Drawable47.icon_8736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8737: DrawableResource
+  get() = Drawable47.icon_8737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8738: DrawableResource
+  get() = Drawable47.icon_8738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8739: DrawableResource
+  get() = Drawable47.icon_8739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_874: DrawableResource
+  get() = Drawable47.icon_874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8740: DrawableResource
+  get() = Drawable47.icon_8740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8741: DrawableResource
+  get() = Drawable47.icon_8741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8742: DrawableResource
+  get() = Drawable47.icon_8742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8743: DrawableResource
+  get() = Drawable47.icon_8743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8744: DrawableResource
+  get() = Drawable47.icon_8744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8745: DrawableResource
+  get() = Drawable47.icon_8745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8746: DrawableResource
+  get() = Drawable47.icon_8746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8747: DrawableResource
+  get() = Drawable47.icon_8747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8748: DrawableResource
+  get() = Drawable47.icon_8748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8749: DrawableResource
+  get() = Drawable47.icon_8749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_875: DrawableResource
+  get() = Drawable47.icon_875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8750: DrawableResource
+  get() = Drawable47.icon_8750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8751: DrawableResource
+  get() = Drawable47.icon_8751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8752: DrawableResource
+  get() = Drawable47.icon_8752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8753: DrawableResource
+  get() = Drawable47.icon_8753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8754: DrawableResource
+  get() = Drawable47.icon_8754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8755: DrawableResource
+  get() = Drawable47.icon_8755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8756: DrawableResource
+  get() = Drawable47.icon_8756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8757: DrawableResource
+  get() = Drawable47.icon_8757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8758: DrawableResource
+  get() = Drawable47.icon_8758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8759: DrawableResource
+  get() = Drawable47.icon_8759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_876: DrawableResource
+  get() = Drawable47.icon_876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8760: DrawableResource
+  get() = Drawable47.icon_8760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8761: DrawableResource
+  get() = Drawable47.icon_8761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8762: DrawableResource
+  get() = Drawable47.icon_8762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8763: DrawableResource
+  get() = Drawable47.icon_8763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8764: DrawableResource
+  get() = Drawable47.icon_8764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8765: DrawableResource
+  get() = Drawable47.icon_8765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8766: DrawableResource
+  get() = Drawable47.icon_8766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8767: DrawableResource
+  get() = Drawable47.icon_8767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8768: DrawableResource
+  get() = Drawable47.icon_8768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8769: DrawableResource
+  get() = Drawable47.icon_8769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_877: DrawableResource
+  get() = Drawable47.icon_877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8770: DrawableResource
+  get() = Drawable47.icon_8770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8771: DrawableResource
+  get() = Drawable47.icon_8771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8772: DrawableResource
+  get() = Drawable47.icon_8772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8773: DrawableResource
+  get() = Drawable47.icon_8773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8774: DrawableResource
+  get() = Drawable47.icon_8774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8775: DrawableResource
+  get() = Drawable47.icon_8775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8776: DrawableResource
+  get() = Drawable47.icon_8776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8777: DrawableResource
+  get() = Drawable47.icon_8777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8778: DrawableResource
+  get() = Drawable47.icon_8778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8779: DrawableResource
+  get() = Drawable47.icon_8779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_878: DrawableResource
+  get() = Drawable47.icon_878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8780: DrawableResource
+  get() = Drawable47.icon_8780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8781: DrawableResource
+  get() = Drawable47.icon_8781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8782: DrawableResource
+  get() = Drawable47.icon_8782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8783: DrawableResource
+  get() = Drawable47.icon_8783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8784: DrawableResource
+  get() = Drawable47.icon_8784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8785: DrawableResource
+  get() = Drawable47.icon_8785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8786: DrawableResource
+  get() = Drawable47.icon_8786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8787: DrawableResource
+  get() = Drawable47.icon_8787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8788: DrawableResource
+  get() = Drawable47.icon_8788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8789: DrawableResource
+  get() = Drawable47.icon_8789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_879: DrawableResource
+  get() = Drawable47.icon_879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8790: DrawableResource
+  get() = Drawable47.icon_8790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8791: DrawableResource
+  get() = Drawable47.icon_8791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8792: DrawableResource
+  get() = Drawable47.icon_8792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8793: DrawableResource
+  get() = Drawable47.icon_8793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8794: DrawableResource
+  get() = Drawable47.icon_8794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8795: DrawableResource
+  get() = Drawable47.icon_8795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8796: DrawableResource
+  get() = Drawable47.icon_8796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8797: DrawableResource
+  get() = Drawable47.icon_8797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8798: DrawableResource
+  get() = Drawable47.icon_8798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8799: DrawableResource
+  get() = Drawable47.icon_8799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_88: DrawableResource
+  get() = Drawable47.icon_88
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_880: DrawableResource
+  get() = Drawable47.icon_880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8800: DrawableResource
+  get() = Drawable47.icon_8800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8801: DrawableResource
+  get() = Drawable47.icon_8801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8802: DrawableResource
+  get() = Drawable47.icon_8802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8803: DrawableResource
+  get() = Drawable47.icon_8803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8804: DrawableResource
+  get() = Drawable47.icon_8804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8805: DrawableResource
+  get() = Drawable47.icon_8805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8806: DrawableResource
+  get() = Drawable47.icon_8806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8807: DrawableResource
+  get() = Drawable47.icon_8807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8808: DrawableResource
+  get() = Drawable47.icon_8808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8809: DrawableResource
+  get() = Drawable47.icon_8809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_881: DrawableResource
+  get() = Drawable47.icon_881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8810: DrawableResource
+  get() = Drawable47.icon_8810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8811: DrawableResource
+  get() = Drawable47.icon_8811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8812: DrawableResource
+  get() = Drawable47.icon_8812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8813: DrawableResource
+  get() = Drawable47.icon_8813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8814: DrawableResource
+  get() = Drawable47.icon_8814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8815: DrawableResource
+  get() = Drawable47.icon_8815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8816: DrawableResource
+  get() = Drawable47.icon_8816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8817: DrawableResource
+  get() = Drawable47.icon_8817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8818: DrawableResource
+  get() = Drawable47.icon_8818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8819: DrawableResource
+  get() = Drawable47.icon_8819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_882: DrawableResource
+  get() = Drawable47.icon_882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8820: DrawableResource
+  get() = Drawable47.icon_8820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8821: DrawableResource
+  get() = Drawable47.icon_8821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8822: DrawableResource
+  get() = Drawable47.icon_8822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8823: DrawableResource
+  get() = Drawable47.icon_8823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8824: DrawableResource
+  get() = Drawable47.icon_8824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8825: DrawableResource
+  get() = Drawable47.icon_8825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8826: DrawableResource
+  get() = Drawable47.icon_8826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8827: DrawableResource
+  get() = Drawable47.icon_8827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8828: DrawableResource
+  get() = Drawable47.icon_8828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8829: DrawableResource
+  get() = Drawable47.icon_8829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_883: DrawableResource
+  get() = Drawable47.icon_883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8830: DrawableResource
+  get() = Drawable47.icon_8830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8831: DrawableResource
+  get() = Drawable47.icon_8831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8832: DrawableResource
+  get() = Drawable47.icon_8832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8833: DrawableResource
+  get() = Drawable47.icon_8833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8834: DrawableResource
+  get() = Drawable47.icon_8834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8835: DrawableResource
+  get() = Drawable47.icon_8835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8836: DrawableResource
+  get() = Drawable47.icon_8836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8837: DrawableResource
+  get() = Drawable47.icon_8837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8838: DrawableResource
+  get() = Drawable47.icon_8838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8839: DrawableResource
+  get() = Drawable47.icon_8839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_884: DrawableResource
+  get() = Drawable47.icon_884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8840: DrawableResource
+  get() = Drawable47.icon_8840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8841: DrawableResource
+  get() = Drawable47.icon_8841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8842: DrawableResource
+  get() = Drawable47.icon_8842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8843: DrawableResource
+  get() = Drawable47.icon_8843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8844: DrawableResource
+  get() = Drawable47.icon_8844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8845: DrawableResource
+  get() = Drawable47.icon_8845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8846: DrawableResource
+  get() = Drawable47.icon_8846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8847: DrawableResource
+  get() = Drawable47.icon_8847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8848: DrawableResource
+  get() = Drawable47.icon_8848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8849: DrawableResource
+  get() = Drawable47.icon_8849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_885: DrawableResource
+  get() = Drawable47.icon_885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8850: DrawableResource
+  get() = Drawable47.icon_8850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8851: DrawableResource
+  get() = Drawable47.icon_8851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8852: DrawableResource
+  get() = Drawable47.icon_8852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8853: DrawableResource
+  get() = Drawable47.icon_8853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8854: DrawableResource
+  get() = Drawable47.icon_8854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8855: DrawableResource
+  get() = Drawable47.icon_8855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8856: DrawableResource
+  get() = Drawable47.icon_8856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8857: DrawableResource
+  get() = Drawable47.icon_8857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8858: DrawableResource
+  get() = Drawable47.icon_8858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8859: DrawableResource
+  get() = Drawable47.icon_8859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_886: DrawableResource
+  get() = Drawable47.icon_886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8860: DrawableResource
+  get() = Drawable47.icon_8860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8861: DrawableResource
+  get() = Drawable47.icon_8861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8862: DrawableResource
+  get() = Drawable47.icon_8862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8863: DrawableResource
+  get() = Drawable47.icon_8863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8864: DrawableResource
+  get() = Drawable47.icon_8864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8865: DrawableResource
+  get() = Drawable47.icon_8865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8866: DrawableResource
+  get() = Drawable47.icon_8866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8867: DrawableResource
+  get() = Drawable47.icon_8867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8868: DrawableResource
+  get() = Drawable47.icon_8868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8869: DrawableResource
+  get() = Drawable47.icon_8869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_887: DrawableResource
+  get() = Drawable47.icon_887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8870: DrawableResource
+  get() = Drawable47.icon_8870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8871: DrawableResource
+  get() = Drawable47.icon_8871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8872: DrawableResource
+  get() = Drawable47.icon_8872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8873: DrawableResource
+  get() = Drawable47.icon_8873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8874: DrawableResource
+  get() = Drawable47.icon_8874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8875: DrawableResource
+  get() = Drawable47.icon_8875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8876: DrawableResource
+  get() = Drawable47.icon_8876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8877: DrawableResource
+  get() = Drawable47.icon_8877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8878: DrawableResource
+  get() = Drawable47.icon_8878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8879: DrawableResource
+  get() = Drawable47.icon_8879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_888: DrawableResource
+  get() = Drawable47.icon_888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8880: DrawableResource
+  get() = Drawable47.icon_8880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8881: DrawableResource
+  get() = Drawable47.icon_8881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8882: DrawableResource
+  get() = Drawable47.icon_8882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8883: DrawableResource
+  get() = Drawable47.icon_8883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8884: DrawableResource
+  get() = Drawable47.icon_8884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8885: DrawableResource
+  get() = Drawable47.icon_8885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8886: DrawableResource
+  get() = Drawable47.icon_8886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8887: DrawableResource
+  get() = Drawable47.icon_8887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8888: DrawableResource
+  get() = Drawable47.icon_8888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8889: DrawableResource
+  get() = Drawable47.icon_8889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_889: DrawableResource
+  get() = Drawable47.icon_889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8890: DrawableResource
+  get() = Drawable47.icon_8890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8891: DrawableResource
+  get() = Drawable47.icon_8891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8892: DrawableResource
+  get() = Drawable47.icon_8892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8893: DrawableResource
+  get() = Drawable47.icon_8893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8894: DrawableResource
+  get() = Drawable47.icon_8894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8895: DrawableResource
+  get() = Drawable47.icon_8895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8896: DrawableResource
+  get() = Drawable47.icon_8896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8897: DrawableResource
+  get() = Drawable47.icon_8897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8898: DrawableResource
+  get() = Drawable47.icon_8898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8899: DrawableResource
+  get() = Drawable47.icon_8899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_89: DrawableResource
+  get() = Drawable47.icon_89
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_890: DrawableResource
+  get() = Drawable47.icon_890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8900: DrawableResource
+  get() = Drawable47.icon_8900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8901: DrawableResource
+  get() = Drawable47.icon_8901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8902: DrawableResource
+  get() = Drawable47.icon_8902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8903: DrawableResource
+  get() = Drawable47.icon_8903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8904: DrawableResource
+  get() = Drawable47.icon_8904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8905: DrawableResource
+  get() = Drawable47.icon_8905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8906: DrawableResource
+  get() = Drawable47.icon_8906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8907: DrawableResource
+  get() = Drawable47.icon_8907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8908: DrawableResource
+  get() = Drawable47.icon_8908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8909: DrawableResource
+  get() = Drawable47.icon_8909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_891: DrawableResource
+  get() = Drawable47.icon_891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8910: DrawableResource
+  get() = Drawable47.icon_8910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8911: DrawableResource
+  get() = Drawable47.icon_8911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8912: DrawableResource
+  get() = Drawable47.icon_8912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8913: DrawableResource
+  get() = Drawable47.icon_8913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8914: DrawableResource
+  get() = Drawable47.icon_8914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8915: DrawableResource
+  get() = Drawable47.icon_8915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8916: DrawableResource
+  get() = Drawable47.icon_8916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8917: DrawableResource
+  get() = Drawable47.icon_8917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8918: DrawableResource
+  get() = Drawable47.icon_8918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8919: DrawableResource
+  get() = Drawable47.icon_8919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_892: DrawableResource
+  get() = Drawable47.icon_892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8920: DrawableResource
+  get() = Drawable47.icon_8920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8921: DrawableResource
+  get() = Drawable47.icon_8921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8922: DrawableResource
+  get() = Drawable47.icon_8922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8923: DrawableResource
+  get() = Drawable47.icon_8923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8924: DrawableResource
+  get() = Drawable47.icon_8924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8925: DrawableResource
+  get() = Drawable47.icon_8925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8926: DrawableResource
+  get() = Drawable47.icon_8926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8927: DrawableResource
+  get() = Drawable47.icon_8927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8928: DrawableResource
+  get() = Drawable47.icon_8928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8929: DrawableResource
+  get() = Drawable47.icon_8929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_893: DrawableResource
+  get() = Drawable47.icon_893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8930: DrawableResource
+  get() = Drawable47.icon_8930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8931: DrawableResource
+  get() = Drawable47.icon_8931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8932: DrawableResource
+  get() = Drawable47.icon_8932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8933: DrawableResource
+  get() = Drawable47.icon_8933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8934: DrawableResource
+  get() = Drawable47.icon_8934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8935: DrawableResource
+  get() = Drawable47.icon_8935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8936: DrawableResource
+  get() = Drawable47.icon_8936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8937: DrawableResource
+  get() = Drawable47.icon_8937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8938: DrawableResource
+  get() = Drawable47.icon_8938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8939: DrawableResource
+  get() = Drawable47.icon_8939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_894: DrawableResource
+  get() = Drawable47.icon_894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8940: DrawableResource
+  get() = Drawable47.icon_8940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8941: DrawableResource
+  get() = Drawable47.icon_8941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8942: DrawableResource
+  get() = Drawable47.icon_8942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8943: DrawableResource
+  get() = Drawable47.icon_8943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8944: DrawableResource
+  get() = Drawable47.icon_8944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8945: DrawableResource
+  get() = Drawable47.icon_8945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8946: DrawableResource
+  get() = Drawable47.icon_8946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8947: DrawableResource
+  get() = Drawable47.icon_8947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8948: DrawableResource
+  get() = Drawable47.icon_8948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8949: DrawableResource
+  get() = Drawable47.icon_8949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_895: DrawableResource
+  get() = Drawable47.icon_895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8950: DrawableResource
+  get() = Drawable47.icon_8950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8951: DrawableResource
+  get() = Drawable47.icon_8951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8952: DrawableResource
+  get() = Drawable47.icon_8952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8953: DrawableResource
+  get() = Drawable47.icon_8953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8954: DrawableResource
+  get() = Drawable47.icon_8954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8955: DrawableResource
+  get() = Drawable47.icon_8955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8956: DrawableResource
+  get() = Drawable47.icon_8956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8957: DrawableResource
+  get() = Drawable47.icon_8957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8958: DrawableResource
+  get() = Drawable47.icon_8958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8959: DrawableResource
+  get() = Drawable47.icon_8959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_896: DrawableResource
+  get() = Drawable47.icon_896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8960: DrawableResource
+  get() = Drawable47.icon_8960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8961: DrawableResource
+  get() = Drawable47.icon_8961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8962: DrawableResource
+  get() = Drawable47.icon_8962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8963: DrawableResource
+  get() = Drawable47.icon_8963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8964: DrawableResource
+  get() = Drawable47.icon_8964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8965: DrawableResource
+  get() = Drawable47.icon_8965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8966: DrawableResource
+  get() = Drawable47.icon_8966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8967: DrawableResource
+  get() = Drawable47.icon_8967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8968: DrawableResource
+  get() = Drawable47.icon_8968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8969: DrawableResource
+  get() = Drawable47.icon_8969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_897: DrawableResource
+  get() = Drawable47.icon_897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8970: DrawableResource
+  get() = Drawable47.icon_8970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8971: DrawableResource
+  get() = Drawable47.icon_8971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8972: DrawableResource
+  get() = Drawable47.icon_8972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8973: DrawableResource
+  get() = Drawable47.icon_8973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8974: DrawableResource
+  get() = Drawable47.icon_8974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8975: DrawableResource
+  get() = Drawable47.icon_8975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8976: DrawableResource
+  get() = Drawable47.icon_8976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8977: DrawableResource
+  get() = Drawable47.icon_8977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8978: DrawableResource
+  get() = Drawable47.icon_8978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8979: DrawableResource
+  get() = Drawable47.icon_8979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_898: DrawableResource
+  get() = Drawable47.icon_898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8980: DrawableResource
+  get() = Drawable47.icon_8980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8981: DrawableResource
+  get() = Drawable47.icon_8981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8982: DrawableResource
+  get() = Drawable47.icon_8982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8983: DrawableResource
+  get() = Drawable47.icon_8983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8984: DrawableResource
+  get() = Drawable47.icon_8984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8985: DrawableResource
+  get() = Drawable47.icon_8985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8986: DrawableResource
+  get() = Drawable47.icon_8986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8987: DrawableResource
+  get() = Drawable47.icon_8987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8988: DrawableResource
+  get() = Drawable47.icon_8988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8989: DrawableResource
+  get() = Drawable47.icon_8989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_899: DrawableResource
+  get() = Drawable47.icon_899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8990: DrawableResource
+  get() = Drawable47.icon_8990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8991: DrawableResource
+  get() = Drawable47.icon_8991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8992: DrawableResource
+  get() = Drawable47.icon_8992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8993: DrawableResource
+  get() = Drawable47.icon_8993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8994: DrawableResource
+  get() = Drawable47.icon_8994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8995: DrawableResource
+  get() = Drawable47.icon_8995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8996: DrawableResource
+  get() = Drawable47.icon_8996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8997: DrawableResource
+  get() = Drawable47.icon_8997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8998: DrawableResource
+  get() = Drawable47.icon_8998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_8999: DrawableResource
+  get() = Drawable47.icon_8999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9: DrawableResource
+  get() = Drawable47.icon_9
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_90: DrawableResource
+  get() = Drawable47.icon_90
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_900: DrawableResource
+  get() = Drawable47.icon_900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9000: DrawableResource
+  get() = Drawable47.icon_9000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9001: DrawableResource
+  get() = Drawable47.icon_9001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9002: DrawableResource
+  get() = Drawable47.icon_9002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9003: DrawableResource
+  get() = Drawable47.icon_9003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9004: DrawableResource
+  get() = Drawable47.icon_9004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9005: DrawableResource
+  get() = Drawable47.icon_9005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9006: DrawableResource
+  get() = Drawable47.icon_9006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9007: DrawableResource
+  get() = Drawable47.icon_9007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9008: DrawableResource
+  get() = Drawable47.icon_9008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9009: DrawableResource
+  get() = Drawable47.icon_9009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_901: DrawableResource
+  get() = Drawable47.icon_901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9010: DrawableResource
+  get() = Drawable47.icon_9010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9011: DrawableResource
+  get() = Drawable47.icon_9011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9012: DrawableResource
+  get() = Drawable47.icon_9012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9013: DrawableResource
+  get() = Drawable47.icon_9013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9014: DrawableResource
+  get() = Drawable47.icon_9014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9015: DrawableResource
+  get() = Drawable47.icon_9015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9016: DrawableResource
+  get() = Drawable47.icon_9016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9017: DrawableResource
+  get() = Drawable47.icon_9017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9018: DrawableResource
+  get() = Drawable47.icon_9018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9019: DrawableResource
+  get() = Drawable47.icon_9019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_902: DrawableResource
+  get() = Drawable47.icon_902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9020: DrawableResource
+  get() = Drawable47.icon_9020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9021: DrawableResource
+  get() = Drawable47.icon_9021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9022: DrawableResource
+  get() = Drawable47.icon_9022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9023: DrawableResource
+  get() = Drawable47.icon_9023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9024: DrawableResource
+  get() = Drawable47.icon_9024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9025: DrawableResource
+  get() = Drawable47.icon_9025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9026: DrawableResource
+  get() = Drawable47.icon_9026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9027: DrawableResource
+  get() = Drawable47.icon_9027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9028: DrawableResource
+  get() = Drawable47.icon_9028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9029: DrawableResource
+  get() = Drawable47.icon_9029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_903: DrawableResource
+  get() = Drawable47.icon_903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9030: DrawableResource
+  get() = Drawable47.icon_9030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9031: DrawableResource
+  get() = Drawable47.icon_9031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9032: DrawableResource
+  get() = Drawable47.icon_9032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9033: DrawableResource
+  get() = Drawable47.icon_9033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9034: DrawableResource
+  get() = Drawable47.icon_9034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9035: DrawableResource
+  get() = Drawable47.icon_9035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9036: DrawableResource
+  get() = Drawable47.icon_9036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9037: DrawableResource
+  get() = Drawable47.icon_9037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9038: DrawableResource
+  get() = Drawable47.icon_9038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9039: DrawableResource
+  get() = Drawable47.icon_9039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_904: DrawableResource
+  get() = Drawable47.icon_904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9040: DrawableResource
+  get() = Drawable47.icon_9040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9041: DrawableResource
+  get() = Drawable47.icon_9041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9042: DrawableResource
+  get() = Drawable47.icon_9042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9043: DrawableResource
+  get() = Drawable47.icon_9043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9044: DrawableResource
+  get() = Drawable47.icon_9044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9045: DrawableResource
+  get() = Drawable47.icon_9045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9046: DrawableResource
+  get() = Drawable47.icon_9046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9047: DrawableResource
+  get() = Drawable47.icon_9047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9048: DrawableResource
+  get() = Drawable47.icon_9048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9049: DrawableResource
+  get() = Drawable47.icon_9049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_905: DrawableResource
+  get() = Drawable47.icon_905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9050: DrawableResource
+  get() = Drawable47.icon_9050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9051: DrawableResource
+  get() = Drawable47.icon_9051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9052: DrawableResource
+  get() = Drawable47.icon_9052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9053: DrawableResource
+  get() = Drawable47.icon_9053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9054: DrawableResource
+  get() = Drawable47.icon_9054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9055: DrawableResource
+  get() = Drawable47.icon_9055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9056: DrawableResource
+  get() = Drawable47.icon_9056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9057: DrawableResource
+  get() = Drawable47.icon_9057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9058: DrawableResource
+  get() = Drawable47.icon_9058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9059: DrawableResource
+  get() = Drawable47.icon_9059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_906: DrawableResource
+  get() = Drawable47.icon_906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9060: DrawableResource
+  get() = Drawable47.icon_9060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9061: DrawableResource
+  get() = Drawable47.icon_9061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9062: DrawableResource
+  get() = Drawable47.icon_9062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9063: DrawableResource
+  get() = Drawable47.icon_9063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9064: DrawableResource
+  get() = Drawable47.icon_9064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9065: DrawableResource
+  get() = Drawable47.icon_9065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9066: DrawableResource
+  get() = Drawable47.icon_9066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9067: DrawableResource
+  get() = Drawable47.icon_9067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9068: DrawableResource
+  get() = Drawable47.icon_9068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9069: DrawableResource
+  get() = Drawable47.icon_9069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_907: DrawableResource
+  get() = Drawable47.icon_907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9070: DrawableResource
+  get() = Drawable47.icon_9070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9071: DrawableResource
+  get() = Drawable47.icon_9071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9072: DrawableResource
+  get() = Drawable47.icon_9072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9073: DrawableResource
+  get() = Drawable47.icon_9073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9074: DrawableResource
+  get() = Drawable47.icon_9074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9075: DrawableResource
+  get() = Drawable47.icon_9075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9076: DrawableResource
+  get() = Drawable47.icon_9076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9077: DrawableResource
+  get() = Drawable47.icon_9077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9078: DrawableResource
+  get() = Drawable47.icon_9078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9079: DrawableResource
+  get() = Drawable47.icon_9079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_908: DrawableResource
+  get() = Drawable47.icon_908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9080: DrawableResource
+  get() = Drawable47.icon_9080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9081: DrawableResource
+  get() = Drawable47.icon_9081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9082: DrawableResource
+  get() = Drawable47.icon_9082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9083: DrawableResource
+  get() = Drawable47.icon_9083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9084: DrawableResource
+  get() = Drawable47.icon_9084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9085: DrawableResource
+  get() = Drawable47.icon_9085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9086: DrawableResource
+  get() = Drawable47.icon_9086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9087: DrawableResource
+  get() = Drawable47.icon_9087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9088: DrawableResource
+  get() = Drawable47.icon_9088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9089: DrawableResource
+  get() = Drawable47.icon_9089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_909: DrawableResource
+  get() = Drawable47.icon_909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9090: DrawableResource
+  get() = Drawable47.icon_9090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9091: DrawableResource
+  get() = Drawable47.icon_9091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9092: DrawableResource
+  get() = Drawable47.icon_9092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9093: DrawableResource
+  get() = Drawable47.icon_9093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9094: DrawableResource
+  get() = Drawable47.icon_9094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9095: DrawableResource
+  get() = Drawable47.icon_9095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9096: DrawableResource
+  get() = Drawable47.icon_9096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9097: DrawableResource
+  get() = Drawable47.icon_9097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9098: DrawableResource
+  get() = Drawable47.icon_9098

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable48.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable48.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable48 {
+  public val icon_9099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9099.xml"),
+          )
+      )
+
+  public val icon_91: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_91",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_91.xml"),
+          )
+      )
+
+  public val icon_910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_910.xml"),
+          )
+      )
+
+  public val icon_9100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9100.xml"),
+          )
+      )
+
+  public val icon_9101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9101.xml"),
+          )
+      )
+
+  public val icon_9102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9102.xml"),
+          )
+      )
+
+  public val icon_9103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9103.xml"),
+          )
+      )
+
+  public val icon_9104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9104.xml"),
+          )
+      )
+
+  public val icon_9105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9105.xml"),
+          )
+      )
+
+  public val icon_9106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9106.xml"),
+          )
+      )
+
+  public val icon_9107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9107.xml"),
+          )
+      )
+
+  public val icon_9108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9108.xml"),
+          )
+      )
+
+  public val icon_9109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9109.xml"),
+          )
+      )
+
+  public val icon_911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_911.xml"),
+          )
+      )
+
+  public val icon_9110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9110.xml"),
+          )
+      )
+
+  public val icon_9111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9111.xml"),
+          )
+      )
+
+  public val icon_9112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9112.xml"),
+          )
+      )
+
+  public val icon_9113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9113.xml"),
+          )
+      )
+
+  public val icon_9114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9114.xml"),
+          )
+      )
+
+  public val icon_9115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9115.xml"),
+          )
+      )
+
+  public val icon_9116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9116.xml"),
+          )
+      )
+
+  public val icon_9117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9117.xml"),
+          )
+      )
+
+  public val icon_9118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9118.xml"),
+          )
+      )
+
+  public val icon_9119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9119.xml"),
+          )
+      )
+
+  public val icon_912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_912.xml"),
+          )
+      )
+
+  public val icon_9120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9120.xml"),
+          )
+      )
+
+  public val icon_9121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9121.xml"),
+          )
+      )
+
+  public val icon_9122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9122.xml"),
+          )
+      )
+
+  public val icon_9123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9123.xml"),
+          )
+      )
+
+  public val icon_9124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9124.xml"),
+          )
+      )
+
+  public val icon_9125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9125.xml"),
+          )
+      )
+
+  public val icon_9126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9126.xml"),
+          )
+      )
+
+  public val icon_9127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9127.xml"),
+          )
+      )
+
+  public val icon_9128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9128.xml"),
+          )
+      )
+
+  public val icon_9129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9129.xml"),
+          )
+      )
+
+  public val icon_913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_913.xml"),
+          )
+      )
+
+  public val icon_9130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9130.xml"),
+          )
+      )
+
+  public val icon_9131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9131.xml"),
+          )
+      )
+
+  public val icon_9132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9132.xml"),
+          )
+      )
+
+  public val icon_9133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9133.xml"),
+          )
+      )
+
+  public val icon_9134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9134.xml"),
+          )
+      )
+
+  public val icon_9135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9135.xml"),
+          )
+      )
+
+  public val icon_9136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9136.xml"),
+          )
+      )
+
+  public val icon_9137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9137.xml"),
+          )
+      )
+
+  public val icon_9138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9138.xml"),
+          )
+      )
+
+  public val icon_9139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9139.xml"),
+          )
+      )
+
+  public val icon_914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_914.xml"),
+          )
+      )
+
+  public val icon_9140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9140.xml"),
+          )
+      )
+
+  public val icon_9141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9141.xml"),
+          )
+      )
+
+  public val icon_9142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9142.xml"),
+          )
+      )
+
+  public val icon_9143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9143.xml"),
+          )
+      )
+
+  public val icon_9144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9144.xml"),
+          )
+      )
+
+  public val icon_9145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9145.xml"),
+          )
+      )
+
+  public val icon_9146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9146.xml"),
+          )
+      )
+
+  public val icon_9147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9147.xml"),
+          )
+      )
+
+  public val icon_9148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9148.xml"),
+          )
+      )
+
+  public val icon_9149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9149.xml"),
+          )
+      )
+
+  public val icon_915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_915.xml"),
+          )
+      )
+
+  public val icon_9150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9150.xml"),
+          )
+      )
+
+  public val icon_9151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9151.xml"),
+          )
+      )
+
+  public val icon_9152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9152.xml"),
+          )
+      )
+
+  public val icon_9153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9153.xml"),
+          )
+      )
+
+  public val icon_9154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9154.xml"),
+          )
+      )
+
+  public val icon_9155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9155.xml"),
+          )
+      )
+
+  public val icon_9156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9156.xml"),
+          )
+      )
+
+  public val icon_9157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9157.xml"),
+          )
+      )
+
+  public val icon_9158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9158.xml"),
+          )
+      )
+
+  public val icon_9159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9159.xml"),
+          )
+      )
+
+  public val icon_916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_916.xml"),
+          )
+      )
+
+  public val icon_9160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9160.xml"),
+          )
+      )
+
+  public val icon_9161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9161.xml"),
+          )
+      )
+
+  public val icon_9162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9162.xml"),
+          )
+      )
+
+  public val icon_9163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9163.xml"),
+          )
+      )
+
+  public val icon_9164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9164.xml"),
+          )
+      )
+
+  public val icon_9165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9165.xml"),
+          )
+      )
+
+  public val icon_9166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9166.xml"),
+          )
+      )
+
+  public val icon_9167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9167.xml"),
+          )
+      )
+
+  public val icon_9168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9168.xml"),
+          )
+      )
+
+  public val icon_9169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9169.xml"),
+          )
+      )
+
+  public val icon_917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_917.xml"),
+          )
+      )
+
+  public val icon_9170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9170.xml"),
+          )
+      )
+
+  public val icon_9171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9171.xml"),
+          )
+      )
+
+  public val icon_9172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9172.xml"),
+          )
+      )
+
+  public val icon_9173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9173.xml"),
+          )
+      )
+
+  public val icon_9174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9174.xml"),
+          )
+      )
+
+  public val icon_9175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9175.xml"),
+          )
+      )
+
+  public val icon_9176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9176.xml"),
+          )
+      )
+
+  public val icon_9177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9177.xml"),
+          )
+      )
+
+  public val icon_9178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9178.xml"),
+          )
+      )
+
+  public val icon_9179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9179.xml"),
+          )
+      )
+
+  public val icon_918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_918.xml"),
+          )
+      )
+
+  public val icon_9180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9180.xml"),
+          )
+      )
+
+  public val icon_9181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9181.xml"),
+          )
+      )
+
+  public val icon_9182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9182.xml"),
+          )
+      )
+
+  public val icon_9183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9183.xml"),
+          )
+      )
+
+  public val icon_9184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9184.xml"),
+          )
+      )
+
+  public val icon_9185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9185.xml"),
+          )
+      )
+
+  public val icon_9186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9186.xml"),
+          )
+      )
+
+  public val icon_9187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9187.xml"),
+          )
+      )
+
+  public val icon_9188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9188.xml"),
+          )
+      )
+
+  public val icon_9189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9189.xml"),
+          )
+      )
+
+  public val icon_919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_919.xml"),
+          )
+      )
+
+  public val icon_9190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9190.xml"),
+          )
+      )
+
+  public val icon_9191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9191.xml"),
+          )
+      )
+
+  public val icon_9192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9192.xml"),
+          )
+      )
+
+  public val icon_9193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9193.xml"),
+          )
+      )
+
+  public val icon_9194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9194.xml"),
+          )
+      )
+
+  public val icon_9195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9195.xml"),
+          )
+      )
+
+  public val icon_9196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9196.xml"),
+          )
+      )
+
+  public val icon_9197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9197.xml"),
+          )
+      )
+
+  public val icon_9198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9198.xml"),
+          )
+      )
+
+  public val icon_9199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9199.xml"),
+          )
+      )
+
+  public val icon_92: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_92",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_92.xml"),
+          )
+      )
+
+  public val icon_920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_920.xml"),
+          )
+      )
+
+  public val icon_9200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9200.xml"),
+          )
+      )
+
+  public val icon_9201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9201.xml"),
+          )
+      )
+
+  public val icon_9202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9202.xml"),
+          )
+      )
+
+  public val icon_9203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9203.xml"),
+          )
+      )
+
+  public val icon_9204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9204.xml"),
+          )
+      )
+
+  public val icon_9205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9205.xml"),
+          )
+      )
+
+  public val icon_9206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9206.xml"),
+          )
+      )
+
+  public val icon_9207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9207.xml"),
+          )
+      )
+
+  public val icon_9208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9208.xml"),
+          )
+      )
+
+  public val icon_9209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9209.xml"),
+          )
+      )
+
+  public val icon_921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_921.xml"),
+          )
+      )
+
+  public val icon_9210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9210.xml"),
+          )
+      )
+
+  public val icon_9211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9211.xml"),
+          )
+      )
+
+  public val icon_9212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9212.xml"),
+          )
+      )
+
+  public val icon_9213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9213.xml"),
+          )
+      )
+
+  public val icon_9214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9214.xml"),
+          )
+      )
+
+  public val icon_9215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9215.xml"),
+          )
+      )
+
+  public val icon_9216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9216.xml"),
+          )
+      )
+
+  public val icon_9217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9217.xml"),
+          )
+      )
+
+  public val icon_9218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9218.xml"),
+          )
+      )
+
+  public val icon_9219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9219.xml"),
+          )
+      )
+
+  public val icon_922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_922.xml"),
+          )
+      )
+
+  public val icon_9220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9220.xml"),
+          )
+      )
+
+  public val icon_9221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9221.xml"),
+          )
+      )
+
+  public val icon_9222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9222.xml"),
+          )
+      )
+
+  public val icon_9223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9223.xml"),
+          )
+      )
+
+  public val icon_9224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9224.xml"),
+          )
+      )
+
+  public val icon_9225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9225.xml"),
+          )
+      )
+
+  public val icon_9226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9226.xml"),
+          )
+      )
+
+  public val icon_9227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9227.xml"),
+          )
+      )
+
+  public val icon_9228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9228.xml"),
+          )
+      )
+
+  public val icon_9229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9229.xml"),
+          )
+      )
+
+  public val icon_923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_923.xml"),
+          )
+      )
+
+  public val icon_9230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9230.xml"),
+          )
+      )
+
+  public val icon_9231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9231.xml"),
+          )
+      )
+
+  public val icon_9232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9232.xml"),
+          )
+      )
+
+  public val icon_9233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9233.xml"),
+          )
+      )
+
+  public val icon_9234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9234.xml"),
+          )
+      )
+
+  public val icon_9235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9235.xml"),
+          )
+      )
+
+  public val icon_9236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9236.xml"),
+          )
+      )
+
+  public val icon_9237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9237.xml"),
+          )
+      )
+
+  public val icon_9238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9238.xml"),
+          )
+      )
+
+  public val icon_9239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9239.xml"),
+          )
+      )
+
+  public val icon_924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_924.xml"),
+          )
+      )
+
+  public val icon_9240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9240.xml"),
+          )
+      )
+
+  public val icon_9241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9241.xml"),
+          )
+      )
+
+  public val icon_9242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9242.xml"),
+          )
+      )
+
+  public val icon_9243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9243.xml"),
+          )
+      )
+
+  public val icon_9244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9244.xml"),
+          )
+      )
+
+  public val icon_9245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9245.xml"),
+          )
+      )
+
+  public val icon_9246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9246.xml"),
+          )
+      )
+
+  public val icon_9247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9247.xml"),
+          )
+      )
+
+  public val icon_9248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9248.xml"),
+          )
+      )
+
+  public val icon_9249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9249.xml"),
+          )
+      )
+
+  public val icon_925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_925.xml"),
+          )
+      )
+
+  public val icon_9250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9250.xml"),
+          )
+      )
+
+  public val icon_9251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9251.xml"),
+          )
+      )
+
+  public val icon_9252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9252.xml"),
+          )
+      )
+
+  public val icon_9253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9253.xml"),
+          )
+      )
+
+  public val icon_9254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9254.xml"),
+          )
+      )
+
+  public val icon_9255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9255.xml"),
+          )
+      )
+
+  public val icon_9256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9256.xml"),
+          )
+      )
+
+  public val icon_9257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9257.xml"),
+          )
+      )
+
+  public val icon_9258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9258.xml"),
+          )
+      )
+
+  public val icon_9259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9259.xml"),
+          )
+      )
+
+  public val icon_926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_926.xml"),
+          )
+      )
+
+  public val icon_9260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9260.xml"),
+          )
+      )
+
+  public val icon_9261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9261.xml"),
+          )
+      )
+
+  public val icon_9262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9262.xml"),
+          )
+      )
+
+  public val icon_9263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9263.xml"),
+          )
+      )
+
+  public val icon_9264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9264.xml"),
+          )
+      )
+
+  public val icon_9265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9265.xml"),
+          )
+      )
+
+  public val icon_9266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9266.xml"),
+          )
+      )
+
+  public val icon_9267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9267.xml"),
+          )
+      )
+
+  public val icon_9268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9268.xml"),
+          )
+      )
+
+  public val icon_9269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9269.xml"),
+          )
+      )
+
+  public val icon_927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_927.xml"),
+          )
+      )
+
+  public val icon_9270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9270.xml"),
+          )
+      )
+
+  public val icon_9271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9271.xml"),
+          )
+      )
+
+  public val icon_9272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9272.xml"),
+          )
+      )
+
+  public val icon_9273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9273.xml"),
+          )
+      )
+
+  public val icon_9274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9274.xml"),
+          )
+      )
+
+  public val icon_9275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9275.xml"),
+          )
+      )
+
+  public val icon_9276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9276.xml"),
+          )
+      )
+
+  public val icon_9277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9277.xml"),
+          )
+      )
+
+  public val icon_9278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9278.xml"),
+          )
+      )
+
+  public val icon_9279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9279.xml"),
+          )
+      )
+
+  public val icon_928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_928.xml"),
+          )
+      )
+
+  public val icon_9280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9280.xml"),
+          )
+      )
+
+  public val icon_9281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9281.xml"),
+          )
+      )
+
+  public val icon_9282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9282.xml"),
+          )
+      )
+
+  public val icon_9283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9283.xml"),
+          )
+      )
+
+  public val icon_9284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9284.xml"),
+          )
+      )
+
+  public val icon_9285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9285.xml"),
+          )
+      )
+
+  public val icon_9286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9286.xml"),
+          )
+      )
+
+  public val icon_9287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9287.xml"),
+          )
+      )
+
+  public val icon_9288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9288.xml"),
+          )
+      )
+
+  public val icon_9289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9289.xml"),
+          )
+      )
+
+  public val icon_929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_929.xml"),
+          )
+      )
+
+  public val icon_9290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9290.xml"),
+          )
+      )
+
+  public val icon_9291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9291.xml"),
+          )
+      )
+
+  public val icon_9292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9292.xml"),
+          )
+      )
+
+  public val icon_9293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9293.xml"),
+          )
+      )
+
+  public val icon_9294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9294.xml"),
+          )
+      )
+
+  public val icon_9295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9295.xml"),
+          )
+      )
+
+  public val icon_9296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9296.xml"),
+          )
+      )
+
+  public val icon_9297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9297.xml"),
+          )
+      )
+
+  public val icon_9298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9298.xml"),
+          )
+      )
+
+  public val icon_9299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9299.xml"),
+          )
+      )
+
+  public val icon_93: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_93",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_93.xml"),
+          )
+      )
+
+  public val icon_930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_930.xml"),
+          )
+      )
+
+  public val icon_9300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9300.xml"),
+          )
+      )
+
+  public val icon_9301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9301.xml"),
+          )
+      )
+
+  public val icon_9302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9302.xml"),
+          )
+      )
+
+  public val icon_9303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9303.xml"),
+          )
+      )
+
+  public val icon_9304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9304.xml"),
+          )
+      )
+
+  public val icon_9305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9305.xml"),
+          )
+      )
+
+  public val icon_9306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9306.xml"),
+          )
+      )
+
+  public val icon_9307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9307.xml"),
+          )
+      )
+
+  public val icon_9308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9308.xml"),
+          )
+      )
+
+  public val icon_9309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9309.xml"),
+          )
+      )
+
+  public val icon_931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_931.xml"),
+          )
+      )
+
+  public val icon_9310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9310.xml"),
+          )
+      )
+
+  public val icon_9311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9311.xml"),
+          )
+      )
+
+  public val icon_9312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9312.xml"),
+          )
+      )
+
+  public val icon_9313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9313.xml"),
+          )
+      )
+
+  public val icon_9314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9314.xml"),
+          )
+      )
+
+  public val icon_9315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9315.xml"),
+          )
+      )
+
+  public val icon_9316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9316.xml"),
+          )
+      )
+
+  public val icon_9317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9317.xml"),
+          )
+      )
+
+  public val icon_9318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9318.xml"),
+          )
+      )
+
+  public val icon_9319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9319.xml"),
+          )
+      )
+
+  public val icon_932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_932.xml"),
+          )
+      )
+
+  public val icon_9320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9320.xml"),
+          )
+      )
+
+  public val icon_9321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9321.xml"),
+          )
+      )
+
+  public val icon_9322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9322.xml"),
+          )
+      )
+
+  public val icon_9323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9323.xml"),
+          )
+      )
+
+  public val icon_9324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9324.xml"),
+          )
+      )
+
+  public val icon_9325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9325.xml"),
+          )
+      )
+
+  public val icon_9326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9326.xml"),
+          )
+      )
+
+  public val icon_9327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9327.xml"),
+          )
+      )
+
+  public val icon_9328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9328.xml"),
+          )
+      )
+
+  public val icon_9329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9329.xml"),
+          )
+      )
+
+  public val icon_933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_933.xml"),
+          )
+      )
+
+  public val icon_9330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9330.xml"),
+          )
+      )
+
+  public val icon_9331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9331.xml"),
+          )
+      )
+
+  public val icon_9332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9332.xml"),
+          )
+      )
+
+  public val icon_9333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9333.xml"),
+          )
+      )
+
+  public val icon_9334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9334.xml"),
+          )
+      )
+
+  public val icon_9335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9335.xml"),
+          )
+      )
+
+  public val icon_9336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9336.xml"),
+          )
+      )
+
+  public val icon_9337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9337.xml"),
+          )
+      )
+
+  public val icon_9338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9338.xml"),
+          )
+      )
+
+  public val icon_9339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9339.xml"),
+          )
+      )
+
+  public val icon_934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_934.xml"),
+          )
+      )
+
+  public val icon_9340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9340.xml"),
+          )
+      )
+
+  public val icon_9341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9341.xml"),
+          )
+      )
+
+  public val icon_9342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9342.xml"),
+          )
+      )
+
+  public val icon_9343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9343.xml"),
+          )
+      )
+
+  public val icon_9344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9344.xml"),
+          )
+      )
+
+  public val icon_9345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9345.xml"),
+          )
+      )
+
+  public val icon_9346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9346.xml"),
+          )
+      )
+
+  public val icon_9347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9347.xml"),
+          )
+      )
+
+  public val icon_9348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9348.xml"),
+          )
+      )
+
+  public val icon_9349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9349.xml"),
+          )
+      )
+
+  public val icon_935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_935.xml"),
+          )
+      )
+
+  public val icon_9350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9350.xml"),
+          )
+      )
+
+  public val icon_9351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9351.xml"),
+          )
+      )
+
+  public val icon_9352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9352.xml"),
+          )
+      )
+
+  public val icon_9353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9353.xml"),
+          )
+      )
+
+  public val icon_9354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9354.xml"),
+          )
+      )
+
+  public val icon_9355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9355.xml"),
+          )
+      )
+
+  public val icon_9356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9356.xml"),
+          )
+      )
+
+  public val icon_9357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9357.xml"),
+          )
+      )
+
+  public val icon_9358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9358.xml"),
+          )
+      )
+
+  public val icon_9359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9359.xml"),
+          )
+      )
+
+  public val icon_936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_936.xml"),
+          )
+      )
+
+  public val icon_9360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9360.xml"),
+          )
+      )
+
+  public val icon_9361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9361.xml"),
+          )
+      )
+
+  public val icon_9362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9362.xml"),
+          )
+      )
+
+  public val icon_9363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9363.xml"),
+          )
+      )
+
+  public val icon_9364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9364.xml"),
+          )
+      )
+
+  public val icon_9365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9365.xml"),
+          )
+      )
+
+  public val icon_9366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9366.xml"),
+          )
+      )
+
+  public val icon_9367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9367.xml"),
+          )
+      )
+
+  public val icon_9368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9368.xml"),
+          )
+      )
+
+  public val icon_9369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9369.xml"),
+          )
+      )
+
+  public val icon_937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_937.xml"),
+          )
+      )
+
+  public val icon_9370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9370.xml"),
+          )
+      )
+
+  public val icon_9371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9371.xml"),
+          )
+      )
+
+  public val icon_9372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9372.xml"),
+          )
+      )
+
+  public val icon_9373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9373.xml"),
+          )
+      )
+
+  public val icon_9374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9374.xml"),
+          )
+      )
+
+  public val icon_9375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9375.xml"),
+          )
+      )
+
+  public val icon_9376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9376.xml"),
+          )
+      )
+
+  public val icon_9377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9377.xml"),
+          )
+      )
+
+  public val icon_9378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9378.xml"),
+          )
+      )
+
+  public val icon_9379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9379.xml"),
+          )
+      )
+
+  public val icon_938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_938.xml"),
+          )
+      )
+
+  public val icon_9380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9380.xml"),
+          )
+      )
+
+  public val icon_9381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9381.xml"),
+          )
+      )
+
+  public val icon_9382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9382.xml"),
+          )
+      )
+
+  public val icon_9383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9383.xml"),
+          )
+      )
+
+  public val icon_9384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9384.xml"),
+          )
+      )
+
+  public val icon_9385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9385.xml"),
+          )
+      )
+
+  public val icon_9386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9386.xml"),
+          )
+      )
+
+  public val icon_9387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9387.xml"),
+          )
+      )
+
+  public val icon_9388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9388.xml"),
+          )
+      )
+
+  public val icon_9389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9389.xml"),
+          )
+      )
+
+  public val icon_939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_939.xml"),
+          )
+      )
+
+  public val icon_9390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9390.xml"),
+          )
+      )
+
+  public val icon_9391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9391.xml"),
+          )
+      )
+
+  public val icon_9392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9392.xml"),
+          )
+      )
+
+  public val icon_9393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9393.xml"),
+          )
+      )
+
+  public val icon_9394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9394.xml"),
+          )
+      )
+
+  public val icon_9395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9395.xml"),
+          )
+      )
+
+  public val icon_9396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9396.xml"),
+          )
+      )
+
+  public val icon_9397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9397.xml"),
+          )
+      )
+
+  public val icon_9398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9398.xml"),
+          )
+      )
+
+  public val icon_9399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9399.xml"),
+          )
+      )
+
+  public val icon_94: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_94",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_94.xml"),
+          )
+      )
+
+  public val icon_940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_940.xml"),
+          )
+      )
+
+  public val icon_9400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9400.xml"),
+          )
+      )
+
+  public val icon_9401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9401.xml"),
+          )
+      )
+
+  public val icon_9402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9402.xml"),
+          )
+      )
+
+  public val icon_9403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9403.xml"),
+          )
+      )
+
+  public val icon_9404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9404.xml"),
+          )
+      )
+
+  public val icon_9405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9405.xml"),
+          )
+      )
+
+  public val icon_9406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9406.xml"),
+          )
+      )
+
+  public val icon_9407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9407.xml"),
+          )
+      )
+
+  public val icon_9408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9408.xml"),
+          )
+      )
+
+  public val icon_9409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9409.xml"),
+          )
+      )
+
+  public val icon_941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_941.xml"),
+          )
+      )
+
+  public val icon_9410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9410.xml"),
+          )
+      )
+
+  public val icon_9411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9411.xml"),
+          )
+      )
+
+  public val icon_9412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9412.xml"),
+          )
+      )
+
+  public val icon_9413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9413.xml"),
+          )
+      )
+
+  public val icon_9414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9414.xml"),
+          )
+      )
+
+  public val icon_9415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9415.xml"),
+          )
+      )
+
+  public val icon_9416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9416.xml"),
+          )
+      )
+
+  public val icon_9417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9417.xml"),
+          )
+      )
+
+  public val icon_9418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9418.xml"),
+          )
+      )
+
+  public val icon_9419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9419.xml"),
+          )
+      )
+
+  public val icon_942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_942.xml"),
+          )
+      )
+
+  public val icon_9420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9420.xml"),
+          )
+      )
+
+  public val icon_9421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9421.xml"),
+          )
+      )
+
+  public val icon_9422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9422.xml"),
+          )
+      )
+
+  public val icon_9423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9423.xml"),
+          )
+      )
+
+  public val icon_9424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9424.xml"),
+          )
+      )
+
+  public val icon_9425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9425.xml"),
+          )
+      )
+
+  public val icon_9426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9426.xml"),
+          )
+      )
+
+  public val icon_9427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9427.xml"),
+          )
+      )
+
+  public val icon_9428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9428.xml"),
+          )
+      )
+
+  public val icon_9429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9429.xml"),
+          )
+      )
+
+  public val icon_943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_943.xml"),
+          )
+      )
+
+  public val icon_9430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9430.xml"),
+          )
+      )
+
+  public val icon_9431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9431.xml"),
+          )
+      )
+
+  public val icon_9432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9432.xml"),
+          )
+      )
+
+  public val icon_9433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9433.xml"),
+          )
+      )
+
+  public val icon_9434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9434.xml"),
+          )
+      )
+
+  public val icon_9435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9435.xml"),
+          )
+      )
+
+  public val icon_9436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9436.xml"),
+          )
+      )
+
+  public val icon_9437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9437.xml"),
+          )
+      )
+
+  public val icon_9438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9438.xml"),
+          )
+      )
+
+  public val icon_9439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9439.xml"),
+          )
+      )
+
+  public val icon_944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_944.xml"),
+          )
+      )
+
+  public val icon_9440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9440.xml"),
+          )
+      )
+
+  public val icon_9441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9441.xml"),
+          )
+      )
+
+  public val icon_9442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9442.xml"),
+          )
+      )
+
+  public val icon_9443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9443.xml"),
+          )
+      )
+
+  public val icon_9444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9444.xml"),
+          )
+      )
+
+  public val icon_9445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9445.xml"),
+          )
+      )
+
+  public val icon_9446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9446.xml"),
+          )
+      )
+
+  public val icon_9447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9447.xml"),
+          )
+      )
+
+  public val icon_9448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9448.xml"),
+          )
+      )
+
+  public val icon_9449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9449.xml"),
+          )
+      )
+
+  public val icon_945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_945.xml"),
+          )
+      )
+
+  public val icon_9450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9450.xml"),
+          )
+      )
+
+  public val icon_9451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9451.xml"),
+          )
+      )
+
+  public val icon_9452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9452.xml"),
+          )
+      )
+
+  public val icon_9453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9453.xml"),
+          )
+      )
+
+  public val icon_9454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9454.xml"),
+          )
+      )
+
+  public val icon_9455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9455.xml"),
+          )
+      )
+
+  public val icon_9456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9456.xml"),
+          )
+      )
+
+  public val icon_9457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9457.xml"),
+          )
+      )
+
+  public val icon_9458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9458.xml"),
+          )
+      )
+
+  public val icon_9459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9459.xml"),
+          )
+      )
+
+  public val icon_946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_946.xml"),
+          )
+      )
+
+  public val icon_9460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9460.xml"),
+          )
+      )
+
+  public val icon_9461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9461.xml"),
+          )
+      )
+
+  public val icon_9462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9462.xml"),
+          )
+      )
+
+  public val icon_9463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9463.xml"),
+          )
+      )
+
+  public val icon_9464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9464.xml"),
+          )
+      )
+
+  public val icon_9465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9465.xml"),
+          )
+      )
+
+  public val icon_9466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9466.xml"),
+          )
+      )
+
+  public val icon_9467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9467.xml"),
+          )
+      )
+
+  public val icon_9468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9468.xml"),
+          )
+      )
+
+  public val icon_9469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9469.xml"),
+          )
+      )
+
+  public val icon_947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_947.xml"),
+          )
+      )
+
+  public val icon_9470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9470.xml"),
+          )
+      )
+
+  public val icon_9471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9471.xml"),
+          )
+      )
+
+  public val icon_9472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9472.xml"),
+          )
+      )
+
+  public val icon_9473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9473.xml"),
+          )
+      )
+
+  public val icon_9474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9474.xml"),
+          )
+      )
+
+  public val icon_9475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9475.xml"),
+          )
+      )
+
+  public val icon_9476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9476.xml"),
+          )
+      )
+
+  public val icon_9477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9477.xml"),
+          )
+      )
+
+  public val icon_9478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9478.xml"),
+          )
+      )
+
+  public val icon_9479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9479.xml"),
+          )
+      )
+
+  public val icon_948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_948.xml"),
+          )
+      )
+
+  public val icon_9480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9480.xml"),
+          )
+      )
+
+  public val icon_9481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9481.xml"),
+          )
+      )
+
+  public val icon_9482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9482.xml"),
+          )
+      )
+
+  public val icon_9483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9483.xml"),
+          )
+      )
+
+  public val icon_9484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9484.xml"),
+          )
+      )
+
+  public val icon_9485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9485.xml"),
+          )
+      )
+
+  public val icon_9486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9486.xml"),
+          )
+      )
+
+  public val icon_9487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9487.xml"),
+          )
+      )
+
+  public val icon_9488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9488.xml"),
+          )
+      )
+
+  public val icon_9489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9489.xml"),
+          )
+      )
+
+  public val icon_949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_949.xml"),
+          )
+      )
+
+  public val icon_9490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9490.xml"),
+          )
+      )
+
+  public val icon_9491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9491.xml"),
+          )
+      )
+
+  public val icon_9492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9492.xml"),
+          )
+      )
+
+  public val icon_9493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9493.xml"),
+          )
+      )
+
+  public val icon_9494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9494.xml"),
+          )
+      )
+
+  public val icon_9495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9495.xml"),
+          )
+      )
+
+  public val icon_9496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9496.xml"),
+          )
+      )
+
+  public val icon_9497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9497.xml"),
+          )
+      )
+
+  public val icon_9498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9498.xml"),
+          )
+      )
+
+  public val icon_9499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9499.xml"),
+          )
+      )
+
+  public val icon_95: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_95",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_95.xml"),
+          )
+      )
+
+  public val icon_950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_950.xml"),
+          )
+      )
+
+  public val icon_9500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9500.xml"),
+          )
+      )
+
+  public val icon_9501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9501.xml"),
+          )
+      )
+
+  public val icon_9502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9502.xml"),
+          )
+      )
+
+  public val icon_9503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9503.xml"),
+          )
+      )
+
+  public val icon_9504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9504.xml"),
+          )
+      )
+
+  public val icon_9505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9505.xml"),
+          )
+      )
+
+  public val icon_9506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9506.xml"),
+          )
+      )
+
+  public val icon_9507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9507.xml"),
+          )
+      )
+
+  public val icon_9508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9508.xml"),
+          )
+      )
+
+  public val icon_9509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9509.xml"),
+          )
+      )
+
+  public val icon_951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_951.xml"),
+          )
+      )
+
+  public val icon_9510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9510.xml"),
+          )
+      )
+
+  public val icon_9511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9511.xml"),
+          )
+      )
+
+  public val icon_9512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9512.xml"),
+          )
+      )
+
+  public val icon_9513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9513.xml"),
+          )
+      )
+
+  public val icon_9514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9514.xml"),
+          )
+      )
+
+  public val icon_9515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9515.xml"),
+          )
+      )
+
+  public val icon_9516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9516.xml"),
+          )
+      )
+
+  public val icon_9517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9517.xml"),
+          )
+      )
+
+  public val icon_9518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9518.xml"),
+          )
+      )
+
+  public val icon_9519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9519.xml"),
+          )
+      )
+
+  public val icon_952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_952.xml"),
+          )
+      )
+
+  public val icon_9520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9520.xml"),
+          )
+      )
+
+  public val icon_9521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9521.xml"),
+          )
+      )
+
+  public val icon_9522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9522.xml"),
+          )
+      )
+
+  public val icon_9523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9523.xml"),
+          )
+      )
+
+  public val icon_9524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9524.xml"),
+          )
+      )
+
+  public val icon_9525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9525.xml"),
+          )
+      )
+
+  public val icon_9526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9526.xml"),
+          )
+      )
+
+  public val icon_9527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9527.xml"),
+          )
+      )
+
+  public val icon_9528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9528.xml"),
+          )
+      )
+
+  public val icon_9529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9529.xml"),
+          )
+      )
+
+  public val icon_953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_953.xml"),
+          )
+      )
+
+  public val icon_9530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9530.xml"),
+          )
+      )
+
+  public val icon_9531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9531.xml"),
+          )
+      )
+
+  public val icon_9532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9532.xml"),
+          )
+      )
+
+  public val icon_9533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9533.xml"),
+          )
+      )
+
+  public val icon_9534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9534.xml"),
+          )
+      )
+
+  public val icon_9535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9535.xml"),
+          )
+      )
+
+  public val icon_9536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9536.xml"),
+          )
+      )
+
+  public val icon_9537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9537.xml"),
+          )
+      )
+
+  public val icon_9538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9538.xml"),
+          )
+      )
+
+  public val icon_9539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9539.xml"),
+          )
+      )
+
+  public val icon_954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_954.xml"),
+          )
+      )
+
+  public val icon_9540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9540.xml"),
+          )
+      )
+
+  public val icon_9541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9541.xml"),
+          )
+      )
+
+  public val icon_9542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9542.xml"),
+          )
+      )
+
+  public val icon_9543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9543.xml"),
+          )
+      )
+
+  public val icon_9544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9544.xml"),
+          )
+      )
+
+  public val icon_9545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9545.xml"),
+          )
+      )
+
+  public val icon_9546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9546.xml"),
+          )
+      )
+
+  public val icon_9547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9547.xml"),
+          )
+      )
+
+  public val icon_9548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9548.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9099: DrawableResource
+  get() = Drawable48.icon_9099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_91: DrawableResource
+  get() = Drawable48.icon_91
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_910: DrawableResource
+  get() = Drawable48.icon_910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9100: DrawableResource
+  get() = Drawable48.icon_9100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9101: DrawableResource
+  get() = Drawable48.icon_9101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9102: DrawableResource
+  get() = Drawable48.icon_9102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9103: DrawableResource
+  get() = Drawable48.icon_9103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9104: DrawableResource
+  get() = Drawable48.icon_9104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9105: DrawableResource
+  get() = Drawable48.icon_9105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9106: DrawableResource
+  get() = Drawable48.icon_9106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9107: DrawableResource
+  get() = Drawable48.icon_9107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9108: DrawableResource
+  get() = Drawable48.icon_9108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9109: DrawableResource
+  get() = Drawable48.icon_9109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_911: DrawableResource
+  get() = Drawable48.icon_911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9110: DrawableResource
+  get() = Drawable48.icon_9110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9111: DrawableResource
+  get() = Drawable48.icon_9111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9112: DrawableResource
+  get() = Drawable48.icon_9112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9113: DrawableResource
+  get() = Drawable48.icon_9113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9114: DrawableResource
+  get() = Drawable48.icon_9114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9115: DrawableResource
+  get() = Drawable48.icon_9115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9116: DrawableResource
+  get() = Drawable48.icon_9116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9117: DrawableResource
+  get() = Drawable48.icon_9117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9118: DrawableResource
+  get() = Drawable48.icon_9118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9119: DrawableResource
+  get() = Drawable48.icon_9119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_912: DrawableResource
+  get() = Drawable48.icon_912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9120: DrawableResource
+  get() = Drawable48.icon_9120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9121: DrawableResource
+  get() = Drawable48.icon_9121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9122: DrawableResource
+  get() = Drawable48.icon_9122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9123: DrawableResource
+  get() = Drawable48.icon_9123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9124: DrawableResource
+  get() = Drawable48.icon_9124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9125: DrawableResource
+  get() = Drawable48.icon_9125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9126: DrawableResource
+  get() = Drawable48.icon_9126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9127: DrawableResource
+  get() = Drawable48.icon_9127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9128: DrawableResource
+  get() = Drawable48.icon_9128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9129: DrawableResource
+  get() = Drawable48.icon_9129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_913: DrawableResource
+  get() = Drawable48.icon_913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9130: DrawableResource
+  get() = Drawable48.icon_9130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9131: DrawableResource
+  get() = Drawable48.icon_9131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9132: DrawableResource
+  get() = Drawable48.icon_9132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9133: DrawableResource
+  get() = Drawable48.icon_9133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9134: DrawableResource
+  get() = Drawable48.icon_9134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9135: DrawableResource
+  get() = Drawable48.icon_9135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9136: DrawableResource
+  get() = Drawable48.icon_9136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9137: DrawableResource
+  get() = Drawable48.icon_9137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9138: DrawableResource
+  get() = Drawable48.icon_9138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9139: DrawableResource
+  get() = Drawable48.icon_9139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_914: DrawableResource
+  get() = Drawable48.icon_914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9140: DrawableResource
+  get() = Drawable48.icon_9140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9141: DrawableResource
+  get() = Drawable48.icon_9141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9142: DrawableResource
+  get() = Drawable48.icon_9142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9143: DrawableResource
+  get() = Drawable48.icon_9143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9144: DrawableResource
+  get() = Drawable48.icon_9144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9145: DrawableResource
+  get() = Drawable48.icon_9145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9146: DrawableResource
+  get() = Drawable48.icon_9146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9147: DrawableResource
+  get() = Drawable48.icon_9147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9148: DrawableResource
+  get() = Drawable48.icon_9148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9149: DrawableResource
+  get() = Drawable48.icon_9149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_915: DrawableResource
+  get() = Drawable48.icon_915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9150: DrawableResource
+  get() = Drawable48.icon_9150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9151: DrawableResource
+  get() = Drawable48.icon_9151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9152: DrawableResource
+  get() = Drawable48.icon_9152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9153: DrawableResource
+  get() = Drawable48.icon_9153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9154: DrawableResource
+  get() = Drawable48.icon_9154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9155: DrawableResource
+  get() = Drawable48.icon_9155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9156: DrawableResource
+  get() = Drawable48.icon_9156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9157: DrawableResource
+  get() = Drawable48.icon_9157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9158: DrawableResource
+  get() = Drawable48.icon_9158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9159: DrawableResource
+  get() = Drawable48.icon_9159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_916: DrawableResource
+  get() = Drawable48.icon_916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9160: DrawableResource
+  get() = Drawable48.icon_9160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9161: DrawableResource
+  get() = Drawable48.icon_9161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9162: DrawableResource
+  get() = Drawable48.icon_9162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9163: DrawableResource
+  get() = Drawable48.icon_9163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9164: DrawableResource
+  get() = Drawable48.icon_9164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9165: DrawableResource
+  get() = Drawable48.icon_9165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9166: DrawableResource
+  get() = Drawable48.icon_9166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9167: DrawableResource
+  get() = Drawable48.icon_9167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9168: DrawableResource
+  get() = Drawable48.icon_9168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9169: DrawableResource
+  get() = Drawable48.icon_9169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_917: DrawableResource
+  get() = Drawable48.icon_917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9170: DrawableResource
+  get() = Drawable48.icon_9170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9171: DrawableResource
+  get() = Drawable48.icon_9171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9172: DrawableResource
+  get() = Drawable48.icon_9172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9173: DrawableResource
+  get() = Drawable48.icon_9173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9174: DrawableResource
+  get() = Drawable48.icon_9174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9175: DrawableResource
+  get() = Drawable48.icon_9175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9176: DrawableResource
+  get() = Drawable48.icon_9176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9177: DrawableResource
+  get() = Drawable48.icon_9177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9178: DrawableResource
+  get() = Drawable48.icon_9178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9179: DrawableResource
+  get() = Drawable48.icon_9179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_918: DrawableResource
+  get() = Drawable48.icon_918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9180: DrawableResource
+  get() = Drawable48.icon_9180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9181: DrawableResource
+  get() = Drawable48.icon_9181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9182: DrawableResource
+  get() = Drawable48.icon_9182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9183: DrawableResource
+  get() = Drawable48.icon_9183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9184: DrawableResource
+  get() = Drawable48.icon_9184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9185: DrawableResource
+  get() = Drawable48.icon_9185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9186: DrawableResource
+  get() = Drawable48.icon_9186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9187: DrawableResource
+  get() = Drawable48.icon_9187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9188: DrawableResource
+  get() = Drawable48.icon_9188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9189: DrawableResource
+  get() = Drawable48.icon_9189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_919: DrawableResource
+  get() = Drawable48.icon_919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9190: DrawableResource
+  get() = Drawable48.icon_9190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9191: DrawableResource
+  get() = Drawable48.icon_9191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9192: DrawableResource
+  get() = Drawable48.icon_9192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9193: DrawableResource
+  get() = Drawable48.icon_9193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9194: DrawableResource
+  get() = Drawable48.icon_9194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9195: DrawableResource
+  get() = Drawable48.icon_9195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9196: DrawableResource
+  get() = Drawable48.icon_9196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9197: DrawableResource
+  get() = Drawable48.icon_9197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9198: DrawableResource
+  get() = Drawable48.icon_9198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9199: DrawableResource
+  get() = Drawable48.icon_9199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_92: DrawableResource
+  get() = Drawable48.icon_92
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_920: DrawableResource
+  get() = Drawable48.icon_920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9200: DrawableResource
+  get() = Drawable48.icon_9200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9201: DrawableResource
+  get() = Drawable48.icon_9201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9202: DrawableResource
+  get() = Drawable48.icon_9202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9203: DrawableResource
+  get() = Drawable48.icon_9203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9204: DrawableResource
+  get() = Drawable48.icon_9204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9205: DrawableResource
+  get() = Drawable48.icon_9205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9206: DrawableResource
+  get() = Drawable48.icon_9206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9207: DrawableResource
+  get() = Drawable48.icon_9207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9208: DrawableResource
+  get() = Drawable48.icon_9208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9209: DrawableResource
+  get() = Drawable48.icon_9209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_921: DrawableResource
+  get() = Drawable48.icon_921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9210: DrawableResource
+  get() = Drawable48.icon_9210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9211: DrawableResource
+  get() = Drawable48.icon_9211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9212: DrawableResource
+  get() = Drawable48.icon_9212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9213: DrawableResource
+  get() = Drawable48.icon_9213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9214: DrawableResource
+  get() = Drawable48.icon_9214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9215: DrawableResource
+  get() = Drawable48.icon_9215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9216: DrawableResource
+  get() = Drawable48.icon_9216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9217: DrawableResource
+  get() = Drawable48.icon_9217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9218: DrawableResource
+  get() = Drawable48.icon_9218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9219: DrawableResource
+  get() = Drawable48.icon_9219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_922: DrawableResource
+  get() = Drawable48.icon_922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9220: DrawableResource
+  get() = Drawable48.icon_9220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9221: DrawableResource
+  get() = Drawable48.icon_9221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9222: DrawableResource
+  get() = Drawable48.icon_9222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9223: DrawableResource
+  get() = Drawable48.icon_9223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9224: DrawableResource
+  get() = Drawable48.icon_9224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9225: DrawableResource
+  get() = Drawable48.icon_9225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9226: DrawableResource
+  get() = Drawable48.icon_9226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9227: DrawableResource
+  get() = Drawable48.icon_9227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9228: DrawableResource
+  get() = Drawable48.icon_9228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9229: DrawableResource
+  get() = Drawable48.icon_9229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_923: DrawableResource
+  get() = Drawable48.icon_923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9230: DrawableResource
+  get() = Drawable48.icon_9230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9231: DrawableResource
+  get() = Drawable48.icon_9231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9232: DrawableResource
+  get() = Drawable48.icon_9232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9233: DrawableResource
+  get() = Drawable48.icon_9233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9234: DrawableResource
+  get() = Drawable48.icon_9234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9235: DrawableResource
+  get() = Drawable48.icon_9235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9236: DrawableResource
+  get() = Drawable48.icon_9236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9237: DrawableResource
+  get() = Drawable48.icon_9237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9238: DrawableResource
+  get() = Drawable48.icon_9238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9239: DrawableResource
+  get() = Drawable48.icon_9239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_924: DrawableResource
+  get() = Drawable48.icon_924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9240: DrawableResource
+  get() = Drawable48.icon_9240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9241: DrawableResource
+  get() = Drawable48.icon_9241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9242: DrawableResource
+  get() = Drawable48.icon_9242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9243: DrawableResource
+  get() = Drawable48.icon_9243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9244: DrawableResource
+  get() = Drawable48.icon_9244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9245: DrawableResource
+  get() = Drawable48.icon_9245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9246: DrawableResource
+  get() = Drawable48.icon_9246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9247: DrawableResource
+  get() = Drawable48.icon_9247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9248: DrawableResource
+  get() = Drawable48.icon_9248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9249: DrawableResource
+  get() = Drawable48.icon_9249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_925: DrawableResource
+  get() = Drawable48.icon_925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9250: DrawableResource
+  get() = Drawable48.icon_9250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9251: DrawableResource
+  get() = Drawable48.icon_9251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9252: DrawableResource
+  get() = Drawable48.icon_9252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9253: DrawableResource
+  get() = Drawable48.icon_9253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9254: DrawableResource
+  get() = Drawable48.icon_9254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9255: DrawableResource
+  get() = Drawable48.icon_9255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9256: DrawableResource
+  get() = Drawable48.icon_9256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9257: DrawableResource
+  get() = Drawable48.icon_9257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9258: DrawableResource
+  get() = Drawable48.icon_9258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9259: DrawableResource
+  get() = Drawable48.icon_9259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_926: DrawableResource
+  get() = Drawable48.icon_926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9260: DrawableResource
+  get() = Drawable48.icon_9260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9261: DrawableResource
+  get() = Drawable48.icon_9261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9262: DrawableResource
+  get() = Drawable48.icon_9262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9263: DrawableResource
+  get() = Drawable48.icon_9263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9264: DrawableResource
+  get() = Drawable48.icon_9264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9265: DrawableResource
+  get() = Drawable48.icon_9265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9266: DrawableResource
+  get() = Drawable48.icon_9266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9267: DrawableResource
+  get() = Drawable48.icon_9267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9268: DrawableResource
+  get() = Drawable48.icon_9268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9269: DrawableResource
+  get() = Drawable48.icon_9269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_927: DrawableResource
+  get() = Drawable48.icon_927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9270: DrawableResource
+  get() = Drawable48.icon_9270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9271: DrawableResource
+  get() = Drawable48.icon_9271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9272: DrawableResource
+  get() = Drawable48.icon_9272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9273: DrawableResource
+  get() = Drawable48.icon_9273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9274: DrawableResource
+  get() = Drawable48.icon_9274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9275: DrawableResource
+  get() = Drawable48.icon_9275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9276: DrawableResource
+  get() = Drawable48.icon_9276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9277: DrawableResource
+  get() = Drawable48.icon_9277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9278: DrawableResource
+  get() = Drawable48.icon_9278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9279: DrawableResource
+  get() = Drawable48.icon_9279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_928: DrawableResource
+  get() = Drawable48.icon_928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9280: DrawableResource
+  get() = Drawable48.icon_9280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9281: DrawableResource
+  get() = Drawable48.icon_9281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9282: DrawableResource
+  get() = Drawable48.icon_9282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9283: DrawableResource
+  get() = Drawable48.icon_9283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9284: DrawableResource
+  get() = Drawable48.icon_9284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9285: DrawableResource
+  get() = Drawable48.icon_9285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9286: DrawableResource
+  get() = Drawable48.icon_9286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9287: DrawableResource
+  get() = Drawable48.icon_9287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9288: DrawableResource
+  get() = Drawable48.icon_9288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9289: DrawableResource
+  get() = Drawable48.icon_9289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_929: DrawableResource
+  get() = Drawable48.icon_929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9290: DrawableResource
+  get() = Drawable48.icon_9290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9291: DrawableResource
+  get() = Drawable48.icon_9291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9292: DrawableResource
+  get() = Drawable48.icon_9292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9293: DrawableResource
+  get() = Drawable48.icon_9293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9294: DrawableResource
+  get() = Drawable48.icon_9294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9295: DrawableResource
+  get() = Drawable48.icon_9295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9296: DrawableResource
+  get() = Drawable48.icon_9296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9297: DrawableResource
+  get() = Drawable48.icon_9297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9298: DrawableResource
+  get() = Drawable48.icon_9298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9299: DrawableResource
+  get() = Drawable48.icon_9299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_93: DrawableResource
+  get() = Drawable48.icon_93
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_930: DrawableResource
+  get() = Drawable48.icon_930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9300: DrawableResource
+  get() = Drawable48.icon_9300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9301: DrawableResource
+  get() = Drawable48.icon_9301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9302: DrawableResource
+  get() = Drawable48.icon_9302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9303: DrawableResource
+  get() = Drawable48.icon_9303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9304: DrawableResource
+  get() = Drawable48.icon_9304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9305: DrawableResource
+  get() = Drawable48.icon_9305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9306: DrawableResource
+  get() = Drawable48.icon_9306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9307: DrawableResource
+  get() = Drawable48.icon_9307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9308: DrawableResource
+  get() = Drawable48.icon_9308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9309: DrawableResource
+  get() = Drawable48.icon_9309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_931: DrawableResource
+  get() = Drawable48.icon_931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9310: DrawableResource
+  get() = Drawable48.icon_9310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9311: DrawableResource
+  get() = Drawable48.icon_9311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9312: DrawableResource
+  get() = Drawable48.icon_9312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9313: DrawableResource
+  get() = Drawable48.icon_9313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9314: DrawableResource
+  get() = Drawable48.icon_9314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9315: DrawableResource
+  get() = Drawable48.icon_9315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9316: DrawableResource
+  get() = Drawable48.icon_9316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9317: DrawableResource
+  get() = Drawable48.icon_9317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9318: DrawableResource
+  get() = Drawable48.icon_9318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9319: DrawableResource
+  get() = Drawable48.icon_9319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_932: DrawableResource
+  get() = Drawable48.icon_932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9320: DrawableResource
+  get() = Drawable48.icon_9320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9321: DrawableResource
+  get() = Drawable48.icon_9321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9322: DrawableResource
+  get() = Drawable48.icon_9322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9323: DrawableResource
+  get() = Drawable48.icon_9323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9324: DrawableResource
+  get() = Drawable48.icon_9324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9325: DrawableResource
+  get() = Drawable48.icon_9325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9326: DrawableResource
+  get() = Drawable48.icon_9326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9327: DrawableResource
+  get() = Drawable48.icon_9327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9328: DrawableResource
+  get() = Drawable48.icon_9328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9329: DrawableResource
+  get() = Drawable48.icon_9329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_933: DrawableResource
+  get() = Drawable48.icon_933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9330: DrawableResource
+  get() = Drawable48.icon_9330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9331: DrawableResource
+  get() = Drawable48.icon_9331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9332: DrawableResource
+  get() = Drawable48.icon_9332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9333: DrawableResource
+  get() = Drawable48.icon_9333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9334: DrawableResource
+  get() = Drawable48.icon_9334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9335: DrawableResource
+  get() = Drawable48.icon_9335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9336: DrawableResource
+  get() = Drawable48.icon_9336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9337: DrawableResource
+  get() = Drawable48.icon_9337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9338: DrawableResource
+  get() = Drawable48.icon_9338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9339: DrawableResource
+  get() = Drawable48.icon_9339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_934: DrawableResource
+  get() = Drawable48.icon_934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9340: DrawableResource
+  get() = Drawable48.icon_9340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9341: DrawableResource
+  get() = Drawable48.icon_9341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9342: DrawableResource
+  get() = Drawable48.icon_9342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9343: DrawableResource
+  get() = Drawable48.icon_9343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9344: DrawableResource
+  get() = Drawable48.icon_9344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9345: DrawableResource
+  get() = Drawable48.icon_9345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9346: DrawableResource
+  get() = Drawable48.icon_9346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9347: DrawableResource
+  get() = Drawable48.icon_9347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9348: DrawableResource
+  get() = Drawable48.icon_9348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9349: DrawableResource
+  get() = Drawable48.icon_9349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_935: DrawableResource
+  get() = Drawable48.icon_935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9350: DrawableResource
+  get() = Drawable48.icon_9350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9351: DrawableResource
+  get() = Drawable48.icon_9351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9352: DrawableResource
+  get() = Drawable48.icon_9352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9353: DrawableResource
+  get() = Drawable48.icon_9353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9354: DrawableResource
+  get() = Drawable48.icon_9354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9355: DrawableResource
+  get() = Drawable48.icon_9355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9356: DrawableResource
+  get() = Drawable48.icon_9356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9357: DrawableResource
+  get() = Drawable48.icon_9357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9358: DrawableResource
+  get() = Drawable48.icon_9358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9359: DrawableResource
+  get() = Drawable48.icon_9359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_936: DrawableResource
+  get() = Drawable48.icon_936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9360: DrawableResource
+  get() = Drawable48.icon_9360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9361: DrawableResource
+  get() = Drawable48.icon_9361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9362: DrawableResource
+  get() = Drawable48.icon_9362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9363: DrawableResource
+  get() = Drawable48.icon_9363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9364: DrawableResource
+  get() = Drawable48.icon_9364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9365: DrawableResource
+  get() = Drawable48.icon_9365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9366: DrawableResource
+  get() = Drawable48.icon_9366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9367: DrawableResource
+  get() = Drawable48.icon_9367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9368: DrawableResource
+  get() = Drawable48.icon_9368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9369: DrawableResource
+  get() = Drawable48.icon_9369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_937: DrawableResource
+  get() = Drawable48.icon_937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9370: DrawableResource
+  get() = Drawable48.icon_9370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9371: DrawableResource
+  get() = Drawable48.icon_9371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9372: DrawableResource
+  get() = Drawable48.icon_9372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9373: DrawableResource
+  get() = Drawable48.icon_9373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9374: DrawableResource
+  get() = Drawable48.icon_9374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9375: DrawableResource
+  get() = Drawable48.icon_9375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9376: DrawableResource
+  get() = Drawable48.icon_9376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9377: DrawableResource
+  get() = Drawable48.icon_9377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9378: DrawableResource
+  get() = Drawable48.icon_9378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9379: DrawableResource
+  get() = Drawable48.icon_9379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_938: DrawableResource
+  get() = Drawable48.icon_938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9380: DrawableResource
+  get() = Drawable48.icon_9380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9381: DrawableResource
+  get() = Drawable48.icon_9381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9382: DrawableResource
+  get() = Drawable48.icon_9382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9383: DrawableResource
+  get() = Drawable48.icon_9383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9384: DrawableResource
+  get() = Drawable48.icon_9384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9385: DrawableResource
+  get() = Drawable48.icon_9385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9386: DrawableResource
+  get() = Drawable48.icon_9386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9387: DrawableResource
+  get() = Drawable48.icon_9387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9388: DrawableResource
+  get() = Drawable48.icon_9388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9389: DrawableResource
+  get() = Drawable48.icon_9389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_939: DrawableResource
+  get() = Drawable48.icon_939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9390: DrawableResource
+  get() = Drawable48.icon_9390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9391: DrawableResource
+  get() = Drawable48.icon_9391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9392: DrawableResource
+  get() = Drawable48.icon_9392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9393: DrawableResource
+  get() = Drawable48.icon_9393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9394: DrawableResource
+  get() = Drawable48.icon_9394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9395: DrawableResource
+  get() = Drawable48.icon_9395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9396: DrawableResource
+  get() = Drawable48.icon_9396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9397: DrawableResource
+  get() = Drawable48.icon_9397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9398: DrawableResource
+  get() = Drawable48.icon_9398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9399: DrawableResource
+  get() = Drawable48.icon_9399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_94: DrawableResource
+  get() = Drawable48.icon_94
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_940: DrawableResource
+  get() = Drawable48.icon_940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9400: DrawableResource
+  get() = Drawable48.icon_9400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9401: DrawableResource
+  get() = Drawable48.icon_9401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9402: DrawableResource
+  get() = Drawable48.icon_9402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9403: DrawableResource
+  get() = Drawable48.icon_9403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9404: DrawableResource
+  get() = Drawable48.icon_9404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9405: DrawableResource
+  get() = Drawable48.icon_9405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9406: DrawableResource
+  get() = Drawable48.icon_9406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9407: DrawableResource
+  get() = Drawable48.icon_9407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9408: DrawableResource
+  get() = Drawable48.icon_9408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9409: DrawableResource
+  get() = Drawable48.icon_9409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_941: DrawableResource
+  get() = Drawable48.icon_941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9410: DrawableResource
+  get() = Drawable48.icon_9410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9411: DrawableResource
+  get() = Drawable48.icon_9411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9412: DrawableResource
+  get() = Drawable48.icon_9412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9413: DrawableResource
+  get() = Drawable48.icon_9413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9414: DrawableResource
+  get() = Drawable48.icon_9414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9415: DrawableResource
+  get() = Drawable48.icon_9415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9416: DrawableResource
+  get() = Drawable48.icon_9416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9417: DrawableResource
+  get() = Drawable48.icon_9417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9418: DrawableResource
+  get() = Drawable48.icon_9418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9419: DrawableResource
+  get() = Drawable48.icon_9419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_942: DrawableResource
+  get() = Drawable48.icon_942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9420: DrawableResource
+  get() = Drawable48.icon_9420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9421: DrawableResource
+  get() = Drawable48.icon_9421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9422: DrawableResource
+  get() = Drawable48.icon_9422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9423: DrawableResource
+  get() = Drawable48.icon_9423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9424: DrawableResource
+  get() = Drawable48.icon_9424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9425: DrawableResource
+  get() = Drawable48.icon_9425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9426: DrawableResource
+  get() = Drawable48.icon_9426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9427: DrawableResource
+  get() = Drawable48.icon_9427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9428: DrawableResource
+  get() = Drawable48.icon_9428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9429: DrawableResource
+  get() = Drawable48.icon_9429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_943: DrawableResource
+  get() = Drawable48.icon_943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9430: DrawableResource
+  get() = Drawable48.icon_9430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9431: DrawableResource
+  get() = Drawable48.icon_9431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9432: DrawableResource
+  get() = Drawable48.icon_9432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9433: DrawableResource
+  get() = Drawable48.icon_9433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9434: DrawableResource
+  get() = Drawable48.icon_9434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9435: DrawableResource
+  get() = Drawable48.icon_9435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9436: DrawableResource
+  get() = Drawable48.icon_9436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9437: DrawableResource
+  get() = Drawable48.icon_9437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9438: DrawableResource
+  get() = Drawable48.icon_9438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9439: DrawableResource
+  get() = Drawable48.icon_9439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_944: DrawableResource
+  get() = Drawable48.icon_944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9440: DrawableResource
+  get() = Drawable48.icon_9440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9441: DrawableResource
+  get() = Drawable48.icon_9441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9442: DrawableResource
+  get() = Drawable48.icon_9442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9443: DrawableResource
+  get() = Drawable48.icon_9443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9444: DrawableResource
+  get() = Drawable48.icon_9444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9445: DrawableResource
+  get() = Drawable48.icon_9445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9446: DrawableResource
+  get() = Drawable48.icon_9446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9447: DrawableResource
+  get() = Drawable48.icon_9447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9448: DrawableResource
+  get() = Drawable48.icon_9448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9449: DrawableResource
+  get() = Drawable48.icon_9449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_945: DrawableResource
+  get() = Drawable48.icon_945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9450: DrawableResource
+  get() = Drawable48.icon_9450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9451: DrawableResource
+  get() = Drawable48.icon_9451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9452: DrawableResource
+  get() = Drawable48.icon_9452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9453: DrawableResource
+  get() = Drawable48.icon_9453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9454: DrawableResource
+  get() = Drawable48.icon_9454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9455: DrawableResource
+  get() = Drawable48.icon_9455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9456: DrawableResource
+  get() = Drawable48.icon_9456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9457: DrawableResource
+  get() = Drawable48.icon_9457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9458: DrawableResource
+  get() = Drawable48.icon_9458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9459: DrawableResource
+  get() = Drawable48.icon_9459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_946: DrawableResource
+  get() = Drawable48.icon_946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9460: DrawableResource
+  get() = Drawable48.icon_9460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9461: DrawableResource
+  get() = Drawable48.icon_9461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9462: DrawableResource
+  get() = Drawable48.icon_9462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9463: DrawableResource
+  get() = Drawable48.icon_9463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9464: DrawableResource
+  get() = Drawable48.icon_9464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9465: DrawableResource
+  get() = Drawable48.icon_9465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9466: DrawableResource
+  get() = Drawable48.icon_9466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9467: DrawableResource
+  get() = Drawable48.icon_9467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9468: DrawableResource
+  get() = Drawable48.icon_9468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9469: DrawableResource
+  get() = Drawable48.icon_9469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_947: DrawableResource
+  get() = Drawable48.icon_947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9470: DrawableResource
+  get() = Drawable48.icon_9470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9471: DrawableResource
+  get() = Drawable48.icon_9471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9472: DrawableResource
+  get() = Drawable48.icon_9472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9473: DrawableResource
+  get() = Drawable48.icon_9473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9474: DrawableResource
+  get() = Drawable48.icon_9474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9475: DrawableResource
+  get() = Drawable48.icon_9475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9476: DrawableResource
+  get() = Drawable48.icon_9476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9477: DrawableResource
+  get() = Drawable48.icon_9477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9478: DrawableResource
+  get() = Drawable48.icon_9478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9479: DrawableResource
+  get() = Drawable48.icon_9479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_948: DrawableResource
+  get() = Drawable48.icon_948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9480: DrawableResource
+  get() = Drawable48.icon_9480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9481: DrawableResource
+  get() = Drawable48.icon_9481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9482: DrawableResource
+  get() = Drawable48.icon_9482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9483: DrawableResource
+  get() = Drawable48.icon_9483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9484: DrawableResource
+  get() = Drawable48.icon_9484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9485: DrawableResource
+  get() = Drawable48.icon_9485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9486: DrawableResource
+  get() = Drawable48.icon_9486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9487: DrawableResource
+  get() = Drawable48.icon_9487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9488: DrawableResource
+  get() = Drawable48.icon_9488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9489: DrawableResource
+  get() = Drawable48.icon_9489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_949: DrawableResource
+  get() = Drawable48.icon_949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9490: DrawableResource
+  get() = Drawable48.icon_9490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9491: DrawableResource
+  get() = Drawable48.icon_9491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9492: DrawableResource
+  get() = Drawable48.icon_9492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9493: DrawableResource
+  get() = Drawable48.icon_9493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9494: DrawableResource
+  get() = Drawable48.icon_9494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9495: DrawableResource
+  get() = Drawable48.icon_9495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9496: DrawableResource
+  get() = Drawable48.icon_9496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9497: DrawableResource
+  get() = Drawable48.icon_9497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9498: DrawableResource
+  get() = Drawable48.icon_9498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9499: DrawableResource
+  get() = Drawable48.icon_9499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_95: DrawableResource
+  get() = Drawable48.icon_95
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_950: DrawableResource
+  get() = Drawable48.icon_950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9500: DrawableResource
+  get() = Drawable48.icon_9500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9501: DrawableResource
+  get() = Drawable48.icon_9501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9502: DrawableResource
+  get() = Drawable48.icon_9502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9503: DrawableResource
+  get() = Drawable48.icon_9503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9504: DrawableResource
+  get() = Drawable48.icon_9504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9505: DrawableResource
+  get() = Drawable48.icon_9505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9506: DrawableResource
+  get() = Drawable48.icon_9506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9507: DrawableResource
+  get() = Drawable48.icon_9507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9508: DrawableResource
+  get() = Drawable48.icon_9508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9509: DrawableResource
+  get() = Drawable48.icon_9509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_951: DrawableResource
+  get() = Drawable48.icon_951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9510: DrawableResource
+  get() = Drawable48.icon_9510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9511: DrawableResource
+  get() = Drawable48.icon_9511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9512: DrawableResource
+  get() = Drawable48.icon_9512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9513: DrawableResource
+  get() = Drawable48.icon_9513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9514: DrawableResource
+  get() = Drawable48.icon_9514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9515: DrawableResource
+  get() = Drawable48.icon_9515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9516: DrawableResource
+  get() = Drawable48.icon_9516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9517: DrawableResource
+  get() = Drawable48.icon_9517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9518: DrawableResource
+  get() = Drawable48.icon_9518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9519: DrawableResource
+  get() = Drawable48.icon_9519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_952: DrawableResource
+  get() = Drawable48.icon_952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9520: DrawableResource
+  get() = Drawable48.icon_9520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9521: DrawableResource
+  get() = Drawable48.icon_9521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9522: DrawableResource
+  get() = Drawable48.icon_9522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9523: DrawableResource
+  get() = Drawable48.icon_9523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9524: DrawableResource
+  get() = Drawable48.icon_9524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9525: DrawableResource
+  get() = Drawable48.icon_9525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9526: DrawableResource
+  get() = Drawable48.icon_9526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9527: DrawableResource
+  get() = Drawable48.icon_9527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9528: DrawableResource
+  get() = Drawable48.icon_9528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9529: DrawableResource
+  get() = Drawable48.icon_9529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_953: DrawableResource
+  get() = Drawable48.icon_953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9530: DrawableResource
+  get() = Drawable48.icon_9530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9531: DrawableResource
+  get() = Drawable48.icon_9531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9532: DrawableResource
+  get() = Drawable48.icon_9532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9533: DrawableResource
+  get() = Drawable48.icon_9533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9534: DrawableResource
+  get() = Drawable48.icon_9534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9535: DrawableResource
+  get() = Drawable48.icon_9535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9536: DrawableResource
+  get() = Drawable48.icon_9536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9537: DrawableResource
+  get() = Drawable48.icon_9537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9538: DrawableResource
+  get() = Drawable48.icon_9538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9539: DrawableResource
+  get() = Drawable48.icon_9539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_954: DrawableResource
+  get() = Drawable48.icon_954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9540: DrawableResource
+  get() = Drawable48.icon_9540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9541: DrawableResource
+  get() = Drawable48.icon_9541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9542: DrawableResource
+  get() = Drawable48.icon_9542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9543: DrawableResource
+  get() = Drawable48.icon_9543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9544: DrawableResource
+  get() = Drawable48.icon_9544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9545: DrawableResource
+  get() = Drawable48.icon_9545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9546: DrawableResource
+  get() = Drawable48.icon_9546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9547: DrawableResource
+  get() = Drawable48.icon_9547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9548: DrawableResource
+  get() = Drawable48.icon_9548

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable49.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable49.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable49 {
+  public val icon_9549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9549.xml"),
+          )
+      )
+
+  public val icon_955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_955.xml"),
+          )
+      )
+
+  public val icon_9550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9550.xml"),
+          )
+      )
+
+  public val icon_9551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9551.xml"),
+          )
+      )
+
+  public val icon_9552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9552.xml"),
+          )
+      )
+
+  public val icon_9553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9553.xml"),
+          )
+      )
+
+  public val icon_9554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9554.xml"),
+          )
+      )
+
+  public val icon_9555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9555.xml"),
+          )
+      )
+
+  public val icon_9556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9556.xml"),
+          )
+      )
+
+  public val icon_9557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9557.xml"),
+          )
+      )
+
+  public val icon_9558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9558.xml"),
+          )
+      )
+
+  public val icon_9559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9559.xml"),
+          )
+      )
+
+  public val icon_956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_956.xml"),
+          )
+      )
+
+  public val icon_9560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9560.xml"),
+          )
+      )
+
+  public val icon_9561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9561.xml"),
+          )
+      )
+
+  public val icon_9562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9562.xml"),
+          )
+      )
+
+  public val icon_9563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9563.xml"),
+          )
+      )
+
+  public val icon_9564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9564.xml"),
+          )
+      )
+
+  public val icon_9565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9565.xml"),
+          )
+      )
+
+  public val icon_9566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9566.xml"),
+          )
+      )
+
+  public val icon_9567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9567.xml"),
+          )
+      )
+
+  public val icon_9568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9568.xml"),
+          )
+      )
+
+  public val icon_9569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9569.xml"),
+          )
+      )
+
+  public val icon_957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_957.xml"),
+          )
+      )
+
+  public val icon_9570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9570.xml"),
+          )
+      )
+
+  public val icon_9571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9571.xml"),
+          )
+      )
+
+  public val icon_9572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9572.xml"),
+          )
+      )
+
+  public val icon_9573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9573.xml"),
+          )
+      )
+
+  public val icon_9574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9574.xml"),
+          )
+      )
+
+  public val icon_9575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9575.xml"),
+          )
+      )
+
+  public val icon_9576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9576.xml"),
+          )
+      )
+
+  public val icon_9577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9577.xml"),
+          )
+      )
+
+  public val icon_9578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9578.xml"),
+          )
+      )
+
+  public val icon_9579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9579.xml"),
+          )
+      )
+
+  public val icon_958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_958.xml"),
+          )
+      )
+
+  public val icon_9580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9580.xml"),
+          )
+      )
+
+  public val icon_9581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9581.xml"),
+          )
+      )
+
+  public val icon_9582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9582.xml"),
+          )
+      )
+
+  public val icon_9583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9583.xml"),
+          )
+      )
+
+  public val icon_9584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9584.xml"),
+          )
+      )
+
+  public val icon_9585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9585.xml"),
+          )
+      )
+
+  public val icon_9586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9586.xml"),
+          )
+      )
+
+  public val icon_9587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9587.xml"),
+          )
+      )
+
+  public val icon_9588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9588.xml"),
+          )
+      )
+
+  public val icon_9589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9589.xml"),
+          )
+      )
+
+  public val icon_959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_959.xml"),
+          )
+      )
+
+  public val icon_9590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9590.xml"),
+          )
+      )
+
+  public val icon_9591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9591.xml"),
+          )
+      )
+
+  public val icon_9592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9592.xml"),
+          )
+      )
+
+  public val icon_9593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9593.xml"),
+          )
+      )
+
+  public val icon_9594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9594.xml"),
+          )
+      )
+
+  public val icon_9595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9595.xml"),
+          )
+      )
+
+  public val icon_9596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9596.xml"),
+          )
+      )
+
+  public val icon_9597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9597.xml"),
+          )
+      )
+
+  public val icon_9598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9598.xml"),
+          )
+      )
+
+  public val icon_9599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9599.xml"),
+          )
+      )
+
+  public val icon_96: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_96",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_96.xml"),
+          )
+      )
+
+  public val icon_960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_960.xml"),
+          )
+      )
+
+  public val icon_9600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9600.xml"),
+          )
+      )
+
+  public val icon_9601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9601.xml"),
+          )
+      )
+
+  public val icon_9602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9602.xml"),
+          )
+      )
+
+  public val icon_9603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9603.xml"),
+          )
+      )
+
+  public val icon_9604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9604.xml"),
+          )
+      )
+
+  public val icon_9605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9605.xml"),
+          )
+      )
+
+  public val icon_9606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9606.xml"),
+          )
+      )
+
+  public val icon_9607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9607.xml"),
+          )
+      )
+
+  public val icon_9608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9608.xml"),
+          )
+      )
+
+  public val icon_9609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9609.xml"),
+          )
+      )
+
+  public val icon_961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_961.xml"),
+          )
+      )
+
+  public val icon_9610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9610.xml"),
+          )
+      )
+
+  public val icon_9611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9611.xml"),
+          )
+      )
+
+  public val icon_9612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9612.xml"),
+          )
+      )
+
+  public val icon_9613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9613.xml"),
+          )
+      )
+
+  public val icon_9614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9614.xml"),
+          )
+      )
+
+  public val icon_9615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9615.xml"),
+          )
+      )
+
+  public val icon_9616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9616.xml"),
+          )
+      )
+
+  public val icon_9617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9617.xml"),
+          )
+      )
+
+  public val icon_9618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9618.xml"),
+          )
+      )
+
+  public val icon_9619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9619.xml"),
+          )
+      )
+
+  public val icon_962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_962.xml"),
+          )
+      )
+
+  public val icon_9620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9620.xml"),
+          )
+      )
+
+  public val icon_9621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9621.xml"),
+          )
+      )
+
+  public val icon_9622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9622.xml"),
+          )
+      )
+
+  public val icon_9623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9623.xml"),
+          )
+      )
+
+  public val icon_9624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9624.xml"),
+          )
+      )
+
+  public val icon_9625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9625.xml"),
+          )
+      )
+
+  public val icon_9626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9626.xml"),
+          )
+      )
+
+  public val icon_9627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9627.xml"),
+          )
+      )
+
+  public val icon_9628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9628.xml"),
+          )
+      )
+
+  public val icon_9629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9629.xml"),
+          )
+      )
+
+  public val icon_963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_963.xml"),
+          )
+      )
+
+  public val icon_9630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9630.xml"),
+          )
+      )
+
+  public val icon_9631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9631.xml"),
+          )
+      )
+
+  public val icon_9632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9632.xml"),
+          )
+      )
+
+  public val icon_9633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9633.xml"),
+          )
+      )
+
+  public val icon_9634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9634.xml"),
+          )
+      )
+
+  public val icon_9635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9635.xml"),
+          )
+      )
+
+  public val icon_9636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9636.xml"),
+          )
+      )
+
+  public val icon_9637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9637.xml"),
+          )
+      )
+
+  public val icon_9638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9638.xml"),
+          )
+      )
+
+  public val icon_9639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9639.xml"),
+          )
+      )
+
+  public val icon_964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_964.xml"),
+          )
+      )
+
+  public val icon_9640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9640.xml"),
+          )
+      )
+
+  public val icon_9641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9641.xml"),
+          )
+      )
+
+  public val icon_9642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9642.xml"),
+          )
+      )
+
+  public val icon_9643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9643.xml"),
+          )
+      )
+
+  public val icon_9644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9644.xml"),
+          )
+      )
+
+  public val icon_9645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9645.xml"),
+          )
+      )
+
+  public val icon_9646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9646.xml"),
+          )
+      )
+
+  public val icon_9647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9647.xml"),
+          )
+      )
+
+  public val icon_9648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9648.xml"),
+          )
+      )
+
+  public val icon_9649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9649.xml"),
+          )
+      )
+
+  public val icon_965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_965.xml"),
+          )
+      )
+
+  public val icon_9650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9650.xml"),
+          )
+      )
+
+  public val icon_9651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9651.xml"),
+          )
+      )
+
+  public val icon_9652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9652.xml"),
+          )
+      )
+
+  public val icon_9653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9653.xml"),
+          )
+      )
+
+  public val icon_9654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9654.xml"),
+          )
+      )
+
+  public val icon_9655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9655.xml"),
+          )
+      )
+
+  public val icon_9656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9656.xml"),
+          )
+      )
+
+  public val icon_9657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9657.xml"),
+          )
+      )
+
+  public val icon_9658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9658.xml"),
+          )
+      )
+
+  public val icon_9659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9659.xml"),
+          )
+      )
+
+  public val icon_966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_966.xml"),
+          )
+      )
+
+  public val icon_9660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9660.xml"),
+          )
+      )
+
+  public val icon_9661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9661.xml"),
+          )
+      )
+
+  public val icon_9662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9662.xml"),
+          )
+      )
+
+  public val icon_9663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9663.xml"),
+          )
+      )
+
+  public val icon_9664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9664.xml"),
+          )
+      )
+
+  public val icon_9665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9665.xml"),
+          )
+      )
+
+  public val icon_9666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9666.xml"),
+          )
+      )
+
+  public val icon_9667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9667.xml"),
+          )
+      )
+
+  public val icon_9668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9668.xml"),
+          )
+      )
+
+  public val icon_9669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9669.xml"),
+          )
+      )
+
+  public val icon_967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_967.xml"),
+          )
+      )
+
+  public val icon_9670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9670.xml"),
+          )
+      )
+
+  public val icon_9671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9671.xml"),
+          )
+      )
+
+  public val icon_9672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9672.xml"),
+          )
+      )
+
+  public val icon_9673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9673.xml"),
+          )
+      )
+
+  public val icon_9674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9674.xml"),
+          )
+      )
+
+  public val icon_9675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9675.xml"),
+          )
+      )
+
+  public val icon_9676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9676.xml"),
+          )
+      )
+
+  public val icon_9677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9677.xml"),
+          )
+      )
+
+  public val icon_9678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9678.xml"),
+          )
+      )
+
+  public val icon_9679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9679.xml"),
+          )
+      )
+
+  public val icon_968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_968.xml"),
+          )
+      )
+
+  public val icon_9680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9680.xml"),
+          )
+      )
+
+  public val icon_9681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9681.xml"),
+          )
+      )
+
+  public val icon_9682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9682.xml"),
+          )
+      )
+
+  public val icon_9683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9683.xml"),
+          )
+      )
+
+  public val icon_9684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9684.xml"),
+          )
+      )
+
+  public val icon_9685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9685.xml"),
+          )
+      )
+
+  public val icon_9686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9686.xml"),
+          )
+      )
+
+  public val icon_9687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9687.xml"),
+          )
+      )
+
+  public val icon_9688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9688.xml"),
+          )
+      )
+
+  public val icon_9689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9689.xml"),
+          )
+      )
+
+  public val icon_969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_969.xml"),
+          )
+      )
+
+  public val icon_9690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9690.xml"),
+          )
+      )
+
+  public val icon_9691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9691.xml"),
+          )
+      )
+
+  public val icon_9692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9692.xml"),
+          )
+      )
+
+  public val icon_9693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9693.xml"),
+          )
+      )
+
+  public val icon_9694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9694.xml"),
+          )
+      )
+
+  public val icon_9695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9695.xml"),
+          )
+      )
+
+  public val icon_9696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9696.xml"),
+          )
+      )
+
+  public val icon_9697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9697.xml"),
+          )
+      )
+
+  public val icon_9698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9698.xml"),
+          )
+      )
+
+  public val icon_9699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9699.xml"),
+          )
+      )
+
+  public val icon_97: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_97",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_97.xml"),
+          )
+      )
+
+  public val icon_970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_970.xml"),
+          )
+      )
+
+  public val icon_9700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9700.xml"),
+          )
+      )
+
+  public val icon_9701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9701.xml"),
+          )
+      )
+
+  public val icon_9702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9702.xml"),
+          )
+      )
+
+  public val icon_9703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9703.xml"),
+          )
+      )
+
+  public val icon_9704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9704.xml"),
+          )
+      )
+
+  public val icon_9705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9705.xml"),
+          )
+      )
+
+  public val icon_9706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9706.xml"),
+          )
+      )
+
+  public val icon_9707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9707.xml"),
+          )
+      )
+
+  public val icon_9708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9708.xml"),
+          )
+      )
+
+  public val icon_9709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9709.xml"),
+          )
+      )
+
+  public val icon_971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_971.xml"),
+          )
+      )
+
+  public val icon_9710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9710.xml"),
+          )
+      )
+
+  public val icon_9711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9711.xml"),
+          )
+      )
+
+  public val icon_9712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9712.xml"),
+          )
+      )
+
+  public val icon_9713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9713.xml"),
+          )
+      )
+
+  public val icon_9714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9714.xml"),
+          )
+      )
+
+  public val icon_9715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9715.xml"),
+          )
+      )
+
+  public val icon_9716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9716.xml"),
+          )
+      )
+
+  public val icon_9717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9717.xml"),
+          )
+      )
+
+  public val icon_9718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9718.xml"),
+          )
+      )
+
+  public val icon_9719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9719.xml"),
+          )
+      )
+
+  public val icon_972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_972.xml"),
+          )
+      )
+
+  public val icon_9720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9720.xml"),
+          )
+      )
+
+  public val icon_9721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9721.xml"),
+          )
+      )
+
+  public val icon_9722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9722.xml"),
+          )
+      )
+
+  public val icon_9723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9723.xml"),
+          )
+      )
+
+  public val icon_9724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9724.xml"),
+          )
+      )
+
+  public val icon_9725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9725.xml"),
+          )
+      )
+
+  public val icon_9726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9726.xml"),
+          )
+      )
+
+  public val icon_9727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9727.xml"),
+          )
+      )
+
+  public val icon_9728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9728.xml"),
+          )
+      )
+
+  public val icon_9729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9729.xml"),
+          )
+      )
+
+  public val icon_973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_973.xml"),
+          )
+      )
+
+  public val icon_9730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9730.xml"),
+          )
+      )
+
+  public val icon_9731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9731.xml"),
+          )
+      )
+
+  public val icon_9732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9732.xml"),
+          )
+      )
+
+  public val icon_9733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9733.xml"),
+          )
+      )
+
+  public val icon_9734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9734.xml"),
+          )
+      )
+
+  public val icon_9735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9735.xml"),
+          )
+      )
+
+  public val icon_9736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9736.xml"),
+          )
+      )
+
+  public val icon_9737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9737.xml"),
+          )
+      )
+
+  public val icon_9738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9738.xml"),
+          )
+      )
+
+  public val icon_9739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9739.xml"),
+          )
+      )
+
+  public val icon_974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_974.xml"),
+          )
+      )
+
+  public val icon_9740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9740.xml"),
+          )
+      )
+
+  public val icon_9741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9741.xml"),
+          )
+      )
+
+  public val icon_9742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9742.xml"),
+          )
+      )
+
+  public val icon_9743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9743.xml"),
+          )
+      )
+
+  public val icon_9744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9744.xml"),
+          )
+      )
+
+  public val icon_9745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9745.xml"),
+          )
+      )
+
+  public val icon_9746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9746.xml"),
+          )
+      )
+
+  public val icon_9747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9747.xml"),
+          )
+      )
+
+  public val icon_9748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9748.xml"),
+          )
+      )
+
+  public val icon_9749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9749.xml"),
+          )
+      )
+
+  public val icon_975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_975.xml"),
+          )
+      )
+
+  public val icon_9750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9750.xml"),
+          )
+      )
+
+  public val icon_9751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9751.xml"),
+          )
+      )
+
+  public val icon_9752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9752.xml"),
+          )
+      )
+
+  public val icon_9753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9753.xml"),
+          )
+      )
+
+  public val icon_9754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9754.xml"),
+          )
+      )
+
+  public val icon_9755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9755.xml"),
+          )
+      )
+
+  public val icon_9756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9756.xml"),
+          )
+      )
+
+  public val icon_9757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9757.xml"),
+          )
+      )
+
+  public val icon_9758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9758.xml"),
+          )
+      )
+
+  public val icon_9759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9759.xml"),
+          )
+      )
+
+  public val icon_976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_976.xml"),
+          )
+      )
+
+  public val icon_9760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9760.xml"),
+          )
+      )
+
+  public val icon_9761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9761.xml"),
+          )
+      )
+
+  public val icon_9762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9762.xml"),
+          )
+      )
+
+  public val icon_9763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9763.xml"),
+          )
+      )
+
+  public val icon_9764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9764.xml"),
+          )
+      )
+
+  public val icon_9765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9765.xml"),
+          )
+      )
+
+  public val icon_9766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9766.xml"),
+          )
+      )
+
+  public val icon_9767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9767.xml"),
+          )
+      )
+
+  public val icon_9768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9768.xml"),
+          )
+      )
+
+  public val icon_9769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9769.xml"),
+          )
+      )
+
+  public val icon_977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_977.xml"),
+          )
+      )
+
+  public val icon_9770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9770.xml"),
+          )
+      )
+
+  public val icon_9771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9771.xml"),
+          )
+      )
+
+  public val icon_9772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9772.xml"),
+          )
+      )
+
+  public val icon_9773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9773.xml"),
+          )
+      )
+
+  public val icon_9774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9774.xml"),
+          )
+      )
+
+  public val icon_9775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9775.xml"),
+          )
+      )
+
+  public val icon_9776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9776.xml"),
+          )
+      )
+
+  public val icon_9777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9777.xml"),
+          )
+      )
+
+  public val icon_9778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9778.xml"),
+          )
+      )
+
+  public val icon_9779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9779.xml"),
+          )
+      )
+
+  public val icon_978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_978.xml"),
+          )
+      )
+
+  public val icon_9780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9780.xml"),
+          )
+      )
+
+  public val icon_9781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9781.xml"),
+          )
+      )
+
+  public val icon_9782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9782.xml"),
+          )
+      )
+
+  public val icon_9783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9783.xml"),
+          )
+      )
+
+  public val icon_9784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9784.xml"),
+          )
+      )
+
+  public val icon_9785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9785.xml"),
+          )
+      )
+
+  public val icon_9786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9786.xml"),
+          )
+      )
+
+  public val icon_9787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9787.xml"),
+          )
+      )
+
+  public val icon_9788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9788.xml"),
+          )
+      )
+
+  public val icon_9789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9789.xml"),
+          )
+      )
+
+  public val icon_979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_979.xml"),
+          )
+      )
+
+  public val icon_9790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9790.xml"),
+          )
+      )
+
+  public val icon_9791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9791.xml"),
+          )
+      )
+
+  public val icon_9792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9792.xml"),
+          )
+      )
+
+  public val icon_9793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9793.xml"),
+          )
+      )
+
+  public val icon_9794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9794.xml"),
+          )
+      )
+
+  public val icon_9795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9795.xml"),
+          )
+      )
+
+  public val icon_9796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9796.xml"),
+          )
+      )
+
+  public val icon_9797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9797.xml"),
+          )
+      )
+
+  public val icon_9798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9798.xml"),
+          )
+      )
+
+  public val icon_9799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9799.xml"),
+          )
+      )
+
+  public val icon_98: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_98",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_98.xml"),
+          )
+      )
+
+  public val icon_980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_980.xml"),
+          )
+      )
+
+  public val icon_9800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9800.xml"),
+          )
+      )
+
+  public val icon_9801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9801.xml"),
+          )
+      )
+
+  public val icon_9802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9802.xml"),
+          )
+      )
+
+  public val icon_9803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9803.xml"),
+          )
+      )
+
+  public val icon_9804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9804.xml"),
+          )
+      )
+
+  public val icon_9805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9805.xml"),
+          )
+      )
+
+  public val icon_9806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9806.xml"),
+          )
+      )
+
+  public val icon_9807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9807.xml"),
+          )
+      )
+
+  public val icon_9808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9808.xml"),
+          )
+      )
+
+  public val icon_9809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9809.xml"),
+          )
+      )
+
+  public val icon_981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_981.xml"),
+          )
+      )
+
+  public val icon_9810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9810.xml"),
+          )
+      )
+
+  public val icon_9811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9811.xml"),
+          )
+      )
+
+  public val icon_9812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9812.xml"),
+          )
+      )
+
+  public val icon_9813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9813.xml"),
+          )
+      )
+
+  public val icon_9814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9814.xml"),
+          )
+      )
+
+  public val icon_9815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9815.xml"),
+          )
+      )
+
+  public val icon_9816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9816.xml"),
+          )
+      )
+
+  public val icon_9817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9817.xml"),
+          )
+      )
+
+  public val icon_9818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9818.xml"),
+          )
+      )
+
+  public val icon_9819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9819.xml"),
+          )
+      )
+
+  public val icon_982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_982.xml"),
+          )
+      )
+
+  public val icon_9820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9820.xml"),
+          )
+      )
+
+  public val icon_9821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9821.xml"),
+          )
+      )
+
+  public val icon_9822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9822.xml"),
+          )
+      )
+
+  public val icon_9823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9823.xml"),
+          )
+      )
+
+  public val icon_9824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9824.xml"),
+          )
+      )
+
+  public val icon_9825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9825.xml"),
+          )
+      )
+
+  public val icon_9826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9826.xml"),
+          )
+      )
+
+  public val icon_9827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9827.xml"),
+          )
+      )
+
+  public val icon_9828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9828.xml"),
+          )
+      )
+
+  public val icon_9829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9829.xml"),
+          )
+      )
+
+  public val icon_983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_983.xml"),
+          )
+      )
+
+  public val icon_9830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9830.xml"),
+          )
+      )
+
+  public val icon_9831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9831.xml"),
+          )
+      )
+
+  public val icon_9832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9832.xml"),
+          )
+      )
+
+  public val icon_9833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9833.xml"),
+          )
+      )
+
+  public val icon_9834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9834.xml"),
+          )
+      )
+
+  public val icon_9835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9835.xml"),
+          )
+      )
+
+  public val icon_9836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9836.xml"),
+          )
+      )
+
+  public val icon_9837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9837.xml"),
+          )
+      )
+
+  public val icon_9838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9838.xml"),
+          )
+      )
+
+  public val icon_9839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9839.xml"),
+          )
+      )
+
+  public val icon_984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_984.xml"),
+          )
+      )
+
+  public val icon_9840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9840.xml"),
+          )
+      )
+
+  public val icon_9841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9841.xml"),
+          )
+      )
+
+  public val icon_9842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9842.xml"),
+          )
+      )
+
+  public val icon_9843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9843.xml"),
+          )
+      )
+
+  public val icon_9844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9844.xml"),
+          )
+      )
+
+  public val icon_9845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9845.xml"),
+          )
+      )
+
+  public val icon_9846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9846.xml"),
+          )
+      )
+
+  public val icon_9847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9847.xml"),
+          )
+      )
+
+  public val icon_9848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9848.xml"),
+          )
+      )
+
+  public val icon_9849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9849.xml"),
+          )
+      )
+
+  public val icon_985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_985.xml"),
+          )
+      )
+
+  public val icon_9850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9850.xml"),
+          )
+      )
+
+  public val icon_9851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9851.xml"),
+          )
+      )
+
+  public val icon_9852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9852.xml"),
+          )
+      )
+
+  public val icon_9853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9853.xml"),
+          )
+      )
+
+  public val icon_9854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9854.xml"),
+          )
+      )
+
+  public val icon_9855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9855.xml"),
+          )
+      )
+
+  public val icon_9856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9856.xml"),
+          )
+      )
+
+  public val icon_9857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9857.xml"),
+          )
+      )
+
+  public val icon_9858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9858.xml"),
+          )
+      )
+
+  public val icon_9859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9859.xml"),
+          )
+      )
+
+  public val icon_986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_986.xml"),
+          )
+      )
+
+  public val icon_9860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9860.xml"),
+          )
+      )
+
+  public val icon_9861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9861.xml"),
+          )
+      )
+
+  public val icon_9862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9862.xml"),
+          )
+      )
+
+  public val icon_9863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9863.xml"),
+          )
+      )
+
+  public val icon_9864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9864.xml"),
+          )
+      )
+
+  public val icon_9865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9865.xml"),
+          )
+      )
+
+  public val icon_9866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9866.xml"),
+          )
+      )
+
+  public val icon_9867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9867.xml"),
+          )
+      )
+
+  public val icon_9868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9868.xml"),
+          )
+      )
+
+  public val icon_9869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9869.xml"),
+          )
+      )
+
+  public val icon_987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_987.xml"),
+          )
+      )
+
+  public val icon_9870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9870.xml"),
+          )
+      )
+
+  public val icon_9871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9871.xml"),
+          )
+      )
+
+  public val icon_9872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9872.xml"),
+          )
+      )
+
+  public val icon_9873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9873.xml"),
+          )
+      )
+
+  public val icon_9874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9874.xml"),
+          )
+      )
+
+  public val icon_9875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9875.xml"),
+          )
+      )
+
+  public val icon_9876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9876.xml"),
+          )
+      )
+
+  public val icon_9877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9877.xml"),
+          )
+      )
+
+  public val icon_9878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9878.xml"),
+          )
+      )
+
+  public val icon_9879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9879.xml"),
+          )
+      )
+
+  public val icon_988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_988.xml"),
+          )
+      )
+
+  public val icon_9880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9880.xml"),
+          )
+      )
+
+  public val icon_9881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9881.xml"),
+          )
+      )
+
+  public val icon_9882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9882.xml"),
+          )
+      )
+
+  public val icon_9883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9883.xml"),
+          )
+      )
+
+  public val icon_9884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9884.xml"),
+          )
+      )
+
+  public val icon_9885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9885.xml"),
+          )
+      )
+
+  public val icon_9886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9886.xml"),
+          )
+      )
+
+  public val icon_9887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9887.xml"),
+          )
+      )
+
+  public val icon_9888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9888.xml"),
+          )
+      )
+
+  public val icon_9889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9889.xml"),
+          )
+      )
+
+  public val icon_989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_989.xml"),
+          )
+      )
+
+  public val icon_9890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9890.xml"),
+          )
+      )
+
+  public val icon_9891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9891.xml"),
+          )
+      )
+
+  public val icon_9892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9892.xml"),
+          )
+      )
+
+  public val icon_9893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9893.xml"),
+          )
+      )
+
+  public val icon_9894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9894.xml"),
+          )
+      )
+
+  public val icon_9895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9895.xml"),
+          )
+      )
+
+  public val icon_9896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9896.xml"),
+          )
+      )
+
+  public val icon_9897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9897.xml"),
+          )
+      )
+
+  public val icon_9898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9898.xml"),
+          )
+      )
+
+  public val icon_9899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9899.xml"),
+          )
+      )
+
+  public val icon_99: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_99",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_99.xml"),
+          )
+      )
+
+  public val icon_990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_990.xml"),
+          )
+      )
+
+  public val icon_9900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9900.xml"),
+          )
+      )
+
+  public val icon_9901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9901.xml"),
+          )
+      )
+
+  public val icon_9902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9902.xml"),
+          )
+      )
+
+  public val icon_9903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9903.xml"),
+          )
+      )
+
+  public val icon_9904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9904.xml"),
+          )
+      )
+
+  public val icon_9905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9905.xml"),
+          )
+      )
+
+  public val icon_9906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9906.xml"),
+          )
+      )
+
+  public val icon_9907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9907.xml"),
+          )
+      )
+
+  public val icon_9908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9908.xml"),
+          )
+      )
+
+  public val icon_9909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9909.xml"),
+          )
+      )
+
+  public val icon_991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_991.xml"),
+          )
+      )
+
+  public val icon_9910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9910.xml"),
+          )
+      )
+
+  public val icon_9911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9911.xml"),
+          )
+      )
+
+  public val icon_9912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9912.xml"),
+          )
+      )
+
+  public val icon_9913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9913.xml"),
+          )
+      )
+
+  public val icon_9914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9914.xml"),
+          )
+      )
+
+  public val icon_9915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9915.xml"),
+          )
+      )
+
+  public val icon_9916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9916.xml"),
+          )
+      )
+
+  public val icon_9917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9917.xml"),
+          )
+      )
+
+  public val icon_9918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9918.xml"),
+          )
+      )
+
+  public val icon_9919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9919.xml"),
+          )
+      )
+
+  public val icon_992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_992.xml"),
+          )
+      )
+
+  public val icon_9920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9920.xml"),
+          )
+      )
+
+  public val icon_9921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9921.xml"),
+          )
+      )
+
+  public val icon_9922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9922.xml"),
+          )
+      )
+
+  public val icon_9923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9923.xml"),
+          )
+      )
+
+  public val icon_9924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9924.xml"),
+          )
+      )
+
+  public val icon_9925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9925.xml"),
+          )
+      )
+
+  public val icon_9926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9926.xml"),
+          )
+      )
+
+  public val icon_9927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9927.xml"),
+          )
+      )
+
+  public val icon_9928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9928.xml"),
+          )
+      )
+
+  public val icon_9929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9929.xml"),
+          )
+      )
+
+  public val icon_993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_993.xml"),
+          )
+      )
+
+  public val icon_9930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9930.xml"),
+          )
+      )
+
+  public val icon_9931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9931.xml"),
+          )
+      )
+
+  public val icon_9932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9932.xml"),
+          )
+      )
+
+  public val icon_9933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9933.xml"),
+          )
+      )
+
+  public val icon_9934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9934.xml"),
+          )
+      )
+
+  public val icon_9935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9935.xml"),
+          )
+      )
+
+  public val icon_9936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9936.xml"),
+          )
+      )
+
+  public val icon_9937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9937.xml"),
+          )
+      )
+
+  public val icon_9938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9938.xml"),
+          )
+      )
+
+  public val icon_9939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9939.xml"),
+          )
+      )
+
+  public val icon_994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_994.xml"),
+          )
+      )
+
+  public val icon_9940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9940.xml"),
+          )
+      )
+
+  public val icon_9941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9941.xml"),
+          )
+      )
+
+  public val icon_9942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9942.xml"),
+          )
+      )
+
+  public val icon_9943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9943.xml"),
+          )
+      )
+
+  public val icon_9944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9944.xml"),
+          )
+      )
+
+  public val icon_9945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9945.xml"),
+          )
+      )
+
+  public val icon_9946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9946.xml"),
+          )
+      )
+
+  public val icon_9947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9947.xml"),
+          )
+      )
+
+  public val icon_9948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9948.xml"),
+          )
+      )
+
+  public val icon_9949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9949.xml"),
+          )
+      )
+
+  public val icon_995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_995.xml"),
+          )
+      )
+
+  public val icon_9950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9950.xml"),
+          )
+      )
+
+  public val icon_9951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9951.xml"),
+          )
+      )
+
+  public val icon_9952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9952.xml"),
+          )
+      )
+
+  public val icon_9953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9953.xml"),
+          )
+      )
+
+  public val icon_9954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9954.xml"),
+          )
+      )
+
+  public val icon_9955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9955.xml"),
+          )
+      )
+
+  public val icon_9956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9956.xml"),
+          )
+      )
+
+  public val icon_9957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9957.xml"),
+          )
+      )
+
+  public val icon_9958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9958.xml"),
+          )
+      )
+
+  public val icon_9959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9959.xml"),
+          )
+      )
+
+  public val icon_996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_996.xml"),
+          )
+      )
+
+  public val icon_9960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9960.xml"),
+          )
+      )
+
+  public val icon_9961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9961.xml"),
+          )
+      )
+
+  public val icon_9962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9962.xml"),
+          )
+      )
+
+  public val icon_9963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9963.xml"),
+          )
+      )
+
+  public val icon_9964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9964.xml"),
+          )
+      )
+
+  public val icon_9965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9965.xml"),
+          )
+      )
+
+  public val icon_9966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9966.xml"),
+          )
+      )
+
+  public val icon_9967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9967.xml"),
+          )
+      )
+
+  public val icon_9968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9968.xml"),
+          )
+      )
+
+  public val icon_9969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9969.xml"),
+          )
+      )
+
+  public val icon_997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_997.xml"),
+          )
+      )
+
+  public val icon_9970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9970.xml"),
+          )
+      )
+
+  public val icon_9971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9971.xml"),
+          )
+      )
+
+  public val icon_9972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9972.xml"),
+          )
+      )
+
+  public val icon_9973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9973.xml"),
+          )
+      )
+
+  public val icon_9974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9974.xml"),
+          )
+      )
+
+  public val icon_9975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9975.xml"),
+          )
+      )
+
+  public val icon_9976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9976.xml"),
+          )
+      )
+
+  public val icon_9977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9977.xml"),
+          )
+      )
+
+  public val icon_9978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9978.xml"),
+          )
+      )
+
+  public val icon_9979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9979.xml"),
+          )
+      )
+
+  public val icon_998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_998.xml"),
+          )
+      )
+
+  public val icon_9980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9980.xml"),
+          )
+      )
+
+  public val icon_9981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9981.xml"),
+          )
+      )
+
+  public val icon_9982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9982.xml"),
+          )
+      )
+
+  public val icon_9983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9983.xml"),
+          )
+      )
+
+  public val icon_9984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9984.xml"),
+          )
+      )
+
+  public val icon_9985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9985.xml"),
+          )
+      )
+
+  public val icon_9986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9986.xml"),
+          )
+      )
+
+  public val icon_9987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9987.xml"),
+          )
+      )
+
+  public val icon_9988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9988.xml"),
+          )
+      )
+
+  public val icon_9989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9989.xml"),
+          )
+      )
+
+  public val icon_999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_999.xml"),
+          )
+      )
+
+  public val icon_9990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9990.xml"),
+          )
+      )
+
+  public val icon_9991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9991.xml"),
+          )
+      )
+
+  public val icon_9992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9992.xml"),
+          )
+      )
+
+  public val icon_9993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9993.xml"),
+          )
+      )
+
+  public val icon_9994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9994.xml"),
+          )
+      )
+
+  public val icon_9995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9995.xml"),
+          )
+      )
+
+  public val icon_9996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9996.xml"),
+          )
+      )
+
+  public val icon_9997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9997.xml"),
+          )
+      )
+
+  public val icon_9998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9998.xml"),
+          )
+      )
+
+  public val icon_9999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_9999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_9999.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9549: DrawableResource
+  get() = Drawable49.icon_9549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_955: DrawableResource
+  get() = Drawable49.icon_955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9550: DrawableResource
+  get() = Drawable49.icon_9550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9551: DrawableResource
+  get() = Drawable49.icon_9551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9552: DrawableResource
+  get() = Drawable49.icon_9552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9553: DrawableResource
+  get() = Drawable49.icon_9553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9554: DrawableResource
+  get() = Drawable49.icon_9554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9555: DrawableResource
+  get() = Drawable49.icon_9555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9556: DrawableResource
+  get() = Drawable49.icon_9556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9557: DrawableResource
+  get() = Drawable49.icon_9557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9558: DrawableResource
+  get() = Drawable49.icon_9558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9559: DrawableResource
+  get() = Drawable49.icon_9559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_956: DrawableResource
+  get() = Drawable49.icon_956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9560: DrawableResource
+  get() = Drawable49.icon_9560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9561: DrawableResource
+  get() = Drawable49.icon_9561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9562: DrawableResource
+  get() = Drawable49.icon_9562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9563: DrawableResource
+  get() = Drawable49.icon_9563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9564: DrawableResource
+  get() = Drawable49.icon_9564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9565: DrawableResource
+  get() = Drawable49.icon_9565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9566: DrawableResource
+  get() = Drawable49.icon_9566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9567: DrawableResource
+  get() = Drawable49.icon_9567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9568: DrawableResource
+  get() = Drawable49.icon_9568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9569: DrawableResource
+  get() = Drawable49.icon_9569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_957: DrawableResource
+  get() = Drawable49.icon_957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9570: DrawableResource
+  get() = Drawable49.icon_9570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9571: DrawableResource
+  get() = Drawable49.icon_9571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9572: DrawableResource
+  get() = Drawable49.icon_9572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9573: DrawableResource
+  get() = Drawable49.icon_9573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9574: DrawableResource
+  get() = Drawable49.icon_9574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9575: DrawableResource
+  get() = Drawable49.icon_9575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9576: DrawableResource
+  get() = Drawable49.icon_9576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9577: DrawableResource
+  get() = Drawable49.icon_9577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9578: DrawableResource
+  get() = Drawable49.icon_9578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9579: DrawableResource
+  get() = Drawable49.icon_9579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_958: DrawableResource
+  get() = Drawable49.icon_958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9580: DrawableResource
+  get() = Drawable49.icon_9580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9581: DrawableResource
+  get() = Drawable49.icon_9581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9582: DrawableResource
+  get() = Drawable49.icon_9582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9583: DrawableResource
+  get() = Drawable49.icon_9583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9584: DrawableResource
+  get() = Drawable49.icon_9584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9585: DrawableResource
+  get() = Drawable49.icon_9585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9586: DrawableResource
+  get() = Drawable49.icon_9586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9587: DrawableResource
+  get() = Drawable49.icon_9587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9588: DrawableResource
+  get() = Drawable49.icon_9588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9589: DrawableResource
+  get() = Drawable49.icon_9589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_959: DrawableResource
+  get() = Drawable49.icon_959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9590: DrawableResource
+  get() = Drawable49.icon_9590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9591: DrawableResource
+  get() = Drawable49.icon_9591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9592: DrawableResource
+  get() = Drawable49.icon_9592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9593: DrawableResource
+  get() = Drawable49.icon_9593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9594: DrawableResource
+  get() = Drawable49.icon_9594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9595: DrawableResource
+  get() = Drawable49.icon_9595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9596: DrawableResource
+  get() = Drawable49.icon_9596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9597: DrawableResource
+  get() = Drawable49.icon_9597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9598: DrawableResource
+  get() = Drawable49.icon_9598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9599: DrawableResource
+  get() = Drawable49.icon_9599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_96: DrawableResource
+  get() = Drawable49.icon_96
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_960: DrawableResource
+  get() = Drawable49.icon_960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9600: DrawableResource
+  get() = Drawable49.icon_9600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9601: DrawableResource
+  get() = Drawable49.icon_9601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9602: DrawableResource
+  get() = Drawable49.icon_9602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9603: DrawableResource
+  get() = Drawable49.icon_9603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9604: DrawableResource
+  get() = Drawable49.icon_9604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9605: DrawableResource
+  get() = Drawable49.icon_9605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9606: DrawableResource
+  get() = Drawable49.icon_9606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9607: DrawableResource
+  get() = Drawable49.icon_9607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9608: DrawableResource
+  get() = Drawable49.icon_9608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9609: DrawableResource
+  get() = Drawable49.icon_9609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_961: DrawableResource
+  get() = Drawable49.icon_961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9610: DrawableResource
+  get() = Drawable49.icon_9610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9611: DrawableResource
+  get() = Drawable49.icon_9611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9612: DrawableResource
+  get() = Drawable49.icon_9612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9613: DrawableResource
+  get() = Drawable49.icon_9613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9614: DrawableResource
+  get() = Drawable49.icon_9614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9615: DrawableResource
+  get() = Drawable49.icon_9615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9616: DrawableResource
+  get() = Drawable49.icon_9616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9617: DrawableResource
+  get() = Drawable49.icon_9617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9618: DrawableResource
+  get() = Drawable49.icon_9618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9619: DrawableResource
+  get() = Drawable49.icon_9619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_962: DrawableResource
+  get() = Drawable49.icon_962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9620: DrawableResource
+  get() = Drawable49.icon_9620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9621: DrawableResource
+  get() = Drawable49.icon_9621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9622: DrawableResource
+  get() = Drawable49.icon_9622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9623: DrawableResource
+  get() = Drawable49.icon_9623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9624: DrawableResource
+  get() = Drawable49.icon_9624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9625: DrawableResource
+  get() = Drawable49.icon_9625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9626: DrawableResource
+  get() = Drawable49.icon_9626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9627: DrawableResource
+  get() = Drawable49.icon_9627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9628: DrawableResource
+  get() = Drawable49.icon_9628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9629: DrawableResource
+  get() = Drawable49.icon_9629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_963: DrawableResource
+  get() = Drawable49.icon_963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9630: DrawableResource
+  get() = Drawable49.icon_9630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9631: DrawableResource
+  get() = Drawable49.icon_9631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9632: DrawableResource
+  get() = Drawable49.icon_9632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9633: DrawableResource
+  get() = Drawable49.icon_9633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9634: DrawableResource
+  get() = Drawable49.icon_9634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9635: DrawableResource
+  get() = Drawable49.icon_9635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9636: DrawableResource
+  get() = Drawable49.icon_9636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9637: DrawableResource
+  get() = Drawable49.icon_9637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9638: DrawableResource
+  get() = Drawable49.icon_9638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9639: DrawableResource
+  get() = Drawable49.icon_9639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_964: DrawableResource
+  get() = Drawable49.icon_964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9640: DrawableResource
+  get() = Drawable49.icon_9640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9641: DrawableResource
+  get() = Drawable49.icon_9641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9642: DrawableResource
+  get() = Drawable49.icon_9642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9643: DrawableResource
+  get() = Drawable49.icon_9643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9644: DrawableResource
+  get() = Drawable49.icon_9644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9645: DrawableResource
+  get() = Drawable49.icon_9645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9646: DrawableResource
+  get() = Drawable49.icon_9646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9647: DrawableResource
+  get() = Drawable49.icon_9647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9648: DrawableResource
+  get() = Drawable49.icon_9648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9649: DrawableResource
+  get() = Drawable49.icon_9649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_965: DrawableResource
+  get() = Drawable49.icon_965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9650: DrawableResource
+  get() = Drawable49.icon_9650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9651: DrawableResource
+  get() = Drawable49.icon_9651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9652: DrawableResource
+  get() = Drawable49.icon_9652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9653: DrawableResource
+  get() = Drawable49.icon_9653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9654: DrawableResource
+  get() = Drawable49.icon_9654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9655: DrawableResource
+  get() = Drawable49.icon_9655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9656: DrawableResource
+  get() = Drawable49.icon_9656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9657: DrawableResource
+  get() = Drawable49.icon_9657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9658: DrawableResource
+  get() = Drawable49.icon_9658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9659: DrawableResource
+  get() = Drawable49.icon_9659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_966: DrawableResource
+  get() = Drawable49.icon_966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9660: DrawableResource
+  get() = Drawable49.icon_9660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9661: DrawableResource
+  get() = Drawable49.icon_9661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9662: DrawableResource
+  get() = Drawable49.icon_9662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9663: DrawableResource
+  get() = Drawable49.icon_9663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9664: DrawableResource
+  get() = Drawable49.icon_9664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9665: DrawableResource
+  get() = Drawable49.icon_9665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9666: DrawableResource
+  get() = Drawable49.icon_9666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9667: DrawableResource
+  get() = Drawable49.icon_9667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9668: DrawableResource
+  get() = Drawable49.icon_9668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9669: DrawableResource
+  get() = Drawable49.icon_9669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_967: DrawableResource
+  get() = Drawable49.icon_967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9670: DrawableResource
+  get() = Drawable49.icon_9670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9671: DrawableResource
+  get() = Drawable49.icon_9671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9672: DrawableResource
+  get() = Drawable49.icon_9672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9673: DrawableResource
+  get() = Drawable49.icon_9673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9674: DrawableResource
+  get() = Drawable49.icon_9674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9675: DrawableResource
+  get() = Drawable49.icon_9675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9676: DrawableResource
+  get() = Drawable49.icon_9676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9677: DrawableResource
+  get() = Drawable49.icon_9677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9678: DrawableResource
+  get() = Drawable49.icon_9678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9679: DrawableResource
+  get() = Drawable49.icon_9679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_968: DrawableResource
+  get() = Drawable49.icon_968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9680: DrawableResource
+  get() = Drawable49.icon_9680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9681: DrawableResource
+  get() = Drawable49.icon_9681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9682: DrawableResource
+  get() = Drawable49.icon_9682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9683: DrawableResource
+  get() = Drawable49.icon_9683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9684: DrawableResource
+  get() = Drawable49.icon_9684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9685: DrawableResource
+  get() = Drawable49.icon_9685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9686: DrawableResource
+  get() = Drawable49.icon_9686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9687: DrawableResource
+  get() = Drawable49.icon_9687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9688: DrawableResource
+  get() = Drawable49.icon_9688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9689: DrawableResource
+  get() = Drawable49.icon_9689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_969: DrawableResource
+  get() = Drawable49.icon_969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9690: DrawableResource
+  get() = Drawable49.icon_9690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9691: DrawableResource
+  get() = Drawable49.icon_9691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9692: DrawableResource
+  get() = Drawable49.icon_9692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9693: DrawableResource
+  get() = Drawable49.icon_9693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9694: DrawableResource
+  get() = Drawable49.icon_9694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9695: DrawableResource
+  get() = Drawable49.icon_9695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9696: DrawableResource
+  get() = Drawable49.icon_9696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9697: DrawableResource
+  get() = Drawable49.icon_9697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9698: DrawableResource
+  get() = Drawable49.icon_9698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9699: DrawableResource
+  get() = Drawable49.icon_9699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_97: DrawableResource
+  get() = Drawable49.icon_97
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_970: DrawableResource
+  get() = Drawable49.icon_970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9700: DrawableResource
+  get() = Drawable49.icon_9700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9701: DrawableResource
+  get() = Drawable49.icon_9701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9702: DrawableResource
+  get() = Drawable49.icon_9702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9703: DrawableResource
+  get() = Drawable49.icon_9703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9704: DrawableResource
+  get() = Drawable49.icon_9704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9705: DrawableResource
+  get() = Drawable49.icon_9705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9706: DrawableResource
+  get() = Drawable49.icon_9706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9707: DrawableResource
+  get() = Drawable49.icon_9707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9708: DrawableResource
+  get() = Drawable49.icon_9708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9709: DrawableResource
+  get() = Drawable49.icon_9709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_971: DrawableResource
+  get() = Drawable49.icon_971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9710: DrawableResource
+  get() = Drawable49.icon_9710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9711: DrawableResource
+  get() = Drawable49.icon_9711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9712: DrawableResource
+  get() = Drawable49.icon_9712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9713: DrawableResource
+  get() = Drawable49.icon_9713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9714: DrawableResource
+  get() = Drawable49.icon_9714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9715: DrawableResource
+  get() = Drawable49.icon_9715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9716: DrawableResource
+  get() = Drawable49.icon_9716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9717: DrawableResource
+  get() = Drawable49.icon_9717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9718: DrawableResource
+  get() = Drawable49.icon_9718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9719: DrawableResource
+  get() = Drawable49.icon_9719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_972: DrawableResource
+  get() = Drawable49.icon_972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9720: DrawableResource
+  get() = Drawable49.icon_9720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9721: DrawableResource
+  get() = Drawable49.icon_9721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9722: DrawableResource
+  get() = Drawable49.icon_9722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9723: DrawableResource
+  get() = Drawable49.icon_9723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9724: DrawableResource
+  get() = Drawable49.icon_9724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9725: DrawableResource
+  get() = Drawable49.icon_9725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9726: DrawableResource
+  get() = Drawable49.icon_9726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9727: DrawableResource
+  get() = Drawable49.icon_9727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9728: DrawableResource
+  get() = Drawable49.icon_9728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9729: DrawableResource
+  get() = Drawable49.icon_9729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_973: DrawableResource
+  get() = Drawable49.icon_973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9730: DrawableResource
+  get() = Drawable49.icon_9730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9731: DrawableResource
+  get() = Drawable49.icon_9731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9732: DrawableResource
+  get() = Drawable49.icon_9732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9733: DrawableResource
+  get() = Drawable49.icon_9733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9734: DrawableResource
+  get() = Drawable49.icon_9734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9735: DrawableResource
+  get() = Drawable49.icon_9735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9736: DrawableResource
+  get() = Drawable49.icon_9736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9737: DrawableResource
+  get() = Drawable49.icon_9737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9738: DrawableResource
+  get() = Drawable49.icon_9738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9739: DrawableResource
+  get() = Drawable49.icon_9739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_974: DrawableResource
+  get() = Drawable49.icon_974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9740: DrawableResource
+  get() = Drawable49.icon_9740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9741: DrawableResource
+  get() = Drawable49.icon_9741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9742: DrawableResource
+  get() = Drawable49.icon_9742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9743: DrawableResource
+  get() = Drawable49.icon_9743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9744: DrawableResource
+  get() = Drawable49.icon_9744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9745: DrawableResource
+  get() = Drawable49.icon_9745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9746: DrawableResource
+  get() = Drawable49.icon_9746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9747: DrawableResource
+  get() = Drawable49.icon_9747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9748: DrawableResource
+  get() = Drawable49.icon_9748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9749: DrawableResource
+  get() = Drawable49.icon_9749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_975: DrawableResource
+  get() = Drawable49.icon_975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9750: DrawableResource
+  get() = Drawable49.icon_9750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9751: DrawableResource
+  get() = Drawable49.icon_9751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9752: DrawableResource
+  get() = Drawable49.icon_9752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9753: DrawableResource
+  get() = Drawable49.icon_9753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9754: DrawableResource
+  get() = Drawable49.icon_9754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9755: DrawableResource
+  get() = Drawable49.icon_9755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9756: DrawableResource
+  get() = Drawable49.icon_9756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9757: DrawableResource
+  get() = Drawable49.icon_9757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9758: DrawableResource
+  get() = Drawable49.icon_9758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9759: DrawableResource
+  get() = Drawable49.icon_9759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_976: DrawableResource
+  get() = Drawable49.icon_976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9760: DrawableResource
+  get() = Drawable49.icon_9760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9761: DrawableResource
+  get() = Drawable49.icon_9761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9762: DrawableResource
+  get() = Drawable49.icon_9762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9763: DrawableResource
+  get() = Drawable49.icon_9763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9764: DrawableResource
+  get() = Drawable49.icon_9764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9765: DrawableResource
+  get() = Drawable49.icon_9765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9766: DrawableResource
+  get() = Drawable49.icon_9766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9767: DrawableResource
+  get() = Drawable49.icon_9767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9768: DrawableResource
+  get() = Drawable49.icon_9768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9769: DrawableResource
+  get() = Drawable49.icon_9769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_977: DrawableResource
+  get() = Drawable49.icon_977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9770: DrawableResource
+  get() = Drawable49.icon_9770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9771: DrawableResource
+  get() = Drawable49.icon_9771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9772: DrawableResource
+  get() = Drawable49.icon_9772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9773: DrawableResource
+  get() = Drawable49.icon_9773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9774: DrawableResource
+  get() = Drawable49.icon_9774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9775: DrawableResource
+  get() = Drawable49.icon_9775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9776: DrawableResource
+  get() = Drawable49.icon_9776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9777: DrawableResource
+  get() = Drawable49.icon_9777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9778: DrawableResource
+  get() = Drawable49.icon_9778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9779: DrawableResource
+  get() = Drawable49.icon_9779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_978: DrawableResource
+  get() = Drawable49.icon_978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9780: DrawableResource
+  get() = Drawable49.icon_9780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9781: DrawableResource
+  get() = Drawable49.icon_9781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9782: DrawableResource
+  get() = Drawable49.icon_9782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9783: DrawableResource
+  get() = Drawable49.icon_9783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9784: DrawableResource
+  get() = Drawable49.icon_9784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9785: DrawableResource
+  get() = Drawable49.icon_9785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9786: DrawableResource
+  get() = Drawable49.icon_9786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9787: DrawableResource
+  get() = Drawable49.icon_9787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9788: DrawableResource
+  get() = Drawable49.icon_9788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9789: DrawableResource
+  get() = Drawable49.icon_9789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_979: DrawableResource
+  get() = Drawable49.icon_979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9790: DrawableResource
+  get() = Drawable49.icon_9790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9791: DrawableResource
+  get() = Drawable49.icon_9791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9792: DrawableResource
+  get() = Drawable49.icon_9792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9793: DrawableResource
+  get() = Drawable49.icon_9793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9794: DrawableResource
+  get() = Drawable49.icon_9794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9795: DrawableResource
+  get() = Drawable49.icon_9795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9796: DrawableResource
+  get() = Drawable49.icon_9796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9797: DrawableResource
+  get() = Drawable49.icon_9797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9798: DrawableResource
+  get() = Drawable49.icon_9798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9799: DrawableResource
+  get() = Drawable49.icon_9799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_98: DrawableResource
+  get() = Drawable49.icon_98
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_980: DrawableResource
+  get() = Drawable49.icon_980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9800: DrawableResource
+  get() = Drawable49.icon_9800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9801: DrawableResource
+  get() = Drawable49.icon_9801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9802: DrawableResource
+  get() = Drawable49.icon_9802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9803: DrawableResource
+  get() = Drawable49.icon_9803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9804: DrawableResource
+  get() = Drawable49.icon_9804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9805: DrawableResource
+  get() = Drawable49.icon_9805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9806: DrawableResource
+  get() = Drawable49.icon_9806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9807: DrawableResource
+  get() = Drawable49.icon_9807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9808: DrawableResource
+  get() = Drawable49.icon_9808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9809: DrawableResource
+  get() = Drawable49.icon_9809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_981: DrawableResource
+  get() = Drawable49.icon_981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9810: DrawableResource
+  get() = Drawable49.icon_9810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9811: DrawableResource
+  get() = Drawable49.icon_9811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9812: DrawableResource
+  get() = Drawable49.icon_9812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9813: DrawableResource
+  get() = Drawable49.icon_9813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9814: DrawableResource
+  get() = Drawable49.icon_9814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9815: DrawableResource
+  get() = Drawable49.icon_9815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9816: DrawableResource
+  get() = Drawable49.icon_9816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9817: DrawableResource
+  get() = Drawable49.icon_9817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9818: DrawableResource
+  get() = Drawable49.icon_9818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9819: DrawableResource
+  get() = Drawable49.icon_9819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_982: DrawableResource
+  get() = Drawable49.icon_982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9820: DrawableResource
+  get() = Drawable49.icon_9820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9821: DrawableResource
+  get() = Drawable49.icon_9821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9822: DrawableResource
+  get() = Drawable49.icon_9822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9823: DrawableResource
+  get() = Drawable49.icon_9823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9824: DrawableResource
+  get() = Drawable49.icon_9824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9825: DrawableResource
+  get() = Drawable49.icon_9825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9826: DrawableResource
+  get() = Drawable49.icon_9826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9827: DrawableResource
+  get() = Drawable49.icon_9827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9828: DrawableResource
+  get() = Drawable49.icon_9828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9829: DrawableResource
+  get() = Drawable49.icon_9829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_983: DrawableResource
+  get() = Drawable49.icon_983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9830: DrawableResource
+  get() = Drawable49.icon_9830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9831: DrawableResource
+  get() = Drawable49.icon_9831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9832: DrawableResource
+  get() = Drawable49.icon_9832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9833: DrawableResource
+  get() = Drawable49.icon_9833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9834: DrawableResource
+  get() = Drawable49.icon_9834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9835: DrawableResource
+  get() = Drawable49.icon_9835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9836: DrawableResource
+  get() = Drawable49.icon_9836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9837: DrawableResource
+  get() = Drawable49.icon_9837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9838: DrawableResource
+  get() = Drawable49.icon_9838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9839: DrawableResource
+  get() = Drawable49.icon_9839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_984: DrawableResource
+  get() = Drawable49.icon_984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9840: DrawableResource
+  get() = Drawable49.icon_9840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9841: DrawableResource
+  get() = Drawable49.icon_9841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9842: DrawableResource
+  get() = Drawable49.icon_9842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9843: DrawableResource
+  get() = Drawable49.icon_9843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9844: DrawableResource
+  get() = Drawable49.icon_9844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9845: DrawableResource
+  get() = Drawable49.icon_9845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9846: DrawableResource
+  get() = Drawable49.icon_9846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9847: DrawableResource
+  get() = Drawable49.icon_9847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9848: DrawableResource
+  get() = Drawable49.icon_9848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9849: DrawableResource
+  get() = Drawable49.icon_9849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_985: DrawableResource
+  get() = Drawable49.icon_985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9850: DrawableResource
+  get() = Drawable49.icon_9850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9851: DrawableResource
+  get() = Drawable49.icon_9851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9852: DrawableResource
+  get() = Drawable49.icon_9852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9853: DrawableResource
+  get() = Drawable49.icon_9853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9854: DrawableResource
+  get() = Drawable49.icon_9854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9855: DrawableResource
+  get() = Drawable49.icon_9855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9856: DrawableResource
+  get() = Drawable49.icon_9856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9857: DrawableResource
+  get() = Drawable49.icon_9857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9858: DrawableResource
+  get() = Drawable49.icon_9858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9859: DrawableResource
+  get() = Drawable49.icon_9859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_986: DrawableResource
+  get() = Drawable49.icon_986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9860: DrawableResource
+  get() = Drawable49.icon_9860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9861: DrawableResource
+  get() = Drawable49.icon_9861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9862: DrawableResource
+  get() = Drawable49.icon_9862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9863: DrawableResource
+  get() = Drawable49.icon_9863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9864: DrawableResource
+  get() = Drawable49.icon_9864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9865: DrawableResource
+  get() = Drawable49.icon_9865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9866: DrawableResource
+  get() = Drawable49.icon_9866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9867: DrawableResource
+  get() = Drawable49.icon_9867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9868: DrawableResource
+  get() = Drawable49.icon_9868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9869: DrawableResource
+  get() = Drawable49.icon_9869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_987: DrawableResource
+  get() = Drawable49.icon_987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9870: DrawableResource
+  get() = Drawable49.icon_9870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9871: DrawableResource
+  get() = Drawable49.icon_9871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9872: DrawableResource
+  get() = Drawable49.icon_9872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9873: DrawableResource
+  get() = Drawable49.icon_9873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9874: DrawableResource
+  get() = Drawable49.icon_9874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9875: DrawableResource
+  get() = Drawable49.icon_9875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9876: DrawableResource
+  get() = Drawable49.icon_9876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9877: DrawableResource
+  get() = Drawable49.icon_9877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9878: DrawableResource
+  get() = Drawable49.icon_9878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9879: DrawableResource
+  get() = Drawable49.icon_9879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_988: DrawableResource
+  get() = Drawable49.icon_988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9880: DrawableResource
+  get() = Drawable49.icon_9880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9881: DrawableResource
+  get() = Drawable49.icon_9881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9882: DrawableResource
+  get() = Drawable49.icon_9882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9883: DrawableResource
+  get() = Drawable49.icon_9883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9884: DrawableResource
+  get() = Drawable49.icon_9884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9885: DrawableResource
+  get() = Drawable49.icon_9885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9886: DrawableResource
+  get() = Drawable49.icon_9886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9887: DrawableResource
+  get() = Drawable49.icon_9887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9888: DrawableResource
+  get() = Drawable49.icon_9888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9889: DrawableResource
+  get() = Drawable49.icon_9889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_989: DrawableResource
+  get() = Drawable49.icon_989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9890: DrawableResource
+  get() = Drawable49.icon_9890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9891: DrawableResource
+  get() = Drawable49.icon_9891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9892: DrawableResource
+  get() = Drawable49.icon_9892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9893: DrawableResource
+  get() = Drawable49.icon_9893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9894: DrawableResource
+  get() = Drawable49.icon_9894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9895: DrawableResource
+  get() = Drawable49.icon_9895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9896: DrawableResource
+  get() = Drawable49.icon_9896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9897: DrawableResource
+  get() = Drawable49.icon_9897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9898: DrawableResource
+  get() = Drawable49.icon_9898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9899: DrawableResource
+  get() = Drawable49.icon_9899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_99: DrawableResource
+  get() = Drawable49.icon_99
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_990: DrawableResource
+  get() = Drawable49.icon_990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9900: DrawableResource
+  get() = Drawable49.icon_9900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9901: DrawableResource
+  get() = Drawable49.icon_9901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9902: DrawableResource
+  get() = Drawable49.icon_9902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9903: DrawableResource
+  get() = Drawable49.icon_9903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9904: DrawableResource
+  get() = Drawable49.icon_9904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9905: DrawableResource
+  get() = Drawable49.icon_9905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9906: DrawableResource
+  get() = Drawable49.icon_9906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9907: DrawableResource
+  get() = Drawable49.icon_9907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9908: DrawableResource
+  get() = Drawable49.icon_9908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9909: DrawableResource
+  get() = Drawable49.icon_9909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_991: DrawableResource
+  get() = Drawable49.icon_991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9910: DrawableResource
+  get() = Drawable49.icon_9910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9911: DrawableResource
+  get() = Drawable49.icon_9911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9912: DrawableResource
+  get() = Drawable49.icon_9912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9913: DrawableResource
+  get() = Drawable49.icon_9913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9914: DrawableResource
+  get() = Drawable49.icon_9914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9915: DrawableResource
+  get() = Drawable49.icon_9915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9916: DrawableResource
+  get() = Drawable49.icon_9916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9917: DrawableResource
+  get() = Drawable49.icon_9917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9918: DrawableResource
+  get() = Drawable49.icon_9918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9919: DrawableResource
+  get() = Drawable49.icon_9919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_992: DrawableResource
+  get() = Drawable49.icon_992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9920: DrawableResource
+  get() = Drawable49.icon_9920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9921: DrawableResource
+  get() = Drawable49.icon_9921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9922: DrawableResource
+  get() = Drawable49.icon_9922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9923: DrawableResource
+  get() = Drawable49.icon_9923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9924: DrawableResource
+  get() = Drawable49.icon_9924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9925: DrawableResource
+  get() = Drawable49.icon_9925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9926: DrawableResource
+  get() = Drawable49.icon_9926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9927: DrawableResource
+  get() = Drawable49.icon_9927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9928: DrawableResource
+  get() = Drawable49.icon_9928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9929: DrawableResource
+  get() = Drawable49.icon_9929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_993: DrawableResource
+  get() = Drawable49.icon_993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9930: DrawableResource
+  get() = Drawable49.icon_9930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9931: DrawableResource
+  get() = Drawable49.icon_9931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9932: DrawableResource
+  get() = Drawable49.icon_9932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9933: DrawableResource
+  get() = Drawable49.icon_9933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9934: DrawableResource
+  get() = Drawable49.icon_9934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9935: DrawableResource
+  get() = Drawable49.icon_9935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9936: DrawableResource
+  get() = Drawable49.icon_9936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9937: DrawableResource
+  get() = Drawable49.icon_9937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9938: DrawableResource
+  get() = Drawable49.icon_9938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9939: DrawableResource
+  get() = Drawable49.icon_9939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_994: DrawableResource
+  get() = Drawable49.icon_994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9940: DrawableResource
+  get() = Drawable49.icon_9940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9941: DrawableResource
+  get() = Drawable49.icon_9941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9942: DrawableResource
+  get() = Drawable49.icon_9942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9943: DrawableResource
+  get() = Drawable49.icon_9943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9944: DrawableResource
+  get() = Drawable49.icon_9944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9945: DrawableResource
+  get() = Drawable49.icon_9945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9946: DrawableResource
+  get() = Drawable49.icon_9946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9947: DrawableResource
+  get() = Drawable49.icon_9947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9948: DrawableResource
+  get() = Drawable49.icon_9948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9949: DrawableResource
+  get() = Drawable49.icon_9949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_995: DrawableResource
+  get() = Drawable49.icon_995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9950: DrawableResource
+  get() = Drawable49.icon_9950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9951: DrawableResource
+  get() = Drawable49.icon_9951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9952: DrawableResource
+  get() = Drawable49.icon_9952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9953: DrawableResource
+  get() = Drawable49.icon_9953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9954: DrawableResource
+  get() = Drawable49.icon_9954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9955: DrawableResource
+  get() = Drawable49.icon_9955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9956: DrawableResource
+  get() = Drawable49.icon_9956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9957: DrawableResource
+  get() = Drawable49.icon_9957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9958: DrawableResource
+  get() = Drawable49.icon_9958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9959: DrawableResource
+  get() = Drawable49.icon_9959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_996: DrawableResource
+  get() = Drawable49.icon_996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9960: DrawableResource
+  get() = Drawable49.icon_9960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9961: DrawableResource
+  get() = Drawable49.icon_9961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9962: DrawableResource
+  get() = Drawable49.icon_9962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9963: DrawableResource
+  get() = Drawable49.icon_9963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9964: DrawableResource
+  get() = Drawable49.icon_9964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9965: DrawableResource
+  get() = Drawable49.icon_9965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9966: DrawableResource
+  get() = Drawable49.icon_9966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9967: DrawableResource
+  get() = Drawable49.icon_9967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9968: DrawableResource
+  get() = Drawable49.icon_9968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9969: DrawableResource
+  get() = Drawable49.icon_9969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_997: DrawableResource
+  get() = Drawable49.icon_997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9970: DrawableResource
+  get() = Drawable49.icon_9970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9971: DrawableResource
+  get() = Drawable49.icon_9971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9972: DrawableResource
+  get() = Drawable49.icon_9972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9973: DrawableResource
+  get() = Drawable49.icon_9973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9974: DrawableResource
+  get() = Drawable49.icon_9974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9975: DrawableResource
+  get() = Drawable49.icon_9975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9976: DrawableResource
+  get() = Drawable49.icon_9976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9977: DrawableResource
+  get() = Drawable49.icon_9977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9978: DrawableResource
+  get() = Drawable49.icon_9978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9979: DrawableResource
+  get() = Drawable49.icon_9979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_998: DrawableResource
+  get() = Drawable49.icon_998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9980: DrawableResource
+  get() = Drawable49.icon_9980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9981: DrawableResource
+  get() = Drawable49.icon_9981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9982: DrawableResource
+  get() = Drawable49.icon_9982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9983: DrawableResource
+  get() = Drawable49.icon_9983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9984: DrawableResource
+  get() = Drawable49.icon_9984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9985: DrawableResource
+  get() = Drawable49.icon_9985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9986: DrawableResource
+  get() = Drawable49.icon_9986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9987: DrawableResource
+  get() = Drawable49.icon_9987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9988: DrawableResource
+  get() = Drawable49.icon_9988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9989: DrawableResource
+  get() = Drawable49.icon_9989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_999: DrawableResource
+  get() = Drawable49.icon_999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9990: DrawableResource
+  get() = Drawable49.icon_9990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9991: DrawableResource
+  get() = Drawable49.icon_9991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9992: DrawableResource
+  get() = Drawable49.icon_9992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9993: DrawableResource
+  get() = Drawable49.icon_9993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9994: DrawableResource
+  get() = Drawable49.icon_9994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9995: DrawableResource
+  get() = Drawable49.icon_9995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9996: DrawableResource
+  get() = Drawable49.icon_9996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9997: DrawableResource
+  get() = Drawable49.icon_9997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9998: DrawableResource
+  get() = Drawable49.icon_9998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_9999: DrawableResource
+  get() = Drawable49.icon_9999

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable5.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable5.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable5 {
+  public val icon_12247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12247.xml"),
+          )
+      )
+
+  public val icon_12248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12248.xml"),
+          )
+      )
+
+  public val icon_12249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12249.xml"),
+          )
+      )
+
+  public val icon_1225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1225.xml"),
+          )
+      )
+
+  public val icon_12250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12250.xml"),
+          )
+      )
+
+  public val icon_12251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12251.xml"),
+          )
+      )
+
+  public val icon_12252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12252.xml"),
+          )
+      )
+
+  public val icon_12253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12253.xml"),
+          )
+      )
+
+  public val icon_12254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12254.xml"),
+          )
+      )
+
+  public val icon_12255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12255.xml"),
+          )
+      )
+
+  public val icon_12256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12256.xml"),
+          )
+      )
+
+  public val icon_12257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12257.xml"),
+          )
+      )
+
+  public val icon_12258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12258.xml"),
+          )
+      )
+
+  public val icon_12259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12259.xml"),
+          )
+      )
+
+  public val icon_1226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1226.xml"),
+          )
+      )
+
+  public val icon_12260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12260.xml"),
+          )
+      )
+
+  public val icon_12261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12261.xml"),
+          )
+      )
+
+  public val icon_12262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12262.xml"),
+          )
+      )
+
+  public val icon_12263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12263.xml"),
+          )
+      )
+
+  public val icon_12264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12264.xml"),
+          )
+      )
+
+  public val icon_12265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12265.xml"),
+          )
+      )
+
+  public val icon_12266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12266.xml"),
+          )
+      )
+
+  public val icon_12267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12267.xml"),
+          )
+      )
+
+  public val icon_12268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12268.xml"),
+          )
+      )
+
+  public val icon_12269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12269.xml"),
+          )
+      )
+
+  public val icon_1227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1227.xml"),
+          )
+      )
+
+  public val icon_12270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12270.xml"),
+          )
+      )
+
+  public val icon_12271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12271.xml"),
+          )
+      )
+
+  public val icon_12272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12272.xml"),
+          )
+      )
+
+  public val icon_12273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12273.xml"),
+          )
+      )
+
+  public val icon_12274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12274.xml"),
+          )
+      )
+
+  public val icon_12275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12275.xml"),
+          )
+      )
+
+  public val icon_12276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12276.xml"),
+          )
+      )
+
+  public val icon_12277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12277.xml"),
+          )
+      )
+
+  public val icon_12278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12278.xml"),
+          )
+      )
+
+  public val icon_12279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12279.xml"),
+          )
+      )
+
+  public val icon_1228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1228.xml"),
+          )
+      )
+
+  public val icon_12280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12280.xml"),
+          )
+      )
+
+  public val icon_12281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12281.xml"),
+          )
+      )
+
+  public val icon_12282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12282.xml"),
+          )
+      )
+
+  public val icon_12283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12283.xml"),
+          )
+      )
+
+  public val icon_12284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12284.xml"),
+          )
+      )
+
+  public val icon_12285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12285.xml"),
+          )
+      )
+
+  public val icon_12286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12286.xml"),
+          )
+      )
+
+  public val icon_12287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12287.xml"),
+          )
+      )
+
+  public val icon_12288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12288.xml"),
+          )
+      )
+
+  public val icon_12289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12289.xml"),
+          )
+      )
+
+  public val icon_1229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1229.xml"),
+          )
+      )
+
+  public val icon_12290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12290.xml"),
+          )
+      )
+
+  public val icon_12291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12291.xml"),
+          )
+      )
+
+  public val icon_12292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12292.xml"),
+          )
+      )
+
+  public val icon_12293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12293.xml"),
+          )
+      )
+
+  public val icon_12294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12294.xml"),
+          )
+      )
+
+  public val icon_12295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12295.xml"),
+          )
+      )
+
+  public val icon_12296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12296.xml"),
+          )
+      )
+
+  public val icon_12297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12297.xml"),
+          )
+      )
+
+  public val icon_12298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12298.xml"),
+          )
+      )
+
+  public val icon_12299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12299.xml"),
+          )
+      )
+
+  public val icon_123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_123.xml"),
+          )
+      )
+
+  public val icon_1230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1230.xml"),
+          )
+      )
+
+  public val icon_12300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12300.xml"),
+          )
+      )
+
+  public val icon_12301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12301.xml"),
+          )
+      )
+
+  public val icon_12302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12302.xml"),
+          )
+      )
+
+  public val icon_12303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12303.xml"),
+          )
+      )
+
+  public val icon_12304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12304.xml"),
+          )
+      )
+
+  public val icon_12305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12305.xml"),
+          )
+      )
+
+  public val icon_12306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12306.xml"),
+          )
+      )
+
+  public val icon_12307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12307.xml"),
+          )
+      )
+
+  public val icon_12308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12308.xml"),
+          )
+      )
+
+  public val icon_12309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12309.xml"),
+          )
+      )
+
+  public val icon_1231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1231.xml"),
+          )
+      )
+
+  public val icon_12310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12310.xml"),
+          )
+      )
+
+  public val icon_12311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12311.xml"),
+          )
+      )
+
+  public val icon_12312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12312.xml"),
+          )
+      )
+
+  public val icon_12313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12313.xml"),
+          )
+      )
+
+  public val icon_12314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12314.xml"),
+          )
+      )
+
+  public val icon_12315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12315.xml"),
+          )
+      )
+
+  public val icon_12316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12316.xml"),
+          )
+      )
+
+  public val icon_12317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12317.xml"),
+          )
+      )
+
+  public val icon_12318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12318.xml"),
+          )
+      )
+
+  public val icon_12319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12319.xml"),
+          )
+      )
+
+  public val icon_1232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1232.xml"),
+          )
+      )
+
+  public val icon_12320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12320.xml"),
+          )
+      )
+
+  public val icon_12321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12321.xml"),
+          )
+      )
+
+  public val icon_12322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12322.xml"),
+          )
+      )
+
+  public val icon_12323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12323.xml"),
+          )
+      )
+
+  public val icon_12324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12324.xml"),
+          )
+      )
+
+  public val icon_12325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12325.xml"),
+          )
+      )
+
+  public val icon_12326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12326.xml"),
+          )
+      )
+
+  public val icon_12327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12327.xml"),
+          )
+      )
+
+  public val icon_12328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12328.xml"),
+          )
+      )
+
+  public val icon_12329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12329.xml"),
+          )
+      )
+
+  public val icon_1233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1233.xml"),
+          )
+      )
+
+  public val icon_12330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12330.xml"),
+          )
+      )
+
+  public val icon_12331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12331.xml"),
+          )
+      )
+
+  public val icon_12332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12332.xml"),
+          )
+      )
+
+  public val icon_12333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12333.xml"),
+          )
+      )
+
+  public val icon_12334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12334.xml"),
+          )
+      )
+
+  public val icon_12335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12335.xml"),
+          )
+      )
+
+  public val icon_12336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12336.xml"),
+          )
+      )
+
+  public val icon_12337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12337.xml"),
+          )
+      )
+
+  public val icon_12338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12338.xml"),
+          )
+      )
+
+  public val icon_12339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12339.xml"),
+          )
+      )
+
+  public val icon_1234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1234.xml"),
+          )
+      )
+
+  public val icon_12340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12340.xml"),
+          )
+      )
+
+  public val icon_12341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12341.xml"),
+          )
+      )
+
+  public val icon_12342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12342.xml"),
+          )
+      )
+
+  public val icon_12343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12343.xml"),
+          )
+      )
+
+  public val icon_12344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12344.xml"),
+          )
+      )
+
+  public val icon_12345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12345.xml"),
+          )
+      )
+
+  public val icon_12346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12346.xml"),
+          )
+      )
+
+  public val icon_12347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12347.xml"),
+          )
+      )
+
+  public val icon_12348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12348.xml"),
+          )
+      )
+
+  public val icon_12349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12349.xml"),
+          )
+      )
+
+  public val icon_1235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1235.xml"),
+          )
+      )
+
+  public val icon_12350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12350.xml"),
+          )
+      )
+
+  public val icon_12351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12351.xml"),
+          )
+      )
+
+  public val icon_12352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12352.xml"),
+          )
+      )
+
+  public val icon_12353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12353.xml"),
+          )
+      )
+
+  public val icon_12354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12354.xml"),
+          )
+      )
+
+  public val icon_12355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12355.xml"),
+          )
+      )
+
+  public val icon_12356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12356.xml"),
+          )
+      )
+
+  public val icon_12357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12357.xml"),
+          )
+      )
+
+  public val icon_12358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12358.xml"),
+          )
+      )
+
+  public val icon_12359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12359.xml"),
+          )
+      )
+
+  public val icon_1236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1236.xml"),
+          )
+      )
+
+  public val icon_12360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12360.xml"),
+          )
+      )
+
+  public val icon_12361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12361.xml"),
+          )
+      )
+
+  public val icon_12362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12362.xml"),
+          )
+      )
+
+  public val icon_12363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12363.xml"),
+          )
+      )
+
+  public val icon_12364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12364.xml"),
+          )
+      )
+
+  public val icon_12365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12365.xml"),
+          )
+      )
+
+  public val icon_12366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12366.xml"),
+          )
+      )
+
+  public val icon_12367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12367.xml"),
+          )
+      )
+
+  public val icon_12368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12368.xml"),
+          )
+      )
+
+  public val icon_12369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12369.xml"),
+          )
+      )
+
+  public val icon_1237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1237.xml"),
+          )
+      )
+
+  public val icon_12370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12370.xml"),
+          )
+      )
+
+  public val icon_12371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12371.xml"),
+          )
+      )
+
+  public val icon_12372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12372.xml"),
+          )
+      )
+
+  public val icon_12373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12373.xml"),
+          )
+      )
+
+  public val icon_12374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12374.xml"),
+          )
+      )
+
+  public val icon_12375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12375.xml"),
+          )
+      )
+
+  public val icon_12376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12376.xml"),
+          )
+      )
+
+  public val icon_12377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12377.xml"),
+          )
+      )
+
+  public val icon_12378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12378.xml"),
+          )
+      )
+
+  public val icon_12379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12379.xml"),
+          )
+      )
+
+  public val icon_1238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1238.xml"),
+          )
+      )
+
+  public val icon_12380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12380.xml"),
+          )
+      )
+
+  public val icon_12381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12381.xml"),
+          )
+      )
+
+  public val icon_12382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12382.xml"),
+          )
+      )
+
+  public val icon_12383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12383.xml"),
+          )
+      )
+
+  public val icon_12384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12384.xml"),
+          )
+      )
+
+  public val icon_12385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12385.xml"),
+          )
+      )
+
+  public val icon_12386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12386.xml"),
+          )
+      )
+
+  public val icon_12387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12387.xml"),
+          )
+      )
+
+  public val icon_12388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12388.xml"),
+          )
+      )
+
+  public val icon_12389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12389.xml"),
+          )
+      )
+
+  public val icon_1239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1239.xml"),
+          )
+      )
+
+  public val icon_12390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12390.xml"),
+          )
+      )
+
+  public val icon_12391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12391.xml"),
+          )
+      )
+
+  public val icon_12392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12392.xml"),
+          )
+      )
+
+  public val icon_12393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12393.xml"),
+          )
+      )
+
+  public val icon_12394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12394.xml"),
+          )
+      )
+
+  public val icon_12395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12395.xml"),
+          )
+      )
+
+  public val icon_12396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12396.xml"),
+          )
+      )
+
+  public val icon_12397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12397.xml"),
+          )
+      )
+
+  public val icon_12398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12398.xml"),
+          )
+      )
+
+  public val icon_12399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12399.xml"),
+          )
+      )
+
+  public val icon_124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_124.xml"),
+          )
+      )
+
+  public val icon_1240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1240.xml"),
+          )
+      )
+
+  public val icon_12400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12400.xml"),
+          )
+      )
+
+  public val icon_12401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12401.xml"),
+          )
+      )
+
+  public val icon_12402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12402.xml"),
+          )
+      )
+
+  public val icon_12403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12403.xml"),
+          )
+      )
+
+  public val icon_12404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12404.xml"),
+          )
+      )
+
+  public val icon_12405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12405.xml"),
+          )
+      )
+
+  public val icon_12406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12406.xml"),
+          )
+      )
+
+  public val icon_12407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12407.xml"),
+          )
+      )
+
+  public val icon_12408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12408.xml"),
+          )
+      )
+
+  public val icon_12409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12409.xml"),
+          )
+      )
+
+  public val icon_1241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1241.xml"),
+          )
+      )
+
+  public val icon_12410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12410.xml"),
+          )
+      )
+
+  public val icon_12411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12411.xml"),
+          )
+      )
+
+  public val icon_12412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12412.xml"),
+          )
+      )
+
+  public val icon_12413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12413.xml"),
+          )
+      )
+
+  public val icon_12414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12414.xml"),
+          )
+      )
+
+  public val icon_12415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12415.xml"),
+          )
+      )
+
+  public val icon_12416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12416.xml"),
+          )
+      )
+
+  public val icon_12417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12417.xml"),
+          )
+      )
+
+  public val icon_12418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12418.xml"),
+          )
+      )
+
+  public val icon_12419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12419.xml"),
+          )
+      )
+
+  public val icon_1242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1242.xml"),
+          )
+      )
+
+  public val icon_12420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12420.xml"),
+          )
+      )
+
+  public val icon_12421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12421.xml"),
+          )
+      )
+
+  public val icon_12422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12422.xml"),
+          )
+      )
+
+  public val icon_12423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12423.xml"),
+          )
+      )
+
+  public val icon_12424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12424.xml"),
+          )
+      )
+
+  public val icon_12425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12425.xml"),
+          )
+      )
+
+  public val icon_12426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12426.xml"),
+          )
+      )
+
+  public val icon_12427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12427.xml"),
+          )
+      )
+
+  public val icon_12428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12428.xml"),
+          )
+      )
+
+  public val icon_12429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12429.xml"),
+          )
+      )
+
+  public val icon_1243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1243.xml"),
+          )
+      )
+
+  public val icon_12430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12430.xml"),
+          )
+      )
+
+  public val icon_12431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12431.xml"),
+          )
+      )
+
+  public val icon_12432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12432.xml"),
+          )
+      )
+
+  public val icon_12433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12433.xml"),
+          )
+      )
+
+  public val icon_12434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12434.xml"),
+          )
+      )
+
+  public val icon_12435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12435.xml"),
+          )
+      )
+
+  public val icon_12436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12436.xml"),
+          )
+      )
+
+  public val icon_12437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12437.xml"),
+          )
+      )
+
+  public val icon_12438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12438.xml"),
+          )
+      )
+
+  public val icon_12439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12439.xml"),
+          )
+      )
+
+  public val icon_1244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1244.xml"),
+          )
+      )
+
+  public val icon_12440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12440.xml"),
+          )
+      )
+
+  public val icon_12441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12441.xml"),
+          )
+      )
+
+  public val icon_12442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12442.xml"),
+          )
+      )
+
+  public val icon_12443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12443.xml"),
+          )
+      )
+
+  public val icon_12444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12444.xml"),
+          )
+      )
+
+  public val icon_12445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12445.xml"),
+          )
+      )
+
+  public val icon_12446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12446.xml"),
+          )
+      )
+
+  public val icon_12447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12447.xml"),
+          )
+      )
+
+  public val icon_12448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12448.xml"),
+          )
+      )
+
+  public val icon_12449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12449.xml"),
+          )
+      )
+
+  public val icon_1245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1245.xml"),
+          )
+      )
+
+  public val icon_12450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12450.xml"),
+          )
+      )
+
+  public val icon_12451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12451.xml"),
+          )
+      )
+
+  public val icon_12452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12452.xml"),
+          )
+      )
+
+  public val icon_12453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12453.xml"),
+          )
+      )
+
+  public val icon_12454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12454.xml"),
+          )
+      )
+
+  public val icon_12455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12455.xml"),
+          )
+      )
+
+  public val icon_12456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12456.xml"),
+          )
+      )
+
+  public val icon_12457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12457.xml"),
+          )
+      )
+
+  public val icon_12458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12458.xml"),
+          )
+      )
+
+  public val icon_12459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12459.xml"),
+          )
+      )
+
+  public val icon_1246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1246.xml"),
+          )
+      )
+
+  public val icon_12460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12460.xml"),
+          )
+      )
+
+  public val icon_12461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12461.xml"),
+          )
+      )
+
+  public val icon_12462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12462.xml"),
+          )
+      )
+
+  public val icon_12463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12463.xml"),
+          )
+      )
+
+  public val icon_12464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12464.xml"),
+          )
+      )
+
+  public val icon_12465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12465.xml"),
+          )
+      )
+
+  public val icon_12466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12466.xml"),
+          )
+      )
+
+  public val icon_12467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12467.xml"),
+          )
+      )
+
+  public val icon_12468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12468.xml"),
+          )
+      )
+
+  public val icon_12469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12469.xml"),
+          )
+      )
+
+  public val icon_1247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1247.xml"),
+          )
+      )
+
+  public val icon_12470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12470.xml"),
+          )
+      )
+
+  public val icon_12471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12471.xml"),
+          )
+      )
+
+  public val icon_12472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12472.xml"),
+          )
+      )
+
+  public val icon_12473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12473.xml"),
+          )
+      )
+
+  public val icon_12474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12474.xml"),
+          )
+      )
+
+  public val icon_12475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12475.xml"),
+          )
+      )
+
+  public val icon_12476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12476.xml"),
+          )
+      )
+
+  public val icon_12477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12477.xml"),
+          )
+      )
+
+  public val icon_12478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12478.xml"),
+          )
+      )
+
+  public val icon_12479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12479.xml"),
+          )
+      )
+
+  public val icon_1248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1248.xml"),
+          )
+      )
+
+  public val icon_12480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12480.xml"),
+          )
+      )
+
+  public val icon_12481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12481.xml"),
+          )
+      )
+
+  public val icon_12482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12482.xml"),
+          )
+      )
+
+  public val icon_12483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12483.xml"),
+          )
+      )
+
+  public val icon_12484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12484.xml"),
+          )
+      )
+
+  public val icon_12485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12485.xml"),
+          )
+      )
+
+  public val icon_12486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12486.xml"),
+          )
+      )
+
+  public val icon_12487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12487.xml"),
+          )
+      )
+
+  public val icon_12488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12488.xml"),
+          )
+      )
+
+  public val icon_12489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12489.xml"),
+          )
+      )
+
+  public val icon_1249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1249.xml"),
+          )
+      )
+
+  public val icon_12490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12490.xml"),
+          )
+      )
+
+  public val icon_12491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12491.xml"),
+          )
+      )
+
+  public val icon_12492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12492.xml"),
+          )
+      )
+
+  public val icon_12493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12493.xml"),
+          )
+      )
+
+  public val icon_12494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12494.xml"),
+          )
+      )
+
+  public val icon_12495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12495.xml"),
+          )
+      )
+
+  public val icon_12496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12496.xml"),
+          )
+      )
+
+  public val icon_12497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12497.xml"),
+          )
+      )
+
+  public val icon_12498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12498.xml"),
+          )
+      )
+
+  public val icon_12499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12499.xml"),
+          )
+      )
+
+  public val icon_125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_125.xml"),
+          )
+      )
+
+  public val icon_1250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1250.xml"),
+          )
+      )
+
+  public val icon_12500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12500.xml"),
+          )
+      )
+
+  public val icon_12501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12501.xml"),
+          )
+      )
+
+  public val icon_12502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12502.xml"),
+          )
+      )
+
+  public val icon_12503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12503.xml"),
+          )
+      )
+
+  public val icon_12504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12504.xml"),
+          )
+      )
+
+  public val icon_12505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12505.xml"),
+          )
+      )
+
+  public val icon_12506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12506.xml"),
+          )
+      )
+
+  public val icon_12507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12507.xml"),
+          )
+      )
+
+  public val icon_12508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12508.xml"),
+          )
+      )
+
+  public val icon_12509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12509.xml"),
+          )
+      )
+
+  public val icon_1251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1251.xml"),
+          )
+      )
+
+  public val icon_12510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12510.xml"),
+          )
+      )
+
+  public val icon_12511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12511.xml"),
+          )
+      )
+
+  public val icon_12512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12512.xml"),
+          )
+      )
+
+  public val icon_12513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12513.xml"),
+          )
+      )
+
+  public val icon_12514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12514.xml"),
+          )
+      )
+
+  public val icon_12515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12515.xml"),
+          )
+      )
+
+  public val icon_12516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12516.xml"),
+          )
+      )
+
+  public val icon_12517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12517.xml"),
+          )
+      )
+
+  public val icon_12518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12518.xml"),
+          )
+      )
+
+  public val icon_12519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12519.xml"),
+          )
+      )
+
+  public val icon_1252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1252.xml"),
+          )
+      )
+
+  public val icon_12520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12520.xml"),
+          )
+      )
+
+  public val icon_12521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12521.xml"),
+          )
+      )
+
+  public val icon_12522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12522.xml"),
+          )
+      )
+
+  public val icon_12523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12523.xml"),
+          )
+      )
+
+  public val icon_12524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12524.xml"),
+          )
+      )
+
+  public val icon_12525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12525.xml"),
+          )
+      )
+
+  public val icon_12526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12526.xml"),
+          )
+      )
+
+  public val icon_12527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12527.xml"),
+          )
+      )
+
+  public val icon_12528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12528.xml"),
+          )
+      )
+
+  public val icon_12529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12529.xml"),
+          )
+      )
+
+  public val icon_1253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1253.xml"),
+          )
+      )
+
+  public val icon_12530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12530.xml"),
+          )
+      )
+
+  public val icon_12531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12531.xml"),
+          )
+      )
+
+  public val icon_12532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12532.xml"),
+          )
+      )
+
+  public val icon_12533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12533.xml"),
+          )
+      )
+
+  public val icon_12534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12534.xml"),
+          )
+      )
+
+  public val icon_12535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12535.xml"),
+          )
+      )
+
+  public val icon_12536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12536.xml"),
+          )
+      )
+
+  public val icon_12537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12537.xml"),
+          )
+      )
+
+  public val icon_12538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12538.xml"),
+          )
+      )
+
+  public val icon_12539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12539.xml"),
+          )
+      )
+
+  public val icon_1254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1254.xml"),
+          )
+      )
+
+  public val icon_12540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12540.xml"),
+          )
+      )
+
+  public val icon_12541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12541.xml"),
+          )
+      )
+
+  public val icon_12542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12542.xml"),
+          )
+      )
+
+  public val icon_12543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12543.xml"),
+          )
+      )
+
+  public val icon_12544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12544.xml"),
+          )
+      )
+
+  public val icon_12545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12545.xml"),
+          )
+      )
+
+  public val icon_12546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12546.xml"),
+          )
+      )
+
+  public val icon_12547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12547.xml"),
+          )
+      )
+
+  public val icon_12548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12548.xml"),
+          )
+      )
+
+  public val icon_12549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12549.xml"),
+          )
+      )
+
+  public val icon_1255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1255.xml"),
+          )
+      )
+
+  public val icon_12550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12550.xml"),
+          )
+      )
+
+  public val icon_12551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12551.xml"),
+          )
+      )
+
+  public val icon_12552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12552.xml"),
+          )
+      )
+
+  public val icon_12553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12553.xml"),
+          )
+      )
+
+  public val icon_12554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12554.xml"),
+          )
+      )
+
+  public val icon_12555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12555.xml"),
+          )
+      )
+
+  public val icon_12556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12556.xml"),
+          )
+      )
+
+  public val icon_12557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12557.xml"),
+          )
+      )
+
+  public val icon_12558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12558.xml"),
+          )
+      )
+
+  public val icon_12559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12559.xml"),
+          )
+      )
+
+  public val icon_1256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1256.xml"),
+          )
+      )
+
+  public val icon_12560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12560.xml"),
+          )
+      )
+
+  public val icon_12561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12561.xml"),
+          )
+      )
+
+  public val icon_12562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12562.xml"),
+          )
+      )
+
+  public val icon_12563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12563.xml"),
+          )
+      )
+
+  public val icon_12564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12564.xml"),
+          )
+      )
+
+  public val icon_12565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12565.xml"),
+          )
+      )
+
+  public val icon_12566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12566.xml"),
+          )
+      )
+
+  public val icon_12567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12567.xml"),
+          )
+      )
+
+  public val icon_12568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12568.xml"),
+          )
+      )
+
+  public val icon_12569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12569.xml"),
+          )
+      )
+
+  public val icon_1257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1257.xml"),
+          )
+      )
+
+  public val icon_12570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12570.xml"),
+          )
+      )
+
+  public val icon_12571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12571.xml"),
+          )
+      )
+
+  public val icon_12572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12572.xml"),
+          )
+      )
+
+  public val icon_12573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12573.xml"),
+          )
+      )
+
+  public val icon_12574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12574.xml"),
+          )
+      )
+
+  public val icon_12575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12575.xml"),
+          )
+      )
+
+  public val icon_12576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12576.xml"),
+          )
+      )
+
+  public val icon_12577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12577.xml"),
+          )
+      )
+
+  public val icon_12578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12578.xml"),
+          )
+      )
+
+  public val icon_12579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12579.xml"),
+          )
+      )
+
+  public val icon_1258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1258.xml"),
+          )
+      )
+
+  public val icon_12580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12580.xml"),
+          )
+      )
+
+  public val icon_12581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12581.xml"),
+          )
+      )
+
+  public val icon_12582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12582.xml"),
+          )
+      )
+
+  public val icon_12583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12583.xml"),
+          )
+      )
+
+  public val icon_12584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12584.xml"),
+          )
+      )
+
+  public val icon_12585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12585.xml"),
+          )
+      )
+
+  public val icon_12586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12586.xml"),
+          )
+      )
+
+  public val icon_12587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12587.xml"),
+          )
+      )
+
+  public val icon_12588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12588.xml"),
+          )
+      )
+
+  public val icon_12589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12589.xml"),
+          )
+      )
+
+  public val icon_1259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1259.xml"),
+          )
+      )
+
+  public val icon_12590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12590.xml"),
+          )
+      )
+
+  public val icon_12591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12591.xml"),
+          )
+      )
+
+  public val icon_12592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12592.xml"),
+          )
+      )
+
+  public val icon_12593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12593.xml"),
+          )
+      )
+
+  public val icon_12594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12594.xml"),
+          )
+      )
+
+  public val icon_12595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12595.xml"),
+          )
+      )
+
+  public val icon_12596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12596.xml"),
+          )
+      )
+
+  public val icon_12597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12597.xml"),
+          )
+      )
+
+  public val icon_12598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12598.xml"),
+          )
+      )
+
+  public val icon_12599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12599.xml"),
+          )
+      )
+
+  public val icon_126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_126.xml"),
+          )
+      )
+
+  public val icon_1260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1260.xml"),
+          )
+      )
+
+  public val icon_12600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12600.xml"),
+          )
+      )
+
+  public val icon_12601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12601.xml"),
+          )
+      )
+
+  public val icon_12602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12602.xml"),
+          )
+      )
+
+  public val icon_12603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12603.xml"),
+          )
+      )
+
+  public val icon_12604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12604.xml"),
+          )
+      )
+
+  public val icon_12605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12605.xml"),
+          )
+      )
+
+  public val icon_12606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12606.xml"),
+          )
+      )
+
+  public val icon_12607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12607.xml"),
+          )
+      )
+
+  public val icon_12608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12608.xml"),
+          )
+      )
+
+  public val icon_12609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12609.xml"),
+          )
+      )
+
+  public val icon_1261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1261.xml"),
+          )
+      )
+
+  public val icon_12610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12610.xml"),
+          )
+      )
+
+  public val icon_12611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12611.xml"),
+          )
+      )
+
+  public val icon_12612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12612.xml"),
+          )
+      )
+
+  public val icon_12613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12613.xml"),
+          )
+      )
+
+  public val icon_12614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12614.xml"),
+          )
+      )
+
+  public val icon_12615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12615.xml"),
+          )
+      )
+
+  public val icon_12616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12616.xml"),
+          )
+      )
+
+  public val icon_12617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12617.xml"),
+          )
+      )
+
+  public val icon_12618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12618.xml"),
+          )
+      )
+
+  public val icon_12619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12619.xml"),
+          )
+      )
+
+  public val icon_1262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1262.xml"),
+          )
+      )
+
+  public val icon_12620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12620.xml"),
+          )
+      )
+
+  public val icon_12621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12621.xml"),
+          )
+      )
+
+  public val icon_12622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12622.xml"),
+          )
+      )
+
+  public val icon_12623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12623.xml"),
+          )
+      )
+
+  public val icon_12624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12624.xml"),
+          )
+      )
+
+  public val icon_12625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12625.xml"),
+          )
+      )
+
+  public val icon_12626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12626.xml"),
+          )
+      )
+
+  public val icon_12627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12627.xml"),
+          )
+      )
+
+  public val icon_12628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12628.xml"),
+          )
+      )
+
+  public val icon_12629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12629.xml"),
+          )
+      )
+
+  public val icon_1263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1263.xml"),
+          )
+      )
+
+  public val icon_12630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12630.xml"),
+          )
+      )
+
+  public val icon_12631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12631.xml"),
+          )
+      )
+
+  public val icon_12632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12632.xml"),
+          )
+      )
+
+  public val icon_12633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12633.xml"),
+          )
+      )
+
+  public val icon_12634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12634.xml"),
+          )
+      )
+
+  public val icon_12635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12635.xml"),
+          )
+      )
+
+  public val icon_12636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12636.xml"),
+          )
+      )
+
+  public val icon_12637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12637.xml"),
+          )
+      )
+
+  public val icon_12638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12638.xml"),
+          )
+      )
+
+  public val icon_12639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12639.xml"),
+          )
+      )
+
+  public val icon_1264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1264.xml"),
+          )
+      )
+
+  public val icon_12640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12640.xml"),
+          )
+      )
+
+  public val icon_12641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12641.xml"),
+          )
+      )
+
+  public val icon_12642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12642.xml"),
+          )
+      )
+
+  public val icon_12643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12643.xml"),
+          )
+      )
+
+  public val icon_12644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12644.xml"),
+          )
+      )
+
+  public val icon_12645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12645.xml"),
+          )
+      )
+
+  public val icon_12646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12646.xml"),
+          )
+      )
+
+  public val icon_12647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12647.xml"),
+          )
+      )
+
+  public val icon_12648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12648.xml"),
+          )
+      )
+
+  public val icon_12649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12649.xml"),
+          )
+      )
+
+  public val icon_1265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1265.xml"),
+          )
+      )
+
+  public val icon_12650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12650.xml"),
+          )
+      )
+
+  public val icon_12651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12651.xml"),
+          )
+      )
+
+  public val icon_12652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12652.xml"),
+          )
+      )
+
+  public val icon_12653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12653.xml"),
+          )
+      )
+
+  public val icon_12654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12654.xml"),
+          )
+      )
+
+  public val icon_12655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12655.xml"),
+          )
+      )
+
+  public val icon_12656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12656.xml"),
+          )
+      )
+
+  public val icon_12657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12657.xml"),
+          )
+      )
+
+  public val icon_12658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12658.xml"),
+          )
+      )
+
+  public val icon_12659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12659.xml"),
+          )
+      )
+
+  public val icon_1266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1266.xml"),
+          )
+      )
+
+  public val icon_12660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12660.xml"),
+          )
+      )
+
+  public val icon_12661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12661.xml"),
+          )
+      )
+
+  public val icon_12662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12662.xml"),
+          )
+      )
+
+  public val icon_12663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12663.xml"),
+          )
+      )
+
+  public val icon_12664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12664.xml"),
+          )
+      )
+
+  public val icon_12665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12665.xml"),
+          )
+      )
+
+  public val icon_12666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12666.xml"),
+          )
+      )
+
+  public val icon_12667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12667.xml"),
+          )
+      )
+
+  public val icon_12668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12668.xml"),
+          )
+      )
+
+  public val icon_12669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12669.xml"),
+          )
+      )
+
+  public val icon_1267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1267.xml"),
+          )
+      )
+
+  public val icon_12670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12670.xml"),
+          )
+      )
+
+  public val icon_12671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12671.xml"),
+          )
+      )
+
+  public val icon_12672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12672.xml"),
+          )
+      )
+
+  public val icon_12673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12673.xml"),
+          )
+      )
+
+  public val icon_12674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12674.xml"),
+          )
+      )
+
+  public val icon_12675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12675.xml"),
+          )
+      )
+
+  public val icon_12676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12676.xml"),
+          )
+      )
+
+  public val icon_12677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12677.xml"),
+          )
+      )
+
+  public val icon_12678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12678.xml"),
+          )
+      )
+
+  public val icon_12679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12679.xml"),
+          )
+      )
+
+  public val icon_1268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1268.xml"),
+          )
+      )
+
+  public val icon_12680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12680.xml"),
+          )
+      )
+
+  public val icon_12681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12681.xml"),
+          )
+      )
+
+  public val icon_12682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12682.xml"),
+          )
+      )
+
+  public val icon_12683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12683.xml"),
+          )
+      )
+
+  public val icon_12684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12684.xml"),
+          )
+      )
+
+  public val icon_12685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12685.xml"),
+          )
+      )
+
+  public val icon_12686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12686.xml"),
+          )
+      )
+
+  public val icon_12687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12687.xml"),
+          )
+      )
+
+  public val icon_12688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12688.xml"),
+          )
+      )
+
+  public val icon_12689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12689.xml"),
+          )
+      )
+
+  public val icon_1269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1269.xml"),
+          )
+      )
+
+  public val icon_12690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12690.xml"),
+          )
+      )
+
+  public val icon_12691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12691.xml"),
+          )
+      )
+
+  public val icon_12692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12692.xml"),
+          )
+      )
+
+  public val icon_12693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12693.xml"),
+          )
+      )
+
+  public val icon_12694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12694.xml"),
+          )
+      )
+
+  public val icon_12695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12695.xml"),
+          )
+      )
+
+  public val icon_12696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12696.xml"),
+          )
+      )
+
+  public val icon_12697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12697.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12247: DrawableResource
+  get() = Drawable5.icon_12247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12248: DrawableResource
+  get() = Drawable5.icon_12248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12249: DrawableResource
+  get() = Drawable5.icon_12249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1225: DrawableResource
+  get() = Drawable5.icon_1225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12250: DrawableResource
+  get() = Drawable5.icon_12250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12251: DrawableResource
+  get() = Drawable5.icon_12251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12252: DrawableResource
+  get() = Drawable5.icon_12252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12253: DrawableResource
+  get() = Drawable5.icon_12253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12254: DrawableResource
+  get() = Drawable5.icon_12254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12255: DrawableResource
+  get() = Drawable5.icon_12255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12256: DrawableResource
+  get() = Drawable5.icon_12256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12257: DrawableResource
+  get() = Drawable5.icon_12257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12258: DrawableResource
+  get() = Drawable5.icon_12258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12259: DrawableResource
+  get() = Drawable5.icon_12259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1226: DrawableResource
+  get() = Drawable5.icon_1226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12260: DrawableResource
+  get() = Drawable5.icon_12260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12261: DrawableResource
+  get() = Drawable5.icon_12261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12262: DrawableResource
+  get() = Drawable5.icon_12262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12263: DrawableResource
+  get() = Drawable5.icon_12263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12264: DrawableResource
+  get() = Drawable5.icon_12264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12265: DrawableResource
+  get() = Drawable5.icon_12265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12266: DrawableResource
+  get() = Drawable5.icon_12266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12267: DrawableResource
+  get() = Drawable5.icon_12267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12268: DrawableResource
+  get() = Drawable5.icon_12268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12269: DrawableResource
+  get() = Drawable5.icon_12269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1227: DrawableResource
+  get() = Drawable5.icon_1227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12270: DrawableResource
+  get() = Drawable5.icon_12270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12271: DrawableResource
+  get() = Drawable5.icon_12271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12272: DrawableResource
+  get() = Drawable5.icon_12272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12273: DrawableResource
+  get() = Drawable5.icon_12273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12274: DrawableResource
+  get() = Drawable5.icon_12274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12275: DrawableResource
+  get() = Drawable5.icon_12275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12276: DrawableResource
+  get() = Drawable5.icon_12276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12277: DrawableResource
+  get() = Drawable5.icon_12277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12278: DrawableResource
+  get() = Drawable5.icon_12278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12279: DrawableResource
+  get() = Drawable5.icon_12279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1228: DrawableResource
+  get() = Drawable5.icon_1228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12280: DrawableResource
+  get() = Drawable5.icon_12280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12281: DrawableResource
+  get() = Drawable5.icon_12281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12282: DrawableResource
+  get() = Drawable5.icon_12282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12283: DrawableResource
+  get() = Drawable5.icon_12283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12284: DrawableResource
+  get() = Drawable5.icon_12284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12285: DrawableResource
+  get() = Drawable5.icon_12285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12286: DrawableResource
+  get() = Drawable5.icon_12286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12287: DrawableResource
+  get() = Drawable5.icon_12287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12288: DrawableResource
+  get() = Drawable5.icon_12288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12289: DrawableResource
+  get() = Drawable5.icon_12289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1229: DrawableResource
+  get() = Drawable5.icon_1229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12290: DrawableResource
+  get() = Drawable5.icon_12290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12291: DrawableResource
+  get() = Drawable5.icon_12291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12292: DrawableResource
+  get() = Drawable5.icon_12292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12293: DrawableResource
+  get() = Drawable5.icon_12293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12294: DrawableResource
+  get() = Drawable5.icon_12294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12295: DrawableResource
+  get() = Drawable5.icon_12295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12296: DrawableResource
+  get() = Drawable5.icon_12296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12297: DrawableResource
+  get() = Drawable5.icon_12297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12298: DrawableResource
+  get() = Drawable5.icon_12298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12299: DrawableResource
+  get() = Drawable5.icon_12299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_123: DrawableResource
+  get() = Drawable5.icon_123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1230: DrawableResource
+  get() = Drawable5.icon_1230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12300: DrawableResource
+  get() = Drawable5.icon_12300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12301: DrawableResource
+  get() = Drawable5.icon_12301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12302: DrawableResource
+  get() = Drawable5.icon_12302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12303: DrawableResource
+  get() = Drawable5.icon_12303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12304: DrawableResource
+  get() = Drawable5.icon_12304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12305: DrawableResource
+  get() = Drawable5.icon_12305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12306: DrawableResource
+  get() = Drawable5.icon_12306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12307: DrawableResource
+  get() = Drawable5.icon_12307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12308: DrawableResource
+  get() = Drawable5.icon_12308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12309: DrawableResource
+  get() = Drawable5.icon_12309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1231: DrawableResource
+  get() = Drawable5.icon_1231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12310: DrawableResource
+  get() = Drawable5.icon_12310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12311: DrawableResource
+  get() = Drawable5.icon_12311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12312: DrawableResource
+  get() = Drawable5.icon_12312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12313: DrawableResource
+  get() = Drawable5.icon_12313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12314: DrawableResource
+  get() = Drawable5.icon_12314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12315: DrawableResource
+  get() = Drawable5.icon_12315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12316: DrawableResource
+  get() = Drawable5.icon_12316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12317: DrawableResource
+  get() = Drawable5.icon_12317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12318: DrawableResource
+  get() = Drawable5.icon_12318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12319: DrawableResource
+  get() = Drawable5.icon_12319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1232: DrawableResource
+  get() = Drawable5.icon_1232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12320: DrawableResource
+  get() = Drawable5.icon_12320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12321: DrawableResource
+  get() = Drawable5.icon_12321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12322: DrawableResource
+  get() = Drawable5.icon_12322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12323: DrawableResource
+  get() = Drawable5.icon_12323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12324: DrawableResource
+  get() = Drawable5.icon_12324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12325: DrawableResource
+  get() = Drawable5.icon_12325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12326: DrawableResource
+  get() = Drawable5.icon_12326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12327: DrawableResource
+  get() = Drawable5.icon_12327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12328: DrawableResource
+  get() = Drawable5.icon_12328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12329: DrawableResource
+  get() = Drawable5.icon_12329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1233: DrawableResource
+  get() = Drawable5.icon_1233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12330: DrawableResource
+  get() = Drawable5.icon_12330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12331: DrawableResource
+  get() = Drawable5.icon_12331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12332: DrawableResource
+  get() = Drawable5.icon_12332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12333: DrawableResource
+  get() = Drawable5.icon_12333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12334: DrawableResource
+  get() = Drawable5.icon_12334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12335: DrawableResource
+  get() = Drawable5.icon_12335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12336: DrawableResource
+  get() = Drawable5.icon_12336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12337: DrawableResource
+  get() = Drawable5.icon_12337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12338: DrawableResource
+  get() = Drawable5.icon_12338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12339: DrawableResource
+  get() = Drawable5.icon_12339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1234: DrawableResource
+  get() = Drawable5.icon_1234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12340: DrawableResource
+  get() = Drawable5.icon_12340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12341: DrawableResource
+  get() = Drawable5.icon_12341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12342: DrawableResource
+  get() = Drawable5.icon_12342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12343: DrawableResource
+  get() = Drawable5.icon_12343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12344: DrawableResource
+  get() = Drawable5.icon_12344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12345: DrawableResource
+  get() = Drawable5.icon_12345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12346: DrawableResource
+  get() = Drawable5.icon_12346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12347: DrawableResource
+  get() = Drawable5.icon_12347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12348: DrawableResource
+  get() = Drawable5.icon_12348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12349: DrawableResource
+  get() = Drawable5.icon_12349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1235: DrawableResource
+  get() = Drawable5.icon_1235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12350: DrawableResource
+  get() = Drawable5.icon_12350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12351: DrawableResource
+  get() = Drawable5.icon_12351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12352: DrawableResource
+  get() = Drawable5.icon_12352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12353: DrawableResource
+  get() = Drawable5.icon_12353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12354: DrawableResource
+  get() = Drawable5.icon_12354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12355: DrawableResource
+  get() = Drawable5.icon_12355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12356: DrawableResource
+  get() = Drawable5.icon_12356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12357: DrawableResource
+  get() = Drawable5.icon_12357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12358: DrawableResource
+  get() = Drawable5.icon_12358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12359: DrawableResource
+  get() = Drawable5.icon_12359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1236: DrawableResource
+  get() = Drawable5.icon_1236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12360: DrawableResource
+  get() = Drawable5.icon_12360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12361: DrawableResource
+  get() = Drawable5.icon_12361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12362: DrawableResource
+  get() = Drawable5.icon_12362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12363: DrawableResource
+  get() = Drawable5.icon_12363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12364: DrawableResource
+  get() = Drawable5.icon_12364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12365: DrawableResource
+  get() = Drawable5.icon_12365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12366: DrawableResource
+  get() = Drawable5.icon_12366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12367: DrawableResource
+  get() = Drawable5.icon_12367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12368: DrawableResource
+  get() = Drawable5.icon_12368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12369: DrawableResource
+  get() = Drawable5.icon_12369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1237: DrawableResource
+  get() = Drawable5.icon_1237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12370: DrawableResource
+  get() = Drawable5.icon_12370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12371: DrawableResource
+  get() = Drawable5.icon_12371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12372: DrawableResource
+  get() = Drawable5.icon_12372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12373: DrawableResource
+  get() = Drawable5.icon_12373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12374: DrawableResource
+  get() = Drawable5.icon_12374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12375: DrawableResource
+  get() = Drawable5.icon_12375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12376: DrawableResource
+  get() = Drawable5.icon_12376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12377: DrawableResource
+  get() = Drawable5.icon_12377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12378: DrawableResource
+  get() = Drawable5.icon_12378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12379: DrawableResource
+  get() = Drawable5.icon_12379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1238: DrawableResource
+  get() = Drawable5.icon_1238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12380: DrawableResource
+  get() = Drawable5.icon_12380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12381: DrawableResource
+  get() = Drawable5.icon_12381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12382: DrawableResource
+  get() = Drawable5.icon_12382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12383: DrawableResource
+  get() = Drawable5.icon_12383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12384: DrawableResource
+  get() = Drawable5.icon_12384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12385: DrawableResource
+  get() = Drawable5.icon_12385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12386: DrawableResource
+  get() = Drawable5.icon_12386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12387: DrawableResource
+  get() = Drawable5.icon_12387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12388: DrawableResource
+  get() = Drawable5.icon_12388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12389: DrawableResource
+  get() = Drawable5.icon_12389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1239: DrawableResource
+  get() = Drawable5.icon_1239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12390: DrawableResource
+  get() = Drawable5.icon_12390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12391: DrawableResource
+  get() = Drawable5.icon_12391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12392: DrawableResource
+  get() = Drawable5.icon_12392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12393: DrawableResource
+  get() = Drawable5.icon_12393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12394: DrawableResource
+  get() = Drawable5.icon_12394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12395: DrawableResource
+  get() = Drawable5.icon_12395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12396: DrawableResource
+  get() = Drawable5.icon_12396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12397: DrawableResource
+  get() = Drawable5.icon_12397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12398: DrawableResource
+  get() = Drawable5.icon_12398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12399: DrawableResource
+  get() = Drawable5.icon_12399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_124: DrawableResource
+  get() = Drawable5.icon_124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1240: DrawableResource
+  get() = Drawable5.icon_1240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12400: DrawableResource
+  get() = Drawable5.icon_12400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12401: DrawableResource
+  get() = Drawable5.icon_12401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12402: DrawableResource
+  get() = Drawable5.icon_12402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12403: DrawableResource
+  get() = Drawable5.icon_12403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12404: DrawableResource
+  get() = Drawable5.icon_12404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12405: DrawableResource
+  get() = Drawable5.icon_12405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12406: DrawableResource
+  get() = Drawable5.icon_12406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12407: DrawableResource
+  get() = Drawable5.icon_12407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12408: DrawableResource
+  get() = Drawable5.icon_12408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12409: DrawableResource
+  get() = Drawable5.icon_12409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1241: DrawableResource
+  get() = Drawable5.icon_1241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12410: DrawableResource
+  get() = Drawable5.icon_12410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12411: DrawableResource
+  get() = Drawable5.icon_12411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12412: DrawableResource
+  get() = Drawable5.icon_12412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12413: DrawableResource
+  get() = Drawable5.icon_12413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12414: DrawableResource
+  get() = Drawable5.icon_12414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12415: DrawableResource
+  get() = Drawable5.icon_12415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12416: DrawableResource
+  get() = Drawable5.icon_12416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12417: DrawableResource
+  get() = Drawable5.icon_12417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12418: DrawableResource
+  get() = Drawable5.icon_12418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12419: DrawableResource
+  get() = Drawable5.icon_12419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1242: DrawableResource
+  get() = Drawable5.icon_1242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12420: DrawableResource
+  get() = Drawable5.icon_12420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12421: DrawableResource
+  get() = Drawable5.icon_12421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12422: DrawableResource
+  get() = Drawable5.icon_12422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12423: DrawableResource
+  get() = Drawable5.icon_12423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12424: DrawableResource
+  get() = Drawable5.icon_12424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12425: DrawableResource
+  get() = Drawable5.icon_12425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12426: DrawableResource
+  get() = Drawable5.icon_12426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12427: DrawableResource
+  get() = Drawable5.icon_12427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12428: DrawableResource
+  get() = Drawable5.icon_12428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12429: DrawableResource
+  get() = Drawable5.icon_12429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1243: DrawableResource
+  get() = Drawable5.icon_1243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12430: DrawableResource
+  get() = Drawable5.icon_12430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12431: DrawableResource
+  get() = Drawable5.icon_12431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12432: DrawableResource
+  get() = Drawable5.icon_12432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12433: DrawableResource
+  get() = Drawable5.icon_12433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12434: DrawableResource
+  get() = Drawable5.icon_12434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12435: DrawableResource
+  get() = Drawable5.icon_12435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12436: DrawableResource
+  get() = Drawable5.icon_12436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12437: DrawableResource
+  get() = Drawable5.icon_12437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12438: DrawableResource
+  get() = Drawable5.icon_12438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12439: DrawableResource
+  get() = Drawable5.icon_12439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1244: DrawableResource
+  get() = Drawable5.icon_1244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12440: DrawableResource
+  get() = Drawable5.icon_12440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12441: DrawableResource
+  get() = Drawable5.icon_12441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12442: DrawableResource
+  get() = Drawable5.icon_12442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12443: DrawableResource
+  get() = Drawable5.icon_12443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12444: DrawableResource
+  get() = Drawable5.icon_12444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12445: DrawableResource
+  get() = Drawable5.icon_12445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12446: DrawableResource
+  get() = Drawable5.icon_12446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12447: DrawableResource
+  get() = Drawable5.icon_12447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12448: DrawableResource
+  get() = Drawable5.icon_12448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12449: DrawableResource
+  get() = Drawable5.icon_12449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1245: DrawableResource
+  get() = Drawable5.icon_1245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12450: DrawableResource
+  get() = Drawable5.icon_12450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12451: DrawableResource
+  get() = Drawable5.icon_12451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12452: DrawableResource
+  get() = Drawable5.icon_12452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12453: DrawableResource
+  get() = Drawable5.icon_12453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12454: DrawableResource
+  get() = Drawable5.icon_12454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12455: DrawableResource
+  get() = Drawable5.icon_12455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12456: DrawableResource
+  get() = Drawable5.icon_12456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12457: DrawableResource
+  get() = Drawable5.icon_12457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12458: DrawableResource
+  get() = Drawable5.icon_12458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12459: DrawableResource
+  get() = Drawable5.icon_12459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1246: DrawableResource
+  get() = Drawable5.icon_1246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12460: DrawableResource
+  get() = Drawable5.icon_12460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12461: DrawableResource
+  get() = Drawable5.icon_12461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12462: DrawableResource
+  get() = Drawable5.icon_12462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12463: DrawableResource
+  get() = Drawable5.icon_12463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12464: DrawableResource
+  get() = Drawable5.icon_12464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12465: DrawableResource
+  get() = Drawable5.icon_12465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12466: DrawableResource
+  get() = Drawable5.icon_12466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12467: DrawableResource
+  get() = Drawable5.icon_12467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12468: DrawableResource
+  get() = Drawable5.icon_12468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12469: DrawableResource
+  get() = Drawable5.icon_12469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1247: DrawableResource
+  get() = Drawable5.icon_1247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12470: DrawableResource
+  get() = Drawable5.icon_12470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12471: DrawableResource
+  get() = Drawable5.icon_12471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12472: DrawableResource
+  get() = Drawable5.icon_12472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12473: DrawableResource
+  get() = Drawable5.icon_12473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12474: DrawableResource
+  get() = Drawable5.icon_12474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12475: DrawableResource
+  get() = Drawable5.icon_12475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12476: DrawableResource
+  get() = Drawable5.icon_12476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12477: DrawableResource
+  get() = Drawable5.icon_12477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12478: DrawableResource
+  get() = Drawable5.icon_12478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12479: DrawableResource
+  get() = Drawable5.icon_12479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1248: DrawableResource
+  get() = Drawable5.icon_1248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12480: DrawableResource
+  get() = Drawable5.icon_12480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12481: DrawableResource
+  get() = Drawable5.icon_12481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12482: DrawableResource
+  get() = Drawable5.icon_12482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12483: DrawableResource
+  get() = Drawable5.icon_12483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12484: DrawableResource
+  get() = Drawable5.icon_12484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12485: DrawableResource
+  get() = Drawable5.icon_12485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12486: DrawableResource
+  get() = Drawable5.icon_12486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12487: DrawableResource
+  get() = Drawable5.icon_12487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12488: DrawableResource
+  get() = Drawable5.icon_12488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12489: DrawableResource
+  get() = Drawable5.icon_12489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1249: DrawableResource
+  get() = Drawable5.icon_1249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12490: DrawableResource
+  get() = Drawable5.icon_12490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12491: DrawableResource
+  get() = Drawable5.icon_12491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12492: DrawableResource
+  get() = Drawable5.icon_12492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12493: DrawableResource
+  get() = Drawable5.icon_12493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12494: DrawableResource
+  get() = Drawable5.icon_12494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12495: DrawableResource
+  get() = Drawable5.icon_12495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12496: DrawableResource
+  get() = Drawable5.icon_12496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12497: DrawableResource
+  get() = Drawable5.icon_12497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12498: DrawableResource
+  get() = Drawable5.icon_12498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12499: DrawableResource
+  get() = Drawable5.icon_12499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_125: DrawableResource
+  get() = Drawable5.icon_125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1250: DrawableResource
+  get() = Drawable5.icon_1250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12500: DrawableResource
+  get() = Drawable5.icon_12500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12501: DrawableResource
+  get() = Drawable5.icon_12501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12502: DrawableResource
+  get() = Drawable5.icon_12502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12503: DrawableResource
+  get() = Drawable5.icon_12503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12504: DrawableResource
+  get() = Drawable5.icon_12504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12505: DrawableResource
+  get() = Drawable5.icon_12505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12506: DrawableResource
+  get() = Drawable5.icon_12506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12507: DrawableResource
+  get() = Drawable5.icon_12507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12508: DrawableResource
+  get() = Drawable5.icon_12508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12509: DrawableResource
+  get() = Drawable5.icon_12509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1251: DrawableResource
+  get() = Drawable5.icon_1251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12510: DrawableResource
+  get() = Drawable5.icon_12510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12511: DrawableResource
+  get() = Drawable5.icon_12511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12512: DrawableResource
+  get() = Drawable5.icon_12512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12513: DrawableResource
+  get() = Drawable5.icon_12513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12514: DrawableResource
+  get() = Drawable5.icon_12514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12515: DrawableResource
+  get() = Drawable5.icon_12515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12516: DrawableResource
+  get() = Drawable5.icon_12516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12517: DrawableResource
+  get() = Drawable5.icon_12517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12518: DrawableResource
+  get() = Drawable5.icon_12518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12519: DrawableResource
+  get() = Drawable5.icon_12519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1252: DrawableResource
+  get() = Drawable5.icon_1252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12520: DrawableResource
+  get() = Drawable5.icon_12520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12521: DrawableResource
+  get() = Drawable5.icon_12521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12522: DrawableResource
+  get() = Drawable5.icon_12522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12523: DrawableResource
+  get() = Drawable5.icon_12523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12524: DrawableResource
+  get() = Drawable5.icon_12524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12525: DrawableResource
+  get() = Drawable5.icon_12525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12526: DrawableResource
+  get() = Drawable5.icon_12526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12527: DrawableResource
+  get() = Drawable5.icon_12527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12528: DrawableResource
+  get() = Drawable5.icon_12528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12529: DrawableResource
+  get() = Drawable5.icon_12529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1253: DrawableResource
+  get() = Drawable5.icon_1253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12530: DrawableResource
+  get() = Drawable5.icon_12530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12531: DrawableResource
+  get() = Drawable5.icon_12531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12532: DrawableResource
+  get() = Drawable5.icon_12532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12533: DrawableResource
+  get() = Drawable5.icon_12533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12534: DrawableResource
+  get() = Drawable5.icon_12534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12535: DrawableResource
+  get() = Drawable5.icon_12535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12536: DrawableResource
+  get() = Drawable5.icon_12536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12537: DrawableResource
+  get() = Drawable5.icon_12537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12538: DrawableResource
+  get() = Drawable5.icon_12538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12539: DrawableResource
+  get() = Drawable5.icon_12539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1254: DrawableResource
+  get() = Drawable5.icon_1254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12540: DrawableResource
+  get() = Drawable5.icon_12540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12541: DrawableResource
+  get() = Drawable5.icon_12541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12542: DrawableResource
+  get() = Drawable5.icon_12542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12543: DrawableResource
+  get() = Drawable5.icon_12543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12544: DrawableResource
+  get() = Drawable5.icon_12544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12545: DrawableResource
+  get() = Drawable5.icon_12545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12546: DrawableResource
+  get() = Drawable5.icon_12546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12547: DrawableResource
+  get() = Drawable5.icon_12547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12548: DrawableResource
+  get() = Drawable5.icon_12548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12549: DrawableResource
+  get() = Drawable5.icon_12549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1255: DrawableResource
+  get() = Drawable5.icon_1255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12550: DrawableResource
+  get() = Drawable5.icon_12550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12551: DrawableResource
+  get() = Drawable5.icon_12551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12552: DrawableResource
+  get() = Drawable5.icon_12552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12553: DrawableResource
+  get() = Drawable5.icon_12553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12554: DrawableResource
+  get() = Drawable5.icon_12554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12555: DrawableResource
+  get() = Drawable5.icon_12555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12556: DrawableResource
+  get() = Drawable5.icon_12556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12557: DrawableResource
+  get() = Drawable5.icon_12557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12558: DrawableResource
+  get() = Drawable5.icon_12558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12559: DrawableResource
+  get() = Drawable5.icon_12559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1256: DrawableResource
+  get() = Drawable5.icon_1256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12560: DrawableResource
+  get() = Drawable5.icon_12560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12561: DrawableResource
+  get() = Drawable5.icon_12561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12562: DrawableResource
+  get() = Drawable5.icon_12562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12563: DrawableResource
+  get() = Drawable5.icon_12563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12564: DrawableResource
+  get() = Drawable5.icon_12564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12565: DrawableResource
+  get() = Drawable5.icon_12565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12566: DrawableResource
+  get() = Drawable5.icon_12566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12567: DrawableResource
+  get() = Drawable5.icon_12567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12568: DrawableResource
+  get() = Drawable5.icon_12568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12569: DrawableResource
+  get() = Drawable5.icon_12569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1257: DrawableResource
+  get() = Drawable5.icon_1257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12570: DrawableResource
+  get() = Drawable5.icon_12570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12571: DrawableResource
+  get() = Drawable5.icon_12571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12572: DrawableResource
+  get() = Drawable5.icon_12572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12573: DrawableResource
+  get() = Drawable5.icon_12573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12574: DrawableResource
+  get() = Drawable5.icon_12574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12575: DrawableResource
+  get() = Drawable5.icon_12575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12576: DrawableResource
+  get() = Drawable5.icon_12576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12577: DrawableResource
+  get() = Drawable5.icon_12577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12578: DrawableResource
+  get() = Drawable5.icon_12578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12579: DrawableResource
+  get() = Drawable5.icon_12579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1258: DrawableResource
+  get() = Drawable5.icon_1258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12580: DrawableResource
+  get() = Drawable5.icon_12580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12581: DrawableResource
+  get() = Drawable5.icon_12581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12582: DrawableResource
+  get() = Drawable5.icon_12582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12583: DrawableResource
+  get() = Drawable5.icon_12583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12584: DrawableResource
+  get() = Drawable5.icon_12584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12585: DrawableResource
+  get() = Drawable5.icon_12585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12586: DrawableResource
+  get() = Drawable5.icon_12586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12587: DrawableResource
+  get() = Drawable5.icon_12587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12588: DrawableResource
+  get() = Drawable5.icon_12588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12589: DrawableResource
+  get() = Drawable5.icon_12589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1259: DrawableResource
+  get() = Drawable5.icon_1259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12590: DrawableResource
+  get() = Drawable5.icon_12590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12591: DrawableResource
+  get() = Drawable5.icon_12591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12592: DrawableResource
+  get() = Drawable5.icon_12592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12593: DrawableResource
+  get() = Drawable5.icon_12593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12594: DrawableResource
+  get() = Drawable5.icon_12594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12595: DrawableResource
+  get() = Drawable5.icon_12595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12596: DrawableResource
+  get() = Drawable5.icon_12596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12597: DrawableResource
+  get() = Drawable5.icon_12597
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12598: DrawableResource
+  get() = Drawable5.icon_12598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12599: DrawableResource
+  get() = Drawable5.icon_12599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_126: DrawableResource
+  get() = Drawable5.icon_126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1260: DrawableResource
+  get() = Drawable5.icon_1260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12600: DrawableResource
+  get() = Drawable5.icon_12600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12601: DrawableResource
+  get() = Drawable5.icon_12601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12602: DrawableResource
+  get() = Drawable5.icon_12602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12603: DrawableResource
+  get() = Drawable5.icon_12603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12604: DrawableResource
+  get() = Drawable5.icon_12604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12605: DrawableResource
+  get() = Drawable5.icon_12605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12606: DrawableResource
+  get() = Drawable5.icon_12606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12607: DrawableResource
+  get() = Drawable5.icon_12607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12608: DrawableResource
+  get() = Drawable5.icon_12608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12609: DrawableResource
+  get() = Drawable5.icon_12609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1261: DrawableResource
+  get() = Drawable5.icon_1261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12610: DrawableResource
+  get() = Drawable5.icon_12610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12611: DrawableResource
+  get() = Drawable5.icon_12611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12612: DrawableResource
+  get() = Drawable5.icon_12612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12613: DrawableResource
+  get() = Drawable5.icon_12613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12614: DrawableResource
+  get() = Drawable5.icon_12614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12615: DrawableResource
+  get() = Drawable5.icon_12615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12616: DrawableResource
+  get() = Drawable5.icon_12616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12617: DrawableResource
+  get() = Drawable5.icon_12617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12618: DrawableResource
+  get() = Drawable5.icon_12618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12619: DrawableResource
+  get() = Drawable5.icon_12619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1262: DrawableResource
+  get() = Drawable5.icon_1262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12620: DrawableResource
+  get() = Drawable5.icon_12620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12621: DrawableResource
+  get() = Drawable5.icon_12621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12622: DrawableResource
+  get() = Drawable5.icon_12622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12623: DrawableResource
+  get() = Drawable5.icon_12623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12624: DrawableResource
+  get() = Drawable5.icon_12624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12625: DrawableResource
+  get() = Drawable5.icon_12625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12626: DrawableResource
+  get() = Drawable5.icon_12626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12627: DrawableResource
+  get() = Drawable5.icon_12627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12628: DrawableResource
+  get() = Drawable5.icon_12628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12629: DrawableResource
+  get() = Drawable5.icon_12629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1263: DrawableResource
+  get() = Drawable5.icon_1263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12630: DrawableResource
+  get() = Drawable5.icon_12630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12631: DrawableResource
+  get() = Drawable5.icon_12631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12632: DrawableResource
+  get() = Drawable5.icon_12632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12633: DrawableResource
+  get() = Drawable5.icon_12633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12634: DrawableResource
+  get() = Drawable5.icon_12634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12635: DrawableResource
+  get() = Drawable5.icon_12635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12636: DrawableResource
+  get() = Drawable5.icon_12636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12637: DrawableResource
+  get() = Drawable5.icon_12637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12638: DrawableResource
+  get() = Drawable5.icon_12638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12639: DrawableResource
+  get() = Drawable5.icon_12639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1264: DrawableResource
+  get() = Drawable5.icon_1264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12640: DrawableResource
+  get() = Drawable5.icon_12640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12641: DrawableResource
+  get() = Drawable5.icon_12641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12642: DrawableResource
+  get() = Drawable5.icon_12642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12643: DrawableResource
+  get() = Drawable5.icon_12643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12644: DrawableResource
+  get() = Drawable5.icon_12644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12645: DrawableResource
+  get() = Drawable5.icon_12645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12646: DrawableResource
+  get() = Drawable5.icon_12646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12647: DrawableResource
+  get() = Drawable5.icon_12647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12648: DrawableResource
+  get() = Drawable5.icon_12648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12649: DrawableResource
+  get() = Drawable5.icon_12649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1265: DrawableResource
+  get() = Drawable5.icon_1265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12650: DrawableResource
+  get() = Drawable5.icon_12650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12651: DrawableResource
+  get() = Drawable5.icon_12651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12652: DrawableResource
+  get() = Drawable5.icon_12652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12653: DrawableResource
+  get() = Drawable5.icon_12653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12654: DrawableResource
+  get() = Drawable5.icon_12654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12655: DrawableResource
+  get() = Drawable5.icon_12655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12656: DrawableResource
+  get() = Drawable5.icon_12656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12657: DrawableResource
+  get() = Drawable5.icon_12657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12658: DrawableResource
+  get() = Drawable5.icon_12658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12659: DrawableResource
+  get() = Drawable5.icon_12659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1266: DrawableResource
+  get() = Drawable5.icon_1266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12660: DrawableResource
+  get() = Drawable5.icon_12660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12661: DrawableResource
+  get() = Drawable5.icon_12661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12662: DrawableResource
+  get() = Drawable5.icon_12662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12663: DrawableResource
+  get() = Drawable5.icon_12663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12664: DrawableResource
+  get() = Drawable5.icon_12664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12665: DrawableResource
+  get() = Drawable5.icon_12665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12666: DrawableResource
+  get() = Drawable5.icon_12666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12667: DrawableResource
+  get() = Drawable5.icon_12667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12668: DrawableResource
+  get() = Drawable5.icon_12668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12669: DrawableResource
+  get() = Drawable5.icon_12669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1267: DrawableResource
+  get() = Drawable5.icon_1267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12670: DrawableResource
+  get() = Drawable5.icon_12670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12671: DrawableResource
+  get() = Drawable5.icon_12671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12672: DrawableResource
+  get() = Drawable5.icon_12672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12673: DrawableResource
+  get() = Drawable5.icon_12673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12674: DrawableResource
+  get() = Drawable5.icon_12674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12675: DrawableResource
+  get() = Drawable5.icon_12675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12676: DrawableResource
+  get() = Drawable5.icon_12676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12677: DrawableResource
+  get() = Drawable5.icon_12677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12678: DrawableResource
+  get() = Drawable5.icon_12678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12679: DrawableResource
+  get() = Drawable5.icon_12679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1268: DrawableResource
+  get() = Drawable5.icon_1268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12680: DrawableResource
+  get() = Drawable5.icon_12680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12681: DrawableResource
+  get() = Drawable5.icon_12681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12682: DrawableResource
+  get() = Drawable5.icon_12682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12683: DrawableResource
+  get() = Drawable5.icon_12683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12684: DrawableResource
+  get() = Drawable5.icon_12684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12685: DrawableResource
+  get() = Drawable5.icon_12685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12686: DrawableResource
+  get() = Drawable5.icon_12686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12687: DrawableResource
+  get() = Drawable5.icon_12687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12688: DrawableResource
+  get() = Drawable5.icon_12688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12689: DrawableResource
+  get() = Drawable5.icon_12689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1269: DrawableResource
+  get() = Drawable5.icon_1269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12690: DrawableResource
+  get() = Drawable5.icon_12690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12691: DrawableResource
+  get() = Drawable5.icon_12691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12692: DrawableResource
+  get() = Drawable5.icon_12692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12693: DrawableResource
+  get() = Drawable5.icon_12693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12694: DrawableResource
+  get() = Drawable5.icon_12694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12695: DrawableResource
+  get() = Drawable5.icon_12695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12696: DrawableResource
+  get() = Drawable5.icon_12696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12697: DrawableResource
+  get() = Drawable5.icon_12697

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable6.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable6.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable6 {
+  public val icon_12698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12698.xml"),
+          )
+      )
+
+  public val icon_12699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12699.xml"),
+          )
+      )
+
+  public val icon_127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_127.xml"),
+          )
+      )
+
+  public val icon_1270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1270.xml"),
+          )
+      )
+
+  public val icon_12700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12700.xml"),
+          )
+      )
+
+  public val icon_12701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12701.xml"),
+          )
+      )
+
+  public val icon_12702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12702.xml"),
+          )
+      )
+
+  public val icon_12703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12703.xml"),
+          )
+      )
+
+  public val icon_12704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12704.xml"),
+          )
+      )
+
+  public val icon_12705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12705.xml"),
+          )
+      )
+
+  public val icon_12706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12706.xml"),
+          )
+      )
+
+  public val icon_12707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12707.xml"),
+          )
+      )
+
+  public val icon_12708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12708.xml"),
+          )
+      )
+
+  public val icon_12709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12709.xml"),
+          )
+      )
+
+  public val icon_1271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1271.xml"),
+          )
+      )
+
+  public val icon_12710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12710.xml"),
+          )
+      )
+
+  public val icon_12711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12711.xml"),
+          )
+      )
+
+  public val icon_12712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12712.xml"),
+          )
+      )
+
+  public val icon_12713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12713.xml"),
+          )
+      )
+
+  public val icon_12714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12714.xml"),
+          )
+      )
+
+  public val icon_12715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12715.xml"),
+          )
+      )
+
+  public val icon_12716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12716.xml"),
+          )
+      )
+
+  public val icon_12717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12717.xml"),
+          )
+      )
+
+  public val icon_12718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12718.xml"),
+          )
+      )
+
+  public val icon_12719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12719.xml"),
+          )
+      )
+
+  public val icon_1272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1272.xml"),
+          )
+      )
+
+  public val icon_12720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12720.xml"),
+          )
+      )
+
+  public val icon_12721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12721.xml"),
+          )
+      )
+
+  public val icon_12722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12722.xml"),
+          )
+      )
+
+  public val icon_12723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12723.xml"),
+          )
+      )
+
+  public val icon_12724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12724.xml"),
+          )
+      )
+
+  public val icon_12725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12725.xml"),
+          )
+      )
+
+  public val icon_12726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12726.xml"),
+          )
+      )
+
+  public val icon_12727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12727.xml"),
+          )
+      )
+
+  public val icon_12728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12728.xml"),
+          )
+      )
+
+  public val icon_12729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12729.xml"),
+          )
+      )
+
+  public val icon_1273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1273.xml"),
+          )
+      )
+
+  public val icon_12730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12730.xml"),
+          )
+      )
+
+  public val icon_12731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12731.xml"),
+          )
+      )
+
+  public val icon_12732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12732.xml"),
+          )
+      )
+
+  public val icon_12733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12733.xml"),
+          )
+      )
+
+  public val icon_12734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12734.xml"),
+          )
+      )
+
+  public val icon_12735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12735.xml"),
+          )
+      )
+
+  public val icon_12736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12736.xml"),
+          )
+      )
+
+  public val icon_12737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12737.xml"),
+          )
+      )
+
+  public val icon_12738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12738.xml"),
+          )
+      )
+
+  public val icon_12739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12739.xml"),
+          )
+      )
+
+  public val icon_1274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1274.xml"),
+          )
+      )
+
+  public val icon_12740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12740.xml"),
+          )
+      )
+
+  public val icon_12741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12741.xml"),
+          )
+      )
+
+  public val icon_12742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12742.xml"),
+          )
+      )
+
+  public val icon_12743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12743.xml"),
+          )
+      )
+
+  public val icon_12744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12744.xml"),
+          )
+      )
+
+  public val icon_12745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12745.xml"),
+          )
+      )
+
+  public val icon_12746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12746.xml"),
+          )
+      )
+
+  public val icon_12747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12747.xml"),
+          )
+      )
+
+  public val icon_12748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12748.xml"),
+          )
+      )
+
+  public val icon_12749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12749.xml"),
+          )
+      )
+
+  public val icon_1275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1275.xml"),
+          )
+      )
+
+  public val icon_12750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12750.xml"),
+          )
+      )
+
+  public val icon_12751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12751.xml"),
+          )
+      )
+
+  public val icon_12752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12752.xml"),
+          )
+      )
+
+  public val icon_12753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12753.xml"),
+          )
+      )
+
+  public val icon_12754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12754.xml"),
+          )
+      )
+
+  public val icon_12755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12755.xml"),
+          )
+      )
+
+  public val icon_12756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12756.xml"),
+          )
+      )
+
+  public val icon_12757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12757.xml"),
+          )
+      )
+
+  public val icon_12758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12758.xml"),
+          )
+      )
+
+  public val icon_12759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12759.xml"),
+          )
+      )
+
+  public val icon_1276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1276.xml"),
+          )
+      )
+
+  public val icon_12760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12760.xml"),
+          )
+      )
+
+  public val icon_12761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12761.xml"),
+          )
+      )
+
+  public val icon_12762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12762.xml"),
+          )
+      )
+
+  public val icon_12763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12763.xml"),
+          )
+      )
+
+  public val icon_12764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12764.xml"),
+          )
+      )
+
+  public val icon_12765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12765.xml"),
+          )
+      )
+
+  public val icon_12766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12766.xml"),
+          )
+      )
+
+  public val icon_12767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12767.xml"),
+          )
+      )
+
+  public val icon_12768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12768.xml"),
+          )
+      )
+
+  public val icon_12769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12769.xml"),
+          )
+      )
+
+  public val icon_1277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1277.xml"),
+          )
+      )
+
+  public val icon_12770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12770.xml"),
+          )
+      )
+
+  public val icon_12771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12771.xml"),
+          )
+      )
+
+  public val icon_12772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12772.xml"),
+          )
+      )
+
+  public val icon_12773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12773.xml"),
+          )
+      )
+
+  public val icon_12774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12774.xml"),
+          )
+      )
+
+  public val icon_12775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12775.xml"),
+          )
+      )
+
+  public val icon_12776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12776.xml"),
+          )
+      )
+
+  public val icon_12777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12777.xml"),
+          )
+      )
+
+  public val icon_12778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12778.xml"),
+          )
+      )
+
+  public val icon_12779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12779.xml"),
+          )
+      )
+
+  public val icon_1278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1278.xml"),
+          )
+      )
+
+  public val icon_12780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12780.xml"),
+          )
+      )
+
+  public val icon_12781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12781.xml"),
+          )
+      )
+
+  public val icon_12782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12782.xml"),
+          )
+      )
+
+  public val icon_12783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12783.xml"),
+          )
+      )
+
+  public val icon_12784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12784.xml"),
+          )
+      )
+
+  public val icon_12785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12785.xml"),
+          )
+      )
+
+  public val icon_12786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12786.xml"),
+          )
+      )
+
+  public val icon_12787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12787.xml"),
+          )
+      )
+
+  public val icon_12788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12788.xml"),
+          )
+      )
+
+  public val icon_12789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12789.xml"),
+          )
+      )
+
+  public val icon_1279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1279.xml"),
+          )
+      )
+
+  public val icon_12790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12790.xml"),
+          )
+      )
+
+  public val icon_12791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12791.xml"),
+          )
+      )
+
+  public val icon_12792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12792.xml"),
+          )
+      )
+
+  public val icon_12793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12793.xml"),
+          )
+      )
+
+  public val icon_12794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12794.xml"),
+          )
+      )
+
+  public val icon_12795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12795.xml"),
+          )
+      )
+
+  public val icon_12796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12796.xml"),
+          )
+      )
+
+  public val icon_12797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12797.xml"),
+          )
+      )
+
+  public val icon_12798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12798.xml"),
+          )
+      )
+
+  public val icon_12799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12799.xml"),
+          )
+      )
+
+  public val icon_128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_128.xml"),
+          )
+      )
+
+  public val icon_1280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1280.xml"),
+          )
+      )
+
+  public val icon_12800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12800.xml"),
+          )
+      )
+
+  public val icon_12801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12801.xml"),
+          )
+      )
+
+  public val icon_12802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12802.xml"),
+          )
+      )
+
+  public val icon_12803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12803.xml"),
+          )
+      )
+
+  public val icon_12804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12804.xml"),
+          )
+      )
+
+  public val icon_12805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12805.xml"),
+          )
+      )
+
+  public val icon_12806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12806.xml"),
+          )
+      )
+
+  public val icon_12807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12807.xml"),
+          )
+      )
+
+  public val icon_12808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12808.xml"),
+          )
+      )
+
+  public val icon_12809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12809.xml"),
+          )
+      )
+
+  public val icon_1281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1281.xml"),
+          )
+      )
+
+  public val icon_12810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12810.xml"),
+          )
+      )
+
+  public val icon_12811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12811.xml"),
+          )
+      )
+
+  public val icon_12812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12812.xml"),
+          )
+      )
+
+  public val icon_12813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12813.xml"),
+          )
+      )
+
+  public val icon_12814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12814.xml"),
+          )
+      )
+
+  public val icon_12815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12815.xml"),
+          )
+      )
+
+  public val icon_12816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12816.xml"),
+          )
+      )
+
+  public val icon_12817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12817.xml"),
+          )
+      )
+
+  public val icon_12818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12818.xml"),
+          )
+      )
+
+  public val icon_12819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12819.xml"),
+          )
+      )
+
+  public val icon_1282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1282.xml"),
+          )
+      )
+
+  public val icon_12820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12820.xml"),
+          )
+      )
+
+  public val icon_12821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12821.xml"),
+          )
+      )
+
+  public val icon_12822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12822.xml"),
+          )
+      )
+
+  public val icon_12823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12823.xml"),
+          )
+      )
+
+  public val icon_12824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12824.xml"),
+          )
+      )
+
+  public val icon_12825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12825.xml"),
+          )
+      )
+
+  public val icon_12826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12826.xml"),
+          )
+      )
+
+  public val icon_12827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12827.xml"),
+          )
+      )
+
+  public val icon_12828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12828.xml"),
+          )
+      )
+
+  public val icon_12829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12829.xml"),
+          )
+      )
+
+  public val icon_1283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1283.xml"),
+          )
+      )
+
+  public val icon_12830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12830.xml"),
+          )
+      )
+
+  public val icon_12831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12831.xml"),
+          )
+      )
+
+  public val icon_12832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12832.xml"),
+          )
+      )
+
+  public val icon_12833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12833.xml"),
+          )
+      )
+
+  public val icon_12834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12834.xml"),
+          )
+      )
+
+  public val icon_12835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12835.xml"),
+          )
+      )
+
+  public val icon_12836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12836.xml"),
+          )
+      )
+
+  public val icon_12837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12837.xml"),
+          )
+      )
+
+  public val icon_12838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12838.xml"),
+          )
+      )
+
+  public val icon_12839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12839.xml"),
+          )
+      )
+
+  public val icon_1284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1284.xml"),
+          )
+      )
+
+  public val icon_12840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12840.xml"),
+          )
+      )
+
+  public val icon_12841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12841.xml"),
+          )
+      )
+
+  public val icon_12842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12842.xml"),
+          )
+      )
+
+  public val icon_12843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12843.xml"),
+          )
+      )
+
+  public val icon_12844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12844.xml"),
+          )
+      )
+
+  public val icon_12845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12845.xml"),
+          )
+      )
+
+  public val icon_12846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12846.xml"),
+          )
+      )
+
+  public val icon_12847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12847.xml"),
+          )
+      )
+
+  public val icon_12848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12848.xml"),
+          )
+      )
+
+  public val icon_12849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12849.xml"),
+          )
+      )
+
+  public val icon_1285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1285.xml"),
+          )
+      )
+
+  public val icon_12850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12850.xml"),
+          )
+      )
+
+  public val icon_12851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12851.xml"),
+          )
+      )
+
+  public val icon_12852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12852.xml"),
+          )
+      )
+
+  public val icon_12853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12853.xml"),
+          )
+      )
+
+  public val icon_12854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12854.xml"),
+          )
+      )
+
+  public val icon_12855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12855.xml"),
+          )
+      )
+
+  public val icon_12856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12856.xml"),
+          )
+      )
+
+  public val icon_12857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12857.xml"),
+          )
+      )
+
+  public val icon_12858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12858.xml"),
+          )
+      )
+
+  public val icon_12859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12859.xml"),
+          )
+      )
+
+  public val icon_1286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1286.xml"),
+          )
+      )
+
+  public val icon_12860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12860.xml"),
+          )
+      )
+
+  public val icon_12861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12861.xml"),
+          )
+      )
+
+  public val icon_12862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12862.xml"),
+          )
+      )
+
+  public val icon_12863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12863.xml"),
+          )
+      )
+
+  public val icon_12864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12864.xml"),
+          )
+      )
+
+  public val icon_12865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12865.xml"),
+          )
+      )
+
+  public val icon_12866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12866.xml"),
+          )
+      )
+
+  public val icon_12867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12867.xml"),
+          )
+      )
+
+  public val icon_12868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12868.xml"),
+          )
+      )
+
+  public val icon_12869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12869.xml"),
+          )
+      )
+
+  public val icon_1287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1287.xml"),
+          )
+      )
+
+  public val icon_12870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12870.xml"),
+          )
+      )
+
+  public val icon_12871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12871.xml"),
+          )
+      )
+
+  public val icon_12872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12872.xml"),
+          )
+      )
+
+  public val icon_12873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12873.xml"),
+          )
+      )
+
+  public val icon_12874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12874.xml"),
+          )
+      )
+
+  public val icon_12875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12875.xml"),
+          )
+      )
+
+  public val icon_12876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12876.xml"),
+          )
+      )
+
+  public val icon_12877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12877.xml"),
+          )
+      )
+
+  public val icon_12878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12878.xml"),
+          )
+      )
+
+  public val icon_12879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12879.xml"),
+          )
+      )
+
+  public val icon_1288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1288.xml"),
+          )
+      )
+
+  public val icon_12880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12880.xml"),
+          )
+      )
+
+  public val icon_12881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12881.xml"),
+          )
+      )
+
+  public val icon_12882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12882.xml"),
+          )
+      )
+
+  public val icon_12883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12883.xml"),
+          )
+      )
+
+  public val icon_12884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12884.xml"),
+          )
+      )
+
+  public val icon_12885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12885.xml"),
+          )
+      )
+
+  public val icon_12886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12886.xml"),
+          )
+      )
+
+  public val icon_12887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12887.xml"),
+          )
+      )
+
+  public val icon_12888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12888.xml"),
+          )
+      )
+
+  public val icon_12889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12889.xml"),
+          )
+      )
+
+  public val icon_1289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1289.xml"),
+          )
+      )
+
+  public val icon_12890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12890.xml"),
+          )
+      )
+
+  public val icon_12891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12891.xml"),
+          )
+      )
+
+  public val icon_12892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12892.xml"),
+          )
+      )
+
+  public val icon_12893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12893.xml"),
+          )
+      )
+
+  public val icon_12894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12894.xml"),
+          )
+      )
+
+  public val icon_12895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12895.xml"),
+          )
+      )
+
+  public val icon_12896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12896.xml"),
+          )
+      )
+
+  public val icon_12897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12897.xml"),
+          )
+      )
+
+  public val icon_12898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12898.xml"),
+          )
+      )
+
+  public val icon_12899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12899.xml"),
+          )
+      )
+
+  public val icon_129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_129.xml"),
+          )
+      )
+
+  public val icon_1290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1290.xml"),
+          )
+      )
+
+  public val icon_12900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12900.xml"),
+          )
+      )
+
+  public val icon_12901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12901.xml"),
+          )
+      )
+
+  public val icon_12902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12902.xml"),
+          )
+      )
+
+  public val icon_12903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12903.xml"),
+          )
+      )
+
+  public val icon_12904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12904.xml"),
+          )
+      )
+
+  public val icon_12905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12905.xml"),
+          )
+      )
+
+  public val icon_12906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12906.xml"),
+          )
+      )
+
+  public val icon_12907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12907.xml"),
+          )
+      )
+
+  public val icon_12908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12908.xml"),
+          )
+      )
+
+  public val icon_12909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12909.xml"),
+          )
+      )
+
+  public val icon_1291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1291.xml"),
+          )
+      )
+
+  public val icon_12910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12910.xml"),
+          )
+      )
+
+  public val icon_12911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12911.xml"),
+          )
+      )
+
+  public val icon_12912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12912.xml"),
+          )
+      )
+
+  public val icon_12913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12913.xml"),
+          )
+      )
+
+  public val icon_12914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12914.xml"),
+          )
+      )
+
+  public val icon_12915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12915.xml"),
+          )
+      )
+
+  public val icon_12916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12916.xml"),
+          )
+      )
+
+  public val icon_12917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12917.xml"),
+          )
+      )
+
+  public val icon_12918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12918.xml"),
+          )
+      )
+
+  public val icon_12919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12919.xml"),
+          )
+      )
+
+  public val icon_1292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1292.xml"),
+          )
+      )
+
+  public val icon_12920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12920.xml"),
+          )
+      )
+
+  public val icon_12921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12921.xml"),
+          )
+      )
+
+  public val icon_12922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12922.xml"),
+          )
+      )
+
+  public val icon_12923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12923.xml"),
+          )
+      )
+
+  public val icon_12924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12924.xml"),
+          )
+      )
+
+  public val icon_12925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12925.xml"),
+          )
+      )
+
+  public val icon_12926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12926.xml"),
+          )
+      )
+
+  public val icon_12927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12927.xml"),
+          )
+      )
+
+  public val icon_12928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12928.xml"),
+          )
+      )
+
+  public val icon_12929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12929.xml"),
+          )
+      )
+
+  public val icon_1293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1293.xml"),
+          )
+      )
+
+  public val icon_12930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12930.xml"),
+          )
+      )
+
+  public val icon_12931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12931.xml"),
+          )
+      )
+
+  public val icon_12932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12932.xml"),
+          )
+      )
+
+  public val icon_12933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12933.xml"),
+          )
+      )
+
+  public val icon_12934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12934.xml"),
+          )
+      )
+
+  public val icon_12935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12935.xml"),
+          )
+      )
+
+  public val icon_12936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12936.xml"),
+          )
+      )
+
+  public val icon_12937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12937.xml"),
+          )
+      )
+
+  public val icon_12938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12938.xml"),
+          )
+      )
+
+  public val icon_12939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12939.xml"),
+          )
+      )
+
+  public val icon_1294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1294.xml"),
+          )
+      )
+
+  public val icon_12940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12940.xml"),
+          )
+      )
+
+  public val icon_12941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12941.xml"),
+          )
+      )
+
+  public val icon_12942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12942.xml"),
+          )
+      )
+
+  public val icon_12943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12943.xml"),
+          )
+      )
+
+  public val icon_12944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12944.xml"),
+          )
+      )
+
+  public val icon_12945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12945.xml"),
+          )
+      )
+
+  public val icon_12946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12946.xml"),
+          )
+      )
+
+  public val icon_12947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12947.xml"),
+          )
+      )
+
+  public val icon_12948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12948.xml"),
+          )
+      )
+
+  public val icon_12949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12949.xml"),
+          )
+      )
+
+  public val icon_1295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1295.xml"),
+          )
+      )
+
+  public val icon_12950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12950.xml"),
+          )
+      )
+
+  public val icon_12951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12951.xml"),
+          )
+      )
+
+  public val icon_12952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12952.xml"),
+          )
+      )
+
+  public val icon_12953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12953.xml"),
+          )
+      )
+
+  public val icon_12954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12954.xml"),
+          )
+      )
+
+  public val icon_12955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12955.xml"),
+          )
+      )
+
+  public val icon_12956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12956.xml"),
+          )
+      )
+
+  public val icon_12957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12957.xml"),
+          )
+      )
+
+  public val icon_12958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12958.xml"),
+          )
+      )
+
+  public val icon_12959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12959.xml"),
+          )
+      )
+
+  public val icon_1296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1296.xml"),
+          )
+      )
+
+  public val icon_12960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12960.xml"),
+          )
+      )
+
+  public val icon_12961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12961.xml"),
+          )
+      )
+
+  public val icon_12962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12962.xml"),
+          )
+      )
+
+  public val icon_12963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12963.xml"),
+          )
+      )
+
+  public val icon_12964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12964.xml"),
+          )
+      )
+
+  public val icon_12965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12965.xml"),
+          )
+      )
+
+  public val icon_12966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12966.xml"),
+          )
+      )
+
+  public val icon_12967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12967.xml"),
+          )
+      )
+
+  public val icon_12968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12968.xml"),
+          )
+      )
+
+  public val icon_12969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12969.xml"),
+          )
+      )
+
+  public val icon_1297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1297.xml"),
+          )
+      )
+
+  public val icon_12970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12970.xml"),
+          )
+      )
+
+  public val icon_12971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12971.xml"),
+          )
+      )
+
+  public val icon_12972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12972.xml"),
+          )
+      )
+
+  public val icon_12973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12973.xml"),
+          )
+      )
+
+  public val icon_12974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12974.xml"),
+          )
+      )
+
+  public val icon_12975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12975.xml"),
+          )
+      )
+
+  public val icon_12976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12976.xml"),
+          )
+      )
+
+  public val icon_12977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12977.xml"),
+          )
+      )
+
+  public val icon_12978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12978.xml"),
+          )
+      )
+
+  public val icon_12979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12979.xml"),
+          )
+      )
+
+  public val icon_1298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1298.xml"),
+          )
+      )
+
+  public val icon_12980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12980.xml"),
+          )
+      )
+
+  public val icon_12981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12981.xml"),
+          )
+      )
+
+  public val icon_12982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12982.xml"),
+          )
+      )
+
+  public val icon_12983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12983.xml"),
+          )
+      )
+
+  public val icon_12984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12984.xml"),
+          )
+      )
+
+  public val icon_12985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12985.xml"),
+          )
+      )
+
+  public val icon_12986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12986.xml"),
+          )
+      )
+
+  public val icon_12987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12987.xml"),
+          )
+      )
+
+  public val icon_12988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12988.xml"),
+          )
+      )
+
+  public val icon_12989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12989.xml"),
+          )
+      )
+
+  public val icon_1299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1299.xml"),
+          )
+      )
+
+  public val icon_12990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12990.xml"),
+          )
+      )
+
+  public val icon_12991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12991.xml"),
+          )
+      )
+
+  public val icon_12992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12992.xml"),
+          )
+      )
+
+  public val icon_12993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12993.xml"),
+          )
+      )
+
+  public val icon_12994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12994.xml"),
+          )
+      )
+
+  public val icon_12995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12995.xml"),
+          )
+      )
+
+  public val icon_12996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12996.xml"),
+          )
+      )
+
+  public val icon_12997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12997.xml"),
+          )
+      )
+
+  public val icon_12998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12998.xml"),
+          )
+      )
+
+  public val icon_12999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_12999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_12999.xml"),
+          )
+      )
+
+  public val icon_13: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13.xml"),
+          )
+      )
+
+  public val icon_130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_130.xml"),
+          )
+      )
+
+  public val icon_1300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1300.xml"),
+          )
+      )
+
+  public val icon_13000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13000.xml"),
+          )
+      )
+
+  public val icon_13001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13001.xml"),
+          )
+      )
+
+  public val icon_13002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13002.xml"),
+          )
+      )
+
+  public val icon_13003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13003.xml"),
+          )
+      )
+
+  public val icon_13004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13004.xml"),
+          )
+      )
+
+  public val icon_13005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13005.xml"),
+          )
+      )
+
+  public val icon_13006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13006.xml"),
+          )
+      )
+
+  public val icon_13007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13007.xml"),
+          )
+      )
+
+  public val icon_13008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13008.xml"),
+          )
+      )
+
+  public val icon_13009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13009.xml"),
+          )
+      )
+
+  public val icon_1301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1301.xml"),
+          )
+      )
+
+  public val icon_13010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13010.xml"),
+          )
+      )
+
+  public val icon_13011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13011.xml"),
+          )
+      )
+
+  public val icon_13012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13012.xml"),
+          )
+      )
+
+  public val icon_13013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13013.xml"),
+          )
+      )
+
+  public val icon_13014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13014.xml"),
+          )
+      )
+
+  public val icon_13015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13015.xml"),
+          )
+      )
+
+  public val icon_13016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13016.xml"),
+          )
+      )
+
+  public val icon_13017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13017.xml"),
+          )
+      )
+
+  public val icon_13018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13018.xml"),
+          )
+      )
+
+  public val icon_13019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13019.xml"),
+          )
+      )
+
+  public val icon_1302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1302.xml"),
+          )
+      )
+
+  public val icon_13020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13020.xml"),
+          )
+      )
+
+  public val icon_13021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13021.xml"),
+          )
+      )
+
+  public val icon_13022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13022.xml"),
+          )
+      )
+
+  public val icon_13023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13023.xml"),
+          )
+      )
+
+  public val icon_13024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13024.xml"),
+          )
+      )
+
+  public val icon_13025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13025.xml"),
+          )
+      )
+
+  public val icon_13026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13026.xml"),
+          )
+      )
+
+  public val icon_13027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13027.xml"),
+          )
+      )
+
+  public val icon_13028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13028.xml"),
+          )
+      )
+
+  public val icon_13029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13029.xml"),
+          )
+      )
+
+  public val icon_1303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1303.xml"),
+          )
+      )
+
+  public val icon_13030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13030.xml"),
+          )
+      )
+
+  public val icon_13031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13031.xml"),
+          )
+      )
+
+  public val icon_13032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13032.xml"),
+          )
+      )
+
+  public val icon_13033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13033.xml"),
+          )
+      )
+
+  public val icon_13034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13034.xml"),
+          )
+      )
+
+  public val icon_13035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13035.xml"),
+          )
+      )
+
+  public val icon_13036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13036.xml"),
+          )
+      )
+
+  public val icon_13037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13037.xml"),
+          )
+      )
+
+  public val icon_13038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13038.xml"),
+          )
+      )
+
+  public val icon_13039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13039.xml"),
+          )
+      )
+
+  public val icon_1304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1304.xml"),
+          )
+      )
+
+  public val icon_13040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13040.xml"),
+          )
+      )
+
+  public val icon_13041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13041.xml"),
+          )
+      )
+
+  public val icon_13042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13042.xml"),
+          )
+      )
+
+  public val icon_13043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13043.xml"),
+          )
+      )
+
+  public val icon_13044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13044.xml"),
+          )
+      )
+
+  public val icon_13045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13045.xml"),
+          )
+      )
+
+  public val icon_13046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13046.xml"),
+          )
+      )
+
+  public val icon_13047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13047.xml"),
+          )
+      )
+
+  public val icon_13048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13048.xml"),
+          )
+      )
+
+  public val icon_13049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13049.xml"),
+          )
+      )
+
+  public val icon_1305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1305.xml"),
+          )
+      )
+
+  public val icon_13050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13050.xml"),
+          )
+      )
+
+  public val icon_13051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13051.xml"),
+          )
+      )
+
+  public val icon_13052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13052.xml"),
+          )
+      )
+
+  public val icon_13053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13053.xml"),
+          )
+      )
+
+  public val icon_13054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13054.xml"),
+          )
+      )
+
+  public val icon_13055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13055.xml"),
+          )
+      )
+
+  public val icon_13056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13056.xml"),
+          )
+      )
+
+  public val icon_13057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13057.xml"),
+          )
+      )
+
+  public val icon_13058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13058.xml"),
+          )
+      )
+
+  public val icon_13059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13059.xml"),
+          )
+      )
+
+  public val icon_1306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1306.xml"),
+          )
+      )
+
+  public val icon_13060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13060.xml"),
+          )
+      )
+
+  public val icon_13061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13061.xml"),
+          )
+      )
+
+  public val icon_13062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13062.xml"),
+          )
+      )
+
+  public val icon_13063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13063.xml"),
+          )
+      )
+
+  public val icon_13064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13064.xml"),
+          )
+      )
+
+  public val icon_13065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13065.xml"),
+          )
+      )
+
+  public val icon_13066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13066.xml"),
+          )
+      )
+
+  public val icon_13067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13067.xml"),
+          )
+      )
+
+  public val icon_13068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13068.xml"),
+          )
+      )
+
+  public val icon_13069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13069.xml"),
+          )
+      )
+
+  public val icon_1307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1307.xml"),
+          )
+      )
+
+  public val icon_13070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13070.xml"),
+          )
+      )
+
+  public val icon_13071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13071.xml"),
+          )
+      )
+
+  public val icon_13072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13072.xml"),
+          )
+      )
+
+  public val icon_13073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13073.xml"),
+          )
+      )
+
+  public val icon_13074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13074.xml"),
+          )
+      )
+
+  public val icon_13075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13075.xml"),
+          )
+      )
+
+  public val icon_13076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13076.xml"),
+          )
+      )
+
+  public val icon_13077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13077.xml"),
+          )
+      )
+
+  public val icon_13078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13078.xml"),
+          )
+      )
+
+  public val icon_13079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13079.xml"),
+          )
+      )
+
+  public val icon_1308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1308.xml"),
+          )
+      )
+
+  public val icon_13080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13080.xml"),
+          )
+      )
+
+  public val icon_13081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13081.xml"),
+          )
+      )
+
+  public val icon_13082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13082.xml"),
+          )
+      )
+
+  public val icon_13083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13083.xml"),
+          )
+      )
+
+  public val icon_13084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13084.xml"),
+          )
+      )
+
+  public val icon_13085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13085.xml"),
+          )
+      )
+
+  public val icon_13086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13086.xml"),
+          )
+      )
+
+  public val icon_13087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13087.xml"),
+          )
+      )
+
+  public val icon_13088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13088.xml"),
+          )
+      )
+
+  public val icon_13089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13089.xml"),
+          )
+      )
+
+  public val icon_1309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1309.xml"),
+          )
+      )
+
+  public val icon_13090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13090.xml"),
+          )
+      )
+
+  public val icon_13091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13091.xml"),
+          )
+      )
+
+  public val icon_13092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13092.xml"),
+          )
+      )
+
+  public val icon_13093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13093.xml"),
+          )
+      )
+
+  public val icon_13094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13094.xml"),
+          )
+      )
+
+  public val icon_13095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13095.xml"),
+          )
+      )
+
+  public val icon_13096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13096.xml"),
+          )
+      )
+
+  public val icon_13097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13097.xml"),
+          )
+      )
+
+  public val icon_13098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13098.xml"),
+          )
+      )
+
+  public val icon_13099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13099.xml"),
+          )
+      )
+
+  public val icon_131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_131.xml"),
+          )
+      )
+
+  public val icon_1310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1310.xml"),
+          )
+      )
+
+  public val icon_13100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13100.xml"),
+          )
+      )
+
+  public val icon_13101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13101.xml"),
+          )
+      )
+
+  public val icon_13102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13102.xml"),
+          )
+      )
+
+  public val icon_13103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13103.xml"),
+          )
+      )
+
+  public val icon_13104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13104.xml"),
+          )
+      )
+
+  public val icon_13105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13105.xml"),
+          )
+      )
+
+  public val icon_13106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13106.xml"),
+          )
+      )
+
+  public val icon_13107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13107.xml"),
+          )
+      )
+
+  public val icon_13108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13108.xml"),
+          )
+      )
+
+  public val icon_13109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13109.xml"),
+          )
+      )
+
+  public val icon_1311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1311.xml"),
+          )
+      )
+
+  public val icon_13110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13110.xml"),
+          )
+      )
+
+  public val icon_13111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13111.xml"),
+          )
+      )
+
+  public val icon_13112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13112.xml"),
+          )
+      )
+
+  public val icon_13113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13113.xml"),
+          )
+      )
+
+  public val icon_13114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13114.xml"),
+          )
+      )
+
+  public val icon_13115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13115.xml"),
+          )
+      )
+
+  public val icon_13116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13116.xml"),
+          )
+      )
+
+  public val icon_13117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13117.xml"),
+          )
+      )
+
+  public val icon_13118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13118.xml"),
+          )
+      )
+
+  public val icon_13119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13119.xml"),
+          )
+      )
+
+  public val icon_1312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1312.xml"),
+          )
+      )
+
+  public val icon_13120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13120.xml"),
+          )
+      )
+
+  public val icon_13121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13121.xml"),
+          )
+      )
+
+  public val icon_13122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13122.xml"),
+          )
+      )
+
+  public val icon_13123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13123.xml"),
+          )
+      )
+
+  public val icon_13124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13124.xml"),
+          )
+      )
+
+  public val icon_13125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13125.xml"),
+          )
+      )
+
+  public val icon_13126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13126.xml"),
+          )
+      )
+
+  public val icon_13127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13127.xml"),
+          )
+      )
+
+  public val icon_13128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13128.xml"),
+          )
+      )
+
+  public val icon_13129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13129.xml"),
+          )
+      )
+
+  public val icon_1313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1313.xml"),
+          )
+      )
+
+  public val icon_13130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13130.xml"),
+          )
+      )
+
+  public val icon_13131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13131.xml"),
+          )
+      )
+
+  public val icon_13132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13132.xml"),
+          )
+      )
+
+  public val icon_13133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13133.xml"),
+          )
+      )
+
+  public val icon_13134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13134.xml"),
+          )
+      )
+
+  public val icon_13135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13135.xml"),
+          )
+      )
+
+  public val icon_13136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13136.xml"),
+          )
+      )
+
+  public val icon_13137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13137.xml"),
+          )
+      )
+
+  public val icon_13138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13138.xml"),
+          )
+      )
+
+  public val icon_13139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13139.xml"),
+          )
+      )
+
+  public val icon_1314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1314.xml"),
+          )
+      )
+
+  public val icon_13140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13140.xml"),
+          )
+      )
+
+  public val icon_13141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13141.xml"),
+          )
+      )
+
+  public val icon_13142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13142.xml"),
+          )
+      )
+
+  public val icon_13143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13143.xml"),
+          )
+      )
+
+  public val icon_13144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13144.xml"),
+          )
+      )
+
+  public val icon_13145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13145.xml"),
+          )
+      )
+
+  public val icon_13146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13146.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12698: DrawableResource
+  get() = Drawable6.icon_12698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12699: DrawableResource
+  get() = Drawable6.icon_12699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_127: DrawableResource
+  get() = Drawable6.icon_127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1270: DrawableResource
+  get() = Drawable6.icon_1270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12700: DrawableResource
+  get() = Drawable6.icon_12700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12701: DrawableResource
+  get() = Drawable6.icon_12701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12702: DrawableResource
+  get() = Drawable6.icon_12702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12703: DrawableResource
+  get() = Drawable6.icon_12703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12704: DrawableResource
+  get() = Drawable6.icon_12704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12705: DrawableResource
+  get() = Drawable6.icon_12705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12706: DrawableResource
+  get() = Drawable6.icon_12706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12707: DrawableResource
+  get() = Drawable6.icon_12707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12708: DrawableResource
+  get() = Drawable6.icon_12708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12709: DrawableResource
+  get() = Drawable6.icon_12709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1271: DrawableResource
+  get() = Drawable6.icon_1271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12710: DrawableResource
+  get() = Drawable6.icon_12710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12711: DrawableResource
+  get() = Drawable6.icon_12711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12712: DrawableResource
+  get() = Drawable6.icon_12712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12713: DrawableResource
+  get() = Drawable6.icon_12713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12714: DrawableResource
+  get() = Drawable6.icon_12714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12715: DrawableResource
+  get() = Drawable6.icon_12715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12716: DrawableResource
+  get() = Drawable6.icon_12716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12717: DrawableResource
+  get() = Drawable6.icon_12717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12718: DrawableResource
+  get() = Drawable6.icon_12718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12719: DrawableResource
+  get() = Drawable6.icon_12719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1272: DrawableResource
+  get() = Drawable6.icon_1272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12720: DrawableResource
+  get() = Drawable6.icon_12720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12721: DrawableResource
+  get() = Drawable6.icon_12721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12722: DrawableResource
+  get() = Drawable6.icon_12722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12723: DrawableResource
+  get() = Drawable6.icon_12723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12724: DrawableResource
+  get() = Drawable6.icon_12724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12725: DrawableResource
+  get() = Drawable6.icon_12725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12726: DrawableResource
+  get() = Drawable6.icon_12726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12727: DrawableResource
+  get() = Drawable6.icon_12727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12728: DrawableResource
+  get() = Drawable6.icon_12728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12729: DrawableResource
+  get() = Drawable6.icon_12729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1273: DrawableResource
+  get() = Drawable6.icon_1273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12730: DrawableResource
+  get() = Drawable6.icon_12730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12731: DrawableResource
+  get() = Drawable6.icon_12731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12732: DrawableResource
+  get() = Drawable6.icon_12732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12733: DrawableResource
+  get() = Drawable6.icon_12733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12734: DrawableResource
+  get() = Drawable6.icon_12734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12735: DrawableResource
+  get() = Drawable6.icon_12735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12736: DrawableResource
+  get() = Drawable6.icon_12736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12737: DrawableResource
+  get() = Drawable6.icon_12737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12738: DrawableResource
+  get() = Drawable6.icon_12738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12739: DrawableResource
+  get() = Drawable6.icon_12739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1274: DrawableResource
+  get() = Drawable6.icon_1274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12740: DrawableResource
+  get() = Drawable6.icon_12740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12741: DrawableResource
+  get() = Drawable6.icon_12741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12742: DrawableResource
+  get() = Drawable6.icon_12742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12743: DrawableResource
+  get() = Drawable6.icon_12743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12744: DrawableResource
+  get() = Drawable6.icon_12744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12745: DrawableResource
+  get() = Drawable6.icon_12745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12746: DrawableResource
+  get() = Drawable6.icon_12746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12747: DrawableResource
+  get() = Drawable6.icon_12747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12748: DrawableResource
+  get() = Drawable6.icon_12748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12749: DrawableResource
+  get() = Drawable6.icon_12749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1275: DrawableResource
+  get() = Drawable6.icon_1275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12750: DrawableResource
+  get() = Drawable6.icon_12750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12751: DrawableResource
+  get() = Drawable6.icon_12751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12752: DrawableResource
+  get() = Drawable6.icon_12752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12753: DrawableResource
+  get() = Drawable6.icon_12753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12754: DrawableResource
+  get() = Drawable6.icon_12754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12755: DrawableResource
+  get() = Drawable6.icon_12755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12756: DrawableResource
+  get() = Drawable6.icon_12756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12757: DrawableResource
+  get() = Drawable6.icon_12757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12758: DrawableResource
+  get() = Drawable6.icon_12758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12759: DrawableResource
+  get() = Drawable6.icon_12759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1276: DrawableResource
+  get() = Drawable6.icon_1276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12760: DrawableResource
+  get() = Drawable6.icon_12760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12761: DrawableResource
+  get() = Drawable6.icon_12761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12762: DrawableResource
+  get() = Drawable6.icon_12762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12763: DrawableResource
+  get() = Drawable6.icon_12763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12764: DrawableResource
+  get() = Drawable6.icon_12764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12765: DrawableResource
+  get() = Drawable6.icon_12765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12766: DrawableResource
+  get() = Drawable6.icon_12766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12767: DrawableResource
+  get() = Drawable6.icon_12767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12768: DrawableResource
+  get() = Drawable6.icon_12768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12769: DrawableResource
+  get() = Drawable6.icon_12769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1277: DrawableResource
+  get() = Drawable6.icon_1277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12770: DrawableResource
+  get() = Drawable6.icon_12770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12771: DrawableResource
+  get() = Drawable6.icon_12771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12772: DrawableResource
+  get() = Drawable6.icon_12772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12773: DrawableResource
+  get() = Drawable6.icon_12773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12774: DrawableResource
+  get() = Drawable6.icon_12774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12775: DrawableResource
+  get() = Drawable6.icon_12775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12776: DrawableResource
+  get() = Drawable6.icon_12776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12777: DrawableResource
+  get() = Drawable6.icon_12777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12778: DrawableResource
+  get() = Drawable6.icon_12778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12779: DrawableResource
+  get() = Drawable6.icon_12779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1278: DrawableResource
+  get() = Drawable6.icon_1278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12780: DrawableResource
+  get() = Drawable6.icon_12780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12781: DrawableResource
+  get() = Drawable6.icon_12781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12782: DrawableResource
+  get() = Drawable6.icon_12782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12783: DrawableResource
+  get() = Drawable6.icon_12783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12784: DrawableResource
+  get() = Drawable6.icon_12784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12785: DrawableResource
+  get() = Drawable6.icon_12785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12786: DrawableResource
+  get() = Drawable6.icon_12786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12787: DrawableResource
+  get() = Drawable6.icon_12787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12788: DrawableResource
+  get() = Drawable6.icon_12788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12789: DrawableResource
+  get() = Drawable6.icon_12789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1279: DrawableResource
+  get() = Drawable6.icon_1279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12790: DrawableResource
+  get() = Drawable6.icon_12790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12791: DrawableResource
+  get() = Drawable6.icon_12791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12792: DrawableResource
+  get() = Drawable6.icon_12792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12793: DrawableResource
+  get() = Drawable6.icon_12793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12794: DrawableResource
+  get() = Drawable6.icon_12794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12795: DrawableResource
+  get() = Drawable6.icon_12795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12796: DrawableResource
+  get() = Drawable6.icon_12796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12797: DrawableResource
+  get() = Drawable6.icon_12797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12798: DrawableResource
+  get() = Drawable6.icon_12798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12799: DrawableResource
+  get() = Drawable6.icon_12799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_128: DrawableResource
+  get() = Drawable6.icon_128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1280: DrawableResource
+  get() = Drawable6.icon_1280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12800: DrawableResource
+  get() = Drawable6.icon_12800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12801: DrawableResource
+  get() = Drawable6.icon_12801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12802: DrawableResource
+  get() = Drawable6.icon_12802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12803: DrawableResource
+  get() = Drawable6.icon_12803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12804: DrawableResource
+  get() = Drawable6.icon_12804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12805: DrawableResource
+  get() = Drawable6.icon_12805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12806: DrawableResource
+  get() = Drawable6.icon_12806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12807: DrawableResource
+  get() = Drawable6.icon_12807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12808: DrawableResource
+  get() = Drawable6.icon_12808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12809: DrawableResource
+  get() = Drawable6.icon_12809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1281: DrawableResource
+  get() = Drawable6.icon_1281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12810: DrawableResource
+  get() = Drawable6.icon_12810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12811: DrawableResource
+  get() = Drawable6.icon_12811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12812: DrawableResource
+  get() = Drawable6.icon_12812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12813: DrawableResource
+  get() = Drawable6.icon_12813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12814: DrawableResource
+  get() = Drawable6.icon_12814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12815: DrawableResource
+  get() = Drawable6.icon_12815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12816: DrawableResource
+  get() = Drawable6.icon_12816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12817: DrawableResource
+  get() = Drawable6.icon_12817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12818: DrawableResource
+  get() = Drawable6.icon_12818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12819: DrawableResource
+  get() = Drawable6.icon_12819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1282: DrawableResource
+  get() = Drawable6.icon_1282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12820: DrawableResource
+  get() = Drawable6.icon_12820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12821: DrawableResource
+  get() = Drawable6.icon_12821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12822: DrawableResource
+  get() = Drawable6.icon_12822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12823: DrawableResource
+  get() = Drawable6.icon_12823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12824: DrawableResource
+  get() = Drawable6.icon_12824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12825: DrawableResource
+  get() = Drawable6.icon_12825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12826: DrawableResource
+  get() = Drawable6.icon_12826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12827: DrawableResource
+  get() = Drawable6.icon_12827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12828: DrawableResource
+  get() = Drawable6.icon_12828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12829: DrawableResource
+  get() = Drawable6.icon_12829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1283: DrawableResource
+  get() = Drawable6.icon_1283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12830: DrawableResource
+  get() = Drawable6.icon_12830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12831: DrawableResource
+  get() = Drawable6.icon_12831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12832: DrawableResource
+  get() = Drawable6.icon_12832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12833: DrawableResource
+  get() = Drawable6.icon_12833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12834: DrawableResource
+  get() = Drawable6.icon_12834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12835: DrawableResource
+  get() = Drawable6.icon_12835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12836: DrawableResource
+  get() = Drawable6.icon_12836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12837: DrawableResource
+  get() = Drawable6.icon_12837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12838: DrawableResource
+  get() = Drawable6.icon_12838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12839: DrawableResource
+  get() = Drawable6.icon_12839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1284: DrawableResource
+  get() = Drawable6.icon_1284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12840: DrawableResource
+  get() = Drawable6.icon_12840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12841: DrawableResource
+  get() = Drawable6.icon_12841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12842: DrawableResource
+  get() = Drawable6.icon_12842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12843: DrawableResource
+  get() = Drawable6.icon_12843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12844: DrawableResource
+  get() = Drawable6.icon_12844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12845: DrawableResource
+  get() = Drawable6.icon_12845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12846: DrawableResource
+  get() = Drawable6.icon_12846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12847: DrawableResource
+  get() = Drawable6.icon_12847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12848: DrawableResource
+  get() = Drawable6.icon_12848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12849: DrawableResource
+  get() = Drawable6.icon_12849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1285: DrawableResource
+  get() = Drawable6.icon_1285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12850: DrawableResource
+  get() = Drawable6.icon_12850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12851: DrawableResource
+  get() = Drawable6.icon_12851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12852: DrawableResource
+  get() = Drawable6.icon_12852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12853: DrawableResource
+  get() = Drawable6.icon_12853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12854: DrawableResource
+  get() = Drawable6.icon_12854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12855: DrawableResource
+  get() = Drawable6.icon_12855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12856: DrawableResource
+  get() = Drawable6.icon_12856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12857: DrawableResource
+  get() = Drawable6.icon_12857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12858: DrawableResource
+  get() = Drawable6.icon_12858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12859: DrawableResource
+  get() = Drawable6.icon_12859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1286: DrawableResource
+  get() = Drawable6.icon_1286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12860: DrawableResource
+  get() = Drawable6.icon_12860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12861: DrawableResource
+  get() = Drawable6.icon_12861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12862: DrawableResource
+  get() = Drawable6.icon_12862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12863: DrawableResource
+  get() = Drawable6.icon_12863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12864: DrawableResource
+  get() = Drawable6.icon_12864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12865: DrawableResource
+  get() = Drawable6.icon_12865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12866: DrawableResource
+  get() = Drawable6.icon_12866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12867: DrawableResource
+  get() = Drawable6.icon_12867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12868: DrawableResource
+  get() = Drawable6.icon_12868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12869: DrawableResource
+  get() = Drawable6.icon_12869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1287: DrawableResource
+  get() = Drawable6.icon_1287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12870: DrawableResource
+  get() = Drawable6.icon_12870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12871: DrawableResource
+  get() = Drawable6.icon_12871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12872: DrawableResource
+  get() = Drawable6.icon_12872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12873: DrawableResource
+  get() = Drawable6.icon_12873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12874: DrawableResource
+  get() = Drawable6.icon_12874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12875: DrawableResource
+  get() = Drawable6.icon_12875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12876: DrawableResource
+  get() = Drawable6.icon_12876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12877: DrawableResource
+  get() = Drawable6.icon_12877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12878: DrawableResource
+  get() = Drawable6.icon_12878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12879: DrawableResource
+  get() = Drawable6.icon_12879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1288: DrawableResource
+  get() = Drawable6.icon_1288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12880: DrawableResource
+  get() = Drawable6.icon_12880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12881: DrawableResource
+  get() = Drawable6.icon_12881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12882: DrawableResource
+  get() = Drawable6.icon_12882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12883: DrawableResource
+  get() = Drawable6.icon_12883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12884: DrawableResource
+  get() = Drawable6.icon_12884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12885: DrawableResource
+  get() = Drawable6.icon_12885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12886: DrawableResource
+  get() = Drawable6.icon_12886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12887: DrawableResource
+  get() = Drawable6.icon_12887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12888: DrawableResource
+  get() = Drawable6.icon_12888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12889: DrawableResource
+  get() = Drawable6.icon_12889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1289: DrawableResource
+  get() = Drawable6.icon_1289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12890: DrawableResource
+  get() = Drawable6.icon_12890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12891: DrawableResource
+  get() = Drawable6.icon_12891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12892: DrawableResource
+  get() = Drawable6.icon_12892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12893: DrawableResource
+  get() = Drawable6.icon_12893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12894: DrawableResource
+  get() = Drawable6.icon_12894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12895: DrawableResource
+  get() = Drawable6.icon_12895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12896: DrawableResource
+  get() = Drawable6.icon_12896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12897: DrawableResource
+  get() = Drawable6.icon_12897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12898: DrawableResource
+  get() = Drawable6.icon_12898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12899: DrawableResource
+  get() = Drawable6.icon_12899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_129: DrawableResource
+  get() = Drawable6.icon_129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1290: DrawableResource
+  get() = Drawable6.icon_1290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12900: DrawableResource
+  get() = Drawable6.icon_12900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12901: DrawableResource
+  get() = Drawable6.icon_12901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12902: DrawableResource
+  get() = Drawable6.icon_12902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12903: DrawableResource
+  get() = Drawable6.icon_12903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12904: DrawableResource
+  get() = Drawable6.icon_12904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12905: DrawableResource
+  get() = Drawable6.icon_12905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12906: DrawableResource
+  get() = Drawable6.icon_12906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12907: DrawableResource
+  get() = Drawable6.icon_12907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12908: DrawableResource
+  get() = Drawable6.icon_12908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12909: DrawableResource
+  get() = Drawable6.icon_12909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1291: DrawableResource
+  get() = Drawable6.icon_1291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12910: DrawableResource
+  get() = Drawable6.icon_12910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12911: DrawableResource
+  get() = Drawable6.icon_12911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12912: DrawableResource
+  get() = Drawable6.icon_12912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12913: DrawableResource
+  get() = Drawable6.icon_12913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12914: DrawableResource
+  get() = Drawable6.icon_12914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12915: DrawableResource
+  get() = Drawable6.icon_12915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12916: DrawableResource
+  get() = Drawable6.icon_12916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12917: DrawableResource
+  get() = Drawable6.icon_12917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12918: DrawableResource
+  get() = Drawable6.icon_12918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12919: DrawableResource
+  get() = Drawable6.icon_12919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1292: DrawableResource
+  get() = Drawable6.icon_1292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12920: DrawableResource
+  get() = Drawable6.icon_12920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12921: DrawableResource
+  get() = Drawable6.icon_12921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12922: DrawableResource
+  get() = Drawable6.icon_12922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12923: DrawableResource
+  get() = Drawable6.icon_12923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12924: DrawableResource
+  get() = Drawable6.icon_12924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12925: DrawableResource
+  get() = Drawable6.icon_12925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12926: DrawableResource
+  get() = Drawable6.icon_12926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12927: DrawableResource
+  get() = Drawable6.icon_12927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12928: DrawableResource
+  get() = Drawable6.icon_12928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12929: DrawableResource
+  get() = Drawable6.icon_12929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1293: DrawableResource
+  get() = Drawable6.icon_1293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12930: DrawableResource
+  get() = Drawable6.icon_12930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12931: DrawableResource
+  get() = Drawable6.icon_12931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12932: DrawableResource
+  get() = Drawable6.icon_12932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12933: DrawableResource
+  get() = Drawable6.icon_12933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12934: DrawableResource
+  get() = Drawable6.icon_12934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12935: DrawableResource
+  get() = Drawable6.icon_12935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12936: DrawableResource
+  get() = Drawable6.icon_12936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12937: DrawableResource
+  get() = Drawable6.icon_12937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12938: DrawableResource
+  get() = Drawable6.icon_12938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12939: DrawableResource
+  get() = Drawable6.icon_12939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1294: DrawableResource
+  get() = Drawable6.icon_1294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12940: DrawableResource
+  get() = Drawable6.icon_12940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12941: DrawableResource
+  get() = Drawable6.icon_12941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12942: DrawableResource
+  get() = Drawable6.icon_12942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12943: DrawableResource
+  get() = Drawable6.icon_12943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12944: DrawableResource
+  get() = Drawable6.icon_12944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12945: DrawableResource
+  get() = Drawable6.icon_12945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12946: DrawableResource
+  get() = Drawable6.icon_12946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12947: DrawableResource
+  get() = Drawable6.icon_12947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12948: DrawableResource
+  get() = Drawable6.icon_12948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12949: DrawableResource
+  get() = Drawable6.icon_12949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1295: DrawableResource
+  get() = Drawable6.icon_1295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12950: DrawableResource
+  get() = Drawable6.icon_12950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12951: DrawableResource
+  get() = Drawable6.icon_12951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12952: DrawableResource
+  get() = Drawable6.icon_12952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12953: DrawableResource
+  get() = Drawable6.icon_12953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12954: DrawableResource
+  get() = Drawable6.icon_12954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12955: DrawableResource
+  get() = Drawable6.icon_12955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12956: DrawableResource
+  get() = Drawable6.icon_12956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12957: DrawableResource
+  get() = Drawable6.icon_12957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12958: DrawableResource
+  get() = Drawable6.icon_12958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12959: DrawableResource
+  get() = Drawable6.icon_12959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1296: DrawableResource
+  get() = Drawable6.icon_1296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12960: DrawableResource
+  get() = Drawable6.icon_12960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12961: DrawableResource
+  get() = Drawable6.icon_12961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12962: DrawableResource
+  get() = Drawable6.icon_12962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12963: DrawableResource
+  get() = Drawable6.icon_12963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12964: DrawableResource
+  get() = Drawable6.icon_12964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12965: DrawableResource
+  get() = Drawable6.icon_12965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12966: DrawableResource
+  get() = Drawable6.icon_12966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12967: DrawableResource
+  get() = Drawable6.icon_12967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12968: DrawableResource
+  get() = Drawable6.icon_12968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12969: DrawableResource
+  get() = Drawable6.icon_12969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1297: DrawableResource
+  get() = Drawable6.icon_1297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12970: DrawableResource
+  get() = Drawable6.icon_12970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12971: DrawableResource
+  get() = Drawable6.icon_12971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12972: DrawableResource
+  get() = Drawable6.icon_12972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12973: DrawableResource
+  get() = Drawable6.icon_12973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12974: DrawableResource
+  get() = Drawable6.icon_12974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12975: DrawableResource
+  get() = Drawable6.icon_12975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12976: DrawableResource
+  get() = Drawable6.icon_12976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12977: DrawableResource
+  get() = Drawable6.icon_12977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12978: DrawableResource
+  get() = Drawable6.icon_12978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12979: DrawableResource
+  get() = Drawable6.icon_12979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1298: DrawableResource
+  get() = Drawable6.icon_1298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12980: DrawableResource
+  get() = Drawable6.icon_12980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12981: DrawableResource
+  get() = Drawable6.icon_12981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12982: DrawableResource
+  get() = Drawable6.icon_12982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12983: DrawableResource
+  get() = Drawable6.icon_12983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12984: DrawableResource
+  get() = Drawable6.icon_12984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12985: DrawableResource
+  get() = Drawable6.icon_12985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12986: DrawableResource
+  get() = Drawable6.icon_12986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12987: DrawableResource
+  get() = Drawable6.icon_12987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12988: DrawableResource
+  get() = Drawable6.icon_12988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12989: DrawableResource
+  get() = Drawable6.icon_12989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1299: DrawableResource
+  get() = Drawable6.icon_1299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12990: DrawableResource
+  get() = Drawable6.icon_12990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12991: DrawableResource
+  get() = Drawable6.icon_12991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12992: DrawableResource
+  get() = Drawable6.icon_12992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12993: DrawableResource
+  get() = Drawable6.icon_12993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12994: DrawableResource
+  get() = Drawable6.icon_12994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12995: DrawableResource
+  get() = Drawable6.icon_12995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12996: DrawableResource
+  get() = Drawable6.icon_12996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12997: DrawableResource
+  get() = Drawable6.icon_12997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12998: DrawableResource
+  get() = Drawable6.icon_12998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_12999: DrawableResource
+  get() = Drawable6.icon_12999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13: DrawableResource
+  get() = Drawable6.icon_13
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_130: DrawableResource
+  get() = Drawable6.icon_130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1300: DrawableResource
+  get() = Drawable6.icon_1300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13000: DrawableResource
+  get() = Drawable6.icon_13000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13001: DrawableResource
+  get() = Drawable6.icon_13001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13002: DrawableResource
+  get() = Drawable6.icon_13002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13003: DrawableResource
+  get() = Drawable6.icon_13003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13004: DrawableResource
+  get() = Drawable6.icon_13004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13005: DrawableResource
+  get() = Drawable6.icon_13005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13006: DrawableResource
+  get() = Drawable6.icon_13006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13007: DrawableResource
+  get() = Drawable6.icon_13007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13008: DrawableResource
+  get() = Drawable6.icon_13008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13009: DrawableResource
+  get() = Drawable6.icon_13009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1301: DrawableResource
+  get() = Drawable6.icon_1301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13010: DrawableResource
+  get() = Drawable6.icon_13010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13011: DrawableResource
+  get() = Drawable6.icon_13011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13012: DrawableResource
+  get() = Drawable6.icon_13012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13013: DrawableResource
+  get() = Drawable6.icon_13013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13014: DrawableResource
+  get() = Drawable6.icon_13014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13015: DrawableResource
+  get() = Drawable6.icon_13015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13016: DrawableResource
+  get() = Drawable6.icon_13016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13017: DrawableResource
+  get() = Drawable6.icon_13017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13018: DrawableResource
+  get() = Drawable6.icon_13018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13019: DrawableResource
+  get() = Drawable6.icon_13019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1302: DrawableResource
+  get() = Drawable6.icon_1302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13020: DrawableResource
+  get() = Drawable6.icon_13020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13021: DrawableResource
+  get() = Drawable6.icon_13021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13022: DrawableResource
+  get() = Drawable6.icon_13022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13023: DrawableResource
+  get() = Drawable6.icon_13023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13024: DrawableResource
+  get() = Drawable6.icon_13024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13025: DrawableResource
+  get() = Drawable6.icon_13025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13026: DrawableResource
+  get() = Drawable6.icon_13026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13027: DrawableResource
+  get() = Drawable6.icon_13027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13028: DrawableResource
+  get() = Drawable6.icon_13028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13029: DrawableResource
+  get() = Drawable6.icon_13029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1303: DrawableResource
+  get() = Drawable6.icon_1303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13030: DrawableResource
+  get() = Drawable6.icon_13030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13031: DrawableResource
+  get() = Drawable6.icon_13031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13032: DrawableResource
+  get() = Drawable6.icon_13032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13033: DrawableResource
+  get() = Drawable6.icon_13033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13034: DrawableResource
+  get() = Drawable6.icon_13034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13035: DrawableResource
+  get() = Drawable6.icon_13035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13036: DrawableResource
+  get() = Drawable6.icon_13036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13037: DrawableResource
+  get() = Drawable6.icon_13037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13038: DrawableResource
+  get() = Drawable6.icon_13038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13039: DrawableResource
+  get() = Drawable6.icon_13039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1304: DrawableResource
+  get() = Drawable6.icon_1304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13040: DrawableResource
+  get() = Drawable6.icon_13040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13041: DrawableResource
+  get() = Drawable6.icon_13041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13042: DrawableResource
+  get() = Drawable6.icon_13042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13043: DrawableResource
+  get() = Drawable6.icon_13043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13044: DrawableResource
+  get() = Drawable6.icon_13044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13045: DrawableResource
+  get() = Drawable6.icon_13045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13046: DrawableResource
+  get() = Drawable6.icon_13046
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13047: DrawableResource
+  get() = Drawable6.icon_13047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13048: DrawableResource
+  get() = Drawable6.icon_13048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13049: DrawableResource
+  get() = Drawable6.icon_13049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1305: DrawableResource
+  get() = Drawable6.icon_1305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13050: DrawableResource
+  get() = Drawable6.icon_13050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13051: DrawableResource
+  get() = Drawable6.icon_13051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13052: DrawableResource
+  get() = Drawable6.icon_13052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13053: DrawableResource
+  get() = Drawable6.icon_13053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13054: DrawableResource
+  get() = Drawable6.icon_13054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13055: DrawableResource
+  get() = Drawable6.icon_13055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13056: DrawableResource
+  get() = Drawable6.icon_13056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13057: DrawableResource
+  get() = Drawable6.icon_13057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13058: DrawableResource
+  get() = Drawable6.icon_13058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13059: DrawableResource
+  get() = Drawable6.icon_13059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1306: DrawableResource
+  get() = Drawable6.icon_1306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13060: DrawableResource
+  get() = Drawable6.icon_13060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13061: DrawableResource
+  get() = Drawable6.icon_13061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13062: DrawableResource
+  get() = Drawable6.icon_13062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13063: DrawableResource
+  get() = Drawable6.icon_13063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13064: DrawableResource
+  get() = Drawable6.icon_13064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13065: DrawableResource
+  get() = Drawable6.icon_13065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13066: DrawableResource
+  get() = Drawable6.icon_13066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13067: DrawableResource
+  get() = Drawable6.icon_13067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13068: DrawableResource
+  get() = Drawable6.icon_13068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13069: DrawableResource
+  get() = Drawable6.icon_13069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1307: DrawableResource
+  get() = Drawable6.icon_1307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13070: DrawableResource
+  get() = Drawable6.icon_13070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13071: DrawableResource
+  get() = Drawable6.icon_13071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13072: DrawableResource
+  get() = Drawable6.icon_13072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13073: DrawableResource
+  get() = Drawable6.icon_13073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13074: DrawableResource
+  get() = Drawable6.icon_13074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13075: DrawableResource
+  get() = Drawable6.icon_13075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13076: DrawableResource
+  get() = Drawable6.icon_13076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13077: DrawableResource
+  get() = Drawable6.icon_13077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13078: DrawableResource
+  get() = Drawable6.icon_13078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13079: DrawableResource
+  get() = Drawable6.icon_13079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1308: DrawableResource
+  get() = Drawable6.icon_1308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13080: DrawableResource
+  get() = Drawable6.icon_13080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13081: DrawableResource
+  get() = Drawable6.icon_13081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13082: DrawableResource
+  get() = Drawable6.icon_13082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13083: DrawableResource
+  get() = Drawable6.icon_13083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13084: DrawableResource
+  get() = Drawable6.icon_13084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13085: DrawableResource
+  get() = Drawable6.icon_13085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13086: DrawableResource
+  get() = Drawable6.icon_13086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13087: DrawableResource
+  get() = Drawable6.icon_13087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13088: DrawableResource
+  get() = Drawable6.icon_13088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13089: DrawableResource
+  get() = Drawable6.icon_13089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1309: DrawableResource
+  get() = Drawable6.icon_1309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13090: DrawableResource
+  get() = Drawable6.icon_13090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13091: DrawableResource
+  get() = Drawable6.icon_13091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13092: DrawableResource
+  get() = Drawable6.icon_13092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13093: DrawableResource
+  get() = Drawable6.icon_13093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13094: DrawableResource
+  get() = Drawable6.icon_13094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13095: DrawableResource
+  get() = Drawable6.icon_13095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13096: DrawableResource
+  get() = Drawable6.icon_13096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13097: DrawableResource
+  get() = Drawable6.icon_13097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13098: DrawableResource
+  get() = Drawable6.icon_13098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13099: DrawableResource
+  get() = Drawable6.icon_13099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_131: DrawableResource
+  get() = Drawable6.icon_131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1310: DrawableResource
+  get() = Drawable6.icon_1310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13100: DrawableResource
+  get() = Drawable6.icon_13100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13101: DrawableResource
+  get() = Drawable6.icon_13101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13102: DrawableResource
+  get() = Drawable6.icon_13102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13103: DrawableResource
+  get() = Drawable6.icon_13103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13104: DrawableResource
+  get() = Drawable6.icon_13104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13105: DrawableResource
+  get() = Drawable6.icon_13105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13106: DrawableResource
+  get() = Drawable6.icon_13106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13107: DrawableResource
+  get() = Drawable6.icon_13107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13108: DrawableResource
+  get() = Drawable6.icon_13108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13109: DrawableResource
+  get() = Drawable6.icon_13109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1311: DrawableResource
+  get() = Drawable6.icon_1311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13110: DrawableResource
+  get() = Drawable6.icon_13110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13111: DrawableResource
+  get() = Drawable6.icon_13111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13112: DrawableResource
+  get() = Drawable6.icon_13112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13113: DrawableResource
+  get() = Drawable6.icon_13113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13114: DrawableResource
+  get() = Drawable6.icon_13114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13115: DrawableResource
+  get() = Drawable6.icon_13115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13116: DrawableResource
+  get() = Drawable6.icon_13116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13117: DrawableResource
+  get() = Drawable6.icon_13117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13118: DrawableResource
+  get() = Drawable6.icon_13118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13119: DrawableResource
+  get() = Drawable6.icon_13119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1312: DrawableResource
+  get() = Drawable6.icon_1312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13120: DrawableResource
+  get() = Drawable6.icon_13120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13121: DrawableResource
+  get() = Drawable6.icon_13121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13122: DrawableResource
+  get() = Drawable6.icon_13122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13123: DrawableResource
+  get() = Drawable6.icon_13123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13124: DrawableResource
+  get() = Drawable6.icon_13124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13125: DrawableResource
+  get() = Drawable6.icon_13125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13126: DrawableResource
+  get() = Drawable6.icon_13126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13127: DrawableResource
+  get() = Drawable6.icon_13127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13128: DrawableResource
+  get() = Drawable6.icon_13128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13129: DrawableResource
+  get() = Drawable6.icon_13129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1313: DrawableResource
+  get() = Drawable6.icon_1313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13130: DrawableResource
+  get() = Drawable6.icon_13130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13131: DrawableResource
+  get() = Drawable6.icon_13131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13132: DrawableResource
+  get() = Drawable6.icon_13132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13133: DrawableResource
+  get() = Drawable6.icon_13133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13134: DrawableResource
+  get() = Drawable6.icon_13134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13135: DrawableResource
+  get() = Drawable6.icon_13135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13136: DrawableResource
+  get() = Drawable6.icon_13136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13137: DrawableResource
+  get() = Drawable6.icon_13137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13138: DrawableResource
+  get() = Drawable6.icon_13138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13139: DrawableResource
+  get() = Drawable6.icon_13139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1314: DrawableResource
+  get() = Drawable6.icon_1314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13140: DrawableResource
+  get() = Drawable6.icon_13140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13141: DrawableResource
+  get() = Drawable6.icon_13141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13142: DrawableResource
+  get() = Drawable6.icon_13142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13143: DrawableResource
+  get() = Drawable6.icon_13143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13144: DrawableResource
+  get() = Drawable6.icon_13144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13145: DrawableResource
+  get() = Drawable6.icon_13145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13146: DrawableResource
+  get() = Drawable6.icon_13146

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable7.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable7.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable7 {
+  public val icon_13147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13147.xml"),
+          )
+      )
+
+  public val icon_13148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13148.xml"),
+          )
+      )
+
+  public val icon_13149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13149.xml"),
+          )
+      )
+
+  public val icon_1315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1315.xml"),
+          )
+      )
+
+  public val icon_13150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13150.xml"),
+          )
+      )
+
+  public val icon_13151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13151.xml"),
+          )
+      )
+
+  public val icon_13152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13152.xml"),
+          )
+      )
+
+  public val icon_13153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13153.xml"),
+          )
+      )
+
+  public val icon_13154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13154.xml"),
+          )
+      )
+
+  public val icon_13155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13155.xml"),
+          )
+      )
+
+  public val icon_13156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13156.xml"),
+          )
+      )
+
+  public val icon_13157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13157.xml"),
+          )
+      )
+
+  public val icon_13158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13158.xml"),
+          )
+      )
+
+  public val icon_13159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13159.xml"),
+          )
+      )
+
+  public val icon_1316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1316.xml"),
+          )
+      )
+
+  public val icon_13160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13160.xml"),
+          )
+      )
+
+  public val icon_13161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13161.xml"),
+          )
+      )
+
+  public val icon_13162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13162.xml"),
+          )
+      )
+
+  public val icon_13163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13163.xml"),
+          )
+      )
+
+  public val icon_13164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13164.xml"),
+          )
+      )
+
+  public val icon_13165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13165.xml"),
+          )
+      )
+
+  public val icon_13166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13166.xml"),
+          )
+      )
+
+  public val icon_13167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13167.xml"),
+          )
+      )
+
+  public val icon_13168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13168.xml"),
+          )
+      )
+
+  public val icon_13169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13169.xml"),
+          )
+      )
+
+  public val icon_1317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1317.xml"),
+          )
+      )
+
+  public val icon_13170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13170.xml"),
+          )
+      )
+
+  public val icon_13171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13171.xml"),
+          )
+      )
+
+  public val icon_13172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13172.xml"),
+          )
+      )
+
+  public val icon_13173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13173.xml"),
+          )
+      )
+
+  public val icon_13174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13174.xml"),
+          )
+      )
+
+  public val icon_13175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13175.xml"),
+          )
+      )
+
+  public val icon_13176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13176.xml"),
+          )
+      )
+
+  public val icon_13177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13177.xml"),
+          )
+      )
+
+  public val icon_13178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13178.xml"),
+          )
+      )
+
+  public val icon_13179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13179.xml"),
+          )
+      )
+
+  public val icon_1318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1318.xml"),
+          )
+      )
+
+  public val icon_13180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13180.xml"),
+          )
+      )
+
+  public val icon_13181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13181.xml"),
+          )
+      )
+
+  public val icon_13182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13182.xml"),
+          )
+      )
+
+  public val icon_13183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13183.xml"),
+          )
+      )
+
+  public val icon_13184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13184.xml"),
+          )
+      )
+
+  public val icon_13185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13185.xml"),
+          )
+      )
+
+  public val icon_13186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13186.xml"),
+          )
+      )
+
+  public val icon_13187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13187.xml"),
+          )
+      )
+
+  public val icon_13188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13188.xml"),
+          )
+      )
+
+  public val icon_13189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13189.xml"),
+          )
+      )
+
+  public val icon_1319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1319.xml"),
+          )
+      )
+
+  public val icon_13190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13190.xml"),
+          )
+      )
+
+  public val icon_13191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13191.xml"),
+          )
+      )
+
+  public val icon_13192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13192.xml"),
+          )
+      )
+
+  public val icon_13193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13193.xml"),
+          )
+      )
+
+  public val icon_13194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13194.xml"),
+          )
+      )
+
+  public val icon_13195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13195.xml"),
+          )
+      )
+
+  public val icon_13196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13196.xml"),
+          )
+      )
+
+  public val icon_13197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13197.xml"),
+          )
+      )
+
+  public val icon_13198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13198.xml"),
+          )
+      )
+
+  public val icon_13199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13199.xml"),
+          )
+      )
+
+  public val icon_132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_132.xml"),
+          )
+      )
+
+  public val icon_1320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1320.xml"),
+          )
+      )
+
+  public val icon_13200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13200.xml"),
+          )
+      )
+
+  public val icon_13201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13201.xml"),
+          )
+      )
+
+  public val icon_13202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13202.xml"),
+          )
+      )
+
+  public val icon_13203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13203.xml"),
+          )
+      )
+
+  public val icon_13204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13204.xml"),
+          )
+      )
+
+  public val icon_13205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13205.xml"),
+          )
+      )
+
+  public val icon_13206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13206.xml"),
+          )
+      )
+
+  public val icon_13207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13207.xml"),
+          )
+      )
+
+  public val icon_13208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13208.xml"),
+          )
+      )
+
+  public val icon_13209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13209.xml"),
+          )
+      )
+
+  public val icon_1321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1321.xml"),
+          )
+      )
+
+  public val icon_13210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13210.xml"),
+          )
+      )
+
+  public val icon_13211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13211.xml"),
+          )
+      )
+
+  public val icon_13212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13212.xml"),
+          )
+      )
+
+  public val icon_13213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13213.xml"),
+          )
+      )
+
+  public val icon_13214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13214.xml"),
+          )
+      )
+
+  public val icon_13215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13215.xml"),
+          )
+      )
+
+  public val icon_13216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13216.xml"),
+          )
+      )
+
+  public val icon_13217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13217.xml"),
+          )
+      )
+
+  public val icon_13218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13218.xml"),
+          )
+      )
+
+  public val icon_13219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13219.xml"),
+          )
+      )
+
+  public val icon_1322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1322.xml"),
+          )
+      )
+
+  public val icon_13220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13220.xml"),
+          )
+      )
+
+  public val icon_13221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13221.xml"),
+          )
+      )
+
+  public val icon_13222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13222.xml"),
+          )
+      )
+
+  public val icon_13223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13223.xml"),
+          )
+      )
+
+  public val icon_13224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13224.xml"),
+          )
+      )
+
+  public val icon_13225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13225.xml"),
+          )
+      )
+
+  public val icon_13226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13226.xml"),
+          )
+      )
+
+  public val icon_13227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13227.xml"),
+          )
+      )
+
+  public val icon_13228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13228.xml"),
+          )
+      )
+
+  public val icon_13229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13229.xml"),
+          )
+      )
+
+  public val icon_1323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1323.xml"),
+          )
+      )
+
+  public val icon_13230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13230.xml"),
+          )
+      )
+
+  public val icon_13231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13231.xml"),
+          )
+      )
+
+  public val icon_13232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13232.xml"),
+          )
+      )
+
+  public val icon_13233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13233.xml"),
+          )
+      )
+
+  public val icon_13234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13234.xml"),
+          )
+      )
+
+  public val icon_13235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13235.xml"),
+          )
+      )
+
+  public val icon_13236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13236.xml"),
+          )
+      )
+
+  public val icon_13237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13237.xml"),
+          )
+      )
+
+  public val icon_13238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13238.xml"),
+          )
+      )
+
+  public val icon_13239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13239.xml"),
+          )
+      )
+
+  public val icon_1324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1324.xml"),
+          )
+      )
+
+  public val icon_13240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13240.xml"),
+          )
+      )
+
+  public val icon_13241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13241.xml"),
+          )
+      )
+
+  public val icon_13242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13242.xml"),
+          )
+      )
+
+  public val icon_13243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13243.xml"),
+          )
+      )
+
+  public val icon_13244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13244.xml"),
+          )
+      )
+
+  public val icon_13245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13245.xml"),
+          )
+      )
+
+  public val icon_13246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13246.xml"),
+          )
+      )
+
+  public val icon_13247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13247.xml"),
+          )
+      )
+
+  public val icon_13248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13248.xml"),
+          )
+      )
+
+  public val icon_13249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13249.xml"),
+          )
+      )
+
+  public val icon_1325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1325.xml"),
+          )
+      )
+
+  public val icon_13250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13250.xml"),
+          )
+      )
+
+  public val icon_13251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13251.xml"),
+          )
+      )
+
+  public val icon_13252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13252.xml"),
+          )
+      )
+
+  public val icon_13253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13253.xml"),
+          )
+      )
+
+  public val icon_13254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13254.xml"),
+          )
+      )
+
+  public val icon_13255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13255.xml"),
+          )
+      )
+
+  public val icon_13256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13256.xml"),
+          )
+      )
+
+  public val icon_13257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13257.xml"),
+          )
+      )
+
+  public val icon_13258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13258.xml"),
+          )
+      )
+
+  public val icon_13259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13259.xml"),
+          )
+      )
+
+  public val icon_1326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1326.xml"),
+          )
+      )
+
+  public val icon_13260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13260.xml"),
+          )
+      )
+
+  public val icon_13261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13261.xml"),
+          )
+      )
+
+  public val icon_13262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13262.xml"),
+          )
+      )
+
+  public val icon_13263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13263.xml"),
+          )
+      )
+
+  public val icon_13264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13264.xml"),
+          )
+      )
+
+  public val icon_13265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13265.xml"),
+          )
+      )
+
+  public val icon_13266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13266.xml"),
+          )
+      )
+
+  public val icon_13267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13267.xml"),
+          )
+      )
+
+  public val icon_13268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13268.xml"),
+          )
+      )
+
+  public val icon_13269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13269.xml"),
+          )
+      )
+
+  public val icon_1327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1327.xml"),
+          )
+      )
+
+  public val icon_13270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13270.xml"),
+          )
+      )
+
+  public val icon_13271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13271.xml"),
+          )
+      )
+
+  public val icon_13272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13272.xml"),
+          )
+      )
+
+  public val icon_13273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13273.xml"),
+          )
+      )
+
+  public val icon_13274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13274.xml"),
+          )
+      )
+
+  public val icon_13275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13275.xml"),
+          )
+      )
+
+  public val icon_13276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13276.xml"),
+          )
+      )
+
+  public val icon_13277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13277.xml"),
+          )
+      )
+
+  public val icon_13278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13278.xml"),
+          )
+      )
+
+  public val icon_13279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13279.xml"),
+          )
+      )
+
+  public val icon_1328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1328.xml"),
+          )
+      )
+
+  public val icon_13280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13280.xml"),
+          )
+      )
+
+  public val icon_13281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13281.xml"),
+          )
+      )
+
+  public val icon_13282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13282.xml"),
+          )
+      )
+
+  public val icon_13283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13283.xml"),
+          )
+      )
+
+  public val icon_13284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13284.xml"),
+          )
+      )
+
+  public val icon_13285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13285.xml"),
+          )
+      )
+
+  public val icon_13286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13286.xml"),
+          )
+      )
+
+  public val icon_13287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13287.xml"),
+          )
+      )
+
+  public val icon_13288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13288.xml"),
+          )
+      )
+
+  public val icon_13289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13289.xml"),
+          )
+      )
+
+  public val icon_1329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1329.xml"),
+          )
+      )
+
+  public val icon_13290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13290.xml"),
+          )
+      )
+
+  public val icon_13291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13291.xml"),
+          )
+      )
+
+  public val icon_13292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13292.xml"),
+          )
+      )
+
+  public val icon_13293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13293.xml"),
+          )
+      )
+
+  public val icon_13294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13294.xml"),
+          )
+      )
+
+  public val icon_13295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13295.xml"),
+          )
+      )
+
+  public val icon_13296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13296.xml"),
+          )
+      )
+
+  public val icon_13297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13297.xml"),
+          )
+      )
+
+  public val icon_13298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13298.xml"),
+          )
+      )
+
+  public val icon_13299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13299.xml"),
+          )
+      )
+
+  public val icon_133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_133.xml"),
+          )
+      )
+
+  public val icon_1330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1330.xml"),
+          )
+      )
+
+  public val icon_13300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13300.xml"),
+          )
+      )
+
+  public val icon_13301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13301.xml"),
+          )
+      )
+
+  public val icon_13302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13302.xml"),
+          )
+      )
+
+  public val icon_13303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13303.xml"),
+          )
+      )
+
+  public val icon_13304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13304.xml"),
+          )
+      )
+
+  public val icon_13305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13305.xml"),
+          )
+      )
+
+  public val icon_13306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13306.xml"),
+          )
+      )
+
+  public val icon_13307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13307.xml"),
+          )
+      )
+
+  public val icon_13308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13308.xml"),
+          )
+      )
+
+  public val icon_13309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13309.xml"),
+          )
+      )
+
+  public val icon_1331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1331.xml"),
+          )
+      )
+
+  public val icon_13310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13310.xml"),
+          )
+      )
+
+  public val icon_13311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13311.xml"),
+          )
+      )
+
+  public val icon_13312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13312.xml"),
+          )
+      )
+
+  public val icon_13313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13313.xml"),
+          )
+      )
+
+  public val icon_13314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13314.xml"),
+          )
+      )
+
+  public val icon_13315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13315.xml"),
+          )
+      )
+
+  public val icon_13316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13316.xml"),
+          )
+      )
+
+  public val icon_13317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13317.xml"),
+          )
+      )
+
+  public val icon_13318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13318.xml"),
+          )
+      )
+
+  public val icon_13319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13319.xml"),
+          )
+      )
+
+  public val icon_1332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1332.xml"),
+          )
+      )
+
+  public val icon_13320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13320.xml"),
+          )
+      )
+
+  public val icon_13321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13321.xml"),
+          )
+      )
+
+  public val icon_13322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13322.xml"),
+          )
+      )
+
+  public val icon_13323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13323.xml"),
+          )
+      )
+
+  public val icon_13324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13324.xml"),
+          )
+      )
+
+  public val icon_13325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13325.xml"),
+          )
+      )
+
+  public val icon_13326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13326.xml"),
+          )
+      )
+
+  public val icon_13327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13327.xml"),
+          )
+      )
+
+  public val icon_13328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13328.xml"),
+          )
+      )
+
+  public val icon_13329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13329.xml"),
+          )
+      )
+
+  public val icon_1333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1333.xml"),
+          )
+      )
+
+  public val icon_13330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13330.xml"),
+          )
+      )
+
+  public val icon_13331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13331.xml"),
+          )
+      )
+
+  public val icon_13332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13332.xml"),
+          )
+      )
+
+  public val icon_13333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13333.xml"),
+          )
+      )
+
+  public val icon_13334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13334.xml"),
+          )
+      )
+
+  public val icon_13335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13335.xml"),
+          )
+      )
+
+  public val icon_13336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13336.xml"),
+          )
+      )
+
+  public val icon_13337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13337.xml"),
+          )
+      )
+
+  public val icon_13338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13338.xml"),
+          )
+      )
+
+  public val icon_13339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13339.xml"),
+          )
+      )
+
+  public val icon_1334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1334.xml"),
+          )
+      )
+
+  public val icon_13340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13340.xml"),
+          )
+      )
+
+  public val icon_13341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13341.xml"),
+          )
+      )
+
+  public val icon_13342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13342.xml"),
+          )
+      )
+
+  public val icon_13343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13343.xml"),
+          )
+      )
+
+  public val icon_13344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13344.xml"),
+          )
+      )
+
+  public val icon_13345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13345.xml"),
+          )
+      )
+
+  public val icon_13346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13346.xml"),
+          )
+      )
+
+  public val icon_13347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13347.xml"),
+          )
+      )
+
+  public val icon_13348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13348.xml"),
+          )
+      )
+
+  public val icon_13349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13349.xml"),
+          )
+      )
+
+  public val icon_1335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1335.xml"),
+          )
+      )
+
+  public val icon_13350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13350.xml"),
+          )
+      )
+
+  public val icon_13351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13351.xml"),
+          )
+      )
+
+  public val icon_13352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13352.xml"),
+          )
+      )
+
+  public val icon_13353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13353.xml"),
+          )
+      )
+
+  public val icon_13354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13354.xml"),
+          )
+      )
+
+  public val icon_13355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13355.xml"),
+          )
+      )
+
+  public val icon_13356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13356.xml"),
+          )
+      )
+
+  public val icon_13357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13357.xml"),
+          )
+      )
+
+  public val icon_13358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13358.xml"),
+          )
+      )
+
+  public val icon_13359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13359.xml"),
+          )
+      )
+
+  public val icon_1336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1336.xml"),
+          )
+      )
+
+  public val icon_13360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13360.xml"),
+          )
+      )
+
+  public val icon_13361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13361.xml"),
+          )
+      )
+
+  public val icon_13362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13362.xml"),
+          )
+      )
+
+  public val icon_13363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13363.xml"),
+          )
+      )
+
+  public val icon_13364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13364.xml"),
+          )
+      )
+
+  public val icon_13365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13365.xml"),
+          )
+      )
+
+  public val icon_13366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13366.xml"),
+          )
+      )
+
+  public val icon_13367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13367.xml"),
+          )
+      )
+
+  public val icon_13368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13368.xml"),
+          )
+      )
+
+  public val icon_13369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13369.xml"),
+          )
+      )
+
+  public val icon_1337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1337.xml"),
+          )
+      )
+
+  public val icon_13370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13370.xml"),
+          )
+      )
+
+  public val icon_13371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13371.xml"),
+          )
+      )
+
+  public val icon_13372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13372.xml"),
+          )
+      )
+
+  public val icon_13373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13373.xml"),
+          )
+      )
+
+  public val icon_13374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13374.xml"),
+          )
+      )
+
+  public val icon_13375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13375.xml"),
+          )
+      )
+
+  public val icon_13376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13376.xml"),
+          )
+      )
+
+  public val icon_13377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13377.xml"),
+          )
+      )
+
+  public val icon_13378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13378.xml"),
+          )
+      )
+
+  public val icon_13379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13379.xml"),
+          )
+      )
+
+  public val icon_1338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1338.xml"),
+          )
+      )
+
+  public val icon_13380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13380.xml"),
+          )
+      )
+
+  public val icon_13381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13381.xml"),
+          )
+      )
+
+  public val icon_13382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13382.xml"),
+          )
+      )
+
+  public val icon_13383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13383.xml"),
+          )
+      )
+
+  public val icon_13384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13384.xml"),
+          )
+      )
+
+  public val icon_13385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13385.xml"),
+          )
+      )
+
+  public val icon_13386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13386.xml"),
+          )
+      )
+
+  public val icon_13387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13387.xml"),
+          )
+      )
+
+  public val icon_13388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13388.xml"),
+          )
+      )
+
+  public val icon_13389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13389.xml"),
+          )
+      )
+
+  public val icon_1339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1339.xml"),
+          )
+      )
+
+  public val icon_13390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13390.xml"),
+          )
+      )
+
+  public val icon_13391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13391.xml"),
+          )
+      )
+
+  public val icon_13392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13392.xml"),
+          )
+      )
+
+  public val icon_13393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13393.xml"),
+          )
+      )
+
+  public val icon_13394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13394.xml"),
+          )
+      )
+
+  public val icon_13395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13395.xml"),
+          )
+      )
+
+  public val icon_13396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13396.xml"),
+          )
+      )
+
+  public val icon_13397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13397.xml"),
+          )
+      )
+
+  public val icon_13398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13398.xml"),
+          )
+      )
+
+  public val icon_13399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13399.xml"),
+          )
+      )
+
+  public val icon_134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_134.xml"),
+          )
+      )
+
+  public val icon_1340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1340.xml"),
+          )
+      )
+
+  public val icon_13400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13400.xml"),
+          )
+      )
+
+  public val icon_13401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13401.xml"),
+          )
+      )
+
+  public val icon_13402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13402.xml"),
+          )
+      )
+
+  public val icon_13403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13403.xml"),
+          )
+      )
+
+  public val icon_13404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13404.xml"),
+          )
+      )
+
+  public val icon_13405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13405.xml"),
+          )
+      )
+
+  public val icon_13406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13406.xml"),
+          )
+      )
+
+  public val icon_13407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13407.xml"),
+          )
+      )
+
+  public val icon_13408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13408.xml"),
+          )
+      )
+
+  public val icon_13409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13409.xml"),
+          )
+      )
+
+  public val icon_1341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1341.xml"),
+          )
+      )
+
+  public val icon_13410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13410.xml"),
+          )
+      )
+
+  public val icon_13411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13411.xml"),
+          )
+      )
+
+  public val icon_13412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13412.xml"),
+          )
+      )
+
+  public val icon_13413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13413.xml"),
+          )
+      )
+
+  public val icon_13414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13414.xml"),
+          )
+      )
+
+  public val icon_13415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13415.xml"),
+          )
+      )
+
+  public val icon_13416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13416.xml"),
+          )
+      )
+
+  public val icon_13417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13417.xml"),
+          )
+      )
+
+  public val icon_13418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13418.xml"),
+          )
+      )
+
+  public val icon_13419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13419.xml"),
+          )
+      )
+
+  public val icon_1342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1342.xml"),
+          )
+      )
+
+  public val icon_13420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13420.xml"),
+          )
+      )
+
+  public val icon_13421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13421.xml"),
+          )
+      )
+
+  public val icon_13422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13422.xml"),
+          )
+      )
+
+  public val icon_13423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13423.xml"),
+          )
+      )
+
+  public val icon_13424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13424.xml"),
+          )
+      )
+
+  public val icon_13425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13425.xml"),
+          )
+      )
+
+  public val icon_13426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13426.xml"),
+          )
+      )
+
+  public val icon_13427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13427.xml"),
+          )
+      )
+
+  public val icon_13428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13428.xml"),
+          )
+      )
+
+  public val icon_13429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13429.xml"),
+          )
+      )
+
+  public val icon_1343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1343.xml"),
+          )
+      )
+
+  public val icon_13430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13430.xml"),
+          )
+      )
+
+  public val icon_13431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13431.xml"),
+          )
+      )
+
+  public val icon_13432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13432.xml"),
+          )
+      )
+
+  public val icon_13433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13433.xml"),
+          )
+      )
+
+  public val icon_13434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13434.xml"),
+          )
+      )
+
+  public val icon_13435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13435.xml"),
+          )
+      )
+
+  public val icon_13436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13436.xml"),
+          )
+      )
+
+  public val icon_13437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13437.xml"),
+          )
+      )
+
+  public val icon_13438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13438.xml"),
+          )
+      )
+
+  public val icon_13439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13439.xml"),
+          )
+      )
+
+  public val icon_1344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1344.xml"),
+          )
+      )
+
+  public val icon_13440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13440.xml"),
+          )
+      )
+
+  public val icon_13441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13441.xml"),
+          )
+      )
+
+  public val icon_13442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13442.xml"),
+          )
+      )
+
+  public val icon_13443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13443.xml"),
+          )
+      )
+
+  public val icon_13444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13444.xml"),
+          )
+      )
+
+  public val icon_13445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13445.xml"),
+          )
+      )
+
+  public val icon_13446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13446.xml"),
+          )
+      )
+
+  public val icon_13447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13447.xml"),
+          )
+      )
+
+  public val icon_13448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13448.xml"),
+          )
+      )
+
+  public val icon_13449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13449.xml"),
+          )
+      )
+
+  public val icon_1345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1345.xml"),
+          )
+      )
+
+  public val icon_13450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13450.xml"),
+          )
+      )
+
+  public val icon_13451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13451.xml"),
+          )
+      )
+
+  public val icon_13452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13452.xml"),
+          )
+      )
+
+  public val icon_13453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13453.xml"),
+          )
+      )
+
+  public val icon_13454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13454.xml"),
+          )
+      )
+
+  public val icon_13455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13455.xml"),
+          )
+      )
+
+  public val icon_13456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13456.xml"),
+          )
+      )
+
+  public val icon_13457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13457.xml"),
+          )
+      )
+
+  public val icon_13458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13458.xml"),
+          )
+      )
+
+  public val icon_13459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13459.xml"),
+          )
+      )
+
+  public val icon_1346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1346.xml"),
+          )
+      )
+
+  public val icon_13460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13460.xml"),
+          )
+      )
+
+  public val icon_13461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13461.xml"),
+          )
+      )
+
+  public val icon_13462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13462.xml"),
+          )
+      )
+
+  public val icon_13463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13463.xml"),
+          )
+      )
+
+  public val icon_13464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13464.xml"),
+          )
+      )
+
+  public val icon_13465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13465.xml"),
+          )
+      )
+
+  public val icon_13466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13466.xml"),
+          )
+      )
+
+  public val icon_13467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13467.xml"),
+          )
+      )
+
+  public val icon_13468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13468.xml"),
+          )
+      )
+
+  public val icon_13469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13469.xml"),
+          )
+      )
+
+  public val icon_1347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1347.xml"),
+          )
+      )
+
+  public val icon_13470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13470.xml"),
+          )
+      )
+
+  public val icon_13471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13471.xml"),
+          )
+      )
+
+  public val icon_13472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13472.xml"),
+          )
+      )
+
+  public val icon_13473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13473.xml"),
+          )
+      )
+
+  public val icon_13474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13474.xml"),
+          )
+      )
+
+  public val icon_13475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13475.xml"),
+          )
+      )
+
+  public val icon_13476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13476.xml"),
+          )
+      )
+
+  public val icon_13477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13477.xml"),
+          )
+      )
+
+  public val icon_13478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13478.xml"),
+          )
+      )
+
+  public val icon_13479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13479.xml"),
+          )
+      )
+
+  public val icon_1348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1348.xml"),
+          )
+      )
+
+  public val icon_13480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13480.xml"),
+          )
+      )
+
+  public val icon_13481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13481.xml"),
+          )
+      )
+
+  public val icon_13482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13482.xml"),
+          )
+      )
+
+  public val icon_13483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13483.xml"),
+          )
+      )
+
+  public val icon_13484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13484.xml"),
+          )
+      )
+
+  public val icon_13485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13485.xml"),
+          )
+      )
+
+  public val icon_13486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13486.xml"),
+          )
+      )
+
+  public val icon_13487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13487.xml"),
+          )
+      )
+
+  public val icon_13488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13488.xml"),
+          )
+      )
+
+  public val icon_13489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13489.xml"),
+          )
+      )
+
+  public val icon_1349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1349.xml"),
+          )
+      )
+
+  public val icon_13490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13490.xml"),
+          )
+      )
+
+  public val icon_13491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13491.xml"),
+          )
+      )
+
+  public val icon_13492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13492.xml"),
+          )
+      )
+
+  public val icon_13493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13493.xml"),
+          )
+      )
+
+  public val icon_13494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13494.xml"),
+          )
+      )
+
+  public val icon_13495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13495.xml"),
+          )
+      )
+
+  public val icon_13496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13496.xml"),
+          )
+      )
+
+  public val icon_13497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13497.xml"),
+          )
+      )
+
+  public val icon_13498: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13498.xml"),
+          )
+      )
+
+  public val icon_13499: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13499.xml"),
+          )
+      )
+
+  public val icon_135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_135.xml"),
+          )
+      )
+
+  public val icon_1350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1350.xml"),
+          )
+      )
+
+  public val icon_13500: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13500.xml"),
+          )
+      )
+
+  public val icon_13501: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13501.xml"),
+          )
+      )
+
+  public val icon_13502: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13502.xml"),
+          )
+      )
+
+  public val icon_13503: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13503.xml"),
+          )
+      )
+
+  public val icon_13504: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13504.xml"),
+          )
+      )
+
+  public val icon_13505: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13505.xml"),
+          )
+      )
+
+  public val icon_13506: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13506.xml"),
+          )
+      )
+
+  public val icon_13507: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13507.xml"),
+          )
+      )
+
+  public val icon_13508: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13508.xml"),
+          )
+      )
+
+  public val icon_13509: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13509.xml"),
+          )
+      )
+
+  public val icon_1351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1351.xml"),
+          )
+      )
+
+  public val icon_13510: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13510.xml"),
+          )
+      )
+
+  public val icon_13511: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13511.xml"),
+          )
+      )
+
+  public val icon_13512: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13512.xml"),
+          )
+      )
+
+  public val icon_13513: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13513.xml"),
+          )
+      )
+
+  public val icon_13514: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13514.xml"),
+          )
+      )
+
+  public val icon_13515: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13515.xml"),
+          )
+      )
+
+  public val icon_13516: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13516.xml"),
+          )
+      )
+
+  public val icon_13517: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13517.xml"),
+          )
+      )
+
+  public val icon_13518: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13518.xml"),
+          )
+      )
+
+  public val icon_13519: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13519.xml"),
+          )
+      )
+
+  public val icon_1352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1352.xml"),
+          )
+      )
+
+  public val icon_13520: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13520.xml"),
+          )
+      )
+
+  public val icon_13521: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13521.xml"),
+          )
+      )
+
+  public val icon_13522: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13522.xml"),
+          )
+      )
+
+  public val icon_13523: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13523.xml"),
+          )
+      )
+
+  public val icon_13524: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13524.xml"),
+          )
+      )
+
+  public val icon_13525: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13525.xml"),
+          )
+      )
+
+  public val icon_13526: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13526.xml"),
+          )
+      )
+
+  public val icon_13527: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13527.xml"),
+          )
+      )
+
+  public val icon_13528: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13528.xml"),
+          )
+      )
+
+  public val icon_13529: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13529.xml"),
+          )
+      )
+
+  public val icon_1353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1353.xml"),
+          )
+      )
+
+  public val icon_13530: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13530.xml"),
+          )
+      )
+
+  public val icon_13531: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13531.xml"),
+          )
+      )
+
+  public val icon_13532: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13532.xml"),
+          )
+      )
+
+  public val icon_13533: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13533.xml"),
+          )
+      )
+
+  public val icon_13534: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13534.xml"),
+          )
+      )
+
+  public val icon_13535: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13535.xml"),
+          )
+      )
+
+  public val icon_13536: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13536.xml"),
+          )
+      )
+
+  public val icon_13537: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13537.xml"),
+          )
+      )
+
+  public val icon_13538: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13538.xml"),
+          )
+      )
+
+  public val icon_13539: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13539.xml"),
+          )
+      )
+
+  public val icon_1354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1354.xml"),
+          )
+      )
+
+  public val icon_13540: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13540.xml"),
+          )
+      )
+
+  public val icon_13541: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13541.xml"),
+          )
+      )
+
+  public val icon_13542: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13542.xml"),
+          )
+      )
+
+  public val icon_13543: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13543.xml"),
+          )
+      )
+
+  public val icon_13544: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13544.xml"),
+          )
+      )
+
+  public val icon_13545: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13545.xml"),
+          )
+      )
+
+  public val icon_13546: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13546.xml"),
+          )
+      )
+
+  public val icon_13547: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13547.xml"),
+          )
+      )
+
+  public val icon_13548: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13548.xml"),
+          )
+      )
+
+  public val icon_13549: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13549.xml"),
+          )
+      )
+
+  public val icon_1355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1355.xml"),
+          )
+      )
+
+  public val icon_13550: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13550.xml"),
+          )
+      )
+
+  public val icon_13551: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13551.xml"),
+          )
+      )
+
+  public val icon_13552: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13552.xml"),
+          )
+      )
+
+  public val icon_13553: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13553.xml"),
+          )
+      )
+
+  public val icon_13554: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13554.xml"),
+          )
+      )
+
+  public val icon_13555: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13555.xml"),
+          )
+      )
+
+  public val icon_13556: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13556.xml"),
+          )
+      )
+
+  public val icon_13557: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13557.xml"),
+          )
+      )
+
+  public val icon_13558: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13558.xml"),
+          )
+      )
+
+  public val icon_13559: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13559.xml"),
+          )
+      )
+
+  public val icon_1356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1356.xml"),
+          )
+      )
+
+  public val icon_13560: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13560.xml"),
+          )
+      )
+
+  public val icon_13561: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13561.xml"),
+          )
+      )
+
+  public val icon_13562: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13562.xml"),
+          )
+      )
+
+  public val icon_13563: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13563.xml"),
+          )
+      )
+
+  public val icon_13564: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13564.xml"),
+          )
+      )
+
+  public val icon_13565: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13565.xml"),
+          )
+      )
+
+  public val icon_13566: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13566.xml"),
+          )
+      )
+
+  public val icon_13567: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13567.xml"),
+          )
+      )
+
+  public val icon_13568: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13568.xml"),
+          )
+      )
+
+  public val icon_13569: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13569.xml"),
+          )
+      )
+
+  public val icon_1357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1357.xml"),
+          )
+      )
+
+  public val icon_13570: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13570.xml"),
+          )
+      )
+
+  public val icon_13571: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13571.xml"),
+          )
+      )
+
+  public val icon_13572: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13572.xml"),
+          )
+      )
+
+  public val icon_13573: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13573.xml"),
+          )
+      )
+
+  public val icon_13574: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13574.xml"),
+          )
+      )
+
+  public val icon_13575: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13575.xml"),
+          )
+      )
+
+  public val icon_13576: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13576.xml"),
+          )
+      )
+
+  public val icon_13577: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13577.xml"),
+          )
+      )
+
+  public val icon_13578: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13578.xml"),
+          )
+      )
+
+  public val icon_13579: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13579.xml"),
+          )
+      )
+
+  public val icon_1358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1358.xml"),
+          )
+      )
+
+  public val icon_13580: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13580.xml"),
+          )
+      )
+
+  public val icon_13581: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13581.xml"),
+          )
+      )
+
+  public val icon_13582: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13582.xml"),
+          )
+      )
+
+  public val icon_13583: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13583.xml"),
+          )
+      )
+
+  public val icon_13584: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13584.xml"),
+          )
+      )
+
+  public val icon_13585: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13585.xml"),
+          )
+      )
+
+  public val icon_13586: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13586.xml"),
+          )
+      )
+
+  public val icon_13587: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13587.xml"),
+          )
+      )
+
+  public val icon_13588: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13588.xml"),
+          )
+      )
+
+  public val icon_13589: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13589.xml"),
+          )
+      )
+
+  public val icon_1359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1359.xml"),
+          )
+      )
+
+  public val icon_13590: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13590.xml"),
+          )
+      )
+
+  public val icon_13591: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13591.xml"),
+          )
+      )
+
+  public val icon_13592: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13592.xml"),
+          )
+      )
+
+  public val icon_13593: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13593.xml"),
+          )
+      )
+
+  public val icon_13594: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13594.xml"),
+          )
+      )
+
+  public val icon_13595: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13595.xml"),
+          )
+      )
+
+  public val icon_13596: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13596.xml"),
+          )
+      )
+
+  public val icon_13597: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13597.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13147: DrawableResource
+  get() = Drawable7.icon_13147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13148: DrawableResource
+  get() = Drawable7.icon_13148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13149: DrawableResource
+  get() = Drawable7.icon_13149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1315: DrawableResource
+  get() = Drawable7.icon_1315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13150: DrawableResource
+  get() = Drawable7.icon_13150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13151: DrawableResource
+  get() = Drawable7.icon_13151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13152: DrawableResource
+  get() = Drawable7.icon_13152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13153: DrawableResource
+  get() = Drawable7.icon_13153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13154: DrawableResource
+  get() = Drawable7.icon_13154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13155: DrawableResource
+  get() = Drawable7.icon_13155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13156: DrawableResource
+  get() = Drawable7.icon_13156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13157: DrawableResource
+  get() = Drawable7.icon_13157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13158: DrawableResource
+  get() = Drawable7.icon_13158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13159: DrawableResource
+  get() = Drawable7.icon_13159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1316: DrawableResource
+  get() = Drawable7.icon_1316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13160: DrawableResource
+  get() = Drawable7.icon_13160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13161: DrawableResource
+  get() = Drawable7.icon_13161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13162: DrawableResource
+  get() = Drawable7.icon_13162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13163: DrawableResource
+  get() = Drawable7.icon_13163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13164: DrawableResource
+  get() = Drawable7.icon_13164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13165: DrawableResource
+  get() = Drawable7.icon_13165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13166: DrawableResource
+  get() = Drawable7.icon_13166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13167: DrawableResource
+  get() = Drawable7.icon_13167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13168: DrawableResource
+  get() = Drawable7.icon_13168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13169: DrawableResource
+  get() = Drawable7.icon_13169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1317: DrawableResource
+  get() = Drawable7.icon_1317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13170: DrawableResource
+  get() = Drawable7.icon_13170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13171: DrawableResource
+  get() = Drawable7.icon_13171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13172: DrawableResource
+  get() = Drawable7.icon_13172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13173: DrawableResource
+  get() = Drawable7.icon_13173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13174: DrawableResource
+  get() = Drawable7.icon_13174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13175: DrawableResource
+  get() = Drawable7.icon_13175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13176: DrawableResource
+  get() = Drawable7.icon_13176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13177: DrawableResource
+  get() = Drawable7.icon_13177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13178: DrawableResource
+  get() = Drawable7.icon_13178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13179: DrawableResource
+  get() = Drawable7.icon_13179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1318: DrawableResource
+  get() = Drawable7.icon_1318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13180: DrawableResource
+  get() = Drawable7.icon_13180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13181: DrawableResource
+  get() = Drawable7.icon_13181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13182: DrawableResource
+  get() = Drawable7.icon_13182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13183: DrawableResource
+  get() = Drawable7.icon_13183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13184: DrawableResource
+  get() = Drawable7.icon_13184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13185: DrawableResource
+  get() = Drawable7.icon_13185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13186: DrawableResource
+  get() = Drawable7.icon_13186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13187: DrawableResource
+  get() = Drawable7.icon_13187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13188: DrawableResource
+  get() = Drawable7.icon_13188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13189: DrawableResource
+  get() = Drawable7.icon_13189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1319: DrawableResource
+  get() = Drawable7.icon_1319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13190: DrawableResource
+  get() = Drawable7.icon_13190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13191: DrawableResource
+  get() = Drawable7.icon_13191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13192: DrawableResource
+  get() = Drawable7.icon_13192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13193: DrawableResource
+  get() = Drawable7.icon_13193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13194: DrawableResource
+  get() = Drawable7.icon_13194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13195: DrawableResource
+  get() = Drawable7.icon_13195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13196: DrawableResource
+  get() = Drawable7.icon_13196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13197: DrawableResource
+  get() = Drawable7.icon_13197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13198: DrawableResource
+  get() = Drawable7.icon_13198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13199: DrawableResource
+  get() = Drawable7.icon_13199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_132: DrawableResource
+  get() = Drawable7.icon_132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1320: DrawableResource
+  get() = Drawable7.icon_1320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13200: DrawableResource
+  get() = Drawable7.icon_13200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13201: DrawableResource
+  get() = Drawable7.icon_13201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13202: DrawableResource
+  get() = Drawable7.icon_13202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13203: DrawableResource
+  get() = Drawable7.icon_13203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13204: DrawableResource
+  get() = Drawable7.icon_13204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13205: DrawableResource
+  get() = Drawable7.icon_13205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13206: DrawableResource
+  get() = Drawable7.icon_13206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13207: DrawableResource
+  get() = Drawable7.icon_13207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13208: DrawableResource
+  get() = Drawable7.icon_13208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13209: DrawableResource
+  get() = Drawable7.icon_13209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1321: DrawableResource
+  get() = Drawable7.icon_1321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13210: DrawableResource
+  get() = Drawable7.icon_13210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13211: DrawableResource
+  get() = Drawable7.icon_13211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13212: DrawableResource
+  get() = Drawable7.icon_13212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13213: DrawableResource
+  get() = Drawable7.icon_13213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13214: DrawableResource
+  get() = Drawable7.icon_13214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13215: DrawableResource
+  get() = Drawable7.icon_13215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13216: DrawableResource
+  get() = Drawable7.icon_13216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13217: DrawableResource
+  get() = Drawable7.icon_13217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13218: DrawableResource
+  get() = Drawable7.icon_13218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13219: DrawableResource
+  get() = Drawable7.icon_13219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1322: DrawableResource
+  get() = Drawable7.icon_1322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13220: DrawableResource
+  get() = Drawable7.icon_13220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13221: DrawableResource
+  get() = Drawable7.icon_13221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13222: DrawableResource
+  get() = Drawable7.icon_13222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13223: DrawableResource
+  get() = Drawable7.icon_13223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13224: DrawableResource
+  get() = Drawable7.icon_13224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13225: DrawableResource
+  get() = Drawable7.icon_13225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13226: DrawableResource
+  get() = Drawable7.icon_13226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13227: DrawableResource
+  get() = Drawable7.icon_13227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13228: DrawableResource
+  get() = Drawable7.icon_13228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13229: DrawableResource
+  get() = Drawable7.icon_13229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1323: DrawableResource
+  get() = Drawable7.icon_1323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13230: DrawableResource
+  get() = Drawable7.icon_13230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13231: DrawableResource
+  get() = Drawable7.icon_13231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13232: DrawableResource
+  get() = Drawable7.icon_13232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13233: DrawableResource
+  get() = Drawable7.icon_13233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13234: DrawableResource
+  get() = Drawable7.icon_13234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13235: DrawableResource
+  get() = Drawable7.icon_13235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13236: DrawableResource
+  get() = Drawable7.icon_13236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13237: DrawableResource
+  get() = Drawable7.icon_13237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13238: DrawableResource
+  get() = Drawable7.icon_13238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13239: DrawableResource
+  get() = Drawable7.icon_13239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1324: DrawableResource
+  get() = Drawable7.icon_1324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13240: DrawableResource
+  get() = Drawable7.icon_13240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13241: DrawableResource
+  get() = Drawable7.icon_13241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13242: DrawableResource
+  get() = Drawable7.icon_13242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13243: DrawableResource
+  get() = Drawable7.icon_13243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13244: DrawableResource
+  get() = Drawable7.icon_13244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13245: DrawableResource
+  get() = Drawable7.icon_13245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13246: DrawableResource
+  get() = Drawable7.icon_13246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13247: DrawableResource
+  get() = Drawable7.icon_13247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13248: DrawableResource
+  get() = Drawable7.icon_13248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13249: DrawableResource
+  get() = Drawable7.icon_13249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1325: DrawableResource
+  get() = Drawable7.icon_1325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13250: DrawableResource
+  get() = Drawable7.icon_13250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13251: DrawableResource
+  get() = Drawable7.icon_13251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13252: DrawableResource
+  get() = Drawable7.icon_13252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13253: DrawableResource
+  get() = Drawable7.icon_13253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13254: DrawableResource
+  get() = Drawable7.icon_13254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13255: DrawableResource
+  get() = Drawable7.icon_13255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13256: DrawableResource
+  get() = Drawable7.icon_13256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13257: DrawableResource
+  get() = Drawable7.icon_13257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13258: DrawableResource
+  get() = Drawable7.icon_13258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13259: DrawableResource
+  get() = Drawable7.icon_13259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1326: DrawableResource
+  get() = Drawable7.icon_1326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13260: DrawableResource
+  get() = Drawable7.icon_13260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13261: DrawableResource
+  get() = Drawable7.icon_13261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13262: DrawableResource
+  get() = Drawable7.icon_13262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13263: DrawableResource
+  get() = Drawable7.icon_13263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13264: DrawableResource
+  get() = Drawable7.icon_13264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13265: DrawableResource
+  get() = Drawable7.icon_13265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13266: DrawableResource
+  get() = Drawable7.icon_13266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13267: DrawableResource
+  get() = Drawable7.icon_13267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13268: DrawableResource
+  get() = Drawable7.icon_13268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13269: DrawableResource
+  get() = Drawable7.icon_13269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1327: DrawableResource
+  get() = Drawable7.icon_1327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13270: DrawableResource
+  get() = Drawable7.icon_13270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13271: DrawableResource
+  get() = Drawable7.icon_13271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13272: DrawableResource
+  get() = Drawable7.icon_13272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13273: DrawableResource
+  get() = Drawable7.icon_13273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13274: DrawableResource
+  get() = Drawable7.icon_13274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13275: DrawableResource
+  get() = Drawable7.icon_13275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13276: DrawableResource
+  get() = Drawable7.icon_13276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13277: DrawableResource
+  get() = Drawable7.icon_13277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13278: DrawableResource
+  get() = Drawable7.icon_13278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13279: DrawableResource
+  get() = Drawable7.icon_13279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1328: DrawableResource
+  get() = Drawable7.icon_1328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13280: DrawableResource
+  get() = Drawable7.icon_13280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13281: DrawableResource
+  get() = Drawable7.icon_13281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13282: DrawableResource
+  get() = Drawable7.icon_13282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13283: DrawableResource
+  get() = Drawable7.icon_13283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13284: DrawableResource
+  get() = Drawable7.icon_13284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13285: DrawableResource
+  get() = Drawable7.icon_13285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13286: DrawableResource
+  get() = Drawable7.icon_13286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13287: DrawableResource
+  get() = Drawable7.icon_13287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13288: DrawableResource
+  get() = Drawable7.icon_13288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13289: DrawableResource
+  get() = Drawable7.icon_13289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1329: DrawableResource
+  get() = Drawable7.icon_1329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13290: DrawableResource
+  get() = Drawable7.icon_13290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13291: DrawableResource
+  get() = Drawable7.icon_13291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13292: DrawableResource
+  get() = Drawable7.icon_13292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13293: DrawableResource
+  get() = Drawable7.icon_13293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13294: DrawableResource
+  get() = Drawable7.icon_13294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13295: DrawableResource
+  get() = Drawable7.icon_13295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13296: DrawableResource
+  get() = Drawable7.icon_13296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13297: DrawableResource
+  get() = Drawable7.icon_13297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13298: DrawableResource
+  get() = Drawable7.icon_13298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13299: DrawableResource
+  get() = Drawable7.icon_13299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_133: DrawableResource
+  get() = Drawable7.icon_133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1330: DrawableResource
+  get() = Drawable7.icon_1330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13300: DrawableResource
+  get() = Drawable7.icon_13300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13301: DrawableResource
+  get() = Drawable7.icon_13301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13302: DrawableResource
+  get() = Drawable7.icon_13302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13303: DrawableResource
+  get() = Drawable7.icon_13303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13304: DrawableResource
+  get() = Drawable7.icon_13304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13305: DrawableResource
+  get() = Drawable7.icon_13305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13306: DrawableResource
+  get() = Drawable7.icon_13306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13307: DrawableResource
+  get() = Drawable7.icon_13307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13308: DrawableResource
+  get() = Drawable7.icon_13308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13309: DrawableResource
+  get() = Drawable7.icon_13309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1331: DrawableResource
+  get() = Drawable7.icon_1331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13310: DrawableResource
+  get() = Drawable7.icon_13310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13311: DrawableResource
+  get() = Drawable7.icon_13311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13312: DrawableResource
+  get() = Drawable7.icon_13312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13313: DrawableResource
+  get() = Drawable7.icon_13313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13314: DrawableResource
+  get() = Drawable7.icon_13314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13315: DrawableResource
+  get() = Drawable7.icon_13315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13316: DrawableResource
+  get() = Drawable7.icon_13316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13317: DrawableResource
+  get() = Drawable7.icon_13317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13318: DrawableResource
+  get() = Drawable7.icon_13318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13319: DrawableResource
+  get() = Drawable7.icon_13319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1332: DrawableResource
+  get() = Drawable7.icon_1332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13320: DrawableResource
+  get() = Drawable7.icon_13320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13321: DrawableResource
+  get() = Drawable7.icon_13321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13322: DrawableResource
+  get() = Drawable7.icon_13322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13323: DrawableResource
+  get() = Drawable7.icon_13323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13324: DrawableResource
+  get() = Drawable7.icon_13324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13325: DrawableResource
+  get() = Drawable7.icon_13325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13326: DrawableResource
+  get() = Drawable7.icon_13326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13327: DrawableResource
+  get() = Drawable7.icon_13327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13328: DrawableResource
+  get() = Drawable7.icon_13328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13329: DrawableResource
+  get() = Drawable7.icon_13329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1333: DrawableResource
+  get() = Drawable7.icon_1333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13330: DrawableResource
+  get() = Drawable7.icon_13330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13331: DrawableResource
+  get() = Drawable7.icon_13331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13332: DrawableResource
+  get() = Drawable7.icon_13332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13333: DrawableResource
+  get() = Drawable7.icon_13333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13334: DrawableResource
+  get() = Drawable7.icon_13334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13335: DrawableResource
+  get() = Drawable7.icon_13335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13336: DrawableResource
+  get() = Drawable7.icon_13336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13337: DrawableResource
+  get() = Drawable7.icon_13337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13338: DrawableResource
+  get() = Drawable7.icon_13338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13339: DrawableResource
+  get() = Drawable7.icon_13339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1334: DrawableResource
+  get() = Drawable7.icon_1334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13340: DrawableResource
+  get() = Drawable7.icon_13340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13341: DrawableResource
+  get() = Drawable7.icon_13341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13342: DrawableResource
+  get() = Drawable7.icon_13342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13343: DrawableResource
+  get() = Drawable7.icon_13343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13344: DrawableResource
+  get() = Drawable7.icon_13344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13345: DrawableResource
+  get() = Drawable7.icon_13345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13346: DrawableResource
+  get() = Drawable7.icon_13346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13347: DrawableResource
+  get() = Drawable7.icon_13347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13348: DrawableResource
+  get() = Drawable7.icon_13348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13349: DrawableResource
+  get() = Drawable7.icon_13349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1335: DrawableResource
+  get() = Drawable7.icon_1335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13350: DrawableResource
+  get() = Drawable7.icon_13350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13351: DrawableResource
+  get() = Drawable7.icon_13351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13352: DrawableResource
+  get() = Drawable7.icon_13352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13353: DrawableResource
+  get() = Drawable7.icon_13353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13354: DrawableResource
+  get() = Drawable7.icon_13354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13355: DrawableResource
+  get() = Drawable7.icon_13355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13356: DrawableResource
+  get() = Drawable7.icon_13356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13357: DrawableResource
+  get() = Drawable7.icon_13357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13358: DrawableResource
+  get() = Drawable7.icon_13358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13359: DrawableResource
+  get() = Drawable7.icon_13359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1336: DrawableResource
+  get() = Drawable7.icon_1336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13360: DrawableResource
+  get() = Drawable7.icon_13360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13361: DrawableResource
+  get() = Drawable7.icon_13361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13362: DrawableResource
+  get() = Drawable7.icon_13362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13363: DrawableResource
+  get() = Drawable7.icon_13363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13364: DrawableResource
+  get() = Drawable7.icon_13364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13365: DrawableResource
+  get() = Drawable7.icon_13365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13366: DrawableResource
+  get() = Drawable7.icon_13366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13367: DrawableResource
+  get() = Drawable7.icon_13367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13368: DrawableResource
+  get() = Drawable7.icon_13368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13369: DrawableResource
+  get() = Drawable7.icon_13369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1337: DrawableResource
+  get() = Drawable7.icon_1337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13370: DrawableResource
+  get() = Drawable7.icon_13370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13371: DrawableResource
+  get() = Drawable7.icon_13371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13372: DrawableResource
+  get() = Drawable7.icon_13372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13373: DrawableResource
+  get() = Drawable7.icon_13373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13374: DrawableResource
+  get() = Drawable7.icon_13374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13375: DrawableResource
+  get() = Drawable7.icon_13375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13376: DrawableResource
+  get() = Drawable7.icon_13376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13377: DrawableResource
+  get() = Drawable7.icon_13377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13378: DrawableResource
+  get() = Drawable7.icon_13378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13379: DrawableResource
+  get() = Drawable7.icon_13379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1338: DrawableResource
+  get() = Drawable7.icon_1338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13380: DrawableResource
+  get() = Drawable7.icon_13380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13381: DrawableResource
+  get() = Drawable7.icon_13381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13382: DrawableResource
+  get() = Drawable7.icon_13382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13383: DrawableResource
+  get() = Drawable7.icon_13383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13384: DrawableResource
+  get() = Drawable7.icon_13384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13385: DrawableResource
+  get() = Drawable7.icon_13385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13386: DrawableResource
+  get() = Drawable7.icon_13386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13387: DrawableResource
+  get() = Drawable7.icon_13387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13388: DrawableResource
+  get() = Drawable7.icon_13388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13389: DrawableResource
+  get() = Drawable7.icon_13389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1339: DrawableResource
+  get() = Drawable7.icon_1339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13390: DrawableResource
+  get() = Drawable7.icon_13390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13391: DrawableResource
+  get() = Drawable7.icon_13391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13392: DrawableResource
+  get() = Drawable7.icon_13392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13393: DrawableResource
+  get() = Drawable7.icon_13393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13394: DrawableResource
+  get() = Drawable7.icon_13394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13395: DrawableResource
+  get() = Drawable7.icon_13395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13396: DrawableResource
+  get() = Drawable7.icon_13396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13397: DrawableResource
+  get() = Drawable7.icon_13397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13398: DrawableResource
+  get() = Drawable7.icon_13398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13399: DrawableResource
+  get() = Drawable7.icon_13399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_134: DrawableResource
+  get() = Drawable7.icon_134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1340: DrawableResource
+  get() = Drawable7.icon_1340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13400: DrawableResource
+  get() = Drawable7.icon_13400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13401: DrawableResource
+  get() = Drawable7.icon_13401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13402: DrawableResource
+  get() = Drawable7.icon_13402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13403: DrawableResource
+  get() = Drawable7.icon_13403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13404: DrawableResource
+  get() = Drawable7.icon_13404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13405: DrawableResource
+  get() = Drawable7.icon_13405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13406: DrawableResource
+  get() = Drawable7.icon_13406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13407: DrawableResource
+  get() = Drawable7.icon_13407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13408: DrawableResource
+  get() = Drawable7.icon_13408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13409: DrawableResource
+  get() = Drawable7.icon_13409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1341: DrawableResource
+  get() = Drawable7.icon_1341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13410: DrawableResource
+  get() = Drawable7.icon_13410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13411: DrawableResource
+  get() = Drawable7.icon_13411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13412: DrawableResource
+  get() = Drawable7.icon_13412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13413: DrawableResource
+  get() = Drawable7.icon_13413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13414: DrawableResource
+  get() = Drawable7.icon_13414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13415: DrawableResource
+  get() = Drawable7.icon_13415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13416: DrawableResource
+  get() = Drawable7.icon_13416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13417: DrawableResource
+  get() = Drawable7.icon_13417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13418: DrawableResource
+  get() = Drawable7.icon_13418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13419: DrawableResource
+  get() = Drawable7.icon_13419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1342: DrawableResource
+  get() = Drawable7.icon_1342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13420: DrawableResource
+  get() = Drawable7.icon_13420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13421: DrawableResource
+  get() = Drawable7.icon_13421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13422: DrawableResource
+  get() = Drawable7.icon_13422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13423: DrawableResource
+  get() = Drawable7.icon_13423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13424: DrawableResource
+  get() = Drawable7.icon_13424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13425: DrawableResource
+  get() = Drawable7.icon_13425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13426: DrawableResource
+  get() = Drawable7.icon_13426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13427: DrawableResource
+  get() = Drawable7.icon_13427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13428: DrawableResource
+  get() = Drawable7.icon_13428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13429: DrawableResource
+  get() = Drawable7.icon_13429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1343: DrawableResource
+  get() = Drawable7.icon_1343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13430: DrawableResource
+  get() = Drawable7.icon_13430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13431: DrawableResource
+  get() = Drawable7.icon_13431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13432: DrawableResource
+  get() = Drawable7.icon_13432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13433: DrawableResource
+  get() = Drawable7.icon_13433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13434: DrawableResource
+  get() = Drawable7.icon_13434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13435: DrawableResource
+  get() = Drawable7.icon_13435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13436: DrawableResource
+  get() = Drawable7.icon_13436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13437: DrawableResource
+  get() = Drawable7.icon_13437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13438: DrawableResource
+  get() = Drawable7.icon_13438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13439: DrawableResource
+  get() = Drawable7.icon_13439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1344: DrawableResource
+  get() = Drawable7.icon_1344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13440: DrawableResource
+  get() = Drawable7.icon_13440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13441: DrawableResource
+  get() = Drawable7.icon_13441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13442: DrawableResource
+  get() = Drawable7.icon_13442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13443: DrawableResource
+  get() = Drawable7.icon_13443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13444: DrawableResource
+  get() = Drawable7.icon_13444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13445: DrawableResource
+  get() = Drawable7.icon_13445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13446: DrawableResource
+  get() = Drawable7.icon_13446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13447: DrawableResource
+  get() = Drawable7.icon_13447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13448: DrawableResource
+  get() = Drawable7.icon_13448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13449: DrawableResource
+  get() = Drawable7.icon_13449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1345: DrawableResource
+  get() = Drawable7.icon_1345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13450: DrawableResource
+  get() = Drawable7.icon_13450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13451: DrawableResource
+  get() = Drawable7.icon_13451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13452: DrawableResource
+  get() = Drawable7.icon_13452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13453: DrawableResource
+  get() = Drawable7.icon_13453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13454: DrawableResource
+  get() = Drawable7.icon_13454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13455: DrawableResource
+  get() = Drawable7.icon_13455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13456: DrawableResource
+  get() = Drawable7.icon_13456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13457: DrawableResource
+  get() = Drawable7.icon_13457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13458: DrawableResource
+  get() = Drawable7.icon_13458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13459: DrawableResource
+  get() = Drawable7.icon_13459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1346: DrawableResource
+  get() = Drawable7.icon_1346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13460: DrawableResource
+  get() = Drawable7.icon_13460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13461: DrawableResource
+  get() = Drawable7.icon_13461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13462: DrawableResource
+  get() = Drawable7.icon_13462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13463: DrawableResource
+  get() = Drawable7.icon_13463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13464: DrawableResource
+  get() = Drawable7.icon_13464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13465: DrawableResource
+  get() = Drawable7.icon_13465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13466: DrawableResource
+  get() = Drawable7.icon_13466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13467: DrawableResource
+  get() = Drawable7.icon_13467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13468: DrawableResource
+  get() = Drawable7.icon_13468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13469: DrawableResource
+  get() = Drawable7.icon_13469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1347: DrawableResource
+  get() = Drawable7.icon_1347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13470: DrawableResource
+  get() = Drawable7.icon_13470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13471: DrawableResource
+  get() = Drawable7.icon_13471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13472: DrawableResource
+  get() = Drawable7.icon_13472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13473: DrawableResource
+  get() = Drawable7.icon_13473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13474: DrawableResource
+  get() = Drawable7.icon_13474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13475: DrawableResource
+  get() = Drawable7.icon_13475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13476: DrawableResource
+  get() = Drawable7.icon_13476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13477: DrawableResource
+  get() = Drawable7.icon_13477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13478: DrawableResource
+  get() = Drawable7.icon_13478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13479: DrawableResource
+  get() = Drawable7.icon_13479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1348: DrawableResource
+  get() = Drawable7.icon_1348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13480: DrawableResource
+  get() = Drawable7.icon_13480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13481: DrawableResource
+  get() = Drawable7.icon_13481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13482: DrawableResource
+  get() = Drawable7.icon_13482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13483: DrawableResource
+  get() = Drawable7.icon_13483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13484: DrawableResource
+  get() = Drawable7.icon_13484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13485: DrawableResource
+  get() = Drawable7.icon_13485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13486: DrawableResource
+  get() = Drawable7.icon_13486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13487: DrawableResource
+  get() = Drawable7.icon_13487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13488: DrawableResource
+  get() = Drawable7.icon_13488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13489: DrawableResource
+  get() = Drawable7.icon_13489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1349: DrawableResource
+  get() = Drawable7.icon_1349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13490: DrawableResource
+  get() = Drawable7.icon_13490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13491: DrawableResource
+  get() = Drawable7.icon_13491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13492: DrawableResource
+  get() = Drawable7.icon_13492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13493: DrawableResource
+  get() = Drawable7.icon_13493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13494: DrawableResource
+  get() = Drawable7.icon_13494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13495: DrawableResource
+  get() = Drawable7.icon_13495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13496: DrawableResource
+  get() = Drawable7.icon_13496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13497: DrawableResource
+  get() = Drawable7.icon_13497
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13498: DrawableResource
+  get() = Drawable7.icon_13498
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13499: DrawableResource
+  get() = Drawable7.icon_13499
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_135: DrawableResource
+  get() = Drawable7.icon_135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1350: DrawableResource
+  get() = Drawable7.icon_1350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13500: DrawableResource
+  get() = Drawable7.icon_13500
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13501: DrawableResource
+  get() = Drawable7.icon_13501
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13502: DrawableResource
+  get() = Drawable7.icon_13502
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13503: DrawableResource
+  get() = Drawable7.icon_13503
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13504: DrawableResource
+  get() = Drawable7.icon_13504
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13505: DrawableResource
+  get() = Drawable7.icon_13505
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13506: DrawableResource
+  get() = Drawable7.icon_13506
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13507: DrawableResource
+  get() = Drawable7.icon_13507
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13508: DrawableResource
+  get() = Drawable7.icon_13508
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13509: DrawableResource
+  get() = Drawable7.icon_13509
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1351: DrawableResource
+  get() = Drawable7.icon_1351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13510: DrawableResource
+  get() = Drawable7.icon_13510
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13511: DrawableResource
+  get() = Drawable7.icon_13511
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13512: DrawableResource
+  get() = Drawable7.icon_13512
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13513: DrawableResource
+  get() = Drawable7.icon_13513
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13514: DrawableResource
+  get() = Drawable7.icon_13514
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13515: DrawableResource
+  get() = Drawable7.icon_13515
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13516: DrawableResource
+  get() = Drawable7.icon_13516
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13517: DrawableResource
+  get() = Drawable7.icon_13517
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13518: DrawableResource
+  get() = Drawable7.icon_13518
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13519: DrawableResource
+  get() = Drawable7.icon_13519
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1352: DrawableResource
+  get() = Drawable7.icon_1352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13520: DrawableResource
+  get() = Drawable7.icon_13520
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13521: DrawableResource
+  get() = Drawable7.icon_13521
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13522: DrawableResource
+  get() = Drawable7.icon_13522
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13523: DrawableResource
+  get() = Drawable7.icon_13523
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13524: DrawableResource
+  get() = Drawable7.icon_13524
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13525: DrawableResource
+  get() = Drawable7.icon_13525
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13526: DrawableResource
+  get() = Drawable7.icon_13526
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13527: DrawableResource
+  get() = Drawable7.icon_13527
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13528: DrawableResource
+  get() = Drawable7.icon_13528
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13529: DrawableResource
+  get() = Drawable7.icon_13529
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1353: DrawableResource
+  get() = Drawable7.icon_1353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13530: DrawableResource
+  get() = Drawable7.icon_13530
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13531: DrawableResource
+  get() = Drawable7.icon_13531
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13532: DrawableResource
+  get() = Drawable7.icon_13532
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13533: DrawableResource
+  get() = Drawable7.icon_13533
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13534: DrawableResource
+  get() = Drawable7.icon_13534
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13535: DrawableResource
+  get() = Drawable7.icon_13535
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13536: DrawableResource
+  get() = Drawable7.icon_13536
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13537: DrawableResource
+  get() = Drawable7.icon_13537
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13538: DrawableResource
+  get() = Drawable7.icon_13538
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13539: DrawableResource
+  get() = Drawable7.icon_13539
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1354: DrawableResource
+  get() = Drawable7.icon_1354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13540: DrawableResource
+  get() = Drawable7.icon_13540
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13541: DrawableResource
+  get() = Drawable7.icon_13541
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13542: DrawableResource
+  get() = Drawable7.icon_13542
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13543: DrawableResource
+  get() = Drawable7.icon_13543
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13544: DrawableResource
+  get() = Drawable7.icon_13544
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13545: DrawableResource
+  get() = Drawable7.icon_13545
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13546: DrawableResource
+  get() = Drawable7.icon_13546
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13547: DrawableResource
+  get() = Drawable7.icon_13547
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13548: DrawableResource
+  get() = Drawable7.icon_13548
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13549: DrawableResource
+  get() = Drawable7.icon_13549
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1355: DrawableResource
+  get() = Drawable7.icon_1355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13550: DrawableResource
+  get() = Drawable7.icon_13550
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13551: DrawableResource
+  get() = Drawable7.icon_13551
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13552: DrawableResource
+  get() = Drawable7.icon_13552
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13553: DrawableResource
+  get() = Drawable7.icon_13553
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13554: DrawableResource
+  get() = Drawable7.icon_13554
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13555: DrawableResource
+  get() = Drawable7.icon_13555
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13556: DrawableResource
+  get() = Drawable7.icon_13556
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13557: DrawableResource
+  get() = Drawable7.icon_13557
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13558: DrawableResource
+  get() = Drawable7.icon_13558
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13559: DrawableResource
+  get() = Drawable7.icon_13559
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1356: DrawableResource
+  get() = Drawable7.icon_1356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13560: DrawableResource
+  get() = Drawable7.icon_13560
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13561: DrawableResource
+  get() = Drawable7.icon_13561
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13562: DrawableResource
+  get() = Drawable7.icon_13562
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13563: DrawableResource
+  get() = Drawable7.icon_13563
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13564: DrawableResource
+  get() = Drawable7.icon_13564
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13565: DrawableResource
+  get() = Drawable7.icon_13565
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13566: DrawableResource
+  get() = Drawable7.icon_13566
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13567: DrawableResource
+  get() = Drawable7.icon_13567
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13568: DrawableResource
+  get() = Drawable7.icon_13568
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13569: DrawableResource
+  get() = Drawable7.icon_13569
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1357: DrawableResource
+  get() = Drawable7.icon_1357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13570: DrawableResource
+  get() = Drawable7.icon_13570
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13571: DrawableResource
+  get() = Drawable7.icon_13571
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13572: DrawableResource
+  get() = Drawable7.icon_13572
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13573: DrawableResource
+  get() = Drawable7.icon_13573
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13574: DrawableResource
+  get() = Drawable7.icon_13574
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13575: DrawableResource
+  get() = Drawable7.icon_13575
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13576: DrawableResource
+  get() = Drawable7.icon_13576
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13577: DrawableResource
+  get() = Drawable7.icon_13577
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13578: DrawableResource
+  get() = Drawable7.icon_13578
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13579: DrawableResource
+  get() = Drawable7.icon_13579
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1358: DrawableResource
+  get() = Drawable7.icon_1358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13580: DrawableResource
+  get() = Drawable7.icon_13580
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13581: DrawableResource
+  get() = Drawable7.icon_13581
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13582: DrawableResource
+  get() = Drawable7.icon_13582
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13583: DrawableResource
+  get() = Drawable7.icon_13583
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13584: DrawableResource
+  get() = Drawable7.icon_13584
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13585: DrawableResource
+  get() = Drawable7.icon_13585
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13586: DrawableResource
+  get() = Drawable7.icon_13586
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13587: DrawableResource
+  get() = Drawable7.icon_13587
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13588: DrawableResource
+  get() = Drawable7.icon_13588
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13589: DrawableResource
+  get() = Drawable7.icon_13589
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1359: DrawableResource
+  get() = Drawable7.icon_1359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13590: DrawableResource
+  get() = Drawable7.icon_13590
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13591: DrawableResource
+  get() = Drawable7.icon_13591
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13592: DrawableResource
+  get() = Drawable7.icon_13592
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13593: DrawableResource
+  get() = Drawable7.icon_13593
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13594: DrawableResource
+  get() = Drawable7.icon_13594
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13595: DrawableResource
+  get() = Drawable7.icon_13595
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13596: DrawableResource
+  get() = Drawable7.icon_13596
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13597: DrawableResource
+  get() = Drawable7.icon_13597

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable8.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable8.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable8 {
+  public val icon_13598: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13598.xml"),
+          )
+      )
+
+  public val icon_13599: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13599.xml"),
+          )
+      )
+
+  public val icon_136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_136.xml"),
+          )
+      )
+
+  public val icon_1360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1360.xml"),
+          )
+      )
+
+  public val icon_13600: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13600.xml"),
+          )
+      )
+
+  public val icon_13601: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13601.xml"),
+          )
+      )
+
+  public val icon_13602: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13602.xml"),
+          )
+      )
+
+  public val icon_13603: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13603.xml"),
+          )
+      )
+
+  public val icon_13604: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13604.xml"),
+          )
+      )
+
+  public val icon_13605: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13605.xml"),
+          )
+      )
+
+  public val icon_13606: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13606.xml"),
+          )
+      )
+
+  public val icon_13607: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13607.xml"),
+          )
+      )
+
+  public val icon_13608: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13608.xml"),
+          )
+      )
+
+  public val icon_13609: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13609.xml"),
+          )
+      )
+
+  public val icon_1361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1361.xml"),
+          )
+      )
+
+  public val icon_13610: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13610.xml"),
+          )
+      )
+
+  public val icon_13611: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13611.xml"),
+          )
+      )
+
+  public val icon_13612: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13612.xml"),
+          )
+      )
+
+  public val icon_13613: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13613.xml"),
+          )
+      )
+
+  public val icon_13614: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13614.xml"),
+          )
+      )
+
+  public val icon_13615: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13615.xml"),
+          )
+      )
+
+  public val icon_13616: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13616.xml"),
+          )
+      )
+
+  public val icon_13617: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13617.xml"),
+          )
+      )
+
+  public val icon_13618: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13618.xml"),
+          )
+      )
+
+  public val icon_13619: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13619.xml"),
+          )
+      )
+
+  public val icon_1362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1362.xml"),
+          )
+      )
+
+  public val icon_13620: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13620.xml"),
+          )
+      )
+
+  public val icon_13621: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13621.xml"),
+          )
+      )
+
+  public val icon_13622: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13622.xml"),
+          )
+      )
+
+  public val icon_13623: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13623.xml"),
+          )
+      )
+
+  public val icon_13624: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13624.xml"),
+          )
+      )
+
+  public val icon_13625: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13625.xml"),
+          )
+      )
+
+  public val icon_13626: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13626.xml"),
+          )
+      )
+
+  public val icon_13627: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13627.xml"),
+          )
+      )
+
+  public val icon_13628: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13628.xml"),
+          )
+      )
+
+  public val icon_13629: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13629.xml"),
+          )
+      )
+
+  public val icon_1363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1363.xml"),
+          )
+      )
+
+  public val icon_13630: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13630.xml"),
+          )
+      )
+
+  public val icon_13631: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13631.xml"),
+          )
+      )
+
+  public val icon_13632: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13632.xml"),
+          )
+      )
+
+  public val icon_13633: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13633.xml"),
+          )
+      )
+
+  public val icon_13634: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13634.xml"),
+          )
+      )
+
+  public val icon_13635: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13635.xml"),
+          )
+      )
+
+  public val icon_13636: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13636.xml"),
+          )
+      )
+
+  public val icon_13637: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13637.xml"),
+          )
+      )
+
+  public val icon_13638: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13638.xml"),
+          )
+      )
+
+  public val icon_13639: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13639.xml"),
+          )
+      )
+
+  public val icon_1364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1364.xml"),
+          )
+      )
+
+  public val icon_13640: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13640.xml"),
+          )
+      )
+
+  public val icon_13641: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13641.xml"),
+          )
+      )
+
+  public val icon_13642: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13642.xml"),
+          )
+      )
+
+  public val icon_13643: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13643.xml"),
+          )
+      )
+
+  public val icon_13644: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13644.xml"),
+          )
+      )
+
+  public val icon_13645: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13645.xml"),
+          )
+      )
+
+  public val icon_13646: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13646.xml"),
+          )
+      )
+
+  public val icon_13647: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13647.xml"),
+          )
+      )
+
+  public val icon_13648: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13648.xml"),
+          )
+      )
+
+  public val icon_13649: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13649.xml"),
+          )
+      )
+
+  public val icon_1365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1365.xml"),
+          )
+      )
+
+  public val icon_13650: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13650.xml"),
+          )
+      )
+
+  public val icon_13651: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13651.xml"),
+          )
+      )
+
+  public val icon_13652: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13652.xml"),
+          )
+      )
+
+  public val icon_13653: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13653.xml"),
+          )
+      )
+
+  public val icon_13654: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13654.xml"),
+          )
+      )
+
+  public val icon_13655: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13655.xml"),
+          )
+      )
+
+  public val icon_13656: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13656.xml"),
+          )
+      )
+
+  public val icon_13657: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13657.xml"),
+          )
+      )
+
+  public val icon_13658: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13658.xml"),
+          )
+      )
+
+  public val icon_13659: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13659.xml"),
+          )
+      )
+
+  public val icon_1366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1366.xml"),
+          )
+      )
+
+  public val icon_13660: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13660.xml"),
+          )
+      )
+
+  public val icon_13661: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13661.xml"),
+          )
+      )
+
+  public val icon_13662: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13662.xml"),
+          )
+      )
+
+  public val icon_13663: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13663.xml"),
+          )
+      )
+
+  public val icon_13664: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13664.xml"),
+          )
+      )
+
+  public val icon_13665: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13665.xml"),
+          )
+      )
+
+  public val icon_13666: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13666.xml"),
+          )
+      )
+
+  public val icon_13667: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13667.xml"),
+          )
+      )
+
+  public val icon_13668: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13668.xml"),
+          )
+      )
+
+  public val icon_13669: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13669.xml"),
+          )
+      )
+
+  public val icon_1367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1367.xml"),
+          )
+      )
+
+  public val icon_13670: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13670.xml"),
+          )
+      )
+
+  public val icon_13671: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13671.xml"),
+          )
+      )
+
+  public val icon_13672: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13672.xml"),
+          )
+      )
+
+  public val icon_13673: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13673.xml"),
+          )
+      )
+
+  public val icon_13674: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13674.xml"),
+          )
+      )
+
+  public val icon_13675: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13675.xml"),
+          )
+      )
+
+  public val icon_13676: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13676.xml"),
+          )
+      )
+
+  public val icon_13677: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13677.xml"),
+          )
+      )
+
+  public val icon_13678: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13678.xml"),
+          )
+      )
+
+  public val icon_13679: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13679.xml"),
+          )
+      )
+
+  public val icon_1368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1368.xml"),
+          )
+      )
+
+  public val icon_13680: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13680.xml"),
+          )
+      )
+
+  public val icon_13681: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13681.xml"),
+          )
+      )
+
+  public val icon_13682: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13682.xml"),
+          )
+      )
+
+  public val icon_13683: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13683.xml"),
+          )
+      )
+
+  public val icon_13684: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13684.xml"),
+          )
+      )
+
+  public val icon_13685: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13685.xml"),
+          )
+      )
+
+  public val icon_13686: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13686.xml"),
+          )
+      )
+
+  public val icon_13687: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13687.xml"),
+          )
+      )
+
+  public val icon_13688: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13688.xml"),
+          )
+      )
+
+  public val icon_13689: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13689.xml"),
+          )
+      )
+
+  public val icon_1369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1369.xml"),
+          )
+      )
+
+  public val icon_13690: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13690.xml"),
+          )
+      )
+
+  public val icon_13691: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13691.xml"),
+          )
+      )
+
+  public val icon_13692: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13692.xml"),
+          )
+      )
+
+  public val icon_13693: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13693.xml"),
+          )
+      )
+
+  public val icon_13694: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13694.xml"),
+          )
+      )
+
+  public val icon_13695: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13695.xml"),
+          )
+      )
+
+  public val icon_13696: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13696.xml"),
+          )
+      )
+
+  public val icon_13697: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13697.xml"),
+          )
+      )
+
+  public val icon_13698: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13698.xml"),
+          )
+      )
+
+  public val icon_13699: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13699.xml"),
+          )
+      )
+
+  public val icon_137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_137.xml"),
+          )
+      )
+
+  public val icon_1370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1370.xml"),
+          )
+      )
+
+  public val icon_13700: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13700.xml"),
+          )
+      )
+
+  public val icon_13701: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13701.xml"),
+          )
+      )
+
+  public val icon_13702: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13702.xml"),
+          )
+      )
+
+  public val icon_13703: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13703.xml"),
+          )
+      )
+
+  public val icon_13704: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13704.xml"),
+          )
+      )
+
+  public val icon_13705: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13705.xml"),
+          )
+      )
+
+  public val icon_13706: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13706.xml"),
+          )
+      )
+
+  public val icon_13707: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13707.xml"),
+          )
+      )
+
+  public val icon_13708: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13708.xml"),
+          )
+      )
+
+  public val icon_13709: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13709.xml"),
+          )
+      )
+
+  public val icon_1371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1371.xml"),
+          )
+      )
+
+  public val icon_13710: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13710.xml"),
+          )
+      )
+
+  public val icon_13711: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13711.xml"),
+          )
+      )
+
+  public val icon_13712: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13712.xml"),
+          )
+      )
+
+  public val icon_13713: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13713.xml"),
+          )
+      )
+
+  public val icon_13714: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13714.xml"),
+          )
+      )
+
+  public val icon_13715: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13715.xml"),
+          )
+      )
+
+  public val icon_13716: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13716.xml"),
+          )
+      )
+
+  public val icon_13717: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13717.xml"),
+          )
+      )
+
+  public val icon_13718: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13718.xml"),
+          )
+      )
+
+  public val icon_13719: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13719.xml"),
+          )
+      )
+
+  public val icon_1372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1372.xml"),
+          )
+      )
+
+  public val icon_13720: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13720.xml"),
+          )
+      )
+
+  public val icon_13721: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13721.xml"),
+          )
+      )
+
+  public val icon_13722: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13722.xml"),
+          )
+      )
+
+  public val icon_13723: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13723.xml"),
+          )
+      )
+
+  public val icon_13724: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13724.xml"),
+          )
+      )
+
+  public val icon_13725: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13725.xml"),
+          )
+      )
+
+  public val icon_13726: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13726.xml"),
+          )
+      )
+
+  public val icon_13727: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13727.xml"),
+          )
+      )
+
+  public val icon_13728: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13728.xml"),
+          )
+      )
+
+  public val icon_13729: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13729.xml"),
+          )
+      )
+
+  public val icon_1373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1373.xml"),
+          )
+      )
+
+  public val icon_13730: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13730.xml"),
+          )
+      )
+
+  public val icon_13731: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13731.xml"),
+          )
+      )
+
+  public val icon_13732: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13732.xml"),
+          )
+      )
+
+  public val icon_13733: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13733.xml"),
+          )
+      )
+
+  public val icon_13734: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13734.xml"),
+          )
+      )
+
+  public val icon_13735: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13735.xml"),
+          )
+      )
+
+  public val icon_13736: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13736.xml"),
+          )
+      )
+
+  public val icon_13737: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13737.xml"),
+          )
+      )
+
+  public val icon_13738: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13738.xml"),
+          )
+      )
+
+  public val icon_13739: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13739.xml"),
+          )
+      )
+
+  public val icon_1374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1374.xml"),
+          )
+      )
+
+  public val icon_13740: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13740.xml"),
+          )
+      )
+
+  public val icon_13741: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13741.xml"),
+          )
+      )
+
+  public val icon_13742: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13742.xml"),
+          )
+      )
+
+  public val icon_13743: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13743.xml"),
+          )
+      )
+
+  public val icon_13744: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13744.xml"),
+          )
+      )
+
+  public val icon_13745: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13745.xml"),
+          )
+      )
+
+  public val icon_13746: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13746.xml"),
+          )
+      )
+
+  public val icon_13747: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13747.xml"),
+          )
+      )
+
+  public val icon_13748: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13748.xml"),
+          )
+      )
+
+  public val icon_13749: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13749.xml"),
+          )
+      )
+
+  public val icon_1375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1375.xml"),
+          )
+      )
+
+  public val icon_13750: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13750.xml"),
+          )
+      )
+
+  public val icon_13751: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13751.xml"),
+          )
+      )
+
+  public val icon_13752: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13752.xml"),
+          )
+      )
+
+  public val icon_13753: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13753.xml"),
+          )
+      )
+
+  public val icon_13754: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13754.xml"),
+          )
+      )
+
+  public val icon_13755: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13755.xml"),
+          )
+      )
+
+  public val icon_13756: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13756.xml"),
+          )
+      )
+
+  public val icon_13757: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13757.xml"),
+          )
+      )
+
+  public val icon_13758: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13758.xml"),
+          )
+      )
+
+  public val icon_13759: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13759.xml"),
+          )
+      )
+
+  public val icon_1376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1376.xml"),
+          )
+      )
+
+  public val icon_13760: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13760.xml"),
+          )
+      )
+
+  public val icon_13761: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13761.xml"),
+          )
+      )
+
+  public val icon_13762: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13762.xml"),
+          )
+      )
+
+  public val icon_13763: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13763.xml"),
+          )
+      )
+
+  public val icon_13764: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13764.xml"),
+          )
+      )
+
+  public val icon_13765: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13765.xml"),
+          )
+      )
+
+  public val icon_13766: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13766.xml"),
+          )
+      )
+
+  public val icon_13767: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13767.xml"),
+          )
+      )
+
+  public val icon_13768: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13768.xml"),
+          )
+      )
+
+  public val icon_13769: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13769.xml"),
+          )
+      )
+
+  public val icon_1377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1377.xml"),
+          )
+      )
+
+  public val icon_13770: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13770.xml"),
+          )
+      )
+
+  public val icon_13771: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13771.xml"),
+          )
+      )
+
+  public val icon_13772: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13772.xml"),
+          )
+      )
+
+  public val icon_13773: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13773.xml"),
+          )
+      )
+
+  public val icon_13774: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13774.xml"),
+          )
+      )
+
+  public val icon_13775: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13775.xml"),
+          )
+      )
+
+  public val icon_13776: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13776.xml"),
+          )
+      )
+
+  public val icon_13777: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13777.xml"),
+          )
+      )
+
+  public val icon_13778: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13778.xml"),
+          )
+      )
+
+  public val icon_13779: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13779.xml"),
+          )
+      )
+
+  public val icon_1378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1378.xml"),
+          )
+      )
+
+  public val icon_13780: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13780.xml"),
+          )
+      )
+
+  public val icon_13781: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13781.xml"),
+          )
+      )
+
+  public val icon_13782: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13782.xml"),
+          )
+      )
+
+  public val icon_13783: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13783.xml"),
+          )
+      )
+
+  public val icon_13784: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13784.xml"),
+          )
+      )
+
+  public val icon_13785: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13785.xml"),
+          )
+      )
+
+  public val icon_13786: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13786.xml"),
+          )
+      )
+
+  public val icon_13787: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13787.xml"),
+          )
+      )
+
+  public val icon_13788: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13788.xml"),
+          )
+      )
+
+  public val icon_13789: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13789.xml"),
+          )
+      )
+
+  public val icon_1379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1379.xml"),
+          )
+      )
+
+  public val icon_13790: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13790.xml"),
+          )
+      )
+
+  public val icon_13791: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13791.xml"),
+          )
+      )
+
+  public val icon_13792: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13792.xml"),
+          )
+      )
+
+  public val icon_13793: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13793.xml"),
+          )
+      )
+
+  public val icon_13794: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13794.xml"),
+          )
+      )
+
+  public val icon_13795: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13795.xml"),
+          )
+      )
+
+  public val icon_13796: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13796.xml"),
+          )
+      )
+
+  public val icon_13797: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13797.xml"),
+          )
+      )
+
+  public val icon_13798: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13798.xml"),
+          )
+      )
+
+  public val icon_13799: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13799.xml"),
+          )
+      )
+
+  public val icon_138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_138.xml"),
+          )
+      )
+
+  public val icon_1380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1380.xml"),
+          )
+      )
+
+  public val icon_13800: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13800.xml"),
+          )
+      )
+
+  public val icon_13801: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13801.xml"),
+          )
+      )
+
+  public val icon_13802: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13802.xml"),
+          )
+      )
+
+  public val icon_13803: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13803.xml"),
+          )
+      )
+
+  public val icon_13804: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13804.xml"),
+          )
+      )
+
+  public val icon_13805: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13805.xml"),
+          )
+      )
+
+  public val icon_13806: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13806.xml"),
+          )
+      )
+
+  public val icon_13807: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13807.xml"),
+          )
+      )
+
+  public val icon_13808: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13808.xml"),
+          )
+      )
+
+  public val icon_13809: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13809.xml"),
+          )
+      )
+
+  public val icon_1381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1381.xml"),
+          )
+      )
+
+  public val icon_13810: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13810.xml"),
+          )
+      )
+
+  public val icon_13811: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13811.xml"),
+          )
+      )
+
+  public val icon_13812: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13812.xml"),
+          )
+      )
+
+  public val icon_13813: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13813.xml"),
+          )
+      )
+
+  public val icon_13814: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13814.xml"),
+          )
+      )
+
+  public val icon_13815: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13815.xml"),
+          )
+      )
+
+  public val icon_13816: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13816.xml"),
+          )
+      )
+
+  public val icon_13817: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13817.xml"),
+          )
+      )
+
+  public val icon_13818: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13818.xml"),
+          )
+      )
+
+  public val icon_13819: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13819.xml"),
+          )
+      )
+
+  public val icon_1382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1382.xml"),
+          )
+      )
+
+  public val icon_13820: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13820.xml"),
+          )
+      )
+
+  public val icon_13821: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13821.xml"),
+          )
+      )
+
+  public val icon_13822: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13822.xml"),
+          )
+      )
+
+  public val icon_13823: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13823.xml"),
+          )
+      )
+
+  public val icon_13824: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13824.xml"),
+          )
+      )
+
+  public val icon_13825: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13825.xml"),
+          )
+      )
+
+  public val icon_13826: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13826.xml"),
+          )
+      )
+
+  public val icon_13827: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13827.xml"),
+          )
+      )
+
+  public val icon_13828: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13828.xml"),
+          )
+      )
+
+  public val icon_13829: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13829.xml"),
+          )
+      )
+
+  public val icon_1383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1383.xml"),
+          )
+      )
+
+  public val icon_13830: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13830.xml"),
+          )
+      )
+
+  public val icon_13831: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13831.xml"),
+          )
+      )
+
+  public val icon_13832: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13832.xml"),
+          )
+      )
+
+  public val icon_13833: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13833.xml"),
+          )
+      )
+
+  public val icon_13834: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13834.xml"),
+          )
+      )
+
+  public val icon_13835: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13835.xml"),
+          )
+      )
+
+  public val icon_13836: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13836.xml"),
+          )
+      )
+
+  public val icon_13837: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13837.xml"),
+          )
+      )
+
+  public val icon_13838: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13838.xml"),
+          )
+      )
+
+  public val icon_13839: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13839.xml"),
+          )
+      )
+
+  public val icon_1384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1384.xml"),
+          )
+      )
+
+  public val icon_13840: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13840.xml"),
+          )
+      )
+
+  public val icon_13841: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13841.xml"),
+          )
+      )
+
+  public val icon_13842: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13842.xml"),
+          )
+      )
+
+  public val icon_13843: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13843.xml"),
+          )
+      )
+
+  public val icon_13844: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13844.xml"),
+          )
+      )
+
+  public val icon_13845: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13845.xml"),
+          )
+      )
+
+  public val icon_13846: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13846.xml"),
+          )
+      )
+
+  public val icon_13847: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13847.xml"),
+          )
+      )
+
+  public val icon_13848: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13848.xml"),
+          )
+      )
+
+  public val icon_13849: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13849.xml"),
+          )
+      )
+
+  public val icon_1385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1385.xml"),
+          )
+      )
+
+  public val icon_13850: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13850.xml"),
+          )
+      )
+
+  public val icon_13851: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13851.xml"),
+          )
+      )
+
+  public val icon_13852: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13852.xml"),
+          )
+      )
+
+  public val icon_13853: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13853.xml"),
+          )
+      )
+
+  public val icon_13854: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13854.xml"),
+          )
+      )
+
+  public val icon_13855: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13855.xml"),
+          )
+      )
+
+  public val icon_13856: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13856.xml"),
+          )
+      )
+
+  public val icon_13857: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13857.xml"),
+          )
+      )
+
+  public val icon_13858: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13858.xml"),
+          )
+      )
+
+  public val icon_13859: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13859.xml"),
+          )
+      )
+
+  public val icon_1386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1386.xml"),
+          )
+      )
+
+  public val icon_13860: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13860.xml"),
+          )
+      )
+
+  public val icon_13861: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13861.xml"),
+          )
+      )
+
+  public val icon_13862: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13862.xml"),
+          )
+      )
+
+  public val icon_13863: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13863.xml"),
+          )
+      )
+
+  public val icon_13864: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13864.xml"),
+          )
+      )
+
+  public val icon_13865: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13865.xml"),
+          )
+      )
+
+  public val icon_13866: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13866.xml"),
+          )
+      )
+
+  public val icon_13867: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13867.xml"),
+          )
+      )
+
+  public val icon_13868: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13868.xml"),
+          )
+      )
+
+  public val icon_13869: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13869.xml"),
+          )
+      )
+
+  public val icon_1387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1387.xml"),
+          )
+      )
+
+  public val icon_13870: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13870.xml"),
+          )
+      )
+
+  public val icon_13871: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13871.xml"),
+          )
+      )
+
+  public val icon_13872: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13872.xml"),
+          )
+      )
+
+  public val icon_13873: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13873.xml"),
+          )
+      )
+
+  public val icon_13874: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13874.xml"),
+          )
+      )
+
+  public val icon_13875: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13875.xml"),
+          )
+      )
+
+  public val icon_13876: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13876.xml"),
+          )
+      )
+
+  public val icon_13877: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13877.xml"),
+          )
+      )
+
+  public val icon_13878: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13878.xml"),
+          )
+      )
+
+  public val icon_13879: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13879.xml"),
+          )
+      )
+
+  public val icon_1388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1388.xml"),
+          )
+      )
+
+  public val icon_13880: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13880.xml"),
+          )
+      )
+
+  public val icon_13881: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13881.xml"),
+          )
+      )
+
+  public val icon_13882: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13882.xml"),
+          )
+      )
+
+  public val icon_13883: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13883.xml"),
+          )
+      )
+
+  public val icon_13884: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13884.xml"),
+          )
+      )
+
+  public val icon_13885: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13885.xml"),
+          )
+      )
+
+  public val icon_13886: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13886.xml"),
+          )
+      )
+
+  public val icon_13887: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13887.xml"),
+          )
+      )
+
+  public val icon_13888: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13888.xml"),
+          )
+      )
+
+  public val icon_13889: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13889.xml"),
+          )
+      )
+
+  public val icon_1389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1389.xml"),
+          )
+      )
+
+  public val icon_13890: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13890.xml"),
+          )
+      )
+
+  public val icon_13891: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13891.xml"),
+          )
+      )
+
+  public val icon_13892: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13892.xml"),
+          )
+      )
+
+  public val icon_13893: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13893.xml"),
+          )
+      )
+
+  public val icon_13894: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13894.xml"),
+          )
+      )
+
+  public val icon_13895: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13895.xml"),
+          )
+      )
+
+  public val icon_13896: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13896.xml"),
+          )
+      )
+
+  public val icon_13897: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13897.xml"),
+          )
+      )
+
+  public val icon_13898: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13898.xml"),
+          )
+      )
+
+  public val icon_13899: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13899.xml"),
+          )
+      )
+
+  public val icon_139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_139.xml"),
+          )
+      )
+
+  public val icon_1390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1390.xml"),
+          )
+      )
+
+  public val icon_13900: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13900.xml"),
+          )
+      )
+
+  public val icon_13901: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13901.xml"),
+          )
+      )
+
+  public val icon_13902: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13902.xml"),
+          )
+      )
+
+  public val icon_13903: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13903.xml"),
+          )
+      )
+
+  public val icon_13904: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13904.xml"),
+          )
+      )
+
+  public val icon_13905: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13905.xml"),
+          )
+      )
+
+  public val icon_13906: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13906.xml"),
+          )
+      )
+
+  public val icon_13907: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13907.xml"),
+          )
+      )
+
+  public val icon_13908: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13908.xml"),
+          )
+      )
+
+  public val icon_13909: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13909.xml"),
+          )
+      )
+
+  public val icon_1391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1391.xml"),
+          )
+      )
+
+  public val icon_13910: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13910.xml"),
+          )
+      )
+
+  public val icon_13911: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13911.xml"),
+          )
+      )
+
+  public val icon_13912: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13912.xml"),
+          )
+      )
+
+  public val icon_13913: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13913.xml"),
+          )
+      )
+
+  public val icon_13914: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13914.xml"),
+          )
+      )
+
+  public val icon_13915: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13915.xml"),
+          )
+      )
+
+  public val icon_13916: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13916.xml"),
+          )
+      )
+
+  public val icon_13917: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13917.xml"),
+          )
+      )
+
+  public val icon_13918: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13918.xml"),
+          )
+      )
+
+  public val icon_13919: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13919.xml"),
+          )
+      )
+
+  public val icon_1392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1392.xml"),
+          )
+      )
+
+  public val icon_13920: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13920.xml"),
+          )
+      )
+
+  public val icon_13921: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13921.xml"),
+          )
+      )
+
+  public val icon_13922: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13922.xml"),
+          )
+      )
+
+  public val icon_13923: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13923.xml"),
+          )
+      )
+
+  public val icon_13924: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13924.xml"),
+          )
+      )
+
+  public val icon_13925: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13925.xml"),
+          )
+      )
+
+  public val icon_13926: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13926.xml"),
+          )
+      )
+
+  public val icon_13927: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13927.xml"),
+          )
+      )
+
+  public val icon_13928: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13928.xml"),
+          )
+      )
+
+  public val icon_13929: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13929.xml"),
+          )
+      )
+
+  public val icon_1393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1393.xml"),
+          )
+      )
+
+  public val icon_13930: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13930.xml"),
+          )
+      )
+
+  public val icon_13931: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13931.xml"),
+          )
+      )
+
+  public val icon_13932: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13932.xml"),
+          )
+      )
+
+  public val icon_13933: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13933.xml"),
+          )
+      )
+
+  public val icon_13934: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13934.xml"),
+          )
+      )
+
+  public val icon_13935: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13935.xml"),
+          )
+      )
+
+  public val icon_13936: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13936.xml"),
+          )
+      )
+
+  public val icon_13937: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13937.xml"),
+          )
+      )
+
+  public val icon_13938: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13938.xml"),
+          )
+      )
+
+  public val icon_13939: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13939.xml"),
+          )
+      )
+
+  public val icon_1394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1394.xml"),
+          )
+      )
+
+  public val icon_13940: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13940.xml"),
+          )
+      )
+
+  public val icon_13941: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13941.xml"),
+          )
+      )
+
+  public val icon_13942: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13942.xml"),
+          )
+      )
+
+  public val icon_13943: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13943.xml"),
+          )
+      )
+
+  public val icon_13944: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13944.xml"),
+          )
+      )
+
+  public val icon_13945: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13945.xml"),
+          )
+      )
+
+  public val icon_13946: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13946.xml"),
+          )
+      )
+
+  public val icon_13947: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13947.xml"),
+          )
+      )
+
+  public val icon_13948: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13948.xml"),
+          )
+      )
+
+  public val icon_13949: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13949.xml"),
+          )
+      )
+
+  public val icon_1395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1395.xml"),
+          )
+      )
+
+  public val icon_13950: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13950.xml"),
+          )
+      )
+
+  public val icon_13951: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13951.xml"),
+          )
+      )
+
+  public val icon_13952: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13952.xml"),
+          )
+      )
+
+  public val icon_13953: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13953.xml"),
+          )
+      )
+
+  public val icon_13954: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13954.xml"),
+          )
+      )
+
+  public val icon_13955: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13955.xml"),
+          )
+      )
+
+  public val icon_13956: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13956.xml"),
+          )
+      )
+
+  public val icon_13957: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13957.xml"),
+          )
+      )
+
+  public val icon_13958: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13958.xml"),
+          )
+      )
+
+  public val icon_13959: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13959.xml"),
+          )
+      )
+
+  public val icon_1396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1396.xml"),
+          )
+      )
+
+  public val icon_13960: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13960.xml"),
+          )
+      )
+
+  public val icon_13961: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13961.xml"),
+          )
+      )
+
+  public val icon_13962: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13962.xml"),
+          )
+      )
+
+  public val icon_13963: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13963.xml"),
+          )
+      )
+
+  public val icon_13964: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13964.xml"),
+          )
+      )
+
+  public val icon_13965: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13965.xml"),
+          )
+      )
+
+  public val icon_13966: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13966.xml"),
+          )
+      )
+
+  public val icon_13967: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13967.xml"),
+          )
+      )
+
+  public val icon_13968: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13968.xml"),
+          )
+      )
+
+  public val icon_13969: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13969.xml"),
+          )
+      )
+
+  public val icon_1397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1397.xml"),
+          )
+      )
+
+  public val icon_13970: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13970.xml"),
+          )
+      )
+
+  public val icon_13971: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13971.xml"),
+          )
+      )
+
+  public val icon_13972: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13972.xml"),
+          )
+      )
+
+  public val icon_13973: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13973.xml"),
+          )
+      )
+
+  public val icon_13974: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13974.xml"),
+          )
+      )
+
+  public val icon_13975: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13975.xml"),
+          )
+      )
+
+  public val icon_13976: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13976.xml"),
+          )
+      )
+
+  public val icon_13977: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13977.xml"),
+          )
+      )
+
+  public val icon_13978: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13978.xml"),
+          )
+      )
+
+  public val icon_13979: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13979.xml"),
+          )
+      )
+
+  public val icon_1398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1398.xml"),
+          )
+      )
+
+  public val icon_13980: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13980.xml"),
+          )
+      )
+
+  public val icon_13981: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13981.xml"),
+          )
+      )
+
+  public val icon_13982: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13982.xml"),
+          )
+      )
+
+  public val icon_13983: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13983.xml"),
+          )
+      )
+
+  public val icon_13984: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13984.xml"),
+          )
+      )
+
+  public val icon_13985: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13985.xml"),
+          )
+      )
+
+  public val icon_13986: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13986.xml"),
+          )
+      )
+
+  public val icon_13987: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13987.xml"),
+          )
+      )
+
+  public val icon_13988: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13988.xml"),
+          )
+      )
+
+  public val icon_13989: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13989.xml"),
+          )
+      )
+
+  public val icon_1399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1399.xml"),
+          )
+      )
+
+  public val icon_13990: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13990.xml"),
+          )
+      )
+
+  public val icon_13991: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13991.xml"),
+          )
+      )
+
+  public val icon_13992: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13992.xml"),
+          )
+      )
+
+  public val icon_13993: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13993.xml"),
+          )
+      )
+
+  public val icon_13994: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13994.xml"),
+          )
+      )
+
+  public val icon_13995: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13995.xml"),
+          )
+      )
+
+  public val icon_13996: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13996.xml"),
+          )
+      )
+
+  public val icon_13997: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13997.xml"),
+          )
+      )
+
+  public val icon_13998: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13998.xml"),
+          )
+      )
+
+  public val icon_13999: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_13999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_13999.xml"),
+          )
+      )
+
+  public val icon_14: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14.xml"),
+          )
+      )
+
+  public val icon_140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_140.xml"),
+          )
+      )
+
+  public val icon_1400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1400.xml"),
+          )
+      )
+
+  public val icon_14000: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14000.xml"),
+          )
+      )
+
+  public val icon_14001: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14001.xml"),
+          )
+      )
+
+  public val icon_14002: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14002.xml"),
+          )
+      )
+
+  public val icon_14003: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14003.xml"),
+          )
+      )
+
+  public val icon_14004: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14004.xml"),
+          )
+      )
+
+  public val icon_14005: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14005.xml"),
+          )
+      )
+
+  public val icon_14006: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14006.xml"),
+          )
+      )
+
+  public val icon_14007: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14007.xml"),
+          )
+      )
+
+  public val icon_14008: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14008.xml"),
+          )
+      )
+
+  public val icon_14009: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14009.xml"),
+          )
+      )
+
+  public val icon_1401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1401.xml"),
+          )
+      )
+
+  public val icon_14010: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14010.xml"),
+          )
+      )
+
+  public val icon_14011: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14011.xml"),
+          )
+      )
+
+  public val icon_14012: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14012.xml"),
+          )
+      )
+
+  public val icon_14013: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14013.xml"),
+          )
+      )
+
+  public val icon_14014: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14014.xml"),
+          )
+      )
+
+  public val icon_14015: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14015.xml"),
+          )
+      )
+
+  public val icon_14016: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14016.xml"),
+          )
+      )
+
+  public val icon_14017: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14017.xml"),
+          )
+      )
+
+  public val icon_14018: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14018.xml"),
+          )
+      )
+
+  public val icon_14019: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14019.xml"),
+          )
+      )
+
+  public val icon_1402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1402.xml"),
+          )
+      )
+
+  public val icon_14020: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14020.xml"),
+          )
+      )
+
+  public val icon_14021: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14021.xml"),
+          )
+      )
+
+  public val icon_14022: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14022.xml"),
+          )
+      )
+
+  public val icon_14023: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14023.xml"),
+          )
+      )
+
+  public val icon_14024: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14024.xml"),
+          )
+      )
+
+  public val icon_14025: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14025.xml"),
+          )
+      )
+
+  public val icon_14026: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14026.xml"),
+          )
+      )
+
+  public val icon_14027: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14027.xml"),
+          )
+      )
+
+  public val icon_14028: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14028.xml"),
+          )
+      )
+
+  public val icon_14029: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14029.xml"),
+          )
+      )
+
+  public val icon_1403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1403.xml"),
+          )
+      )
+
+  public val icon_14030: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14030.xml"),
+          )
+      )
+
+  public val icon_14031: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14031.xml"),
+          )
+      )
+
+  public val icon_14032: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14032.xml"),
+          )
+      )
+
+  public val icon_14033: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14033.xml"),
+          )
+      )
+
+  public val icon_14034: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14034.xml"),
+          )
+      )
+
+  public val icon_14035: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14035.xml"),
+          )
+      )
+
+  public val icon_14036: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14036.xml"),
+          )
+      )
+
+  public val icon_14037: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14037.xml"),
+          )
+      )
+
+  public val icon_14038: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14038.xml"),
+          )
+      )
+
+  public val icon_14039: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14039.xml"),
+          )
+      )
+
+  public val icon_1404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1404.xml"),
+          )
+      )
+
+  public val icon_14040: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14040.xml"),
+          )
+      )
+
+  public val icon_14041: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14041.xml"),
+          )
+      )
+
+  public val icon_14042: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14042.xml"),
+          )
+      )
+
+  public val icon_14043: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14043.xml"),
+          )
+      )
+
+  public val icon_14044: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14044.xml"),
+          )
+      )
+
+  public val icon_14045: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14045.xml"),
+          )
+      )
+
+  public val icon_14046: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14046.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13598: DrawableResource
+  get() = Drawable8.icon_13598
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13599: DrawableResource
+  get() = Drawable8.icon_13599
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_136: DrawableResource
+  get() = Drawable8.icon_136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1360: DrawableResource
+  get() = Drawable8.icon_1360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13600: DrawableResource
+  get() = Drawable8.icon_13600
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13601: DrawableResource
+  get() = Drawable8.icon_13601
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13602: DrawableResource
+  get() = Drawable8.icon_13602
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13603: DrawableResource
+  get() = Drawable8.icon_13603
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13604: DrawableResource
+  get() = Drawable8.icon_13604
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13605: DrawableResource
+  get() = Drawable8.icon_13605
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13606: DrawableResource
+  get() = Drawable8.icon_13606
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13607: DrawableResource
+  get() = Drawable8.icon_13607
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13608: DrawableResource
+  get() = Drawable8.icon_13608
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13609: DrawableResource
+  get() = Drawable8.icon_13609
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1361: DrawableResource
+  get() = Drawable8.icon_1361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13610: DrawableResource
+  get() = Drawable8.icon_13610
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13611: DrawableResource
+  get() = Drawable8.icon_13611
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13612: DrawableResource
+  get() = Drawable8.icon_13612
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13613: DrawableResource
+  get() = Drawable8.icon_13613
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13614: DrawableResource
+  get() = Drawable8.icon_13614
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13615: DrawableResource
+  get() = Drawable8.icon_13615
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13616: DrawableResource
+  get() = Drawable8.icon_13616
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13617: DrawableResource
+  get() = Drawable8.icon_13617
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13618: DrawableResource
+  get() = Drawable8.icon_13618
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13619: DrawableResource
+  get() = Drawable8.icon_13619
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1362: DrawableResource
+  get() = Drawable8.icon_1362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13620: DrawableResource
+  get() = Drawable8.icon_13620
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13621: DrawableResource
+  get() = Drawable8.icon_13621
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13622: DrawableResource
+  get() = Drawable8.icon_13622
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13623: DrawableResource
+  get() = Drawable8.icon_13623
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13624: DrawableResource
+  get() = Drawable8.icon_13624
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13625: DrawableResource
+  get() = Drawable8.icon_13625
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13626: DrawableResource
+  get() = Drawable8.icon_13626
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13627: DrawableResource
+  get() = Drawable8.icon_13627
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13628: DrawableResource
+  get() = Drawable8.icon_13628
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13629: DrawableResource
+  get() = Drawable8.icon_13629
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1363: DrawableResource
+  get() = Drawable8.icon_1363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13630: DrawableResource
+  get() = Drawable8.icon_13630
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13631: DrawableResource
+  get() = Drawable8.icon_13631
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13632: DrawableResource
+  get() = Drawable8.icon_13632
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13633: DrawableResource
+  get() = Drawable8.icon_13633
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13634: DrawableResource
+  get() = Drawable8.icon_13634
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13635: DrawableResource
+  get() = Drawable8.icon_13635
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13636: DrawableResource
+  get() = Drawable8.icon_13636
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13637: DrawableResource
+  get() = Drawable8.icon_13637
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13638: DrawableResource
+  get() = Drawable8.icon_13638
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13639: DrawableResource
+  get() = Drawable8.icon_13639
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1364: DrawableResource
+  get() = Drawable8.icon_1364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13640: DrawableResource
+  get() = Drawable8.icon_13640
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13641: DrawableResource
+  get() = Drawable8.icon_13641
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13642: DrawableResource
+  get() = Drawable8.icon_13642
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13643: DrawableResource
+  get() = Drawable8.icon_13643
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13644: DrawableResource
+  get() = Drawable8.icon_13644
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13645: DrawableResource
+  get() = Drawable8.icon_13645
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13646: DrawableResource
+  get() = Drawable8.icon_13646
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13647: DrawableResource
+  get() = Drawable8.icon_13647
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13648: DrawableResource
+  get() = Drawable8.icon_13648
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13649: DrawableResource
+  get() = Drawable8.icon_13649
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1365: DrawableResource
+  get() = Drawable8.icon_1365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13650: DrawableResource
+  get() = Drawable8.icon_13650
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13651: DrawableResource
+  get() = Drawable8.icon_13651
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13652: DrawableResource
+  get() = Drawable8.icon_13652
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13653: DrawableResource
+  get() = Drawable8.icon_13653
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13654: DrawableResource
+  get() = Drawable8.icon_13654
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13655: DrawableResource
+  get() = Drawable8.icon_13655
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13656: DrawableResource
+  get() = Drawable8.icon_13656
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13657: DrawableResource
+  get() = Drawable8.icon_13657
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13658: DrawableResource
+  get() = Drawable8.icon_13658
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13659: DrawableResource
+  get() = Drawable8.icon_13659
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1366: DrawableResource
+  get() = Drawable8.icon_1366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13660: DrawableResource
+  get() = Drawable8.icon_13660
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13661: DrawableResource
+  get() = Drawable8.icon_13661
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13662: DrawableResource
+  get() = Drawable8.icon_13662
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13663: DrawableResource
+  get() = Drawable8.icon_13663
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13664: DrawableResource
+  get() = Drawable8.icon_13664
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13665: DrawableResource
+  get() = Drawable8.icon_13665
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13666: DrawableResource
+  get() = Drawable8.icon_13666
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13667: DrawableResource
+  get() = Drawable8.icon_13667
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13668: DrawableResource
+  get() = Drawable8.icon_13668
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13669: DrawableResource
+  get() = Drawable8.icon_13669
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1367: DrawableResource
+  get() = Drawable8.icon_1367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13670: DrawableResource
+  get() = Drawable8.icon_13670
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13671: DrawableResource
+  get() = Drawable8.icon_13671
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13672: DrawableResource
+  get() = Drawable8.icon_13672
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13673: DrawableResource
+  get() = Drawable8.icon_13673
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13674: DrawableResource
+  get() = Drawable8.icon_13674
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13675: DrawableResource
+  get() = Drawable8.icon_13675
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13676: DrawableResource
+  get() = Drawable8.icon_13676
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13677: DrawableResource
+  get() = Drawable8.icon_13677
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13678: DrawableResource
+  get() = Drawable8.icon_13678
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13679: DrawableResource
+  get() = Drawable8.icon_13679
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1368: DrawableResource
+  get() = Drawable8.icon_1368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13680: DrawableResource
+  get() = Drawable8.icon_13680
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13681: DrawableResource
+  get() = Drawable8.icon_13681
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13682: DrawableResource
+  get() = Drawable8.icon_13682
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13683: DrawableResource
+  get() = Drawable8.icon_13683
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13684: DrawableResource
+  get() = Drawable8.icon_13684
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13685: DrawableResource
+  get() = Drawable8.icon_13685
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13686: DrawableResource
+  get() = Drawable8.icon_13686
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13687: DrawableResource
+  get() = Drawable8.icon_13687
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13688: DrawableResource
+  get() = Drawable8.icon_13688
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13689: DrawableResource
+  get() = Drawable8.icon_13689
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1369: DrawableResource
+  get() = Drawable8.icon_1369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13690: DrawableResource
+  get() = Drawable8.icon_13690
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13691: DrawableResource
+  get() = Drawable8.icon_13691
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13692: DrawableResource
+  get() = Drawable8.icon_13692
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13693: DrawableResource
+  get() = Drawable8.icon_13693
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13694: DrawableResource
+  get() = Drawable8.icon_13694
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13695: DrawableResource
+  get() = Drawable8.icon_13695
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13696: DrawableResource
+  get() = Drawable8.icon_13696
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13697: DrawableResource
+  get() = Drawable8.icon_13697
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13698: DrawableResource
+  get() = Drawable8.icon_13698
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13699: DrawableResource
+  get() = Drawable8.icon_13699
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_137: DrawableResource
+  get() = Drawable8.icon_137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1370: DrawableResource
+  get() = Drawable8.icon_1370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13700: DrawableResource
+  get() = Drawable8.icon_13700
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13701: DrawableResource
+  get() = Drawable8.icon_13701
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13702: DrawableResource
+  get() = Drawable8.icon_13702
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13703: DrawableResource
+  get() = Drawable8.icon_13703
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13704: DrawableResource
+  get() = Drawable8.icon_13704
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13705: DrawableResource
+  get() = Drawable8.icon_13705
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13706: DrawableResource
+  get() = Drawable8.icon_13706
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13707: DrawableResource
+  get() = Drawable8.icon_13707
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13708: DrawableResource
+  get() = Drawable8.icon_13708
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13709: DrawableResource
+  get() = Drawable8.icon_13709
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1371: DrawableResource
+  get() = Drawable8.icon_1371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13710: DrawableResource
+  get() = Drawable8.icon_13710
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13711: DrawableResource
+  get() = Drawable8.icon_13711
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13712: DrawableResource
+  get() = Drawable8.icon_13712
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13713: DrawableResource
+  get() = Drawable8.icon_13713
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13714: DrawableResource
+  get() = Drawable8.icon_13714
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13715: DrawableResource
+  get() = Drawable8.icon_13715
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13716: DrawableResource
+  get() = Drawable8.icon_13716
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13717: DrawableResource
+  get() = Drawable8.icon_13717
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13718: DrawableResource
+  get() = Drawable8.icon_13718
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13719: DrawableResource
+  get() = Drawable8.icon_13719
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1372: DrawableResource
+  get() = Drawable8.icon_1372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13720: DrawableResource
+  get() = Drawable8.icon_13720
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13721: DrawableResource
+  get() = Drawable8.icon_13721
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13722: DrawableResource
+  get() = Drawable8.icon_13722
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13723: DrawableResource
+  get() = Drawable8.icon_13723
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13724: DrawableResource
+  get() = Drawable8.icon_13724
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13725: DrawableResource
+  get() = Drawable8.icon_13725
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13726: DrawableResource
+  get() = Drawable8.icon_13726
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13727: DrawableResource
+  get() = Drawable8.icon_13727
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13728: DrawableResource
+  get() = Drawable8.icon_13728
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13729: DrawableResource
+  get() = Drawable8.icon_13729
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1373: DrawableResource
+  get() = Drawable8.icon_1373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13730: DrawableResource
+  get() = Drawable8.icon_13730
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13731: DrawableResource
+  get() = Drawable8.icon_13731
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13732: DrawableResource
+  get() = Drawable8.icon_13732
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13733: DrawableResource
+  get() = Drawable8.icon_13733
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13734: DrawableResource
+  get() = Drawable8.icon_13734
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13735: DrawableResource
+  get() = Drawable8.icon_13735
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13736: DrawableResource
+  get() = Drawable8.icon_13736
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13737: DrawableResource
+  get() = Drawable8.icon_13737
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13738: DrawableResource
+  get() = Drawable8.icon_13738
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13739: DrawableResource
+  get() = Drawable8.icon_13739
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1374: DrawableResource
+  get() = Drawable8.icon_1374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13740: DrawableResource
+  get() = Drawable8.icon_13740
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13741: DrawableResource
+  get() = Drawable8.icon_13741
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13742: DrawableResource
+  get() = Drawable8.icon_13742
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13743: DrawableResource
+  get() = Drawable8.icon_13743
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13744: DrawableResource
+  get() = Drawable8.icon_13744
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13745: DrawableResource
+  get() = Drawable8.icon_13745
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13746: DrawableResource
+  get() = Drawable8.icon_13746
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13747: DrawableResource
+  get() = Drawable8.icon_13747
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13748: DrawableResource
+  get() = Drawable8.icon_13748
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13749: DrawableResource
+  get() = Drawable8.icon_13749
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1375: DrawableResource
+  get() = Drawable8.icon_1375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13750: DrawableResource
+  get() = Drawable8.icon_13750
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13751: DrawableResource
+  get() = Drawable8.icon_13751
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13752: DrawableResource
+  get() = Drawable8.icon_13752
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13753: DrawableResource
+  get() = Drawable8.icon_13753
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13754: DrawableResource
+  get() = Drawable8.icon_13754
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13755: DrawableResource
+  get() = Drawable8.icon_13755
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13756: DrawableResource
+  get() = Drawable8.icon_13756
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13757: DrawableResource
+  get() = Drawable8.icon_13757
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13758: DrawableResource
+  get() = Drawable8.icon_13758
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13759: DrawableResource
+  get() = Drawable8.icon_13759
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1376: DrawableResource
+  get() = Drawable8.icon_1376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13760: DrawableResource
+  get() = Drawable8.icon_13760
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13761: DrawableResource
+  get() = Drawable8.icon_13761
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13762: DrawableResource
+  get() = Drawable8.icon_13762
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13763: DrawableResource
+  get() = Drawable8.icon_13763
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13764: DrawableResource
+  get() = Drawable8.icon_13764
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13765: DrawableResource
+  get() = Drawable8.icon_13765
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13766: DrawableResource
+  get() = Drawable8.icon_13766
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13767: DrawableResource
+  get() = Drawable8.icon_13767
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13768: DrawableResource
+  get() = Drawable8.icon_13768
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13769: DrawableResource
+  get() = Drawable8.icon_13769
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1377: DrawableResource
+  get() = Drawable8.icon_1377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13770: DrawableResource
+  get() = Drawable8.icon_13770
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13771: DrawableResource
+  get() = Drawable8.icon_13771
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13772: DrawableResource
+  get() = Drawable8.icon_13772
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13773: DrawableResource
+  get() = Drawable8.icon_13773
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13774: DrawableResource
+  get() = Drawable8.icon_13774
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13775: DrawableResource
+  get() = Drawable8.icon_13775
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13776: DrawableResource
+  get() = Drawable8.icon_13776
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13777: DrawableResource
+  get() = Drawable8.icon_13777
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13778: DrawableResource
+  get() = Drawable8.icon_13778
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13779: DrawableResource
+  get() = Drawable8.icon_13779
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1378: DrawableResource
+  get() = Drawable8.icon_1378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13780: DrawableResource
+  get() = Drawable8.icon_13780
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13781: DrawableResource
+  get() = Drawable8.icon_13781
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13782: DrawableResource
+  get() = Drawable8.icon_13782
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13783: DrawableResource
+  get() = Drawable8.icon_13783
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13784: DrawableResource
+  get() = Drawable8.icon_13784
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13785: DrawableResource
+  get() = Drawable8.icon_13785
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13786: DrawableResource
+  get() = Drawable8.icon_13786
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13787: DrawableResource
+  get() = Drawable8.icon_13787
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13788: DrawableResource
+  get() = Drawable8.icon_13788
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13789: DrawableResource
+  get() = Drawable8.icon_13789
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1379: DrawableResource
+  get() = Drawable8.icon_1379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13790: DrawableResource
+  get() = Drawable8.icon_13790
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13791: DrawableResource
+  get() = Drawable8.icon_13791
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13792: DrawableResource
+  get() = Drawable8.icon_13792
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13793: DrawableResource
+  get() = Drawable8.icon_13793
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13794: DrawableResource
+  get() = Drawable8.icon_13794
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13795: DrawableResource
+  get() = Drawable8.icon_13795
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13796: DrawableResource
+  get() = Drawable8.icon_13796
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13797: DrawableResource
+  get() = Drawable8.icon_13797
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13798: DrawableResource
+  get() = Drawable8.icon_13798
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13799: DrawableResource
+  get() = Drawable8.icon_13799
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_138: DrawableResource
+  get() = Drawable8.icon_138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1380: DrawableResource
+  get() = Drawable8.icon_1380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13800: DrawableResource
+  get() = Drawable8.icon_13800
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13801: DrawableResource
+  get() = Drawable8.icon_13801
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13802: DrawableResource
+  get() = Drawable8.icon_13802
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13803: DrawableResource
+  get() = Drawable8.icon_13803
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13804: DrawableResource
+  get() = Drawable8.icon_13804
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13805: DrawableResource
+  get() = Drawable8.icon_13805
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13806: DrawableResource
+  get() = Drawable8.icon_13806
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13807: DrawableResource
+  get() = Drawable8.icon_13807
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13808: DrawableResource
+  get() = Drawable8.icon_13808
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13809: DrawableResource
+  get() = Drawable8.icon_13809
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1381: DrawableResource
+  get() = Drawable8.icon_1381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13810: DrawableResource
+  get() = Drawable8.icon_13810
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13811: DrawableResource
+  get() = Drawable8.icon_13811
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13812: DrawableResource
+  get() = Drawable8.icon_13812
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13813: DrawableResource
+  get() = Drawable8.icon_13813
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13814: DrawableResource
+  get() = Drawable8.icon_13814
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13815: DrawableResource
+  get() = Drawable8.icon_13815
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13816: DrawableResource
+  get() = Drawable8.icon_13816
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13817: DrawableResource
+  get() = Drawable8.icon_13817
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13818: DrawableResource
+  get() = Drawable8.icon_13818
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13819: DrawableResource
+  get() = Drawable8.icon_13819
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1382: DrawableResource
+  get() = Drawable8.icon_1382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13820: DrawableResource
+  get() = Drawable8.icon_13820
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13821: DrawableResource
+  get() = Drawable8.icon_13821
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13822: DrawableResource
+  get() = Drawable8.icon_13822
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13823: DrawableResource
+  get() = Drawable8.icon_13823
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13824: DrawableResource
+  get() = Drawable8.icon_13824
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13825: DrawableResource
+  get() = Drawable8.icon_13825
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13826: DrawableResource
+  get() = Drawable8.icon_13826
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13827: DrawableResource
+  get() = Drawable8.icon_13827
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13828: DrawableResource
+  get() = Drawable8.icon_13828
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13829: DrawableResource
+  get() = Drawable8.icon_13829
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1383: DrawableResource
+  get() = Drawable8.icon_1383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13830: DrawableResource
+  get() = Drawable8.icon_13830
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13831: DrawableResource
+  get() = Drawable8.icon_13831
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13832: DrawableResource
+  get() = Drawable8.icon_13832
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13833: DrawableResource
+  get() = Drawable8.icon_13833
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13834: DrawableResource
+  get() = Drawable8.icon_13834
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13835: DrawableResource
+  get() = Drawable8.icon_13835
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13836: DrawableResource
+  get() = Drawable8.icon_13836
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13837: DrawableResource
+  get() = Drawable8.icon_13837
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13838: DrawableResource
+  get() = Drawable8.icon_13838
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13839: DrawableResource
+  get() = Drawable8.icon_13839
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1384: DrawableResource
+  get() = Drawable8.icon_1384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13840: DrawableResource
+  get() = Drawable8.icon_13840
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13841: DrawableResource
+  get() = Drawable8.icon_13841
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13842: DrawableResource
+  get() = Drawable8.icon_13842
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13843: DrawableResource
+  get() = Drawable8.icon_13843
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13844: DrawableResource
+  get() = Drawable8.icon_13844
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13845: DrawableResource
+  get() = Drawable8.icon_13845
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13846: DrawableResource
+  get() = Drawable8.icon_13846
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13847: DrawableResource
+  get() = Drawable8.icon_13847
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13848: DrawableResource
+  get() = Drawable8.icon_13848
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13849: DrawableResource
+  get() = Drawable8.icon_13849
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1385: DrawableResource
+  get() = Drawable8.icon_1385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13850: DrawableResource
+  get() = Drawable8.icon_13850
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13851: DrawableResource
+  get() = Drawable8.icon_13851
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13852: DrawableResource
+  get() = Drawable8.icon_13852
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13853: DrawableResource
+  get() = Drawable8.icon_13853
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13854: DrawableResource
+  get() = Drawable8.icon_13854
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13855: DrawableResource
+  get() = Drawable8.icon_13855
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13856: DrawableResource
+  get() = Drawable8.icon_13856
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13857: DrawableResource
+  get() = Drawable8.icon_13857
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13858: DrawableResource
+  get() = Drawable8.icon_13858
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13859: DrawableResource
+  get() = Drawable8.icon_13859
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1386: DrawableResource
+  get() = Drawable8.icon_1386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13860: DrawableResource
+  get() = Drawable8.icon_13860
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13861: DrawableResource
+  get() = Drawable8.icon_13861
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13862: DrawableResource
+  get() = Drawable8.icon_13862
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13863: DrawableResource
+  get() = Drawable8.icon_13863
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13864: DrawableResource
+  get() = Drawable8.icon_13864
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13865: DrawableResource
+  get() = Drawable8.icon_13865
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13866: DrawableResource
+  get() = Drawable8.icon_13866
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13867: DrawableResource
+  get() = Drawable8.icon_13867
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13868: DrawableResource
+  get() = Drawable8.icon_13868
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13869: DrawableResource
+  get() = Drawable8.icon_13869
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1387: DrawableResource
+  get() = Drawable8.icon_1387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13870: DrawableResource
+  get() = Drawable8.icon_13870
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13871: DrawableResource
+  get() = Drawable8.icon_13871
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13872: DrawableResource
+  get() = Drawable8.icon_13872
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13873: DrawableResource
+  get() = Drawable8.icon_13873
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13874: DrawableResource
+  get() = Drawable8.icon_13874
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13875: DrawableResource
+  get() = Drawable8.icon_13875
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13876: DrawableResource
+  get() = Drawable8.icon_13876
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13877: DrawableResource
+  get() = Drawable8.icon_13877
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13878: DrawableResource
+  get() = Drawable8.icon_13878
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13879: DrawableResource
+  get() = Drawable8.icon_13879
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1388: DrawableResource
+  get() = Drawable8.icon_1388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13880: DrawableResource
+  get() = Drawable8.icon_13880
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13881: DrawableResource
+  get() = Drawable8.icon_13881
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13882: DrawableResource
+  get() = Drawable8.icon_13882
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13883: DrawableResource
+  get() = Drawable8.icon_13883
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13884: DrawableResource
+  get() = Drawable8.icon_13884
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13885: DrawableResource
+  get() = Drawable8.icon_13885
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13886: DrawableResource
+  get() = Drawable8.icon_13886
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13887: DrawableResource
+  get() = Drawable8.icon_13887
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13888: DrawableResource
+  get() = Drawable8.icon_13888
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13889: DrawableResource
+  get() = Drawable8.icon_13889
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1389: DrawableResource
+  get() = Drawable8.icon_1389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13890: DrawableResource
+  get() = Drawable8.icon_13890
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13891: DrawableResource
+  get() = Drawable8.icon_13891
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13892: DrawableResource
+  get() = Drawable8.icon_13892
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13893: DrawableResource
+  get() = Drawable8.icon_13893
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13894: DrawableResource
+  get() = Drawable8.icon_13894
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13895: DrawableResource
+  get() = Drawable8.icon_13895
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13896: DrawableResource
+  get() = Drawable8.icon_13896
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13897: DrawableResource
+  get() = Drawable8.icon_13897
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13898: DrawableResource
+  get() = Drawable8.icon_13898
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13899: DrawableResource
+  get() = Drawable8.icon_13899
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_139: DrawableResource
+  get() = Drawable8.icon_139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1390: DrawableResource
+  get() = Drawable8.icon_1390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13900: DrawableResource
+  get() = Drawable8.icon_13900
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13901: DrawableResource
+  get() = Drawable8.icon_13901
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13902: DrawableResource
+  get() = Drawable8.icon_13902
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13903: DrawableResource
+  get() = Drawable8.icon_13903
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13904: DrawableResource
+  get() = Drawable8.icon_13904
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13905: DrawableResource
+  get() = Drawable8.icon_13905
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13906: DrawableResource
+  get() = Drawable8.icon_13906
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13907: DrawableResource
+  get() = Drawable8.icon_13907
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13908: DrawableResource
+  get() = Drawable8.icon_13908
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13909: DrawableResource
+  get() = Drawable8.icon_13909
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1391: DrawableResource
+  get() = Drawable8.icon_1391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13910: DrawableResource
+  get() = Drawable8.icon_13910
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13911: DrawableResource
+  get() = Drawable8.icon_13911
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13912: DrawableResource
+  get() = Drawable8.icon_13912
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13913: DrawableResource
+  get() = Drawable8.icon_13913
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13914: DrawableResource
+  get() = Drawable8.icon_13914
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13915: DrawableResource
+  get() = Drawable8.icon_13915
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13916: DrawableResource
+  get() = Drawable8.icon_13916
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13917: DrawableResource
+  get() = Drawable8.icon_13917
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13918: DrawableResource
+  get() = Drawable8.icon_13918
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13919: DrawableResource
+  get() = Drawable8.icon_13919
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1392: DrawableResource
+  get() = Drawable8.icon_1392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13920: DrawableResource
+  get() = Drawable8.icon_13920
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13921: DrawableResource
+  get() = Drawable8.icon_13921
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13922: DrawableResource
+  get() = Drawable8.icon_13922
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13923: DrawableResource
+  get() = Drawable8.icon_13923
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13924: DrawableResource
+  get() = Drawable8.icon_13924
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13925: DrawableResource
+  get() = Drawable8.icon_13925
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13926: DrawableResource
+  get() = Drawable8.icon_13926
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13927: DrawableResource
+  get() = Drawable8.icon_13927
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13928: DrawableResource
+  get() = Drawable8.icon_13928
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13929: DrawableResource
+  get() = Drawable8.icon_13929
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1393: DrawableResource
+  get() = Drawable8.icon_1393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13930: DrawableResource
+  get() = Drawable8.icon_13930
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13931: DrawableResource
+  get() = Drawable8.icon_13931
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13932: DrawableResource
+  get() = Drawable8.icon_13932
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13933: DrawableResource
+  get() = Drawable8.icon_13933
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13934: DrawableResource
+  get() = Drawable8.icon_13934
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13935: DrawableResource
+  get() = Drawable8.icon_13935
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13936: DrawableResource
+  get() = Drawable8.icon_13936
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13937: DrawableResource
+  get() = Drawable8.icon_13937
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13938: DrawableResource
+  get() = Drawable8.icon_13938
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13939: DrawableResource
+  get() = Drawable8.icon_13939
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1394: DrawableResource
+  get() = Drawable8.icon_1394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13940: DrawableResource
+  get() = Drawable8.icon_13940
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13941: DrawableResource
+  get() = Drawable8.icon_13941
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13942: DrawableResource
+  get() = Drawable8.icon_13942
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13943: DrawableResource
+  get() = Drawable8.icon_13943
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13944: DrawableResource
+  get() = Drawable8.icon_13944
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13945: DrawableResource
+  get() = Drawable8.icon_13945
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13946: DrawableResource
+  get() = Drawable8.icon_13946
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13947: DrawableResource
+  get() = Drawable8.icon_13947
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13948: DrawableResource
+  get() = Drawable8.icon_13948
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13949: DrawableResource
+  get() = Drawable8.icon_13949
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1395: DrawableResource
+  get() = Drawable8.icon_1395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13950: DrawableResource
+  get() = Drawable8.icon_13950
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13951: DrawableResource
+  get() = Drawable8.icon_13951
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13952: DrawableResource
+  get() = Drawable8.icon_13952
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13953: DrawableResource
+  get() = Drawable8.icon_13953
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13954: DrawableResource
+  get() = Drawable8.icon_13954
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13955: DrawableResource
+  get() = Drawable8.icon_13955
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13956: DrawableResource
+  get() = Drawable8.icon_13956
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13957: DrawableResource
+  get() = Drawable8.icon_13957
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13958: DrawableResource
+  get() = Drawable8.icon_13958
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13959: DrawableResource
+  get() = Drawable8.icon_13959
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1396: DrawableResource
+  get() = Drawable8.icon_1396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13960: DrawableResource
+  get() = Drawable8.icon_13960
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13961: DrawableResource
+  get() = Drawable8.icon_13961
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13962: DrawableResource
+  get() = Drawable8.icon_13962
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13963: DrawableResource
+  get() = Drawable8.icon_13963
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13964: DrawableResource
+  get() = Drawable8.icon_13964
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13965: DrawableResource
+  get() = Drawable8.icon_13965
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13966: DrawableResource
+  get() = Drawable8.icon_13966
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13967: DrawableResource
+  get() = Drawable8.icon_13967
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13968: DrawableResource
+  get() = Drawable8.icon_13968
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13969: DrawableResource
+  get() = Drawable8.icon_13969
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1397: DrawableResource
+  get() = Drawable8.icon_1397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13970: DrawableResource
+  get() = Drawable8.icon_13970
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13971: DrawableResource
+  get() = Drawable8.icon_13971
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13972: DrawableResource
+  get() = Drawable8.icon_13972
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13973: DrawableResource
+  get() = Drawable8.icon_13973
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13974: DrawableResource
+  get() = Drawable8.icon_13974
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13975: DrawableResource
+  get() = Drawable8.icon_13975
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13976: DrawableResource
+  get() = Drawable8.icon_13976
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13977: DrawableResource
+  get() = Drawable8.icon_13977
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13978: DrawableResource
+  get() = Drawable8.icon_13978
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13979: DrawableResource
+  get() = Drawable8.icon_13979
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1398: DrawableResource
+  get() = Drawable8.icon_1398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13980: DrawableResource
+  get() = Drawable8.icon_13980
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13981: DrawableResource
+  get() = Drawable8.icon_13981
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13982: DrawableResource
+  get() = Drawable8.icon_13982
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13983: DrawableResource
+  get() = Drawable8.icon_13983
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13984: DrawableResource
+  get() = Drawable8.icon_13984
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13985: DrawableResource
+  get() = Drawable8.icon_13985
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13986: DrawableResource
+  get() = Drawable8.icon_13986
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13987: DrawableResource
+  get() = Drawable8.icon_13987
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13988: DrawableResource
+  get() = Drawable8.icon_13988
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13989: DrawableResource
+  get() = Drawable8.icon_13989
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1399: DrawableResource
+  get() = Drawable8.icon_1399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13990: DrawableResource
+  get() = Drawable8.icon_13990
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13991: DrawableResource
+  get() = Drawable8.icon_13991
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13992: DrawableResource
+  get() = Drawable8.icon_13992
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13993: DrawableResource
+  get() = Drawable8.icon_13993
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13994: DrawableResource
+  get() = Drawable8.icon_13994
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13995: DrawableResource
+  get() = Drawable8.icon_13995
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13996: DrawableResource
+  get() = Drawable8.icon_13996
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13997: DrawableResource
+  get() = Drawable8.icon_13997
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13998: DrawableResource
+  get() = Drawable8.icon_13998
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_13999: DrawableResource
+  get() = Drawable8.icon_13999
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14: DrawableResource
+  get() = Drawable8.icon_14
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_140: DrawableResource
+  get() = Drawable8.icon_140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1400: DrawableResource
+  get() = Drawable8.icon_1400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14000: DrawableResource
+  get() = Drawable8.icon_14000
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14001: DrawableResource
+  get() = Drawable8.icon_14001
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14002: DrawableResource
+  get() = Drawable8.icon_14002
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14003: DrawableResource
+  get() = Drawable8.icon_14003
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14004: DrawableResource
+  get() = Drawable8.icon_14004
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14005: DrawableResource
+  get() = Drawable8.icon_14005
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14006: DrawableResource
+  get() = Drawable8.icon_14006
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14007: DrawableResource
+  get() = Drawable8.icon_14007
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14008: DrawableResource
+  get() = Drawable8.icon_14008
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14009: DrawableResource
+  get() = Drawable8.icon_14009
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1401: DrawableResource
+  get() = Drawable8.icon_1401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14010: DrawableResource
+  get() = Drawable8.icon_14010
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14011: DrawableResource
+  get() = Drawable8.icon_14011
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14012: DrawableResource
+  get() = Drawable8.icon_14012
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14013: DrawableResource
+  get() = Drawable8.icon_14013
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14014: DrawableResource
+  get() = Drawable8.icon_14014
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14015: DrawableResource
+  get() = Drawable8.icon_14015
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14016: DrawableResource
+  get() = Drawable8.icon_14016
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14017: DrawableResource
+  get() = Drawable8.icon_14017
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14018: DrawableResource
+  get() = Drawable8.icon_14018
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14019: DrawableResource
+  get() = Drawable8.icon_14019
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1402: DrawableResource
+  get() = Drawable8.icon_1402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14020: DrawableResource
+  get() = Drawable8.icon_14020
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14021: DrawableResource
+  get() = Drawable8.icon_14021
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14022: DrawableResource
+  get() = Drawable8.icon_14022
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14023: DrawableResource
+  get() = Drawable8.icon_14023
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14024: DrawableResource
+  get() = Drawable8.icon_14024
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14025: DrawableResource
+  get() = Drawable8.icon_14025
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14026: DrawableResource
+  get() = Drawable8.icon_14026
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14027: DrawableResource
+  get() = Drawable8.icon_14027
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14028: DrawableResource
+  get() = Drawable8.icon_14028
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14029: DrawableResource
+  get() = Drawable8.icon_14029
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1403: DrawableResource
+  get() = Drawable8.icon_1403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14030: DrawableResource
+  get() = Drawable8.icon_14030
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14031: DrawableResource
+  get() = Drawable8.icon_14031
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14032: DrawableResource
+  get() = Drawable8.icon_14032
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14033: DrawableResource
+  get() = Drawable8.icon_14033
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14034: DrawableResource
+  get() = Drawable8.icon_14034
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14035: DrawableResource
+  get() = Drawable8.icon_14035
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14036: DrawableResource
+  get() = Drawable8.icon_14036
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14037: DrawableResource
+  get() = Drawable8.icon_14037
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14038: DrawableResource
+  get() = Drawable8.icon_14038
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14039: DrawableResource
+  get() = Drawable8.icon_14039
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1404: DrawableResource
+  get() = Drawable8.icon_1404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14040: DrawableResource
+  get() = Drawable8.icon_14040
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14041: DrawableResource
+  get() = Drawable8.icon_14041
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14042: DrawableResource
+  get() = Drawable8.icon_14042
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14043: DrawableResource
+  get() = Drawable8.icon_14043
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14044: DrawableResource
+  get() = Drawable8.icon_14044
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14045: DrawableResource
+  get() = Drawable8.icon_14045
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14046: DrawableResource
+  get() = Drawable8.icon_14046

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable9.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Drawable9.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable9 {
+  public val icon_14047: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14047.xml"),
+          )
+      )
+
+  public val icon_14048: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14048.xml"),
+          )
+      )
+
+  public val icon_14049: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14049.xml"),
+          )
+      )
+
+  public val icon_1405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1405.xml"),
+          )
+      )
+
+  public val icon_14050: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14050.xml"),
+          )
+      )
+
+  public val icon_14051: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14051.xml"),
+          )
+      )
+
+  public val icon_14052: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14052.xml"),
+          )
+      )
+
+  public val icon_14053: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14053.xml"),
+          )
+      )
+
+  public val icon_14054: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14054.xml"),
+          )
+      )
+
+  public val icon_14055: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14055.xml"),
+          )
+      )
+
+  public val icon_14056: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14056.xml"),
+          )
+      )
+
+  public val icon_14057: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14057.xml"),
+          )
+      )
+
+  public val icon_14058: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14058.xml"),
+          )
+      )
+
+  public val icon_14059: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14059.xml"),
+          )
+      )
+
+  public val icon_1406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1406.xml"),
+          )
+      )
+
+  public val icon_14060: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14060.xml"),
+          )
+      )
+
+  public val icon_14061: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14061.xml"),
+          )
+      )
+
+  public val icon_14062: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14062.xml"),
+          )
+      )
+
+  public val icon_14063: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14063.xml"),
+          )
+      )
+
+  public val icon_14064: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14064.xml"),
+          )
+      )
+
+  public val icon_14065: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14065.xml"),
+          )
+      )
+
+  public val icon_14066: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14066.xml"),
+          )
+      )
+
+  public val icon_14067: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14067.xml"),
+          )
+      )
+
+  public val icon_14068: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14068.xml"),
+          )
+      )
+
+  public val icon_14069: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14069.xml"),
+          )
+      )
+
+  public val icon_1407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1407.xml"),
+          )
+      )
+
+  public val icon_14070: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14070.xml"),
+          )
+      )
+
+  public val icon_14071: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14071.xml"),
+          )
+      )
+
+  public val icon_14072: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14072.xml"),
+          )
+      )
+
+  public val icon_14073: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14073.xml"),
+          )
+      )
+
+  public val icon_14074: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14074.xml"),
+          )
+      )
+
+  public val icon_14075: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14075.xml"),
+          )
+      )
+
+  public val icon_14076: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14076.xml"),
+          )
+      )
+
+  public val icon_14077: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14077.xml"),
+          )
+      )
+
+  public val icon_14078: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14078.xml"),
+          )
+      )
+
+  public val icon_14079: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14079.xml"),
+          )
+      )
+
+  public val icon_1408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1408.xml"),
+          )
+      )
+
+  public val icon_14080: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14080.xml"),
+          )
+      )
+
+  public val icon_14081: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14081.xml"),
+          )
+      )
+
+  public val icon_14082: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14082.xml"),
+          )
+      )
+
+  public val icon_14083: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14083.xml"),
+          )
+      )
+
+  public val icon_14084: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14084.xml"),
+          )
+      )
+
+  public val icon_14085: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14085.xml"),
+          )
+      )
+
+  public val icon_14086: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14086.xml"),
+          )
+      )
+
+  public val icon_14087: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14087.xml"),
+          )
+      )
+
+  public val icon_14088: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14088.xml"),
+          )
+      )
+
+  public val icon_14089: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14089.xml"),
+          )
+      )
+
+  public val icon_1409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1409.xml"),
+          )
+      )
+
+  public val icon_14090: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14090.xml"),
+          )
+      )
+
+  public val icon_14091: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14091.xml"),
+          )
+      )
+
+  public val icon_14092: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14092.xml"),
+          )
+      )
+
+  public val icon_14093: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14093.xml"),
+          )
+      )
+
+  public val icon_14094: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14094.xml"),
+          )
+      )
+
+  public val icon_14095: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14095.xml"),
+          )
+      )
+
+  public val icon_14096: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14096.xml"),
+          )
+      )
+
+  public val icon_14097: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14097.xml"),
+          )
+      )
+
+  public val icon_14098: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14098.xml"),
+          )
+      )
+
+  public val icon_14099: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14099.xml"),
+          )
+      )
+
+  public val icon_141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_141.xml"),
+          )
+      )
+
+  public val icon_1410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1410.xml"),
+          )
+      )
+
+  public val icon_14100: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14100.xml"),
+          )
+      )
+
+  public val icon_14101: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14101.xml"),
+          )
+      )
+
+  public val icon_14102: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14102.xml"),
+          )
+      )
+
+  public val icon_14103: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14103.xml"),
+          )
+      )
+
+  public val icon_14104: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14104.xml"),
+          )
+      )
+
+  public val icon_14105: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14105.xml"),
+          )
+      )
+
+  public val icon_14106: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14106.xml"),
+          )
+      )
+
+  public val icon_14107: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14107.xml"),
+          )
+      )
+
+  public val icon_14108: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14108.xml"),
+          )
+      )
+
+  public val icon_14109: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14109.xml"),
+          )
+      )
+
+  public val icon_1411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1411.xml"),
+          )
+      )
+
+  public val icon_14110: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14110.xml"),
+          )
+      )
+
+  public val icon_14111: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14111.xml"),
+          )
+      )
+
+  public val icon_14112: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14112.xml"),
+          )
+      )
+
+  public val icon_14113: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14113.xml"),
+          )
+      )
+
+  public val icon_14114: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14114.xml"),
+          )
+      )
+
+  public val icon_14115: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14115.xml"),
+          )
+      )
+
+  public val icon_14116: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14116.xml"),
+          )
+      )
+
+  public val icon_14117: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14117.xml"),
+          )
+      )
+
+  public val icon_14118: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14118.xml"),
+          )
+      )
+
+  public val icon_14119: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14119.xml"),
+          )
+      )
+
+  public val icon_1412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1412.xml"),
+          )
+      )
+
+  public val icon_14120: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14120.xml"),
+          )
+      )
+
+  public val icon_14121: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14121.xml"),
+          )
+      )
+
+  public val icon_14122: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14122.xml"),
+          )
+      )
+
+  public val icon_14123: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14123.xml"),
+          )
+      )
+
+  public val icon_14124: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14124.xml"),
+          )
+      )
+
+  public val icon_14125: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14125.xml"),
+          )
+      )
+
+  public val icon_14126: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14126.xml"),
+          )
+      )
+
+  public val icon_14127: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14127.xml"),
+          )
+      )
+
+  public val icon_14128: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14128.xml"),
+          )
+      )
+
+  public val icon_14129: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14129.xml"),
+          )
+      )
+
+  public val icon_1413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1413.xml"),
+          )
+      )
+
+  public val icon_14130: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14130.xml"),
+          )
+      )
+
+  public val icon_14131: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14131.xml"),
+          )
+      )
+
+  public val icon_14132: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14132.xml"),
+          )
+      )
+
+  public val icon_14133: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14133.xml"),
+          )
+      )
+
+  public val icon_14134: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14134.xml"),
+          )
+      )
+
+  public val icon_14135: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14135.xml"),
+          )
+      )
+
+  public val icon_14136: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14136.xml"),
+          )
+      )
+
+  public val icon_14137: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14137.xml"),
+          )
+      )
+
+  public val icon_14138: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14138.xml"),
+          )
+      )
+
+  public val icon_14139: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14139.xml"),
+          )
+      )
+
+  public val icon_1414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1414.xml"),
+          )
+      )
+
+  public val icon_14140: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14140.xml"),
+          )
+      )
+
+  public val icon_14141: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14141.xml"),
+          )
+      )
+
+  public val icon_14142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14142.xml"),
+          )
+      )
+
+  public val icon_14143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14143.xml"),
+          )
+      )
+
+  public val icon_14144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14144.xml"),
+          )
+      )
+
+  public val icon_14145: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14145.xml"),
+          )
+      )
+
+  public val icon_14146: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14146.xml"),
+          )
+      )
+
+  public val icon_14147: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14147.xml"),
+          )
+      )
+
+  public val icon_14148: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14148.xml"),
+          )
+      )
+
+  public val icon_14149: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14149.xml"),
+          )
+      )
+
+  public val icon_1415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1415.xml"),
+          )
+      )
+
+  public val icon_14150: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14150.xml"),
+          )
+      )
+
+  public val icon_14151: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14151.xml"),
+          )
+      )
+
+  public val icon_14152: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14152.xml"),
+          )
+      )
+
+  public val icon_14153: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14153.xml"),
+          )
+      )
+
+  public val icon_14154: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14154.xml"),
+          )
+      )
+
+  public val icon_14155: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14155.xml"),
+          )
+      )
+
+  public val icon_14156: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14156.xml"),
+          )
+      )
+
+  public val icon_14157: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14157.xml"),
+          )
+      )
+
+  public val icon_14158: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14158.xml"),
+          )
+      )
+
+  public val icon_14159: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14159.xml"),
+          )
+      )
+
+  public val icon_1416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1416.xml"),
+          )
+      )
+
+  public val icon_14160: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14160.xml"),
+          )
+      )
+
+  public val icon_14161: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14161.xml"),
+          )
+      )
+
+  public val icon_14162: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14162.xml"),
+          )
+      )
+
+  public val icon_14163: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14163.xml"),
+          )
+      )
+
+  public val icon_14164: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14164.xml"),
+          )
+      )
+
+  public val icon_14165: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14165.xml"),
+          )
+      )
+
+  public val icon_14166: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14166.xml"),
+          )
+      )
+
+  public val icon_14167: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14167.xml"),
+          )
+      )
+
+  public val icon_14168: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14168.xml"),
+          )
+      )
+
+  public val icon_14169: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14169.xml"),
+          )
+      )
+
+  public val icon_1417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1417.xml"),
+          )
+      )
+
+  public val icon_14170: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14170.xml"),
+          )
+      )
+
+  public val icon_14171: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14171.xml"),
+          )
+      )
+
+  public val icon_14172: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14172.xml"),
+          )
+      )
+
+  public val icon_14173: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14173.xml"),
+          )
+      )
+
+  public val icon_14174: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14174.xml"),
+          )
+      )
+
+  public val icon_14175: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14175.xml"),
+          )
+      )
+
+  public val icon_14176: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14176.xml"),
+          )
+      )
+
+  public val icon_14177: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14177.xml"),
+          )
+      )
+
+  public val icon_14178: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14178.xml"),
+          )
+      )
+
+  public val icon_14179: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14179.xml"),
+          )
+      )
+
+  public val icon_1418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1418.xml"),
+          )
+      )
+
+  public val icon_14180: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14180.xml"),
+          )
+      )
+
+  public val icon_14181: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14181.xml"),
+          )
+      )
+
+  public val icon_14182: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14182.xml"),
+          )
+      )
+
+  public val icon_14183: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14183.xml"),
+          )
+      )
+
+  public val icon_14184: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14184.xml"),
+          )
+      )
+
+  public val icon_14185: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14185.xml"),
+          )
+      )
+
+  public val icon_14186: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14186.xml"),
+          )
+      )
+
+  public val icon_14187: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14187.xml"),
+          )
+      )
+
+  public val icon_14188: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14188.xml"),
+          )
+      )
+
+  public val icon_14189: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14189.xml"),
+          )
+      )
+
+  public val icon_1419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1419.xml"),
+          )
+      )
+
+  public val icon_14190: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14190.xml"),
+          )
+      )
+
+  public val icon_14191: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14191.xml"),
+          )
+      )
+
+  public val icon_14192: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14192.xml"),
+          )
+      )
+
+  public val icon_14193: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14193.xml"),
+          )
+      )
+
+  public val icon_14194: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14194.xml"),
+          )
+      )
+
+  public val icon_14195: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14195.xml"),
+          )
+      )
+
+  public val icon_14196: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14196.xml"),
+          )
+      )
+
+  public val icon_14197: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14197.xml"),
+          )
+      )
+
+  public val icon_14198: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14198.xml"),
+          )
+      )
+
+  public val icon_14199: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14199.xml"),
+          )
+      )
+
+  public val icon_142: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_142.xml"),
+          )
+      )
+
+  public val icon_1420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1420.xml"),
+          )
+      )
+
+  public val icon_14200: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14200.xml"),
+          )
+      )
+
+  public val icon_14201: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14201.xml"),
+          )
+      )
+
+  public val icon_14202: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14202.xml"),
+          )
+      )
+
+  public val icon_14203: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14203.xml"),
+          )
+      )
+
+  public val icon_14204: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14204.xml"),
+          )
+      )
+
+  public val icon_14205: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14205.xml"),
+          )
+      )
+
+  public val icon_14206: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14206.xml"),
+          )
+      )
+
+  public val icon_14207: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14207.xml"),
+          )
+      )
+
+  public val icon_14208: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14208.xml"),
+          )
+      )
+
+  public val icon_14209: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14209.xml"),
+          )
+      )
+
+  public val icon_1421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1421.xml"),
+          )
+      )
+
+  public val icon_14210: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14210.xml"),
+          )
+      )
+
+  public val icon_14211: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14211.xml"),
+          )
+      )
+
+  public val icon_14212: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14212.xml"),
+          )
+      )
+
+  public val icon_14213: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14213.xml"),
+          )
+      )
+
+  public val icon_14214: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14214.xml"),
+          )
+      )
+
+  public val icon_14215: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14215.xml"),
+          )
+      )
+
+  public val icon_14216: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14216.xml"),
+          )
+      )
+
+  public val icon_14217: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14217.xml"),
+          )
+      )
+
+  public val icon_14218: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14218.xml"),
+          )
+      )
+
+  public val icon_14219: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14219.xml"),
+          )
+      )
+
+  public val icon_1422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1422.xml"),
+          )
+      )
+
+  public val icon_14220: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14220.xml"),
+          )
+      )
+
+  public val icon_14221: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14221.xml"),
+          )
+      )
+
+  public val icon_14222: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14222.xml"),
+          )
+      )
+
+  public val icon_14223: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14223.xml"),
+          )
+      )
+
+  public val icon_14224: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14224.xml"),
+          )
+      )
+
+  public val icon_14225: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14225.xml"),
+          )
+      )
+
+  public val icon_14226: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14226.xml"),
+          )
+      )
+
+  public val icon_14227: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14227.xml"),
+          )
+      )
+
+  public val icon_14228: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14228.xml"),
+          )
+      )
+
+  public val icon_14229: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14229.xml"),
+          )
+      )
+
+  public val icon_1423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1423.xml"),
+          )
+      )
+
+  public val icon_14230: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14230.xml"),
+          )
+      )
+
+  public val icon_14231: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14231.xml"),
+          )
+      )
+
+  public val icon_14232: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14232.xml"),
+          )
+      )
+
+  public val icon_14233: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14233.xml"),
+          )
+      )
+
+  public val icon_14234: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14234.xml"),
+          )
+      )
+
+  public val icon_14235: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14235.xml"),
+          )
+      )
+
+  public val icon_14236: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14236.xml"),
+          )
+      )
+
+  public val icon_14237: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14237.xml"),
+          )
+      )
+
+  public val icon_14238: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14238.xml"),
+          )
+      )
+
+  public val icon_14239: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14239.xml"),
+          )
+      )
+
+  public val icon_1424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1424.xml"),
+          )
+      )
+
+  public val icon_14240: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14240.xml"),
+          )
+      )
+
+  public val icon_14241: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14241.xml"),
+          )
+      )
+
+  public val icon_14242: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14242.xml"),
+          )
+      )
+
+  public val icon_14243: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14243.xml"),
+          )
+      )
+
+  public val icon_14244: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14244.xml"),
+          )
+      )
+
+  public val icon_14245: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14245.xml"),
+          )
+      )
+
+  public val icon_14246: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14246.xml"),
+          )
+      )
+
+  public val icon_14247: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14247.xml"),
+          )
+      )
+
+  public val icon_14248: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14248.xml"),
+          )
+      )
+
+  public val icon_14249: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14249.xml"),
+          )
+      )
+
+  public val icon_1425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1425.xml"),
+          )
+      )
+
+  public val icon_14250: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14250.xml"),
+          )
+      )
+
+  public val icon_14251: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14251.xml"),
+          )
+      )
+
+  public val icon_14252: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14252.xml"),
+          )
+      )
+
+  public val icon_14253: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14253.xml"),
+          )
+      )
+
+  public val icon_14254: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14254.xml"),
+          )
+      )
+
+  public val icon_14255: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14255.xml"),
+          )
+      )
+
+  public val icon_14256: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14256.xml"),
+          )
+      )
+
+  public val icon_14257: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14257.xml"),
+          )
+      )
+
+  public val icon_14258: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14258.xml"),
+          )
+      )
+
+  public val icon_14259: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14259.xml"),
+          )
+      )
+
+  public val icon_1426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1426.xml"),
+          )
+      )
+
+  public val icon_14260: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14260.xml"),
+          )
+      )
+
+  public val icon_14261: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14261.xml"),
+          )
+      )
+
+  public val icon_14262: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14262.xml"),
+          )
+      )
+
+  public val icon_14263: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14263.xml"),
+          )
+      )
+
+  public val icon_14264: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14264.xml"),
+          )
+      )
+
+  public val icon_14265: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14265.xml"),
+          )
+      )
+
+  public val icon_14266: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14266.xml"),
+          )
+      )
+
+  public val icon_14267: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14267.xml"),
+          )
+      )
+
+  public val icon_14268: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14268.xml"),
+          )
+      )
+
+  public val icon_14269: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14269.xml"),
+          )
+      )
+
+  public val icon_1427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1427.xml"),
+          )
+      )
+
+  public val icon_14270: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14270.xml"),
+          )
+      )
+
+  public val icon_14271: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14271.xml"),
+          )
+      )
+
+  public val icon_14272: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14272.xml"),
+          )
+      )
+
+  public val icon_14273: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14273.xml"),
+          )
+      )
+
+  public val icon_14274: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14274.xml"),
+          )
+      )
+
+  public val icon_14275: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14275.xml"),
+          )
+      )
+
+  public val icon_14276: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14276.xml"),
+          )
+      )
+
+  public val icon_14277: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14277.xml"),
+          )
+      )
+
+  public val icon_14278: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14278.xml"),
+          )
+      )
+
+  public val icon_14279: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14279.xml"),
+          )
+      )
+
+  public val icon_1428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1428.xml"),
+          )
+      )
+
+  public val icon_14280: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14280.xml"),
+          )
+      )
+
+  public val icon_14281: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14281.xml"),
+          )
+      )
+
+  public val icon_14282: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14282.xml"),
+          )
+      )
+
+  public val icon_14283: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14283.xml"),
+          )
+      )
+
+  public val icon_14284: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14284.xml"),
+          )
+      )
+
+  public val icon_14285: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14285.xml"),
+          )
+      )
+
+  public val icon_14286: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14286.xml"),
+          )
+      )
+
+  public val icon_14287: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14287.xml"),
+          )
+      )
+
+  public val icon_14288: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14288.xml"),
+          )
+      )
+
+  public val icon_14289: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14289.xml"),
+          )
+      )
+
+  public val icon_1429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1429.xml"),
+          )
+      )
+
+  public val icon_14290: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14290.xml"),
+          )
+      )
+
+  public val icon_14291: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14291.xml"),
+          )
+      )
+
+  public val icon_14292: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14292.xml"),
+          )
+      )
+
+  public val icon_14293: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14293.xml"),
+          )
+      )
+
+  public val icon_14294: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14294.xml"),
+          )
+      )
+
+  public val icon_14295: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14295.xml"),
+          )
+      )
+
+  public val icon_14296: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14296.xml"),
+          )
+      )
+
+  public val icon_14297: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14297.xml"),
+          )
+      )
+
+  public val icon_14298: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14298.xml"),
+          )
+      )
+
+  public val icon_14299: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14299.xml"),
+          )
+      )
+
+  public val icon_143: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_143.xml"),
+          )
+      )
+
+  public val icon_1430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1430.xml"),
+          )
+      )
+
+  public val icon_14300: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14300.xml"),
+          )
+      )
+
+  public val icon_14301: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14301.xml"),
+          )
+      )
+
+  public val icon_14302: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14302.xml"),
+          )
+      )
+
+  public val icon_14303: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14303.xml"),
+          )
+      )
+
+  public val icon_14304: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14304.xml"),
+          )
+      )
+
+  public val icon_14305: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14305.xml"),
+          )
+      )
+
+  public val icon_14306: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14306.xml"),
+          )
+      )
+
+  public val icon_14307: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14307.xml"),
+          )
+      )
+
+  public val icon_14308: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14308.xml"),
+          )
+      )
+
+  public val icon_14309: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14309.xml"),
+          )
+      )
+
+  public val icon_1431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1431.xml"),
+          )
+      )
+
+  public val icon_14310: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14310.xml"),
+          )
+      )
+
+  public val icon_14311: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14311.xml"),
+          )
+      )
+
+  public val icon_14312: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14312.xml"),
+          )
+      )
+
+  public val icon_14313: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14313.xml"),
+          )
+      )
+
+  public val icon_14314: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14314.xml"),
+          )
+      )
+
+  public val icon_14315: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14315.xml"),
+          )
+      )
+
+  public val icon_14316: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14316.xml"),
+          )
+      )
+
+  public val icon_14317: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14317.xml"),
+          )
+      )
+
+  public val icon_14318: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14318.xml"),
+          )
+      )
+
+  public val icon_14319: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14319.xml"),
+          )
+      )
+
+  public val icon_1432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1432.xml"),
+          )
+      )
+
+  public val icon_14320: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14320.xml"),
+          )
+      )
+
+  public val icon_14321: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14321.xml"),
+          )
+      )
+
+  public val icon_14322: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14322.xml"),
+          )
+      )
+
+  public val icon_14323: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14323.xml"),
+          )
+      )
+
+  public val icon_14324: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14324.xml"),
+          )
+      )
+
+  public val icon_14325: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14325.xml"),
+          )
+      )
+
+  public val icon_14326: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14326.xml"),
+          )
+      )
+
+  public val icon_14327: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14327.xml"),
+          )
+      )
+
+  public val icon_14328: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14328.xml"),
+          )
+      )
+
+  public val icon_14329: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14329.xml"),
+          )
+      )
+
+  public val icon_1433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1433.xml"),
+          )
+      )
+
+  public val icon_14330: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14330.xml"),
+          )
+      )
+
+  public val icon_14331: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14331.xml"),
+          )
+      )
+
+  public val icon_14332: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14332.xml"),
+          )
+      )
+
+  public val icon_14333: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14333.xml"),
+          )
+      )
+
+  public val icon_14334: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14334.xml"),
+          )
+      )
+
+  public val icon_14335: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14335.xml"),
+          )
+      )
+
+  public val icon_14336: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14336.xml"),
+          )
+      )
+
+  public val icon_14337: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14337.xml"),
+          )
+      )
+
+  public val icon_14338: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14338.xml"),
+          )
+      )
+
+  public val icon_14339: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14339.xml"),
+          )
+      )
+
+  public val icon_1434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1434.xml"),
+          )
+      )
+
+  public val icon_14340: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14340.xml"),
+          )
+      )
+
+  public val icon_14341: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14341.xml"),
+          )
+      )
+
+  public val icon_14342: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14342.xml"),
+          )
+      )
+
+  public val icon_14343: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14343.xml"),
+          )
+      )
+
+  public val icon_14344: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14344.xml"),
+          )
+      )
+
+  public val icon_14345: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14345.xml"),
+          )
+      )
+
+  public val icon_14346: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14346.xml"),
+          )
+      )
+
+  public val icon_14347: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14347.xml"),
+          )
+      )
+
+  public val icon_14348: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14348.xml"),
+          )
+      )
+
+  public val icon_14349: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14349.xml"),
+          )
+      )
+
+  public val icon_1435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1435.xml"),
+          )
+      )
+
+  public val icon_14350: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14350.xml"),
+          )
+      )
+
+  public val icon_14351: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14351.xml"),
+          )
+      )
+
+  public val icon_14352: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14352.xml"),
+          )
+      )
+
+  public val icon_14353: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14353.xml"),
+          )
+      )
+
+  public val icon_14354: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14354.xml"),
+          )
+      )
+
+  public val icon_14355: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14355.xml"),
+          )
+      )
+
+  public val icon_14356: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14356.xml"),
+          )
+      )
+
+  public val icon_14357: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14357.xml"),
+          )
+      )
+
+  public val icon_14358: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14358.xml"),
+          )
+      )
+
+  public val icon_14359: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14359.xml"),
+          )
+      )
+
+  public val icon_1436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1436.xml"),
+          )
+      )
+
+  public val icon_14360: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14360.xml"),
+          )
+      )
+
+  public val icon_14361: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14361.xml"),
+          )
+      )
+
+  public val icon_14362: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14362.xml"),
+          )
+      )
+
+  public val icon_14363: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14363.xml"),
+          )
+      )
+
+  public val icon_14364: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14364.xml"),
+          )
+      )
+
+  public val icon_14365: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14365.xml"),
+          )
+      )
+
+  public val icon_14366: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14366.xml"),
+          )
+      )
+
+  public val icon_14367: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14367.xml"),
+          )
+      )
+
+  public val icon_14368: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14368.xml"),
+          )
+      )
+
+  public val icon_14369: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14369.xml"),
+          )
+      )
+
+  public val icon_1437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1437.xml"),
+          )
+      )
+
+  public val icon_14370: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14370.xml"),
+          )
+      )
+
+  public val icon_14371: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14371.xml"),
+          )
+      )
+
+  public val icon_14372: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14372.xml"),
+          )
+      )
+
+  public val icon_14373: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14373.xml"),
+          )
+      )
+
+  public val icon_14374: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14374.xml"),
+          )
+      )
+
+  public val icon_14375: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14375.xml"),
+          )
+      )
+
+  public val icon_14376: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14376.xml"),
+          )
+      )
+
+  public val icon_14377: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14377.xml"),
+          )
+      )
+
+  public val icon_14378: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14378.xml"),
+          )
+      )
+
+  public val icon_14379: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14379.xml"),
+          )
+      )
+
+  public val icon_1438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1438.xml"),
+          )
+      )
+
+  public val icon_14380: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14380.xml"),
+          )
+      )
+
+  public val icon_14381: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14381.xml"),
+          )
+      )
+
+  public val icon_14382: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14382.xml"),
+          )
+      )
+
+  public val icon_14383: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14383.xml"),
+          )
+      )
+
+  public val icon_14384: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14384.xml"),
+          )
+      )
+
+  public val icon_14385: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14385.xml"),
+          )
+      )
+
+  public val icon_14386: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14386.xml"),
+          )
+      )
+
+  public val icon_14387: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14387.xml"),
+          )
+      )
+
+  public val icon_14388: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14388.xml"),
+          )
+      )
+
+  public val icon_14389: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14389.xml"),
+          )
+      )
+
+  public val icon_1439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1439.xml"),
+          )
+      )
+
+  public val icon_14390: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14390.xml"),
+          )
+      )
+
+  public val icon_14391: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14391.xml"),
+          )
+      )
+
+  public val icon_14392: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14392.xml"),
+          )
+      )
+
+  public val icon_14393: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14393.xml"),
+          )
+      )
+
+  public val icon_14394: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14394.xml"),
+          )
+      )
+
+  public val icon_14395: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14395.xml"),
+          )
+      )
+
+  public val icon_14396: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14396.xml"),
+          )
+      )
+
+  public val icon_14397: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14397.xml"),
+          )
+      )
+
+  public val icon_14398: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14398.xml"),
+          )
+      )
+
+  public val icon_14399: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14399.xml"),
+          )
+      )
+
+  public val icon_144: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_144.xml"),
+          )
+      )
+
+  public val icon_1440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1440.xml"),
+          )
+      )
+
+  public val icon_14400: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14400.xml"),
+          )
+      )
+
+  public val icon_14401: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14401.xml"),
+          )
+      )
+
+  public val icon_14402: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14402.xml"),
+          )
+      )
+
+  public val icon_14403: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14403.xml"),
+          )
+      )
+
+  public val icon_14404: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14404.xml"),
+          )
+      )
+
+  public val icon_14405: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14405.xml"),
+          )
+      )
+
+  public val icon_14406: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14406.xml"),
+          )
+      )
+
+  public val icon_14407: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14407.xml"),
+          )
+      )
+
+  public val icon_14408: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14408.xml"),
+          )
+      )
+
+  public val icon_14409: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14409.xml"),
+          )
+      )
+
+  public val icon_1441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1441.xml"),
+          )
+      )
+
+  public val icon_14410: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14410.xml"),
+          )
+      )
+
+  public val icon_14411: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14411.xml"),
+          )
+      )
+
+  public val icon_14412: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14412.xml"),
+          )
+      )
+
+  public val icon_14413: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14413.xml"),
+          )
+      )
+
+  public val icon_14414: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14414.xml"),
+          )
+      )
+
+  public val icon_14415: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14415.xml"),
+          )
+      )
+
+  public val icon_14416: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14416.xml"),
+          )
+      )
+
+  public val icon_14417: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14417.xml"),
+          )
+      )
+
+  public val icon_14418: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14418.xml"),
+          )
+      )
+
+  public val icon_14419: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14419.xml"),
+          )
+      )
+
+  public val icon_1442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1442.xml"),
+          )
+      )
+
+  public val icon_14420: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14420.xml"),
+          )
+      )
+
+  public val icon_14421: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14421.xml"),
+          )
+      )
+
+  public val icon_14422: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14422.xml"),
+          )
+      )
+
+  public val icon_14423: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14423.xml"),
+          )
+      )
+
+  public val icon_14424: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14424.xml"),
+          )
+      )
+
+  public val icon_14425: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14425.xml"),
+          )
+      )
+
+  public val icon_14426: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14426.xml"),
+          )
+      )
+
+  public val icon_14427: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14427.xml"),
+          )
+      )
+
+  public val icon_14428: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14428.xml"),
+          )
+      )
+
+  public val icon_14429: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14429.xml"),
+          )
+      )
+
+  public val icon_1443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1443.xml"),
+          )
+      )
+
+  public val icon_14430: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14430.xml"),
+          )
+      )
+
+  public val icon_14431: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14431.xml"),
+          )
+      )
+
+  public val icon_14432: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14432.xml"),
+          )
+      )
+
+  public val icon_14433: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14433.xml"),
+          )
+      )
+
+  public val icon_14434: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14434.xml"),
+          )
+      )
+
+  public val icon_14435: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14435.xml"),
+          )
+      )
+
+  public val icon_14436: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14436.xml"),
+          )
+      )
+
+  public val icon_14437: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14437.xml"),
+          )
+      )
+
+  public val icon_14438: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14438.xml"),
+          )
+      )
+
+  public val icon_14439: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14439.xml"),
+          )
+      )
+
+  public val icon_1444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1444.xml"),
+          )
+      )
+
+  public val icon_14440: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14440.xml"),
+          )
+      )
+
+  public val icon_14441: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14441.xml"),
+          )
+      )
+
+  public val icon_14442: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14442.xml"),
+          )
+      )
+
+  public val icon_14443: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14443.xml"),
+          )
+      )
+
+  public val icon_14444: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14444.xml"),
+          )
+      )
+
+  public val icon_14445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14445.xml"),
+          )
+      )
+
+  public val icon_14446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14446.xml"),
+          )
+      )
+
+  public val icon_14447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14447.xml"),
+          )
+      )
+
+  public val icon_14448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14448.xml"),
+          )
+      )
+
+  public val icon_14449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14449.xml"),
+          )
+      )
+
+  public val icon_1445: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1445.xml"),
+          )
+      )
+
+  public val icon_14450: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14450.xml"),
+          )
+      )
+
+  public val icon_14451: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14451.xml"),
+          )
+      )
+
+  public val icon_14452: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14452.xml"),
+          )
+      )
+
+  public val icon_14453: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14453.xml"),
+          )
+      )
+
+  public val icon_14454: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14454.xml"),
+          )
+      )
+
+  public val icon_14455: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14455.xml"),
+          )
+      )
+
+  public val icon_14456: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14456.xml"),
+          )
+      )
+
+  public val icon_14457: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14457.xml"),
+          )
+      )
+
+  public val icon_14458: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14458.xml"),
+          )
+      )
+
+  public val icon_14459: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14459.xml"),
+          )
+      )
+
+  public val icon_1446: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1446.xml"),
+          )
+      )
+
+  public val icon_14460: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14460.xml"),
+          )
+      )
+
+  public val icon_14461: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14461.xml"),
+          )
+      )
+
+  public val icon_14462: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14462.xml"),
+          )
+      )
+
+  public val icon_14463: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14463.xml"),
+          )
+      )
+
+  public val icon_14464: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14464.xml"),
+          )
+      )
+
+  public val icon_14465: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14465.xml"),
+          )
+      )
+
+  public val icon_14466: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14466.xml"),
+          )
+      )
+
+  public val icon_14467: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14467.xml"),
+          )
+      )
+
+  public val icon_14468: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14468.xml"),
+          )
+      )
+
+  public val icon_14469: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14469.xml"),
+          )
+      )
+
+  public val icon_1447: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1447.xml"),
+          )
+      )
+
+  public val icon_14470: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14470.xml"),
+          )
+      )
+
+  public val icon_14471: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14471.xml"),
+          )
+      )
+
+  public val icon_14472: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14472.xml"),
+          )
+      )
+
+  public val icon_14473: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14473.xml"),
+          )
+      )
+
+  public val icon_14474: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14474.xml"),
+          )
+      )
+
+  public val icon_14475: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14475.xml"),
+          )
+      )
+
+  public val icon_14476: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14476.xml"),
+          )
+      )
+
+  public val icon_14477: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14477.xml"),
+          )
+      )
+
+  public val icon_14478: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14478.xml"),
+          )
+      )
+
+  public val icon_14479: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14479.xml"),
+          )
+      )
+
+  public val icon_1448: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1448.xml"),
+          )
+      )
+
+  public val icon_14480: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14480.xml"),
+          )
+      )
+
+  public val icon_14481: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14481.xml"),
+          )
+      )
+
+  public val icon_14482: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14482.xml"),
+          )
+      )
+
+  public val icon_14483: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14483.xml"),
+          )
+      )
+
+  public val icon_14484: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14484.xml"),
+          )
+      )
+
+  public val icon_14485: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14485.xml"),
+          )
+      )
+
+  public val icon_14486: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14486.xml"),
+          )
+      )
+
+  public val icon_14487: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14487.xml"),
+          )
+      )
+
+  public val icon_14488: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14488.xml"),
+          )
+      )
+
+  public val icon_14489: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14489.xml"),
+          )
+      )
+
+  public val icon_1449: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_1449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_1449.xml"),
+          )
+      )
+
+  public val icon_14490: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14490.xml"),
+          )
+      )
+
+  public val icon_14491: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14491.xml"),
+          )
+      )
+
+  public val icon_14492: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14492.xml"),
+          )
+      )
+
+  public val icon_14493: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14493.xml"),
+          )
+      )
+
+  public val icon_14494: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14494.xml"),
+          )
+      )
+
+  public val icon_14495: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14495.xml"),
+          )
+      )
+
+  public val icon_14496: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14496.xml"),
+          )
+      )
+
+  public val icon_14497: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:icon_14497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/icon_14497.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14047: DrawableResource
+  get() = Drawable9.icon_14047
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14048: DrawableResource
+  get() = Drawable9.icon_14048
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14049: DrawableResource
+  get() = Drawable9.icon_14049
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1405: DrawableResource
+  get() = Drawable9.icon_1405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14050: DrawableResource
+  get() = Drawable9.icon_14050
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14051: DrawableResource
+  get() = Drawable9.icon_14051
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14052: DrawableResource
+  get() = Drawable9.icon_14052
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14053: DrawableResource
+  get() = Drawable9.icon_14053
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14054: DrawableResource
+  get() = Drawable9.icon_14054
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14055: DrawableResource
+  get() = Drawable9.icon_14055
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14056: DrawableResource
+  get() = Drawable9.icon_14056
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14057: DrawableResource
+  get() = Drawable9.icon_14057
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14058: DrawableResource
+  get() = Drawable9.icon_14058
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14059: DrawableResource
+  get() = Drawable9.icon_14059
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1406: DrawableResource
+  get() = Drawable9.icon_1406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14060: DrawableResource
+  get() = Drawable9.icon_14060
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14061: DrawableResource
+  get() = Drawable9.icon_14061
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14062: DrawableResource
+  get() = Drawable9.icon_14062
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14063: DrawableResource
+  get() = Drawable9.icon_14063
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14064: DrawableResource
+  get() = Drawable9.icon_14064
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14065: DrawableResource
+  get() = Drawable9.icon_14065
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14066: DrawableResource
+  get() = Drawable9.icon_14066
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14067: DrawableResource
+  get() = Drawable9.icon_14067
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14068: DrawableResource
+  get() = Drawable9.icon_14068
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14069: DrawableResource
+  get() = Drawable9.icon_14069
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1407: DrawableResource
+  get() = Drawable9.icon_1407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14070: DrawableResource
+  get() = Drawable9.icon_14070
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14071: DrawableResource
+  get() = Drawable9.icon_14071
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14072: DrawableResource
+  get() = Drawable9.icon_14072
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14073: DrawableResource
+  get() = Drawable9.icon_14073
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14074: DrawableResource
+  get() = Drawable9.icon_14074
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14075: DrawableResource
+  get() = Drawable9.icon_14075
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14076: DrawableResource
+  get() = Drawable9.icon_14076
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14077: DrawableResource
+  get() = Drawable9.icon_14077
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14078: DrawableResource
+  get() = Drawable9.icon_14078
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14079: DrawableResource
+  get() = Drawable9.icon_14079
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1408: DrawableResource
+  get() = Drawable9.icon_1408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14080: DrawableResource
+  get() = Drawable9.icon_14080
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14081: DrawableResource
+  get() = Drawable9.icon_14081
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14082: DrawableResource
+  get() = Drawable9.icon_14082
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14083: DrawableResource
+  get() = Drawable9.icon_14083
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14084: DrawableResource
+  get() = Drawable9.icon_14084
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14085: DrawableResource
+  get() = Drawable9.icon_14085
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14086: DrawableResource
+  get() = Drawable9.icon_14086
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14087: DrawableResource
+  get() = Drawable9.icon_14087
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14088: DrawableResource
+  get() = Drawable9.icon_14088
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14089: DrawableResource
+  get() = Drawable9.icon_14089
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1409: DrawableResource
+  get() = Drawable9.icon_1409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14090: DrawableResource
+  get() = Drawable9.icon_14090
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14091: DrawableResource
+  get() = Drawable9.icon_14091
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14092: DrawableResource
+  get() = Drawable9.icon_14092
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14093: DrawableResource
+  get() = Drawable9.icon_14093
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14094: DrawableResource
+  get() = Drawable9.icon_14094
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14095: DrawableResource
+  get() = Drawable9.icon_14095
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14096: DrawableResource
+  get() = Drawable9.icon_14096
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14097: DrawableResource
+  get() = Drawable9.icon_14097
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14098: DrawableResource
+  get() = Drawable9.icon_14098
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14099: DrawableResource
+  get() = Drawable9.icon_14099
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_141: DrawableResource
+  get() = Drawable9.icon_141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1410: DrawableResource
+  get() = Drawable9.icon_1410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14100: DrawableResource
+  get() = Drawable9.icon_14100
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14101: DrawableResource
+  get() = Drawable9.icon_14101
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14102: DrawableResource
+  get() = Drawable9.icon_14102
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14103: DrawableResource
+  get() = Drawable9.icon_14103
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14104: DrawableResource
+  get() = Drawable9.icon_14104
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14105: DrawableResource
+  get() = Drawable9.icon_14105
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14106: DrawableResource
+  get() = Drawable9.icon_14106
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14107: DrawableResource
+  get() = Drawable9.icon_14107
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14108: DrawableResource
+  get() = Drawable9.icon_14108
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14109: DrawableResource
+  get() = Drawable9.icon_14109
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1411: DrawableResource
+  get() = Drawable9.icon_1411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14110: DrawableResource
+  get() = Drawable9.icon_14110
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14111: DrawableResource
+  get() = Drawable9.icon_14111
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14112: DrawableResource
+  get() = Drawable9.icon_14112
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14113: DrawableResource
+  get() = Drawable9.icon_14113
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14114: DrawableResource
+  get() = Drawable9.icon_14114
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14115: DrawableResource
+  get() = Drawable9.icon_14115
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14116: DrawableResource
+  get() = Drawable9.icon_14116
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14117: DrawableResource
+  get() = Drawable9.icon_14117
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14118: DrawableResource
+  get() = Drawable9.icon_14118
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14119: DrawableResource
+  get() = Drawable9.icon_14119
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1412: DrawableResource
+  get() = Drawable9.icon_1412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14120: DrawableResource
+  get() = Drawable9.icon_14120
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14121: DrawableResource
+  get() = Drawable9.icon_14121
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14122: DrawableResource
+  get() = Drawable9.icon_14122
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14123: DrawableResource
+  get() = Drawable9.icon_14123
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14124: DrawableResource
+  get() = Drawable9.icon_14124
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14125: DrawableResource
+  get() = Drawable9.icon_14125
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14126: DrawableResource
+  get() = Drawable9.icon_14126
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14127: DrawableResource
+  get() = Drawable9.icon_14127
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14128: DrawableResource
+  get() = Drawable9.icon_14128
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14129: DrawableResource
+  get() = Drawable9.icon_14129
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1413: DrawableResource
+  get() = Drawable9.icon_1413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14130: DrawableResource
+  get() = Drawable9.icon_14130
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14131: DrawableResource
+  get() = Drawable9.icon_14131
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14132: DrawableResource
+  get() = Drawable9.icon_14132
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14133: DrawableResource
+  get() = Drawable9.icon_14133
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14134: DrawableResource
+  get() = Drawable9.icon_14134
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14135: DrawableResource
+  get() = Drawable9.icon_14135
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14136: DrawableResource
+  get() = Drawable9.icon_14136
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14137: DrawableResource
+  get() = Drawable9.icon_14137
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14138: DrawableResource
+  get() = Drawable9.icon_14138
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14139: DrawableResource
+  get() = Drawable9.icon_14139
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1414: DrawableResource
+  get() = Drawable9.icon_1414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14140: DrawableResource
+  get() = Drawable9.icon_14140
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14141: DrawableResource
+  get() = Drawable9.icon_14141
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14142: DrawableResource
+  get() = Drawable9.icon_14142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14143: DrawableResource
+  get() = Drawable9.icon_14143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14144: DrawableResource
+  get() = Drawable9.icon_14144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14145: DrawableResource
+  get() = Drawable9.icon_14145
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14146: DrawableResource
+  get() = Drawable9.icon_14146
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14147: DrawableResource
+  get() = Drawable9.icon_14147
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14148: DrawableResource
+  get() = Drawable9.icon_14148
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14149: DrawableResource
+  get() = Drawable9.icon_14149
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1415: DrawableResource
+  get() = Drawable9.icon_1415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14150: DrawableResource
+  get() = Drawable9.icon_14150
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14151: DrawableResource
+  get() = Drawable9.icon_14151
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14152: DrawableResource
+  get() = Drawable9.icon_14152
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14153: DrawableResource
+  get() = Drawable9.icon_14153
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14154: DrawableResource
+  get() = Drawable9.icon_14154
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14155: DrawableResource
+  get() = Drawable9.icon_14155
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14156: DrawableResource
+  get() = Drawable9.icon_14156
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14157: DrawableResource
+  get() = Drawable9.icon_14157
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14158: DrawableResource
+  get() = Drawable9.icon_14158
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14159: DrawableResource
+  get() = Drawable9.icon_14159
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1416: DrawableResource
+  get() = Drawable9.icon_1416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14160: DrawableResource
+  get() = Drawable9.icon_14160
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14161: DrawableResource
+  get() = Drawable9.icon_14161
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14162: DrawableResource
+  get() = Drawable9.icon_14162
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14163: DrawableResource
+  get() = Drawable9.icon_14163
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14164: DrawableResource
+  get() = Drawable9.icon_14164
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14165: DrawableResource
+  get() = Drawable9.icon_14165
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14166: DrawableResource
+  get() = Drawable9.icon_14166
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14167: DrawableResource
+  get() = Drawable9.icon_14167
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14168: DrawableResource
+  get() = Drawable9.icon_14168
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14169: DrawableResource
+  get() = Drawable9.icon_14169
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1417: DrawableResource
+  get() = Drawable9.icon_1417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14170: DrawableResource
+  get() = Drawable9.icon_14170
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14171: DrawableResource
+  get() = Drawable9.icon_14171
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14172: DrawableResource
+  get() = Drawable9.icon_14172
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14173: DrawableResource
+  get() = Drawable9.icon_14173
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14174: DrawableResource
+  get() = Drawable9.icon_14174
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14175: DrawableResource
+  get() = Drawable9.icon_14175
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14176: DrawableResource
+  get() = Drawable9.icon_14176
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14177: DrawableResource
+  get() = Drawable9.icon_14177
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14178: DrawableResource
+  get() = Drawable9.icon_14178
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14179: DrawableResource
+  get() = Drawable9.icon_14179
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1418: DrawableResource
+  get() = Drawable9.icon_1418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14180: DrawableResource
+  get() = Drawable9.icon_14180
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14181: DrawableResource
+  get() = Drawable9.icon_14181
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14182: DrawableResource
+  get() = Drawable9.icon_14182
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14183: DrawableResource
+  get() = Drawable9.icon_14183
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14184: DrawableResource
+  get() = Drawable9.icon_14184
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14185: DrawableResource
+  get() = Drawable9.icon_14185
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14186: DrawableResource
+  get() = Drawable9.icon_14186
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14187: DrawableResource
+  get() = Drawable9.icon_14187
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14188: DrawableResource
+  get() = Drawable9.icon_14188
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14189: DrawableResource
+  get() = Drawable9.icon_14189
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1419: DrawableResource
+  get() = Drawable9.icon_1419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14190: DrawableResource
+  get() = Drawable9.icon_14190
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14191: DrawableResource
+  get() = Drawable9.icon_14191
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14192: DrawableResource
+  get() = Drawable9.icon_14192
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14193: DrawableResource
+  get() = Drawable9.icon_14193
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14194: DrawableResource
+  get() = Drawable9.icon_14194
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14195: DrawableResource
+  get() = Drawable9.icon_14195
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14196: DrawableResource
+  get() = Drawable9.icon_14196
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14197: DrawableResource
+  get() = Drawable9.icon_14197
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14198: DrawableResource
+  get() = Drawable9.icon_14198
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14199: DrawableResource
+  get() = Drawable9.icon_14199
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_142: DrawableResource
+  get() = Drawable9.icon_142
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1420: DrawableResource
+  get() = Drawable9.icon_1420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14200: DrawableResource
+  get() = Drawable9.icon_14200
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14201: DrawableResource
+  get() = Drawable9.icon_14201
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14202: DrawableResource
+  get() = Drawable9.icon_14202
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14203: DrawableResource
+  get() = Drawable9.icon_14203
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14204: DrawableResource
+  get() = Drawable9.icon_14204
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14205: DrawableResource
+  get() = Drawable9.icon_14205
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14206: DrawableResource
+  get() = Drawable9.icon_14206
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14207: DrawableResource
+  get() = Drawable9.icon_14207
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14208: DrawableResource
+  get() = Drawable9.icon_14208
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14209: DrawableResource
+  get() = Drawable9.icon_14209
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1421: DrawableResource
+  get() = Drawable9.icon_1421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14210: DrawableResource
+  get() = Drawable9.icon_14210
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14211: DrawableResource
+  get() = Drawable9.icon_14211
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14212: DrawableResource
+  get() = Drawable9.icon_14212
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14213: DrawableResource
+  get() = Drawable9.icon_14213
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14214: DrawableResource
+  get() = Drawable9.icon_14214
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14215: DrawableResource
+  get() = Drawable9.icon_14215
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14216: DrawableResource
+  get() = Drawable9.icon_14216
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14217: DrawableResource
+  get() = Drawable9.icon_14217
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14218: DrawableResource
+  get() = Drawable9.icon_14218
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14219: DrawableResource
+  get() = Drawable9.icon_14219
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1422: DrawableResource
+  get() = Drawable9.icon_1422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14220: DrawableResource
+  get() = Drawable9.icon_14220
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14221: DrawableResource
+  get() = Drawable9.icon_14221
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14222: DrawableResource
+  get() = Drawable9.icon_14222
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14223: DrawableResource
+  get() = Drawable9.icon_14223
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14224: DrawableResource
+  get() = Drawable9.icon_14224
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14225: DrawableResource
+  get() = Drawable9.icon_14225
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14226: DrawableResource
+  get() = Drawable9.icon_14226
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14227: DrawableResource
+  get() = Drawable9.icon_14227
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14228: DrawableResource
+  get() = Drawable9.icon_14228
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14229: DrawableResource
+  get() = Drawable9.icon_14229
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1423: DrawableResource
+  get() = Drawable9.icon_1423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14230: DrawableResource
+  get() = Drawable9.icon_14230
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14231: DrawableResource
+  get() = Drawable9.icon_14231
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14232: DrawableResource
+  get() = Drawable9.icon_14232
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14233: DrawableResource
+  get() = Drawable9.icon_14233
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14234: DrawableResource
+  get() = Drawable9.icon_14234
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14235: DrawableResource
+  get() = Drawable9.icon_14235
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14236: DrawableResource
+  get() = Drawable9.icon_14236
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14237: DrawableResource
+  get() = Drawable9.icon_14237
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14238: DrawableResource
+  get() = Drawable9.icon_14238
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14239: DrawableResource
+  get() = Drawable9.icon_14239
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1424: DrawableResource
+  get() = Drawable9.icon_1424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14240: DrawableResource
+  get() = Drawable9.icon_14240
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14241: DrawableResource
+  get() = Drawable9.icon_14241
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14242: DrawableResource
+  get() = Drawable9.icon_14242
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14243: DrawableResource
+  get() = Drawable9.icon_14243
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14244: DrawableResource
+  get() = Drawable9.icon_14244
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14245: DrawableResource
+  get() = Drawable9.icon_14245
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14246: DrawableResource
+  get() = Drawable9.icon_14246
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14247: DrawableResource
+  get() = Drawable9.icon_14247
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14248: DrawableResource
+  get() = Drawable9.icon_14248
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14249: DrawableResource
+  get() = Drawable9.icon_14249
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1425: DrawableResource
+  get() = Drawable9.icon_1425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14250: DrawableResource
+  get() = Drawable9.icon_14250
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14251: DrawableResource
+  get() = Drawable9.icon_14251
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14252: DrawableResource
+  get() = Drawable9.icon_14252
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14253: DrawableResource
+  get() = Drawable9.icon_14253
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14254: DrawableResource
+  get() = Drawable9.icon_14254
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14255: DrawableResource
+  get() = Drawable9.icon_14255
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14256: DrawableResource
+  get() = Drawable9.icon_14256
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14257: DrawableResource
+  get() = Drawable9.icon_14257
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14258: DrawableResource
+  get() = Drawable9.icon_14258
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14259: DrawableResource
+  get() = Drawable9.icon_14259
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1426: DrawableResource
+  get() = Drawable9.icon_1426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14260: DrawableResource
+  get() = Drawable9.icon_14260
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14261: DrawableResource
+  get() = Drawable9.icon_14261
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14262: DrawableResource
+  get() = Drawable9.icon_14262
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14263: DrawableResource
+  get() = Drawable9.icon_14263
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14264: DrawableResource
+  get() = Drawable9.icon_14264
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14265: DrawableResource
+  get() = Drawable9.icon_14265
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14266: DrawableResource
+  get() = Drawable9.icon_14266
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14267: DrawableResource
+  get() = Drawable9.icon_14267
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14268: DrawableResource
+  get() = Drawable9.icon_14268
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14269: DrawableResource
+  get() = Drawable9.icon_14269
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1427: DrawableResource
+  get() = Drawable9.icon_1427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14270: DrawableResource
+  get() = Drawable9.icon_14270
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14271: DrawableResource
+  get() = Drawable9.icon_14271
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14272: DrawableResource
+  get() = Drawable9.icon_14272
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14273: DrawableResource
+  get() = Drawable9.icon_14273
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14274: DrawableResource
+  get() = Drawable9.icon_14274
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14275: DrawableResource
+  get() = Drawable9.icon_14275
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14276: DrawableResource
+  get() = Drawable9.icon_14276
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14277: DrawableResource
+  get() = Drawable9.icon_14277
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14278: DrawableResource
+  get() = Drawable9.icon_14278
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14279: DrawableResource
+  get() = Drawable9.icon_14279
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1428: DrawableResource
+  get() = Drawable9.icon_1428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14280: DrawableResource
+  get() = Drawable9.icon_14280
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14281: DrawableResource
+  get() = Drawable9.icon_14281
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14282: DrawableResource
+  get() = Drawable9.icon_14282
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14283: DrawableResource
+  get() = Drawable9.icon_14283
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14284: DrawableResource
+  get() = Drawable9.icon_14284
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14285: DrawableResource
+  get() = Drawable9.icon_14285
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14286: DrawableResource
+  get() = Drawable9.icon_14286
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14287: DrawableResource
+  get() = Drawable9.icon_14287
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14288: DrawableResource
+  get() = Drawable9.icon_14288
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14289: DrawableResource
+  get() = Drawable9.icon_14289
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1429: DrawableResource
+  get() = Drawable9.icon_1429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14290: DrawableResource
+  get() = Drawable9.icon_14290
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14291: DrawableResource
+  get() = Drawable9.icon_14291
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14292: DrawableResource
+  get() = Drawable9.icon_14292
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14293: DrawableResource
+  get() = Drawable9.icon_14293
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14294: DrawableResource
+  get() = Drawable9.icon_14294
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14295: DrawableResource
+  get() = Drawable9.icon_14295
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14296: DrawableResource
+  get() = Drawable9.icon_14296
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14297: DrawableResource
+  get() = Drawable9.icon_14297
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14298: DrawableResource
+  get() = Drawable9.icon_14298
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14299: DrawableResource
+  get() = Drawable9.icon_14299
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_143: DrawableResource
+  get() = Drawable9.icon_143
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1430: DrawableResource
+  get() = Drawable9.icon_1430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14300: DrawableResource
+  get() = Drawable9.icon_14300
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14301: DrawableResource
+  get() = Drawable9.icon_14301
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14302: DrawableResource
+  get() = Drawable9.icon_14302
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14303: DrawableResource
+  get() = Drawable9.icon_14303
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14304: DrawableResource
+  get() = Drawable9.icon_14304
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14305: DrawableResource
+  get() = Drawable9.icon_14305
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14306: DrawableResource
+  get() = Drawable9.icon_14306
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14307: DrawableResource
+  get() = Drawable9.icon_14307
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14308: DrawableResource
+  get() = Drawable9.icon_14308
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14309: DrawableResource
+  get() = Drawable9.icon_14309
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1431: DrawableResource
+  get() = Drawable9.icon_1431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14310: DrawableResource
+  get() = Drawable9.icon_14310
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14311: DrawableResource
+  get() = Drawable9.icon_14311
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14312: DrawableResource
+  get() = Drawable9.icon_14312
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14313: DrawableResource
+  get() = Drawable9.icon_14313
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14314: DrawableResource
+  get() = Drawable9.icon_14314
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14315: DrawableResource
+  get() = Drawable9.icon_14315
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14316: DrawableResource
+  get() = Drawable9.icon_14316
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14317: DrawableResource
+  get() = Drawable9.icon_14317
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14318: DrawableResource
+  get() = Drawable9.icon_14318
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14319: DrawableResource
+  get() = Drawable9.icon_14319
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1432: DrawableResource
+  get() = Drawable9.icon_1432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14320: DrawableResource
+  get() = Drawable9.icon_14320
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14321: DrawableResource
+  get() = Drawable9.icon_14321
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14322: DrawableResource
+  get() = Drawable9.icon_14322
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14323: DrawableResource
+  get() = Drawable9.icon_14323
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14324: DrawableResource
+  get() = Drawable9.icon_14324
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14325: DrawableResource
+  get() = Drawable9.icon_14325
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14326: DrawableResource
+  get() = Drawable9.icon_14326
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14327: DrawableResource
+  get() = Drawable9.icon_14327
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14328: DrawableResource
+  get() = Drawable9.icon_14328
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14329: DrawableResource
+  get() = Drawable9.icon_14329
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1433: DrawableResource
+  get() = Drawable9.icon_1433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14330: DrawableResource
+  get() = Drawable9.icon_14330
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14331: DrawableResource
+  get() = Drawable9.icon_14331
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14332: DrawableResource
+  get() = Drawable9.icon_14332
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14333: DrawableResource
+  get() = Drawable9.icon_14333
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14334: DrawableResource
+  get() = Drawable9.icon_14334
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14335: DrawableResource
+  get() = Drawable9.icon_14335
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14336: DrawableResource
+  get() = Drawable9.icon_14336
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14337: DrawableResource
+  get() = Drawable9.icon_14337
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14338: DrawableResource
+  get() = Drawable9.icon_14338
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14339: DrawableResource
+  get() = Drawable9.icon_14339
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1434: DrawableResource
+  get() = Drawable9.icon_1434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14340: DrawableResource
+  get() = Drawable9.icon_14340
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14341: DrawableResource
+  get() = Drawable9.icon_14341
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14342: DrawableResource
+  get() = Drawable9.icon_14342
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14343: DrawableResource
+  get() = Drawable9.icon_14343
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14344: DrawableResource
+  get() = Drawable9.icon_14344
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14345: DrawableResource
+  get() = Drawable9.icon_14345
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14346: DrawableResource
+  get() = Drawable9.icon_14346
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14347: DrawableResource
+  get() = Drawable9.icon_14347
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14348: DrawableResource
+  get() = Drawable9.icon_14348
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14349: DrawableResource
+  get() = Drawable9.icon_14349
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1435: DrawableResource
+  get() = Drawable9.icon_1435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14350: DrawableResource
+  get() = Drawable9.icon_14350
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14351: DrawableResource
+  get() = Drawable9.icon_14351
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14352: DrawableResource
+  get() = Drawable9.icon_14352
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14353: DrawableResource
+  get() = Drawable9.icon_14353
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14354: DrawableResource
+  get() = Drawable9.icon_14354
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14355: DrawableResource
+  get() = Drawable9.icon_14355
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14356: DrawableResource
+  get() = Drawable9.icon_14356
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14357: DrawableResource
+  get() = Drawable9.icon_14357
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14358: DrawableResource
+  get() = Drawable9.icon_14358
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14359: DrawableResource
+  get() = Drawable9.icon_14359
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1436: DrawableResource
+  get() = Drawable9.icon_1436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14360: DrawableResource
+  get() = Drawable9.icon_14360
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14361: DrawableResource
+  get() = Drawable9.icon_14361
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14362: DrawableResource
+  get() = Drawable9.icon_14362
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14363: DrawableResource
+  get() = Drawable9.icon_14363
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14364: DrawableResource
+  get() = Drawable9.icon_14364
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14365: DrawableResource
+  get() = Drawable9.icon_14365
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14366: DrawableResource
+  get() = Drawable9.icon_14366
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14367: DrawableResource
+  get() = Drawable9.icon_14367
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14368: DrawableResource
+  get() = Drawable9.icon_14368
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14369: DrawableResource
+  get() = Drawable9.icon_14369
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1437: DrawableResource
+  get() = Drawable9.icon_1437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14370: DrawableResource
+  get() = Drawable9.icon_14370
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14371: DrawableResource
+  get() = Drawable9.icon_14371
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14372: DrawableResource
+  get() = Drawable9.icon_14372
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14373: DrawableResource
+  get() = Drawable9.icon_14373
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14374: DrawableResource
+  get() = Drawable9.icon_14374
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14375: DrawableResource
+  get() = Drawable9.icon_14375
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14376: DrawableResource
+  get() = Drawable9.icon_14376
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14377: DrawableResource
+  get() = Drawable9.icon_14377
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14378: DrawableResource
+  get() = Drawable9.icon_14378
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14379: DrawableResource
+  get() = Drawable9.icon_14379
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1438: DrawableResource
+  get() = Drawable9.icon_1438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14380: DrawableResource
+  get() = Drawable9.icon_14380
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14381: DrawableResource
+  get() = Drawable9.icon_14381
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14382: DrawableResource
+  get() = Drawable9.icon_14382
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14383: DrawableResource
+  get() = Drawable9.icon_14383
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14384: DrawableResource
+  get() = Drawable9.icon_14384
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14385: DrawableResource
+  get() = Drawable9.icon_14385
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14386: DrawableResource
+  get() = Drawable9.icon_14386
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14387: DrawableResource
+  get() = Drawable9.icon_14387
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14388: DrawableResource
+  get() = Drawable9.icon_14388
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14389: DrawableResource
+  get() = Drawable9.icon_14389
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1439: DrawableResource
+  get() = Drawable9.icon_1439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14390: DrawableResource
+  get() = Drawable9.icon_14390
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14391: DrawableResource
+  get() = Drawable9.icon_14391
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14392: DrawableResource
+  get() = Drawable9.icon_14392
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14393: DrawableResource
+  get() = Drawable9.icon_14393
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14394: DrawableResource
+  get() = Drawable9.icon_14394
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14395: DrawableResource
+  get() = Drawable9.icon_14395
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14396: DrawableResource
+  get() = Drawable9.icon_14396
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14397: DrawableResource
+  get() = Drawable9.icon_14397
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14398: DrawableResource
+  get() = Drawable9.icon_14398
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14399: DrawableResource
+  get() = Drawable9.icon_14399
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_144: DrawableResource
+  get() = Drawable9.icon_144
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1440: DrawableResource
+  get() = Drawable9.icon_1440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14400: DrawableResource
+  get() = Drawable9.icon_14400
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14401: DrawableResource
+  get() = Drawable9.icon_14401
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14402: DrawableResource
+  get() = Drawable9.icon_14402
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14403: DrawableResource
+  get() = Drawable9.icon_14403
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14404: DrawableResource
+  get() = Drawable9.icon_14404
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14405: DrawableResource
+  get() = Drawable9.icon_14405
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14406: DrawableResource
+  get() = Drawable9.icon_14406
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14407: DrawableResource
+  get() = Drawable9.icon_14407
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14408: DrawableResource
+  get() = Drawable9.icon_14408
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14409: DrawableResource
+  get() = Drawable9.icon_14409
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1441: DrawableResource
+  get() = Drawable9.icon_1441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14410: DrawableResource
+  get() = Drawable9.icon_14410
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14411: DrawableResource
+  get() = Drawable9.icon_14411
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14412: DrawableResource
+  get() = Drawable9.icon_14412
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14413: DrawableResource
+  get() = Drawable9.icon_14413
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14414: DrawableResource
+  get() = Drawable9.icon_14414
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14415: DrawableResource
+  get() = Drawable9.icon_14415
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14416: DrawableResource
+  get() = Drawable9.icon_14416
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14417: DrawableResource
+  get() = Drawable9.icon_14417
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14418: DrawableResource
+  get() = Drawable9.icon_14418
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14419: DrawableResource
+  get() = Drawable9.icon_14419
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1442: DrawableResource
+  get() = Drawable9.icon_1442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14420: DrawableResource
+  get() = Drawable9.icon_14420
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14421: DrawableResource
+  get() = Drawable9.icon_14421
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14422: DrawableResource
+  get() = Drawable9.icon_14422
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14423: DrawableResource
+  get() = Drawable9.icon_14423
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14424: DrawableResource
+  get() = Drawable9.icon_14424
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14425: DrawableResource
+  get() = Drawable9.icon_14425
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14426: DrawableResource
+  get() = Drawable9.icon_14426
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14427: DrawableResource
+  get() = Drawable9.icon_14427
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14428: DrawableResource
+  get() = Drawable9.icon_14428
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14429: DrawableResource
+  get() = Drawable9.icon_14429
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1443: DrawableResource
+  get() = Drawable9.icon_1443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14430: DrawableResource
+  get() = Drawable9.icon_14430
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14431: DrawableResource
+  get() = Drawable9.icon_14431
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14432: DrawableResource
+  get() = Drawable9.icon_14432
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14433: DrawableResource
+  get() = Drawable9.icon_14433
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14434: DrawableResource
+  get() = Drawable9.icon_14434
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14435: DrawableResource
+  get() = Drawable9.icon_14435
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14436: DrawableResource
+  get() = Drawable9.icon_14436
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14437: DrawableResource
+  get() = Drawable9.icon_14437
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14438: DrawableResource
+  get() = Drawable9.icon_14438
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14439: DrawableResource
+  get() = Drawable9.icon_14439
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1444: DrawableResource
+  get() = Drawable9.icon_1444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14440: DrawableResource
+  get() = Drawable9.icon_14440
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14441: DrawableResource
+  get() = Drawable9.icon_14441
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14442: DrawableResource
+  get() = Drawable9.icon_14442
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14443: DrawableResource
+  get() = Drawable9.icon_14443
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14444: DrawableResource
+  get() = Drawable9.icon_14444
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14445: DrawableResource
+  get() = Drawable9.icon_14445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14446: DrawableResource
+  get() = Drawable9.icon_14446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14447: DrawableResource
+  get() = Drawable9.icon_14447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14448: DrawableResource
+  get() = Drawable9.icon_14448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14449: DrawableResource
+  get() = Drawable9.icon_14449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1445: DrawableResource
+  get() = Drawable9.icon_1445
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14450: DrawableResource
+  get() = Drawable9.icon_14450
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14451: DrawableResource
+  get() = Drawable9.icon_14451
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14452: DrawableResource
+  get() = Drawable9.icon_14452
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14453: DrawableResource
+  get() = Drawable9.icon_14453
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14454: DrawableResource
+  get() = Drawable9.icon_14454
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14455: DrawableResource
+  get() = Drawable9.icon_14455
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14456: DrawableResource
+  get() = Drawable9.icon_14456
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14457: DrawableResource
+  get() = Drawable9.icon_14457
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14458: DrawableResource
+  get() = Drawable9.icon_14458
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14459: DrawableResource
+  get() = Drawable9.icon_14459
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1446: DrawableResource
+  get() = Drawable9.icon_1446
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14460: DrawableResource
+  get() = Drawable9.icon_14460
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14461: DrawableResource
+  get() = Drawable9.icon_14461
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14462: DrawableResource
+  get() = Drawable9.icon_14462
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14463: DrawableResource
+  get() = Drawable9.icon_14463
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14464: DrawableResource
+  get() = Drawable9.icon_14464
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14465: DrawableResource
+  get() = Drawable9.icon_14465
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14466: DrawableResource
+  get() = Drawable9.icon_14466
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14467: DrawableResource
+  get() = Drawable9.icon_14467
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14468: DrawableResource
+  get() = Drawable9.icon_14468
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14469: DrawableResource
+  get() = Drawable9.icon_14469
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1447: DrawableResource
+  get() = Drawable9.icon_1447
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14470: DrawableResource
+  get() = Drawable9.icon_14470
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14471: DrawableResource
+  get() = Drawable9.icon_14471
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14472: DrawableResource
+  get() = Drawable9.icon_14472
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14473: DrawableResource
+  get() = Drawable9.icon_14473
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14474: DrawableResource
+  get() = Drawable9.icon_14474
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14475: DrawableResource
+  get() = Drawable9.icon_14475
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14476: DrawableResource
+  get() = Drawable9.icon_14476
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14477: DrawableResource
+  get() = Drawable9.icon_14477
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14478: DrawableResource
+  get() = Drawable9.icon_14478
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14479: DrawableResource
+  get() = Drawable9.icon_14479
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1448: DrawableResource
+  get() = Drawable9.icon_1448
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14480: DrawableResource
+  get() = Drawable9.icon_14480
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14481: DrawableResource
+  get() = Drawable9.icon_14481
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14482: DrawableResource
+  get() = Drawable9.icon_14482
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14483: DrawableResource
+  get() = Drawable9.icon_14483
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14484: DrawableResource
+  get() = Drawable9.icon_14484
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14485: DrawableResource
+  get() = Drawable9.icon_14485
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14486: DrawableResource
+  get() = Drawable9.icon_14486
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14487: DrawableResource
+  get() = Drawable9.icon_14487
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14488: DrawableResource
+  get() = Drawable9.icon_14488
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14489: DrawableResource
+  get() = Drawable9.icon_14489
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_1449: DrawableResource
+  get() = Drawable9.icon_1449
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14490: DrawableResource
+  get() = Drawable9.icon_14490
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14491: DrawableResource
+  get() = Drawable9.icon_14491
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14492: DrawableResource
+  get() = Drawable9.icon_14492
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14493: DrawableResource
+  get() = Drawable9.icon_14493
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14494: DrawableResource
+  get() = Drawable9.icon_14494
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14495: DrawableResource
+  get() = Drawable9.icon_14495
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14496: DrawableResource
+  get() = Drawable9.icon_14496
+
+@ExperimentalResourceApi
+internal val Res.drawable.icon_14497: DrawableResource
+  get() = Drawable9.icon_14497

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/Res.kt
@@ -3,7 +3,7 @@
   org.jetbrains.compose.resources.ExperimentalResourceApi::class,
 )
 
-package app.group.resources_test.generated.resources
+package app.group.huge.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String0.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String0.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String0 {
+  public val str_0: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_0", "str_0",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1", "str_1",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10", "str_10",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_100", "str_100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1000", "str_1000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10000", "str_10000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10001", "str_10001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10002", "str_10002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10003", "str_10003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10004", "str_10004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10005", "str_10005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10006", "str_10006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10007", "str_10007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10008", "str_10008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10009", "str_10009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1001", "str_1001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10010", "str_10010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10011", "str_10011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10012", "str_10012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10013", "str_10013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10014", "str_10014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10015", "str_10015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10016", "str_10016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10017", "str_10017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10018", "str_10018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10019", "str_10019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1002", "str_1002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10020", "str_10020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10021", "str_10021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10022", "str_10022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10023", "str_10023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10024", "str_10024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10025", "str_10025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10026", "str_10026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10027", "str_10027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10028", "str_10028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10029", "str_10029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1003", "str_1003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10030", "str_10030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10031", "str_10031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10032", "str_10032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10033", "str_10033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10034", "str_10034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10035", "str_10035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10036", "str_10036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10037", "str_10037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10038", "str_10038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10039", "str_10039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1004", "str_1004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10040", "str_10040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10041", "str_10041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10042", "str_10042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10043", "str_10043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10044", "str_10044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10045", "str_10045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10046", "str_10046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10047", "str_10047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10048", "str_10048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10049", "str_10049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1005", "str_1005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10050", "str_10050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10051", "str_10051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10052", "str_10052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10053", "str_10053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10054", "str_10054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10055", "str_10055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10056", "str_10056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10057", "str_10057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10058", "str_10058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10059", "str_10059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1006", "str_1006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10060", "str_10060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10061", "str_10061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10062", "str_10062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10063", "str_10063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10064", "str_10064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10065", "str_10065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10066", "str_10066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10067", "str_10067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10068", "str_10068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10069", "str_10069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1007", "str_1007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10070", "str_10070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10071", "str_10071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10072", "str_10072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10073", "str_10073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10074", "str_10074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10075", "str_10075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10076", "str_10076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10077", "str_10077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10078", "str_10078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10079", "str_10079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1008", "str_1008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10080", "str_10080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10081", "str_10081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10082", "str_10082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10083", "str_10083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10084", "str_10084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10085", "str_10085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10086", "str_10086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10087", "str_10087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10088", "str_10088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10089", "str_10089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1009", "str_1009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10090", "str_10090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10091", "str_10091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10092", "str_10092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10093", "str_10093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10094", "str_10094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10095", "str_10095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10096", "str_10096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10097", "str_10097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10098", "str_10098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10099", "str_10099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_101", "str_101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1010", "str_1010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10100", "str_10100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10101", "str_10101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10102", "str_10102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10103", "str_10103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10104", "str_10104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10105", "str_10105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10106", "str_10106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10107", "str_10107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10108", "str_10108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10109", "str_10109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1011", "str_1011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10110", "str_10110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10111", "str_10111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10112", "str_10112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10113", "str_10113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10114", "str_10114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10115", "str_10115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10116", "str_10116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10117", "str_10117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10118", "str_10118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10119", "str_10119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1012", "str_1012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10120", "str_10120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10121", "str_10121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10122", "str_10122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10123", "str_10123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10124", "str_10124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10125", "str_10125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10126", "str_10126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10127", "str_10127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10128", "str_10128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10129", "str_10129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1013", "str_1013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10130", "str_10130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10131", "str_10131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10132", "str_10132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10133", "str_10133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10134", "str_10134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10135", "str_10135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10136", "str_10136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10137", "str_10137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10138", "str_10138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10139", "str_10139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1014", "str_1014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10140", "str_10140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10141", "str_10141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10142", "str_10142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10143", "str_10143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10144", "str_10144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10145", "str_10145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10146", "str_10146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10147", "str_10147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10148", "str_10148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10149", "str_10149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1015", "str_1015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10150", "str_10150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10151", "str_10151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10152", "str_10152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10153", "str_10153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10154", "str_10154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10155", "str_10155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10156", "str_10156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10157", "str_10157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10158", "str_10158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10159", "str_10159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1016", "str_1016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10160", "str_10160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10161", "str_10161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10162", "str_10162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10163", "str_10163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10164", "str_10164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10165", "str_10165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10166", "str_10166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10167", "str_10167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10168", "str_10168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10169", "str_10169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1017", "str_1017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10170", "str_10170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10171", "str_10171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10172", "str_10172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10173", "str_10173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10174", "str_10174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10175", "str_10175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10176", "str_10176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10177", "str_10177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10178", "str_10178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10179", "str_10179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1018", "str_1018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10180", "str_10180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10181", "str_10181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10182", "str_10182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10183", "str_10183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10184", "str_10184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10185", "str_10185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10186", "str_10186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10187", "str_10187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10188", "str_10188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10189", "str_10189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1019", "str_1019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10190", "str_10190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10191", "str_10191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10192", "str_10192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10193", "str_10193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10194", "str_10194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10195", "str_10195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10196", "str_10196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10197", "str_10197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10198", "str_10198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10199", "str_10199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_102", "str_102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1020", "str_1020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10200", "str_10200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10201", "str_10201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10202", "str_10202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10203", "str_10203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10204", "str_10204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10205", "str_10205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10206", "str_10206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10207", "str_10207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10208", "str_10208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10209", "str_10209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1021", "str_1021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10210", "str_10210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10211", "str_10211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10212", "str_10212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10213", "str_10213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10214", "str_10214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10215", "str_10215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10216", "str_10216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10217", "str_10217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10218", "str_10218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10219", "str_10219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1022", "str_1022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10220", "str_10220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10221", "str_10221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10222", "str_10222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10223", "str_10223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10224", "str_10224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10225", "str_10225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10226", "str_10226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10227", "str_10227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10228", "str_10228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10229", "str_10229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1023", "str_1023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10230", "str_10230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10231", "str_10231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10232", "str_10232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10233", "str_10233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10234", "str_10234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10235", "str_10235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10236", "str_10236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10237", "str_10237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10238", "str_10238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10239", "str_10239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1024", "str_1024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10240", "str_10240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10241", "str_10241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10242", "str_10242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10243", "str_10243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10244", "str_10244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10245", "str_10245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10246", "str_10246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10247", "str_10247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10248", "str_10248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10249", "str_10249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1025", "str_1025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10250", "str_10250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10251", "str_10251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10252", "str_10252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10253", "str_10253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10254", "str_10254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10255", "str_10255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10256", "str_10256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10257", "str_10257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10258", "str_10258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10259", "str_10259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1026", "str_1026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10260", "str_10260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10261", "str_10261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10262", "str_10262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10263", "str_10263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10264", "str_10264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10265", "str_10265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10266", "str_10266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10267", "str_10267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10268", "str_10268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10269", "str_10269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1027", "str_1027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10270", "str_10270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10271", "str_10271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10272", "str_10272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10273", "str_10273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10274", "str_10274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10275", "str_10275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10276", "str_10276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10277", "str_10277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10278", "str_10278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10279", "str_10279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1028", "str_1028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10280", "str_10280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10281", "str_10281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10282", "str_10282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10283", "str_10283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10284", "str_10284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10285", "str_10285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10286", "str_10286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10287", "str_10287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10288", "str_10288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10289", "str_10289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1029", "str_1029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10290", "str_10290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10291", "str_10291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10292", "str_10292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10293", "str_10293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10294", "str_10294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10295", "str_10295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10296", "str_10296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10297", "str_10297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10298", "str_10298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10299", "str_10299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_103", "str_103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1030", "str_1030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10300", "str_10300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10301", "str_10301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10302", "str_10302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10303", "str_10303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10304", "str_10304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10305", "str_10305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10306", "str_10306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10307", "str_10307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10308", "str_10308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10309", "str_10309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1031", "str_1031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10310", "str_10310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10311", "str_10311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10312", "str_10312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10313", "str_10313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10314", "str_10314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10315", "str_10315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10316", "str_10316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10317", "str_10317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10318", "str_10318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10319", "str_10319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1032", "str_1032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10320", "str_10320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10321", "str_10321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10322", "str_10322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10323", "str_10323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10324", "str_10324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10325", "str_10325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10326", "str_10326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10327", "str_10327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10328", "str_10328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10329", "str_10329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1033", "str_1033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10330", "str_10330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10331", "str_10331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10332", "str_10332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10333", "str_10333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10334", "str_10334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10335", "str_10335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10336", "str_10336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10337", "str_10337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10338", "str_10338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10339", "str_10339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1034", "str_1034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10340", "str_10340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10341", "str_10341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10342", "str_10342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10343", "str_10343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10344", "str_10344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10345", "str_10345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10346", "str_10346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10347", "str_10347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10348", "str_10348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10349", "str_10349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1035", "str_1035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10350", "str_10350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10351", "str_10351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10352", "str_10352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10353", "str_10353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10354", "str_10354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10355", "str_10355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10356", "str_10356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10357", "str_10357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10358", "str_10358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10359", "str_10359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1036", "str_1036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10360", "str_10360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10361", "str_10361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10362", "str_10362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10363", "str_10363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10364", "str_10364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10365", "str_10365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10366", "str_10366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10367", "str_10367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10368", "str_10368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10369", "str_10369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1037", "str_1037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10370", "str_10370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10371", "str_10371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10372", "str_10372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10373", "str_10373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10374", "str_10374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10375", "str_10375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10376", "str_10376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10377", "str_10377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10378", "str_10378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10379", "str_10379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1038", "str_1038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10380", "str_10380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10381", "str_10381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10382", "str_10382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10383", "str_10383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10384", "str_10384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10385", "str_10385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10386", "str_10386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10387", "str_10387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10388", "str_10388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10389", "str_10389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1039", "str_1039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10390", "str_10390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10391", "str_10391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10392", "str_10392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10393", "str_10393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10394", "str_10394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10395", "str_10395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10396", "str_10396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10397", "str_10397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10398", "str_10398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10399", "str_10399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_104", "str_104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1040", "str_1040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10400", "str_10400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10401", "str_10401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10402", "str_10402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10403", "str_10403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10404", "str_10404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10405", "str_10405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10406", "str_10406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10407", "str_10407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10408", "str_10408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10409", "str_10409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1041", "str_1041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10410", "str_10410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10411", "str_10411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10412", "str_10412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10413", "str_10413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10414", "str_10414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10415", "str_10415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10416", "str_10416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10417", "str_10417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10418", "str_10418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10419", "str_10419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1042", "str_1042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10420", "str_10420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10421", "str_10421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10422", "str_10422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10423", "str_10423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10424", "str_10424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10425", "str_10425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10426", "str_10426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10427", "str_10427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10428", "str_10428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10429", "str_10429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1043", "str_1043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10430", "str_10430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10431", "str_10431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10432", "str_10432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10433", "str_10433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10434", "str_10434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10435", "str_10435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10436", "str_10436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10437", "str_10437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10438", "str_10438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10439", "str_10439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1044", "str_1044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10440", "str_10440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10441", "str_10441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10442", "str_10442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10443", "str_10443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10444", "str_10444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10445", "str_10445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10446", "str_10446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_0: StringResource
+  get() = String0.str_0
+
+@ExperimentalResourceApi
+internal val Res.string.str_1: StringResource
+  get() = String0.str_1
+
+@ExperimentalResourceApi
+internal val Res.string.str_10: StringResource
+  get() = String0.str_10
+
+@ExperimentalResourceApi
+internal val Res.string.str_100: StringResource
+  get() = String0.str_100
+
+@ExperimentalResourceApi
+internal val Res.string.str_1000: StringResource
+  get() = String0.str_1000
+
+@ExperimentalResourceApi
+internal val Res.string.str_10000: StringResource
+  get() = String0.str_10000
+
+@ExperimentalResourceApi
+internal val Res.string.str_10001: StringResource
+  get() = String0.str_10001
+
+@ExperimentalResourceApi
+internal val Res.string.str_10002: StringResource
+  get() = String0.str_10002
+
+@ExperimentalResourceApi
+internal val Res.string.str_10003: StringResource
+  get() = String0.str_10003
+
+@ExperimentalResourceApi
+internal val Res.string.str_10004: StringResource
+  get() = String0.str_10004
+
+@ExperimentalResourceApi
+internal val Res.string.str_10005: StringResource
+  get() = String0.str_10005
+
+@ExperimentalResourceApi
+internal val Res.string.str_10006: StringResource
+  get() = String0.str_10006
+
+@ExperimentalResourceApi
+internal val Res.string.str_10007: StringResource
+  get() = String0.str_10007
+
+@ExperimentalResourceApi
+internal val Res.string.str_10008: StringResource
+  get() = String0.str_10008
+
+@ExperimentalResourceApi
+internal val Res.string.str_10009: StringResource
+  get() = String0.str_10009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1001: StringResource
+  get() = String0.str_1001
+
+@ExperimentalResourceApi
+internal val Res.string.str_10010: StringResource
+  get() = String0.str_10010
+
+@ExperimentalResourceApi
+internal val Res.string.str_10011: StringResource
+  get() = String0.str_10011
+
+@ExperimentalResourceApi
+internal val Res.string.str_10012: StringResource
+  get() = String0.str_10012
+
+@ExperimentalResourceApi
+internal val Res.string.str_10013: StringResource
+  get() = String0.str_10013
+
+@ExperimentalResourceApi
+internal val Res.string.str_10014: StringResource
+  get() = String0.str_10014
+
+@ExperimentalResourceApi
+internal val Res.string.str_10015: StringResource
+  get() = String0.str_10015
+
+@ExperimentalResourceApi
+internal val Res.string.str_10016: StringResource
+  get() = String0.str_10016
+
+@ExperimentalResourceApi
+internal val Res.string.str_10017: StringResource
+  get() = String0.str_10017
+
+@ExperimentalResourceApi
+internal val Res.string.str_10018: StringResource
+  get() = String0.str_10018
+
+@ExperimentalResourceApi
+internal val Res.string.str_10019: StringResource
+  get() = String0.str_10019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1002: StringResource
+  get() = String0.str_1002
+
+@ExperimentalResourceApi
+internal val Res.string.str_10020: StringResource
+  get() = String0.str_10020
+
+@ExperimentalResourceApi
+internal val Res.string.str_10021: StringResource
+  get() = String0.str_10021
+
+@ExperimentalResourceApi
+internal val Res.string.str_10022: StringResource
+  get() = String0.str_10022
+
+@ExperimentalResourceApi
+internal val Res.string.str_10023: StringResource
+  get() = String0.str_10023
+
+@ExperimentalResourceApi
+internal val Res.string.str_10024: StringResource
+  get() = String0.str_10024
+
+@ExperimentalResourceApi
+internal val Res.string.str_10025: StringResource
+  get() = String0.str_10025
+
+@ExperimentalResourceApi
+internal val Res.string.str_10026: StringResource
+  get() = String0.str_10026
+
+@ExperimentalResourceApi
+internal val Res.string.str_10027: StringResource
+  get() = String0.str_10027
+
+@ExperimentalResourceApi
+internal val Res.string.str_10028: StringResource
+  get() = String0.str_10028
+
+@ExperimentalResourceApi
+internal val Res.string.str_10029: StringResource
+  get() = String0.str_10029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1003: StringResource
+  get() = String0.str_1003
+
+@ExperimentalResourceApi
+internal val Res.string.str_10030: StringResource
+  get() = String0.str_10030
+
+@ExperimentalResourceApi
+internal val Res.string.str_10031: StringResource
+  get() = String0.str_10031
+
+@ExperimentalResourceApi
+internal val Res.string.str_10032: StringResource
+  get() = String0.str_10032
+
+@ExperimentalResourceApi
+internal val Res.string.str_10033: StringResource
+  get() = String0.str_10033
+
+@ExperimentalResourceApi
+internal val Res.string.str_10034: StringResource
+  get() = String0.str_10034
+
+@ExperimentalResourceApi
+internal val Res.string.str_10035: StringResource
+  get() = String0.str_10035
+
+@ExperimentalResourceApi
+internal val Res.string.str_10036: StringResource
+  get() = String0.str_10036
+
+@ExperimentalResourceApi
+internal val Res.string.str_10037: StringResource
+  get() = String0.str_10037
+
+@ExperimentalResourceApi
+internal val Res.string.str_10038: StringResource
+  get() = String0.str_10038
+
+@ExperimentalResourceApi
+internal val Res.string.str_10039: StringResource
+  get() = String0.str_10039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1004: StringResource
+  get() = String0.str_1004
+
+@ExperimentalResourceApi
+internal val Res.string.str_10040: StringResource
+  get() = String0.str_10040
+
+@ExperimentalResourceApi
+internal val Res.string.str_10041: StringResource
+  get() = String0.str_10041
+
+@ExperimentalResourceApi
+internal val Res.string.str_10042: StringResource
+  get() = String0.str_10042
+
+@ExperimentalResourceApi
+internal val Res.string.str_10043: StringResource
+  get() = String0.str_10043
+
+@ExperimentalResourceApi
+internal val Res.string.str_10044: StringResource
+  get() = String0.str_10044
+
+@ExperimentalResourceApi
+internal val Res.string.str_10045: StringResource
+  get() = String0.str_10045
+
+@ExperimentalResourceApi
+internal val Res.string.str_10046: StringResource
+  get() = String0.str_10046
+
+@ExperimentalResourceApi
+internal val Res.string.str_10047: StringResource
+  get() = String0.str_10047
+
+@ExperimentalResourceApi
+internal val Res.string.str_10048: StringResource
+  get() = String0.str_10048
+
+@ExperimentalResourceApi
+internal val Res.string.str_10049: StringResource
+  get() = String0.str_10049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1005: StringResource
+  get() = String0.str_1005
+
+@ExperimentalResourceApi
+internal val Res.string.str_10050: StringResource
+  get() = String0.str_10050
+
+@ExperimentalResourceApi
+internal val Res.string.str_10051: StringResource
+  get() = String0.str_10051
+
+@ExperimentalResourceApi
+internal val Res.string.str_10052: StringResource
+  get() = String0.str_10052
+
+@ExperimentalResourceApi
+internal val Res.string.str_10053: StringResource
+  get() = String0.str_10053
+
+@ExperimentalResourceApi
+internal val Res.string.str_10054: StringResource
+  get() = String0.str_10054
+
+@ExperimentalResourceApi
+internal val Res.string.str_10055: StringResource
+  get() = String0.str_10055
+
+@ExperimentalResourceApi
+internal val Res.string.str_10056: StringResource
+  get() = String0.str_10056
+
+@ExperimentalResourceApi
+internal val Res.string.str_10057: StringResource
+  get() = String0.str_10057
+
+@ExperimentalResourceApi
+internal val Res.string.str_10058: StringResource
+  get() = String0.str_10058
+
+@ExperimentalResourceApi
+internal val Res.string.str_10059: StringResource
+  get() = String0.str_10059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1006: StringResource
+  get() = String0.str_1006
+
+@ExperimentalResourceApi
+internal val Res.string.str_10060: StringResource
+  get() = String0.str_10060
+
+@ExperimentalResourceApi
+internal val Res.string.str_10061: StringResource
+  get() = String0.str_10061
+
+@ExperimentalResourceApi
+internal val Res.string.str_10062: StringResource
+  get() = String0.str_10062
+
+@ExperimentalResourceApi
+internal val Res.string.str_10063: StringResource
+  get() = String0.str_10063
+
+@ExperimentalResourceApi
+internal val Res.string.str_10064: StringResource
+  get() = String0.str_10064
+
+@ExperimentalResourceApi
+internal val Res.string.str_10065: StringResource
+  get() = String0.str_10065
+
+@ExperimentalResourceApi
+internal val Res.string.str_10066: StringResource
+  get() = String0.str_10066
+
+@ExperimentalResourceApi
+internal val Res.string.str_10067: StringResource
+  get() = String0.str_10067
+
+@ExperimentalResourceApi
+internal val Res.string.str_10068: StringResource
+  get() = String0.str_10068
+
+@ExperimentalResourceApi
+internal val Res.string.str_10069: StringResource
+  get() = String0.str_10069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1007: StringResource
+  get() = String0.str_1007
+
+@ExperimentalResourceApi
+internal val Res.string.str_10070: StringResource
+  get() = String0.str_10070
+
+@ExperimentalResourceApi
+internal val Res.string.str_10071: StringResource
+  get() = String0.str_10071
+
+@ExperimentalResourceApi
+internal val Res.string.str_10072: StringResource
+  get() = String0.str_10072
+
+@ExperimentalResourceApi
+internal val Res.string.str_10073: StringResource
+  get() = String0.str_10073
+
+@ExperimentalResourceApi
+internal val Res.string.str_10074: StringResource
+  get() = String0.str_10074
+
+@ExperimentalResourceApi
+internal val Res.string.str_10075: StringResource
+  get() = String0.str_10075
+
+@ExperimentalResourceApi
+internal val Res.string.str_10076: StringResource
+  get() = String0.str_10076
+
+@ExperimentalResourceApi
+internal val Res.string.str_10077: StringResource
+  get() = String0.str_10077
+
+@ExperimentalResourceApi
+internal val Res.string.str_10078: StringResource
+  get() = String0.str_10078
+
+@ExperimentalResourceApi
+internal val Res.string.str_10079: StringResource
+  get() = String0.str_10079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1008: StringResource
+  get() = String0.str_1008
+
+@ExperimentalResourceApi
+internal val Res.string.str_10080: StringResource
+  get() = String0.str_10080
+
+@ExperimentalResourceApi
+internal val Res.string.str_10081: StringResource
+  get() = String0.str_10081
+
+@ExperimentalResourceApi
+internal val Res.string.str_10082: StringResource
+  get() = String0.str_10082
+
+@ExperimentalResourceApi
+internal val Res.string.str_10083: StringResource
+  get() = String0.str_10083
+
+@ExperimentalResourceApi
+internal val Res.string.str_10084: StringResource
+  get() = String0.str_10084
+
+@ExperimentalResourceApi
+internal val Res.string.str_10085: StringResource
+  get() = String0.str_10085
+
+@ExperimentalResourceApi
+internal val Res.string.str_10086: StringResource
+  get() = String0.str_10086
+
+@ExperimentalResourceApi
+internal val Res.string.str_10087: StringResource
+  get() = String0.str_10087
+
+@ExperimentalResourceApi
+internal val Res.string.str_10088: StringResource
+  get() = String0.str_10088
+
+@ExperimentalResourceApi
+internal val Res.string.str_10089: StringResource
+  get() = String0.str_10089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1009: StringResource
+  get() = String0.str_1009
+
+@ExperimentalResourceApi
+internal val Res.string.str_10090: StringResource
+  get() = String0.str_10090
+
+@ExperimentalResourceApi
+internal val Res.string.str_10091: StringResource
+  get() = String0.str_10091
+
+@ExperimentalResourceApi
+internal val Res.string.str_10092: StringResource
+  get() = String0.str_10092
+
+@ExperimentalResourceApi
+internal val Res.string.str_10093: StringResource
+  get() = String0.str_10093
+
+@ExperimentalResourceApi
+internal val Res.string.str_10094: StringResource
+  get() = String0.str_10094
+
+@ExperimentalResourceApi
+internal val Res.string.str_10095: StringResource
+  get() = String0.str_10095
+
+@ExperimentalResourceApi
+internal val Res.string.str_10096: StringResource
+  get() = String0.str_10096
+
+@ExperimentalResourceApi
+internal val Res.string.str_10097: StringResource
+  get() = String0.str_10097
+
+@ExperimentalResourceApi
+internal val Res.string.str_10098: StringResource
+  get() = String0.str_10098
+
+@ExperimentalResourceApi
+internal val Res.string.str_10099: StringResource
+  get() = String0.str_10099
+
+@ExperimentalResourceApi
+internal val Res.string.str_101: StringResource
+  get() = String0.str_101
+
+@ExperimentalResourceApi
+internal val Res.string.str_1010: StringResource
+  get() = String0.str_1010
+
+@ExperimentalResourceApi
+internal val Res.string.str_10100: StringResource
+  get() = String0.str_10100
+
+@ExperimentalResourceApi
+internal val Res.string.str_10101: StringResource
+  get() = String0.str_10101
+
+@ExperimentalResourceApi
+internal val Res.string.str_10102: StringResource
+  get() = String0.str_10102
+
+@ExperimentalResourceApi
+internal val Res.string.str_10103: StringResource
+  get() = String0.str_10103
+
+@ExperimentalResourceApi
+internal val Res.string.str_10104: StringResource
+  get() = String0.str_10104
+
+@ExperimentalResourceApi
+internal val Res.string.str_10105: StringResource
+  get() = String0.str_10105
+
+@ExperimentalResourceApi
+internal val Res.string.str_10106: StringResource
+  get() = String0.str_10106
+
+@ExperimentalResourceApi
+internal val Res.string.str_10107: StringResource
+  get() = String0.str_10107
+
+@ExperimentalResourceApi
+internal val Res.string.str_10108: StringResource
+  get() = String0.str_10108
+
+@ExperimentalResourceApi
+internal val Res.string.str_10109: StringResource
+  get() = String0.str_10109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1011: StringResource
+  get() = String0.str_1011
+
+@ExperimentalResourceApi
+internal val Res.string.str_10110: StringResource
+  get() = String0.str_10110
+
+@ExperimentalResourceApi
+internal val Res.string.str_10111: StringResource
+  get() = String0.str_10111
+
+@ExperimentalResourceApi
+internal val Res.string.str_10112: StringResource
+  get() = String0.str_10112
+
+@ExperimentalResourceApi
+internal val Res.string.str_10113: StringResource
+  get() = String0.str_10113
+
+@ExperimentalResourceApi
+internal val Res.string.str_10114: StringResource
+  get() = String0.str_10114
+
+@ExperimentalResourceApi
+internal val Res.string.str_10115: StringResource
+  get() = String0.str_10115
+
+@ExperimentalResourceApi
+internal val Res.string.str_10116: StringResource
+  get() = String0.str_10116
+
+@ExperimentalResourceApi
+internal val Res.string.str_10117: StringResource
+  get() = String0.str_10117
+
+@ExperimentalResourceApi
+internal val Res.string.str_10118: StringResource
+  get() = String0.str_10118
+
+@ExperimentalResourceApi
+internal val Res.string.str_10119: StringResource
+  get() = String0.str_10119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1012: StringResource
+  get() = String0.str_1012
+
+@ExperimentalResourceApi
+internal val Res.string.str_10120: StringResource
+  get() = String0.str_10120
+
+@ExperimentalResourceApi
+internal val Res.string.str_10121: StringResource
+  get() = String0.str_10121
+
+@ExperimentalResourceApi
+internal val Res.string.str_10122: StringResource
+  get() = String0.str_10122
+
+@ExperimentalResourceApi
+internal val Res.string.str_10123: StringResource
+  get() = String0.str_10123
+
+@ExperimentalResourceApi
+internal val Res.string.str_10124: StringResource
+  get() = String0.str_10124
+
+@ExperimentalResourceApi
+internal val Res.string.str_10125: StringResource
+  get() = String0.str_10125
+
+@ExperimentalResourceApi
+internal val Res.string.str_10126: StringResource
+  get() = String0.str_10126
+
+@ExperimentalResourceApi
+internal val Res.string.str_10127: StringResource
+  get() = String0.str_10127
+
+@ExperimentalResourceApi
+internal val Res.string.str_10128: StringResource
+  get() = String0.str_10128
+
+@ExperimentalResourceApi
+internal val Res.string.str_10129: StringResource
+  get() = String0.str_10129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1013: StringResource
+  get() = String0.str_1013
+
+@ExperimentalResourceApi
+internal val Res.string.str_10130: StringResource
+  get() = String0.str_10130
+
+@ExperimentalResourceApi
+internal val Res.string.str_10131: StringResource
+  get() = String0.str_10131
+
+@ExperimentalResourceApi
+internal val Res.string.str_10132: StringResource
+  get() = String0.str_10132
+
+@ExperimentalResourceApi
+internal val Res.string.str_10133: StringResource
+  get() = String0.str_10133
+
+@ExperimentalResourceApi
+internal val Res.string.str_10134: StringResource
+  get() = String0.str_10134
+
+@ExperimentalResourceApi
+internal val Res.string.str_10135: StringResource
+  get() = String0.str_10135
+
+@ExperimentalResourceApi
+internal val Res.string.str_10136: StringResource
+  get() = String0.str_10136
+
+@ExperimentalResourceApi
+internal val Res.string.str_10137: StringResource
+  get() = String0.str_10137
+
+@ExperimentalResourceApi
+internal val Res.string.str_10138: StringResource
+  get() = String0.str_10138
+
+@ExperimentalResourceApi
+internal val Res.string.str_10139: StringResource
+  get() = String0.str_10139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1014: StringResource
+  get() = String0.str_1014
+
+@ExperimentalResourceApi
+internal val Res.string.str_10140: StringResource
+  get() = String0.str_10140
+
+@ExperimentalResourceApi
+internal val Res.string.str_10141: StringResource
+  get() = String0.str_10141
+
+@ExperimentalResourceApi
+internal val Res.string.str_10142: StringResource
+  get() = String0.str_10142
+
+@ExperimentalResourceApi
+internal val Res.string.str_10143: StringResource
+  get() = String0.str_10143
+
+@ExperimentalResourceApi
+internal val Res.string.str_10144: StringResource
+  get() = String0.str_10144
+
+@ExperimentalResourceApi
+internal val Res.string.str_10145: StringResource
+  get() = String0.str_10145
+
+@ExperimentalResourceApi
+internal val Res.string.str_10146: StringResource
+  get() = String0.str_10146
+
+@ExperimentalResourceApi
+internal val Res.string.str_10147: StringResource
+  get() = String0.str_10147
+
+@ExperimentalResourceApi
+internal val Res.string.str_10148: StringResource
+  get() = String0.str_10148
+
+@ExperimentalResourceApi
+internal val Res.string.str_10149: StringResource
+  get() = String0.str_10149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1015: StringResource
+  get() = String0.str_1015
+
+@ExperimentalResourceApi
+internal val Res.string.str_10150: StringResource
+  get() = String0.str_10150
+
+@ExperimentalResourceApi
+internal val Res.string.str_10151: StringResource
+  get() = String0.str_10151
+
+@ExperimentalResourceApi
+internal val Res.string.str_10152: StringResource
+  get() = String0.str_10152
+
+@ExperimentalResourceApi
+internal val Res.string.str_10153: StringResource
+  get() = String0.str_10153
+
+@ExperimentalResourceApi
+internal val Res.string.str_10154: StringResource
+  get() = String0.str_10154
+
+@ExperimentalResourceApi
+internal val Res.string.str_10155: StringResource
+  get() = String0.str_10155
+
+@ExperimentalResourceApi
+internal val Res.string.str_10156: StringResource
+  get() = String0.str_10156
+
+@ExperimentalResourceApi
+internal val Res.string.str_10157: StringResource
+  get() = String0.str_10157
+
+@ExperimentalResourceApi
+internal val Res.string.str_10158: StringResource
+  get() = String0.str_10158
+
+@ExperimentalResourceApi
+internal val Res.string.str_10159: StringResource
+  get() = String0.str_10159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1016: StringResource
+  get() = String0.str_1016
+
+@ExperimentalResourceApi
+internal val Res.string.str_10160: StringResource
+  get() = String0.str_10160
+
+@ExperimentalResourceApi
+internal val Res.string.str_10161: StringResource
+  get() = String0.str_10161
+
+@ExperimentalResourceApi
+internal val Res.string.str_10162: StringResource
+  get() = String0.str_10162
+
+@ExperimentalResourceApi
+internal val Res.string.str_10163: StringResource
+  get() = String0.str_10163
+
+@ExperimentalResourceApi
+internal val Res.string.str_10164: StringResource
+  get() = String0.str_10164
+
+@ExperimentalResourceApi
+internal val Res.string.str_10165: StringResource
+  get() = String0.str_10165
+
+@ExperimentalResourceApi
+internal val Res.string.str_10166: StringResource
+  get() = String0.str_10166
+
+@ExperimentalResourceApi
+internal val Res.string.str_10167: StringResource
+  get() = String0.str_10167
+
+@ExperimentalResourceApi
+internal val Res.string.str_10168: StringResource
+  get() = String0.str_10168
+
+@ExperimentalResourceApi
+internal val Res.string.str_10169: StringResource
+  get() = String0.str_10169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1017: StringResource
+  get() = String0.str_1017
+
+@ExperimentalResourceApi
+internal val Res.string.str_10170: StringResource
+  get() = String0.str_10170
+
+@ExperimentalResourceApi
+internal val Res.string.str_10171: StringResource
+  get() = String0.str_10171
+
+@ExperimentalResourceApi
+internal val Res.string.str_10172: StringResource
+  get() = String0.str_10172
+
+@ExperimentalResourceApi
+internal val Res.string.str_10173: StringResource
+  get() = String0.str_10173
+
+@ExperimentalResourceApi
+internal val Res.string.str_10174: StringResource
+  get() = String0.str_10174
+
+@ExperimentalResourceApi
+internal val Res.string.str_10175: StringResource
+  get() = String0.str_10175
+
+@ExperimentalResourceApi
+internal val Res.string.str_10176: StringResource
+  get() = String0.str_10176
+
+@ExperimentalResourceApi
+internal val Res.string.str_10177: StringResource
+  get() = String0.str_10177
+
+@ExperimentalResourceApi
+internal val Res.string.str_10178: StringResource
+  get() = String0.str_10178
+
+@ExperimentalResourceApi
+internal val Res.string.str_10179: StringResource
+  get() = String0.str_10179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1018: StringResource
+  get() = String0.str_1018
+
+@ExperimentalResourceApi
+internal val Res.string.str_10180: StringResource
+  get() = String0.str_10180
+
+@ExperimentalResourceApi
+internal val Res.string.str_10181: StringResource
+  get() = String0.str_10181
+
+@ExperimentalResourceApi
+internal val Res.string.str_10182: StringResource
+  get() = String0.str_10182
+
+@ExperimentalResourceApi
+internal val Res.string.str_10183: StringResource
+  get() = String0.str_10183
+
+@ExperimentalResourceApi
+internal val Res.string.str_10184: StringResource
+  get() = String0.str_10184
+
+@ExperimentalResourceApi
+internal val Res.string.str_10185: StringResource
+  get() = String0.str_10185
+
+@ExperimentalResourceApi
+internal val Res.string.str_10186: StringResource
+  get() = String0.str_10186
+
+@ExperimentalResourceApi
+internal val Res.string.str_10187: StringResource
+  get() = String0.str_10187
+
+@ExperimentalResourceApi
+internal val Res.string.str_10188: StringResource
+  get() = String0.str_10188
+
+@ExperimentalResourceApi
+internal val Res.string.str_10189: StringResource
+  get() = String0.str_10189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1019: StringResource
+  get() = String0.str_1019
+
+@ExperimentalResourceApi
+internal val Res.string.str_10190: StringResource
+  get() = String0.str_10190
+
+@ExperimentalResourceApi
+internal val Res.string.str_10191: StringResource
+  get() = String0.str_10191
+
+@ExperimentalResourceApi
+internal val Res.string.str_10192: StringResource
+  get() = String0.str_10192
+
+@ExperimentalResourceApi
+internal val Res.string.str_10193: StringResource
+  get() = String0.str_10193
+
+@ExperimentalResourceApi
+internal val Res.string.str_10194: StringResource
+  get() = String0.str_10194
+
+@ExperimentalResourceApi
+internal val Res.string.str_10195: StringResource
+  get() = String0.str_10195
+
+@ExperimentalResourceApi
+internal val Res.string.str_10196: StringResource
+  get() = String0.str_10196
+
+@ExperimentalResourceApi
+internal val Res.string.str_10197: StringResource
+  get() = String0.str_10197
+
+@ExperimentalResourceApi
+internal val Res.string.str_10198: StringResource
+  get() = String0.str_10198
+
+@ExperimentalResourceApi
+internal val Res.string.str_10199: StringResource
+  get() = String0.str_10199
+
+@ExperimentalResourceApi
+internal val Res.string.str_102: StringResource
+  get() = String0.str_102
+
+@ExperimentalResourceApi
+internal val Res.string.str_1020: StringResource
+  get() = String0.str_1020
+
+@ExperimentalResourceApi
+internal val Res.string.str_10200: StringResource
+  get() = String0.str_10200
+
+@ExperimentalResourceApi
+internal val Res.string.str_10201: StringResource
+  get() = String0.str_10201
+
+@ExperimentalResourceApi
+internal val Res.string.str_10202: StringResource
+  get() = String0.str_10202
+
+@ExperimentalResourceApi
+internal val Res.string.str_10203: StringResource
+  get() = String0.str_10203
+
+@ExperimentalResourceApi
+internal val Res.string.str_10204: StringResource
+  get() = String0.str_10204
+
+@ExperimentalResourceApi
+internal val Res.string.str_10205: StringResource
+  get() = String0.str_10205
+
+@ExperimentalResourceApi
+internal val Res.string.str_10206: StringResource
+  get() = String0.str_10206
+
+@ExperimentalResourceApi
+internal val Res.string.str_10207: StringResource
+  get() = String0.str_10207
+
+@ExperimentalResourceApi
+internal val Res.string.str_10208: StringResource
+  get() = String0.str_10208
+
+@ExperimentalResourceApi
+internal val Res.string.str_10209: StringResource
+  get() = String0.str_10209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1021: StringResource
+  get() = String0.str_1021
+
+@ExperimentalResourceApi
+internal val Res.string.str_10210: StringResource
+  get() = String0.str_10210
+
+@ExperimentalResourceApi
+internal val Res.string.str_10211: StringResource
+  get() = String0.str_10211
+
+@ExperimentalResourceApi
+internal val Res.string.str_10212: StringResource
+  get() = String0.str_10212
+
+@ExperimentalResourceApi
+internal val Res.string.str_10213: StringResource
+  get() = String0.str_10213
+
+@ExperimentalResourceApi
+internal val Res.string.str_10214: StringResource
+  get() = String0.str_10214
+
+@ExperimentalResourceApi
+internal val Res.string.str_10215: StringResource
+  get() = String0.str_10215
+
+@ExperimentalResourceApi
+internal val Res.string.str_10216: StringResource
+  get() = String0.str_10216
+
+@ExperimentalResourceApi
+internal val Res.string.str_10217: StringResource
+  get() = String0.str_10217
+
+@ExperimentalResourceApi
+internal val Res.string.str_10218: StringResource
+  get() = String0.str_10218
+
+@ExperimentalResourceApi
+internal val Res.string.str_10219: StringResource
+  get() = String0.str_10219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1022: StringResource
+  get() = String0.str_1022
+
+@ExperimentalResourceApi
+internal val Res.string.str_10220: StringResource
+  get() = String0.str_10220
+
+@ExperimentalResourceApi
+internal val Res.string.str_10221: StringResource
+  get() = String0.str_10221
+
+@ExperimentalResourceApi
+internal val Res.string.str_10222: StringResource
+  get() = String0.str_10222
+
+@ExperimentalResourceApi
+internal val Res.string.str_10223: StringResource
+  get() = String0.str_10223
+
+@ExperimentalResourceApi
+internal val Res.string.str_10224: StringResource
+  get() = String0.str_10224
+
+@ExperimentalResourceApi
+internal val Res.string.str_10225: StringResource
+  get() = String0.str_10225
+
+@ExperimentalResourceApi
+internal val Res.string.str_10226: StringResource
+  get() = String0.str_10226
+
+@ExperimentalResourceApi
+internal val Res.string.str_10227: StringResource
+  get() = String0.str_10227
+
+@ExperimentalResourceApi
+internal val Res.string.str_10228: StringResource
+  get() = String0.str_10228
+
+@ExperimentalResourceApi
+internal val Res.string.str_10229: StringResource
+  get() = String0.str_10229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1023: StringResource
+  get() = String0.str_1023
+
+@ExperimentalResourceApi
+internal val Res.string.str_10230: StringResource
+  get() = String0.str_10230
+
+@ExperimentalResourceApi
+internal val Res.string.str_10231: StringResource
+  get() = String0.str_10231
+
+@ExperimentalResourceApi
+internal val Res.string.str_10232: StringResource
+  get() = String0.str_10232
+
+@ExperimentalResourceApi
+internal val Res.string.str_10233: StringResource
+  get() = String0.str_10233
+
+@ExperimentalResourceApi
+internal val Res.string.str_10234: StringResource
+  get() = String0.str_10234
+
+@ExperimentalResourceApi
+internal val Res.string.str_10235: StringResource
+  get() = String0.str_10235
+
+@ExperimentalResourceApi
+internal val Res.string.str_10236: StringResource
+  get() = String0.str_10236
+
+@ExperimentalResourceApi
+internal val Res.string.str_10237: StringResource
+  get() = String0.str_10237
+
+@ExperimentalResourceApi
+internal val Res.string.str_10238: StringResource
+  get() = String0.str_10238
+
+@ExperimentalResourceApi
+internal val Res.string.str_10239: StringResource
+  get() = String0.str_10239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1024: StringResource
+  get() = String0.str_1024
+
+@ExperimentalResourceApi
+internal val Res.string.str_10240: StringResource
+  get() = String0.str_10240
+
+@ExperimentalResourceApi
+internal val Res.string.str_10241: StringResource
+  get() = String0.str_10241
+
+@ExperimentalResourceApi
+internal val Res.string.str_10242: StringResource
+  get() = String0.str_10242
+
+@ExperimentalResourceApi
+internal val Res.string.str_10243: StringResource
+  get() = String0.str_10243
+
+@ExperimentalResourceApi
+internal val Res.string.str_10244: StringResource
+  get() = String0.str_10244
+
+@ExperimentalResourceApi
+internal val Res.string.str_10245: StringResource
+  get() = String0.str_10245
+
+@ExperimentalResourceApi
+internal val Res.string.str_10246: StringResource
+  get() = String0.str_10246
+
+@ExperimentalResourceApi
+internal val Res.string.str_10247: StringResource
+  get() = String0.str_10247
+
+@ExperimentalResourceApi
+internal val Res.string.str_10248: StringResource
+  get() = String0.str_10248
+
+@ExperimentalResourceApi
+internal val Res.string.str_10249: StringResource
+  get() = String0.str_10249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1025: StringResource
+  get() = String0.str_1025
+
+@ExperimentalResourceApi
+internal val Res.string.str_10250: StringResource
+  get() = String0.str_10250
+
+@ExperimentalResourceApi
+internal val Res.string.str_10251: StringResource
+  get() = String0.str_10251
+
+@ExperimentalResourceApi
+internal val Res.string.str_10252: StringResource
+  get() = String0.str_10252
+
+@ExperimentalResourceApi
+internal val Res.string.str_10253: StringResource
+  get() = String0.str_10253
+
+@ExperimentalResourceApi
+internal val Res.string.str_10254: StringResource
+  get() = String0.str_10254
+
+@ExperimentalResourceApi
+internal val Res.string.str_10255: StringResource
+  get() = String0.str_10255
+
+@ExperimentalResourceApi
+internal val Res.string.str_10256: StringResource
+  get() = String0.str_10256
+
+@ExperimentalResourceApi
+internal val Res.string.str_10257: StringResource
+  get() = String0.str_10257
+
+@ExperimentalResourceApi
+internal val Res.string.str_10258: StringResource
+  get() = String0.str_10258
+
+@ExperimentalResourceApi
+internal val Res.string.str_10259: StringResource
+  get() = String0.str_10259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1026: StringResource
+  get() = String0.str_1026
+
+@ExperimentalResourceApi
+internal val Res.string.str_10260: StringResource
+  get() = String0.str_10260
+
+@ExperimentalResourceApi
+internal val Res.string.str_10261: StringResource
+  get() = String0.str_10261
+
+@ExperimentalResourceApi
+internal val Res.string.str_10262: StringResource
+  get() = String0.str_10262
+
+@ExperimentalResourceApi
+internal val Res.string.str_10263: StringResource
+  get() = String0.str_10263
+
+@ExperimentalResourceApi
+internal val Res.string.str_10264: StringResource
+  get() = String0.str_10264
+
+@ExperimentalResourceApi
+internal val Res.string.str_10265: StringResource
+  get() = String0.str_10265
+
+@ExperimentalResourceApi
+internal val Res.string.str_10266: StringResource
+  get() = String0.str_10266
+
+@ExperimentalResourceApi
+internal val Res.string.str_10267: StringResource
+  get() = String0.str_10267
+
+@ExperimentalResourceApi
+internal val Res.string.str_10268: StringResource
+  get() = String0.str_10268
+
+@ExperimentalResourceApi
+internal val Res.string.str_10269: StringResource
+  get() = String0.str_10269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1027: StringResource
+  get() = String0.str_1027
+
+@ExperimentalResourceApi
+internal val Res.string.str_10270: StringResource
+  get() = String0.str_10270
+
+@ExperimentalResourceApi
+internal val Res.string.str_10271: StringResource
+  get() = String0.str_10271
+
+@ExperimentalResourceApi
+internal val Res.string.str_10272: StringResource
+  get() = String0.str_10272
+
+@ExperimentalResourceApi
+internal val Res.string.str_10273: StringResource
+  get() = String0.str_10273
+
+@ExperimentalResourceApi
+internal val Res.string.str_10274: StringResource
+  get() = String0.str_10274
+
+@ExperimentalResourceApi
+internal val Res.string.str_10275: StringResource
+  get() = String0.str_10275
+
+@ExperimentalResourceApi
+internal val Res.string.str_10276: StringResource
+  get() = String0.str_10276
+
+@ExperimentalResourceApi
+internal val Res.string.str_10277: StringResource
+  get() = String0.str_10277
+
+@ExperimentalResourceApi
+internal val Res.string.str_10278: StringResource
+  get() = String0.str_10278
+
+@ExperimentalResourceApi
+internal val Res.string.str_10279: StringResource
+  get() = String0.str_10279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1028: StringResource
+  get() = String0.str_1028
+
+@ExperimentalResourceApi
+internal val Res.string.str_10280: StringResource
+  get() = String0.str_10280
+
+@ExperimentalResourceApi
+internal val Res.string.str_10281: StringResource
+  get() = String0.str_10281
+
+@ExperimentalResourceApi
+internal val Res.string.str_10282: StringResource
+  get() = String0.str_10282
+
+@ExperimentalResourceApi
+internal val Res.string.str_10283: StringResource
+  get() = String0.str_10283
+
+@ExperimentalResourceApi
+internal val Res.string.str_10284: StringResource
+  get() = String0.str_10284
+
+@ExperimentalResourceApi
+internal val Res.string.str_10285: StringResource
+  get() = String0.str_10285
+
+@ExperimentalResourceApi
+internal val Res.string.str_10286: StringResource
+  get() = String0.str_10286
+
+@ExperimentalResourceApi
+internal val Res.string.str_10287: StringResource
+  get() = String0.str_10287
+
+@ExperimentalResourceApi
+internal val Res.string.str_10288: StringResource
+  get() = String0.str_10288
+
+@ExperimentalResourceApi
+internal val Res.string.str_10289: StringResource
+  get() = String0.str_10289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1029: StringResource
+  get() = String0.str_1029
+
+@ExperimentalResourceApi
+internal val Res.string.str_10290: StringResource
+  get() = String0.str_10290
+
+@ExperimentalResourceApi
+internal val Res.string.str_10291: StringResource
+  get() = String0.str_10291
+
+@ExperimentalResourceApi
+internal val Res.string.str_10292: StringResource
+  get() = String0.str_10292
+
+@ExperimentalResourceApi
+internal val Res.string.str_10293: StringResource
+  get() = String0.str_10293
+
+@ExperimentalResourceApi
+internal val Res.string.str_10294: StringResource
+  get() = String0.str_10294
+
+@ExperimentalResourceApi
+internal val Res.string.str_10295: StringResource
+  get() = String0.str_10295
+
+@ExperimentalResourceApi
+internal val Res.string.str_10296: StringResource
+  get() = String0.str_10296
+
+@ExperimentalResourceApi
+internal val Res.string.str_10297: StringResource
+  get() = String0.str_10297
+
+@ExperimentalResourceApi
+internal val Res.string.str_10298: StringResource
+  get() = String0.str_10298
+
+@ExperimentalResourceApi
+internal val Res.string.str_10299: StringResource
+  get() = String0.str_10299
+
+@ExperimentalResourceApi
+internal val Res.string.str_103: StringResource
+  get() = String0.str_103
+
+@ExperimentalResourceApi
+internal val Res.string.str_1030: StringResource
+  get() = String0.str_1030
+
+@ExperimentalResourceApi
+internal val Res.string.str_10300: StringResource
+  get() = String0.str_10300
+
+@ExperimentalResourceApi
+internal val Res.string.str_10301: StringResource
+  get() = String0.str_10301
+
+@ExperimentalResourceApi
+internal val Res.string.str_10302: StringResource
+  get() = String0.str_10302
+
+@ExperimentalResourceApi
+internal val Res.string.str_10303: StringResource
+  get() = String0.str_10303
+
+@ExperimentalResourceApi
+internal val Res.string.str_10304: StringResource
+  get() = String0.str_10304
+
+@ExperimentalResourceApi
+internal val Res.string.str_10305: StringResource
+  get() = String0.str_10305
+
+@ExperimentalResourceApi
+internal val Res.string.str_10306: StringResource
+  get() = String0.str_10306
+
+@ExperimentalResourceApi
+internal val Res.string.str_10307: StringResource
+  get() = String0.str_10307
+
+@ExperimentalResourceApi
+internal val Res.string.str_10308: StringResource
+  get() = String0.str_10308
+
+@ExperimentalResourceApi
+internal val Res.string.str_10309: StringResource
+  get() = String0.str_10309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1031: StringResource
+  get() = String0.str_1031
+
+@ExperimentalResourceApi
+internal val Res.string.str_10310: StringResource
+  get() = String0.str_10310
+
+@ExperimentalResourceApi
+internal val Res.string.str_10311: StringResource
+  get() = String0.str_10311
+
+@ExperimentalResourceApi
+internal val Res.string.str_10312: StringResource
+  get() = String0.str_10312
+
+@ExperimentalResourceApi
+internal val Res.string.str_10313: StringResource
+  get() = String0.str_10313
+
+@ExperimentalResourceApi
+internal val Res.string.str_10314: StringResource
+  get() = String0.str_10314
+
+@ExperimentalResourceApi
+internal val Res.string.str_10315: StringResource
+  get() = String0.str_10315
+
+@ExperimentalResourceApi
+internal val Res.string.str_10316: StringResource
+  get() = String0.str_10316
+
+@ExperimentalResourceApi
+internal val Res.string.str_10317: StringResource
+  get() = String0.str_10317
+
+@ExperimentalResourceApi
+internal val Res.string.str_10318: StringResource
+  get() = String0.str_10318
+
+@ExperimentalResourceApi
+internal val Res.string.str_10319: StringResource
+  get() = String0.str_10319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1032: StringResource
+  get() = String0.str_1032
+
+@ExperimentalResourceApi
+internal val Res.string.str_10320: StringResource
+  get() = String0.str_10320
+
+@ExperimentalResourceApi
+internal val Res.string.str_10321: StringResource
+  get() = String0.str_10321
+
+@ExperimentalResourceApi
+internal val Res.string.str_10322: StringResource
+  get() = String0.str_10322
+
+@ExperimentalResourceApi
+internal val Res.string.str_10323: StringResource
+  get() = String0.str_10323
+
+@ExperimentalResourceApi
+internal val Res.string.str_10324: StringResource
+  get() = String0.str_10324
+
+@ExperimentalResourceApi
+internal val Res.string.str_10325: StringResource
+  get() = String0.str_10325
+
+@ExperimentalResourceApi
+internal val Res.string.str_10326: StringResource
+  get() = String0.str_10326
+
+@ExperimentalResourceApi
+internal val Res.string.str_10327: StringResource
+  get() = String0.str_10327
+
+@ExperimentalResourceApi
+internal val Res.string.str_10328: StringResource
+  get() = String0.str_10328
+
+@ExperimentalResourceApi
+internal val Res.string.str_10329: StringResource
+  get() = String0.str_10329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1033: StringResource
+  get() = String0.str_1033
+
+@ExperimentalResourceApi
+internal val Res.string.str_10330: StringResource
+  get() = String0.str_10330
+
+@ExperimentalResourceApi
+internal val Res.string.str_10331: StringResource
+  get() = String0.str_10331
+
+@ExperimentalResourceApi
+internal val Res.string.str_10332: StringResource
+  get() = String0.str_10332
+
+@ExperimentalResourceApi
+internal val Res.string.str_10333: StringResource
+  get() = String0.str_10333
+
+@ExperimentalResourceApi
+internal val Res.string.str_10334: StringResource
+  get() = String0.str_10334
+
+@ExperimentalResourceApi
+internal val Res.string.str_10335: StringResource
+  get() = String0.str_10335
+
+@ExperimentalResourceApi
+internal val Res.string.str_10336: StringResource
+  get() = String0.str_10336
+
+@ExperimentalResourceApi
+internal val Res.string.str_10337: StringResource
+  get() = String0.str_10337
+
+@ExperimentalResourceApi
+internal val Res.string.str_10338: StringResource
+  get() = String0.str_10338
+
+@ExperimentalResourceApi
+internal val Res.string.str_10339: StringResource
+  get() = String0.str_10339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1034: StringResource
+  get() = String0.str_1034
+
+@ExperimentalResourceApi
+internal val Res.string.str_10340: StringResource
+  get() = String0.str_10340
+
+@ExperimentalResourceApi
+internal val Res.string.str_10341: StringResource
+  get() = String0.str_10341
+
+@ExperimentalResourceApi
+internal val Res.string.str_10342: StringResource
+  get() = String0.str_10342
+
+@ExperimentalResourceApi
+internal val Res.string.str_10343: StringResource
+  get() = String0.str_10343
+
+@ExperimentalResourceApi
+internal val Res.string.str_10344: StringResource
+  get() = String0.str_10344
+
+@ExperimentalResourceApi
+internal val Res.string.str_10345: StringResource
+  get() = String0.str_10345
+
+@ExperimentalResourceApi
+internal val Res.string.str_10346: StringResource
+  get() = String0.str_10346
+
+@ExperimentalResourceApi
+internal val Res.string.str_10347: StringResource
+  get() = String0.str_10347
+
+@ExperimentalResourceApi
+internal val Res.string.str_10348: StringResource
+  get() = String0.str_10348
+
+@ExperimentalResourceApi
+internal val Res.string.str_10349: StringResource
+  get() = String0.str_10349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1035: StringResource
+  get() = String0.str_1035
+
+@ExperimentalResourceApi
+internal val Res.string.str_10350: StringResource
+  get() = String0.str_10350
+
+@ExperimentalResourceApi
+internal val Res.string.str_10351: StringResource
+  get() = String0.str_10351
+
+@ExperimentalResourceApi
+internal val Res.string.str_10352: StringResource
+  get() = String0.str_10352
+
+@ExperimentalResourceApi
+internal val Res.string.str_10353: StringResource
+  get() = String0.str_10353
+
+@ExperimentalResourceApi
+internal val Res.string.str_10354: StringResource
+  get() = String0.str_10354
+
+@ExperimentalResourceApi
+internal val Res.string.str_10355: StringResource
+  get() = String0.str_10355
+
+@ExperimentalResourceApi
+internal val Res.string.str_10356: StringResource
+  get() = String0.str_10356
+
+@ExperimentalResourceApi
+internal val Res.string.str_10357: StringResource
+  get() = String0.str_10357
+
+@ExperimentalResourceApi
+internal val Res.string.str_10358: StringResource
+  get() = String0.str_10358
+
+@ExperimentalResourceApi
+internal val Res.string.str_10359: StringResource
+  get() = String0.str_10359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1036: StringResource
+  get() = String0.str_1036
+
+@ExperimentalResourceApi
+internal val Res.string.str_10360: StringResource
+  get() = String0.str_10360
+
+@ExperimentalResourceApi
+internal val Res.string.str_10361: StringResource
+  get() = String0.str_10361
+
+@ExperimentalResourceApi
+internal val Res.string.str_10362: StringResource
+  get() = String0.str_10362
+
+@ExperimentalResourceApi
+internal val Res.string.str_10363: StringResource
+  get() = String0.str_10363
+
+@ExperimentalResourceApi
+internal val Res.string.str_10364: StringResource
+  get() = String0.str_10364
+
+@ExperimentalResourceApi
+internal val Res.string.str_10365: StringResource
+  get() = String0.str_10365
+
+@ExperimentalResourceApi
+internal val Res.string.str_10366: StringResource
+  get() = String0.str_10366
+
+@ExperimentalResourceApi
+internal val Res.string.str_10367: StringResource
+  get() = String0.str_10367
+
+@ExperimentalResourceApi
+internal val Res.string.str_10368: StringResource
+  get() = String0.str_10368
+
+@ExperimentalResourceApi
+internal val Res.string.str_10369: StringResource
+  get() = String0.str_10369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1037: StringResource
+  get() = String0.str_1037
+
+@ExperimentalResourceApi
+internal val Res.string.str_10370: StringResource
+  get() = String0.str_10370
+
+@ExperimentalResourceApi
+internal val Res.string.str_10371: StringResource
+  get() = String0.str_10371
+
+@ExperimentalResourceApi
+internal val Res.string.str_10372: StringResource
+  get() = String0.str_10372
+
+@ExperimentalResourceApi
+internal val Res.string.str_10373: StringResource
+  get() = String0.str_10373
+
+@ExperimentalResourceApi
+internal val Res.string.str_10374: StringResource
+  get() = String0.str_10374
+
+@ExperimentalResourceApi
+internal val Res.string.str_10375: StringResource
+  get() = String0.str_10375
+
+@ExperimentalResourceApi
+internal val Res.string.str_10376: StringResource
+  get() = String0.str_10376
+
+@ExperimentalResourceApi
+internal val Res.string.str_10377: StringResource
+  get() = String0.str_10377
+
+@ExperimentalResourceApi
+internal val Res.string.str_10378: StringResource
+  get() = String0.str_10378
+
+@ExperimentalResourceApi
+internal val Res.string.str_10379: StringResource
+  get() = String0.str_10379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1038: StringResource
+  get() = String0.str_1038
+
+@ExperimentalResourceApi
+internal val Res.string.str_10380: StringResource
+  get() = String0.str_10380
+
+@ExperimentalResourceApi
+internal val Res.string.str_10381: StringResource
+  get() = String0.str_10381
+
+@ExperimentalResourceApi
+internal val Res.string.str_10382: StringResource
+  get() = String0.str_10382
+
+@ExperimentalResourceApi
+internal val Res.string.str_10383: StringResource
+  get() = String0.str_10383
+
+@ExperimentalResourceApi
+internal val Res.string.str_10384: StringResource
+  get() = String0.str_10384
+
+@ExperimentalResourceApi
+internal val Res.string.str_10385: StringResource
+  get() = String0.str_10385
+
+@ExperimentalResourceApi
+internal val Res.string.str_10386: StringResource
+  get() = String0.str_10386
+
+@ExperimentalResourceApi
+internal val Res.string.str_10387: StringResource
+  get() = String0.str_10387
+
+@ExperimentalResourceApi
+internal val Res.string.str_10388: StringResource
+  get() = String0.str_10388
+
+@ExperimentalResourceApi
+internal val Res.string.str_10389: StringResource
+  get() = String0.str_10389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1039: StringResource
+  get() = String0.str_1039
+
+@ExperimentalResourceApi
+internal val Res.string.str_10390: StringResource
+  get() = String0.str_10390
+
+@ExperimentalResourceApi
+internal val Res.string.str_10391: StringResource
+  get() = String0.str_10391
+
+@ExperimentalResourceApi
+internal val Res.string.str_10392: StringResource
+  get() = String0.str_10392
+
+@ExperimentalResourceApi
+internal val Res.string.str_10393: StringResource
+  get() = String0.str_10393
+
+@ExperimentalResourceApi
+internal val Res.string.str_10394: StringResource
+  get() = String0.str_10394
+
+@ExperimentalResourceApi
+internal val Res.string.str_10395: StringResource
+  get() = String0.str_10395
+
+@ExperimentalResourceApi
+internal val Res.string.str_10396: StringResource
+  get() = String0.str_10396
+
+@ExperimentalResourceApi
+internal val Res.string.str_10397: StringResource
+  get() = String0.str_10397
+
+@ExperimentalResourceApi
+internal val Res.string.str_10398: StringResource
+  get() = String0.str_10398
+
+@ExperimentalResourceApi
+internal val Res.string.str_10399: StringResource
+  get() = String0.str_10399
+
+@ExperimentalResourceApi
+internal val Res.string.str_104: StringResource
+  get() = String0.str_104
+
+@ExperimentalResourceApi
+internal val Res.string.str_1040: StringResource
+  get() = String0.str_1040
+
+@ExperimentalResourceApi
+internal val Res.string.str_10400: StringResource
+  get() = String0.str_10400
+
+@ExperimentalResourceApi
+internal val Res.string.str_10401: StringResource
+  get() = String0.str_10401
+
+@ExperimentalResourceApi
+internal val Res.string.str_10402: StringResource
+  get() = String0.str_10402
+
+@ExperimentalResourceApi
+internal val Res.string.str_10403: StringResource
+  get() = String0.str_10403
+
+@ExperimentalResourceApi
+internal val Res.string.str_10404: StringResource
+  get() = String0.str_10404
+
+@ExperimentalResourceApi
+internal val Res.string.str_10405: StringResource
+  get() = String0.str_10405
+
+@ExperimentalResourceApi
+internal val Res.string.str_10406: StringResource
+  get() = String0.str_10406
+
+@ExperimentalResourceApi
+internal val Res.string.str_10407: StringResource
+  get() = String0.str_10407
+
+@ExperimentalResourceApi
+internal val Res.string.str_10408: StringResource
+  get() = String0.str_10408
+
+@ExperimentalResourceApi
+internal val Res.string.str_10409: StringResource
+  get() = String0.str_10409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1041: StringResource
+  get() = String0.str_1041
+
+@ExperimentalResourceApi
+internal val Res.string.str_10410: StringResource
+  get() = String0.str_10410
+
+@ExperimentalResourceApi
+internal val Res.string.str_10411: StringResource
+  get() = String0.str_10411
+
+@ExperimentalResourceApi
+internal val Res.string.str_10412: StringResource
+  get() = String0.str_10412
+
+@ExperimentalResourceApi
+internal val Res.string.str_10413: StringResource
+  get() = String0.str_10413
+
+@ExperimentalResourceApi
+internal val Res.string.str_10414: StringResource
+  get() = String0.str_10414
+
+@ExperimentalResourceApi
+internal val Res.string.str_10415: StringResource
+  get() = String0.str_10415
+
+@ExperimentalResourceApi
+internal val Res.string.str_10416: StringResource
+  get() = String0.str_10416
+
+@ExperimentalResourceApi
+internal val Res.string.str_10417: StringResource
+  get() = String0.str_10417
+
+@ExperimentalResourceApi
+internal val Res.string.str_10418: StringResource
+  get() = String0.str_10418
+
+@ExperimentalResourceApi
+internal val Res.string.str_10419: StringResource
+  get() = String0.str_10419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1042: StringResource
+  get() = String0.str_1042
+
+@ExperimentalResourceApi
+internal val Res.string.str_10420: StringResource
+  get() = String0.str_10420
+
+@ExperimentalResourceApi
+internal val Res.string.str_10421: StringResource
+  get() = String0.str_10421
+
+@ExperimentalResourceApi
+internal val Res.string.str_10422: StringResource
+  get() = String0.str_10422
+
+@ExperimentalResourceApi
+internal val Res.string.str_10423: StringResource
+  get() = String0.str_10423
+
+@ExperimentalResourceApi
+internal val Res.string.str_10424: StringResource
+  get() = String0.str_10424
+
+@ExperimentalResourceApi
+internal val Res.string.str_10425: StringResource
+  get() = String0.str_10425
+
+@ExperimentalResourceApi
+internal val Res.string.str_10426: StringResource
+  get() = String0.str_10426
+
+@ExperimentalResourceApi
+internal val Res.string.str_10427: StringResource
+  get() = String0.str_10427
+
+@ExperimentalResourceApi
+internal val Res.string.str_10428: StringResource
+  get() = String0.str_10428
+
+@ExperimentalResourceApi
+internal val Res.string.str_10429: StringResource
+  get() = String0.str_10429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1043: StringResource
+  get() = String0.str_1043
+
+@ExperimentalResourceApi
+internal val Res.string.str_10430: StringResource
+  get() = String0.str_10430
+
+@ExperimentalResourceApi
+internal val Res.string.str_10431: StringResource
+  get() = String0.str_10431
+
+@ExperimentalResourceApi
+internal val Res.string.str_10432: StringResource
+  get() = String0.str_10432
+
+@ExperimentalResourceApi
+internal val Res.string.str_10433: StringResource
+  get() = String0.str_10433
+
+@ExperimentalResourceApi
+internal val Res.string.str_10434: StringResource
+  get() = String0.str_10434
+
+@ExperimentalResourceApi
+internal val Res.string.str_10435: StringResource
+  get() = String0.str_10435
+
+@ExperimentalResourceApi
+internal val Res.string.str_10436: StringResource
+  get() = String0.str_10436
+
+@ExperimentalResourceApi
+internal val Res.string.str_10437: StringResource
+  get() = String0.str_10437
+
+@ExperimentalResourceApi
+internal val Res.string.str_10438: StringResource
+  get() = String0.str_10438
+
+@ExperimentalResourceApi
+internal val Res.string.str_10439: StringResource
+  get() = String0.str_10439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1044: StringResource
+  get() = String0.str_1044
+
+@ExperimentalResourceApi
+internal val Res.string.str_10440: StringResource
+  get() = String0.str_10440
+
+@ExperimentalResourceApi
+internal val Res.string.str_10441: StringResource
+  get() = String0.str_10441
+
+@ExperimentalResourceApi
+internal val Res.string.str_10442: StringResource
+  get() = String0.str_10442
+
+@ExperimentalResourceApi
+internal val Res.string.str_10443: StringResource
+  get() = String0.str_10443
+
+@ExperimentalResourceApi
+internal val Res.string.str_10444: StringResource
+  get() = String0.str_10444
+
+@ExperimentalResourceApi
+internal val Res.string.str_10445: StringResource
+  get() = String0.str_10445
+
+@ExperimentalResourceApi
+internal val Res.string.str_10446: StringResource
+  get() = String0.str_10446

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String1.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String1.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String1 {
+  public val str_10447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10447", "str_10447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10448", "str_10448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10449", "str_10449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1045", "str_1045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10450", "str_10450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10451", "str_10451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10452", "str_10452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10453", "str_10453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10454", "str_10454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10455", "str_10455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10456", "str_10456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10457", "str_10457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10458", "str_10458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10459", "str_10459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1046", "str_1046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10460", "str_10460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10461", "str_10461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10462", "str_10462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10463", "str_10463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10464", "str_10464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10465", "str_10465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10466", "str_10466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10467", "str_10467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10468", "str_10468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10469", "str_10469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1047", "str_1047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10470", "str_10470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10471", "str_10471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10472", "str_10472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10473", "str_10473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10474", "str_10474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10475", "str_10475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10476", "str_10476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10477", "str_10477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10478", "str_10478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10479", "str_10479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1048", "str_1048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10480", "str_10480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10481", "str_10481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10482", "str_10482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10483", "str_10483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10484", "str_10484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10485", "str_10485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10486", "str_10486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10487", "str_10487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10488", "str_10488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10489", "str_10489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1049", "str_1049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10490", "str_10490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10491", "str_10491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10492", "str_10492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10493", "str_10493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10494", "str_10494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10495", "str_10495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10496", "str_10496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10497", "str_10497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10498", "str_10498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10499", "str_10499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_105", "str_105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1050", "str_1050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10500", "str_10500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10501", "str_10501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10502", "str_10502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10503", "str_10503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10504", "str_10504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10505", "str_10505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10506", "str_10506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10507", "str_10507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10508", "str_10508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10509", "str_10509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1051", "str_1051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10510", "str_10510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10511", "str_10511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10512", "str_10512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10513", "str_10513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10514", "str_10514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10515", "str_10515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10516", "str_10516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10517", "str_10517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10518", "str_10518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10519", "str_10519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1052", "str_1052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10520", "str_10520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10521", "str_10521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10522", "str_10522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10523", "str_10523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10524", "str_10524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10525", "str_10525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10526", "str_10526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10527", "str_10527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10528", "str_10528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10529", "str_10529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1053", "str_1053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10530", "str_10530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10531", "str_10531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10532", "str_10532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10533", "str_10533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10534", "str_10534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10535", "str_10535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10536", "str_10536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10537", "str_10537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10538", "str_10538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10539", "str_10539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1054", "str_1054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10540", "str_10540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10541", "str_10541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10542", "str_10542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10543", "str_10543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10544", "str_10544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10545", "str_10545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10546", "str_10546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10547", "str_10547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10548", "str_10548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10549", "str_10549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1055", "str_1055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10550", "str_10550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10551", "str_10551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10552", "str_10552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10553", "str_10553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10554", "str_10554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10555", "str_10555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10556", "str_10556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10557", "str_10557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10558", "str_10558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10559", "str_10559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1056", "str_1056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10560", "str_10560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10561", "str_10561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10562", "str_10562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10563", "str_10563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10564", "str_10564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10565", "str_10565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10566", "str_10566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10567", "str_10567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10568", "str_10568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10569", "str_10569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1057", "str_1057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10570", "str_10570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10571", "str_10571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10572", "str_10572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10573", "str_10573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10574", "str_10574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10575", "str_10575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10576", "str_10576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10577", "str_10577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10578", "str_10578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10579", "str_10579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1058", "str_1058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10580", "str_10580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10581", "str_10581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10582", "str_10582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10583", "str_10583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10584", "str_10584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10585", "str_10585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10586", "str_10586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10587", "str_10587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10588", "str_10588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10589", "str_10589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1059", "str_1059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10590", "str_10590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10591", "str_10591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10592", "str_10592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10593", "str_10593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10594", "str_10594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10595", "str_10595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10596", "str_10596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10597", "str_10597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10598", "str_10598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10599", "str_10599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_106", "str_106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1060", "str_1060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10600", "str_10600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10601", "str_10601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10602", "str_10602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10603", "str_10603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10604", "str_10604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10605", "str_10605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10606", "str_10606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10607", "str_10607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10608", "str_10608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10609", "str_10609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1061", "str_1061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10610", "str_10610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10611", "str_10611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10612", "str_10612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10613", "str_10613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10614", "str_10614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10615", "str_10615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10616", "str_10616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10617", "str_10617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10618", "str_10618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10619", "str_10619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1062", "str_1062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10620", "str_10620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10621", "str_10621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10622", "str_10622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10623", "str_10623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10624", "str_10624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10625", "str_10625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10626", "str_10626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10627", "str_10627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10628", "str_10628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10629", "str_10629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1063", "str_1063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10630", "str_10630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10631", "str_10631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10632", "str_10632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10633", "str_10633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10634", "str_10634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10635", "str_10635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10636", "str_10636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10637", "str_10637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10638", "str_10638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10639", "str_10639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1064", "str_1064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10640", "str_10640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10641", "str_10641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10642", "str_10642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10643", "str_10643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10644", "str_10644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10645", "str_10645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10646", "str_10646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10647", "str_10647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10648", "str_10648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10649", "str_10649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1065", "str_1065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10650", "str_10650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10651", "str_10651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10652", "str_10652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10653", "str_10653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10654", "str_10654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10655", "str_10655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10656", "str_10656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10657", "str_10657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10658", "str_10658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10659", "str_10659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1066", "str_1066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10660", "str_10660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10661", "str_10661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10662", "str_10662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10663", "str_10663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10664", "str_10664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10665", "str_10665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10666", "str_10666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10667", "str_10667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10668", "str_10668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10669", "str_10669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1067", "str_1067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10670", "str_10670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10671", "str_10671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10672", "str_10672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10673", "str_10673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10674", "str_10674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10675", "str_10675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10676", "str_10676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10677", "str_10677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10678", "str_10678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10679", "str_10679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1068", "str_1068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10680", "str_10680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10681", "str_10681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10682", "str_10682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10683", "str_10683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10684", "str_10684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10685", "str_10685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10686", "str_10686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10687", "str_10687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10688", "str_10688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10689", "str_10689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1069", "str_1069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10690", "str_10690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10691", "str_10691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10692", "str_10692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10693", "str_10693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10694", "str_10694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10695", "str_10695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10696", "str_10696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10697", "str_10697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10698", "str_10698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10699", "str_10699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_107", "str_107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1070", "str_1070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10700", "str_10700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10701", "str_10701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10702", "str_10702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10703", "str_10703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10704", "str_10704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10705", "str_10705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10706", "str_10706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10707", "str_10707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10708", "str_10708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10709", "str_10709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1071", "str_1071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10710", "str_10710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10711", "str_10711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10712", "str_10712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10713", "str_10713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10714", "str_10714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10715", "str_10715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10716", "str_10716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10717", "str_10717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10718", "str_10718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10719", "str_10719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1072", "str_1072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10720", "str_10720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10721", "str_10721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10722", "str_10722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10723", "str_10723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10724", "str_10724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10725", "str_10725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10726", "str_10726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10727", "str_10727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10728", "str_10728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10729", "str_10729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1073", "str_1073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10730", "str_10730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10731", "str_10731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10732", "str_10732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10733", "str_10733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10734", "str_10734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10735", "str_10735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10736", "str_10736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10737", "str_10737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10738", "str_10738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10739", "str_10739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1074", "str_1074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10740", "str_10740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10741", "str_10741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10742", "str_10742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10743", "str_10743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10744", "str_10744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10745", "str_10745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10746", "str_10746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10747", "str_10747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10748", "str_10748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10749", "str_10749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1075", "str_1075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10750", "str_10750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10751", "str_10751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10752", "str_10752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10753", "str_10753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10754", "str_10754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10755", "str_10755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10756", "str_10756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10757", "str_10757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10758", "str_10758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10759", "str_10759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1076", "str_1076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10760", "str_10760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10761", "str_10761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10762", "str_10762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10763", "str_10763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10764", "str_10764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10765", "str_10765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10766", "str_10766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10767", "str_10767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10768", "str_10768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10769", "str_10769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1077", "str_1077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10770", "str_10770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10771", "str_10771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10772", "str_10772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10773", "str_10773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10774", "str_10774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10775", "str_10775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10776", "str_10776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10777", "str_10777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10778", "str_10778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10779", "str_10779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1078", "str_1078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10780", "str_10780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10781", "str_10781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10782", "str_10782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10783", "str_10783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10784", "str_10784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10785", "str_10785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10786", "str_10786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10787", "str_10787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10788", "str_10788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10789", "str_10789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1079", "str_1079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10790", "str_10790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10791", "str_10791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10792", "str_10792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10793", "str_10793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10794", "str_10794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10795", "str_10795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10796", "str_10796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10797", "str_10797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10798", "str_10798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10799", "str_10799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_108", "str_108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1080", "str_1080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10800", "str_10800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10801", "str_10801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10802", "str_10802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10803", "str_10803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10804", "str_10804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10805", "str_10805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10806", "str_10806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10807", "str_10807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10808", "str_10808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10809", "str_10809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1081", "str_1081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10810", "str_10810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10811", "str_10811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10812", "str_10812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10813", "str_10813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10814", "str_10814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10815", "str_10815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10816", "str_10816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10817", "str_10817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10818", "str_10818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10819", "str_10819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1082", "str_1082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10820", "str_10820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10821", "str_10821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10822", "str_10822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10823", "str_10823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10824", "str_10824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10825", "str_10825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10826", "str_10826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10827", "str_10827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10828", "str_10828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10829", "str_10829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1083", "str_1083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10830", "str_10830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10831", "str_10831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10832", "str_10832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10833", "str_10833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10834", "str_10834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10835", "str_10835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10836", "str_10836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10837", "str_10837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10838", "str_10838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10839", "str_10839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1084", "str_1084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10840", "str_10840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10841", "str_10841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10842", "str_10842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10843", "str_10843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10844", "str_10844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10845", "str_10845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10846", "str_10846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10847", "str_10847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10848", "str_10848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10849", "str_10849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1085", "str_1085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10850", "str_10850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10851", "str_10851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10852", "str_10852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10853", "str_10853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10854", "str_10854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10855", "str_10855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10856", "str_10856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10857", "str_10857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10858", "str_10858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10859", "str_10859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1086", "str_1086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10860", "str_10860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10861", "str_10861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10862", "str_10862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10863", "str_10863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10864", "str_10864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10865", "str_10865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10866", "str_10866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10867", "str_10867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10868", "str_10868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10869", "str_10869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1087", "str_1087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10870", "str_10870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10871", "str_10871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10872", "str_10872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10873", "str_10873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10874", "str_10874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10875", "str_10875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10876", "str_10876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10877", "str_10877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10878", "str_10878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10879", "str_10879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1088", "str_1088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10880", "str_10880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10881", "str_10881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10882", "str_10882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10883", "str_10883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10884", "str_10884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10885", "str_10885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10886", "str_10886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10887", "str_10887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10888", "str_10888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10889", "str_10889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1089", "str_1089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10890", "str_10890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10891", "str_10891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10892", "str_10892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10893", "str_10893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10894", "str_10894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10895", "str_10895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10896", "str_10896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10897", "str_10897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_10447: StringResource
+  get() = String1.str_10447
+
+@ExperimentalResourceApi
+internal val Res.string.str_10448: StringResource
+  get() = String1.str_10448
+
+@ExperimentalResourceApi
+internal val Res.string.str_10449: StringResource
+  get() = String1.str_10449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1045: StringResource
+  get() = String1.str_1045
+
+@ExperimentalResourceApi
+internal val Res.string.str_10450: StringResource
+  get() = String1.str_10450
+
+@ExperimentalResourceApi
+internal val Res.string.str_10451: StringResource
+  get() = String1.str_10451
+
+@ExperimentalResourceApi
+internal val Res.string.str_10452: StringResource
+  get() = String1.str_10452
+
+@ExperimentalResourceApi
+internal val Res.string.str_10453: StringResource
+  get() = String1.str_10453
+
+@ExperimentalResourceApi
+internal val Res.string.str_10454: StringResource
+  get() = String1.str_10454
+
+@ExperimentalResourceApi
+internal val Res.string.str_10455: StringResource
+  get() = String1.str_10455
+
+@ExperimentalResourceApi
+internal val Res.string.str_10456: StringResource
+  get() = String1.str_10456
+
+@ExperimentalResourceApi
+internal val Res.string.str_10457: StringResource
+  get() = String1.str_10457
+
+@ExperimentalResourceApi
+internal val Res.string.str_10458: StringResource
+  get() = String1.str_10458
+
+@ExperimentalResourceApi
+internal val Res.string.str_10459: StringResource
+  get() = String1.str_10459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1046: StringResource
+  get() = String1.str_1046
+
+@ExperimentalResourceApi
+internal val Res.string.str_10460: StringResource
+  get() = String1.str_10460
+
+@ExperimentalResourceApi
+internal val Res.string.str_10461: StringResource
+  get() = String1.str_10461
+
+@ExperimentalResourceApi
+internal val Res.string.str_10462: StringResource
+  get() = String1.str_10462
+
+@ExperimentalResourceApi
+internal val Res.string.str_10463: StringResource
+  get() = String1.str_10463
+
+@ExperimentalResourceApi
+internal val Res.string.str_10464: StringResource
+  get() = String1.str_10464
+
+@ExperimentalResourceApi
+internal val Res.string.str_10465: StringResource
+  get() = String1.str_10465
+
+@ExperimentalResourceApi
+internal val Res.string.str_10466: StringResource
+  get() = String1.str_10466
+
+@ExperimentalResourceApi
+internal val Res.string.str_10467: StringResource
+  get() = String1.str_10467
+
+@ExperimentalResourceApi
+internal val Res.string.str_10468: StringResource
+  get() = String1.str_10468
+
+@ExperimentalResourceApi
+internal val Res.string.str_10469: StringResource
+  get() = String1.str_10469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1047: StringResource
+  get() = String1.str_1047
+
+@ExperimentalResourceApi
+internal val Res.string.str_10470: StringResource
+  get() = String1.str_10470
+
+@ExperimentalResourceApi
+internal val Res.string.str_10471: StringResource
+  get() = String1.str_10471
+
+@ExperimentalResourceApi
+internal val Res.string.str_10472: StringResource
+  get() = String1.str_10472
+
+@ExperimentalResourceApi
+internal val Res.string.str_10473: StringResource
+  get() = String1.str_10473
+
+@ExperimentalResourceApi
+internal val Res.string.str_10474: StringResource
+  get() = String1.str_10474
+
+@ExperimentalResourceApi
+internal val Res.string.str_10475: StringResource
+  get() = String1.str_10475
+
+@ExperimentalResourceApi
+internal val Res.string.str_10476: StringResource
+  get() = String1.str_10476
+
+@ExperimentalResourceApi
+internal val Res.string.str_10477: StringResource
+  get() = String1.str_10477
+
+@ExperimentalResourceApi
+internal val Res.string.str_10478: StringResource
+  get() = String1.str_10478
+
+@ExperimentalResourceApi
+internal val Res.string.str_10479: StringResource
+  get() = String1.str_10479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1048: StringResource
+  get() = String1.str_1048
+
+@ExperimentalResourceApi
+internal val Res.string.str_10480: StringResource
+  get() = String1.str_10480
+
+@ExperimentalResourceApi
+internal val Res.string.str_10481: StringResource
+  get() = String1.str_10481
+
+@ExperimentalResourceApi
+internal val Res.string.str_10482: StringResource
+  get() = String1.str_10482
+
+@ExperimentalResourceApi
+internal val Res.string.str_10483: StringResource
+  get() = String1.str_10483
+
+@ExperimentalResourceApi
+internal val Res.string.str_10484: StringResource
+  get() = String1.str_10484
+
+@ExperimentalResourceApi
+internal val Res.string.str_10485: StringResource
+  get() = String1.str_10485
+
+@ExperimentalResourceApi
+internal val Res.string.str_10486: StringResource
+  get() = String1.str_10486
+
+@ExperimentalResourceApi
+internal val Res.string.str_10487: StringResource
+  get() = String1.str_10487
+
+@ExperimentalResourceApi
+internal val Res.string.str_10488: StringResource
+  get() = String1.str_10488
+
+@ExperimentalResourceApi
+internal val Res.string.str_10489: StringResource
+  get() = String1.str_10489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1049: StringResource
+  get() = String1.str_1049
+
+@ExperimentalResourceApi
+internal val Res.string.str_10490: StringResource
+  get() = String1.str_10490
+
+@ExperimentalResourceApi
+internal val Res.string.str_10491: StringResource
+  get() = String1.str_10491
+
+@ExperimentalResourceApi
+internal val Res.string.str_10492: StringResource
+  get() = String1.str_10492
+
+@ExperimentalResourceApi
+internal val Res.string.str_10493: StringResource
+  get() = String1.str_10493
+
+@ExperimentalResourceApi
+internal val Res.string.str_10494: StringResource
+  get() = String1.str_10494
+
+@ExperimentalResourceApi
+internal val Res.string.str_10495: StringResource
+  get() = String1.str_10495
+
+@ExperimentalResourceApi
+internal val Res.string.str_10496: StringResource
+  get() = String1.str_10496
+
+@ExperimentalResourceApi
+internal val Res.string.str_10497: StringResource
+  get() = String1.str_10497
+
+@ExperimentalResourceApi
+internal val Res.string.str_10498: StringResource
+  get() = String1.str_10498
+
+@ExperimentalResourceApi
+internal val Res.string.str_10499: StringResource
+  get() = String1.str_10499
+
+@ExperimentalResourceApi
+internal val Res.string.str_105: StringResource
+  get() = String1.str_105
+
+@ExperimentalResourceApi
+internal val Res.string.str_1050: StringResource
+  get() = String1.str_1050
+
+@ExperimentalResourceApi
+internal val Res.string.str_10500: StringResource
+  get() = String1.str_10500
+
+@ExperimentalResourceApi
+internal val Res.string.str_10501: StringResource
+  get() = String1.str_10501
+
+@ExperimentalResourceApi
+internal val Res.string.str_10502: StringResource
+  get() = String1.str_10502
+
+@ExperimentalResourceApi
+internal val Res.string.str_10503: StringResource
+  get() = String1.str_10503
+
+@ExperimentalResourceApi
+internal val Res.string.str_10504: StringResource
+  get() = String1.str_10504
+
+@ExperimentalResourceApi
+internal val Res.string.str_10505: StringResource
+  get() = String1.str_10505
+
+@ExperimentalResourceApi
+internal val Res.string.str_10506: StringResource
+  get() = String1.str_10506
+
+@ExperimentalResourceApi
+internal val Res.string.str_10507: StringResource
+  get() = String1.str_10507
+
+@ExperimentalResourceApi
+internal val Res.string.str_10508: StringResource
+  get() = String1.str_10508
+
+@ExperimentalResourceApi
+internal val Res.string.str_10509: StringResource
+  get() = String1.str_10509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1051: StringResource
+  get() = String1.str_1051
+
+@ExperimentalResourceApi
+internal val Res.string.str_10510: StringResource
+  get() = String1.str_10510
+
+@ExperimentalResourceApi
+internal val Res.string.str_10511: StringResource
+  get() = String1.str_10511
+
+@ExperimentalResourceApi
+internal val Res.string.str_10512: StringResource
+  get() = String1.str_10512
+
+@ExperimentalResourceApi
+internal val Res.string.str_10513: StringResource
+  get() = String1.str_10513
+
+@ExperimentalResourceApi
+internal val Res.string.str_10514: StringResource
+  get() = String1.str_10514
+
+@ExperimentalResourceApi
+internal val Res.string.str_10515: StringResource
+  get() = String1.str_10515
+
+@ExperimentalResourceApi
+internal val Res.string.str_10516: StringResource
+  get() = String1.str_10516
+
+@ExperimentalResourceApi
+internal val Res.string.str_10517: StringResource
+  get() = String1.str_10517
+
+@ExperimentalResourceApi
+internal val Res.string.str_10518: StringResource
+  get() = String1.str_10518
+
+@ExperimentalResourceApi
+internal val Res.string.str_10519: StringResource
+  get() = String1.str_10519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1052: StringResource
+  get() = String1.str_1052
+
+@ExperimentalResourceApi
+internal val Res.string.str_10520: StringResource
+  get() = String1.str_10520
+
+@ExperimentalResourceApi
+internal val Res.string.str_10521: StringResource
+  get() = String1.str_10521
+
+@ExperimentalResourceApi
+internal val Res.string.str_10522: StringResource
+  get() = String1.str_10522
+
+@ExperimentalResourceApi
+internal val Res.string.str_10523: StringResource
+  get() = String1.str_10523
+
+@ExperimentalResourceApi
+internal val Res.string.str_10524: StringResource
+  get() = String1.str_10524
+
+@ExperimentalResourceApi
+internal val Res.string.str_10525: StringResource
+  get() = String1.str_10525
+
+@ExperimentalResourceApi
+internal val Res.string.str_10526: StringResource
+  get() = String1.str_10526
+
+@ExperimentalResourceApi
+internal val Res.string.str_10527: StringResource
+  get() = String1.str_10527
+
+@ExperimentalResourceApi
+internal val Res.string.str_10528: StringResource
+  get() = String1.str_10528
+
+@ExperimentalResourceApi
+internal val Res.string.str_10529: StringResource
+  get() = String1.str_10529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1053: StringResource
+  get() = String1.str_1053
+
+@ExperimentalResourceApi
+internal val Res.string.str_10530: StringResource
+  get() = String1.str_10530
+
+@ExperimentalResourceApi
+internal val Res.string.str_10531: StringResource
+  get() = String1.str_10531
+
+@ExperimentalResourceApi
+internal val Res.string.str_10532: StringResource
+  get() = String1.str_10532
+
+@ExperimentalResourceApi
+internal val Res.string.str_10533: StringResource
+  get() = String1.str_10533
+
+@ExperimentalResourceApi
+internal val Res.string.str_10534: StringResource
+  get() = String1.str_10534
+
+@ExperimentalResourceApi
+internal val Res.string.str_10535: StringResource
+  get() = String1.str_10535
+
+@ExperimentalResourceApi
+internal val Res.string.str_10536: StringResource
+  get() = String1.str_10536
+
+@ExperimentalResourceApi
+internal val Res.string.str_10537: StringResource
+  get() = String1.str_10537
+
+@ExperimentalResourceApi
+internal val Res.string.str_10538: StringResource
+  get() = String1.str_10538
+
+@ExperimentalResourceApi
+internal val Res.string.str_10539: StringResource
+  get() = String1.str_10539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1054: StringResource
+  get() = String1.str_1054
+
+@ExperimentalResourceApi
+internal val Res.string.str_10540: StringResource
+  get() = String1.str_10540
+
+@ExperimentalResourceApi
+internal val Res.string.str_10541: StringResource
+  get() = String1.str_10541
+
+@ExperimentalResourceApi
+internal val Res.string.str_10542: StringResource
+  get() = String1.str_10542
+
+@ExperimentalResourceApi
+internal val Res.string.str_10543: StringResource
+  get() = String1.str_10543
+
+@ExperimentalResourceApi
+internal val Res.string.str_10544: StringResource
+  get() = String1.str_10544
+
+@ExperimentalResourceApi
+internal val Res.string.str_10545: StringResource
+  get() = String1.str_10545
+
+@ExperimentalResourceApi
+internal val Res.string.str_10546: StringResource
+  get() = String1.str_10546
+
+@ExperimentalResourceApi
+internal val Res.string.str_10547: StringResource
+  get() = String1.str_10547
+
+@ExperimentalResourceApi
+internal val Res.string.str_10548: StringResource
+  get() = String1.str_10548
+
+@ExperimentalResourceApi
+internal val Res.string.str_10549: StringResource
+  get() = String1.str_10549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1055: StringResource
+  get() = String1.str_1055
+
+@ExperimentalResourceApi
+internal val Res.string.str_10550: StringResource
+  get() = String1.str_10550
+
+@ExperimentalResourceApi
+internal val Res.string.str_10551: StringResource
+  get() = String1.str_10551
+
+@ExperimentalResourceApi
+internal val Res.string.str_10552: StringResource
+  get() = String1.str_10552
+
+@ExperimentalResourceApi
+internal val Res.string.str_10553: StringResource
+  get() = String1.str_10553
+
+@ExperimentalResourceApi
+internal val Res.string.str_10554: StringResource
+  get() = String1.str_10554
+
+@ExperimentalResourceApi
+internal val Res.string.str_10555: StringResource
+  get() = String1.str_10555
+
+@ExperimentalResourceApi
+internal val Res.string.str_10556: StringResource
+  get() = String1.str_10556
+
+@ExperimentalResourceApi
+internal val Res.string.str_10557: StringResource
+  get() = String1.str_10557
+
+@ExperimentalResourceApi
+internal val Res.string.str_10558: StringResource
+  get() = String1.str_10558
+
+@ExperimentalResourceApi
+internal val Res.string.str_10559: StringResource
+  get() = String1.str_10559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1056: StringResource
+  get() = String1.str_1056
+
+@ExperimentalResourceApi
+internal val Res.string.str_10560: StringResource
+  get() = String1.str_10560
+
+@ExperimentalResourceApi
+internal val Res.string.str_10561: StringResource
+  get() = String1.str_10561
+
+@ExperimentalResourceApi
+internal val Res.string.str_10562: StringResource
+  get() = String1.str_10562
+
+@ExperimentalResourceApi
+internal val Res.string.str_10563: StringResource
+  get() = String1.str_10563
+
+@ExperimentalResourceApi
+internal val Res.string.str_10564: StringResource
+  get() = String1.str_10564
+
+@ExperimentalResourceApi
+internal val Res.string.str_10565: StringResource
+  get() = String1.str_10565
+
+@ExperimentalResourceApi
+internal val Res.string.str_10566: StringResource
+  get() = String1.str_10566
+
+@ExperimentalResourceApi
+internal val Res.string.str_10567: StringResource
+  get() = String1.str_10567
+
+@ExperimentalResourceApi
+internal val Res.string.str_10568: StringResource
+  get() = String1.str_10568
+
+@ExperimentalResourceApi
+internal val Res.string.str_10569: StringResource
+  get() = String1.str_10569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1057: StringResource
+  get() = String1.str_1057
+
+@ExperimentalResourceApi
+internal val Res.string.str_10570: StringResource
+  get() = String1.str_10570
+
+@ExperimentalResourceApi
+internal val Res.string.str_10571: StringResource
+  get() = String1.str_10571
+
+@ExperimentalResourceApi
+internal val Res.string.str_10572: StringResource
+  get() = String1.str_10572
+
+@ExperimentalResourceApi
+internal val Res.string.str_10573: StringResource
+  get() = String1.str_10573
+
+@ExperimentalResourceApi
+internal val Res.string.str_10574: StringResource
+  get() = String1.str_10574
+
+@ExperimentalResourceApi
+internal val Res.string.str_10575: StringResource
+  get() = String1.str_10575
+
+@ExperimentalResourceApi
+internal val Res.string.str_10576: StringResource
+  get() = String1.str_10576
+
+@ExperimentalResourceApi
+internal val Res.string.str_10577: StringResource
+  get() = String1.str_10577
+
+@ExperimentalResourceApi
+internal val Res.string.str_10578: StringResource
+  get() = String1.str_10578
+
+@ExperimentalResourceApi
+internal val Res.string.str_10579: StringResource
+  get() = String1.str_10579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1058: StringResource
+  get() = String1.str_1058
+
+@ExperimentalResourceApi
+internal val Res.string.str_10580: StringResource
+  get() = String1.str_10580
+
+@ExperimentalResourceApi
+internal val Res.string.str_10581: StringResource
+  get() = String1.str_10581
+
+@ExperimentalResourceApi
+internal val Res.string.str_10582: StringResource
+  get() = String1.str_10582
+
+@ExperimentalResourceApi
+internal val Res.string.str_10583: StringResource
+  get() = String1.str_10583
+
+@ExperimentalResourceApi
+internal val Res.string.str_10584: StringResource
+  get() = String1.str_10584
+
+@ExperimentalResourceApi
+internal val Res.string.str_10585: StringResource
+  get() = String1.str_10585
+
+@ExperimentalResourceApi
+internal val Res.string.str_10586: StringResource
+  get() = String1.str_10586
+
+@ExperimentalResourceApi
+internal val Res.string.str_10587: StringResource
+  get() = String1.str_10587
+
+@ExperimentalResourceApi
+internal val Res.string.str_10588: StringResource
+  get() = String1.str_10588
+
+@ExperimentalResourceApi
+internal val Res.string.str_10589: StringResource
+  get() = String1.str_10589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1059: StringResource
+  get() = String1.str_1059
+
+@ExperimentalResourceApi
+internal val Res.string.str_10590: StringResource
+  get() = String1.str_10590
+
+@ExperimentalResourceApi
+internal val Res.string.str_10591: StringResource
+  get() = String1.str_10591
+
+@ExperimentalResourceApi
+internal val Res.string.str_10592: StringResource
+  get() = String1.str_10592
+
+@ExperimentalResourceApi
+internal val Res.string.str_10593: StringResource
+  get() = String1.str_10593
+
+@ExperimentalResourceApi
+internal val Res.string.str_10594: StringResource
+  get() = String1.str_10594
+
+@ExperimentalResourceApi
+internal val Res.string.str_10595: StringResource
+  get() = String1.str_10595
+
+@ExperimentalResourceApi
+internal val Res.string.str_10596: StringResource
+  get() = String1.str_10596
+
+@ExperimentalResourceApi
+internal val Res.string.str_10597: StringResource
+  get() = String1.str_10597
+
+@ExperimentalResourceApi
+internal val Res.string.str_10598: StringResource
+  get() = String1.str_10598
+
+@ExperimentalResourceApi
+internal val Res.string.str_10599: StringResource
+  get() = String1.str_10599
+
+@ExperimentalResourceApi
+internal val Res.string.str_106: StringResource
+  get() = String1.str_106
+
+@ExperimentalResourceApi
+internal val Res.string.str_1060: StringResource
+  get() = String1.str_1060
+
+@ExperimentalResourceApi
+internal val Res.string.str_10600: StringResource
+  get() = String1.str_10600
+
+@ExperimentalResourceApi
+internal val Res.string.str_10601: StringResource
+  get() = String1.str_10601
+
+@ExperimentalResourceApi
+internal val Res.string.str_10602: StringResource
+  get() = String1.str_10602
+
+@ExperimentalResourceApi
+internal val Res.string.str_10603: StringResource
+  get() = String1.str_10603
+
+@ExperimentalResourceApi
+internal val Res.string.str_10604: StringResource
+  get() = String1.str_10604
+
+@ExperimentalResourceApi
+internal val Res.string.str_10605: StringResource
+  get() = String1.str_10605
+
+@ExperimentalResourceApi
+internal val Res.string.str_10606: StringResource
+  get() = String1.str_10606
+
+@ExperimentalResourceApi
+internal val Res.string.str_10607: StringResource
+  get() = String1.str_10607
+
+@ExperimentalResourceApi
+internal val Res.string.str_10608: StringResource
+  get() = String1.str_10608
+
+@ExperimentalResourceApi
+internal val Res.string.str_10609: StringResource
+  get() = String1.str_10609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1061: StringResource
+  get() = String1.str_1061
+
+@ExperimentalResourceApi
+internal val Res.string.str_10610: StringResource
+  get() = String1.str_10610
+
+@ExperimentalResourceApi
+internal val Res.string.str_10611: StringResource
+  get() = String1.str_10611
+
+@ExperimentalResourceApi
+internal val Res.string.str_10612: StringResource
+  get() = String1.str_10612
+
+@ExperimentalResourceApi
+internal val Res.string.str_10613: StringResource
+  get() = String1.str_10613
+
+@ExperimentalResourceApi
+internal val Res.string.str_10614: StringResource
+  get() = String1.str_10614
+
+@ExperimentalResourceApi
+internal val Res.string.str_10615: StringResource
+  get() = String1.str_10615
+
+@ExperimentalResourceApi
+internal val Res.string.str_10616: StringResource
+  get() = String1.str_10616
+
+@ExperimentalResourceApi
+internal val Res.string.str_10617: StringResource
+  get() = String1.str_10617
+
+@ExperimentalResourceApi
+internal val Res.string.str_10618: StringResource
+  get() = String1.str_10618
+
+@ExperimentalResourceApi
+internal val Res.string.str_10619: StringResource
+  get() = String1.str_10619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1062: StringResource
+  get() = String1.str_1062
+
+@ExperimentalResourceApi
+internal val Res.string.str_10620: StringResource
+  get() = String1.str_10620
+
+@ExperimentalResourceApi
+internal val Res.string.str_10621: StringResource
+  get() = String1.str_10621
+
+@ExperimentalResourceApi
+internal val Res.string.str_10622: StringResource
+  get() = String1.str_10622
+
+@ExperimentalResourceApi
+internal val Res.string.str_10623: StringResource
+  get() = String1.str_10623
+
+@ExperimentalResourceApi
+internal val Res.string.str_10624: StringResource
+  get() = String1.str_10624
+
+@ExperimentalResourceApi
+internal val Res.string.str_10625: StringResource
+  get() = String1.str_10625
+
+@ExperimentalResourceApi
+internal val Res.string.str_10626: StringResource
+  get() = String1.str_10626
+
+@ExperimentalResourceApi
+internal val Res.string.str_10627: StringResource
+  get() = String1.str_10627
+
+@ExperimentalResourceApi
+internal val Res.string.str_10628: StringResource
+  get() = String1.str_10628
+
+@ExperimentalResourceApi
+internal val Res.string.str_10629: StringResource
+  get() = String1.str_10629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1063: StringResource
+  get() = String1.str_1063
+
+@ExperimentalResourceApi
+internal val Res.string.str_10630: StringResource
+  get() = String1.str_10630
+
+@ExperimentalResourceApi
+internal val Res.string.str_10631: StringResource
+  get() = String1.str_10631
+
+@ExperimentalResourceApi
+internal val Res.string.str_10632: StringResource
+  get() = String1.str_10632
+
+@ExperimentalResourceApi
+internal val Res.string.str_10633: StringResource
+  get() = String1.str_10633
+
+@ExperimentalResourceApi
+internal val Res.string.str_10634: StringResource
+  get() = String1.str_10634
+
+@ExperimentalResourceApi
+internal val Res.string.str_10635: StringResource
+  get() = String1.str_10635
+
+@ExperimentalResourceApi
+internal val Res.string.str_10636: StringResource
+  get() = String1.str_10636
+
+@ExperimentalResourceApi
+internal val Res.string.str_10637: StringResource
+  get() = String1.str_10637
+
+@ExperimentalResourceApi
+internal val Res.string.str_10638: StringResource
+  get() = String1.str_10638
+
+@ExperimentalResourceApi
+internal val Res.string.str_10639: StringResource
+  get() = String1.str_10639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1064: StringResource
+  get() = String1.str_1064
+
+@ExperimentalResourceApi
+internal val Res.string.str_10640: StringResource
+  get() = String1.str_10640
+
+@ExperimentalResourceApi
+internal val Res.string.str_10641: StringResource
+  get() = String1.str_10641
+
+@ExperimentalResourceApi
+internal val Res.string.str_10642: StringResource
+  get() = String1.str_10642
+
+@ExperimentalResourceApi
+internal val Res.string.str_10643: StringResource
+  get() = String1.str_10643
+
+@ExperimentalResourceApi
+internal val Res.string.str_10644: StringResource
+  get() = String1.str_10644
+
+@ExperimentalResourceApi
+internal val Res.string.str_10645: StringResource
+  get() = String1.str_10645
+
+@ExperimentalResourceApi
+internal val Res.string.str_10646: StringResource
+  get() = String1.str_10646
+
+@ExperimentalResourceApi
+internal val Res.string.str_10647: StringResource
+  get() = String1.str_10647
+
+@ExperimentalResourceApi
+internal val Res.string.str_10648: StringResource
+  get() = String1.str_10648
+
+@ExperimentalResourceApi
+internal val Res.string.str_10649: StringResource
+  get() = String1.str_10649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1065: StringResource
+  get() = String1.str_1065
+
+@ExperimentalResourceApi
+internal val Res.string.str_10650: StringResource
+  get() = String1.str_10650
+
+@ExperimentalResourceApi
+internal val Res.string.str_10651: StringResource
+  get() = String1.str_10651
+
+@ExperimentalResourceApi
+internal val Res.string.str_10652: StringResource
+  get() = String1.str_10652
+
+@ExperimentalResourceApi
+internal val Res.string.str_10653: StringResource
+  get() = String1.str_10653
+
+@ExperimentalResourceApi
+internal val Res.string.str_10654: StringResource
+  get() = String1.str_10654
+
+@ExperimentalResourceApi
+internal val Res.string.str_10655: StringResource
+  get() = String1.str_10655
+
+@ExperimentalResourceApi
+internal val Res.string.str_10656: StringResource
+  get() = String1.str_10656
+
+@ExperimentalResourceApi
+internal val Res.string.str_10657: StringResource
+  get() = String1.str_10657
+
+@ExperimentalResourceApi
+internal val Res.string.str_10658: StringResource
+  get() = String1.str_10658
+
+@ExperimentalResourceApi
+internal val Res.string.str_10659: StringResource
+  get() = String1.str_10659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1066: StringResource
+  get() = String1.str_1066
+
+@ExperimentalResourceApi
+internal val Res.string.str_10660: StringResource
+  get() = String1.str_10660
+
+@ExperimentalResourceApi
+internal val Res.string.str_10661: StringResource
+  get() = String1.str_10661
+
+@ExperimentalResourceApi
+internal val Res.string.str_10662: StringResource
+  get() = String1.str_10662
+
+@ExperimentalResourceApi
+internal val Res.string.str_10663: StringResource
+  get() = String1.str_10663
+
+@ExperimentalResourceApi
+internal val Res.string.str_10664: StringResource
+  get() = String1.str_10664
+
+@ExperimentalResourceApi
+internal val Res.string.str_10665: StringResource
+  get() = String1.str_10665
+
+@ExperimentalResourceApi
+internal val Res.string.str_10666: StringResource
+  get() = String1.str_10666
+
+@ExperimentalResourceApi
+internal val Res.string.str_10667: StringResource
+  get() = String1.str_10667
+
+@ExperimentalResourceApi
+internal val Res.string.str_10668: StringResource
+  get() = String1.str_10668
+
+@ExperimentalResourceApi
+internal val Res.string.str_10669: StringResource
+  get() = String1.str_10669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1067: StringResource
+  get() = String1.str_1067
+
+@ExperimentalResourceApi
+internal val Res.string.str_10670: StringResource
+  get() = String1.str_10670
+
+@ExperimentalResourceApi
+internal val Res.string.str_10671: StringResource
+  get() = String1.str_10671
+
+@ExperimentalResourceApi
+internal val Res.string.str_10672: StringResource
+  get() = String1.str_10672
+
+@ExperimentalResourceApi
+internal val Res.string.str_10673: StringResource
+  get() = String1.str_10673
+
+@ExperimentalResourceApi
+internal val Res.string.str_10674: StringResource
+  get() = String1.str_10674
+
+@ExperimentalResourceApi
+internal val Res.string.str_10675: StringResource
+  get() = String1.str_10675
+
+@ExperimentalResourceApi
+internal val Res.string.str_10676: StringResource
+  get() = String1.str_10676
+
+@ExperimentalResourceApi
+internal val Res.string.str_10677: StringResource
+  get() = String1.str_10677
+
+@ExperimentalResourceApi
+internal val Res.string.str_10678: StringResource
+  get() = String1.str_10678
+
+@ExperimentalResourceApi
+internal val Res.string.str_10679: StringResource
+  get() = String1.str_10679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1068: StringResource
+  get() = String1.str_1068
+
+@ExperimentalResourceApi
+internal val Res.string.str_10680: StringResource
+  get() = String1.str_10680
+
+@ExperimentalResourceApi
+internal val Res.string.str_10681: StringResource
+  get() = String1.str_10681
+
+@ExperimentalResourceApi
+internal val Res.string.str_10682: StringResource
+  get() = String1.str_10682
+
+@ExperimentalResourceApi
+internal val Res.string.str_10683: StringResource
+  get() = String1.str_10683
+
+@ExperimentalResourceApi
+internal val Res.string.str_10684: StringResource
+  get() = String1.str_10684
+
+@ExperimentalResourceApi
+internal val Res.string.str_10685: StringResource
+  get() = String1.str_10685
+
+@ExperimentalResourceApi
+internal val Res.string.str_10686: StringResource
+  get() = String1.str_10686
+
+@ExperimentalResourceApi
+internal val Res.string.str_10687: StringResource
+  get() = String1.str_10687
+
+@ExperimentalResourceApi
+internal val Res.string.str_10688: StringResource
+  get() = String1.str_10688
+
+@ExperimentalResourceApi
+internal val Res.string.str_10689: StringResource
+  get() = String1.str_10689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1069: StringResource
+  get() = String1.str_1069
+
+@ExperimentalResourceApi
+internal val Res.string.str_10690: StringResource
+  get() = String1.str_10690
+
+@ExperimentalResourceApi
+internal val Res.string.str_10691: StringResource
+  get() = String1.str_10691
+
+@ExperimentalResourceApi
+internal val Res.string.str_10692: StringResource
+  get() = String1.str_10692
+
+@ExperimentalResourceApi
+internal val Res.string.str_10693: StringResource
+  get() = String1.str_10693
+
+@ExperimentalResourceApi
+internal val Res.string.str_10694: StringResource
+  get() = String1.str_10694
+
+@ExperimentalResourceApi
+internal val Res.string.str_10695: StringResource
+  get() = String1.str_10695
+
+@ExperimentalResourceApi
+internal val Res.string.str_10696: StringResource
+  get() = String1.str_10696
+
+@ExperimentalResourceApi
+internal val Res.string.str_10697: StringResource
+  get() = String1.str_10697
+
+@ExperimentalResourceApi
+internal val Res.string.str_10698: StringResource
+  get() = String1.str_10698
+
+@ExperimentalResourceApi
+internal val Res.string.str_10699: StringResource
+  get() = String1.str_10699
+
+@ExperimentalResourceApi
+internal val Res.string.str_107: StringResource
+  get() = String1.str_107
+
+@ExperimentalResourceApi
+internal val Res.string.str_1070: StringResource
+  get() = String1.str_1070
+
+@ExperimentalResourceApi
+internal val Res.string.str_10700: StringResource
+  get() = String1.str_10700
+
+@ExperimentalResourceApi
+internal val Res.string.str_10701: StringResource
+  get() = String1.str_10701
+
+@ExperimentalResourceApi
+internal val Res.string.str_10702: StringResource
+  get() = String1.str_10702
+
+@ExperimentalResourceApi
+internal val Res.string.str_10703: StringResource
+  get() = String1.str_10703
+
+@ExperimentalResourceApi
+internal val Res.string.str_10704: StringResource
+  get() = String1.str_10704
+
+@ExperimentalResourceApi
+internal val Res.string.str_10705: StringResource
+  get() = String1.str_10705
+
+@ExperimentalResourceApi
+internal val Res.string.str_10706: StringResource
+  get() = String1.str_10706
+
+@ExperimentalResourceApi
+internal val Res.string.str_10707: StringResource
+  get() = String1.str_10707
+
+@ExperimentalResourceApi
+internal val Res.string.str_10708: StringResource
+  get() = String1.str_10708
+
+@ExperimentalResourceApi
+internal val Res.string.str_10709: StringResource
+  get() = String1.str_10709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1071: StringResource
+  get() = String1.str_1071
+
+@ExperimentalResourceApi
+internal val Res.string.str_10710: StringResource
+  get() = String1.str_10710
+
+@ExperimentalResourceApi
+internal val Res.string.str_10711: StringResource
+  get() = String1.str_10711
+
+@ExperimentalResourceApi
+internal val Res.string.str_10712: StringResource
+  get() = String1.str_10712
+
+@ExperimentalResourceApi
+internal val Res.string.str_10713: StringResource
+  get() = String1.str_10713
+
+@ExperimentalResourceApi
+internal val Res.string.str_10714: StringResource
+  get() = String1.str_10714
+
+@ExperimentalResourceApi
+internal val Res.string.str_10715: StringResource
+  get() = String1.str_10715
+
+@ExperimentalResourceApi
+internal val Res.string.str_10716: StringResource
+  get() = String1.str_10716
+
+@ExperimentalResourceApi
+internal val Res.string.str_10717: StringResource
+  get() = String1.str_10717
+
+@ExperimentalResourceApi
+internal val Res.string.str_10718: StringResource
+  get() = String1.str_10718
+
+@ExperimentalResourceApi
+internal val Res.string.str_10719: StringResource
+  get() = String1.str_10719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1072: StringResource
+  get() = String1.str_1072
+
+@ExperimentalResourceApi
+internal val Res.string.str_10720: StringResource
+  get() = String1.str_10720
+
+@ExperimentalResourceApi
+internal val Res.string.str_10721: StringResource
+  get() = String1.str_10721
+
+@ExperimentalResourceApi
+internal val Res.string.str_10722: StringResource
+  get() = String1.str_10722
+
+@ExperimentalResourceApi
+internal val Res.string.str_10723: StringResource
+  get() = String1.str_10723
+
+@ExperimentalResourceApi
+internal val Res.string.str_10724: StringResource
+  get() = String1.str_10724
+
+@ExperimentalResourceApi
+internal val Res.string.str_10725: StringResource
+  get() = String1.str_10725
+
+@ExperimentalResourceApi
+internal val Res.string.str_10726: StringResource
+  get() = String1.str_10726
+
+@ExperimentalResourceApi
+internal val Res.string.str_10727: StringResource
+  get() = String1.str_10727
+
+@ExperimentalResourceApi
+internal val Res.string.str_10728: StringResource
+  get() = String1.str_10728
+
+@ExperimentalResourceApi
+internal val Res.string.str_10729: StringResource
+  get() = String1.str_10729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1073: StringResource
+  get() = String1.str_1073
+
+@ExperimentalResourceApi
+internal val Res.string.str_10730: StringResource
+  get() = String1.str_10730
+
+@ExperimentalResourceApi
+internal val Res.string.str_10731: StringResource
+  get() = String1.str_10731
+
+@ExperimentalResourceApi
+internal val Res.string.str_10732: StringResource
+  get() = String1.str_10732
+
+@ExperimentalResourceApi
+internal val Res.string.str_10733: StringResource
+  get() = String1.str_10733
+
+@ExperimentalResourceApi
+internal val Res.string.str_10734: StringResource
+  get() = String1.str_10734
+
+@ExperimentalResourceApi
+internal val Res.string.str_10735: StringResource
+  get() = String1.str_10735
+
+@ExperimentalResourceApi
+internal val Res.string.str_10736: StringResource
+  get() = String1.str_10736
+
+@ExperimentalResourceApi
+internal val Res.string.str_10737: StringResource
+  get() = String1.str_10737
+
+@ExperimentalResourceApi
+internal val Res.string.str_10738: StringResource
+  get() = String1.str_10738
+
+@ExperimentalResourceApi
+internal val Res.string.str_10739: StringResource
+  get() = String1.str_10739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1074: StringResource
+  get() = String1.str_1074
+
+@ExperimentalResourceApi
+internal val Res.string.str_10740: StringResource
+  get() = String1.str_10740
+
+@ExperimentalResourceApi
+internal val Res.string.str_10741: StringResource
+  get() = String1.str_10741
+
+@ExperimentalResourceApi
+internal val Res.string.str_10742: StringResource
+  get() = String1.str_10742
+
+@ExperimentalResourceApi
+internal val Res.string.str_10743: StringResource
+  get() = String1.str_10743
+
+@ExperimentalResourceApi
+internal val Res.string.str_10744: StringResource
+  get() = String1.str_10744
+
+@ExperimentalResourceApi
+internal val Res.string.str_10745: StringResource
+  get() = String1.str_10745
+
+@ExperimentalResourceApi
+internal val Res.string.str_10746: StringResource
+  get() = String1.str_10746
+
+@ExperimentalResourceApi
+internal val Res.string.str_10747: StringResource
+  get() = String1.str_10747
+
+@ExperimentalResourceApi
+internal val Res.string.str_10748: StringResource
+  get() = String1.str_10748
+
+@ExperimentalResourceApi
+internal val Res.string.str_10749: StringResource
+  get() = String1.str_10749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1075: StringResource
+  get() = String1.str_1075
+
+@ExperimentalResourceApi
+internal val Res.string.str_10750: StringResource
+  get() = String1.str_10750
+
+@ExperimentalResourceApi
+internal val Res.string.str_10751: StringResource
+  get() = String1.str_10751
+
+@ExperimentalResourceApi
+internal val Res.string.str_10752: StringResource
+  get() = String1.str_10752
+
+@ExperimentalResourceApi
+internal val Res.string.str_10753: StringResource
+  get() = String1.str_10753
+
+@ExperimentalResourceApi
+internal val Res.string.str_10754: StringResource
+  get() = String1.str_10754
+
+@ExperimentalResourceApi
+internal val Res.string.str_10755: StringResource
+  get() = String1.str_10755
+
+@ExperimentalResourceApi
+internal val Res.string.str_10756: StringResource
+  get() = String1.str_10756
+
+@ExperimentalResourceApi
+internal val Res.string.str_10757: StringResource
+  get() = String1.str_10757
+
+@ExperimentalResourceApi
+internal val Res.string.str_10758: StringResource
+  get() = String1.str_10758
+
+@ExperimentalResourceApi
+internal val Res.string.str_10759: StringResource
+  get() = String1.str_10759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1076: StringResource
+  get() = String1.str_1076
+
+@ExperimentalResourceApi
+internal val Res.string.str_10760: StringResource
+  get() = String1.str_10760
+
+@ExperimentalResourceApi
+internal val Res.string.str_10761: StringResource
+  get() = String1.str_10761
+
+@ExperimentalResourceApi
+internal val Res.string.str_10762: StringResource
+  get() = String1.str_10762
+
+@ExperimentalResourceApi
+internal val Res.string.str_10763: StringResource
+  get() = String1.str_10763
+
+@ExperimentalResourceApi
+internal val Res.string.str_10764: StringResource
+  get() = String1.str_10764
+
+@ExperimentalResourceApi
+internal val Res.string.str_10765: StringResource
+  get() = String1.str_10765
+
+@ExperimentalResourceApi
+internal val Res.string.str_10766: StringResource
+  get() = String1.str_10766
+
+@ExperimentalResourceApi
+internal val Res.string.str_10767: StringResource
+  get() = String1.str_10767
+
+@ExperimentalResourceApi
+internal val Res.string.str_10768: StringResource
+  get() = String1.str_10768
+
+@ExperimentalResourceApi
+internal val Res.string.str_10769: StringResource
+  get() = String1.str_10769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1077: StringResource
+  get() = String1.str_1077
+
+@ExperimentalResourceApi
+internal val Res.string.str_10770: StringResource
+  get() = String1.str_10770
+
+@ExperimentalResourceApi
+internal val Res.string.str_10771: StringResource
+  get() = String1.str_10771
+
+@ExperimentalResourceApi
+internal val Res.string.str_10772: StringResource
+  get() = String1.str_10772
+
+@ExperimentalResourceApi
+internal val Res.string.str_10773: StringResource
+  get() = String1.str_10773
+
+@ExperimentalResourceApi
+internal val Res.string.str_10774: StringResource
+  get() = String1.str_10774
+
+@ExperimentalResourceApi
+internal val Res.string.str_10775: StringResource
+  get() = String1.str_10775
+
+@ExperimentalResourceApi
+internal val Res.string.str_10776: StringResource
+  get() = String1.str_10776
+
+@ExperimentalResourceApi
+internal val Res.string.str_10777: StringResource
+  get() = String1.str_10777
+
+@ExperimentalResourceApi
+internal val Res.string.str_10778: StringResource
+  get() = String1.str_10778
+
+@ExperimentalResourceApi
+internal val Res.string.str_10779: StringResource
+  get() = String1.str_10779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1078: StringResource
+  get() = String1.str_1078
+
+@ExperimentalResourceApi
+internal val Res.string.str_10780: StringResource
+  get() = String1.str_10780
+
+@ExperimentalResourceApi
+internal val Res.string.str_10781: StringResource
+  get() = String1.str_10781
+
+@ExperimentalResourceApi
+internal val Res.string.str_10782: StringResource
+  get() = String1.str_10782
+
+@ExperimentalResourceApi
+internal val Res.string.str_10783: StringResource
+  get() = String1.str_10783
+
+@ExperimentalResourceApi
+internal val Res.string.str_10784: StringResource
+  get() = String1.str_10784
+
+@ExperimentalResourceApi
+internal val Res.string.str_10785: StringResource
+  get() = String1.str_10785
+
+@ExperimentalResourceApi
+internal val Res.string.str_10786: StringResource
+  get() = String1.str_10786
+
+@ExperimentalResourceApi
+internal val Res.string.str_10787: StringResource
+  get() = String1.str_10787
+
+@ExperimentalResourceApi
+internal val Res.string.str_10788: StringResource
+  get() = String1.str_10788
+
+@ExperimentalResourceApi
+internal val Res.string.str_10789: StringResource
+  get() = String1.str_10789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1079: StringResource
+  get() = String1.str_1079
+
+@ExperimentalResourceApi
+internal val Res.string.str_10790: StringResource
+  get() = String1.str_10790
+
+@ExperimentalResourceApi
+internal val Res.string.str_10791: StringResource
+  get() = String1.str_10791
+
+@ExperimentalResourceApi
+internal val Res.string.str_10792: StringResource
+  get() = String1.str_10792
+
+@ExperimentalResourceApi
+internal val Res.string.str_10793: StringResource
+  get() = String1.str_10793
+
+@ExperimentalResourceApi
+internal val Res.string.str_10794: StringResource
+  get() = String1.str_10794
+
+@ExperimentalResourceApi
+internal val Res.string.str_10795: StringResource
+  get() = String1.str_10795
+
+@ExperimentalResourceApi
+internal val Res.string.str_10796: StringResource
+  get() = String1.str_10796
+
+@ExperimentalResourceApi
+internal val Res.string.str_10797: StringResource
+  get() = String1.str_10797
+
+@ExperimentalResourceApi
+internal val Res.string.str_10798: StringResource
+  get() = String1.str_10798
+
+@ExperimentalResourceApi
+internal val Res.string.str_10799: StringResource
+  get() = String1.str_10799
+
+@ExperimentalResourceApi
+internal val Res.string.str_108: StringResource
+  get() = String1.str_108
+
+@ExperimentalResourceApi
+internal val Res.string.str_1080: StringResource
+  get() = String1.str_1080
+
+@ExperimentalResourceApi
+internal val Res.string.str_10800: StringResource
+  get() = String1.str_10800
+
+@ExperimentalResourceApi
+internal val Res.string.str_10801: StringResource
+  get() = String1.str_10801
+
+@ExperimentalResourceApi
+internal val Res.string.str_10802: StringResource
+  get() = String1.str_10802
+
+@ExperimentalResourceApi
+internal val Res.string.str_10803: StringResource
+  get() = String1.str_10803
+
+@ExperimentalResourceApi
+internal val Res.string.str_10804: StringResource
+  get() = String1.str_10804
+
+@ExperimentalResourceApi
+internal val Res.string.str_10805: StringResource
+  get() = String1.str_10805
+
+@ExperimentalResourceApi
+internal val Res.string.str_10806: StringResource
+  get() = String1.str_10806
+
+@ExperimentalResourceApi
+internal val Res.string.str_10807: StringResource
+  get() = String1.str_10807
+
+@ExperimentalResourceApi
+internal val Res.string.str_10808: StringResource
+  get() = String1.str_10808
+
+@ExperimentalResourceApi
+internal val Res.string.str_10809: StringResource
+  get() = String1.str_10809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1081: StringResource
+  get() = String1.str_1081
+
+@ExperimentalResourceApi
+internal val Res.string.str_10810: StringResource
+  get() = String1.str_10810
+
+@ExperimentalResourceApi
+internal val Res.string.str_10811: StringResource
+  get() = String1.str_10811
+
+@ExperimentalResourceApi
+internal val Res.string.str_10812: StringResource
+  get() = String1.str_10812
+
+@ExperimentalResourceApi
+internal val Res.string.str_10813: StringResource
+  get() = String1.str_10813
+
+@ExperimentalResourceApi
+internal val Res.string.str_10814: StringResource
+  get() = String1.str_10814
+
+@ExperimentalResourceApi
+internal val Res.string.str_10815: StringResource
+  get() = String1.str_10815
+
+@ExperimentalResourceApi
+internal val Res.string.str_10816: StringResource
+  get() = String1.str_10816
+
+@ExperimentalResourceApi
+internal val Res.string.str_10817: StringResource
+  get() = String1.str_10817
+
+@ExperimentalResourceApi
+internal val Res.string.str_10818: StringResource
+  get() = String1.str_10818
+
+@ExperimentalResourceApi
+internal val Res.string.str_10819: StringResource
+  get() = String1.str_10819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1082: StringResource
+  get() = String1.str_1082
+
+@ExperimentalResourceApi
+internal val Res.string.str_10820: StringResource
+  get() = String1.str_10820
+
+@ExperimentalResourceApi
+internal val Res.string.str_10821: StringResource
+  get() = String1.str_10821
+
+@ExperimentalResourceApi
+internal val Res.string.str_10822: StringResource
+  get() = String1.str_10822
+
+@ExperimentalResourceApi
+internal val Res.string.str_10823: StringResource
+  get() = String1.str_10823
+
+@ExperimentalResourceApi
+internal val Res.string.str_10824: StringResource
+  get() = String1.str_10824
+
+@ExperimentalResourceApi
+internal val Res.string.str_10825: StringResource
+  get() = String1.str_10825
+
+@ExperimentalResourceApi
+internal val Res.string.str_10826: StringResource
+  get() = String1.str_10826
+
+@ExperimentalResourceApi
+internal val Res.string.str_10827: StringResource
+  get() = String1.str_10827
+
+@ExperimentalResourceApi
+internal val Res.string.str_10828: StringResource
+  get() = String1.str_10828
+
+@ExperimentalResourceApi
+internal val Res.string.str_10829: StringResource
+  get() = String1.str_10829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1083: StringResource
+  get() = String1.str_1083
+
+@ExperimentalResourceApi
+internal val Res.string.str_10830: StringResource
+  get() = String1.str_10830
+
+@ExperimentalResourceApi
+internal val Res.string.str_10831: StringResource
+  get() = String1.str_10831
+
+@ExperimentalResourceApi
+internal val Res.string.str_10832: StringResource
+  get() = String1.str_10832
+
+@ExperimentalResourceApi
+internal val Res.string.str_10833: StringResource
+  get() = String1.str_10833
+
+@ExperimentalResourceApi
+internal val Res.string.str_10834: StringResource
+  get() = String1.str_10834
+
+@ExperimentalResourceApi
+internal val Res.string.str_10835: StringResource
+  get() = String1.str_10835
+
+@ExperimentalResourceApi
+internal val Res.string.str_10836: StringResource
+  get() = String1.str_10836
+
+@ExperimentalResourceApi
+internal val Res.string.str_10837: StringResource
+  get() = String1.str_10837
+
+@ExperimentalResourceApi
+internal val Res.string.str_10838: StringResource
+  get() = String1.str_10838
+
+@ExperimentalResourceApi
+internal val Res.string.str_10839: StringResource
+  get() = String1.str_10839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1084: StringResource
+  get() = String1.str_1084
+
+@ExperimentalResourceApi
+internal val Res.string.str_10840: StringResource
+  get() = String1.str_10840
+
+@ExperimentalResourceApi
+internal val Res.string.str_10841: StringResource
+  get() = String1.str_10841
+
+@ExperimentalResourceApi
+internal val Res.string.str_10842: StringResource
+  get() = String1.str_10842
+
+@ExperimentalResourceApi
+internal val Res.string.str_10843: StringResource
+  get() = String1.str_10843
+
+@ExperimentalResourceApi
+internal val Res.string.str_10844: StringResource
+  get() = String1.str_10844
+
+@ExperimentalResourceApi
+internal val Res.string.str_10845: StringResource
+  get() = String1.str_10845
+
+@ExperimentalResourceApi
+internal val Res.string.str_10846: StringResource
+  get() = String1.str_10846
+
+@ExperimentalResourceApi
+internal val Res.string.str_10847: StringResource
+  get() = String1.str_10847
+
+@ExperimentalResourceApi
+internal val Res.string.str_10848: StringResource
+  get() = String1.str_10848
+
+@ExperimentalResourceApi
+internal val Res.string.str_10849: StringResource
+  get() = String1.str_10849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1085: StringResource
+  get() = String1.str_1085
+
+@ExperimentalResourceApi
+internal val Res.string.str_10850: StringResource
+  get() = String1.str_10850
+
+@ExperimentalResourceApi
+internal val Res.string.str_10851: StringResource
+  get() = String1.str_10851
+
+@ExperimentalResourceApi
+internal val Res.string.str_10852: StringResource
+  get() = String1.str_10852
+
+@ExperimentalResourceApi
+internal val Res.string.str_10853: StringResource
+  get() = String1.str_10853
+
+@ExperimentalResourceApi
+internal val Res.string.str_10854: StringResource
+  get() = String1.str_10854
+
+@ExperimentalResourceApi
+internal val Res.string.str_10855: StringResource
+  get() = String1.str_10855
+
+@ExperimentalResourceApi
+internal val Res.string.str_10856: StringResource
+  get() = String1.str_10856
+
+@ExperimentalResourceApi
+internal val Res.string.str_10857: StringResource
+  get() = String1.str_10857
+
+@ExperimentalResourceApi
+internal val Res.string.str_10858: StringResource
+  get() = String1.str_10858
+
+@ExperimentalResourceApi
+internal val Res.string.str_10859: StringResource
+  get() = String1.str_10859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1086: StringResource
+  get() = String1.str_1086
+
+@ExperimentalResourceApi
+internal val Res.string.str_10860: StringResource
+  get() = String1.str_10860
+
+@ExperimentalResourceApi
+internal val Res.string.str_10861: StringResource
+  get() = String1.str_10861
+
+@ExperimentalResourceApi
+internal val Res.string.str_10862: StringResource
+  get() = String1.str_10862
+
+@ExperimentalResourceApi
+internal val Res.string.str_10863: StringResource
+  get() = String1.str_10863
+
+@ExperimentalResourceApi
+internal val Res.string.str_10864: StringResource
+  get() = String1.str_10864
+
+@ExperimentalResourceApi
+internal val Res.string.str_10865: StringResource
+  get() = String1.str_10865
+
+@ExperimentalResourceApi
+internal val Res.string.str_10866: StringResource
+  get() = String1.str_10866
+
+@ExperimentalResourceApi
+internal val Res.string.str_10867: StringResource
+  get() = String1.str_10867
+
+@ExperimentalResourceApi
+internal val Res.string.str_10868: StringResource
+  get() = String1.str_10868
+
+@ExperimentalResourceApi
+internal val Res.string.str_10869: StringResource
+  get() = String1.str_10869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1087: StringResource
+  get() = String1.str_1087
+
+@ExperimentalResourceApi
+internal val Res.string.str_10870: StringResource
+  get() = String1.str_10870
+
+@ExperimentalResourceApi
+internal val Res.string.str_10871: StringResource
+  get() = String1.str_10871
+
+@ExperimentalResourceApi
+internal val Res.string.str_10872: StringResource
+  get() = String1.str_10872
+
+@ExperimentalResourceApi
+internal val Res.string.str_10873: StringResource
+  get() = String1.str_10873
+
+@ExperimentalResourceApi
+internal val Res.string.str_10874: StringResource
+  get() = String1.str_10874
+
+@ExperimentalResourceApi
+internal val Res.string.str_10875: StringResource
+  get() = String1.str_10875
+
+@ExperimentalResourceApi
+internal val Res.string.str_10876: StringResource
+  get() = String1.str_10876
+
+@ExperimentalResourceApi
+internal val Res.string.str_10877: StringResource
+  get() = String1.str_10877
+
+@ExperimentalResourceApi
+internal val Res.string.str_10878: StringResource
+  get() = String1.str_10878
+
+@ExperimentalResourceApi
+internal val Res.string.str_10879: StringResource
+  get() = String1.str_10879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1088: StringResource
+  get() = String1.str_1088
+
+@ExperimentalResourceApi
+internal val Res.string.str_10880: StringResource
+  get() = String1.str_10880
+
+@ExperimentalResourceApi
+internal val Res.string.str_10881: StringResource
+  get() = String1.str_10881
+
+@ExperimentalResourceApi
+internal val Res.string.str_10882: StringResource
+  get() = String1.str_10882
+
+@ExperimentalResourceApi
+internal val Res.string.str_10883: StringResource
+  get() = String1.str_10883
+
+@ExperimentalResourceApi
+internal val Res.string.str_10884: StringResource
+  get() = String1.str_10884
+
+@ExperimentalResourceApi
+internal val Res.string.str_10885: StringResource
+  get() = String1.str_10885
+
+@ExperimentalResourceApi
+internal val Res.string.str_10886: StringResource
+  get() = String1.str_10886
+
+@ExperimentalResourceApi
+internal val Res.string.str_10887: StringResource
+  get() = String1.str_10887
+
+@ExperimentalResourceApi
+internal val Res.string.str_10888: StringResource
+  get() = String1.str_10888
+
+@ExperimentalResourceApi
+internal val Res.string.str_10889: StringResource
+  get() = String1.str_10889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1089: StringResource
+  get() = String1.str_1089
+
+@ExperimentalResourceApi
+internal val Res.string.str_10890: StringResource
+  get() = String1.str_10890
+
+@ExperimentalResourceApi
+internal val Res.string.str_10891: StringResource
+  get() = String1.str_10891
+
+@ExperimentalResourceApi
+internal val Res.string.str_10892: StringResource
+  get() = String1.str_10892
+
+@ExperimentalResourceApi
+internal val Res.string.str_10893: StringResource
+  get() = String1.str_10893
+
+@ExperimentalResourceApi
+internal val Res.string.str_10894: StringResource
+  get() = String1.str_10894
+
+@ExperimentalResourceApi
+internal val Res.string.str_10895: StringResource
+  get() = String1.str_10895
+
+@ExperimentalResourceApi
+internal val Res.string.str_10896: StringResource
+  get() = String1.str_10896
+
+@ExperimentalResourceApi
+internal val Res.string.str_10897: StringResource
+  get() = String1.str_10897

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String10.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String10.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String10 {
+  public val str_14498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14498", "str_14498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14499", "str_14499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_145", "str_145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1450", "str_1450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14500", "str_14500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14501", "str_14501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14502", "str_14502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14503", "str_14503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14504", "str_14504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14505", "str_14505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14506", "str_14506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14507", "str_14507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14508", "str_14508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14509", "str_14509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1451", "str_1451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14510", "str_14510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14511", "str_14511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14512", "str_14512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14513", "str_14513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14514", "str_14514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14515", "str_14515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14516", "str_14516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14517", "str_14517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14518", "str_14518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14519", "str_14519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1452", "str_1452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14520", "str_14520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14521", "str_14521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14522", "str_14522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14523", "str_14523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14524", "str_14524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14525", "str_14525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14526", "str_14526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14527", "str_14527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14528", "str_14528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14529", "str_14529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1453", "str_1453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14530", "str_14530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14531", "str_14531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14532", "str_14532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14533", "str_14533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14534", "str_14534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14535", "str_14535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14536", "str_14536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14537", "str_14537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14538", "str_14538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14539", "str_14539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1454", "str_1454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14540", "str_14540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14541", "str_14541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14542", "str_14542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14543", "str_14543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14544", "str_14544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14545", "str_14545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14546", "str_14546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14547", "str_14547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14548", "str_14548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14549", "str_14549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1455", "str_1455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14550", "str_14550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14551", "str_14551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14552", "str_14552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14553", "str_14553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14554", "str_14554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14555", "str_14555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14556", "str_14556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14557", "str_14557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14558", "str_14558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14559", "str_14559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1456", "str_1456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14560", "str_14560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14561", "str_14561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14562", "str_14562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14563", "str_14563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14564", "str_14564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14565", "str_14565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14566", "str_14566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14567", "str_14567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14568", "str_14568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14569", "str_14569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1457", "str_1457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14570", "str_14570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14571", "str_14571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14572", "str_14572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14573", "str_14573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14574", "str_14574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14575", "str_14575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14576", "str_14576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14577", "str_14577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14578", "str_14578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14579", "str_14579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1458", "str_1458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14580", "str_14580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14581", "str_14581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14582", "str_14582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14583", "str_14583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14584", "str_14584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14585", "str_14585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14586", "str_14586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14587", "str_14587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14588", "str_14588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14589", "str_14589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1459", "str_1459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14590", "str_14590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14591", "str_14591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14592", "str_14592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14593", "str_14593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14594", "str_14594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14595", "str_14595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14596", "str_14596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14597", "str_14597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14598", "str_14598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14599", "str_14599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_146", "str_146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1460", "str_1460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14600", "str_14600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14601", "str_14601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14602", "str_14602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14603", "str_14603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14604", "str_14604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14605", "str_14605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14606", "str_14606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14607", "str_14607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14608", "str_14608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14609", "str_14609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1461", "str_1461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14610", "str_14610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14611", "str_14611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14612", "str_14612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14613", "str_14613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14614", "str_14614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14615", "str_14615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14616", "str_14616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14617", "str_14617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14618", "str_14618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14619", "str_14619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1462", "str_1462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14620", "str_14620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14621", "str_14621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14622", "str_14622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14623", "str_14623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14624", "str_14624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14625", "str_14625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14626", "str_14626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14627", "str_14627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14628", "str_14628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14629", "str_14629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1463", "str_1463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14630", "str_14630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14631", "str_14631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14632", "str_14632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14633", "str_14633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14634", "str_14634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14635", "str_14635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14636", "str_14636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14637", "str_14637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14638", "str_14638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14639", "str_14639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1464", "str_1464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14640", "str_14640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14641", "str_14641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14642", "str_14642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14643", "str_14643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14644", "str_14644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14645", "str_14645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14646", "str_14646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14647", "str_14647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14648", "str_14648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14649", "str_14649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1465", "str_1465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14650", "str_14650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14651", "str_14651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14652", "str_14652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14653", "str_14653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14654", "str_14654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14655", "str_14655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14656", "str_14656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14657", "str_14657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14658", "str_14658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14659", "str_14659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1466", "str_1466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14660", "str_14660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14661", "str_14661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14662", "str_14662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14663", "str_14663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14664", "str_14664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14665", "str_14665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14666", "str_14666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14667", "str_14667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14668", "str_14668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14669", "str_14669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1467", "str_1467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14670", "str_14670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14671", "str_14671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14672", "str_14672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14673", "str_14673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14674", "str_14674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14675", "str_14675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14676", "str_14676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14677", "str_14677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14678", "str_14678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14679", "str_14679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1468", "str_1468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14680", "str_14680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14681", "str_14681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14682", "str_14682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14683", "str_14683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14684", "str_14684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14685", "str_14685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14686", "str_14686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14687", "str_14687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14688", "str_14688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14689", "str_14689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1469", "str_1469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14690", "str_14690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14691", "str_14691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14692", "str_14692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14693", "str_14693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14694", "str_14694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14695", "str_14695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14696", "str_14696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14697", "str_14697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14698", "str_14698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14699", "str_14699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_147", "str_147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1470", "str_1470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14700", "str_14700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14701", "str_14701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14702", "str_14702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14703", "str_14703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14704", "str_14704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14705", "str_14705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14706", "str_14706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14707", "str_14707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14708", "str_14708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14709", "str_14709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1471", "str_1471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14710", "str_14710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14711", "str_14711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14712", "str_14712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14713", "str_14713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14714", "str_14714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14715", "str_14715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14716", "str_14716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14717", "str_14717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14718", "str_14718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14719", "str_14719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1472", "str_1472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14720", "str_14720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14721", "str_14721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14722", "str_14722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14723", "str_14723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14724", "str_14724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14725", "str_14725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14726", "str_14726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14727", "str_14727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14728", "str_14728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14729", "str_14729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1473", "str_1473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14730", "str_14730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14731", "str_14731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14732", "str_14732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14733", "str_14733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14734", "str_14734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14735", "str_14735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14736", "str_14736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14737", "str_14737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14738", "str_14738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14739", "str_14739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1474", "str_1474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14740", "str_14740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14741", "str_14741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14742", "str_14742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14743", "str_14743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14744", "str_14744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14745", "str_14745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14746", "str_14746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14747", "str_14747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14748", "str_14748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14749", "str_14749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1475", "str_1475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14750", "str_14750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14751", "str_14751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14752", "str_14752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14753", "str_14753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14754", "str_14754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14755", "str_14755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14756", "str_14756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14757", "str_14757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14758", "str_14758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14759", "str_14759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1476", "str_1476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14760", "str_14760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14761", "str_14761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14762", "str_14762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14763", "str_14763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14764", "str_14764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14765", "str_14765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14766", "str_14766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14767", "str_14767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14768", "str_14768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14769", "str_14769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1477", "str_1477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14770", "str_14770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14771", "str_14771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14772", "str_14772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14773", "str_14773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14774", "str_14774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14775", "str_14775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14776", "str_14776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14777", "str_14777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14778", "str_14778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14779", "str_14779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1478", "str_1478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14780", "str_14780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14781", "str_14781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14782", "str_14782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14783", "str_14783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14784", "str_14784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14785", "str_14785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14786", "str_14786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14787", "str_14787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14788", "str_14788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14789", "str_14789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1479", "str_1479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14790", "str_14790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14791", "str_14791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14792", "str_14792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14793", "str_14793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14794", "str_14794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14795", "str_14795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14796", "str_14796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14797", "str_14797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14798", "str_14798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14799", "str_14799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_148", "str_148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1480", "str_1480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14800", "str_14800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14801", "str_14801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14802", "str_14802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14803", "str_14803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14804", "str_14804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14805", "str_14805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14806", "str_14806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14807", "str_14807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14808", "str_14808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14809", "str_14809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1481", "str_1481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14810", "str_14810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14811", "str_14811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14812", "str_14812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14813", "str_14813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14814", "str_14814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14815", "str_14815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14816", "str_14816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14817", "str_14817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14818", "str_14818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14819", "str_14819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1482", "str_1482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14820", "str_14820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14821", "str_14821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14822", "str_14822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14823", "str_14823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14824", "str_14824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14825", "str_14825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14826", "str_14826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14827", "str_14827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14828", "str_14828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14829", "str_14829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1483", "str_1483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14830", "str_14830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14831", "str_14831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14832", "str_14832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14833", "str_14833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14834", "str_14834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14835", "str_14835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14836", "str_14836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14837", "str_14837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14838", "str_14838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14839", "str_14839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1484", "str_1484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14840", "str_14840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14841", "str_14841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14842", "str_14842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14843", "str_14843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14844", "str_14844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14845", "str_14845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14846", "str_14846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14847", "str_14847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14848", "str_14848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14849", "str_14849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1485", "str_1485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14850", "str_14850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14851", "str_14851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14852", "str_14852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14853", "str_14853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14854", "str_14854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14855", "str_14855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14856", "str_14856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14857", "str_14857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14858", "str_14858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14859", "str_14859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1486", "str_1486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14860", "str_14860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14861", "str_14861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14862", "str_14862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14863", "str_14863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14864", "str_14864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14865", "str_14865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14866", "str_14866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14867", "str_14867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14868", "str_14868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14869", "str_14869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1487", "str_1487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14870", "str_14870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14871", "str_14871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14872", "str_14872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14873", "str_14873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14874", "str_14874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14875", "str_14875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14876", "str_14876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14877", "str_14877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14878", "str_14878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14879", "str_14879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1488", "str_1488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14880", "str_14880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14881", "str_14881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14882", "str_14882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14883", "str_14883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14884", "str_14884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14885", "str_14885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14886", "str_14886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14887", "str_14887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14888", "str_14888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14889", "str_14889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1489", "str_1489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14890", "str_14890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14891", "str_14891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14892", "str_14892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14893", "str_14893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14894", "str_14894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14895", "str_14895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14896", "str_14896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14897", "str_14897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14898", "str_14898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14899", "str_14899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_149", "str_149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1490", "str_1490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14900", "str_14900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14901", "str_14901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14902", "str_14902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14903", "str_14903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14904", "str_14904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14905", "str_14905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14906", "str_14906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14907", "str_14907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14908", "str_14908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14909", "str_14909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1491", "str_1491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14910", "str_14910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14911", "str_14911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14912", "str_14912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14913", "str_14913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14914", "str_14914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14915", "str_14915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14916", "str_14916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14917", "str_14917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14918", "str_14918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14919", "str_14919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1492", "str_1492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14920", "str_14920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14921", "str_14921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14922", "str_14922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14923", "str_14923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14924", "str_14924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14925", "str_14925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14926", "str_14926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14927", "str_14927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14928", "str_14928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14929", "str_14929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1493", "str_1493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14930", "str_14930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14931", "str_14931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14932", "str_14932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14933", "str_14933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14934", "str_14934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14935", "str_14935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14936", "str_14936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14937", "str_14937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14938", "str_14938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14939", "str_14939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1494", "str_1494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14940", "str_14940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14941", "str_14941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14942", "str_14942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14943", "str_14943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14944", "str_14944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14945", "str_14945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14946", "str_14946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14947", "str_14947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_14498: StringResource
+  get() = String10.str_14498
+
+@ExperimentalResourceApi
+internal val Res.string.str_14499: StringResource
+  get() = String10.str_14499
+
+@ExperimentalResourceApi
+internal val Res.string.str_145: StringResource
+  get() = String10.str_145
+
+@ExperimentalResourceApi
+internal val Res.string.str_1450: StringResource
+  get() = String10.str_1450
+
+@ExperimentalResourceApi
+internal val Res.string.str_14500: StringResource
+  get() = String10.str_14500
+
+@ExperimentalResourceApi
+internal val Res.string.str_14501: StringResource
+  get() = String10.str_14501
+
+@ExperimentalResourceApi
+internal val Res.string.str_14502: StringResource
+  get() = String10.str_14502
+
+@ExperimentalResourceApi
+internal val Res.string.str_14503: StringResource
+  get() = String10.str_14503
+
+@ExperimentalResourceApi
+internal val Res.string.str_14504: StringResource
+  get() = String10.str_14504
+
+@ExperimentalResourceApi
+internal val Res.string.str_14505: StringResource
+  get() = String10.str_14505
+
+@ExperimentalResourceApi
+internal val Res.string.str_14506: StringResource
+  get() = String10.str_14506
+
+@ExperimentalResourceApi
+internal val Res.string.str_14507: StringResource
+  get() = String10.str_14507
+
+@ExperimentalResourceApi
+internal val Res.string.str_14508: StringResource
+  get() = String10.str_14508
+
+@ExperimentalResourceApi
+internal val Res.string.str_14509: StringResource
+  get() = String10.str_14509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1451: StringResource
+  get() = String10.str_1451
+
+@ExperimentalResourceApi
+internal val Res.string.str_14510: StringResource
+  get() = String10.str_14510
+
+@ExperimentalResourceApi
+internal val Res.string.str_14511: StringResource
+  get() = String10.str_14511
+
+@ExperimentalResourceApi
+internal val Res.string.str_14512: StringResource
+  get() = String10.str_14512
+
+@ExperimentalResourceApi
+internal val Res.string.str_14513: StringResource
+  get() = String10.str_14513
+
+@ExperimentalResourceApi
+internal val Res.string.str_14514: StringResource
+  get() = String10.str_14514
+
+@ExperimentalResourceApi
+internal val Res.string.str_14515: StringResource
+  get() = String10.str_14515
+
+@ExperimentalResourceApi
+internal val Res.string.str_14516: StringResource
+  get() = String10.str_14516
+
+@ExperimentalResourceApi
+internal val Res.string.str_14517: StringResource
+  get() = String10.str_14517
+
+@ExperimentalResourceApi
+internal val Res.string.str_14518: StringResource
+  get() = String10.str_14518
+
+@ExperimentalResourceApi
+internal val Res.string.str_14519: StringResource
+  get() = String10.str_14519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1452: StringResource
+  get() = String10.str_1452
+
+@ExperimentalResourceApi
+internal val Res.string.str_14520: StringResource
+  get() = String10.str_14520
+
+@ExperimentalResourceApi
+internal val Res.string.str_14521: StringResource
+  get() = String10.str_14521
+
+@ExperimentalResourceApi
+internal val Res.string.str_14522: StringResource
+  get() = String10.str_14522
+
+@ExperimentalResourceApi
+internal val Res.string.str_14523: StringResource
+  get() = String10.str_14523
+
+@ExperimentalResourceApi
+internal val Res.string.str_14524: StringResource
+  get() = String10.str_14524
+
+@ExperimentalResourceApi
+internal val Res.string.str_14525: StringResource
+  get() = String10.str_14525
+
+@ExperimentalResourceApi
+internal val Res.string.str_14526: StringResource
+  get() = String10.str_14526
+
+@ExperimentalResourceApi
+internal val Res.string.str_14527: StringResource
+  get() = String10.str_14527
+
+@ExperimentalResourceApi
+internal val Res.string.str_14528: StringResource
+  get() = String10.str_14528
+
+@ExperimentalResourceApi
+internal val Res.string.str_14529: StringResource
+  get() = String10.str_14529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1453: StringResource
+  get() = String10.str_1453
+
+@ExperimentalResourceApi
+internal val Res.string.str_14530: StringResource
+  get() = String10.str_14530
+
+@ExperimentalResourceApi
+internal val Res.string.str_14531: StringResource
+  get() = String10.str_14531
+
+@ExperimentalResourceApi
+internal val Res.string.str_14532: StringResource
+  get() = String10.str_14532
+
+@ExperimentalResourceApi
+internal val Res.string.str_14533: StringResource
+  get() = String10.str_14533
+
+@ExperimentalResourceApi
+internal val Res.string.str_14534: StringResource
+  get() = String10.str_14534
+
+@ExperimentalResourceApi
+internal val Res.string.str_14535: StringResource
+  get() = String10.str_14535
+
+@ExperimentalResourceApi
+internal val Res.string.str_14536: StringResource
+  get() = String10.str_14536
+
+@ExperimentalResourceApi
+internal val Res.string.str_14537: StringResource
+  get() = String10.str_14537
+
+@ExperimentalResourceApi
+internal val Res.string.str_14538: StringResource
+  get() = String10.str_14538
+
+@ExperimentalResourceApi
+internal val Res.string.str_14539: StringResource
+  get() = String10.str_14539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1454: StringResource
+  get() = String10.str_1454
+
+@ExperimentalResourceApi
+internal val Res.string.str_14540: StringResource
+  get() = String10.str_14540
+
+@ExperimentalResourceApi
+internal val Res.string.str_14541: StringResource
+  get() = String10.str_14541
+
+@ExperimentalResourceApi
+internal val Res.string.str_14542: StringResource
+  get() = String10.str_14542
+
+@ExperimentalResourceApi
+internal val Res.string.str_14543: StringResource
+  get() = String10.str_14543
+
+@ExperimentalResourceApi
+internal val Res.string.str_14544: StringResource
+  get() = String10.str_14544
+
+@ExperimentalResourceApi
+internal val Res.string.str_14545: StringResource
+  get() = String10.str_14545
+
+@ExperimentalResourceApi
+internal val Res.string.str_14546: StringResource
+  get() = String10.str_14546
+
+@ExperimentalResourceApi
+internal val Res.string.str_14547: StringResource
+  get() = String10.str_14547
+
+@ExperimentalResourceApi
+internal val Res.string.str_14548: StringResource
+  get() = String10.str_14548
+
+@ExperimentalResourceApi
+internal val Res.string.str_14549: StringResource
+  get() = String10.str_14549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1455: StringResource
+  get() = String10.str_1455
+
+@ExperimentalResourceApi
+internal val Res.string.str_14550: StringResource
+  get() = String10.str_14550
+
+@ExperimentalResourceApi
+internal val Res.string.str_14551: StringResource
+  get() = String10.str_14551
+
+@ExperimentalResourceApi
+internal val Res.string.str_14552: StringResource
+  get() = String10.str_14552
+
+@ExperimentalResourceApi
+internal val Res.string.str_14553: StringResource
+  get() = String10.str_14553
+
+@ExperimentalResourceApi
+internal val Res.string.str_14554: StringResource
+  get() = String10.str_14554
+
+@ExperimentalResourceApi
+internal val Res.string.str_14555: StringResource
+  get() = String10.str_14555
+
+@ExperimentalResourceApi
+internal val Res.string.str_14556: StringResource
+  get() = String10.str_14556
+
+@ExperimentalResourceApi
+internal val Res.string.str_14557: StringResource
+  get() = String10.str_14557
+
+@ExperimentalResourceApi
+internal val Res.string.str_14558: StringResource
+  get() = String10.str_14558
+
+@ExperimentalResourceApi
+internal val Res.string.str_14559: StringResource
+  get() = String10.str_14559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1456: StringResource
+  get() = String10.str_1456
+
+@ExperimentalResourceApi
+internal val Res.string.str_14560: StringResource
+  get() = String10.str_14560
+
+@ExperimentalResourceApi
+internal val Res.string.str_14561: StringResource
+  get() = String10.str_14561
+
+@ExperimentalResourceApi
+internal val Res.string.str_14562: StringResource
+  get() = String10.str_14562
+
+@ExperimentalResourceApi
+internal val Res.string.str_14563: StringResource
+  get() = String10.str_14563
+
+@ExperimentalResourceApi
+internal val Res.string.str_14564: StringResource
+  get() = String10.str_14564
+
+@ExperimentalResourceApi
+internal val Res.string.str_14565: StringResource
+  get() = String10.str_14565
+
+@ExperimentalResourceApi
+internal val Res.string.str_14566: StringResource
+  get() = String10.str_14566
+
+@ExperimentalResourceApi
+internal val Res.string.str_14567: StringResource
+  get() = String10.str_14567
+
+@ExperimentalResourceApi
+internal val Res.string.str_14568: StringResource
+  get() = String10.str_14568
+
+@ExperimentalResourceApi
+internal val Res.string.str_14569: StringResource
+  get() = String10.str_14569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1457: StringResource
+  get() = String10.str_1457
+
+@ExperimentalResourceApi
+internal val Res.string.str_14570: StringResource
+  get() = String10.str_14570
+
+@ExperimentalResourceApi
+internal val Res.string.str_14571: StringResource
+  get() = String10.str_14571
+
+@ExperimentalResourceApi
+internal val Res.string.str_14572: StringResource
+  get() = String10.str_14572
+
+@ExperimentalResourceApi
+internal val Res.string.str_14573: StringResource
+  get() = String10.str_14573
+
+@ExperimentalResourceApi
+internal val Res.string.str_14574: StringResource
+  get() = String10.str_14574
+
+@ExperimentalResourceApi
+internal val Res.string.str_14575: StringResource
+  get() = String10.str_14575
+
+@ExperimentalResourceApi
+internal val Res.string.str_14576: StringResource
+  get() = String10.str_14576
+
+@ExperimentalResourceApi
+internal val Res.string.str_14577: StringResource
+  get() = String10.str_14577
+
+@ExperimentalResourceApi
+internal val Res.string.str_14578: StringResource
+  get() = String10.str_14578
+
+@ExperimentalResourceApi
+internal val Res.string.str_14579: StringResource
+  get() = String10.str_14579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1458: StringResource
+  get() = String10.str_1458
+
+@ExperimentalResourceApi
+internal val Res.string.str_14580: StringResource
+  get() = String10.str_14580
+
+@ExperimentalResourceApi
+internal val Res.string.str_14581: StringResource
+  get() = String10.str_14581
+
+@ExperimentalResourceApi
+internal val Res.string.str_14582: StringResource
+  get() = String10.str_14582
+
+@ExperimentalResourceApi
+internal val Res.string.str_14583: StringResource
+  get() = String10.str_14583
+
+@ExperimentalResourceApi
+internal val Res.string.str_14584: StringResource
+  get() = String10.str_14584
+
+@ExperimentalResourceApi
+internal val Res.string.str_14585: StringResource
+  get() = String10.str_14585
+
+@ExperimentalResourceApi
+internal val Res.string.str_14586: StringResource
+  get() = String10.str_14586
+
+@ExperimentalResourceApi
+internal val Res.string.str_14587: StringResource
+  get() = String10.str_14587
+
+@ExperimentalResourceApi
+internal val Res.string.str_14588: StringResource
+  get() = String10.str_14588
+
+@ExperimentalResourceApi
+internal val Res.string.str_14589: StringResource
+  get() = String10.str_14589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1459: StringResource
+  get() = String10.str_1459
+
+@ExperimentalResourceApi
+internal val Res.string.str_14590: StringResource
+  get() = String10.str_14590
+
+@ExperimentalResourceApi
+internal val Res.string.str_14591: StringResource
+  get() = String10.str_14591
+
+@ExperimentalResourceApi
+internal val Res.string.str_14592: StringResource
+  get() = String10.str_14592
+
+@ExperimentalResourceApi
+internal val Res.string.str_14593: StringResource
+  get() = String10.str_14593
+
+@ExperimentalResourceApi
+internal val Res.string.str_14594: StringResource
+  get() = String10.str_14594
+
+@ExperimentalResourceApi
+internal val Res.string.str_14595: StringResource
+  get() = String10.str_14595
+
+@ExperimentalResourceApi
+internal val Res.string.str_14596: StringResource
+  get() = String10.str_14596
+
+@ExperimentalResourceApi
+internal val Res.string.str_14597: StringResource
+  get() = String10.str_14597
+
+@ExperimentalResourceApi
+internal val Res.string.str_14598: StringResource
+  get() = String10.str_14598
+
+@ExperimentalResourceApi
+internal val Res.string.str_14599: StringResource
+  get() = String10.str_14599
+
+@ExperimentalResourceApi
+internal val Res.string.str_146: StringResource
+  get() = String10.str_146
+
+@ExperimentalResourceApi
+internal val Res.string.str_1460: StringResource
+  get() = String10.str_1460
+
+@ExperimentalResourceApi
+internal val Res.string.str_14600: StringResource
+  get() = String10.str_14600
+
+@ExperimentalResourceApi
+internal val Res.string.str_14601: StringResource
+  get() = String10.str_14601
+
+@ExperimentalResourceApi
+internal val Res.string.str_14602: StringResource
+  get() = String10.str_14602
+
+@ExperimentalResourceApi
+internal val Res.string.str_14603: StringResource
+  get() = String10.str_14603
+
+@ExperimentalResourceApi
+internal val Res.string.str_14604: StringResource
+  get() = String10.str_14604
+
+@ExperimentalResourceApi
+internal val Res.string.str_14605: StringResource
+  get() = String10.str_14605
+
+@ExperimentalResourceApi
+internal val Res.string.str_14606: StringResource
+  get() = String10.str_14606
+
+@ExperimentalResourceApi
+internal val Res.string.str_14607: StringResource
+  get() = String10.str_14607
+
+@ExperimentalResourceApi
+internal val Res.string.str_14608: StringResource
+  get() = String10.str_14608
+
+@ExperimentalResourceApi
+internal val Res.string.str_14609: StringResource
+  get() = String10.str_14609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1461: StringResource
+  get() = String10.str_1461
+
+@ExperimentalResourceApi
+internal val Res.string.str_14610: StringResource
+  get() = String10.str_14610
+
+@ExperimentalResourceApi
+internal val Res.string.str_14611: StringResource
+  get() = String10.str_14611
+
+@ExperimentalResourceApi
+internal val Res.string.str_14612: StringResource
+  get() = String10.str_14612
+
+@ExperimentalResourceApi
+internal val Res.string.str_14613: StringResource
+  get() = String10.str_14613
+
+@ExperimentalResourceApi
+internal val Res.string.str_14614: StringResource
+  get() = String10.str_14614
+
+@ExperimentalResourceApi
+internal val Res.string.str_14615: StringResource
+  get() = String10.str_14615
+
+@ExperimentalResourceApi
+internal val Res.string.str_14616: StringResource
+  get() = String10.str_14616
+
+@ExperimentalResourceApi
+internal val Res.string.str_14617: StringResource
+  get() = String10.str_14617
+
+@ExperimentalResourceApi
+internal val Res.string.str_14618: StringResource
+  get() = String10.str_14618
+
+@ExperimentalResourceApi
+internal val Res.string.str_14619: StringResource
+  get() = String10.str_14619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1462: StringResource
+  get() = String10.str_1462
+
+@ExperimentalResourceApi
+internal val Res.string.str_14620: StringResource
+  get() = String10.str_14620
+
+@ExperimentalResourceApi
+internal val Res.string.str_14621: StringResource
+  get() = String10.str_14621
+
+@ExperimentalResourceApi
+internal val Res.string.str_14622: StringResource
+  get() = String10.str_14622
+
+@ExperimentalResourceApi
+internal val Res.string.str_14623: StringResource
+  get() = String10.str_14623
+
+@ExperimentalResourceApi
+internal val Res.string.str_14624: StringResource
+  get() = String10.str_14624
+
+@ExperimentalResourceApi
+internal val Res.string.str_14625: StringResource
+  get() = String10.str_14625
+
+@ExperimentalResourceApi
+internal val Res.string.str_14626: StringResource
+  get() = String10.str_14626
+
+@ExperimentalResourceApi
+internal val Res.string.str_14627: StringResource
+  get() = String10.str_14627
+
+@ExperimentalResourceApi
+internal val Res.string.str_14628: StringResource
+  get() = String10.str_14628
+
+@ExperimentalResourceApi
+internal val Res.string.str_14629: StringResource
+  get() = String10.str_14629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1463: StringResource
+  get() = String10.str_1463
+
+@ExperimentalResourceApi
+internal val Res.string.str_14630: StringResource
+  get() = String10.str_14630
+
+@ExperimentalResourceApi
+internal val Res.string.str_14631: StringResource
+  get() = String10.str_14631
+
+@ExperimentalResourceApi
+internal val Res.string.str_14632: StringResource
+  get() = String10.str_14632
+
+@ExperimentalResourceApi
+internal val Res.string.str_14633: StringResource
+  get() = String10.str_14633
+
+@ExperimentalResourceApi
+internal val Res.string.str_14634: StringResource
+  get() = String10.str_14634
+
+@ExperimentalResourceApi
+internal val Res.string.str_14635: StringResource
+  get() = String10.str_14635
+
+@ExperimentalResourceApi
+internal val Res.string.str_14636: StringResource
+  get() = String10.str_14636
+
+@ExperimentalResourceApi
+internal val Res.string.str_14637: StringResource
+  get() = String10.str_14637
+
+@ExperimentalResourceApi
+internal val Res.string.str_14638: StringResource
+  get() = String10.str_14638
+
+@ExperimentalResourceApi
+internal val Res.string.str_14639: StringResource
+  get() = String10.str_14639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1464: StringResource
+  get() = String10.str_1464
+
+@ExperimentalResourceApi
+internal val Res.string.str_14640: StringResource
+  get() = String10.str_14640
+
+@ExperimentalResourceApi
+internal val Res.string.str_14641: StringResource
+  get() = String10.str_14641
+
+@ExperimentalResourceApi
+internal val Res.string.str_14642: StringResource
+  get() = String10.str_14642
+
+@ExperimentalResourceApi
+internal val Res.string.str_14643: StringResource
+  get() = String10.str_14643
+
+@ExperimentalResourceApi
+internal val Res.string.str_14644: StringResource
+  get() = String10.str_14644
+
+@ExperimentalResourceApi
+internal val Res.string.str_14645: StringResource
+  get() = String10.str_14645
+
+@ExperimentalResourceApi
+internal val Res.string.str_14646: StringResource
+  get() = String10.str_14646
+
+@ExperimentalResourceApi
+internal val Res.string.str_14647: StringResource
+  get() = String10.str_14647
+
+@ExperimentalResourceApi
+internal val Res.string.str_14648: StringResource
+  get() = String10.str_14648
+
+@ExperimentalResourceApi
+internal val Res.string.str_14649: StringResource
+  get() = String10.str_14649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1465: StringResource
+  get() = String10.str_1465
+
+@ExperimentalResourceApi
+internal val Res.string.str_14650: StringResource
+  get() = String10.str_14650
+
+@ExperimentalResourceApi
+internal val Res.string.str_14651: StringResource
+  get() = String10.str_14651
+
+@ExperimentalResourceApi
+internal val Res.string.str_14652: StringResource
+  get() = String10.str_14652
+
+@ExperimentalResourceApi
+internal val Res.string.str_14653: StringResource
+  get() = String10.str_14653
+
+@ExperimentalResourceApi
+internal val Res.string.str_14654: StringResource
+  get() = String10.str_14654
+
+@ExperimentalResourceApi
+internal val Res.string.str_14655: StringResource
+  get() = String10.str_14655
+
+@ExperimentalResourceApi
+internal val Res.string.str_14656: StringResource
+  get() = String10.str_14656
+
+@ExperimentalResourceApi
+internal val Res.string.str_14657: StringResource
+  get() = String10.str_14657
+
+@ExperimentalResourceApi
+internal val Res.string.str_14658: StringResource
+  get() = String10.str_14658
+
+@ExperimentalResourceApi
+internal val Res.string.str_14659: StringResource
+  get() = String10.str_14659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1466: StringResource
+  get() = String10.str_1466
+
+@ExperimentalResourceApi
+internal val Res.string.str_14660: StringResource
+  get() = String10.str_14660
+
+@ExperimentalResourceApi
+internal val Res.string.str_14661: StringResource
+  get() = String10.str_14661
+
+@ExperimentalResourceApi
+internal val Res.string.str_14662: StringResource
+  get() = String10.str_14662
+
+@ExperimentalResourceApi
+internal val Res.string.str_14663: StringResource
+  get() = String10.str_14663
+
+@ExperimentalResourceApi
+internal val Res.string.str_14664: StringResource
+  get() = String10.str_14664
+
+@ExperimentalResourceApi
+internal val Res.string.str_14665: StringResource
+  get() = String10.str_14665
+
+@ExperimentalResourceApi
+internal val Res.string.str_14666: StringResource
+  get() = String10.str_14666
+
+@ExperimentalResourceApi
+internal val Res.string.str_14667: StringResource
+  get() = String10.str_14667
+
+@ExperimentalResourceApi
+internal val Res.string.str_14668: StringResource
+  get() = String10.str_14668
+
+@ExperimentalResourceApi
+internal val Res.string.str_14669: StringResource
+  get() = String10.str_14669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1467: StringResource
+  get() = String10.str_1467
+
+@ExperimentalResourceApi
+internal val Res.string.str_14670: StringResource
+  get() = String10.str_14670
+
+@ExperimentalResourceApi
+internal val Res.string.str_14671: StringResource
+  get() = String10.str_14671
+
+@ExperimentalResourceApi
+internal val Res.string.str_14672: StringResource
+  get() = String10.str_14672
+
+@ExperimentalResourceApi
+internal val Res.string.str_14673: StringResource
+  get() = String10.str_14673
+
+@ExperimentalResourceApi
+internal val Res.string.str_14674: StringResource
+  get() = String10.str_14674
+
+@ExperimentalResourceApi
+internal val Res.string.str_14675: StringResource
+  get() = String10.str_14675
+
+@ExperimentalResourceApi
+internal val Res.string.str_14676: StringResource
+  get() = String10.str_14676
+
+@ExperimentalResourceApi
+internal val Res.string.str_14677: StringResource
+  get() = String10.str_14677
+
+@ExperimentalResourceApi
+internal val Res.string.str_14678: StringResource
+  get() = String10.str_14678
+
+@ExperimentalResourceApi
+internal val Res.string.str_14679: StringResource
+  get() = String10.str_14679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1468: StringResource
+  get() = String10.str_1468
+
+@ExperimentalResourceApi
+internal val Res.string.str_14680: StringResource
+  get() = String10.str_14680
+
+@ExperimentalResourceApi
+internal val Res.string.str_14681: StringResource
+  get() = String10.str_14681
+
+@ExperimentalResourceApi
+internal val Res.string.str_14682: StringResource
+  get() = String10.str_14682
+
+@ExperimentalResourceApi
+internal val Res.string.str_14683: StringResource
+  get() = String10.str_14683
+
+@ExperimentalResourceApi
+internal val Res.string.str_14684: StringResource
+  get() = String10.str_14684
+
+@ExperimentalResourceApi
+internal val Res.string.str_14685: StringResource
+  get() = String10.str_14685
+
+@ExperimentalResourceApi
+internal val Res.string.str_14686: StringResource
+  get() = String10.str_14686
+
+@ExperimentalResourceApi
+internal val Res.string.str_14687: StringResource
+  get() = String10.str_14687
+
+@ExperimentalResourceApi
+internal val Res.string.str_14688: StringResource
+  get() = String10.str_14688
+
+@ExperimentalResourceApi
+internal val Res.string.str_14689: StringResource
+  get() = String10.str_14689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1469: StringResource
+  get() = String10.str_1469
+
+@ExperimentalResourceApi
+internal val Res.string.str_14690: StringResource
+  get() = String10.str_14690
+
+@ExperimentalResourceApi
+internal val Res.string.str_14691: StringResource
+  get() = String10.str_14691
+
+@ExperimentalResourceApi
+internal val Res.string.str_14692: StringResource
+  get() = String10.str_14692
+
+@ExperimentalResourceApi
+internal val Res.string.str_14693: StringResource
+  get() = String10.str_14693
+
+@ExperimentalResourceApi
+internal val Res.string.str_14694: StringResource
+  get() = String10.str_14694
+
+@ExperimentalResourceApi
+internal val Res.string.str_14695: StringResource
+  get() = String10.str_14695
+
+@ExperimentalResourceApi
+internal val Res.string.str_14696: StringResource
+  get() = String10.str_14696
+
+@ExperimentalResourceApi
+internal val Res.string.str_14697: StringResource
+  get() = String10.str_14697
+
+@ExperimentalResourceApi
+internal val Res.string.str_14698: StringResource
+  get() = String10.str_14698
+
+@ExperimentalResourceApi
+internal val Res.string.str_14699: StringResource
+  get() = String10.str_14699
+
+@ExperimentalResourceApi
+internal val Res.string.str_147: StringResource
+  get() = String10.str_147
+
+@ExperimentalResourceApi
+internal val Res.string.str_1470: StringResource
+  get() = String10.str_1470
+
+@ExperimentalResourceApi
+internal val Res.string.str_14700: StringResource
+  get() = String10.str_14700
+
+@ExperimentalResourceApi
+internal val Res.string.str_14701: StringResource
+  get() = String10.str_14701
+
+@ExperimentalResourceApi
+internal val Res.string.str_14702: StringResource
+  get() = String10.str_14702
+
+@ExperimentalResourceApi
+internal val Res.string.str_14703: StringResource
+  get() = String10.str_14703
+
+@ExperimentalResourceApi
+internal val Res.string.str_14704: StringResource
+  get() = String10.str_14704
+
+@ExperimentalResourceApi
+internal val Res.string.str_14705: StringResource
+  get() = String10.str_14705
+
+@ExperimentalResourceApi
+internal val Res.string.str_14706: StringResource
+  get() = String10.str_14706
+
+@ExperimentalResourceApi
+internal val Res.string.str_14707: StringResource
+  get() = String10.str_14707
+
+@ExperimentalResourceApi
+internal val Res.string.str_14708: StringResource
+  get() = String10.str_14708
+
+@ExperimentalResourceApi
+internal val Res.string.str_14709: StringResource
+  get() = String10.str_14709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1471: StringResource
+  get() = String10.str_1471
+
+@ExperimentalResourceApi
+internal val Res.string.str_14710: StringResource
+  get() = String10.str_14710
+
+@ExperimentalResourceApi
+internal val Res.string.str_14711: StringResource
+  get() = String10.str_14711
+
+@ExperimentalResourceApi
+internal val Res.string.str_14712: StringResource
+  get() = String10.str_14712
+
+@ExperimentalResourceApi
+internal val Res.string.str_14713: StringResource
+  get() = String10.str_14713
+
+@ExperimentalResourceApi
+internal val Res.string.str_14714: StringResource
+  get() = String10.str_14714
+
+@ExperimentalResourceApi
+internal val Res.string.str_14715: StringResource
+  get() = String10.str_14715
+
+@ExperimentalResourceApi
+internal val Res.string.str_14716: StringResource
+  get() = String10.str_14716
+
+@ExperimentalResourceApi
+internal val Res.string.str_14717: StringResource
+  get() = String10.str_14717
+
+@ExperimentalResourceApi
+internal val Res.string.str_14718: StringResource
+  get() = String10.str_14718
+
+@ExperimentalResourceApi
+internal val Res.string.str_14719: StringResource
+  get() = String10.str_14719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1472: StringResource
+  get() = String10.str_1472
+
+@ExperimentalResourceApi
+internal val Res.string.str_14720: StringResource
+  get() = String10.str_14720
+
+@ExperimentalResourceApi
+internal val Res.string.str_14721: StringResource
+  get() = String10.str_14721
+
+@ExperimentalResourceApi
+internal val Res.string.str_14722: StringResource
+  get() = String10.str_14722
+
+@ExperimentalResourceApi
+internal val Res.string.str_14723: StringResource
+  get() = String10.str_14723
+
+@ExperimentalResourceApi
+internal val Res.string.str_14724: StringResource
+  get() = String10.str_14724
+
+@ExperimentalResourceApi
+internal val Res.string.str_14725: StringResource
+  get() = String10.str_14725
+
+@ExperimentalResourceApi
+internal val Res.string.str_14726: StringResource
+  get() = String10.str_14726
+
+@ExperimentalResourceApi
+internal val Res.string.str_14727: StringResource
+  get() = String10.str_14727
+
+@ExperimentalResourceApi
+internal val Res.string.str_14728: StringResource
+  get() = String10.str_14728
+
+@ExperimentalResourceApi
+internal val Res.string.str_14729: StringResource
+  get() = String10.str_14729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1473: StringResource
+  get() = String10.str_1473
+
+@ExperimentalResourceApi
+internal val Res.string.str_14730: StringResource
+  get() = String10.str_14730
+
+@ExperimentalResourceApi
+internal val Res.string.str_14731: StringResource
+  get() = String10.str_14731
+
+@ExperimentalResourceApi
+internal val Res.string.str_14732: StringResource
+  get() = String10.str_14732
+
+@ExperimentalResourceApi
+internal val Res.string.str_14733: StringResource
+  get() = String10.str_14733
+
+@ExperimentalResourceApi
+internal val Res.string.str_14734: StringResource
+  get() = String10.str_14734
+
+@ExperimentalResourceApi
+internal val Res.string.str_14735: StringResource
+  get() = String10.str_14735
+
+@ExperimentalResourceApi
+internal val Res.string.str_14736: StringResource
+  get() = String10.str_14736
+
+@ExperimentalResourceApi
+internal val Res.string.str_14737: StringResource
+  get() = String10.str_14737
+
+@ExperimentalResourceApi
+internal val Res.string.str_14738: StringResource
+  get() = String10.str_14738
+
+@ExperimentalResourceApi
+internal val Res.string.str_14739: StringResource
+  get() = String10.str_14739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1474: StringResource
+  get() = String10.str_1474
+
+@ExperimentalResourceApi
+internal val Res.string.str_14740: StringResource
+  get() = String10.str_14740
+
+@ExperimentalResourceApi
+internal val Res.string.str_14741: StringResource
+  get() = String10.str_14741
+
+@ExperimentalResourceApi
+internal val Res.string.str_14742: StringResource
+  get() = String10.str_14742
+
+@ExperimentalResourceApi
+internal val Res.string.str_14743: StringResource
+  get() = String10.str_14743
+
+@ExperimentalResourceApi
+internal val Res.string.str_14744: StringResource
+  get() = String10.str_14744
+
+@ExperimentalResourceApi
+internal val Res.string.str_14745: StringResource
+  get() = String10.str_14745
+
+@ExperimentalResourceApi
+internal val Res.string.str_14746: StringResource
+  get() = String10.str_14746
+
+@ExperimentalResourceApi
+internal val Res.string.str_14747: StringResource
+  get() = String10.str_14747
+
+@ExperimentalResourceApi
+internal val Res.string.str_14748: StringResource
+  get() = String10.str_14748
+
+@ExperimentalResourceApi
+internal val Res.string.str_14749: StringResource
+  get() = String10.str_14749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1475: StringResource
+  get() = String10.str_1475
+
+@ExperimentalResourceApi
+internal val Res.string.str_14750: StringResource
+  get() = String10.str_14750
+
+@ExperimentalResourceApi
+internal val Res.string.str_14751: StringResource
+  get() = String10.str_14751
+
+@ExperimentalResourceApi
+internal val Res.string.str_14752: StringResource
+  get() = String10.str_14752
+
+@ExperimentalResourceApi
+internal val Res.string.str_14753: StringResource
+  get() = String10.str_14753
+
+@ExperimentalResourceApi
+internal val Res.string.str_14754: StringResource
+  get() = String10.str_14754
+
+@ExperimentalResourceApi
+internal val Res.string.str_14755: StringResource
+  get() = String10.str_14755
+
+@ExperimentalResourceApi
+internal val Res.string.str_14756: StringResource
+  get() = String10.str_14756
+
+@ExperimentalResourceApi
+internal val Res.string.str_14757: StringResource
+  get() = String10.str_14757
+
+@ExperimentalResourceApi
+internal val Res.string.str_14758: StringResource
+  get() = String10.str_14758
+
+@ExperimentalResourceApi
+internal val Res.string.str_14759: StringResource
+  get() = String10.str_14759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1476: StringResource
+  get() = String10.str_1476
+
+@ExperimentalResourceApi
+internal val Res.string.str_14760: StringResource
+  get() = String10.str_14760
+
+@ExperimentalResourceApi
+internal val Res.string.str_14761: StringResource
+  get() = String10.str_14761
+
+@ExperimentalResourceApi
+internal val Res.string.str_14762: StringResource
+  get() = String10.str_14762
+
+@ExperimentalResourceApi
+internal val Res.string.str_14763: StringResource
+  get() = String10.str_14763
+
+@ExperimentalResourceApi
+internal val Res.string.str_14764: StringResource
+  get() = String10.str_14764
+
+@ExperimentalResourceApi
+internal val Res.string.str_14765: StringResource
+  get() = String10.str_14765
+
+@ExperimentalResourceApi
+internal val Res.string.str_14766: StringResource
+  get() = String10.str_14766
+
+@ExperimentalResourceApi
+internal val Res.string.str_14767: StringResource
+  get() = String10.str_14767
+
+@ExperimentalResourceApi
+internal val Res.string.str_14768: StringResource
+  get() = String10.str_14768
+
+@ExperimentalResourceApi
+internal val Res.string.str_14769: StringResource
+  get() = String10.str_14769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1477: StringResource
+  get() = String10.str_1477
+
+@ExperimentalResourceApi
+internal val Res.string.str_14770: StringResource
+  get() = String10.str_14770
+
+@ExperimentalResourceApi
+internal val Res.string.str_14771: StringResource
+  get() = String10.str_14771
+
+@ExperimentalResourceApi
+internal val Res.string.str_14772: StringResource
+  get() = String10.str_14772
+
+@ExperimentalResourceApi
+internal val Res.string.str_14773: StringResource
+  get() = String10.str_14773
+
+@ExperimentalResourceApi
+internal val Res.string.str_14774: StringResource
+  get() = String10.str_14774
+
+@ExperimentalResourceApi
+internal val Res.string.str_14775: StringResource
+  get() = String10.str_14775
+
+@ExperimentalResourceApi
+internal val Res.string.str_14776: StringResource
+  get() = String10.str_14776
+
+@ExperimentalResourceApi
+internal val Res.string.str_14777: StringResource
+  get() = String10.str_14777
+
+@ExperimentalResourceApi
+internal val Res.string.str_14778: StringResource
+  get() = String10.str_14778
+
+@ExperimentalResourceApi
+internal val Res.string.str_14779: StringResource
+  get() = String10.str_14779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1478: StringResource
+  get() = String10.str_1478
+
+@ExperimentalResourceApi
+internal val Res.string.str_14780: StringResource
+  get() = String10.str_14780
+
+@ExperimentalResourceApi
+internal val Res.string.str_14781: StringResource
+  get() = String10.str_14781
+
+@ExperimentalResourceApi
+internal val Res.string.str_14782: StringResource
+  get() = String10.str_14782
+
+@ExperimentalResourceApi
+internal val Res.string.str_14783: StringResource
+  get() = String10.str_14783
+
+@ExperimentalResourceApi
+internal val Res.string.str_14784: StringResource
+  get() = String10.str_14784
+
+@ExperimentalResourceApi
+internal val Res.string.str_14785: StringResource
+  get() = String10.str_14785
+
+@ExperimentalResourceApi
+internal val Res.string.str_14786: StringResource
+  get() = String10.str_14786
+
+@ExperimentalResourceApi
+internal val Res.string.str_14787: StringResource
+  get() = String10.str_14787
+
+@ExperimentalResourceApi
+internal val Res.string.str_14788: StringResource
+  get() = String10.str_14788
+
+@ExperimentalResourceApi
+internal val Res.string.str_14789: StringResource
+  get() = String10.str_14789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1479: StringResource
+  get() = String10.str_1479
+
+@ExperimentalResourceApi
+internal val Res.string.str_14790: StringResource
+  get() = String10.str_14790
+
+@ExperimentalResourceApi
+internal val Res.string.str_14791: StringResource
+  get() = String10.str_14791
+
+@ExperimentalResourceApi
+internal val Res.string.str_14792: StringResource
+  get() = String10.str_14792
+
+@ExperimentalResourceApi
+internal val Res.string.str_14793: StringResource
+  get() = String10.str_14793
+
+@ExperimentalResourceApi
+internal val Res.string.str_14794: StringResource
+  get() = String10.str_14794
+
+@ExperimentalResourceApi
+internal val Res.string.str_14795: StringResource
+  get() = String10.str_14795
+
+@ExperimentalResourceApi
+internal val Res.string.str_14796: StringResource
+  get() = String10.str_14796
+
+@ExperimentalResourceApi
+internal val Res.string.str_14797: StringResource
+  get() = String10.str_14797
+
+@ExperimentalResourceApi
+internal val Res.string.str_14798: StringResource
+  get() = String10.str_14798
+
+@ExperimentalResourceApi
+internal val Res.string.str_14799: StringResource
+  get() = String10.str_14799
+
+@ExperimentalResourceApi
+internal val Res.string.str_148: StringResource
+  get() = String10.str_148
+
+@ExperimentalResourceApi
+internal val Res.string.str_1480: StringResource
+  get() = String10.str_1480
+
+@ExperimentalResourceApi
+internal val Res.string.str_14800: StringResource
+  get() = String10.str_14800
+
+@ExperimentalResourceApi
+internal val Res.string.str_14801: StringResource
+  get() = String10.str_14801
+
+@ExperimentalResourceApi
+internal val Res.string.str_14802: StringResource
+  get() = String10.str_14802
+
+@ExperimentalResourceApi
+internal val Res.string.str_14803: StringResource
+  get() = String10.str_14803
+
+@ExperimentalResourceApi
+internal val Res.string.str_14804: StringResource
+  get() = String10.str_14804
+
+@ExperimentalResourceApi
+internal val Res.string.str_14805: StringResource
+  get() = String10.str_14805
+
+@ExperimentalResourceApi
+internal val Res.string.str_14806: StringResource
+  get() = String10.str_14806
+
+@ExperimentalResourceApi
+internal val Res.string.str_14807: StringResource
+  get() = String10.str_14807
+
+@ExperimentalResourceApi
+internal val Res.string.str_14808: StringResource
+  get() = String10.str_14808
+
+@ExperimentalResourceApi
+internal val Res.string.str_14809: StringResource
+  get() = String10.str_14809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1481: StringResource
+  get() = String10.str_1481
+
+@ExperimentalResourceApi
+internal val Res.string.str_14810: StringResource
+  get() = String10.str_14810
+
+@ExperimentalResourceApi
+internal val Res.string.str_14811: StringResource
+  get() = String10.str_14811
+
+@ExperimentalResourceApi
+internal val Res.string.str_14812: StringResource
+  get() = String10.str_14812
+
+@ExperimentalResourceApi
+internal val Res.string.str_14813: StringResource
+  get() = String10.str_14813
+
+@ExperimentalResourceApi
+internal val Res.string.str_14814: StringResource
+  get() = String10.str_14814
+
+@ExperimentalResourceApi
+internal val Res.string.str_14815: StringResource
+  get() = String10.str_14815
+
+@ExperimentalResourceApi
+internal val Res.string.str_14816: StringResource
+  get() = String10.str_14816
+
+@ExperimentalResourceApi
+internal val Res.string.str_14817: StringResource
+  get() = String10.str_14817
+
+@ExperimentalResourceApi
+internal val Res.string.str_14818: StringResource
+  get() = String10.str_14818
+
+@ExperimentalResourceApi
+internal val Res.string.str_14819: StringResource
+  get() = String10.str_14819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1482: StringResource
+  get() = String10.str_1482
+
+@ExperimentalResourceApi
+internal val Res.string.str_14820: StringResource
+  get() = String10.str_14820
+
+@ExperimentalResourceApi
+internal val Res.string.str_14821: StringResource
+  get() = String10.str_14821
+
+@ExperimentalResourceApi
+internal val Res.string.str_14822: StringResource
+  get() = String10.str_14822
+
+@ExperimentalResourceApi
+internal val Res.string.str_14823: StringResource
+  get() = String10.str_14823
+
+@ExperimentalResourceApi
+internal val Res.string.str_14824: StringResource
+  get() = String10.str_14824
+
+@ExperimentalResourceApi
+internal val Res.string.str_14825: StringResource
+  get() = String10.str_14825
+
+@ExperimentalResourceApi
+internal val Res.string.str_14826: StringResource
+  get() = String10.str_14826
+
+@ExperimentalResourceApi
+internal val Res.string.str_14827: StringResource
+  get() = String10.str_14827
+
+@ExperimentalResourceApi
+internal val Res.string.str_14828: StringResource
+  get() = String10.str_14828
+
+@ExperimentalResourceApi
+internal val Res.string.str_14829: StringResource
+  get() = String10.str_14829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1483: StringResource
+  get() = String10.str_1483
+
+@ExperimentalResourceApi
+internal val Res.string.str_14830: StringResource
+  get() = String10.str_14830
+
+@ExperimentalResourceApi
+internal val Res.string.str_14831: StringResource
+  get() = String10.str_14831
+
+@ExperimentalResourceApi
+internal val Res.string.str_14832: StringResource
+  get() = String10.str_14832
+
+@ExperimentalResourceApi
+internal val Res.string.str_14833: StringResource
+  get() = String10.str_14833
+
+@ExperimentalResourceApi
+internal val Res.string.str_14834: StringResource
+  get() = String10.str_14834
+
+@ExperimentalResourceApi
+internal val Res.string.str_14835: StringResource
+  get() = String10.str_14835
+
+@ExperimentalResourceApi
+internal val Res.string.str_14836: StringResource
+  get() = String10.str_14836
+
+@ExperimentalResourceApi
+internal val Res.string.str_14837: StringResource
+  get() = String10.str_14837
+
+@ExperimentalResourceApi
+internal val Res.string.str_14838: StringResource
+  get() = String10.str_14838
+
+@ExperimentalResourceApi
+internal val Res.string.str_14839: StringResource
+  get() = String10.str_14839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1484: StringResource
+  get() = String10.str_1484
+
+@ExperimentalResourceApi
+internal val Res.string.str_14840: StringResource
+  get() = String10.str_14840
+
+@ExperimentalResourceApi
+internal val Res.string.str_14841: StringResource
+  get() = String10.str_14841
+
+@ExperimentalResourceApi
+internal val Res.string.str_14842: StringResource
+  get() = String10.str_14842
+
+@ExperimentalResourceApi
+internal val Res.string.str_14843: StringResource
+  get() = String10.str_14843
+
+@ExperimentalResourceApi
+internal val Res.string.str_14844: StringResource
+  get() = String10.str_14844
+
+@ExperimentalResourceApi
+internal val Res.string.str_14845: StringResource
+  get() = String10.str_14845
+
+@ExperimentalResourceApi
+internal val Res.string.str_14846: StringResource
+  get() = String10.str_14846
+
+@ExperimentalResourceApi
+internal val Res.string.str_14847: StringResource
+  get() = String10.str_14847
+
+@ExperimentalResourceApi
+internal val Res.string.str_14848: StringResource
+  get() = String10.str_14848
+
+@ExperimentalResourceApi
+internal val Res.string.str_14849: StringResource
+  get() = String10.str_14849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1485: StringResource
+  get() = String10.str_1485
+
+@ExperimentalResourceApi
+internal val Res.string.str_14850: StringResource
+  get() = String10.str_14850
+
+@ExperimentalResourceApi
+internal val Res.string.str_14851: StringResource
+  get() = String10.str_14851
+
+@ExperimentalResourceApi
+internal val Res.string.str_14852: StringResource
+  get() = String10.str_14852
+
+@ExperimentalResourceApi
+internal val Res.string.str_14853: StringResource
+  get() = String10.str_14853
+
+@ExperimentalResourceApi
+internal val Res.string.str_14854: StringResource
+  get() = String10.str_14854
+
+@ExperimentalResourceApi
+internal val Res.string.str_14855: StringResource
+  get() = String10.str_14855
+
+@ExperimentalResourceApi
+internal val Res.string.str_14856: StringResource
+  get() = String10.str_14856
+
+@ExperimentalResourceApi
+internal val Res.string.str_14857: StringResource
+  get() = String10.str_14857
+
+@ExperimentalResourceApi
+internal val Res.string.str_14858: StringResource
+  get() = String10.str_14858
+
+@ExperimentalResourceApi
+internal val Res.string.str_14859: StringResource
+  get() = String10.str_14859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1486: StringResource
+  get() = String10.str_1486
+
+@ExperimentalResourceApi
+internal val Res.string.str_14860: StringResource
+  get() = String10.str_14860
+
+@ExperimentalResourceApi
+internal val Res.string.str_14861: StringResource
+  get() = String10.str_14861
+
+@ExperimentalResourceApi
+internal val Res.string.str_14862: StringResource
+  get() = String10.str_14862
+
+@ExperimentalResourceApi
+internal val Res.string.str_14863: StringResource
+  get() = String10.str_14863
+
+@ExperimentalResourceApi
+internal val Res.string.str_14864: StringResource
+  get() = String10.str_14864
+
+@ExperimentalResourceApi
+internal val Res.string.str_14865: StringResource
+  get() = String10.str_14865
+
+@ExperimentalResourceApi
+internal val Res.string.str_14866: StringResource
+  get() = String10.str_14866
+
+@ExperimentalResourceApi
+internal val Res.string.str_14867: StringResource
+  get() = String10.str_14867
+
+@ExperimentalResourceApi
+internal val Res.string.str_14868: StringResource
+  get() = String10.str_14868
+
+@ExperimentalResourceApi
+internal val Res.string.str_14869: StringResource
+  get() = String10.str_14869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1487: StringResource
+  get() = String10.str_1487
+
+@ExperimentalResourceApi
+internal val Res.string.str_14870: StringResource
+  get() = String10.str_14870
+
+@ExperimentalResourceApi
+internal val Res.string.str_14871: StringResource
+  get() = String10.str_14871
+
+@ExperimentalResourceApi
+internal val Res.string.str_14872: StringResource
+  get() = String10.str_14872
+
+@ExperimentalResourceApi
+internal val Res.string.str_14873: StringResource
+  get() = String10.str_14873
+
+@ExperimentalResourceApi
+internal val Res.string.str_14874: StringResource
+  get() = String10.str_14874
+
+@ExperimentalResourceApi
+internal val Res.string.str_14875: StringResource
+  get() = String10.str_14875
+
+@ExperimentalResourceApi
+internal val Res.string.str_14876: StringResource
+  get() = String10.str_14876
+
+@ExperimentalResourceApi
+internal val Res.string.str_14877: StringResource
+  get() = String10.str_14877
+
+@ExperimentalResourceApi
+internal val Res.string.str_14878: StringResource
+  get() = String10.str_14878
+
+@ExperimentalResourceApi
+internal val Res.string.str_14879: StringResource
+  get() = String10.str_14879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1488: StringResource
+  get() = String10.str_1488
+
+@ExperimentalResourceApi
+internal val Res.string.str_14880: StringResource
+  get() = String10.str_14880
+
+@ExperimentalResourceApi
+internal val Res.string.str_14881: StringResource
+  get() = String10.str_14881
+
+@ExperimentalResourceApi
+internal val Res.string.str_14882: StringResource
+  get() = String10.str_14882
+
+@ExperimentalResourceApi
+internal val Res.string.str_14883: StringResource
+  get() = String10.str_14883
+
+@ExperimentalResourceApi
+internal val Res.string.str_14884: StringResource
+  get() = String10.str_14884
+
+@ExperimentalResourceApi
+internal val Res.string.str_14885: StringResource
+  get() = String10.str_14885
+
+@ExperimentalResourceApi
+internal val Res.string.str_14886: StringResource
+  get() = String10.str_14886
+
+@ExperimentalResourceApi
+internal val Res.string.str_14887: StringResource
+  get() = String10.str_14887
+
+@ExperimentalResourceApi
+internal val Res.string.str_14888: StringResource
+  get() = String10.str_14888
+
+@ExperimentalResourceApi
+internal val Res.string.str_14889: StringResource
+  get() = String10.str_14889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1489: StringResource
+  get() = String10.str_1489
+
+@ExperimentalResourceApi
+internal val Res.string.str_14890: StringResource
+  get() = String10.str_14890
+
+@ExperimentalResourceApi
+internal val Res.string.str_14891: StringResource
+  get() = String10.str_14891
+
+@ExperimentalResourceApi
+internal val Res.string.str_14892: StringResource
+  get() = String10.str_14892
+
+@ExperimentalResourceApi
+internal val Res.string.str_14893: StringResource
+  get() = String10.str_14893
+
+@ExperimentalResourceApi
+internal val Res.string.str_14894: StringResource
+  get() = String10.str_14894
+
+@ExperimentalResourceApi
+internal val Res.string.str_14895: StringResource
+  get() = String10.str_14895
+
+@ExperimentalResourceApi
+internal val Res.string.str_14896: StringResource
+  get() = String10.str_14896
+
+@ExperimentalResourceApi
+internal val Res.string.str_14897: StringResource
+  get() = String10.str_14897
+
+@ExperimentalResourceApi
+internal val Res.string.str_14898: StringResource
+  get() = String10.str_14898
+
+@ExperimentalResourceApi
+internal val Res.string.str_14899: StringResource
+  get() = String10.str_14899
+
+@ExperimentalResourceApi
+internal val Res.string.str_149: StringResource
+  get() = String10.str_149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1490: StringResource
+  get() = String10.str_1490
+
+@ExperimentalResourceApi
+internal val Res.string.str_14900: StringResource
+  get() = String10.str_14900
+
+@ExperimentalResourceApi
+internal val Res.string.str_14901: StringResource
+  get() = String10.str_14901
+
+@ExperimentalResourceApi
+internal val Res.string.str_14902: StringResource
+  get() = String10.str_14902
+
+@ExperimentalResourceApi
+internal val Res.string.str_14903: StringResource
+  get() = String10.str_14903
+
+@ExperimentalResourceApi
+internal val Res.string.str_14904: StringResource
+  get() = String10.str_14904
+
+@ExperimentalResourceApi
+internal val Res.string.str_14905: StringResource
+  get() = String10.str_14905
+
+@ExperimentalResourceApi
+internal val Res.string.str_14906: StringResource
+  get() = String10.str_14906
+
+@ExperimentalResourceApi
+internal val Res.string.str_14907: StringResource
+  get() = String10.str_14907
+
+@ExperimentalResourceApi
+internal val Res.string.str_14908: StringResource
+  get() = String10.str_14908
+
+@ExperimentalResourceApi
+internal val Res.string.str_14909: StringResource
+  get() = String10.str_14909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1491: StringResource
+  get() = String10.str_1491
+
+@ExperimentalResourceApi
+internal val Res.string.str_14910: StringResource
+  get() = String10.str_14910
+
+@ExperimentalResourceApi
+internal val Res.string.str_14911: StringResource
+  get() = String10.str_14911
+
+@ExperimentalResourceApi
+internal val Res.string.str_14912: StringResource
+  get() = String10.str_14912
+
+@ExperimentalResourceApi
+internal val Res.string.str_14913: StringResource
+  get() = String10.str_14913
+
+@ExperimentalResourceApi
+internal val Res.string.str_14914: StringResource
+  get() = String10.str_14914
+
+@ExperimentalResourceApi
+internal val Res.string.str_14915: StringResource
+  get() = String10.str_14915
+
+@ExperimentalResourceApi
+internal val Res.string.str_14916: StringResource
+  get() = String10.str_14916
+
+@ExperimentalResourceApi
+internal val Res.string.str_14917: StringResource
+  get() = String10.str_14917
+
+@ExperimentalResourceApi
+internal val Res.string.str_14918: StringResource
+  get() = String10.str_14918
+
+@ExperimentalResourceApi
+internal val Res.string.str_14919: StringResource
+  get() = String10.str_14919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1492: StringResource
+  get() = String10.str_1492
+
+@ExperimentalResourceApi
+internal val Res.string.str_14920: StringResource
+  get() = String10.str_14920
+
+@ExperimentalResourceApi
+internal val Res.string.str_14921: StringResource
+  get() = String10.str_14921
+
+@ExperimentalResourceApi
+internal val Res.string.str_14922: StringResource
+  get() = String10.str_14922
+
+@ExperimentalResourceApi
+internal val Res.string.str_14923: StringResource
+  get() = String10.str_14923
+
+@ExperimentalResourceApi
+internal val Res.string.str_14924: StringResource
+  get() = String10.str_14924
+
+@ExperimentalResourceApi
+internal val Res.string.str_14925: StringResource
+  get() = String10.str_14925
+
+@ExperimentalResourceApi
+internal val Res.string.str_14926: StringResource
+  get() = String10.str_14926
+
+@ExperimentalResourceApi
+internal val Res.string.str_14927: StringResource
+  get() = String10.str_14927
+
+@ExperimentalResourceApi
+internal val Res.string.str_14928: StringResource
+  get() = String10.str_14928
+
+@ExperimentalResourceApi
+internal val Res.string.str_14929: StringResource
+  get() = String10.str_14929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1493: StringResource
+  get() = String10.str_1493
+
+@ExperimentalResourceApi
+internal val Res.string.str_14930: StringResource
+  get() = String10.str_14930
+
+@ExperimentalResourceApi
+internal val Res.string.str_14931: StringResource
+  get() = String10.str_14931
+
+@ExperimentalResourceApi
+internal val Res.string.str_14932: StringResource
+  get() = String10.str_14932
+
+@ExperimentalResourceApi
+internal val Res.string.str_14933: StringResource
+  get() = String10.str_14933
+
+@ExperimentalResourceApi
+internal val Res.string.str_14934: StringResource
+  get() = String10.str_14934
+
+@ExperimentalResourceApi
+internal val Res.string.str_14935: StringResource
+  get() = String10.str_14935
+
+@ExperimentalResourceApi
+internal val Res.string.str_14936: StringResource
+  get() = String10.str_14936
+
+@ExperimentalResourceApi
+internal val Res.string.str_14937: StringResource
+  get() = String10.str_14937
+
+@ExperimentalResourceApi
+internal val Res.string.str_14938: StringResource
+  get() = String10.str_14938
+
+@ExperimentalResourceApi
+internal val Res.string.str_14939: StringResource
+  get() = String10.str_14939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1494: StringResource
+  get() = String10.str_1494
+
+@ExperimentalResourceApi
+internal val Res.string.str_14940: StringResource
+  get() = String10.str_14940
+
+@ExperimentalResourceApi
+internal val Res.string.str_14941: StringResource
+  get() = String10.str_14941
+
+@ExperimentalResourceApi
+internal val Res.string.str_14942: StringResource
+  get() = String10.str_14942
+
+@ExperimentalResourceApi
+internal val Res.string.str_14943: StringResource
+  get() = String10.str_14943
+
+@ExperimentalResourceApi
+internal val Res.string.str_14944: StringResource
+  get() = String10.str_14944
+
+@ExperimentalResourceApi
+internal val Res.string.str_14945: StringResource
+  get() = String10.str_14945
+
+@ExperimentalResourceApi
+internal val Res.string.str_14946: StringResource
+  get() = String10.str_14946
+
+@ExperimentalResourceApi
+internal val Res.string.str_14947: StringResource
+  get() = String10.str_14947

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String11.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String11.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String11 {
+  public val str_14948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14948", "str_14948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14949", "str_14949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1495", "str_1495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14950", "str_14950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14951", "str_14951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14952", "str_14952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14953", "str_14953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14954", "str_14954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14955", "str_14955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14956", "str_14956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14957", "str_14957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14958", "str_14958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14959", "str_14959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1496", "str_1496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14960", "str_14960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14961", "str_14961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14962", "str_14962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14963", "str_14963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14964", "str_14964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14965", "str_14965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14966", "str_14966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14967", "str_14967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14968", "str_14968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14969", "str_14969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1497", "str_1497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14970", "str_14970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14971", "str_14971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14972", "str_14972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14973", "str_14973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14974", "str_14974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14975", "str_14975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14976", "str_14976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14977", "str_14977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14978", "str_14978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14979", "str_14979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1498", "str_1498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14980", "str_14980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14981", "str_14981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14982", "str_14982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14983", "str_14983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14984", "str_14984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14985", "str_14985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14986", "str_14986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14987", "str_14987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14988", "str_14988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14989", "str_14989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1499", "str_1499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14990", "str_14990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14991", "str_14991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14992", "str_14992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14993", "str_14993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14994", "str_14994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14995", "str_14995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14996", "str_14996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14997", "str_14997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14998", "str_14998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14999", "str_14999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15", "str_15",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_150", "str_150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1500", "str_1500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15000", "str_15000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15001", "str_15001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15002", "str_15002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15003", "str_15003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15004", "str_15004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15005", "str_15005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15006", "str_15006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15007", "str_15007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15008", "str_15008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15009", "str_15009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1501", "str_1501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15010", "str_15010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15011", "str_15011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15012", "str_15012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15013", "str_15013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15014", "str_15014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15015", "str_15015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15016", "str_15016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15017", "str_15017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15018", "str_15018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15019", "str_15019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1502", "str_1502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15020", "str_15020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15021", "str_15021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15022", "str_15022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15023", "str_15023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15024", "str_15024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15025", "str_15025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15026", "str_15026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15027", "str_15027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15028", "str_15028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15029", "str_15029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1503", "str_1503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15030", "str_15030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15031", "str_15031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15032", "str_15032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15033", "str_15033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15034", "str_15034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15035", "str_15035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15036", "str_15036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15037", "str_15037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15038", "str_15038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15039", "str_15039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1504", "str_1504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15040", "str_15040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15041", "str_15041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15042", "str_15042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15043", "str_15043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15044", "str_15044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15045", "str_15045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15046", "str_15046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15047", "str_15047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15048", "str_15048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15049", "str_15049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1505", "str_1505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15050", "str_15050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15051", "str_15051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15052", "str_15052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15053", "str_15053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15054", "str_15054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15055", "str_15055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15056", "str_15056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15057", "str_15057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15058", "str_15058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15059", "str_15059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1506", "str_1506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15060", "str_15060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15061", "str_15061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15062", "str_15062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15063", "str_15063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15064", "str_15064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15065", "str_15065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15066", "str_15066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15067", "str_15067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15068", "str_15068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15069", "str_15069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1507", "str_1507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15070", "str_15070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15071", "str_15071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15072", "str_15072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15073", "str_15073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15074", "str_15074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15075", "str_15075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15076", "str_15076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15077", "str_15077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15078", "str_15078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15079", "str_15079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1508", "str_1508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15080", "str_15080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15081", "str_15081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15082", "str_15082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15083", "str_15083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15084", "str_15084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15085", "str_15085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15086", "str_15086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15087", "str_15087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15088", "str_15088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15089", "str_15089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1509", "str_1509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15090", "str_15090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15091", "str_15091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15092", "str_15092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15093", "str_15093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15094", "str_15094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15095", "str_15095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15096", "str_15096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15097", "str_15097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15098", "str_15098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15099", "str_15099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_151", "str_151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1510", "str_1510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15100", "str_15100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15101", "str_15101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15102", "str_15102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15103", "str_15103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15104", "str_15104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15105", "str_15105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15106", "str_15106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15107", "str_15107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15108", "str_15108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15109", "str_15109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1511", "str_1511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15110", "str_15110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15111", "str_15111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15112", "str_15112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15113", "str_15113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15114", "str_15114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15115", "str_15115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15116", "str_15116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15117", "str_15117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15118", "str_15118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15119", "str_15119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1512", "str_1512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15120", "str_15120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15121", "str_15121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15122", "str_15122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15123", "str_15123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15124", "str_15124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15125", "str_15125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15126", "str_15126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15127", "str_15127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15128", "str_15128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15129", "str_15129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1513", "str_1513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15130", "str_15130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15131", "str_15131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15132", "str_15132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15133", "str_15133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15134", "str_15134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15135", "str_15135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15136", "str_15136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15137", "str_15137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15138", "str_15138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15139", "str_15139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1514", "str_1514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15140", "str_15140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15141", "str_15141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15142", "str_15142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15143", "str_15143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15144", "str_15144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15145", "str_15145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15146", "str_15146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15147", "str_15147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15148", "str_15148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15149", "str_15149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1515", "str_1515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15150", "str_15150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15151", "str_15151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15152", "str_15152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15153", "str_15153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15154", "str_15154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15155", "str_15155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15156", "str_15156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15157", "str_15157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15158", "str_15158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15159", "str_15159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1516", "str_1516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15160", "str_15160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15161", "str_15161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15162", "str_15162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15163", "str_15163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15164", "str_15164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15165", "str_15165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15166", "str_15166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15167", "str_15167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15168", "str_15168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15169", "str_15169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1517", "str_1517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15170", "str_15170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15171", "str_15171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15172", "str_15172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15173", "str_15173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15174", "str_15174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15175", "str_15175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15176", "str_15176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15177", "str_15177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15178", "str_15178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15179", "str_15179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1518", "str_1518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15180", "str_15180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15181", "str_15181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15182", "str_15182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15183", "str_15183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15184", "str_15184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15185", "str_15185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15186", "str_15186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15187", "str_15187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15188", "str_15188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15189", "str_15189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1519", "str_1519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15190", "str_15190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15191", "str_15191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15192", "str_15192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15193", "str_15193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15194", "str_15194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15195", "str_15195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15196", "str_15196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15197", "str_15197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15198", "str_15198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15199", "str_15199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_152", "str_152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1520", "str_1520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15200", "str_15200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15201", "str_15201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15202", "str_15202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15203", "str_15203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15204", "str_15204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15205", "str_15205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15206", "str_15206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15207", "str_15207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15208", "str_15208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15209", "str_15209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1521", "str_1521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15210", "str_15210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15211", "str_15211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15212", "str_15212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15213", "str_15213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15214", "str_15214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15215", "str_15215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15216", "str_15216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15217", "str_15217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15218", "str_15218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15219", "str_15219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1522", "str_1522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15220", "str_15220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15221", "str_15221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15222", "str_15222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15223", "str_15223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15224", "str_15224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15225", "str_15225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15226", "str_15226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15227", "str_15227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15228", "str_15228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15229", "str_15229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1523", "str_1523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15230", "str_15230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15231", "str_15231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15232", "str_15232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15233", "str_15233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15234", "str_15234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15235", "str_15235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15236", "str_15236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15237", "str_15237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15238", "str_15238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15239", "str_15239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1524", "str_1524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15240", "str_15240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15241", "str_15241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15242", "str_15242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15243", "str_15243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15244", "str_15244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15245", "str_15245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15246", "str_15246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15247", "str_15247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15248", "str_15248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15249", "str_15249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1525", "str_1525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15250", "str_15250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15251", "str_15251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15252", "str_15252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15253", "str_15253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15254", "str_15254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15255", "str_15255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15256", "str_15256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15257", "str_15257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15258", "str_15258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15259", "str_15259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1526", "str_1526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15260", "str_15260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15261", "str_15261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15262", "str_15262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15263", "str_15263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15264", "str_15264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15265", "str_15265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15266", "str_15266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15267", "str_15267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15268", "str_15268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15269", "str_15269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1527", "str_1527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15270", "str_15270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15271", "str_15271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15272", "str_15272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15273", "str_15273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15274", "str_15274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15275", "str_15275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15276", "str_15276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15277", "str_15277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15278", "str_15278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15279", "str_15279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1528", "str_1528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15280", "str_15280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15281", "str_15281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15282", "str_15282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15283", "str_15283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15284", "str_15284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15285", "str_15285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15286", "str_15286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15287", "str_15287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15288", "str_15288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15289", "str_15289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1529", "str_1529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15290", "str_15290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15291", "str_15291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15292", "str_15292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15293", "str_15293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15294", "str_15294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15295", "str_15295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15296", "str_15296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15297", "str_15297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15298", "str_15298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15299", "str_15299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_153", "str_153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1530", "str_1530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15300", "str_15300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15301", "str_15301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15302", "str_15302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15303", "str_15303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15304", "str_15304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15305", "str_15305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15306", "str_15306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15307", "str_15307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15308", "str_15308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15309", "str_15309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1531", "str_1531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15310", "str_15310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15311", "str_15311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15312", "str_15312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15313", "str_15313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15314", "str_15314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15315", "str_15315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15316", "str_15316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15317", "str_15317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15318", "str_15318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15319", "str_15319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1532", "str_1532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15320", "str_15320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15321", "str_15321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15322", "str_15322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15323", "str_15323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15324", "str_15324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15325", "str_15325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15326", "str_15326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15327", "str_15327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15328", "str_15328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15329", "str_15329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1533", "str_1533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15330", "str_15330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15331", "str_15331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15332", "str_15332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15333", "str_15333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15334", "str_15334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15335", "str_15335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15336", "str_15336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15337", "str_15337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15338", "str_15338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15339", "str_15339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1534", "str_1534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15340", "str_15340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15341", "str_15341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15342", "str_15342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15343", "str_15343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15344", "str_15344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15345", "str_15345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15346", "str_15346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15347", "str_15347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15348", "str_15348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15349", "str_15349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1535", "str_1535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15350", "str_15350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15351", "str_15351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15352", "str_15352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15353", "str_15353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15354", "str_15354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15355", "str_15355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15356", "str_15356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15357", "str_15357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15358", "str_15358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15359", "str_15359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1536", "str_1536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15360", "str_15360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15361", "str_15361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15362", "str_15362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15363", "str_15363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15364", "str_15364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15365", "str_15365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15366", "str_15366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15367", "str_15367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15368", "str_15368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15369", "str_15369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1537", "str_1537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15370", "str_15370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15371", "str_15371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15372", "str_15372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15373", "str_15373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15374", "str_15374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15375", "str_15375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15376", "str_15376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15377", "str_15377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15378", "str_15378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15379", "str_15379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1538", "str_1538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15380", "str_15380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15381", "str_15381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15382", "str_15382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15383", "str_15383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15384", "str_15384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15385", "str_15385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15386", "str_15386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15387", "str_15387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15388", "str_15388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15389", "str_15389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1539", "str_1539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15390", "str_15390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15391", "str_15391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15392", "str_15392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15393", "str_15393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15394", "str_15394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15395", "str_15395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15396", "str_15396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15397", "str_15397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_14948: StringResource
+  get() = String11.str_14948
+
+@ExperimentalResourceApi
+internal val Res.string.str_14949: StringResource
+  get() = String11.str_14949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1495: StringResource
+  get() = String11.str_1495
+
+@ExperimentalResourceApi
+internal val Res.string.str_14950: StringResource
+  get() = String11.str_14950
+
+@ExperimentalResourceApi
+internal val Res.string.str_14951: StringResource
+  get() = String11.str_14951
+
+@ExperimentalResourceApi
+internal val Res.string.str_14952: StringResource
+  get() = String11.str_14952
+
+@ExperimentalResourceApi
+internal val Res.string.str_14953: StringResource
+  get() = String11.str_14953
+
+@ExperimentalResourceApi
+internal val Res.string.str_14954: StringResource
+  get() = String11.str_14954
+
+@ExperimentalResourceApi
+internal val Res.string.str_14955: StringResource
+  get() = String11.str_14955
+
+@ExperimentalResourceApi
+internal val Res.string.str_14956: StringResource
+  get() = String11.str_14956
+
+@ExperimentalResourceApi
+internal val Res.string.str_14957: StringResource
+  get() = String11.str_14957
+
+@ExperimentalResourceApi
+internal val Res.string.str_14958: StringResource
+  get() = String11.str_14958
+
+@ExperimentalResourceApi
+internal val Res.string.str_14959: StringResource
+  get() = String11.str_14959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1496: StringResource
+  get() = String11.str_1496
+
+@ExperimentalResourceApi
+internal val Res.string.str_14960: StringResource
+  get() = String11.str_14960
+
+@ExperimentalResourceApi
+internal val Res.string.str_14961: StringResource
+  get() = String11.str_14961
+
+@ExperimentalResourceApi
+internal val Res.string.str_14962: StringResource
+  get() = String11.str_14962
+
+@ExperimentalResourceApi
+internal val Res.string.str_14963: StringResource
+  get() = String11.str_14963
+
+@ExperimentalResourceApi
+internal val Res.string.str_14964: StringResource
+  get() = String11.str_14964
+
+@ExperimentalResourceApi
+internal val Res.string.str_14965: StringResource
+  get() = String11.str_14965
+
+@ExperimentalResourceApi
+internal val Res.string.str_14966: StringResource
+  get() = String11.str_14966
+
+@ExperimentalResourceApi
+internal val Res.string.str_14967: StringResource
+  get() = String11.str_14967
+
+@ExperimentalResourceApi
+internal val Res.string.str_14968: StringResource
+  get() = String11.str_14968
+
+@ExperimentalResourceApi
+internal val Res.string.str_14969: StringResource
+  get() = String11.str_14969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1497: StringResource
+  get() = String11.str_1497
+
+@ExperimentalResourceApi
+internal val Res.string.str_14970: StringResource
+  get() = String11.str_14970
+
+@ExperimentalResourceApi
+internal val Res.string.str_14971: StringResource
+  get() = String11.str_14971
+
+@ExperimentalResourceApi
+internal val Res.string.str_14972: StringResource
+  get() = String11.str_14972
+
+@ExperimentalResourceApi
+internal val Res.string.str_14973: StringResource
+  get() = String11.str_14973
+
+@ExperimentalResourceApi
+internal val Res.string.str_14974: StringResource
+  get() = String11.str_14974
+
+@ExperimentalResourceApi
+internal val Res.string.str_14975: StringResource
+  get() = String11.str_14975
+
+@ExperimentalResourceApi
+internal val Res.string.str_14976: StringResource
+  get() = String11.str_14976
+
+@ExperimentalResourceApi
+internal val Res.string.str_14977: StringResource
+  get() = String11.str_14977
+
+@ExperimentalResourceApi
+internal val Res.string.str_14978: StringResource
+  get() = String11.str_14978
+
+@ExperimentalResourceApi
+internal val Res.string.str_14979: StringResource
+  get() = String11.str_14979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1498: StringResource
+  get() = String11.str_1498
+
+@ExperimentalResourceApi
+internal val Res.string.str_14980: StringResource
+  get() = String11.str_14980
+
+@ExperimentalResourceApi
+internal val Res.string.str_14981: StringResource
+  get() = String11.str_14981
+
+@ExperimentalResourceApi
+internal val Res.string.str_14982: StringResource
+  get() = String11.str_14982
+
+@ExperimentalResourceApi
+internal val Res.string.str_14983: StringResource
+  get() = String11.str_14983
+
+@ExperimentalResourceApi
+internal val Res.string.str_14984: StringResource
+  get() = String11.str_14984
+
+@ExperimentalResourceApi
+internal val Res.string.str_14985: StringResource
+  get() = String11.str_14985
+
+@ExperimentalResourceApi
+internal val Res.string.str_14986: StringResource
+  get() = String11.str_14986
+
+@ExperimentalResourceApi
+internal val Res.string.str_14987: StringResource
+  get() = String11.str_14987
+
+@ExperimentalResourceApi
+internal val Res.string.str_14988: StringResource
+  get() = String11.str_14988
+
+@ExperimentalResourceApi
+internal val Res.string.str_14989: StringResource
+  get() = String11.str_14989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1499: StringResource
+  get() = String11.str_1499
+
+@ExperimentalResourceApi
+internal val Res.string.str_14990: StringResource
+  get() = String11.str_14990
+
+@ExperimentalResourceApi
+internal val Res.string.str_14991: StringResource
+  get() = String11.str_14991
+
+@ExperimentalResourceApi
+internal val Res.string.str_14992: StringResource
+  get() = String11.str_14992
+
+@ExperimentalResourceApi
+internal val Res.string.str_14993: StringResource
+  get() = String11.str_14993
+
+@ExperimentalResourceApi
+internal val Res.string.str_14994: StringResource
+  get() = String11.str_14994
+
+@ExperimentalResourceApi
+internal val Res.string.str_14995: StringResource
+  get() = String11.str_14995
+
+@ExperimentalResourceApi
+internal val Res.string.str_14996: StringResource
+  get() = String11.str_14996
+
+@ExperimentalResourceApi
+internal val Res.string.str_14997: StringResource
+  get() = String11.str_14997
+
+@ExperimentalResourceApi
+internal val Res.string.str_14998: StringResource
+  get() = String11.str_14998
+
+@ExperimentalResourceApi
+internal val Res.string.str_14999: StringResource
+  get() = String11.str_14999
+
+@ExperimentalResourceApi
+internal val Res.string.str_15: StringResource
+  get() = String11.str_15
+
+@ExperimentalResourceApi
+internal val Res.string.str_150: StringResource
+  get() = String11.str_150
+
+@ExperimentalResourceApi
+internal val Res.string.str_1500: StringResource
+  get() = String11.str_1500
+
+@ExperimentalResourceApi
+internal val Res.string.str_15000: StringResource
+  get() = String11.str_15000
+
+@ExperimentalResourceApi
+internal val Res.string.str_15001: StringResource
+  get() = String11.str_15001
+
+@ExperimentalResourceApi
+internal val Res.string.str_15002: StringResource
+  get() = String11.str_15002
+
+@ExperimentalResourceApi
+internal val Res.string.str_15003: StringResource
+  get() = String11.str_15003
+
+@ExperimentalResourceApi
+internal val Res.string.str_15004: StringResource
+  get() = String11.str_15004
+
+@ExperimentalResourceApi
+internal val Res.string.str_15005: StringResource
+  get() = String11.str_15005
+
+@ExperimentalResourceApi
+internal val Res.string.str_15006: StringResource
+  get() = String11.str_15006
+
+@ExperimentalResourceApi
+internal val Res.string.str_15007: StringResource
+  get() = String11.str_15007
+
+@ExperimentalResourceApi
+internal val Res.string.str_15008: StringResource
+  get() = String11.str_15008
+
+@ExperimentalResourceApi
+internal val Res.string.str_15009: StringResource
+  get() = String11.str_15009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1501: StringResource
+  get() = String11.str_1501
+
+@ExperimentalResourceApi
+internal val Res.string.str_15010: StringResource
+  get() = String11.str_15010
+
+@ExperimentalResourceApi
+internal val Res.string.str_15011: StringResource
+  get() = String11.str_15011
+
+@ExperimentalResourceApi
+internal val Res.string.str_15012: StringResource
+  get() = String11.str_15012
+
+@ExperimentalResourceApi
+internal val Res.string.str_15013: StringResource
+  get() = String11.str_15013
+
+@ExperimentalResourceApi
+internal val Res.string.str_15014: StringResource
+  get() = String11.str_15014
+
+@ExperimentalResourceApi
+internal val Res.string.str_15015: StringResource
+  get() = String11.str_15015
+
+@ExperimentalResourceApi
+internal val Res.string.str_15016: StringResource
+  get() = String11.str_15016
+
+@ExperimentalResourceApi
+internal val Res.string.str_15017: StringResource
+  get() = String11.str_15017
+
+@ExperimentalResourceApi
+internal val Res.string.str_15018: StringResource
+  get() = String11.str_15018
+
+@ExperimentalResourceApi
+internal val Res.string.str_15019: StringResource
+  get() = String11.str_15019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1502: StringResource
+  get() = String11.str_1502
+
+@ExperimentalResourceApi
+internal val Res.string.str_15020: StringResource
+  get() = String11.str_15020
+
+@ExperimentalResourceApi
+internal val Res.string.str_15021: StringResource
+  get() = String11.str_15021
+
+@ExperimentalResourceApi
+internal val Res.string.str_15022: StringResource
+  get() = String11.str_15022
+
+@ExperimentalResourceApi
+internal val Res.string.str_15023: StringResource
+  get() = String11.str_15023
+
+@ExperimentalResourceApi
+internal val Res.string.str_15024: StringResource
+  get() = String11.str_15024
+
+@ExperimentalResourceApi
+internal val Res.string.str_15025: StringResource
+  get() = String11.str_15025
+
+@ExperimentalResourceApi
+internal val Res.string.str_15026: StringResource
+  get() = String11.str_15026
+
+@ExperimentalResourceApi
+internal val Res.string.str_15027: StringResource
+  get() = String11.str_15027
+
+@ExperimentalResourceApi
+internal val Res.string.str_15028: StringResource
+  get() = String11.str_15028
+
+@ExperimentalResourceApi
+internal val Res.string.str_15029: StringResource
+  get() = String11.str_15029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1503: StringResource
+  get() = String11.str_1503
+
+@ExperimentalResourceApi
+internal val Res.string.str_15030: StringResource
+  get() = String11.str_15030
+
+@ExperimentalResourceApi
+internal val Res.string.str_15031: StringResource
+  get() = String11.str_15031
+
+@ExperimentalResourceApi
+internal val Res.string.str_15032: StringResource
+  get() = String11.str_15032
+
+@ExperimentalResourceApi
+internal val Res.string.str_15033: StringResource
+  get() = String11.str_15033
+
+@ExperimentalResourceApi
+internal val Res.string.str_15034: StringResource
+  get() = String11.str_15034
+
+@ExperimentalResourceApi
+internal val Res.string.str_15035: StringResource
+  get() = String11.str_15035
+
+@ExperimentalResourceApi
+internal val Res.string.str_15036: StringResource
+  get() = String11.str_15036
+
+@ExperimentalResourceApi
+internal val Res.string.str_15037: StringResource
+  get() = String11.str_15037
+
+@ExperimentalResourceApi
+internal val Res.string.str_15038: StringResource
+  get() = String11.str_15038
+
+@ExperimentalResourceApi
+internal val Res.string.str_15039: StringResource
+  get() = String11.str_15039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1504: StringResource
+  get() = String11.str_1504
+
+@ExperimentalResourceApi
+internal val Res.string.str_15040: StringResource
+  get() = String11.str_15040
+
+@ExperimentalResourceApi
+internal val Res.string.str_15041: StringResource
+  get() = String11.str_15041
+
+@ExperimentalResourceApi
+internal val Res.string.str_15042: StringResource
+  get() = String11.str_15042
+
+@ExperimentalResourceApi
+internal val Res.string.str_15043: StringResource
+  get() = String11.str_15043
+
+@ExperimentalResourceApi
+internal val Res.string.str_15044: StringResource
+  get() = String11.str_15044
+
+@ExperimentalResourceApi
+internal val Res.string.str_15045: StringResource
+  get() = String11.str_15045
+
+@ExperimentalResourceApi
+internal val Res.string.str_15046: StringResource
+  get() = String11.str_15046
+
+@ExperimentalResourceApi
+internal val Res.string.str_15047: StringResource
+  get() = String11.str_15047
+
+@ExperimentalResourceApi
+internal val Res.string.str_15048: StringResource
+  get() = String11.str_15048
+
+@ExperimentalResourceApi
+internal val Res.string.str_15049: StringResource
+  get() = String11.str_15049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1505: StringResource
+  get() = String11.str_1505
+
+@ExperimentalResourceApi
+internal val Res.string.str_15050: StringResource
+  get() = String11.str_15050
+
+@ExperimentalResourceApi
+internal val Res.string.str_15051: StringResource
+  get() = String11.str_15051
+
+@ExperimentalResourceApi
+internal val Res.string.str_15052: StringResource
+  get() = String11.str_15052
+
+@ExperimentalResourceApi
+internal val Res.string.str_15053: StringResource
+  get() = String11.str_15053
+
+@ExperimentalResourceApi
+internal val Res.string.str_15054: StringResource
+  get() = String11.str_15054
+
+@ExperimentalResourceApi
+internal val Res.string.str_15055: StringResource
+  get() = String11.str_15055
+
+@ExperimentalResourceApi
+internal val Res.string.str_15056: StringResource
+  get() = String11.str_15056
+
+@ExperimentalResourceApi
+internal val Res.string.str_15057: StringResource
+  get() = String11.str_15057
+
+@ExperimentalResourceApi
+internal val Res.string.str_15058: StringResource
+  get() = String11.str_15058
+
+@ExperimentalResourceApi
+internal val Res.string.str_15059: StringResource
+  get() = String11.str_15059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1506: StringResource
+  get() = String11.str_1506
+
+@ExperimentalResourceApi
+internal val Res.string.str_15060: StringResource
+  get() = String11.str_15060
+
+@ExperimentalResourceApi
+internal val Res.string.str_15061: StringResource
+  get() = String11.str_15061
+
+@ExperimentalResourceApi
+internal val Res.string.str_15062: StringResource
+  get() = String11.str_15062
+
+@ExperimentalResourceApi
+internal val Res.string.str_15063: StringResource
+  get() = String11.str_15063
+
+@ExperimentalResourceApi
+internal val Res.string.str_15064: StringResource
+  get() = String11.str_15064
+
+@ExperimentalResourceApi
+internal val Res.string.str_15065: StringResource
+  get() = String11.str_15065
+
+@ExperimentalResourceApi
+internal val Res.string.str_15066: StringResource
+  get() = String11.str_15066
+
+@ExperimentalResourceApi
+internal val Res.string.str_15067: StringResource
+  get() = String11.str_15067
+
+@ExperimentalResourceApi
+internal val Res.string.str_15068: StringResource
+  get() = String11.str_15068
+
+@ExperimentalResourceApi
+internal val Res.string.str_15069: StringResource
+  get() = String11.str_15069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1507: StringResource
+  get() = String11.str_1507
+
+@ExperimentalResourceApi
+internal val Res.string.str_15070: StringResource
+  get() = String11.str_15070
+
+@ExperimentalResourceApi
+internal val Res.string.str_15071: StringResource
+  get() = String11.str_15071
+
+@ExperimentalResourceApi
+internal val Res.string.str_15072: StringResource
+  get() = String11.str_15072
+
+@ExperimentalResourceApi
+internal val Res.string.str_15073: StringResource
+  get() = String11.str_15073
+
+@ExperimentalResourceApi
+internal val Res.string.str_15074: StringResource
+  get() = String11.str_15074
+
+@ExperimentalResourceApi
+internal val Res.string.str_15075: StringResource
+  get() = String11.str_15075
+
+@ExperimentalResourceApi
+internal val Res.string.str_15076: StringResource
+  get() = String11.str_15076
+
+@ExperimentalResourceApi
+internal val Res.string.str_15077: StringResource
+  get() = String11.str_15077
+
+@ExperimentalResourceApi
+internal val Res.string.str_15078: StringResource
+  get() = String11.str_15078
+
+@ExperimentalResourceApi
+internal val Res.string.str_15079: StringResource
+  get() = String11.str_15079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1508: StringResource
+  get() = String11.str_1508
+
+@ExperimentalResourceApi
+internal val Res.string.str_15080: StringResource
+  get() = String11.str_15080
+
+@ExperimentalResourceApi
+internal val Res.string.str_15081: StringResource
+  get() = String11.str_15081
+
+@ExperimentalResourceApi
+internal val Res.string.str_15082: StringResource
+  get() = String11.str_15082
+
+@ExperimentalResourceApi
+internal val Res.string.str_15083: StringResource
+  get() = String11.str_15083
+
+@ExperimentalResourceApi
+internal val Res.string.str_15084: StringResource
+  get() = String11.str_15084
+
+@ExperimentalResourceApi
+internal val Res.string.str_15085: StringResource
+  get() = String11.str_15085
+
+@ExperimentalResourceApi
+internal val Res.string.str_15086: StringResource
+  get() = String11.str_15086
+
+@ExperimentalResourceApi
+internal val Res.string.str_15087: StringResource
+  get() = String11.str_15087
+
+@ExperimentalResourceApi
+internal val Res.string.str_15088: StringResource
+  get() = String11.str_15088
+
+@ExperimentalResourceApi
+internal val Res.string.str_15089: StringResource
+  get() = String11.str_15089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1509: StringResource
+  get() = String11.str_1509
+
+@ExperimentalResourceApi
+internal val Res.string.str_15090: StringResource
+  get() = String11.str_15090
+
+@ExperimentalResourceApi
+internal val Res.string.str_15091: StringResource
+  get() = String11.str_15091
+
+@ExperimentalResourceApi
+internal val Res.string.str_15092: StringResource
+  get() = String11.str_15092
+
+@ExperimentalResourceApi
+internal val Res.string.str_15093: StringResource
+  get() = String11.str_15093
+
+@ExperimentalResourceApi
+internal val Res.string.str_15094: StringResource
+  get() = String11.str_15094
+
+@ExperimentalResourceApi
+internal val Res.string.str_15095: StringResource
+  get() = String11.str_15095
+
+@ExperimentalResourceApi
+internal val Res.string.str_15096: StringResource
+  get() = String11.str_15096
+
+@ExperimentalResourceApi
+internal val Res.string.str_15097: StringResource
+  get() = String11.str_15097
+
+@ExperimentalResourceApi
+internal val Res.string.str_15098: StringResource
+  get() = String11.str_15098
+
+@ExperimentalResourceApi
+internal val Res.string.str_15099: StringResource
+  get() = String11.str_15099
+
+@ExperimentalResourceApi
+internal val Res.string.str_151: StringResource
+  get() = String11.str_151
+
+@ExperimentalResourceApi
+internal val Res.string.str_1510: StringResource
+  get() = String11.str_1510
+
+@ExperimentalResourceApi
+internal val Res.string.str_15100: StringResource
+  get() = String11.str_15100
+
+@ExperimentalResourceApi
+internal val Res.string.str_15101: StringResource
+  get() = String11.str_15101
+
+@ExperimentalResourceApi
+internal val Res.string.str_15102: StringResource
+  get() = String11.str_15102
+
+@ExperimentalResourceApi
+internal val Res.string.str_15103: StringResource
+  get() = String11.str_15103
+
+@ExperimentalResourceApi
+internal val Res.string.str_15104: StringResource
+  get() = String11.str_15104
+
+@ExperimentalResourceApi
+internal val Res.string.str_15105: StringResource
+  get() = String11.str_15105
+
+@ExperimentalResourceApi
+internal val Res.string.str_15106: StringResource
+  get() = String11.str_15106
+
+@ExperimentalResourceApi
+internal val Res.string.str_15107: StringResource
+  get() = String11.str_15107
+
+@ExperimentalResourceApi
+internal val Res.string.str_15108: StringResource
+  get() = String11.str_15108
+
+@ExperimentalResourceApi
+internal val Res.string.str_15109: StringResource
+  get() = String11.str_15109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1511: StringResource
+  get() = String11.str_1511
+
+@ExperimentalResourceApi
+internal val Res.string.str_15110: StringResource
+  get() = String11.str_15110
+
+@ExperimentalResourceApi
+internal val Res.string.str_15111: StringResource
+  get() = String11.str_15111
+
+@ExperimentalResourceApi
+internal val Res.string.str_15112: StringResource
+  get() = String11.str_15112
+
+@ExperimentalResourceApi
+internal val Res.string.str_15113: StringResource
+  get() = String11.str_15113
+
+@ExperimentalResourceApi
+internal val Res.string.str_15114: StringResource
+  get() = String11.str_15114
+
+@ExperimentalResourceApi
+internal val Res.string.str_15115: StringResource
+  get() = String11.str_15115
+
+@ExperimentalResourceApi
+internal val Res.string.str_15116: StringResource
+  get() = String11.str_15116
+
+@ExperimentalResourceApi
+internal val Res.string.str_15117: StringResource
+  get() = String11.str_15117
+
+@ExperimentalResourceApi
+internal val Res.string.str_15118: StringResource
+  get() = String11.str_15118
+
+@ExperimentalResourceApi
+internal val Res.string.str_15119: StringResource
+  get() = String11.str_15119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1512: StringResource
+  get() = String11.str_1512
+
+@ExperimentalResourceApi
+internal val Res.string.str_15120: StringResource
+  get() = String11.str_15120
+
+@ExperimentalResourceApi
+internal val Res.string.str_15121: StringResource
+  get() = String11.str_15121
+
+@ExperimentalResourceApi
+internal val Res.string.str_15122: StringResource
+  get() = String11.str_15122
+
+@ExperimentalResourceApi
+internal val Res.string.str_15123: StringResource
+  get() = String11.str_15123
+
+@ExperimentalResourceApi
+internal val Res.string.str_15124: StringResource
+  get() = String11.str_15124
+
+@ExperimentalResourceApi
+internal val Res.string.str_15125: StringResource
+  get() = String11.str_15125
+
+@ExperimentalResourceApi
+internal val Res.string.str_15126: StringResource
+  get() = String11.str_15126
+
+@ExperimentalResourceApi
+internal val Res.string.str_15127: StringResource
+  get() = String11.str_15127
+
+@ExperimentalResourceApi
+internal val Res.string.str_15128: StringResource
+  get() = String11.str_15128
+
+@ExperimentalResourceApi
+internal val Res.string.str_15129: StringResource
+  get() = String11.str_15129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1513: StringResource
+  get() = String11.str_1513
+
+@ExperimentalResourceApi
+internal val Res.string.str_15130: StringResource
+  get() = String11.str_15130
+
+@ExperimentalResourceApi
+internal val Res.string.str_15131: StringResource
+  get() = String11.str_15131
+
+@ExperimentalResourceApi
+internal val Res.string.str_15132: StringResource
+  get() = String11.str_15132
+
+@ExperimentalResourceApi
+internal val Res.string.str_15133: StringResource
+  get() = String11.str_15133
+
+@ExperimentalResourceApi
+internal val Res.string.str_15134: StringResource
+  get() = String11.str_15134
+
+@ExperimentalResourceApi
+internal val Res.string.str_15135: StringResource
+  get() = String11.str_15135
+
+@ExperimentalResourceApi
+internal val Res.string.str_15136: StringResource
+  get() = String11.str_15136
+
+@ExperimentalResourceApi
+internal val Res.string.str_15137: StringResource
+  get() = String11.str_15137
+
+@ExperimentalResourceApi
+internal val Res.string.str_15138: StringResource
+  get() = String11.str_15138
+
+@ExperimentalResourceApi
+internal val Res.string.str_15139: StringResource
+  get() = String11.str_15139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1514: StringResource
+  get() = String11.str_1514
+
+@ExperimentalResourceApi
+internal val Res.string.str_15140: StringResource
+  get() = String11.str_15140
+
+@ExperimentalResourceApi
+internal val Res.string.str_15141: StringResource
+  get() = String11.str_15141
+
+@ExperimentalResourceApi
+internal val Res.string.str_15142: StringResource
+  get() = String11.str_15142
+
+@ExperimentalResourceApi
+internal val Res.string.str_15143: StringResource
+  get() = String11.str_15143
+
+@ExperimentalResourceApi
+internal val Res.string.str_15144: StringResource
+  get() = String11.str_15144
+
+@ExperimentalResourceApi
+internal val Res.string.str_15145: StringResource
+  get() = String11.str_15145
+
+@ExperimentalResourceApi
+internal val Res.string.str_15146: StringResource
+  get() = String11.str_15146
+
+@ExperimentalResourceApi
+internal val Res.string.str_15147: StringResource
+  get() = String11.str_15147
+
+@ExperimentalResourceApi
+internal val Res.string.str_15148: StringResource
+  get() = String11.str_15148
+
+@ExperimentalResourceApi
+internal val Res.string.str_15149: StringResource
+  get() = String11.str_15149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1515: StringResource
+  get() = String11.str_1515
+
+@ExperimentalResourceApi
+internal val Res.string.str_15150: StringResource
+  get() = String11.str_15150
+
+@ExperimentalResourceApi
+internal val Res.string.str_15151: StringResource
+  get() = String11.str_15151
+
+@ExperimentalResourceApi
+internal val Res.string.str_15152: StringResource
+  get() = String11.str_15152
+
+@ExperimentalResourceApi
+internal val Res.string.str_15153: StringResource
+  get() = String11.str_15153
+
+@ExperimentalResourceApi
+internal val Res.string.str_15154: StringResource
+  get() = String11.str_15154
+
+@ExperimentalResourceApi
+internal val Res.string.str_15155: StringResource
+  get() = String11.str_15155
+
+@ExperimentalResourceApi
+internal val Res.string.str_15156: StringResource
+  get() = String11.str_15156
+
+@ExperimentalResourceApi
+internal val Res.string.str_15157: StringResource
+  get() = String11.str_15157
+
+@ExperimentalResourceApi
+internal val Res.string.str_15158: StringResource
+  get() = String11.str_15158
+
+@ExperimentalResourceApi
+internal val Res.string.str_15159: StringResource
+  get() = String11.str_15159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1516: StringResource
+  get() = String11.str_1516
+
+@ExperimentalResourceApi
+internal val Res.string.str_15160: StringResource
+  get() = String11.str_15160
+
+@ExperimentalResourceApi
+internal val Res.string.str_15161: StringResource
+  get() = String11.str_15161
+
+@ExperimentalResourceApi
+internal val Res.string.str_15162: StringResource
+  get() = String11.str_15162
+
+@ExperimentalResourceApi
+internal val Res.string.str_15163: StringResource
+  get() = String11.str_15163
+
+@ExperimentalResourceApi
+internal val Res.string.str_15164: StringResource
+  get() = String11.str_15164
+
+@ExperimentalResourceApi
+internal val Res.string.str_15165: StringResource
+  get() = String11.str_15165
+
+@ExperimentalResourceApi
+internal val Res.string.str_15166: StringResource
+  get() = String11.str_15166
+
+@ExperimentalResourceApi
+internal val Res.string.str_15167: StringResource
+  get() = String11.str_15167
+
+@ExperimentalResourceApi
+internal val Res.string.str_15168: StringResource
+  get() = String11.str_15168
+
+@ExperimentalResourceApi
+internal val Res.string.str_15169: StringResource
+  get() = String11.str_15169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1517: StringResource
+  get() = String11.str_1517
+
+@ExperimentalResourceApi
+internal val Res.string.str_15170: StringResource
+  get() = String11.str_15170
+
+@ExperimentalResourceApi
+internal val Res.string.str_15171: StringResource
+  get() = String11.str_15171
+
+@ExperimentalResourceApi
+internal val Res.string.str_15172: StringResource
+  get() = String11.str_15172
+
+@ExperimentalResourceApi
+internal val Res.string.str_15173: StringResource
+  get() = String11.str_15173
+
+@ExperimentalResourceApi
+internal val Res.string.str_15174: StringResource
+  get() = String11.str_15174
+
+@ExperimentalResourceApi
+internal val Res.string.str_15175: StringResource
+  get() = String11.str_15175
+
+@ExperimentalResourceApi
+internal val Res.string.str_15176: StringResource
+  get() = String11.str_15176
+
+@ExperimentalResourceApi
+internal val Res.string.str_15177: StringResource
+  get() = String11.str_15177
+
+@ExperimentalResourceApi
+internal val Res.string.str_15178: StringResource
+  get() = String11.str_15178
+
+@ExperimentalResourceApi
+internal val Res.string.str_15179: StringResource
+  get() = String11.str_15179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1518: StringResource
+  get() = String11.str_1518
+
+@ExperimentalResourceApi
+internal val Res.string.str_15180: StringResource
+  get() = String11.str_15180
+
+@ExperimentalResourceApi
+internal val Res.string.str_15181: StringResource
+  get() = String11.str_15181
+
+@ExperimentalResourceApi
+internal val Res.string.str_15182: StringResource
+  get() = String11.str_15182
+
+@ExperimentalResourceApi
+internal val Res.string.str_15183: StringResource
+  get() = String11.str_15183
+
+@ExperimentalResourceApi
+internal val Res.string.str_15184: StringResource
+  get() = String11.str_15184
+
+@ExperimentalResourceApi
+internal val Res.string.str_15185: StringResource
+  get() = String11.str_15185
+
+@ExperimentalResourceApi
+internal val Res.string.str_15186: StringResource
+  get() = String11.str_15186
+
+@ExperimentalResourceApi
+internal val Res.string.str_15187: StringResource
+  get() = String11.str_15187
+
+@ExperimentalResourceApi
+internal val Res.string.str_15188: StringResource
+  get() = String11.str_15188
+
+@ExperimentalResourceApi
+internal val Res.string.str_15189: StringResource
+  get() = String11.str_15189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1519: StringResource
+  get() = String11.str_1519
+
+@ExperimentalResourceApi
+internal val Res.string.str_15190: StringResource
+  get() = String11.str_15190
+
+@ExperimentalResourceApi
+internal val Res.string.str_15191: StringResource
+  get() = String11.str_15191
+
+@ExperimentalResourceApi
+internal val Res.string.str_15192: StringResource
+  get() = String11.str_15192
+
+@ExperimentalResourceApi
+internal val Res.string.str_15193: StringResource
+  get() = String11.str_15193
+
+@ExperimentalResourceApi
+internal val Res.string.str_15194: StringResource
+  get() = String11.str_15194
+
+@ExperimentalResourceApi
+internal val Res.string.str_15195: StringResource
+  get() = String11.str_15195
+
+@ExperimentalResourceApi
+internal val Res.string.str_15196: StringResource
+  get() = String11.str_15196
+
+@ExperimentalResourceApi
+internal val Res.string.str_15197: StringResource
+  get() = String11.str_15197
+
+@ExperimentalResourceApi
+internal val Res.string.str_15198: StringResource
+  get() = String11.str_15198
+
+@ExperimentalResourceApi
+internal val Res.string.str_15199: StringResource
+  get() = String11.str_15199
+
+@ExperimentalResourceApi
+internal val Res.string.str_152: StringResource
+  get() = String11.str_152
+
+@ExperimentalResourceApi
+internal val Res.string.str_1520: StringResource
+  get() = String11.str_1520
+
+@ExperimentalResourceApi
+internal val Res.string.str_15200: StringResource
+  get() = String11.str_15200
+
+@ExperimentalResourceApi
+internal val Res.string.str_15201: StringResource
+  get() = String11.str_15201
+
+@ExperimentalResourceApi
+internal val Res.string.str_15202: StringResource
+  get() = String11.str_15202
+
+@ExperimentalResourceApi
+internal val Res.string.str_15203: StringResource
+  get() = String11.str_15203
+
+@ExperimentalResourceApi
+internal val Res.string.str_15204: StringResource
+  get() = String11.str_15204
+
+@ExperimentalResourceApi
+internal val Res.string.str_15205: StringResource
+  get() = String11.str_15205
+
+@ExperimentalResourceApi
+internal val Res.string.str_15206: StringResource
+  get() = String11.str_15206
+
+@ExperimentalResourceApi
+internal val Res.string.str_15207: StringResource
+  get() = String11.str_15207
+
+@ExperimentalResourceApi
+internal val Res.string.str_15208: StringResource
+  get() = String11.str_15208
+
+@ExperimentalResourceApi
+internal val Res.string.str_15209: StringResource
+  get() = String11.str_15209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1521: StringResource
+  get() = String11.str_1521
+
+@ExperimentalResourceApi
+internal val Res.string.str_15210: StringResource
+  get() = String11.str_15210
+
+@ExperimentalResourceApi
+internal val Res.string.str_15211: StringResource
+  get() = String11.str_15211
+
+@ExperimentalResourceApi
+internal val Res.string.str_15212: StringResource
+  get() = String11.str_15212
+
+@ExperimentalResourceApi
+internal val Res.string.str_15213: StringResource
+  get() = String11.str_15213
+
+@ExperimentalResourceApi
+internal val Res.string.str_15214: StringResource
+  get() = String11.str_15214
+
+@ExperimentalResourceApi
+internal val Res.string.str_15215: StringResource
+  get() = String11.str_15215
+
+@ExperimentalResourceApi
+internal val Res.string.str_15216: StringResource
+  get() = String11.str_15216
+
+@ExperimentalResourceApi
+internal val Res.string.str_15217: StringResource
+  get() = String11.str_15217
+
+@ExperimentalResourceApi
+internal val Res.string.str_15218: StringResource
+  get() = String11.str_15218
+
+@ExperimentalResourceApi
+internal val Res.string.str_15219: StringResource
+  get() = String11.str_15219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1522: StringResource
+  get() = String11.str_1522
+
+@ExperimentalResourceApi
+internal val Res.string.str_15220: StringResource
+  get() = String11.str_15220
+
+@ExperimentalResourceApi
+internal val Res.string.str_15221: StringResource
+  get() = String11.str_15221
+
+@ExperimentalResourceApi
+internal val Res.string.str_15222: StringResource
+  get() = String11.str_15222
+
+@ExperimentalResourceApi
+internal val Res.string.str_15223: StringResource
+  get() = String11.str_15223
+
+@ExperimentalResourceApi
+internal val Res.string.str_15224: StringResource
+  get() = String11.str_15224
+
+@ExperimentalResourceApi
+internal val Res.string.str_15225: StringResource
+  get() = String11.str_15225
+
+@ExperimentalResourceApi
+internal val Res.string.str_15226: StringResource
+  get() = String11.str_15226
+
+@ExperimentalResourceApi
+internal val Res.string.str_15227: StringResource
+  get() = String11.str_15227
+
+@ExperimentalResourceApi
+internal val Res.string.str_15228: StringResource
+  get() = String11.str_15228
+
+@ExperimentalResourceApi
+internal val Res.string.str_15229: StringResource
+  get() = String11.str_15229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1523: StringResource
+  get() = String11.str_1523
+
+@ExperimentalResourceApi
+internal val Res.string.str_15230: StringResource
+  get() = String11.str_15230
+
+@ExperimentalResourceApi
+internal val Res.string.str_15231: StringResource
+  get() = String11.str_15231
+
+@ExperimentalResourceApi
+internal val Res.string.str_15232: StringResource
+  get() = String11.str_15232
+
+@ExperimentalResourceApi
+internal val Res.string.str_15233: StringResource
+  get() = String11.str_15233
+
+@ExperimentalResourceApi
+internal val Res.string.str_15234: StringResource
+  get() = String11.str_15234
+
+@ExperimentalResourceApi
+internal val Res.string.str_15235: StringResource
+  get() = String11.str_15235
+
+@ExperimentalResourceApi
+internal val Res.string.str_15236: StringResource
+  get() = String11.str_15236
+
+@ExperimentalResourceApi
+internal val Res.string.str_15237: StringResource
+  get() = String11.str_15237
+
+@ExperimentalResourceApi
+internal val Res.string.str_15238: StringResource
+  get() = String11.str_15238
+
+@ExperimentalResourceApi
+internal val Res.string.str_15239: StringResource
+  get() = String11.str_15239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1524: StringResource
+  get() = String11.str_1524
+
+@ExperimentalResourceApi
+internal val Res.string.str_15240: StringResource
+  get() = String11.str_15240
+
+@ExperimentalResourceApi
+internal val Res.string.str_15241: StringResource
+  get() = String11.str_15241
+
+@ExperimentalResourceApi
+internal val Res.string.str_15242: StringResource
+  get() = String11.str_15242
+
+@ExperimentalResourceApi
+internal val Res.string.str_15243: StringResource
+  get() = String11.str_15243
+
+@ExperimentalResourceApi
+internal val Res.string.str_15244: StringResource
+  get() = String11.str_15244
+
+@ExperimentalResourceApi
+internal val Res.string.str_15245: StringResource
+  get() = String11.str_15245
+
+@ExperimentalResourceApi
+internal val Res.string.str_15246: StringResource
+  get() = String11.str_15246
+
+@ExperimentalResourceApi
+internal val Res.string.str_15247: StringResource
+  get() = String11.str_15247
+
+@ExperimentalResourceApi
+internal val Res.string.str_15248: StringResource
+  get() = String11.str_15248
+
+@ExperimentalResourceApi
+internal val Res.string.str_15249: StringResource
+  get() = String11.str_15249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1525: StringResource
+  get() = String11.str_1525
+
+@ExperimentalResourceApi
+internal val Res.string.str_15250: StringResource
+  get() = String11.str_15250
+
+@ExperimentalResourceApi
+internal val Res.string.str_15251: StringResource
+  get() = String11.str_15251
+
+@ExperimentalResourceApi
+internal val Res.string.str_15252: StringResource
+  get() = String11.str_15252
+
+@ExperimentalResourceApi
+internal val Res.string.str_15253: StringResource
+  get() = String11.str_15253
+
+@ExperimentalResourceApi
+internal val Res.string.str_15254: StringResource
+  get() = String11.str_15254
+
+@ExperimentalResourceApi
+internal val Res.string.str_15255: StringResource
+  get() = String11.str_15255
+
+@ExperimentalResourceApi
+internal val Res.string.str_15256: StringResource
+  get() = String11.str_15256
+
+@ExperimentalResourceApi
+internal val Res.string.str_15257: StringResource
+  get() = String11.str_15257
+
+@ExperimentalResourceApi
+internal val Res.string.str_15258: StringResource
+  get() = String11.str_15258
+
+@ExperimentalResourceApi
+internal val Res.string.str_15259: StringResource
+  get() = String11.str_15259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1526: StringResource
+  get() = String11.str_1526
+
+@ExperimentalResourceApi
+internal val Res.string.str_15260: StringResource
+  get() = String11.str_15260
+
+@ExperimentalResourceApi
+internal val Res.string.str_15261: StringResource
+  get() = String11.str_15261
+
+@ExperimentalResourceApi
+internal val Res.string.str_15262: StringResource
+  get() = String11.str_15262
+
+@ExperimentalResourceApi
+internal val Res.string.str_15263: StringResource
+  get() = String11.str_15263
+
+@ExperimentalResourceApi
+internal val Res.string.str_15264: StringResource
+  get() = String11.str_15264
+
+@ExperimentalResourceApi
+internal val Res.string.str_15265: StringResource
+  get() = String11.str_15265
+
+@ExperimentalResourceApi
+internal val Res.string.str_15266: StringResource
+  get() = String11.str_15266
+
+@ExperimentalResourceApi
+internal val Res.string.str_15267: StringResource
+  get() = String11.str_15267
+
+@ExperimentalResourceApi
+internal val Res.string.str_15268: StringResource
+  get() = String11.str_15268
+
+@ExperimentalResourceApi
+internal val Res.string.str_15269: StringResource
+  get() = String11.str_15269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1527: StringResource
+  get() = String11.str_1527
+
+@ExperimentalResourceApi
+internal val Res.string.str_15270: StringResource
+  get() = String11.str_15270
+
+@ExperimentalResourceApi
+internal val Res.string.str_15271: StringResource
+  get() = String11.str_15271
+
+@ExperimentalResourceApi
+internal val Res.string.str_15272: StringResource
+  get() = String11.str_15272
+
+@ExperimentalResourceApi
+internal val Res.string.str_15273: StringResource
+  get() = String11.str_15273
+
+@ExperimentalResourceApi
+internal val Res.string.str_15274: StringResource
+  get() = String11.str_15274
+
+@ExperimentalResourceApi
+internal val Res.string.str_15275: StringResource
+  get() = String11.str_15275
+
+@ExperimentalResourceApi
+internal val Res.string.str_15276: StringResource
+  get() = String11.str_15276
+
+@ExperimentalResourceApi
+internal val Res.string.str_15277: StringResource
+  get() = String11.str_15277
+
+@ExperimentalResourceApi
+internal val Res.string.str_15278: StringResource
+  get() = String11.str_15278
+
+@ExperimentalResourceApi
+internal val Res.string.str_15279: StringResource
+  get() = String11.str_15279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1528: StringResource
+  get() = String11.str_1528
+
+@ExperimentalResourceApi
+internal val Res.string.str_15280: StringResource
+  get() = String11.str_15280
+
+@ExperimentalResourceApi
+internal val Res.string.str_15281: StringResource
+  get() = String11.str_15281
+
+@ExperimentalResourceApi
+internal val Res.string.str_15282: StringResource
+  get() = String11.str_15282
+
+@ExperimentalResourceApi
+internal val Res.string.str_15283: StringResource
+  get() = String11.str_15283
+
+@ExperimentalResourceApi
+internal val Res.string.str_15284: StringResource
+  get() = String11.str_15284
+
+@ExperimentalResourceApi
+internal val Res.string.str_15285: StringResource
+  get() = String11.str_15285
+
+@ExperimentalResourceApi
+internal val Res.string.str_15286: StringResource
+  get() = String11.str_15286
+
+@ExperimentalResourceApi
+internal val Res.string.str_15287: StringResource
+  get() = String11.str_15287
+
+@ExperimentalResourceApi
+internal val Res.string.str_15288: StringResource
+  get() = String11.str_15288
+
+@ExperimentalResourceApi
+internal val Res.string.str_15289: StringResource
+  get() = String11.str_15289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1529: StringResource
+  get() = String11.str_1529
+
+@ExperimentalResourceApi
+internal val Res.string.str_15290: StringResource
+  get() = String11.str_15290
+
+@ExperimentalResourceApi
+internal val Res.string.str_15291: StringResource
+  get() = String11.str_15291
+
+@ExperimentalResourceApi
+internal val Res.string.str_15292: StringResource
+  get() = String11.str_15292
+
+@ExperimentalResourceApi
+internal val Res.string.str_15293: StringResource
+  get() = String11.str_15293
+
+@ExperimentalResourceApi
+internal val Res.string.str_15294: StringResource
+  get() = String11.str_15294
+
+@ExperimentalResourceApi
+internal val Res.string.str_15295: StringResource
+  get() = String11.str_15295
+
+@ExperimentalResourceApi
+internal val Res.string.str_15296: StringResource
+  get() = String11.str_15296
+
+@ExperimentalResourceApi
+internal val Res.string.str_15297: StringResource
+  get() = String11.str_15297
+
+@ExperimentalResourceApi
+internal val Res.string.str_15298: StringResource
+  get() = String11.str_15298
+
+@ExperimentalResourceApi
+internal val Res.string.str_15299: StringResource
+  get() = String11.str_15299
+
+@ExperimentalResourceApi
+internal val Res.string.str_153: StringResource
+  get() = String11.str_153
+
+@ExperimentalResourceApi
+internal val Res.string.str_1530: StringResource
+  get() = String11.str_1530
+
+@ExperimentalResourceApi
+internal val Res.string.str_15300: StringResource
+  get() = String11.str_15300
+
+@ExperimentalResourceApi
+internal val Res.string.str_15301: StringResource
+  get() = String11.str_15301
+
+@ExperimentalResourceApi
+internal val Res.string.str_15302: StringResource
+  get() = String11.str_15302
+
+@ExperimentalResourceApi
+internal val Res.string.str_15303: StringResource
+  get() = String11.str_15303
+
+@ExperimentalResourceApi
+internal val Res.string.str_15304: StringResource
+  get() = String11.str_15304
+
+@ExperimentalResourceApi
+internal val Res.string.str_15305: StringResource
+  get() = String11.str_15305
+
+@ExperimentalResourceApi
+internal val Res.string.str_15306: StringResource
+  get() = String11.str_15306
+
+@ExperimentalResourceApi
+internal val Res.string.str_15307: StringResource
+  get() = String11.str_15307
+
+@ExperimentalResourceApi
+internal val Res.string.str_15308: StringResource
+  get() = String11.str_15308
+
+@ExperimentalResourceApi
+internal val Res.string.str_15309: StringResource
+  get() = String11.str_15309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1531: StringResource
+  get() = String11.str_1531
+
+@ExperimentalResourceApi
+internal val Res.string.str_15310: StringResource
+  get() = String11.str_15310
+
+@ExperimentalResourceApi
+internal val Res.string.str_15311: StringResource
+  get() = String11.str_15311
+
+@ExperimentalResourceApi
+internal val Res.string.str_15312: StringResource
+  get() = String11.str_15312
+
+@ExperimentalResourceApi
+internal val Res.string.str_15313: StringResource
+  get() = String11.str_15313
+
+@ExperimentalResourceApi
+internal val Res.string.str_15314: StringResource
+  get() = String11.str_15314
+
+@ExperimentalResourceApi
+internal val Res.string.str_15315: StringResource
+  get() = String11.str_15315
+
+@ExperimentalResourceApi
+internal val Res.string.str_15316: StringResource
+  get() = String11.str_15316
+
+@ExperimentalResourceApi
+internal val Res.string.str_15317: StringResource
+  get() = String11.str_15317
+
+@ExperimentalResourceApi
+internal val Res.string.str_15318: StringResource
+  get() = String11.str_15318
+
+@ExperimentalResourceApi
+internal val Res.string.str_15319: StringResource
+  get() = String11.str_15319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1532: StringResource
+  get() = String11.str_1532
+
+@ExperimentalResourceApi
+internal val Res.string.str_15320: StringResource
+  get() = String11.str_15320
+
+@ExperimentalResourceApi
+internal val Res.string.str_15321: StringResource
+  get() = String11.str_15321
+
+@ExperimentalResourceApi
+internal val Res.string.str_15322: StringResource
+  get() = String11.str_15322
+
+@ExperimentalResourceApi
+internal val Res.string.str_15323: StringResource
+  get() = String11.str_15323
+
+@ExperimentalResourceApi
+internal val Res.string.str_15324: StringResource
+  get() = String11.str_15324
+
+@ExperimentalResourceApi
+internal val Res.string.str_15325: StringResource
+  get() = String11.str_15325
+
+@ExperimentalResourceApi
+internal val Res.string.str_15326: StringResource
+  get() = String11.str_15326
+
+@ExperimentalResourceApi
+internal val Res.string.str_15327: StringResource
+  get() = String11.str_15327
+
+@ExperimentalResourceApi
+internal val Res.string.str_15328: StringResource
+  get() = String11.str_15328
+
+@ExperimentalResourceApi
+internal val Res.string.str_15329: StringResource
+  get() = String11.str_15329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1533: StringResource
+  get() = String11.str_1533
+
+@ExperimentalResourceApi
+internal val Res.string.str_15330: StringResource
+  get() = String11.str_15330
+
+@ExperimentalResourceApi
+internal val Res.string.str_15331: StringResource
+  get() = String11.str_15331
+
+@ExperimentalResourceApi
+internal val Res.string.str_15332: StringResource
+  get() = String11.str_15332
+
+@ExperimentalResourceApi
+internal val Res.string.str_15333: StringResource
+  get() = String11.str_15333
+
+@ExperimentalResourceApi
+internal val Res.string.str_15334: StringResource
+  get() = String11.str_15334
+
+@ExperimentalResourceApi
+internal val Res.string.str_15335: StringResource
+  get() = String11.str_15335
+
+@ExperimentalResourceApi
+internal val Res.string.str_15336: StringResource
+  get() = String11.str_15336
+
+@ExperimentalResourceApi
+internal val Res.string.str_15337: StringResource
+  get() = String11.str_15337
+
+@ExperimentalResourceApi
+internal val Res.string.str_15338: StringResource
+  get() = String11.str_15338
+
+@ExperimentalResourceApi
+internal val Res.string.str_15339: StringResource
+  get() = String11.str_15339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1534: StringResource
+  get() = String11.str_1534
+
+@ExperimentalResourceApi
+internal val Res.string.str_15340: StringResource
+  get() = String11.str_15340
+
+@ExperimentalResourceApi
+internal val Res.string.str_15341: StringResource
+  get() = String11.str_15341
+
+@ExperimentalResourceApi
+internal val Res.string.str_15342: StringResource
+  get() = String11.str_15342
+
+@ExperimentalResourceApi
+internal val Res.string.str_15343: StringResource
+  get() = String11.str_15343
+
+@ExperimentalResourceApi
+internal val Res.string.str_15344: StringResource
+  get() = String11.str_15344
+
+@ExperimentalResourceApi
+internal val Res.string.str_15345: StringResource
+  get() = String11.str_15345
+
+@ExperimentalResourceApi
+internal val Res.string.str_15346: StringResource
+  get() = String11.str_15346
+
+@ExperimentalResourceApi
+internal val Res.string.str_15347: StringResource
+  get() = String11.str_15347
+
+@ExperimentalResourceApi
+internal val Res.string.str_15348: StringResource
+  get() = String11.str_15348
+
+@ExperimentalResourceApi
+internal val Res.string.str_15349: StringResource
+  get() = String11.str_15349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1535: StringResource
+  get() = String11.str_1535
+
+@ExperimentalResourceApi
+internal val Res.string.str_15350: StringResource
+  get() = String11.str_15350
+
+@ExperimentalResourceApi
+internal val Res.string.str_15351: StringResource
+  get() = String11.str_15351
+
+@ExperimentalResourceApi
+internal val Res.string.str_15352: StringResource
+  get() = String11.str_15352
+
+@ExperimentalResourceApi
+internal val Res.string.str_15353: StringResource
+  get() = String11.str_15353
+
+@ExperimentalResourceApi
+internal val Res.string.str_15354: StringResource
+  get() = String11.str_15354
+
+@ExperimentalResourceApi
+internal val Res.string.str_15355: StringResource
+  get() = String11.str_15355
+
+@ExperimentalResourceApi
+internal val Res.string.str_15356: StringResource
+  get() = String11.str_15356
+
+@ExperimentalResourceApi
+internal val Res.string.str_15357: StringResource
+  get() = String11.str_15357
+
+@ExperimentalResourceApi
+internal val Res.string.str_15358: StringResource
+  get() = String11.str_15358
+
+@ExperimentalResourceApi
+internal val Res.string.str_15359: StringResource
+  get() = String11.str_15359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1536: StringResource
+  get() = String11.str_1536
+
+@ExperimentalResourceApi
+internal val Res.string.str_15360: StringResource
+  get() = String11.str_15360
+
+@ExperimentalResourceApi
+internal val Res.string.str_15361: StringResource
+  get() = String11.str_15361
+
+@ExperimentalResourceApi
+internal val Res.string.str_15362: StringResource
+  get() = String11.str_15362
+
+@ExperimentalResourceApi
+internal val Res.string.str_15363: StringResource
+  get() = String11.str_15363
+
+@ExperimentalResourceApi
+internal val Res.string.str_15364: StringResource
+  get() = String11.str_15364
+
+@ExperimentalResourceApi
+internal val Res.string.str_15365: StringResource
+  get() = String11.str_15365
+
+@ExperimentalResourceApi
+internal val Res.string.str_15366: StringResource
+  get() = String11.str_15366
+
+@ExperimentalResourceApi
+internal val Res.string.str_15367: StringResource
+  get() = String11.str_15367
+
+@ExperimentalResourceApi
+internal val Res.string.str_15368: StringResource
+  get() = String11.str_15368
+
+@ExperimentalResourceApi
+internal val Res.string.str_15369: StringResource
+  get() = String11.str_15369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1537: StringResource
+  get() = String11.str_1537
+
+@ExperimentalResourceApi
+internal val Res.string.str_15370: StringResource
+  get() = String11.str_15370
+
+@ExperimentalResourceApi
+internal val Res.string.str_15371: StringResource
+  get() = String11.str_15371
+
+@ExperimentalResourceApi
+internal val Res.string.str_15372: StringResource
+  get() = String11.str_15372
+
+@ExperimentalResourceApi
+internal val Res.string.str_15373: StringResource
+  get() = String11.str_15373
+
+@ExperimentalResourceApi
+internal val Res.string.str_15374: StringResource
+  get() = String11.str_15374
+
+@ExperimentalResourceApi
+internal val Res.string.str_15375: StringResource
+  get() = String11.str_15375
+
+@ExperimentalResourceApi
+internal val Res.string.str_15376: StringResource
+  get() = String11.str_15376
+
+@ExperimentalResourceApi
+internal val Res.string.str_15377: StringResource
+  get() = String11.str_15377
+
+@ExperimentalResourceApi
+internal val Res.string.str_15378: StringResource
+  get() = String11.str_15378
+
+@ExperimentalResourceApi
+internal val Res.string.str_15379: StringResource
+  get() = String11.str_15379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1538: StringResource
+  get() = String11.str_1538
+
+@ExperimentalResourceApi
+internal val Res.string.str_15380: StringResource
+  get() = String11.str_15380
+
+@ExperimentalResourceApi
+internal val Res.string.str_15381: StringResource
+  get() = String11.str_15381
+
+@ExperimentalResourceApi
+internal val Res.string.str_15382: StringResource
+  get() = String11.str_15382
+
+@ExperimentalResourceApi
+internal val Res.string.str_15383: StringResource
+  get() = String11.str_15383
+
+@ExperimentalResourceApi
+internal val Res.string.str_15384: StringResource
+  get() = String11.str_15384
+
+@ExperimentalResourceApi
+internal val Res.string.str_15385: StringResource
+  get() = String11.str_15385
+
+@ExperimentalResourceApi
+internal val Res.string.str_15386: StringResource
+  get() = String11.str_15386
+
+@ExperimentalResourceApi
+internal val Res.string.str_15387: StringResource
+  get() = String11.str_15387
+
+@ExperimentalResourceApi
+internal val Res.string.str_15388: StringResource
+  get() = String11.str_15388
+
+@ExperimentalResourceApi
+internal val Res.string.str_15389: StringResource
+  get() = String11.str_15389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1539: StringResource
+  get() = String11.str_1539
+
+@ExperimentalResourceApi
+internal val Res.string.str_15390: StringResource
+  get() = String11.str_15390
+
+@ExperimentalResourceApi
+internal val Res.string.str_15391: StringResource
+  get() = String11.str_15391
+
+@ExperimentalResourceApi
+internal val Res.string.str_15392: StringResource
+  get() = String11.str_15392
+
+@ExperimentalResourceApi
+internal val Res.string.str_15393: StringResource
+  get() = String11.str_15393
+
+@ExperimentalResourceApi
+internal val Res.string.str_15394: StringResource
+  get() = String11.str_15394
+
+@ExperimentalResourceApi
+internal val Res.string.str_15395: StringResource
+  get() = String11.str_15395
+
+@ExperimentalResourceApi
+internal val Res.string.str_15396: StringResource
+  get() = String11.str_15396
+
+@ExperimentalResourceApi
+internal val Res.string.str_15397: StringResource
+  get() = String11.str_15397

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String12.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String12.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String12 {
+  public val str_15398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15398", "str_15398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15399", "str_15399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_154", "str_154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1540", "str_1540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15400", "str_15400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15401", "str_15401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15402", "str_15402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15403", "str_15403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15404", "str_15404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15405", "str_15405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15406", "str_15406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15407", "str_15407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15408", "str_15408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15409", "str_15409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1541", "str_1541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15410", "str_15410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15411", "str_15411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15412", "str_15412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15413", "str_15413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15414", "str_15414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15415", "str_15415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15416", "str_15416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15417", "str_15417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15418", "str_15418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15419", "str_15419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1542", "str_1542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15420", "str_15420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15421", "str_15421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15422", "str_15422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15423", "str_15423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15424", "str_15424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15425", "str_15425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15426", "str_15426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15427", "str_15427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15428", "str_15428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15429", "str_15429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1543", "str_1543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15430", "str_15430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15431", "str_15431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15432", "str_15432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15433", "str_15433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15434", "str_15434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15435", "str_15435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15436", "str_15436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15437", "str_15437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15438", "str_15438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15439", "str_15439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1544", "str_1544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15440", "str_15440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15441", "str_15441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15442", "str_15442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15443", "str_15443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15444", "str_15444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15445", "str_15445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15446", "str_15446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15447", "str_15447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15448", "str_15448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15449", "str_15449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1545", "str_1545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15450", "str_15450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15451", "str_15451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15452", "str_15452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15453", "str_15453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15454", "str_15454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15455", "str_15455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15456", "str_15456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15457", "str_15457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15458", "str_15458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15459", "str_15459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1546", "str_1546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15460", "str_15460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15461", "str_15461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15462", "str_15462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15463", "str_15463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15464", "str_15464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15465", "str_15465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15466", "str_15466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15467", "str_15467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15468", "str_15468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15469", "str_15469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1547", "str_1547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15470", "str_15470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15471", "str_15471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15472", "str_15472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15473", "str_15473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15474", "str_15474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15475", "str_15475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15476", "str_15476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15477", "str_15477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15478", "str_15478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15479", "str_15479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1548", "str_1548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15480", "str_15480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15481", "str_15481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15482", "str_15482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15483", "str_15483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15484", "str_15484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15485", "str_15485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15486", "str_15486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15487", "str_15487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15488", "str_15488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15489", "str_15489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1549", "str_1549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15490", "str_15490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15491", "str_15491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15492", "str_15492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15493", "str_15493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15494", "str_15494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15495", "str_15495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15496", "str_15496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15497", "str_15497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15498", "str_15498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15499", "str_15499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_155", "str_155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1550", "str_1550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15500", "str_15500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15501", "str_15501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15502", "str_15502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15503", "str_15503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15504", "str_15504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15505", "str_15505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15506", "str_15506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15507", "str_15507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15508", "str_15508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15509", "str_15509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1551", "str_1551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15510", "str_15510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15511", "str_15511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15512", "str_15512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15513", "str_15513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15514", "str_15514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15515", "str_15515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15516", "str_15516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15517", "str_15517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15518", "str_15518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15519", "str_15519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1552", "str_1552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15520", "str_15520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15521", "str_15521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15522", "str_15522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15523", "str_15523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15524", "str_15524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15525", "str_15525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15526", "str_15526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15527", "str_15527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15528", "str_15528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15529", "str_15529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1553", "str_1553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15530", "str_15530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15531", "str_15531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15532", "str_15532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15533", "str_15533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15534", "str_15534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15535", "str_15535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15536", "str_15536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15537", "str_15537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15538", "str_15538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15539", "str_15539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1554", "str_1554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15540", "str_15540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15541", "str_15541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15542", "str_15542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15543", "str_15543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15544", "str_15544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15545", "str_15545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15546", "str_15546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15547", "str_15547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15548", "str_15548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15549", "str_15549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1555", "str_1555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15550", "str_15550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15551", "str_15551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15552", "str_15552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15553", "str_15553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15554", "str_15554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15555", "str_15555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15556", "str_15556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15557", "str_15557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15558", "str_15558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15559", "str_15559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1556", "str_1556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15560", "str_15560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15561", "str_15561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15562", "str_15562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15563", "str_15563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15564", "str_15564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15565", "str_15565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15566", "str_15566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15567", "str_15567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15568", "str_15568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15569", "str_15569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1557", "str_1557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15570", "str_15570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15571", "str_15571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15572", "str_15572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15573", "str_15573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15574", "str_15574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15575", "str_15575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15576", "str_15576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15577", "str_15577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15578", "str_15578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15579", "str_15579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1558", "str_1558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15580", "str_15580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15581", "str_15581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15582", "str_15582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15583", "str_15583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15584", "str_15584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15585", "str_15585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15586", "str_15586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15587", "str_15587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15588", "str_15588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15589", "str_15589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1559", "str_1559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15590", "str_15590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15591", "str_15591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15592", "str_15592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15593", "str_15593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15594", "str_15594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15595", "str_15595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15596", "str_15596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15597", "str_15597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15598", "str_15598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15599", "str_15599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_156", "str_156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1560", "str_1560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15600", "str_15600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15601", "str_15601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15602", "str_15602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15603", "str_15603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15604", "str_15604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15605", "str_15605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15606", "str_15606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15607", "str_15607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15608", "str_15608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15609", "str_15609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1561", "str_1561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15610", "str_15610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15611", "str_15611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15612", "str_15612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15613", "str_15613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15614", "str_15614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15615", "str_15615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15616", "str_15616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15617", "str_15617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15618", "str_15618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15619", "str_15619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1562", "str_1562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15620", "str_15620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15621", "str_15621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15622", "str_15622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15623", "str_15623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15624", "str_15624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15625", "str_15625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15626", "str_15626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15627", "str_15627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15628", "str_15628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15629", "str_15629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1563", "str_1563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15630", "str_15630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15631", "str_15631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15632", "str_15632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15633", "str_15633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15634", "str_15634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15635", "str_15635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15636", "str_15636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15637", "str_15637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15638", "str_15638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15639", "str_15639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1564", "str_1564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15640", "str_15640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15641", "str_15641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15642", "str_15642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15643", "str_15643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15644", "str_15644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15645", "str_15645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15646", "str_15646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15647", "str_15647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15648", "str_15648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15649", "str_15649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1565", "str_1565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15650", "str_15650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15651", "str_15651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15652", "str_15652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15653", "str_15653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15654", "str_15654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15655", "str_15655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15656", "str_15656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15657", "str_15657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15658", "str_15658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15659", "str_15659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1566", "str_1566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15660", "str_15660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15661", "str_15661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15662", "str_15662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15663", "str_15663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15664", "str_15664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15665", "str_15665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15666", "str_15666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15667", "str_15667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15668", "str_15668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15669", "str_15669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1567", "str_1567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15670", "str_15670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15671", "str_15671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15672", "str_15672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15673", "str_15673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15674", "str_15674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15675", "str_15675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15676", "str_15676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15677", "str_15677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15678", "str_15678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15679", "str_15679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1568", "str_1568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15680", "str_15680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15681", "str_15681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15682", "str_15682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15683", "str_15683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15684", "str_15684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15685", "str_15685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15686", "str_15686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15687", "str_15687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15688", "str_15688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15689", "str_15689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1569", "str_1569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15690", "str_15690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15691", "str_15691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15692", "str_15692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15693", "str_15693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15694", "str_15694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15695", "str_15695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15696", "str_15696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15697", "str_15697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15698", "str_15698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15699", "str_15699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_157", "str_157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1570", "str_1570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15700", "str_15700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15701", "str_15701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15702", "str_15702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15703", "str_15703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15704", "str_15704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15705", "str_15705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15706", "str_15706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15707", "str_15707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15708", "str_15708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15709", "str_15709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1571", "str_1571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15710", "str_15710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15711", "str_15711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15712", "str_15712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15713", "str_15713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15714", "str_15714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15715", "str_15715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15716", "str_15716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15717", "str_15717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15718", "str_15718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15719", "str_15719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1572", "str_1572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15720", "str_15720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15721", "str_15721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15722", "str_15722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15723", "str_15723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15724", "str_15724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15725", "str_15725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15726", "str_15726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15727", "str_15727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15728", "str_15728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15729", "str_15729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1573", "str_1573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15730", "str_15730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15731", "str_15731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15732", "str_15732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15733", "str_15733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15734", "str_15734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15735", "str_15735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15736", "str_15736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15737", "str_15737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15738", "str_15738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15739", "str_15739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1574", "str_1574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15740", "str_15740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15741", "str_15741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15742", "str_15742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15743", "str_15743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15744", "str_15744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15745", "str_15745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15746", "str_15746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15747", "str_15747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15748", "str_15748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15749", "str_15749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1575", "str_1575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15750", "str_15750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15751", "str_15751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15752", "str_15752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15753", "str_15753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15754", "str_15754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15755", "str_15755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15756", "str_15756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15757", "str_15757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15758", "str_15758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15759", "str_15759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1576", "str_1576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15760", "str_15760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15761", "str_15761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15762", "str_15762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15763", "str_15763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15764", "str_15764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15765", "str_15765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15766", "str_15766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15767", "str_15767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15768", "str_15768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15769", "str_15769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1577", "str_1577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15770", "str_15770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15771", "str_15771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15772", "str_15772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15773", "str_15773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15774", "str_15774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15775", "str_15775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15776", "str_15776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15777", "str_15777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15778", "str_15778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15779", "str_15779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1578", "str_1578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15780", "str_15780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15781", "str_15781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15782", "str_15782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15783", "str_15783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15784", "str_15784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15785", "str_15785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15786", "str_15786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15787", "str_15787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15788", "str_15788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15789", "str_15789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1579", "str_1579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15790", "str_15790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15791", "str_15791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15792", "str_15792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15793", "str_15793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15794", "str_15794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15795", "str_15795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15796", "str_15796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15797", "str_15797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15798", "str_15798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15799", "str_15799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_158", "str_158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1580", "str_1580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15800", "str_15800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15801", "str_15801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15802", "str_15802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15803", "str_15803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15804", "str_15804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15805", "str_15805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15806", "str_15806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15807", "str_15807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15808", "str_15808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15809", "str_15809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1581", "str_1581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15810", "str_15810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15811", "str_15811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15812", "str_15812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15813", "str_15813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15814", "str_15814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15815", "str_15815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15816", "str_15816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15817", "str_15817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15818", "str_15818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15819", "str_15819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1582", "str_1582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15820", "str_15820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15821", "str_15821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15822", "str_15822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15823", "str_15823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15824", "str_15824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15825", "str_15825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15826", "str_15826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15827", "str_15827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15828", "str_15828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15829", "str_15829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1583", "str_1583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15830", "str_15830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15831", "str_15831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15832", "str_15832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15833", "str_15833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15834", "str_15834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15835", "str_15835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15836", "str_15836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15837", "str_15837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15838", "str_15838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15839", "str_15839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1584", "str_1584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15840", "str_15840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15841", "str_15841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15842", "str_15842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15843", "str_15843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15844", "str_15844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15845", "str_15845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15846", "str_15846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15847", "str_15847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_15398: StringResource
+  get() = String12.str_15398
+
+@ExperimentalResourceApi
+internal val Res.string.str_15399: StringResource
+  get() = String12.str_15399
+
+@ExperimentalResourceApi
+internal val Res.string.str_154: StringResource
+  get() = String12.str_154
+
+@ExperimentalResourceApi
+internal val Res.string.str_1540: StringResource
+  get() = String12.str_1540
+
+@ExperimentalResourceApi
+internal val Res.string.str_15400: StringResource
+  get() = String12.str_15400
+
+@ExperimentalResourceApi
+internal val Res.string.str_15401: StringResource
+  get() = String12.str_15401
+
+@ExperimentalResourceApi
+internal val Res.string.str_15402: StringResource
+  get() = String12.str_15402
+
+@ExperimentalResourceApi
+internal val Res.string.str_15403: StringResource
+  get() = String12.str_15403
+
+@ExperimentalResourceApi
+internal val Res.string.str_15404: StringResource
+  get() = String12.str_15404
+
+@ExperimentalResourceApi
+internal val Res.string.str_15405: StringResource
+  get() = String12.str_15405
+
+@ExperimentalResourceApi
+internal val Res.string.str_15406: StringResource
+  get() = String12.str_15406
+
+@ExperimentalResourceApi
+internal val Res.string.str_15407: StringResource
+  get() = String12.str_15407
+
+@ExperimentalResourceApi
+internal val Res.string.str_15408: StringResource
+  get() = String12.str_15408
+
+@ExperimentalResourceApi
+internal val Res.string.str_15409: StringResource
+  get() = String12.str_15409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1541: StringResource
+  get() = String12.str_1541
+
+@ExperimentalResourceApi
+internal val Res.string.str_15410: StringResource
+  get() = String12.str_15410
+
+@ExperimentalResourceApi
+internal val Res.string.str_15411: StringResource
+  get() = String12.str_15411
+
+@ExperimentalResourceApi
+internal val Res.string.str_15412: StringResource
+  get() = String12.str_15412
+
+@ExperimentalResourceApi
+internal val Res.string.str_15413: StringResource
+  get() = String12.str_15413
+
+@ExperimentalResourceApi
+internal val Res.string.str_15414: StringResource
+  get() = String12.str_15414
+
+@ExperimentalResourceApi
+internal val Res.string.str_15415: StringResource
+  get() = String12.str_15415
+
+@ExperimentalResourceApi
+internal val Res.string.str_15416: StringResource
+  get() = String12.str_15416
+
+@ExperimentalResourceApi
+internal val Res.string.str_15417: StringResource
+  get() = String12.str_15417
+
+@ExperimentalResourceApi
+internal val Res.string.str_15418: StringResource
+  get() = String12.str_15418
+
+@ExperimentalResourceApi
+internal val Res.string.str_15419: StringResource
+  get() = String12.str_15419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1542: StringResource
+  get() = String12.str_1542
+
+@ExperimentalResourceApi
+internal val Res.string.str_15420: StringResource
+  get() = String12.str_15420
+
+@ExperimentalResourceApi
+internal val Res.string.str_15421: StringResource
+  get() = String12.str_15421
+
+@ExperimentalResourceApi
+internal val Res.string.str_15422: StringResource
+  get() = String12.str_15422
+
+@ExperimentalResourceApi
+internal val Res.string.str_15423: StringResource
+  get() = String12.str_15423
+
+@ExperimentalResourceApi
+internal val Res.string.str_15424: StringResource
+  get() = String12.str_15424
+
+@ExperimentalResourceApi
+internal val Res.string.str_15425: StringResource
+  get() = String12.str_15425
+
+@ExperimentalResourceApi
+internal val Res.string.str_15426: StringResource
+  get() = String12.str_15426
+
+@ExperimentalResourceApi
+internal val Res.string.str_15427: StringResource
+  get() = String12.str_15427
+
+@ExperimentalResourceApi
+internal val Res.string.str_15428: StringResource
+  get() = String12.str_15428
+
+@ExperimentalResourceApi
+internal val Res.string.str_15429: StringResource
+  get() = String12.str_15429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1543: StringResource
+  get() = String12.str_1543
+
+@ExperimentalResourceApi
+internal val Res.string.str_15430: StringResource
+  get() = String12.str_15430
+
+@ExperimentalResourceApi
+internal val Res.string.str_15431: StringResource
+  get() = String12.str_15431
+
+@ExperimentalResourceApi
+internal val Res.string.str_15432: StringResource
+  get() = String12.str_15432
+
+@ExperimentalResourceApi
+internal val Res.string.str_15433: StringResource
+  get() = String12.str_15433
+
+@ExperimentalResourceApi
+internal val Res.string.str_15434: StringResource
+  get() = String12.str_15434
+
+@ExperimentalResourceApi
+internal val Res.string.str_15435: StringResource
+  get() = String12.str_15435
+
+@ExperimentalResourceApi
+internal val Res.string.str_15436: StringResource
+  get() = String12.str_15436
+
+@ExperimentalResourceApi
+internal val Res.string.str_15437: StringResource
+  get() = String12.str_15437
+
+@ExperimentalResourceApi
+internal val Res.string.str_15438: StringResource
+  get() = String12.str_15438
+
+@ExperimentalResourceApi
+internal val Res.string.str_15439: StringResource
+  get() = String12.str_15439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1544: StringResource
+  get() = String12.str_1544
+
+@ExperimentalResourceApi
+internal val Res.string.str_15440: StringResource
+  get() = String12.str_15440
+
+@ExperimentalResourceApi
+internal val Res.string.str_15441: StringResource
+  get() = String12.str_15441
+
+@ExperimentalResourceApi
+internal val Res.string.str_15442: StringResource
+  get() = String12.str_15442
+
+@ExperimentalResourceApi
+internal val Res.string.str_15443: StringResource
+  get() = String12.str_15443
+
+@ExperimentalResourceApi
+internal val Res.string.str_15444: StringResource
+  get() = String12.str_15444
+
+@ExperimentalResourceApi
+internal val Res.string.str_15445: StringResource
+  get() = String12.str_15445
+
+@ExperimentalResourceApi
+internal val Res.string.str_15446: StringResource
+  get() = String12.str_15446
+
+@ExperimentalResourceApi
+internal val Res.string.str_15447: StringResource
+  get() = String12.str_15447
+
+@ExperimentalResourceApi
+internal val Res.string.str_15448: StringResource
+  get() = String12.str_15448
+
+@ExperimentalResourceApi
+internal val Res.string.str_15449: StringResource
+  get() = String12.str_15449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1545: StringResource
+  get() = String12.str_1545
+
+@ExperimentalResourceApi
+internal val Res.string.str_15450: StringResource
+  get() = String12.str_15450
+
+@ExperimentalResourceApi
+internal val Res.string.str_15451: StringResource
+  get() = String12.str_15451
+
+@ExperimentalResourceApi
+internal val Res.string.str_15452: StringResource
+  get() = String12.str_15452
+
+@ExperimentalResourceApi
+internal val Res.string.str_15453: StringResource
+  get() = String12.str_15453
+
+@ExperimentalResourceApi
+internal val Res.string.str_15454: StringResource
+  get() = String12.str_15454
+
+@ExperimentalResourceApi
+internal val Res.string.str_15455: StringResource
+  get() = String12.str_15455
+
+@ExperimentalResourceApi
+internal val Res.string.str_15456: StringResource
+  get() = String12.str_15456
+
+@ExperimentalResourceApi
+internal val Res.string.str_15457: StringResource
+  get() = String12.str_15457
+
+@ExperimentalResourceApi
+internal val Res.string.str_15458: StringResource
+  get() = String12.str_15458
+
+@ExperimentalResourceApi
+internal val Res.string.str_15459: StringResource
+  get() = String12.str_15459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1546: StringResource
+  get() = String12.str_1546
+
+@ExperimentalResourceApi
+internal val Res.string.str_15460: StringResource
+  get() = String12.str_15460
+
+@ExperimentalResourceApi
+internal val Res.string.str_15461: StringResource
+  get() = String12.str_15461
+
+@ExperimentalResourceApi
+internal val Res.string.str_15462: StringResource
+  get() = String12.str_15462
+
+@ExperimentalResourceApi
+internal val Res.string.str_15463: StringResource
+  get() = String12.str_15463
+
+@ExperimentalResourceApi
+internal val Res.string.str_15464: StringResource
+  get() = String12.str_15464
+
+@ExperimentalResourceApi
+internal val Res.string.str_15465: StringResource
+  get() = String12.str_15465
+
+@ExperimentalResourceApi
+internal val Res.string.str_15466: StringResource
+  get() = String12.str_15466
+
+@ExperimentalResourceApi
+internal val Res.string.str_15467: StringResource
+  get() = String12.str_15467
+
+@ExperimentalResourceApi
+internal val Res.string.str_15468: StringResource
+  get() = String12.str_15468
+
+@ExperimentalResourceApi
+internal val Res.string.str_15469: StringResource
+  get() = String12.str_15469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1547: StringResource
+  get() = String12.str_1547
+
+@ExperimentalResourceApi
+internal val Res.string.str_15470: StringResource
+  get() = String12.str_15470
+
+@ExperimentalResourceApi
+internal val Res.string.str_15471: StringResource
+  get() = String12.str_15471
+
+@ExperimentalResourceApi
+internal val Res.string.str_15472: StringResource
+  get() = String12.str_15472
+
+@ExperimentalResourceApi
+internal val Res.string.str_15473: StringResource
+  get() = String12.str_15473
+
+@ExperimentalResourceApi
+internal val Res.string.str_15474: StringResource
+  get() = String12.str_15474
+
+@ExperimentalResourceApi
+internal val Res.string.str_15475: StringResource
+  get() = String12.str_15475
+
+@ExperimentalResourceApi
+internal val Res.string.str_15476: StringResource
+  get() = String12.str_15476
+
+@ExperimentalResourceApi
+internal val Res.string.str_15477: StringResource
+  get() = String12.str_15477
+
+@ExperimentalResourceApi
+internal val Res.string.str_15478: StringResource
+  get() = String12.str_15478
+
+@ExperimentalResourceApi
+internal val Res.string.str_15479: StringResource
+  get() = String12.str_15479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1548: StringResource
+  get() = String12.str_1548
+
+@ExperimentalResourceApi
+internal val Res.string.str_15480: StringResource
+  get() = String12.str_15480
+
+@ExperimentalResourceApi
+internal val Res.string.str_15481: StringResource
+  get() = String12.str_15481
+
+@ExperimentalResourceApi
+internal val Res.string.str_15482: StringResource
+  get() = String12.str_15482
+
+@ExperimentalResourceApi
+internal val Res.string.str_15483: StringResource
+  get() = String12.str_15483
+
+@ExperimentalResourceApi
+internal val Res.string.str_15484: StringResource
+  get() = String12.str_15484
+
+@ExperimentalResourceApi
+internal val Res.string.str_15485: StringResource
+  get() = String12.str_15485
+
+@ExperimentalResourceApi
+internal val Res.string.str_15486: StringResource
+  get() = String12.str_15486
+
+@ExperimentalResourceApi
+internal val Res.string.str_15487: StringResource
+  get() = String12.str_15487
+
+@ExperimentalResourceApi
+internal val Res.string.str_15488: StringResource
+  get() = String12.str_15488
+
+@ExperimentalResourceApi
+internal val Res.string.str_15489: StringResource
+  get() = String12.str_15489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1549: StringResource
+  get() = String12.str_1549
+
+@ExperimentalResourceApi
+internal val Res.string.str_15490: StringResource
+  get() = String12.str_15490
+
+@ExperimentalResourceApi
+internal val Res.string.str_15491: StringResource
+  get() = String12.str_15491
+
+@ExperimentalResourceApi
+internal val Res.string.str_15492: StringResource
+  get() = String12.str_15492
+
+@ExperimentalResourceApi
+internal val Res.string.str_15493: StringResource
+  get() = String12.str_15493
+
+@ExperimentalResourceApi
+internal val Res.string.str_15494: StringResource
+  get() = String12.str_15494
+
+@ExperimentalResourceApi
+internal val Res.string.str_15495: StringResource
+  get() = String12.str_15495
+
+@ExperimentalResourceApi
+internal val Res.string.str_15496: StringResource
+  get() = String12.str_15496
+
+@ExperimentalResourceApi
+internal val Res.string.str_15497: StringResource
+  get() = String12.str_15497
+
+@ExperimentalResourceApi
+internal val Res.string.str_15498: StringResource
+  get() = String12.str_15498
+
+@ExperimentalResourceApi
+internal val Res.string.str_15499: StringResource
+  get() = String12.str_15499
+
+@ExperimentalResourceApi
+internal val Res.string.str_155: StringResource
+  get() = String12.str_155
+
+@ExperimentalResourceApi
+internal val Res.string.str_1550: StringResource
+  get() = String12.str_1550
+
+@ExperimentalResourceApi
+internal val Res.string.str_15500: StringResource
+  get() = String12.str_15500
+
+@ExperimentalResourceApi
+internal val Res.string.str_15501: StringResource
+  get() = String12.str_15501
+
+@ExperimentalResourceApi
+internal val Res.string.str_15502: StringResource
+  get() = String12.str_15502
+
+@ExperimentalResourceApi
+internal val Res.string.str_15503: StringResource
+  get() = String12.str_15503
+
+@ExperimentalResourceApi
+internal val Res.string.str_15504: StringResource
+  get() = String12.str_15504
+
+@ExperimentalResourceApi
+internal val Res.string.str_15505: StringResource
+  get() = String12.str_15505
+
+@ExperimentalResourceApi
+internal val Res.string.str_15506: StringResource
+  get() = String12.str_15506
+
+@ExperimentalResourceApi
+internal val Res.string.str_15507: StringResource
+  get() = String12.str_15507
+
+@ExperimentalResourceApi
+internal val Res.string.str_15508: StringResource
+  get() = String12.str_15508
+
+@ExperimentalResourceApi
+internal val Res.string.str_15509: StringResource
+  get() = String12.str_15509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1551: StringResource
+  get() = String12.str_1551
+
+@ExperimentalResourceApi
+internal val Res.string.str_15510: StringResource
+  get() = String12.str_15510
+
+@ExperimentalResourceApi
+internal val Res.string.str_15511: StringResource
+  get() = String12.str_15511
+
+@ExperimentalResourceApi
+internal val Res.string.str_15512: StringResource
+  get() = String12.str_15512
+
+@ExperimentalResourceApi
+internal val Res.string.str_15513: StringResource
+  get() = String12.str_15513
+
+@ExperimentalResourceApi
+internal val Res.string.str_15514: StringResource
+  get() = String12.str_15514
+
+@ExperimentalResourceApi
+internal val Res.string.str_15515: StringResource
+  get() = String12.str_15515
+
+@ExperimentalResourceApi
+internal val Res.string.str_15516: StringResource
+  get() = String12.str_15516
+
+@ExperimentalResourceApi
+internal val Res.string.str_15517: StringResource
+  get() = String12.str_15517
+
+@ExperimentalResourceApi
+internal val Res.string.str_15518: StringResource
+  get() = String12.str_15518
+
+@ExperimentalResourceApi
+internal val Res.string.str_15519: StringResource
+  get() = String12.str_15519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1552: StringResource
+  get() = String12.str_1552
+
+@ExperimentalResourceApi
+internal val Res.string.str_15520: StringResource
+  get() = String12.str_15520
+
+@ExperimentalResourceApi
+internal val Res.string.str_15521: StringResource
+  get() = String12.str_15521
+
+@ExperimentalResourceApi
+internal val Res.string.str_15522: StringResource
+  get() = String12.str_15522
+
+@ExperimentalResourceApi
+internal val Res.string.str_15523: StringResource
+  get() = String12.str_15523
+
+@ExperimentalResourceApi
+internal val Res.string.str_15524: StringResource
+  get() = String12.str_15524
+
+@ExperimentalResourceApi
+internal val Res.string.str_15525: StringResource
+  get() = String12.str_15525
+
+@ExperimentalResourceApi
+internal val Res.string.str_15526: StringResource
+  get() = String12.str_15526
+
+@ExperimentalResourceApi
+internal val Res.string.str_15527: StringResource
+  get() = String12.str_15527
+
+@ExperimentalResourceApi
+internal val Res.string.str_15528: StringResource
+  get() = String12.str_15528
+
+@ExperimentalResourceApi
+internal val Res.string.str_15529: StringResource
+  get() = String12.str_15529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1553: StringResource
+  get() = String12.str_1553
+
+@ExperimentalResourceApi
+internal val Res.string.str_15530: StringResource
+  get() = String12.str_15530
+
+@ExperimentalResourceApi
+internal val Res.string.str_15531: StringResource
+  get() = String12.str_15531
+
+@ExperimentalResourceApi
+internal val Res.string.str_15532: StringResource
+  get() = String12.str_15532
+
+@ExperimentalResourceApi
+internal val Res.string.str_15533: StringResource
+  get() = String12.str_15533
+
+@ExperimentalResourceApi
+internal val Res.string.str_15534: StringResource
+  get() = String12.str_15534
+
+@ExperimentalResourceApi
+internal val Res.string.str_15535: StringResource
+  get() = String12.str_15535
+
+@ExperimentalResourceApi
+internal val Res.string.str_15536: StringResource
+  get() = String12.str_15536
+
+@ExperimentalResourceApi
+internal val Res.string.str_15537: StringResource
+  get() = String12.str_15537
+
+@ExperimentalResourceApi
+internal val Res.string.str_15538: StringResource
+  get() = String12.str_15538
+
+@ExperimentalResourceApi
+internal val Res.string.str_15539: StringResource
+  get() = String12.str_15539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1554: StringResource
+  get() = String12.str_1554
+
+@ExperimentalResourceApi
+internal val Res.string.str_15540: StringResource
+  get() = String12.str_15540
+
+@ExperimentalResourceApi
+internal val Res.string.str_15541: StringResource
+  get() = String12.str_15541
+
+@ExperimentalResourceApi
+internal val Res.string.str_15542: StringResource
+  get() = String12.str_15542
+
+@ExperimentalResourceApi
+internal val Res.string.str_15543: StringResource
+  get() = String12.str_15543
+
+@ExperimentalResourceApi
+internal val Res.string.str_15544: StringResource
+  get() = String12.str_15544
+
+@ExperimentalResourceApi
+internal val Res.string.str_15545: StringResource
+  get() = String12.str_15545
+
+@ExperimentalResourceApi
+internal val Res.string.str_15546: StringResource
+  get() = String12.str_15546
+
+@ExperimentalResourceApi
+internal val Res.string.str_15547: StringResource
+  get() = String12.str_15547
+
+@ExperimentalResourceApi
+internal val Res.string.str_15548: StringResource
+  get() = String12.str_15548
+
+@ExperimentalResourceApi
+internal val Res.string.str_15549: StringResource
+  get() = String12.str_15549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1555: StringResource
+  get() = String12.str_1555
+
+@ExperimentalResourceApi
+internal val Res.string.str_15550: StringResource
+  get() = String12.str_15550
+
+@ExperimentalResourceApi
+internal val Res.string.str_15551: StringResource
+  get() = String12.str_15551
+
+@ExperimentalResourceApi
+internal val Res.string.str_15552: StringResource
+  get() = String12.str_15552
+
+@ExperimentalResourceApi
+internal val Res.string.str_15553: StringResource
+  get() = String12.str_15553
+
+@ExperimentalResourceApi
+internal val Res.string.str_15554: StringResource
+  get() = String12.str_15554
+
+@ExperimentalResourceApi
+internal val Res.string.str_15555: StringResource
+  get() = String12.str_15555
+
+@ExperimentalResourceApi
+internal val Res.string.str_15556: StringResource
+  get() = String12.str_15556
+
+@ExperimentalResourceApi
+internal val Res.string.str_15557: StringResource
+  get() = String12.str_15557
+
+@ExperimentalResourceApi
+internal val Res.string.str_15558: StringResource
+  get() = String12.str_15558
+
+@ExperimentalResourceApi
+internal val Res.string.str_15559: StringResource
+  get() = String12.str_15559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1556: StringResource
+  get() = String12.str_1556
+
+@ExperimentalResourceApi
+internal val Res.string.str_15560: StringResource
+  get() = String12.str_15560
+
+@ExperimentalResourceApi
+internal val Res.string.str_15561: StringResource
+  get() = String12.str_15561
+
+@ExperimentalResourceApi
+internal val Res.string.str_15562: StringResource
+  get() = String12.str_15562
+
+@ExperimentalResourceApi
+internal val Res.string.str_15563: StringResource
+  get() = String12.str_15563
+
+@ExperimentalResourceApi
+internal val Res.string.str_15564: StringResource
+  get() = String12.str_15564
+
+@ExperimentalResourceApi
+internal val Res.string.str_15565: StringResource
+  get() = String12.str_15565
+
+@ExperimentalResourceApi
+internal val Res.string.str_15566: StringResource
+  get() = String12.str_15566
+
+@ExperimentalResourceApi
+internal val Res.string.str_15567: StringResource
+  get() = String12.str_15567
+
+@ExperimentalResourceApi
+internal val Res.string.str_15568: StringResource
+  get() = String12.str_15568
+
+@ExperimentalResourceApi
+internal val Res.string.str_15569: StringResource
+  get() = String12.str_15569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1557: StringResource
+  get() = String12.str_1557
+
+@ExperimentalResourceApi
+internal val Res.string.str_15570: StringResource
+  get() = String12.str_15570
+
+@ExperimentalResourceApi
+internal val Res.string.str_15571: StringResource
+  get() = String12.str_15571
+
+@ExperimentalResourceApi
+internal val Res.string.str_15572: StringResource
+  get() = String12.str_15572
+
+@ExperimentalResourceApi
+internal val Res.string.str_15573: StringResource
+  get() = String12.str_15573
+
+@ExperimentalResourceApi
+internal val Res.string.str_15574: StringResource
+  get() = String12.str_15574
+
+@ExperimentalResourceApi
+internal val Res.string.str_15575: StringResource
+  get() = String12.str_15575
+
+@ExperimentalResourceApi
+internal val Res.string.str_15576: StringResource
+  get() = String12.str_15576
+
+@ExperimentalResourceApi
+internal val Res.string.str_15577: StringResource
+  get() = String12.str_15577
+
+@ExperimentalResourceApi
+internal val Res.string.str_15578: StringResource
+  get() = String12.str_15578
+
+@ExperimentalResourceApi
+internal val Res.string.str_15579: StringResource
+  get() = String12.str_15579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1558: StringResource
+  get() = String12.str_1558
+
+@ExperimentalResourceApi
+internal val Res.string.str_15580: StringResource
+  get() = String12.str_15580
+
+@ExperimentalResourceApi
+internal val Res.string.str_15581: StringResource
+  get() = String12.str_15581
+
+@ExperimentalResourceApi
+internal val Res.string.str_15582: StringResource
+  get() = String12.str_15582
+
+@ExperimentalResourceApi
+internal val Res.string.str_15583: StringResource
+  get() = String12.str_15583
+
+@ExperimentalResourceApi
+internal val Res.string.str_15584: StringResource
+  get() = String12.str_15584
+
+@ExperimentalResourceApi
+internal val Res.string.str_15585: StringResource
+  get() = String12.str_15585
+
+@ExperimentalResourceApi
+internal val Res.string.str_15586: StringResource
+  get() = String12.str_15586
+
+@ExperimentalResourceApi
+internal val Res.string.str_15587: StringResource
+  get() = String12.str_15587
+
+@ExperimentalResourceApi
+internal val Res.string.str_15588: StringResource
+  get() = String12.str_15588
+
+@ExperimentalResourceApi
+internal val Res.string.str_15589: StringResource
+  get() = String12.str_15589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1559: StringResource
+  get() = String12.str_1559
+
+@ExperimentalResourceApi
+internal val Res.string.str_15590: StringResource
+  get() = String12.str_15590
+
+@ExperimentalResourceApi
+internal val Res.string.str_15591: StringResource
+  get() = String12.str_15591
+
+@ExperimentalResourceApi
+internal val Res.string.str_15592: StringResource
+  get() = String12.str_15592
+
+@ExperimentalResourceApi
+internal val Res.string.str_15593: StringResource
+  get() = String12.str_15593
+
+@ExperimentalResourceApi
+internal val Res.string.str_15594: StringResource
+  get() = String12.str_15594
+
+@ExperimentalResourceApi
+internal val Res.string.str_15595: StringResource
+  get() = String12.str_15595
+
+@ExperimentalResourceApi
+internal val Res.string.str_15596: StringResource
+  get() = String12.str_15596
+
+@ExperimentalResourceApi
+internal val Res.string.str_15597: StringResource
+  get() = String12.str_15597
+
+@ExperimentalResourceApi
+internal val Res.string.str_15598: StringResource
+  get() = String12.str_15598
+
+@ExperimentalResourceApi
+internal val Res.string.str_15599: StringResource
+  get() = String12.str_15599
+
+@ExperimentalResourceApi
+internal val Res.string.str_156: StringResource
+  get() = String12.str_156
+
+@ExperimentalResourceApi
+internal val Res.string.str_1560: StringResource
+  get() = String12.str_1560
+
+@ExperimentalResourceApi
+internal val Res.string.str_15600: StringResource
+  get() = String12.str_15600
+
+@ExperimentalResourceApi
+internal val Res.string.str_15601: StringResource
+  get() = String12.str_15601
+
+@ExperimentalResourceApi
+internal val Res.string.str_15602: StringResource
+  get() = String12.str_15602
+
+@ExperimentalResourceApi
+internal val Res.string.str_15603: StringResource
+  get() = String12.str_15603
+
+@ExperimentalResourceApi
+internal val Res.string.str_15604: StringResource
+  get() = String12.str_15604
+
+@ExperimentalResourceApi
+internal val Res.string.str_15605: StringResource
+  get() = String12.str_15605
+
+@ExperimentalResourceApi
+internal val Res.string.str_15606: StringResource
+  get() = String12.str_15606
+
+@ExperimentalResourceApi
+internal val Res.string.str_15607: StringResource
+  get() = String12.str_15607
+
+@ExperimentalResourceApi
+internal val Res.string.str_15608: StringResource
+  get() = String12.str_15608
+
+@ExperimentalResourceApi
+internal val Res.string.str_15609: StringResource
+  get() = String12.str_15609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1561: StringResource
+  get() = String12.str_1561
+
+@ExperimentalResourceApi
+internal val Res.string.str_15610: StringResource
+  get() = String12.str_15610
+
+@ExperimentalResourceApi
+internal val Res.string.str_15611: StringResource
+  get() = String12.str_15611
+
+@ExperimentalResourceApi
+internal val Res.string.str_15612: StringResource
+  get() = String12.str_15612
+
+@ExperimentalResourceApi
+internal val Res.string.str_15613: StringResource
+  get() = String12.str_15613
+
+@ExperimentalResourceApi
+internal val Res.string.str_15614: StringResource
+  get() = String12.str_15614
+
+@ExperimentalResourceApi
+internal val Res.string.str_15615: StringResource
+  get() = String12.str_15615
+
+@ExperimentalResourceApi
+internal val Res.string.str_15616: StringResource
+  get() = String12.str_15616
+
+@ExperimentalResourceApi
+internal val Res.string.str_15617: StringResource
+  get() = String12.str_15617
+
+@ExperimentalResourceApi
+internal val Res.string.str_15618: StringResource
+  get() = String12.str_15618
+
+@ExperimentalResourceApi
+internal val Res.string.str_15619: StringResource
+  get() = String12.str_15619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1562: StringResource
+  get() = String12.str_1562
+
+@ExperimentalResourceApi
+internal val Res.string.str_15620: StringResource
+  get() = String12.str_15620
+
+@ExperimentalResourceApi
+internal val Res.string.str_15621: StringResource
+  get() = String12.str_15621
+
+@ExperimentalResourceApi
+internal val Res.string.str_15622: StringResource
+  get() = String12.str_15622
+
+@ExperimentalResourceApi
+internal val Res.string.str_15623: StringResource
+  get() = String12.str_15623
+
+@ExperimentalResourceApi
+internal val Res.string.str_15624: StringResource
+  get() = String12.str_15624
+
+@ExperimentalResourceApi
+internal val Res.string.str_15625: StringResource
+  get() = String12.str_15625
+
+@ExperimentalResourceApi
+internal val Res.string.str_15626: StringResource
+  get() = String12.str_15626
+
+@ExperimentalResourceApi
+internal val Res.string.str_15627: StringResource
+  get() = String12.str_15627
+
+@ExperimentalResourceApi
+internal val Res.string.str_15628: StringResource
+  get() = String12.str_15628
+
+@ExperimentalResourceApi
+internal val Res.string.str_15629: StringResource
+  get() = String12.str_15629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1563: StringResource
+  get() = String12.str_1563
+
+@ExperimentalResourceApi
+internal val Res.string.str_15630: StringResource
+  get() = String12.str_15630
+
+@ExperimentalResourceApi
+internal val Res.string.str_15631: StringResource
+  get() = String12.str_15631
+
+@ExperimentalResourceApi
+internal val Res.string.str_15632: StringResource
+  get() = String12.str_15632
+
+@ExperimentalResourceApi
+internal val Res.string.str_15633: StringResource
+  get() = String12.str_15633
+
+@ExperimentalResourceApi
+internal val Res.string.str_15634: StringResource
+  get() = String12.str_15634
+
+@ExperimentalResourceApi
+internal val Res.string.str_15635: StringResource
+  get() = String12.str_15635
+
+@ExperimentalResourceApi
+internal val Res.string.str_15636: StringResource
+  get() = String12.str_15636
+
+@ExperimentalResourceApi
+internal val Res.string.str_15637: StringResource
+  get() = String12.str_15637
+
+@ExperimentalResourceApi
+internal val Res.string.str_15638: StringResource
+  get() = String12.str_15638
+
+@ExperimentalResourceApi
+internal val Res.string.str_15639: StringResource
+  get() = String12.str_15639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1564: StringResource
+  get() = String12.str_1564
+
+@ExperimentalResourceApi
+internal val Res.string.str_15640: StringResource
+  get() = String12.str_15640
+
+@ExperimentalResourceApi
+internal val Res.string.str_15641: StringResource
+  get() = String12.str_15641
+
+@ExperimentalResourceApi
+internal val Res.string.str_15642: StringResource
+  get() = String12.str_15642
+
+@ExperimentalResourceApi
+internal val Res.string.str_15643: StringResource
+  get() = String12.str_15643
+
+@ExperimentalResourceApi
+internal val Res.string.str_15644: StringResource
+  get() = String12.str_15644
+
+@ExperimentalResourceApi
+internal val Res.string.str_15645: StringResource
+  get() = String12.str_15645
+
+@ExperimentalResourceApi
+internal val Res.string.str_15646: StringResource
+  get() = String12.str_15646
+
+@ExperimentalResourceApi
+internal val Res.string.str_15647: StringResource
+  get() = String12.str_15647
+
+@ExperimentalResourceApi
+internal val Res.string.str_15648: StringResource
+  get() = String12.str_15648
+
+@ExperimentalResourceApi
+internal val Res.string.str_15649: StringResource
+  get() = String12.str_15649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1565: StringResource
+  get() = String12.str_1565
+
+@ExperimentalResourceApi
+internal val Res.string.str_15650: StringResource
+  get() = String12.str_15650
+
+@ExperimentalResourceApi
+internal val Res.string.str_15651: StringResource
+  get() = String12.str_15651
+
+@ExperimentalResourceApi
+internal val Res.string.str_15652: StringResource
+  get() = String12.str_15652
+
+@ExperimentalResourceApi
+internal val Res.string.str_15653: StringResource
+  get() = String12.str_15653
+
+@ExperimentalResourceApi
+internal val Res.string.str_15654: StringResource
+  get() = String12.str_15654
+
+@ExperimentalResourceApi
+internal val Res.string.str_15655: StringResource
+  get() = String12.str_15655
+
+@ExperimentalResourceApi
+internal val Res.string.str_15656: StringResource
+  get() = String12.str_15656
+
+@ExperimentalResourceApi
+internal val Res.string.str_15657: StringResource
+  get() = String12.str_15657
+
+@ExperimentalResourceApi
+internal val Res.string.str_15658: StringResource
+  get() = String12.str_15658
+
+@ExperimentalResourceApi
+internal val Res.string.str_15659: StringResource
+  get() = String12.str_15659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1566: StringResource
+  get() = String12.str_1566
+
+@ExperimentalResourceApi
+internal val Res.string.str_15660: StringResource
+  get() = String12.str_15660
+
+@ExperimentalResourceApi
+internal val Res.string.str_15661: StringResource
+  get() = String12.str_15661
+
+@ExperimentalResourceApi
+internal val Res.string.str_15662: StringResource
+  get() = String12.str_15662
+
+@ExperimentalResourceApi
+internal val Res.string.str_15663: StringResource
+  get() = String12.str_15663
+
+@ExperimentalResourceApi
+internal val Res.string.str_15664: StringResource
+  get() = String12.str_15664
+
+@ExperimentalResourceApi
+internal val Res.string.str_15665: StringResource
+  get() = String12.str_15665
+
+@ExperimentalResourceApi
+internal val Res.string.str_15666: StringResource
+  get() = String12.str_15666
+
+@ExperimentalResourceApi
+internal val Res.string.str_15667: StringResource
+  get() = String12.str_15667
+
+@ExperimentalResourceApi
+internal val Res.string.str_15668: StringResource
+  get() = String12.str_15668
+
+@ExperimentalResourceApi
+internal val Res.string.str_15669: StringResource
+  get() = String12.str_15669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1567: StringResource
+  get() = String12.str_1567
+
+@ExperimentalResourceApi
+internal val Res.string.str_15670: StringResource
+  get() = String12.str_15670
+
+@ExperimentalResourceApi
+internal val Res.string.str_15671: StringResource
+  get() = String12.str_15671
+
+@ExperimentalResourceApi
+internal val Res.string.str_15672: StringResource
+  get() = String12.str_15672
+
+@ExperimentalResourceApi
+internal val Res.string.str_15673: StringResource
+  get() = String12.str_15673
+
+@ExperimentalResourceApi
+internal val Res.string.str_15674: StringResource
+  get() = String12.str_15674
+
+@ExperimentalResourceApi
+internal val Res.string.str_15675: StringResource
+  get() = String12.str_15675
+
+@ExperimentalResourceApi
+internal val Res.string.str_15676: StringResource
+  get() = String12.str_15676
+
+@ExperimentalResourceApi
+internal val Res.string.str_15677: StringResource
+  get() = String12.str_15677
+
+@ExperimentalResourceApi
+internal val Res.string.str_15678: StringResource
+  get() = String12.str_15678
+
+@ExperimentalResourceApi
+internal val Res.string.str_15679: StringResource
+  get() = String12.str_15679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1568: StringResource
+  get() = String12.str_1568
+
+@ExperimentalResourceApi
+internal val Res.string.str_15680: StringResource
+  get() = String12.str_15680
+
+@ExperimentalResourceApi
+internal val Res.string.str_15681: StringResource
+  get() = String12.str_15681
+
+@ExperimentalResourceApi
+internal val Res.string.str_15682: StringResource
+  get() = String12.str_15682
+
+@ExperimentalResourceApi
+internal val Res.string.str_15683: StringResource
+  get() = String12.str_15683
+
+@ExperimentalResourceApi
+internal val Res.string.str_15684: StringResource
+  get() = String12.str_15684
+
+@ExperimentalResourceApi
+internal val Res.string.str_15685: StringResource
+  get() = String12.str_15685
+
+@ExperimentalResourceApi
+internal val Res.string.str_15686: StringResource
+  get() = String12.str_15686
+
+@ExperimentalResourceApi
+internal val Res.string.str_15687: StringResource
+  get() = String12.str_15687
+
+@ExperimentalResourceApi
+internal val Res.string.str_15688: StringResource
+  get() = String12.str_15688
+
+@ExperimentalResourceApi
+internal val Res.string.str_15689: StringResource
+  get() = String12.str_15689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1569: StringResource
+  get() = String12.str_1569
+
+@ExperimentalResourceApi
+internal val Res.string.str_15690: StringResource
+  get() = String12.str_15690
+
+@ExperimentalResourceApi
+internal val Res.string.str_15691: StringResource
+  get() = String12.str_15691
+
+@ExperimentalResourceApi
+internal val Res.string.str_15692: StringResource
+  get() = String12.str_15692
+
+@ExperimentalResourceApi
+internal val Res.string.str_15693: StringResource
+  get() = String12.str_15693
+
+@ExperimentalResourceApi
+internal val Res.string.str_15694: StringResource
+  get() = String12.str_15694
+
+@ExperimentalResourceApi
+internal val Res.string.str_15695: StringResource
+  get() = String12.str_15695
+
+@ExperimentalResourceApi
+internal val Res.string.str_15696: StringResource
+  get() = String12.str_15696
+
+@ExperimentalResourceApi
+internal val Res.string.str_15697: StringResource
+  get() = String12.str_15697
+
+@ExperimentalResourceApi
+internal val Res.string.str_15698: StringResource
+  get() = String12.str_15698
+
+@ExperimentalResourceApi
+internal val Res.string.str_15699: StringResource
+  get() = String12.str_15699
+
+@ExperimentalResourceApi
+internal val Res.string.str_157: StringResource
+  get() = String12.str_157
+
+@ExperimentalResourceApi
+internal val Res.string.str_1570: StringResource
+  get() = String12.str_1570
+
+@ExperimentalResourceApi
+internal val Res.string.str_15700: StringResource
+  get() = String12.str_15700
+
+@ExperimentalResourceApi
+internal val Res.string.str_15701: StringResource
+  get() = String12.str_15701
+
+@ExperimentalResourceApi
+internal val Res.string.str_15702: StringResource
+  get() = String12.str_15702
+
+@ExperimentalResourceApi
+internal val Res.string.str_15703: StringResource
+  get() = String12.str_15703
+
+@ExperimentalResourceApi
+internal val Res.string.str_15704: StringResource
+  get() = String12.str_15704
+
+@ExperimentalResourceApi
+internal val Res.string.str_15705: StringResource
+  get() = String12.str_15705
+
+@ExperimentalResourceApi
+internal val Res.string.str_15706: StringResource
+  get() = String12.str_15706
+
+@ExperimentalResourceApi
+internal val Res.string.str_15707: StringResource
+  get() = String12.str_15707
+
+@ExperimentalResourceApi
+internal val Res.string.str_15708: StringResource
+  get() = String12.str_15708
+
+@ExperimentalResourceApi
+internal val Res.string.str_15709: StringResource
+  get() = String12.str_15709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1571: StringResource
+  get() = String12.str_1571
+
+@ExperimentalResourceApi
+internal val Res.string.str_15710: StringResource
+  get() = String12.str_15710
+
+@ExperimentalResourceApi
+internal val Res.string.str_15711: StringResource
+  get() = String12.str_15711
+
+@ExperimentalResourceApi
+internal val Res.string.str_15712: StringResource
+  get() = String12.str_15712
+
+@ExperimentalResourceApi
+internal val Res.string.str_15713: StringResource
+  get() = String12.str_15713
+
+@ExperimentalResourceApi
+internal val Res.string.str_15714: StringResource
+  get() = String12.str_15714
+
+@ExperimentalResourceApi
+internal val Res.string.str_15715: StringResource
+  get() = String12.str_15715
+
+@ExperimentalResourceApi
+internal val Res.string.str_15716: StringResource
+  get() = String12.str_15716
+
+@ExperimentalResourceApi
+internal val Res.string.str_15717: StringResource
+  get() = String12.str_15717
+
+@ExperimentalResourceApi
+internal val Res.string.str_15718: StringResource
+  get() = String12.str_15718
+
+@ExperimentalResourceApi
+internal val Res.string.str_15719: StringResource
+  get() = String12.str_15719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1572: StringResource
+  get() = String12.str_1572
+
+@ExperimentalResourceApi
+internal val Res.string.str_15720: StringResource
+  get() = String12.str_15720
+
+@ExperimentalResourceApi
+internal val Res.string.str_15721: StringResource
+  get() = String12.str_15721
+
+@ExperimentalResourceApi
+internal val Res.string.str_15722: StringResource
+  get() = String12.str_15722
+
+@ExperimentalResourceApi
+internal val Res.string.str_15723: StringResource
+  get() = String12.str_15723
+
+@ExperimentalResourceApi
+internal val Res.string.str_15724: StringResource
+  get() = String12.str_15724
+
+@ExperimentalResourceApi
+internal val Res.string.str_15725: StringResource
+  get() = String12.str_15725
+
+@ExperimentalResourceApi
+internal val Res.string.str_15726: StringResource
+  get() = String12.str_15726
+
+@ExperimentalResourceApi
+internal val Res.string.str_15727: StringResource
+  get() = String12.str_15727
+
+@ExperimentalResourceApi
+internal val Res.string.str_15728: StringResource
+  get() = String12.str_15728
+
+@ExperimentalResourceApi
+internal val Res.string.str_15729: StringResource
+  get() = String12.str_15729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1573: StringResource
+  get() = String12.str_1573
+
+@ExperimentalResourceApi
+internal val Res.string.str_15730: StringResource
+  get() = String12.str_15730
+
+@ExperimentalResourceApi
+internal val Res.string.str_15731: StringResource
+  get() = String12.str_15731
+
+@ExperimentalResourceApi
+internal val Res.string.str_15732: StringResource
+  get() = String12.str_15732
+
+@ExperimentalResourceApi
+internal val Res.string.str_15733: StringResource
+  get() = String12.str_15733
+
+@ExperimentalResourceApi
+internal val Res.string.str_15734: StringResource
+  get() = String12.str_15734
+
+@ExperimentalResourceApi
+internal val Res.string.str_15735: StringResource
+  get() = String12.str_15735
+
+@ExperimentalResourceApi
+internal val Res.string.str_15736: StringResource
+  get() = String12.str_15736
+
+@ExperimentalResourceApi
+internal val Res.string.str_15737: StringResource
+  get() = String12.str_15737
+
+@ExperimentalResourceApi
+internal val Res.string.str_15738: StringResource
+  get() = String12.str_15738
+
+@ExperimentalResourceApi
+internal val Res.string.str_15739: StringResource
+  get() = String12.str_15739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1574: StringResource
+  get() = String12.str_1574
+
+@ExperimentalResourceApi
+internal val Res.string.str_15740: StringResource
+  get() = String12.str_15740
+
+@ExperimentalResourceApi
+internal val Res.string.str_15741: StringResource
+  get() = String12.str_15741
+
+@ExperimentalResourceApi
+internal val Res.string.str_15742: StringResource
+  get() = String12.str_15742
+
+@ExperimentalResourceApi
+internal val Res.string.str_15743: StringResource
+  get() = String12.str_15743
+
+@ExperimentalResourceApi
+internal val Res.string.str_15744: StringResource
+  get() = String12.str_15744
+
+@ExperimentalResourceApi
+internal val Res.string.str_15745: StringResource
+  get() = String12.str_15745
+
+@ExperimentalResourceApi
+internal val Res.string.str_15746: StringResource
+  get() = String12.str_15746
+
+@ExperimentalResourceApi
+internal val Res.string.str_15747: StringResource
+  get() = String12.str_15747
+
+@ExperimentalResourceApi
+internal val Res.string.str_15748: StringResource
+  get() = String12.str_15748
+
+@ExperimentalResourceApi
+internal val Res.string.str_15749: StringResource
+  get() = String12.str_15749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1575: StringResource
+  get() = String12.str_1575
+
+@ExperimentalResourceApi
+internal val Res.string.str_15750: StringResource
+  get() = String12.str_15750
+
+@ExperimentalResourceApi
+internal val Res.string.str_15751: StringResource
+  get() = String12.str_15751
+
+@ExperimentalResourceApi
+internal val Res.string.str_15752: StringResource
+  get() = String12.str_15752
+
+@ExperimentalResourceApi
+internal val Res.string.str_15753: StringResource
+  get() = String12.str_15753
+
+@ExperimentalResourceApi
+internal val Res.string.str_15754: StringResource
+  get() = String12.str_15754
+
+@ExperimentalResourceApi
+internal val Res.string.str_15755: StringResource
+  get() = String12.str_15755
+
+@ExperimentalResourceApi
+internal val Res.string.str_15756: StringResource
+  get() = String12.str_15756
+
+@ExperimentalResourceApi
+internal val Res.string.str_15757: StringResource
+  get() = String12.str_15757
+
+@ExperimentalResourceApi
+internal val Res.string.str_15758: StringResource
+  get() = String12.str_15758
+
+@ExperimentalResourceApi
+internal val Res.string.str_15759: StringResource
+  get() = String12.str_15759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1576: StringResource
+  get() = String12.str_1576
+
+@ExperimentalResourceApi
+internal val Res.string.str_15760: StringResource
+  get() = String12.str_15760
+
+@ExperimentalResourceApi
+internal val Res.string.str_15761: StringResource
+  get() = String12.str_15761
+
+@ExperimentalResourceApi
+internal val Res.string.str_15762: StringResource
+  get() = String12.str_15762
+
+@ExperimentalResourceApi
+internal val Res.string.str_15763: StringResource
+  get() = String12.str_15763
+
+@ExperimentalResourceApi
+internal val Res.string.str_15764: StringResource
+  get() = String12.str_15764
+
+@ExperimentalResourceApi
+internal val Res.string.str_15765: StringResource
+  get() = String12.str_15765
+
+@ExperimentalResourceApi
+internal val Res.string.str_15766: StringResource
+  get() = String12.str_15766
+
+@ExperimentalResourceApi
+internal val Res.string.str_15767: StringResource
+  get() = String12.str_15767
+
+@ExperimentalResourceApi
+internal val Res.string.str_15768: StringResource
+  get() = String12.str_15768
+
+@ExperimentalResourceApi
+internal val Res.string.str_15769: StringResource
+  get() = String12.str_15769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1577: StringResource
+  get() = String12.str_1577
+
+@ExperimentalResourceApi
+internal val Res.string.str_15770: StringResource
+  get() = String12.str_15770
+
+@ExperimentalResourceApi
+internal val Res.string.str_15771: StringResource
+  get() = String12.str_15771
+
+@ExperimentalResourceApi
+internal val Res.string.str_15772: StringResource
+  get() = String12.str_15772
+
+@ExperimentalResourceApi
+internal val Res.string.str_15773: StringResource
+  get() = String12.str_15773
+
+@ExperimentalResourceApi
+internal val Res.string.str_15774: StringResource
+  get() = String12.str_15774
+
+@ExperimentalResourceApi
+internal val Res.string.str_15775: StringResource
+  get() = String12.str_15775
+
+@ExperimentalResourceApi
+internal val Res.string.str_15776: StringResource
+  get() = String12.str_15776
+
+@ExperimentalResourceApi
+internal val Res.string.str_15777: StringResource
+  get() = String12.str_15777
+
+@ExperimentalResourceApi
+internal val Res.string.str_15778: StringResource
+  get() = String12.str_15778
+
+@ExperimentalResourceApi
+internal val Res.string.str_15779: StringResource
+  get() = String12.str_15779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1578: StringResource
+  get() = String12.str_1578
+
+@ExperimentalResourceApi
+internal val Res.string.str_15780: StringResource
+  get() = String12.str_15780
+
+@ExperimentalResourceApi
+internal val Res.string.str_15781: StringResource
+  get() = String12.str_15781
+
+@ExperimentalResourceApi
+internal val Res.string.str_15782: StringResource
+  get() = String12.str_15782
+
+@ExperimentalResourceApi
+internal val Res.string.str_15783: StringResource
+  get() = String12.str_15783
+
+@ExperimentalResourceApi
+internal val Res.string.str_15784: StringResource
+  get() = String12.str_15784
+
+@ExperimentalResourceApi
+internal val Res.string.str_15785: StringResource
+  get() = String12.str_15785
+
+@ExperimentalResourceApi
+internal val Res.string.str_15786: StringResource
+  get() = String12.str_15786
+
+@ExperimentalResourceApi
+internal val Res.string.str_15787: StringResource
+  get() = String12.str_15787
+
+@ExperimentalResourceApi
+internal val Res.string.str_15788: StringResource
+  get() = String12.str_15788
+
+@ExperimentalResourceApi
+internal val Res.string.str_15789: StringResource
+  get() = String12.str_15789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1579: StringResource
+  get() = String12.str_1579
+
+@ExperimentalResourceApi
+internal val Res.string.str_15790: StringResource
+  get() = String12.str_15790
+
+@ExperimentalResourceApi
+internal val Res.string.str_15791: StringResource
+  get() = String12.str_15791
+
+@ExperimentalResourceApi
+internal val Res.string.str_15792: StringResource
+  get() = String12.str_15792
+
+@ExperimentalResourceApi
+internal val Res.string.str_15793: StringResource
+  get() = String12.str_15793
+
+@ExperimentalResourceApi
+internal val Res.string.str_15794: StringResource
+  get() = String12.str_15794
+
+@ExperimentalResourceApi
+internal val Res.string.str_15795: StringResource
+  get() = String12.str_15795
+
+@ExperimentalResourceApi
+internal val Res.string.str_15796: StringResource
+  get() = String12.str_15796
+
+@ExperimentalResourceApi
+internal val Res.string.str_15797: StringResource
+  get() = String12.str_15797
+
+@ExperimentalResourceApi
+internal val Res.string.str_15798: StringResource
+  get() = String12.str_15798
+
+@ExperimentalResourceApi
+internal val Res.string.str_15799: StringResource
+  get() = String12.str_15799
+
+@ExperimentalResourceApi
+internal val Res.string.str_158: StringResource
+  get() = String12.str_158
+
+@ExperimentalResourceApi
+internal val Res.string.str_1580: StringResource
+  get() = String12.str_1580
+
+@ExperimentalResourceApi
+internal val Res.string.str_15800: StringResource
+  get() = String12.str_15800
+
+@ExperimentalResourceApi
+internal val Res.string.str_15801: StringResource
+  get() = String12.str_15801
+
+@ExperimentalResourceApi
+internal val Res.string.str_15802: StringResource
+  get() = String12.str_15802
+
+@ExperimentalResourceApi
+internal val Res.string.str_15803: StringResource
+  get() = String12.str_15803
+
+@ExperimentalResourceApi
+internal val Res.string.str_15804: StringResource
+  get() = String12.str_15804
+
+@ExperimentalResourceApi
+internal val Res.string.str_15805: StringResource
+  get() = String12.str_15805
+
+@ExperimentalResourceApi
+internal val Res.string.str_15806: StringResource
+  get() = String12.str_15806
+
+@ExperimentalResourceApi
+internal val Res.string.str_15807: StringResource
+  get() = String12.str_15807
+
+@ExperimentalResourceApi
+internal val Res.string.str_15808: StringResource
+  get() = String12.str_15808
+
+@ExperimentalResourceApi
+internal val Res.string.str_15809: StringResource
+  get() = String12.str_15809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1581: StringResource
+  get() = String12.str_1581
+
+@ExperimentalResourceApi
+internal val Res.string.str_15810: StringResource
+  get() = String12.str_15810
+
+@ExperimentalResourceApi
+internal val Res.string.str_15811: StringResource
+  get() = String12.str_15811
+
+@ExperimentalResourceApi
+internal val Res.string.str_15812: StringResource
+  get() = String12.str_15812
+
+@ExperimentalResourceApi
+internal val Res.string.str_15813: StringResource
+  get() = String12.str_15813
+
+@ExperimentalResourceApi
+internal val Res.string.str_15814: StringResource
+  get() = String12.str_15814
+
+@ExperimentalResourceApi
+internal val Res.string.str_15815: StringResource
+  get() = String12.str_15815
+
+@ExperimentalResourceApi
+internal val Res.string.str_15816: StringResource
+  get() = String12.str_15816
+
+@ExperimentalResourceApi
+internal val Res.string.str_15817: StringResource
+  get() = String12.str_15817
+
+@ExperimentalResourceApi
+internal val Res.string.str_15818: StringResource
+  get() = String12.str_15818
+
+@ExperimentalResourceApi
+internal val Res.string.str_15819: StringResource
+  get() = String12.str_15819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1582: StringResource
+  get() = String12.str_1582
+
+@ExperimentalResourceApi
+internal val Res.string.str_15820: StringResource
+  get() = String12.str_15820
+
+@ExperimentalResourceApi
+internal val Res.string.str_15821: StringResource
+  get() = String12.str_15821
+
+@ExperimentalResourceApi
+internal val Res.string.str_15822: StringResource
+  get() = String12.str_15822
+
+@ExperimentalResourceApi
+internal val Res.string.str_15823: StringResource
+  get() = String12.str_15823
+
+@ExperimentalResourceApi
+internal val Res.string.str_15824: StringResource
+  get() = String12.str_15824
+
+@ExperimentalResourceApi
+internal val Res.string.str_15825: StringResource
+  get() = String12.str_15825
+
+@ExperimentalResourceApi
+internal val Res.string.str_15826: StringResource
+  get() = String12.str_15826
+
+@ExperimentalResourceApi
+internal val Res.string.str_15827: StringResource
+  get() = String12.str_15827
+
+@ExperimentalResourceApi
+internal val Res.string.str_15828: StringResource
+  get() = String12.str_15828
+
+@ExperimentalResourceApi
+internal val Res.string.str_15829: StringResource
+  get() = String12.str_15829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1583: StringResource
+  get() = String12.str_1583
+
+@ExperimentalResourceApi
+internal val Res.string.str_15830: StringResource
+  get() = String12.str_15830
+
+@ExperimentalResourceApi
+internal val Res.string.str_15831: StringResource
+  get() = String12.str_15831
+
+@ExperimentalResourceApi
+internal val Res.string.str_15832: StringResource
+  get() = String12.str_15832
+
+@ExperimentalResourceApi
+internal val Res.string.str_15833: StringResource
+  get() = String12.str_15833
+
+@ExperimentalResourceApi
+internal val Res.string.str_15834: StringResource
+  get() = String12.str_15834
+
+@ExperimentalResourceApi
+internal val Res.string.str_15835: StringResource
+  get() = String12.str_15835
+
+@ExperimentalResourceApi
+internal val Res.string.str_15836: StringResource
+  get() = String12.str_15836
+
+@ExperimentalResourceApi
+internal val Res.string.str_15837: StringResource
+  get() = String12.str_15837
+
+@ExperimentalResourceApi
+internal val Res.string.str_15838: StringResource
+  get() = String12.str_15838
+
+@ExperimentalResourceApi
+internal val Res.string.str_15839: StringResource
+  get() = String12.str_15839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1584: StringResource
+  get() = String12.str_1584
+
+@ExperimentalResourceApi
+internal val Res.string.str_15840: StringResource
+  get() = String12.str_15840
+
+@ExperimentalResourceApi
+internal val Res.string.str_15841: StringResource
+  get() = String12.str_15841
+
+@ExperimentalResourceApi
+internal val Res.string.str_15842: StringResource
+  get() = String12.str_15842
+
+@ExperimentalResourceApi
+internal val Res.string.str_15843: StringResource
+  get() = String12.str_15843
+
+@ExperimentalResourceApi
+internal val Res.string.str_15844: StringResource
+  get() = String12.str_15844
+
+@ExperimentalResourceApi
+internal val Res.string.str_15845: StringResource
+  get() = String12.str_15845
+
+@ExperimentalResourceApi
+internal val Res.string.str_15846: StringResource
+  get() = String12.str_15846
+
+@ExperimentalResourceApi
+internal val Res.string.str_15847: StringResource
+  get() = String12.str_15847

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String13.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String13.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String13 {
+  public val str_15848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15848", "str_15848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15849", "str_15849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1585", "str_1585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15850", "str_15850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15851", "str_15851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15852", "str_15852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15853", "str_15853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15854", "str_15854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15855", "str_15855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15856", "str_15856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15857", "str_15857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15858", "str_15858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15859", "str_15859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1586", "str_1586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15860", "str_15860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15861", "str_15861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15862", "str_15862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15863", "str_15863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15864", "str_15864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15865", "str_15865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15866", "str_15866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15867", "str_15867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15868", "str_15868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15869", "str_15869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1587", "str_1587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15870", "str_15870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15871", "str_15871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15872", "str_15872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15873", "str_15873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15874", "str_15874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15875", "str_15875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15876", "str_15876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15877", "str_15877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15878", "str_15878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15879", "str_15879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1588", "str_1588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15880", "str_15880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15881", "str_15881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15882", "str_15882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15883", "str_15883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15884", "str_15884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15885", "str_15885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15886", "str_15886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15887", "str_15887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15888", "str_15888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15889", "str_15889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1589", "str_1589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15890", "str_15890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15891", "str_15891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15892", "str_15892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15893", "str_15893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15894", "str_15894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15895", "str_15895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15896", "str_15896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15897", "str_15897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15898", "str_15898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15899", "str_15899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_159", "str_159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1590", "str_1590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15900", "str_15900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15901", "str_15901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15902", "str_15902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15903", "str_15903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15904", "str_15904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15905", "str_15905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15906", "str_15906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15907", "str_15907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15908", "str_15908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15909", "str_15909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1591", "str_1591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15910", "str_15910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15911", "str_15911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15912", "str_15912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15913", "str_15913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15914", "str_15914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15915", "str_15915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15916", "str_15916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15917", "str_15917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15918", "str_15918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15919", "str_15919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1592", "str_1592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15920", "str_15920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15921", "str_15921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15922", "str_15922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15923", "str_15923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15924", "str_15924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15925", "str_15925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15926", "str_15926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15927", "str_15927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15928", "str_15928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15929", "str_15929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1593", "str_1593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15930", "str_15930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15931", "str_15931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15932", "str_15932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15933", "str_15933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15934", "str_15934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15935", "str_15935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15936", "str_15936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15937", "str_15937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15938", "str_15938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15939", "str_15939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1594", "str_1594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15940", "str_15940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15941", "str_15941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15942", "str_15942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15943", "str_15943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15944", "str_15944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15945", "str_15945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15946", "str_15946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15947", "str_15947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15948", "str_15948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15949", "str_15949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1595", "str_1595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15950", "str_15950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15951", "str_15951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15952", "str_15952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15953", "str_15953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15954", "str_15954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15955", "str_15955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15956", "str_15956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15957", "str_15957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15958", "str_15958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15959", "str_15959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1596", "str_1596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15960", "str_15960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15961", "str_15961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15962", "str_15962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15963", "str_15963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15964", "str_15964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15965", "str_15965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15966", "str_15966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15967", "str_15967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15968", "str_15968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15969", "str_15969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1597", "str_1597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15970", "str_15970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15971", "str_15971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15972", "str_15972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15973", "str_15973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15974", "str_15974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15975", "str_15975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15976", "str_15976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15977", "str_15977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15978", "str_15978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15979", "str_15979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1598", "str_1598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15980", "str_15980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15981", "str_15981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15982", "str_15982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15983", "str_15983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15984", "str_15984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15985", "str_15985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15986", "str_15986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15987", "str_15987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15988", "str_15988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15989", "str_15989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1599", "str_1599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15990", "str_15990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15991", "str_15991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15992", "str_15992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15993", "str_15993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15994", "str_15994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15995", "str_15995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15996", "str_15996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15997", "str_15997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15998", "str_15998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_15999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_15999", "str_15999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16", "str_16",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_160", "str_160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1600", "str_1600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16000", "str_16000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16001", "str_16001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16002", "str_16002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16003", "str_16003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16004", "str_16004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16005", "str_16005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16006", "str_16006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16007", "str_16007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16008", "str_16008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16009", "str_16009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1601", "str_1601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16010", "str_16010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16011", "str_16011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16012", "str_16012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16013", "str_16013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16014", "str_16014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16015", "str_16015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16016", "str_16016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16017", "str_16017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16018", "str_16018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16019", "str_16019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1602", "str_1602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16020", "str_16020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16021", "str_16021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16022", "str_16022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16023", "str_16023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16024", "str_16024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16025", "str_16025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16026", "str_16026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16027", "str_16027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16028", "str_16028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16029", "str_16029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1603", "str_1603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16030", "str_16030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16031", "str_16031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16032", "str_16032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16033", "str_16033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16034", "str_16034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16035", "str_16035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16036", "str_16036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16037", "str_16037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16038", "str_16038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16039", "str_16039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1604", "str_1604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16040", "str_16040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16041", "str_16041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16042", "str_16042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16043", "str_16043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16044", "str_16044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16045", "str_16045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16046", "str_16046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16047", "str_16047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16048", "str_16048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16049", "str_16049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1605", "str_1605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16050", "str_16050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16051", "str_16051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16052", "str_16052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16053", "str_16053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16054", "str_16054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16055", "str_16055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16056", "str_16056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16057", "str_16057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16058", "str_16058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16059", "str_16059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1606", "str_1606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16060", "str_16060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16061", "str_16061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16062", "str_16062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16063", "str_16063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16064", "str_16064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16065", "str_16065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16066", "str_16066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16067", "str_16067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16068", "str_16068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16069", "str_16069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1607", "str_1607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16070", "str_16070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16071", "str_16071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16072", "str_16072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16073", "str_16073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16074", "str_16074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16075", "str_16075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16076", "str_16076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16077", "str_16077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16078", "str_16078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16079", "str_16079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1608", "str_1608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16080", "str_16080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16081", "str_16081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16082", "str_16082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16083", "str_16083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16084", "str_16084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16085", "str_16085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16086", "str_16086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16087", "str_16087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16088", "str_16088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16089", "str_16089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1609", "str_1609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16090", "str_16090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16091", "str_16091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16092", "str_16092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16093", "str_16093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16094", "str_16094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16095", "str_16095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16096", "str_16096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16097", "str_16097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16098", "str_16098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16099", "str_16099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_161", "str_161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1610", "str_1610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16100", "str_16100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16101", "str_16101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16102", "str_16102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16103", "str_16103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16104", "str_16104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16105", "str_16105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16106", "str_16106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16107", "str_16107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16108", "str_16108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16109", "str_16109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1611", "str_1611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16110", "str_16110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16111", "str_16111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16112", "str_16112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16113", "str_16113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16114", "str_16114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16115", "str_16115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16116", "str_16116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16117", "str_16117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16118", "str_16118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16119", "str_16119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1612", "str_1612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16120", "str_16120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16121", "str_16121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16122", "str_16122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16123", "str_16123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16124", "str_16124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16125", "str_16125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16126", "str_16126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16127", "str_16127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16128", "str_16128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16129", "str_16129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1613", "str_1613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16130", "str_16130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16131", "str_16131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16132", "str_16132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16133", "str_16133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16134", "str_16134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16135", "str_16135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16136", "str_16136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16137", "str_16137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16138", "str_16138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16139", "str_16139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1614", "str_1614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16140", "str_16140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16141", "str_16141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16142", "str_16142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16143", "str_16143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16144", "str_16144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16145", "str_16145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16146", "str_16146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16147", "str_16147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16148", "str_16148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16149", "str_16149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1615", "str_1615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16150", "str_16150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16151", "str_16151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16152", "str_16152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16153", "str_16153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16154", "str_16154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16155", "str_16155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16156", "str_16156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16157", "str_16157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16158", "str_16158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16159", "str_16159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1616", "str_1616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16160", "str_16160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16161", "str_16161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16162", "str_16162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16163", "str_16163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16164", "str_16164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16165", "str_16165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16166", "str_16166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16167", "str_16167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16168", "str_16168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16169", "str_16169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1617", "str_1617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16170", "str_16170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16171", "str_16171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16172", "str_16172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16173", "str_16173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16174", "str_16174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16175", "str_16175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16176", "str_16176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16177", "str_16177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16178", "str_16178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16179", "str_16179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1618", "str_1618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16180", "str_16180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16181", "str_16181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16182", "str_16182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16183", "str_16183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16184", "str_16184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16185", "str_16185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16186", "str_16186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16187", "str_16187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16188", "str_16188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16189", "str_16189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1619", "str_1619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16190", "str_16190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16191", "str_16191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16192", "str_16192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16193", "str_16193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16194", "str_16194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16195", "str_16195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16196", "str_16196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16197", "str_16197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16198", "str_16198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16199", "str_16199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_162", "str_162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1620", "str_1620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16200", "str_16200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16201", "str_16201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16202", "str_16202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16203", "str_16203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16204", "str_16204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16205", "str_16205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16206", "str_16206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16207", "str_16207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16208", "str_16208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16209", "str_16209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1621", "str_1621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16210", "str_16210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16211", "str_16211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16212", "str_16212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16213", "str_16213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16214", "str_16214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16215", "str_16215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16216", "str_16216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16217", "str_16217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16218", "str_16218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16219", "str_16219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1622", "str_1622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16220", "str_16220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16221", "str_16221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16222", "str_16222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16223", "str_16223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16224", "str_16224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16225", "str_16225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16226", "str_16226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16227", "str_16227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16228", "str_16228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16229", "str_16229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1623", "str_1623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16230", "str_16230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16231", "str_16231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16232", "str_16232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16233", "str_16233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16234", "str_16234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16235", "str_16235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16236", "str_16236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16237", "str_16237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16238", "str_16238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16239", "str_16239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1624", "str_1624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16240", "str_16240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16241", "str_16241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16242", "str_16242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16243", "str_16243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16244", "str_16244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16245", "str_16245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16246", "str_16246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16247", "str_16247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16248", "str_16248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16249", "str_16249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1625", "str_1625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16250", "str_16250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16251", "str_16251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16252", "str_16252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16253", "str_16253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16254", "str_16254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16255", "str_16255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16256", "str_16256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16257", "str_16257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16258", "str_16258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16259", "str_16259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1626", "str_1626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16260", "str_16260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16261", "str_16261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16262", "str_16262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16263", "str_16263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16264", "str_16264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16265", "str_16265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16266", "str_16266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16267", "str_16267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16268", "str_16268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16269", "str_16269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1627", "str_1627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16270", "str_16270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16271", "str_16271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16272", "str_16272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16273", "str_16273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16274", "str_16274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16275", "str_16275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16276", "str_16276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16277", "str_16277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16278", "str_16278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16279", "str_16279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1628", "str_1628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16280", "str_16280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16281", "str_16281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16282", "str_16282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16283", "str_16283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16284", "str_16284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16285", "str_16285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16286", "str_16286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16287", "str_16287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16288", "str_16288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16289", "str_16289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1629", "str_1629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16290", "str_16290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16291", "str_16291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16292", "str_16292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16293", "str_16293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16294", "str_16294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16295", "str_16295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16296", "str_16296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16297", "str_16297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_15848: StringResource
+  get() = String13.str_15848
+
+@ExperimentalResourceApi
+internal val Res.string.str_15849: StringResource
+  get() = String13.str_15849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1585: StringResource
+  get() = String13.str_1585
+
+@ExperimentalResourceApi
+internal val Res.string.str_15850: StringResource
+  get() = String13.str_15850
+
+@ExperimentalResourceApi
+internal val Res.string.str_15851: StringResource
+  get() = String13.str_15851
+
+@ExperimentalResourceApi
+internal val Res.string.str_15852: StringResource
+  get() = String13.str_15852
+
+@ExperimentalResourceApi
+internal val Res.string.str_15853: StringResource
+  get() = String13.str_15853
+
+@ExperimentalResourceApi
+internal val Res.string.str_15854: StringResource
+  get() = String13.str_15854
+
+@ExperimentalResourceApi
+internal val Res.string.str_15855: StringResource
+  get() = String13.str_15855
+
+@ExperimentalResourceApi
+internal val Res.string.str_15856: StringResource
+  get() = String13.str_15856
+
+@ExperimentalResourceApi
+internal val Res.string.str_15857: StringResource
+  get() = String13.str_15857
+
+@ExperimentalResourceApi
+internal val Res.string.str_15858: StringResource
+  get() = String13.str_15858
+
+@ExperimentalResourceApi
+internal val Res.string.str_15859: StringResource
+  get() = String13.str_15859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1586: StringResource
+  get() = String13.str_1586
+
+@ExperimentalResourceApi
+internal val Res.string.str_15860: StringResource
+  get() = String13.str_15860
+
+@ExperimentalResourceApi
+internal val Res.string.str_15861: StringResource
+  get() = String13.str_15861
+
+@ExperimentalResourceApi
+internal val Res.string.str_15862: StringResource
+  get() = String13.str_15862
+
+@ExperimentalResourceApi
+internal val Res.string.str_15863: StringResource
+  get() = String13.str_15863
+
+@ExperimentalResourceApi
+internal val Res.string.str_15864: StringResource
+  get() = String13.str_15864
+
+@ExperimentalResourceApi
+internal val Res.string.str_15865: StringResource
+  get() = String13.str_15865
+
+@ExperimentalResourceApi
+internal val Res.string.str_15866: StringResource
+  get() = String13.str_15866
+
+@ExperimentalResourceApi
+internal val Res.string.str_15867: StringResource
+  get() = String13.str_15867
+
+@ExperimentalResourceApi
+internal val Res.string.str_15868: StringResource
+  get() = String13.str_15868
+
+@ExperimentalResourceApi
+internal val Res.string.str_15869: StringResource
+  get() = String13.str_15869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1587: StringResource
+  get() = String13.str_1587
+
+@ExperimentalResourceApi
+internal val Res.string.str_15870: StringResource
+  get() = String13.str_15870
+
+@ExperimentalResourceApi
+internal val Res.string.str_15871: StringResource
+  get() = String13.str_15871
+
+@ExperimentalResourceApi
+internal val Res.string.str_15872: StringResource
+  get() = String13.str_15872
+
+@ExperimentalResourceApi
+internal val Res.string.str_15873: StringResource
+  get() = String13.str_15873
+
+@ExperimentalResourceApi
+internal val Res.string.str_15874: StringResource
+  get() = String13.str_15874
+
+@ExperimentalResourceApi
+internal val Res.string.str_15875: StringResource
+  get() = String13.str_15875
+
+@ExperimentalResourceApi
+internal val Res.string.str_15876: StringResource
+  get() = String13.str_15876
+
+@ExperimentalResourceApi
+internal val Res.string.str_15877: StringResource
+  get() = String13.str_15877
+
+@ExperimentalResourceApi
+internal val Res.string.str_15878: StringResource
+  get() = String13.str_15878
+
+@ExperimentalResourceApi
+internal val Res.string.str_15879: StringResource
+  get() = String13.str_15879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1588: StringResource
+  get() = String13.str_1588
+
+@ExperimentalResourceApi
+internal val Res.string.str_15880: StringResource
+  get() = String13.str_15880
+
+@ExperimentalResourceApi
+internal val Res.string.str_15881: StringResource
+  get() = String13.str_15881
+
+@ExperimentalResourceApi
+internal val Res.string.str_15882: StringResource
+  get() = String13.str_15882
+
+@ExperimentalResourceApi
+internal val Res.string.str_15883: StringResource
+  get() = String13.str_15883
+
+@ExperimentalResourceApi
+internal val Res.string.str_15884: StringResource
+  get() = String13.str_15884
+
+@ExperimentalResourceApi
+internal val Res.string.str_15885: StringResource
+  get() = String13.str_15885
+
+@ExperimentalResourceApi
+internal val Res.string.str_15886: StringResource
+  get() = String13.str_15886
+
+@ExperimentalResourceApi
+internal val Res.string.str_15887: StringResource
+  get() = String13.str_15887
+
+@ExperimentalResourceApi
+internal val Res.string.str_15888: StringResource
+  get() = String13.str_15888
+
+@ExperimentalResourceApi
+internal val Res.string.str_15889: StringResource
+  get() = String13.str_15889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1589: StringResource
+  get() = String13.str_1589
+
+@ExperimentalResourceApi
+internal val Res.string.str_15890: StringResource
+  get() = String13.str_15890
+
+@ExperimentalResourceApi
+internal val Res.string.str_15891: StringResource
+  get() = String13.str_15891
+
+@ExperimentalResourceApi
+internal val Res.string.str_15892: StringResource
+  get() = String13.str_15892
+
+@ExperimentalResourceApi
+internal val Res.string.str_15893: StringResource
+  get() = String13.str_15893
+
+@ExperimentalResourceApi
+internal val Res.string.str_15894: StringResource
+  get() = String13.str_15894
+
+@ExperimentalResourceApi
+internal val Res.string.str_15895: StringResource
+  get() = String13.str_15895
+
+@ExperimentalResourceApi
+internal val Res.string.str_15896: StringResource
+  get() = String13.str_15896
+
+@ExperimentalResourceApi
+internal val Res.string.str_15897: StringResource
+  get() = String13.str_15897
+
+@ExperimentalResourceApi
+internal val Res.string.str_15898: StringResource
+  get() = String13.str_15898
+
+@ExperimentalResourceApi
+internal val Res.string.str_15899: StringResource
+  get() = String13.str_15899
+
+@ExperimentalResourceApi
+internal val Res.string.str_159: StringResource
+  get() = String13.str_159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1590: StringResource
+  get() = String13.str_1590
+
+@ExperimentalResourceApi
+internal val Res.string.str_15900: StringResource
+  get() = String13.str_15900
+
+@ExperimentalResourceApi
+internal val Res.string.str_15901: StringResource
+  get() = String13.str_15901
+
+@ExperimentalResourceApi
+internal val Res.string.str_15902: StringResource
+  get() = String13.str_15902
+
+@ExperimentalResourceApi
+internal val Res.string.str_15903: StringResource
+  get() = String13.str_15903
+
+@ExperimentalResourceApi
+internal val Res.string.str_15904: StringResource
+  get() = String13.str_15904
+
+@ExperimentalResourceApi
+internal val Res.string.str_15905: StringResource
+  get() = String13.str_15905
+
+@ExperimentalResourceApi
+internal val Res.string.str_15906: StringResource
+  get() = String13.str_15906
+
+@ExperimentalResourceApi
+internal val Res.string.str_15907: StringResource
+  get() = String13.str_15907
+
+@ExperimentalResourceApi
+internal val Res.string.str_15908: StringResource
+  get() = String13.str_15908
+
+@ExperimentalResourceApi
+internal val Res.string.str_15909: StringResource
+  get() = String13.str_15909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1591: StringResource
+  get() = String13.str_1591
+
+@ExperimentalResourceApi
+internal val Res.string.str_15910: StringResource
+  get() = String13.str_15910
+
+@ExperimentalResourceApi
+internal val Res.string.str_15911: StringResource
+  get() = String13.str_15911
+
+@ExperimentalResourceApi
+internal val Res.string.str_15912: StringResource
+  get() = String13.str_15912
+
+@ExperimentalResourceApi
+internal val Res.string.str_15913: StringResource
+  get() = String13.str_15913
+
+@ExperimentalResourceApi
+internal val Res.string.str_15914: StringResource
+  get() = String13.str_15914
+
+@ExperimentalResourceApi
+internal val Res.string.str_15915: StringResource
+  get() = String13.str_15915
+
+@ExperimentalResourceApi
+internal val Res.string.str_15916: StringResource
+  get() = String13.str_15916
+
+@ExperimentalResourceApi
+internal val Res.string.str_15917: StringResource
+  get() = String13.str_15917
+
+@ExperimentalResourceApi
+internal val Res.string.str_15918: StringResource
+  get() = String13.str_15918
+
+@ExperimentalResourceApi
+internal val Res.string.str_15919: StringResource
+  get() = String13.str_15919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1592: StringResource
+  get() = String13.str_1592
+
+@ExperimentalResourceApi
+internal val Res.string.str_15920: StringResource
+  get() = String13.str_15920
+
+@ExperimentalResourceApi
+internal val Res.string.str_15921: StringResource
+  get() = String13.str_15921
+
+@ExperimentalResourceApi
+internal val Res.string.str_15922: StringResource
+  get() = String13.str_15922
+
+@ExperimentalResourceApi
+internal val Res.string.str_15923: StringResource
+  get() = String13.str_15923
+
+@ExperimentalResourceApi
+internal val Res.string.str_15924: StringResource
+  get() = String13.str_15924
+
+@ExperimentalResourceApi
+internal val Res.string.str_15925: StringResource
+  get() = String13.str_15925
+
+@ExperimentalResourceApi
+internal val Res.string.str_15926: StringResource
+  get() = String13.str_15926
+
+@ExperimentalResourceApi
+internal val Res.string.str_15927: StringResource
+  get() = String13.str_15927
+
+@ExperimentalResourceApi
+internal val Res.string.str_15928: StringResource
+  get() = String13.str_15928
+
+@ExperimentalResourceApi
+internal val Res.string.str_15929: StringResource
+  get() = String13.str_15929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1593: StringResource
+  get() = String13.str_1593
+
+@ExperimentalResourceApi
+internal val Res.string.str_15930: StringResource
+  get() = String13.str_15930
+
+@ExperimentalResourceApi
+internal val Res.string.str_15931: StringResource
+  get() = String13.str_15931
+
+@ExperimentalResourceApi
+internal val Res.string.str_15932: StringResource
+  get() = String13.str_15932
+
+@ExperimentalResourceApi
+internal val Res.string.str_15933: StringResource
+  get() = String13.str_15933
+
+@ExperimentalResourceApi
+internal val Res.string.str_15934: StringResource
+  get() = String13.str_15934
+
+@ExperimentalResourceApi
+internal val Res.string.str_15935: StringResource
+  get() = String13.str_15935
+
+@ExperimentalResourceApi
+internal val Res.string.str_15936: StringResource
+  get() = String13.str_15936
+
+@ExperimentalResourceApi
+internal val Res.string.str_15937: StringResource
+  get() = String13.str_15937
+
+@ExperimentalResourceApi
+internal val Res.string.str_15938: StringResource
+  get() = String13.str_15938
+
+@ExperimentalResourceApi
+internal val Res.string.str_15939: StringResource
+  get() = String13.str_15939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1594: StringResource
+  get() = String13.str_1594
+
+@ExperimentalResourceApi
+internal val Res.string.str_15940: StringResource
+  get() = String13.str_15940
+
+@ExperimentalResourceApi
+internal val Res.string.str_15941: StringResource
+  get() = String13.str_15941
+
+@ExperimentalResourceApi
+internal val Res.string.str_15942: StringResource
+  get() = String13.str_15942
+
+@ExperimentalResourceApi
+internal val Res.string.str_15943: StringResource
+  get() = String13.str_15943
+
+@ExperimentalResourceApi
+internal val Res.string.str_15944: StringResource
+  get() = String13.str_15944
+
+@ExperimentalResourceApi
+internal val Res.string.str_15945: StringResource
+  get() = String13.str_15945
+
+@ExperimentalResourceApi
+internal val Res.string.str_15946: StringResource
+  get() = String13.str_15946
+
+@ExperimentalResourceApi
+internal val Res.string.str_15947: StringResource
+  get() = String13.str_15947
+
+@ExperimentalResourceApi
+internal val Res.string.str_15948: StringResource
+  get() = String13.str_15948
+
+@ExperimentalResourceApi
+internal val Res.string.str_15949: StringResource
+  get() = String13.str_15949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1595: StringResource
+  get() = String13.str_1595
+
+@ExperimentalResourceApi
+internal val Res.string.str_15950: StringResource
+  get() = String13.str_15950
+
+@ExperimentalResourceApi
+internal val Res.string.str_15951: StringResource
+  get() = String13.str_15951
+
+@ExperimentalResourceApi
+internal val Res.string.str_15952: StringResource
+  get() = String13.str_15952
+
+@ExperimentalResourceApi
+internal val Res.string.str_15953: StringResource
+  get() = String13.str_15953
+
+@ExperimentalResourceApi
+internal val Res.string.str_15954: StringResource
+  get() = String13.str_15954
+
+@ExperimentalResourceApi
+internal val Res.string.str_15955: StringResource
+  get() = String13.str_15955
+
+@ExperimentalResourceApi
+internal val Res.string.str_15956: StringResource
+  get() = String13.str_15956
+
+@ExperimentalResourceApi
+internal val Res.string.str_15957: StringResource
+  get() = String13.str_15957
+
+@ExperimentalResourceApi
+internal val Res.string.str_15958: StringResource
+  get() = String13.str_15958
+
+@ExperimentalResourceApi
+internal val Res.string.str_15959: StringResource
+  get() = String13.str_15959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1596: StringResource
+  get() = String13.str_1596
+
+@ExperimentalResourceApi
+internal val Res.string.str_15960: StringResource
+  get() = String13.str_15960
+
+@ExperimentalResourceApi
+internal val Res.string.str_15961: StringResource
+  get() = String13.str_15961
+
+@ExperimentalResourceApi
+internal val Res.string.str_15962: StringResource
+  get() = String13.str_15962
+
+@ExperimentalResourceApi
+internal val Res.string.str_15963: StringResource
+  get() = String13.str_15963
+
+@ExperimentalResourceApi
+internal val Res.string.str_15964: StringResource
+  get() = String13.str_15964
+
+@ExperimentalResourceApi
+internal val Res.string.str_15965: StringResource
+  get() = String13.str_15965
+
+@ExperimentalResourceApi
+internal val Res.string.str_15966: StringResource
+  get() = String13.str_15966
+
+@ExperimentalResourceApi
+internal val Res.string.str_15967: StringResource
+  get() = String13.str_15967
+
+@ExperimentalResourceApi
+internal val Res.string.str_15968: StringResource
+  get() = String13.str_15968
+
+@ExperimentalResourceApi
+internal val Res.string.str_15969: StringResource
+  get() = String13.str_15969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1597: StringResource
+  get() = String13.str_1597
+
+@ExperimentalResourceApi
+internal val Res.string.str_15970: StringResource
+  get() = String13.str_15970
+
+@ExperimentalResourceApi
+internal val Res.string.str_15971: StringResource
+  get() = String13.str_15971
+
+@ExperimentalResourceApi
+internal val Res.string.str_15972: StringResource
+  get() = String13.str_15972
+
+@ExperimentalResourceApi
+internal val Res.string.str_15973: StringResource
+  get() = String13.str_15973
+
+@ExperimentalResourceApi
+internal val Res.string.str_15974: StringResource
+  get() = String13.str_15974
+
+@ExperimentalResourceApi
+internal val Res.string.str_15975: StringResource
+  get() = String13.str_15975
+
+@ExperimentalResourceApi
+internal val Res.string.str_15976: StringResource
+  get() = String13.str_15976
+
+@ExperimentalResourceApi
+internal val Res.string.str_15977: StringResource
+  get() = String13.str_15977
+
+@ExperimentalResourceApi
+internal val Res.string.str_15978: StringResource
+  get() = String13.str_15978
+
+@ExperimentalResourceApi
+internal val Res.string.str_15979: StringResource
+  get() = String13.str_15979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1598: StringResource
+  get() = String13.str_1598
+
+@ExperimentalResourceApi
+internal val Res.string.str_15980: StringResource
+  get() = String13.str_15980
+
+@ExperimentalResourceApi
+internal val Res.string.str_15981: StringResource
+  get() = String13.str_15981
+
+@ExperimentalResourceApi
+internal val Res.string.str_15982: StringResource
+  get() = String13.str_15982
+
+@ExperimentalResourceApi
+internal val Res.string.str_15983: StringResource
+  get() = String13.str_15983
+
+@ExperimentalResourceApi
+internal val Res.string.str_15984: StringResource
+  get() = String13.str_15984
+
+@ExperimentalResourceApi
+internal val Res.string.str_15985: StringResource
+  get() = String13.str_15985
+
+@ExperimentalResourceApi
+internal val Res.string.str_15986: StringResource
+  get() = String13.str_15986
+
+@ExperimentalResourceApi
+internal val Res.string.str_15987: StringResource
+  get() = String13.str_15987
+
+@ExperimentalResourceApi
+internal val Res.string.str_15988: StringResource
+  get() = String13.str_15988
+
+@ExperimentalResourceApi
+internal val Res.string.str_15989: StringResource
+  get() = String13.str_15989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1599: StringResource
+  get() = String13.str_1599
+
+@ExperimentalResourceApi
+internal val Res.string.str_15990: StringResource
+  get() = String13.str_15990
+
+@ExperimentalResourceApi
+internal val Res.string.str_15991: StringResource
+  get() = String13.str_15991
+
+@ExperimentalResourceApi
+internal val Res.string.str_15992: StringResource
+  get() = String13.str_15992
+
+@ExperimentalResourceApi
+internal val Res.string.str_15993: StringResource
+  get() = String13.str_15993
+
+@ExperimentalResourceApi
+internal val Res.string.str_15994: StringResource
+  get() = String13.str_15994
+
+@ExperimentalResourceApi
+internal val Res.string.str_15995: StringResource
+  get() = String13.str_15995
+
+@ExperimentalResourceApi
+internal val Res.string.str_15996: StringResource
+  get() = String13.str_15996
+
+@ExperimentalResourceApi
+internal val Res.string.str_15997: StringResource
+  get() = String13.str_15997
+
+@ExperimentalResourceApi
+internal val Res.string.str_15998: StringResource
+  get() = String13.str_15998
+
+@ExperimentalResourceApi
+internal val Res.string.str_15999: StringResource
+  get() = String13.str_15999
+
+@ExperimentalResourceApi
+internal val Res.string.str_16: StringResource
+  get() = String13.str_16
+
+@ExperimentalResourceApi
+internal val Res.string.str_160: StringResource
+  get() = String13.str_160
+
+@ExperimentalResourceApi
+internal val Res.string.str_1600: StringResource
+  get() = String13.str_1600
+
+@ExperimentalResourceApi
+internal val Res.string.str_16000: StringResource
+  get() = String13.str_16000
+
+@ExperimentalResourceApi
+internal val Res.string.str_16001: StringResource
+  get() = String13.str_16001
+
+@ExperimentalResourceApi
+internal val Res.string.str_16002: StringResource
+  get() = String13.str_16002
+
+@ExperimentalResourceApi
+internal val Res.string.str_16003: StringResource
+  get() = String13.str_16003
+
+@ExperimentalResourceApi
+internal val Res.string.str_16004: StringResource
+  get() = String13.str_16004
+
+@ExperimentalResourceApi
+internal val Res.string.str_16005: StringResource
+  get() = String13.str_16005
+
+@ExperimentalResourceApi
+internal val Res.string.str_16006: StringResource
+  get() = String13.str_16006
+
+@ExperimentalResourceApi
+internal val Res.string.str_16007: StringResource
+  get() = String13.str_16007
+
+@ExperimentalResourceApi
+internal val Res.string.str_16008: StringResource
+  get() = String13.str_16008
+
+@ExperimentalResourceApi
+internal val Res.string.str_16009: StringResource
+  get() = String13.str_16009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1601: StringResource
+  get() = String13.str_1601
+
+@ExperimentalResourceApi
+internal val Res.string.str_16010: StringResource
+  get() = String13.str_16010
+
+@ExperimentalResourceApi
+internal val Res.string.str_16011: StringResource
+  get() = String13.str_16011
+
+@ExperimentalResourceApi
+internal val Res.string.str_16012: StringResource
+  get() = String13.str_16012
+
+@ExperimentalResourceApi
+internal val Res.string.str_16013: StringResource
+  get() = String13.str_16013
+
+@ExperimentalResourceApi
+internal val Res.string.str_16014: StringResource
+  get() = String13.str_16014
+
+@ExperimentalResourceApi
+internal val Res.string.str_16015: StringResource
+  get() = String13.str_16015
+
+@ExperimentalResourceApi
+internal val Res.string.str_16016: StringResource
+  get() = String13.str_16016
+
+@ExperimentalResourceApi
+internal val Res.string.str_16017: StringResource
+  get() = String13.str_16017
+
+@ExperimentalResourceApi
+internal val Res.string.str_16018: StringResource
+  get() = String13.str_16018
+
+@ExperimentalResourceApi
+internal val Res.string.str_16019: StringResource
+  get() = String13.str_16019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1602: StringResource
+  get() = String13.str_1602
+
+@ExperimentalResourceApi
+internal val Res.string.str_16020: StringResource
+  get() = String13.str_16020
+
+@ExperimentalResourceApi
+internal val Res.string.str_16021: StringResource
+  get() = String13.str_16021
+
+@ExperimentalResourceApi
+internal val Res.string.str_16022: StringResource
+  get() = String13.str_16022
+
+@ExperimentalResourceApi
+internal val Res.string.str_16023: StringResource
+  get() = String13.str_16023
+
+@ExperimentalResourceApi
+internal val Res.string.str_16024: StringResource
+  get() = String13.str_16024
+
+@ExperimentalResourceApi
+internal val Res.string.str_16025: StringResource
+  get() = String13.str_16025
+
+@ExperimentalResourceApi
+internal val Res.string.str_16026: StringResource
+  get() = String13.str_16026
+
+@ExperimentalResourceApi
+internal val Res.string.str_16027: StringResource
+  get() = String13.str_16027
+
+@ExperimentalResourceApi
+internal val Res.string.str_16028: StringResource
+  get() = String13.str_16028
+
+@ExperimentalResourceApi
+internal val Res.string.str_16029: StringResource
+  get() = String13.str_16029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1603: StringResource
+  get() = String13.str_1603
+
+@ExperimentalResourceApi
+internal val Res.string.str_16030: StringResource
+  get() = String13.str_16030
+
+@ExperimentalResourceApi
+internal val Res.string.str_16031: StringResource
+  get() = String13.str_16031
+
+@ExperimentalResourceApi
+internal val Res.string.str_16032: StringResource
+  get() = String13.str_16032
+
+@ExperimentalResourceApi
+internal val Res.string.str_16033: StringResource
+  get() = String13.str_16033
+
+@ExperimentalResourceApi
+internal val Res.string.str_16034: StringResource
+  get() = String13.str_16034
+
+@ExperimentalResourceApi
+internal val Res.string.str_16035: StringResource
+  get() = String13.str_16035
+
+@ExperimentalResourceApi
+internal val Res.string.str_16036: StringResource
+  get() = String13.str_16036
+
+@ExperimentalResourceApi
+internal val Res.string.str_16037: StringResource
+  get() = String13.str_16037
+
+@ExperimentalResourceApi
+internal val Res.string.str_16038: StringResource
+  get() = String13.str_16038
+
+@ExperimentalResourceApi
+internal val Res.string.str_16039: StringResource
+  get() = String13.str_16039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1604: StringResource
+  get() = String13.str_1604
+
+@ExperimentalResourceApi
+internal val Res.string.str_16040: StringResource
+  get() = String13.str_16040
+
+@ExperimentalResourceApi
+internal val Res.string.str_16041: StringResource
+  get() = String13.str_16041
+
+@ExperimentalResourceApi
+internal val Res.string.str_16042: StringResource
+  get() = String13.str_16042
+
+@ExperimentalResourceApi
+internal val Res.string.str_16043: StringResource
+  get() = String13.str_16043
+
+@ExperimentalResourceApi
+internal val Res.string.str_16044: StringResource
+  get() = String13.str_16044
+
+@ExperimentalResourceApi
+internal val Res.string.str_16045: StringResource
+  get() = String13.str_16045
+
+@ExperimentalResourceApi
+internal val Res.string.str_16046: StringResource
+  get() = String13.str_16046
+
+@ExperimentalResourceApi
+internal val Res.string.str_16047: StringResource
+  get() = String13.str_16047
+
+@ExperimentalResourceApi
+internal val Res.string.str_16048: StringResource
+  get() = String13.str_16048
+
+@ExperimentalResourceApi
+internal val Res.string.str_16049: StringResource
+  get() = String13.str_16049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1605: StringResource
+  get() = String13.str_1605
+
+@ExperimentalResourceApi
+internal val Res.string.str_16050: StringResource
+  get() = String13.str_16050
+
+@ExperimentalResourceApi
+internal val Res.string.str_16051: StringResource
+  get() = String13.str_16051
+
+@ExperimentalResourceApi
+internal val Res.string.str_16052: StringResource
+  get() = String13.str_16052
+
+@ExperimentalResourceApi
+internal val Res.string.str_16053: StringResource
+  get() = String13.str_16053
+
+@ExperimentalResourceApi
+internal val Res.string.str_16054: StringResource
+  get() = String13.str_16054
+
+@ExperimentalResourceApi
+internal val Res.string.str_16055: StringResource
+  get() = String13.str_16055
+
+@ExperimentalResourceApi
+internal val Res.string.str_16056: StringResource
+  get() = String13.str_16056
+
+@ExperimentalResourceApi
+internal val Res.string.str_16057: StringResource
+  get() = String13.str_16057
+
+@ExperimentalResourceApi
+internal val Res.string.str_16058: StringResource
+  get() = String13.str_16058
+
+@ExperimentalResourceApi
+internal val Res.string.str_16059: StringResource
+  get() = String13.str_16059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1606: StringResource
+  get() = String13.str_1606
+
+@ExperimentalResourceApi
+internal val Res.string.str_16060: StringResource
+  get() = String13.str_16060
+
+@ExperimentalResourceApi
+internal val Res.string.str_16061: StringResource
+  get() = String13.str_16061
+
+@ExperimentalResourceApi
+internal val Res.string.str_16062: StringResource
+  get() = String13.str_16062
+
+@ExperimentalResourceApi
+internal val Res.string.str_16063: StringResource
+  get() = String13.str_16063
+
+@ExperimentalResourceApi
+internal val Res.string.str_16064: StringResource
+  get() = String13.str_16064
+
+@ExperimentalResourceApi
+internal val Res.string.str_16065: StringResource
+  get() = String13.str_16065
+
+@ExperimentalResourceApi
+internal val Res.string.str_16066: StringResource
+  get() = String13.str_16066
+
+@ExperimentalResourceApi
+internal val Res.string.str_16067: StringResource
+  get() = String13.str_16067
+
+@ExperimentalResourceApi
+internal val Res.string.str_16068: StringResource
+  get() = String13.str_16068
+
+@ExperimentalResourceApi
+internal val Res.string.str_16069: StringResource
+  get() = String13.str_16069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1607: StringResource
+  get() = String13.str_1607
+
+@ExperimentalResourceApi
+internal val Res.string.str_16070: StringResource
+  get() = String13.str_16070
+
+@ExperimentalResourceApi
+internal val Res.string.str_16071: StringResource
+  get() = String13.str_16071
+
+@ExperimentalResourceApi
+internal val Res.string.str_16072: StringResource
+  get() = String13.str_16072
+
+@ExperimentalResourceApi
+internal val Res.string.str_16073: StringResource
+  get() = String13.str_16073
+
+@ExperimentalResourceApi
+internal val Res.string.str_16074: StringResource
+  get() = String13.str_16074
+
+@ExperimentalResourceApi
+internal val Res.string.str_16075: StringResource
+  get() = String13.str_16075
+
+@ExperimentalResourceApi
+internal val Res.string.str_16076: StringResource
+  get() = String13.str_16076
+
+@ExperimentalResourceApi
+internal val Res.string.str_16077: StringResource
+  get() = String13.str_16077
+
+@ExperimentalResourceApi
+internal val Res.string.str_16078: StringResource
+  get() = String13.str_16078
+
+@ExperimentalResourceApi
+internal val Res.string.str_16079: StringResource
+  get() = String13.str_16079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1608: StringResource
+  get() = String13.str_1608
+
+@ExperimentalResourceApi
+internal val Res.string.str_16080: StringResource
+  get() = String13.str_16080
+
+@ExperimentalResourceApi
+internal val Res.string.str_16081: StringResource
+  get() = String13.str_16081
+
+@ExperimentalResourceApi
+internal val Res.string.str_16082: StringResource
+  get() = String13.str_16082
+
+@ExperimentalResourceApi
+internal val Res.string.str_16083: StringResource
+  get() = String13.str_16083
+
+@ExperimentalResourceApi
+internal val Res.string.str_16084: StringResource
+  get() = String13.str_16084
+
+@ExperimentalResourceApi
+internal val Res.string.str_16085: StringResource
+  get() = String13.str_16085
+
+@ExperimentalResourceApi
+internal val Res.string.str_16086: StringResource
+  get() = String13.str_16086
+
+@ExperimentalResourceApi
+internal val Res.string.str_16087: StringResource
+  get() = String13.str_16087
+
+@ExperimentalResourceApi
+internal val Res.string.str_16088: StringResource
+  get() = String13.str_16088
+
+@ExperimentalResourceApi
+internal val Res.string.str_16089: StringResource
+  get() = String13.str_16089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1609: StringResource
+  get() = String13.str_1609
+
+@ExperimentalResourceApi
+internal val Res.string.str_16090: StringResource
+  get() = String13.str_16090
+
+@ExperimentalResourceApi
+internal val Res.string.str_16091: StringResource
+  get() = String13.str_16091
+
+@ExperimentalResourceApi
+internal val Res.string.str_16092: StringResource
+  get() = String13.str_16092
+
+@ExperimentalResourceApi
+internal val Res.string.str_16093: StringResource
+  get() = String13.str_16093
+
+@ExperimentalResourceApi
+internal val Res.string.str_16094: StringResource
+  get() = String13.str_16094
+
+@ExperimentalResourceApi
+internal val Res.string.str_16095: StringResource
+  get() = String13.str_16095
+
+@ExperimentalResourceApi
+internal val Res.string.str_16096: StringResource
+  get() = String13.str_16096
+
+@ExperimentalResourceApi
+internal val Res.string.str_16097: StringResource
+  get() = String13.str_16097
+
+@ExperimentalResourceApi
+internal val Res.string.str_16098: StringResource
+  get() = String13.str_16098
+
+@ExperimentalResourceApi
+internal val Res.string.str_16099: StringResource
+  get() = String13.str_16099
+
+@ExperimentalResourceApi
+internal val Res.string.str_161: StringResource
+  get() = String13.str_161
+
+@ExperimentalResourceApi
+internal val Res.string.str_1610: StringResource
+  get() = String13.str_1610
+
+@ExperimentalResourceApi
+internal val Res.string.str_16100: StringResource
+  get() = String13.str_16100
+
+@ExperimentalResourceApi
+internal val Res.string.str_16101: StringResource
+  get() = String13.str_16101
+
+@ExperimentalResourceApi
+internal val Res.string.str_16102: StringResource
+  get() = String13.str_16102
+
+@ExperimentalResourceApi
+internal val Res.string.str_16103: StringResource
+  get() = String13.str_16103
+
+@ExperimentalResourceApi
+internal val Res.string.str_16104: StringResource
+  get() = String13.str_16104
+
+@ExperimentalResourceApi
+internal val Res.string.str_16105: StringResource
+  get() = String13.str_16105
+
+@ExperimentalResourceApi
+internal val Res.string.str_16106: StringResource
+  get() = String13.str_16106
+
+@ExperimentalResourceApi
+internal val Res.string.str_16107: StringResource
+  get() = String13.str_16107
+
+@ExperimentalResourceApi
+internal val Res.string.str_16108: StringResource
+  get() = String13.str_16108
+
+@ExperimentalResourceApi
+internal val Res.string.str_16109: StringResource
+  get() = String13.str_16109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1611: StringResource
+  get() = String13.str_1611
+
+@ExperimentalResourceApi
+internal val Res.string.str_16110: StringResource
+  get() = String13.str_16110
+
+@ExperimentalResourceApi
+internal val Res.string.str_16111: StringResource
+  get() = String13.str_16111
+
+@ExperimentalResourceApi
+internal val Res.string.str_16112: StringResource
+  get() = String13.str_16112
+
+@ExperimentalResourceApi
+internal val Res.string.str_16113: StringResource
+  get() = String13.str_16113
+
+@ExperimentalResourceApi
+internal val Res.string.str_16114: StringResource
+  get() = String13.str_16114
+
+@ExperimentalResourceApi
+internal val Res.string.str_16115: StringResource
+  get() = String13.str_16115
+
+@ExperimentalResourceApi
+internal val Res.string.str_16116: StringResource
+  get() = String13.str_16116
+
+@ExperimentalResourceApi
+internal val Res.string.str_16117: StringResource
+  get() = String13.str_16117
+
+@ExperimentalResourceApi
+internal val Res.string.str_16118: StringResource
+  get() = String13.str_16118
+
+@ExperimentalResourceApi
+internal val Res.string.str_16119: StringResource
+  get() = String13.str_16119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1612: StringResource
+  get() = String13.str_1612
+
+@ExperimentalResourceApi
+internal val Res.string.str_16120: StringResource
+  get() = String13.str_16120
+
+@ExperimentalResourceApi
+internal val Res.string.str_16121: StringResource
+  get() = String13.str_16121
+
+@ExperimentalResourceApi
+internal val Res.string.str_16122: StringResource
+  get() = String13.str_16122
+
+@ExperimentalResourceApi
+internal val Res.string.str_16123: StringResource
+  get() = String13.str_16123
+
+@ExperimentalResourceApi
+internal val Res.string.str_16124: StringResource
+  get() = String13.str_16124
+
+@ExperimentalResourceApi
+internal val Res.string.str_16125: StringResource
+  get() = String13.str_16125
+
+@ExperimentalResourceApi
+internal val Res.string.str_16126: StringResource
+  get() = String13.str_16126
+
+@ExperimentalResourceApi
+internal val Res.string.str_16127: StringResource
+  get() = String13.str_16127
+
+@ExperimentalResourceApi
+internal val Res.string.str_16128: StringResource
+  get() = String13.str_16128
+
+@ExperimentalResourceApi
+internal val Res.string.str_16129: StringResource
+  get() = String13.str_16129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1613: StringResource
+  get() = String13.str_1613
+
+@ExperimentalResourceApi
+internal val Res.string.str_16130: StringResource
+  get() = String13.str_16130
+
+@ExperimentalResourceApi
+internal val Res.string.str_16131: StringResource
+  get() = String13.str_16131
+
+@ExperimentalResourceApi
+internal val Res.string.str_16132: StringResource
+  get() = String13.str_16132
+
+@ExperimentalResourceApi
+internal val Res.string.str_16133: StringResource
+  get() = String13.str_16133
+
+@ExperimentalResourceApi
+internal val Res.string.str_16134: StringResource
+  get() = String13.str_16134
+
+@ExperimentalResourceApi
+internal val Res.string.str_16135: StringResource
+  get() = String13.str_16135
+
+@ExperimentalResourceApi
+internal val Res.string.str_16136: StringResource
+  get() = String13.str_16136
+
+@ExperimentalResourceApi
+internal val Res.string.str_16137: StringResource
+  get() = String13.str_16137
+
+@ExperimentalResourceApi
+internal val Res.string.str_16138: StringResource
+  get() = String13.str_16138
+
+@ExperimentalResourceApi
+internal val Res.string.str_16139: StringResource
+  get() = String13.str_16139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1614: StringResource
+  get() = String13.str_1614
+
+@ExperimentalResourceApi
+internal val Res.string.str_16140: StringResource
+  get() = String13.str_16140
+
+@ExperimentalResourceApi
+internal val Res.string.str_16141: StringResource
+  get() = String13.str_16141
+
+@ExperimentalResourceApi
+internal val Res.string.str_16142: StringResource
+  get() = String13.str_16142
+
+@ExperimentalResourceApi
+internal val Res.string.str_16143: StringResource
+  get() = String13.str_16143
+
+@ExperimentalResourceApi
+internal val Res.string.str_16144: StringResource
+  get() = String13.str_16144
+
+@ExperimentalResourceApi
+internal val Res.string.str_16145: StringResource
+  get() = String13.str_16145
+
+@ExperimentalResourceApi
+internal val Res.string.str_16146: StringResource
+  get() = String13.str_16146
+
+@ExperimentalResourceApi
+internal val Res.string.str_16147: StringResource
+  get() = String13.str_16147
+
+@ExperimentalResourceApi
+internal val Res.string.str_16148: StringResource
+  get() = String13.str_16148
+
+@ExperimentalResourceApi
+internal val Res.string.str_16149: StringResource
+  get() = String13.str_16149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1615: StringResource
+  get() = String13.str_1615
+
+@ExperimentalResourceApi
+internal val Res.string.str_16150: StringResource
+  get() = String13.str_16150
+
+@ExperimentalResourceApi
+internal val Res.string.str_16151: StringResource
+  get() = String13.str_16151
+
+@ExperimentalResourceApi
+internal val Res.string.str_16152: StringResource
+  get() = String13.str_16152
+
+@ExperimentalResourceApi
+internal val Res.string.str_16153: StringResource
+  get() = String13.str_16153
+
+@ExperimentalResourceApi
+internal val Res.string.str_16154: StringResource
+  get() = String13.str_16154
+
+@ExperimentalResourceApi
+internal val Res.string.str_16155: StringResource
+  get() = String13.str_16155
+
+@ExperimentalResourceApi
+internal val Res.string.str_16156: StringResource
+  get() = String13.str_16156
+
+@ExperimentalResourceApi
+internal val Res.string.str_16157: StringResource
+  get() = String13.str_16157
+
+@ExperimentalResourceApi
+internal val Res.string.str_16158: StringResource
+  get() = String13.str_16158
+
+@ExperimentalResourceApi
+internal val Res.string.str_16159: StringResource
+  get() = String13.str_16159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1616: StringResource
+  get() = String13.str_1616
+
+@ExperimentalResourceApi
+internal val Res.string.str_16160: StringResource
+  get() = String13.str_16160
+
+@ExperimentalResourceApi
+internal val Res.string.str_16161: StringResource
+  get() = String13.str_16161
+
+@ExperimentalResourceApi
+internal val Res.string.str_16162: StringResource
+  get() = String13.str_16162
+
+@ExperimentalResourceApi
+internal val Res.string.str_16163: StringResource
+  get() = String13.str_16163
+
+@ExperimentalResourceApi
+internal val Res.string.str_16164: StringResource
+  get() = String13.str_16164
+
+@ExperimentalResourceApi
+internal val Res.string.str_16165: StringResource
+  get() = String13.str_16165
+
+@ExperimentalResourceApi
+internal val Res.string.str_16166: StringResource
+  get() = String13.str_16166
+
+@ExperimentalResourceApi
+internal val Res.string.str_16167: StringResource
+  get() = String13.str_16167
+
+@ExperimentalResourceApi
+internal val Res.string.str_16168: StringResource
+  get() = String13.str_16168
+
+@ExperimentalResourceApi
+internal val Res.string.str_16169: StringResource
+  get() = String13.str_16169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1617: StringResource
+  get() = String13.str_1617
+
+@ExperimentalResourceApi
+internal val Res.string.str_16170: StringResource
+  get() = String13.str_16170
+
+@ExperimentalResourceApi
+internal val Res.string.str_16171: StringResource
+  get() = String13.str_16171
+
+@ExperimentalResourceApi
+internal val Res.string.str_16172: StringResource
+  get() = String13.str_16172
+
+@ExperimentalResourceApi
+internal val Res.string.str_16173: StringResource
+  get() = String13.str_16173
+
+@ExperimentalResourceApi
+internal val Res.string.str_16174: StringResource
+  get() = String13.str_16174
+
+@ExperimentalResourceApi
+internal val Res.string.str_16175: StringResource
+  get() = String13.str_16175
+
+@ExperimentalResourceApi
+internal val Res.string.str_16176: StringResource
+  get() = String13.str_16176
+
+@ExperimentalResourceApi
+internal val Res.string.str_16177: StringResource
+  get() = String13.str_16177
+
+@ExperimentalResourceApi
+internal val Res.string.str_16178: StringResource
+  get() = String13.str_16178
+
+@ExperimentalResourceApi
+internal val Res.string.str_16179: StringResource
+  get() = String13.str_16179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1618: StringResource
+  get() = String13.str_1618
+
+@ExperimentalResourceApi
+internal val Res.string.str_16180: StringResource
+  get() = String13.str_16180
+
+@ExperimentalResourceApi
+internal val Res.string.str_16181: StringResource
+  get() = String13.str_16181
+
+@ExperimentalResourceApi
+internal val Res.string.str_16182: StringResource
+  get() = String13.str_16182
+
+@ExperimentalResourceApi
+internal val Res.string.str_16183: StringResource
+  get() = String13.str_16183
+
+@ExperimentalResourceApi
+internal val Res.string.str_16184: StringResource
+  get() = String13.str_16184
+
+@ExperimentalResourceApi
+internal val Res.string.str_16185: StringResource
+  get() = String13.str_16185
+
+@ExperimentalResourceApi
+internal val Res.string.str_16186: StringResource
+  get() = String13.str_16186
+
+@ExperimentalResourceApi
+internal val Res.string.str_16187: StringResource
+  get() = String13.str_16187
+
+@ExperimentalResourceApi
+internal val Res.string.str_16188: StringResource
+  get() = String13.str_16188
+
+@ExperimentalResourceApi
+internal val Res.string.str_16189: StringResource
+  get() = String13.str_16189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1619: StringResource
+  get() = String13.str_1619
+
+@ExperimentalResourceApi
+internal val Res.string.str_16190: StringResource
+  get() = String13.str_16190
+
+@ExperimentalResourceApi
+internal val Res.string.str_16191: StringResource
+  get() = String13.str_16191
+
+@ExperimentalResourceApi
+internal val Res.string.str_16192: StringResource
+  get() = String13.str_16192
+
+@ExperimentalResourceApi
+internal val Res.string.str_16193: StringResource
+  get() = String13.str_16193
+
+@ExperimentalResourceApi
+internal val Res.string.str_16194: StringResource
+  get() = String13.str_16194
+
+@ExperimentalResourceApi
+internal val Res.string.str_16195: StringResource
+  get() = String13.str_16195
+
+@ExperimentalResourceApi
+internal val Res.string.str_16196: StringResource
+  get() = String13.str_16196
+
+@ExperimentalResourceApi
+internal val Res.string.str_16197: StringResource
+  get() = String13.str_16197
+
+@ExperimentalResourceApi
+internal val Res.string.str_16198: StringResource
+  get() = String13.str_16198
+
+@ExperimentalResourceApi
+internal val Res.string.str_16199: StringResource
+  get() = String13.str_16199
+
+@ExperimentalResourceApi
+internal val Res.string.str_162: StringResource
+  get() = String13.str_162
+
+@ExperimentalResourceApi
+internal val Res.string.str_1620: StringResource
+  get() = String13.str_1620
+
+@ExperimentalResourceApi
+internal val Res.string.str_16200: StringResource
+  get() = String13.str_16200
+
+@ExperimentalResourceApi
+internal val Res.string.str_16201: StringResource
+  get() = String13.str_16201
+
+@ExperimentalResourceApi
+internal val Res.string.str_16202: StringResource
+  get() = String13.str_16202
+
+@ExperimentalResourceApi
+internal val Res.string.str_16203: StringResource
+  get() = String13.str_16203
+
+@ExperimentalResourceApi
+internal val Res.string.str_16204: StringResource
+  get() = String13.str_16204
+
+@ExperimentalResourceApi
+internal val Res.string.str_16205: StringResource
+  get() = String13.str_16205
+
+@ExperimentalResourceApi
+internal val Res.string.str_16206: StringResource
+  get() = String13.str_16206
+
+@ExperimentalResourceApi
+internal val Res.string.str_16207: StringResource
+  get() = String13.str_16207
+
+@ExperimentalResourceApi
+internal val Res.string.str_16208: StringResource
+  get() = String13.str_16208
+
+@ExperimentalResourceApi
+internal val Res.string.str_16209: StringResource
+  get() = String13.str_16209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1621: StringResource
+  get() = String13.str_1621
+
+@ExperimentalResourceApi
+internal val Res.string.str_16210: StringResource
+  get() = String13.str_16210
+
+@ExperimentalResourceApi
+internal val Res.string.str_16211: StringResource
+  get() = String13.str_16211
+
+@ExperimentalResourceApi
+internal val Res.string.str_16212: StringResource
+  get() = String13.str_16212
+
+@ExperimentalResourceApi
+internal val Res.string.str_16213: StringResource
+  get() = String13.str_16213
+
+@ExperimentalResourceApi
+internal val Res.string.str_16214: StringResource
+  get() = String13.str_16214
+
+@ExperimentalResourceApi
+internal val Res.string.str_16215: StringResource
+  get() = String13.str_16215
+
+@ExperimentalResourceApi
+internal val Res.string.str_16216: StringResource
+  get() = String13.str_16216
+
+@ExperimentalResourceApi
+internal val Res.string.str_16217: StringResource
+  get() = String13.str_16217
+
+@ExperimentalResourceApi
+internal val Res.string.str_16218: StringResource
+  get() = String13.str_16218
+
+@ExperimentalResourceApi
+internal val Res.string.str_16219: StringResource
+  get() = String13.str_16219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1622: StringResource
+  get() = String13.str_1622
+
+@ExperimentalResourceApi
+internal val Res.string.str_16220: StringResource
+  get() = String13.str_16220
+
+@ExperimentalResourceApi
+internal val Res.string.str_16221: StringResource
+  get() = String13.str_16221
+
+@ExperimentalResourceApi
+internal val Res.string.str_16222: StringResource
+  get() = String13.str_16222
+
+@ExperimentalResourceApi
+internal val Res.string.str_16223: StringResource
+  get() = String13.str_16223
+
+@ExperimentalResourceApi
+internal val Res.string.str_16224: StringResource
+  get() = String13.str_16224
+
+@ExperimentalResourceApi
+internal val Res.string.str_16225: StringResource
+  get() = String13.str_16225
+
+@ExperimentalResourceApi
+internal val Res.string.str_16226: StringResource
+  get() = String13.str_16226
+
+@ExperimentalResourceApi
+internal val Res.string.str_16227: StringResource
+  get() = String13.str_16227
+
+@ExperimentalResourceApi
+internal val Res.string.str_16228: StringResource
+  get() = String13.str_16228
+
+@ExperimentalResourceApi
+internal val Res.string.str_16229: StringResource
+  get() = String13.str_16229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1623: StringResource
+  get() = String13.str_1623
+
+@ExperimentalResourceApi
+internal val Res.string.str_16230: StringResource
+  get() = String13.str_16230
+
+@ExperimentalResourceApi
+internal val Res.string.str_16231: StringResource
+  get() = String13.str_16231
+
+@ExperimentalResourceApi
+internal val Res.string.str_16232: StringResource
+  get() = String13.str_16232
+
+@ExperimentalResourceApi
+internal val Res.string.str_16233: StringResource
+  get() = String13.str_16233
+
+@ExperimentalResourceApi
+internal val Res.string.str_16234: StringResource
+  get() = String13.str_16234
+
+@ExperimentalResourceApi
+internal val Res.string.str_16235: StringResource
+  get() = String13.str_16235
+
+@ExperimentalResourceApi
+internal val Res.string.str_16236: StringResource
+  get() = String13.str_16236
+
+@ExperimentalResourceApi
+internal val Res.string.str_16237: StringResource
+  get() = String13.str_16237
+
+@ExperimentalResourceApi
+internal val Res.string.str_16238: StringResource
+  get() = String13.str_16238
+
+@ExperimentalResourceApi
+internal val Res.string.str_16239: StringResource
+  get() = String13.str_16239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1624: StringResource
+  get() = String13.str_1624
+
+@ExperimentalResourceApi
+internal val Res.string.str_16240: StringResource
+  get() = String13.str_16240
+
+@ExperimentalResourceApi
+internal val Res.string.str_16241: StringResource
+  get() = String13.str_16241
+
+@ExperimentalResourceApi
+internal val Res.string.str_16242: StringResource
+  get() = String13.str_16242
+
+@ExperimentalResourceApi
+internal val Res.string.str_16243: StringResource
+  get() = String13.str_16243
+
+@ExperimentalResourceApi
+internal val Res.string.str_16244: StringResource
+  get() = String13.str_16244
+
+@ExperimentalResourceApi
+internal val Res.string.str_16245: StringResource
+  get() = String13.str_16245
+
+@ExperimentalResourceApi
+internal val Res.string.str_16246: StringResource
+  get() = String13.str_16246
+
+@ExperimentalResourceApi
+internal val Res.string.str_16247: StringResource
+  get() = String13.str_16247
+
+@ExperimentalResourceApi
+internal val Res.string.str_16248: StringResource
+  get() = String13.str_16248
+
+@ExperimentalResourceApi
+internal val Res.string.str_16249: StringResource
+  get() = String13.str_16249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1625: StringResource
+  get() = String13.str_1625
+
+@ExperimentalResourceApi
+internal val Res.string.str_16250: StringResource
+  get() = String13.str_16250
+
+@ExperimentalResourceApi
+internal val Res.string.str_16251: StringResource
+  get() = String13.str_16251
+
+@ExperimentalResourceApi
+internal val Res.string.str_16252: StringResource
+  get() = String13.str_16252
+
+@ExperimentalResourceApi
+internal val Res.string.str_16253: StringResource
+  get() = String13.str_16253
+
+@ExperimentalResourceApi
+internal val Res.string.str_16254: StringResource
+  get() = String13.str_16254
+
+@ExperimentalResourceApi
+internal val Res.string.str_16255: StringResource
+  get() = String13.str_16255
+
+@ExperimentalResourceApi
+internal val Res.string.str_16256: StringResource
+  get() = String13.str_16256
+
+@ExperimentalResourceApi
+internal val Res.string.str_16257: StringResource
+  get() = String13.str_16257
+
+@ExperimentalResourceApi
+internal val Res.string.str_16258: StringResource
+  get() = String13.str_16258
+
+@ExperimentalResourceApi
+internal val Res.string.str_16259: StringResource
+  get() = String13.str_16259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1626: StringResource
+  get() = String13.str_1626
+
+@ExperimentalResourceApi
+internal val Res.string.str_16260: StringResource
+  get() = String13.str_16260
+
+@ExperimentalResourceApi
+internal val Res.string.str_16261: StringResource
+  get() = String13.str_16261
+
+@ExperimentalResourceApi
+internal val Res.string.str_16262: StringResource
+  get() = String13.str_16262
+
+@ExperimentalResourceApi
+internal val Res.string.str_16263: StringResource
+  get() = String13.str_16263
+
+@ExperimentalResourceApi
+internal val Res.string.str_16264: StringResource
+  get() = String13.str_16264
+
+@ExperimentalResourceApi
+internal val Res.string.str_16265: StringResource
+  get() = String13.str_16265
+
+@ExperimentalResourceApi
+internal val Res.string.str_16266: StringResource
+  get() = String13.str_16266
+
+@ExperimentalResourceApi
+internal val Res.string.str_16267: StringResource
+  get() = String13.str_16267
+
+@ExperimentalResourceApi
+internal val Res.string.str_16268: StringResource
+  get() = String13.str_16268
+
+@ExperimentalResourceApi
+internal val Res.string.str_16269: StringResource
+  get() = String13.str_16269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1627: StringResource
+  get() = String13.str_1627
+
+@ExperimentalResourceApi
+internal val Res.string.str_16270: StringResource
+  get() = String13.str_16270
+
+@ExperimentalResourceApi
+internal val Res.string.str_16271: StringResource
+  get() = String13.str_16271
+
+@ExperimentalResourceApi
+internal val Res.string.str_16272: StringResource
+  get() = String13.str_16272
+
+@ExperimentalResourceApi
+internal val Res.string.str_16273: StringResource
+  get() = String13.str_16273
+
+@ExperimentalResourceApi
+internal val Res.string.str_16274: StringResource
+  get() = String13.str_16274
+
+@ExperimentalResourceApi
+internal val Res.string.str_16275: StringResource
+  get() = String13.str_16275
+
+@ExperimentalResourceApi
+internal val Res.string.str_16276: StringResource
+  get() = String13.str_16276
+
+@ExperimentalResourceApi
+internal val Res.string.str_16277: StringResource
+  get() = String13.str_16277
+
+@ExperimentalResourceApi
+internal val Res.string.str_16278: StringResource
+  get() = String13.str_16278
+
+@ExperimentalResourceApi
+internal val Res.string.str_16279: StringResource
+  get() = String13.str_16279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1628: StringResource
+  get() = String13.str_1628
+
+@ExperimentalResourceApi
+internal val Res.string.str_16280: StringResource
+  get() = String13.str_16280
+
+@ExperimentalResourceApi
+internal val Res.string.str_16281: StringResource
+  get() = String13.str_16281
+
+@ExperimentalResourceApi
+internal val Res.string.str_16282: StringResource
+  get() = String13.str_16282
+
+@ExperimentalResourceApi
+internal val Res.string.str_16283: StringResource
+  get() = String13.str_16283
+
+@ExperimentalResourceApi
+internal val Res.string.str_16284: StringResource
+  get() = String13.str_16284
+
+@ExperimentalResourceApi
+internal val Res.string.str_16285: StringResource
+  get() = String13.str_16285
+
+@ExperimentalResourceApi
+internal val Res.string.str_16286: StringResource
+  get() = String13.str_16286
+
+@ExperimentalResourceApi
+internal val Res.string.str_16287: StringResource
+  get() = String13.str_16287
+
+@ExperimentalResourceApi
+internal val Res.string.str_16288: StringResource
+  get() = String13.str_16288
+
+@ExperimentalResourceApi
+internal val Res.string.str_16289: StringResource
+  get() = String13.str_16289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1629: StringResource
+  get() = String13.str_1629
+
+@ExperimentalResourceApi
+internal val Res.string.str_16290: StringResource
+  get() = String13.str_16290
+
+@ExperimentalResourceApi
+internal val Res.string.str_16291: StringResource
+  get() = String13.str_16291
+
+@ExperimentalResourceApi
+internal val Res.string.str_16292: StringResource
+  get() = String13.str_16292
+
+@ExperimentalResourceApi
+internal val Res.string.str_16293: StringResource
+  get() = String13.str_16293
+
+@ExperimentalResourceApi
+internal val Res.string.str_16294: StringResource
+  get() = String13.str_16294
+
+@ExperimentalResourceApi
+internal val Res.string.str_16295: StringResource
+  get() = String13.str_16295
+
+@ExperimentalResourceApi
+internal val Res.string.str_16296: StringResource
+  get() = String13.str_16296
+
+@ExperimentalResourceApi
+internal val Res.string.str_16297: StringResource
+  get() = String13.str_16297

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String14.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String14.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String14 {
+  public val str_16298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16298", "str_16298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16299", "str_16299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_163", "str_163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1630", "str_1630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16300", "str_16300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16301", "str_16301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16302", "str_16302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16303", "str_16303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16304", "str_16304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16305", "str_16305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16306", "str_16306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16307", "str_16307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16308", "str_16308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16309", "str_16309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1631", "str_1631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16310", "str_16310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16311", "str_16311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16312", "str_16312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16313", "str_16313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16314", "str_16314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16315", "str_16315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16316", "str_16316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16317", "str_16317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16318", "str_16318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16319", "str_16319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1632", "str_1632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16320", "str_16320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16321", "str_16321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16322", "str_16322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16323", "str_16323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16324", "str_16324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16325", "str_16325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16326", "str_16326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16327", "str_16327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16328", "str_16328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16329", "str_16329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1633", "str_1633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16330", "str_16330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16331", "str_16331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16332", "str_16332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16333", "str_16333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16334", "str_16334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16335", "str_16335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16336", "str_16336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16337", "str_16337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16338", "str_16338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16339", "str_16339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1634", "str_1634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16340", "str_16340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16341", "str_16341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16342", "str_16342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16343", "str_16343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16344", "str_16344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16345", "str_16345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16346", "str_16346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16347", "str_16347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16348", "str_16348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16349", "str_16349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1635", "str_1635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16350", "str_16350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16351", "str_16351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16352", "str_16352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16353", "str_16353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16354", "str_16354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16355", "str_16355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16356", "str_16356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16357", "str_16357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16358", "str_16358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16359", "str_16359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1636", "str_1636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16360", "str_16360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16361", "str_16361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16362", "str_16362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16363", "str_16363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16364", "str_16364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16365", "str_16365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16366", "str_16366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16367", "str_16367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16368", "str_16368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16369", "str_16369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1637", "str_1637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16370", "str_16370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16371", "str_16371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16372", "str_16372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16373", "str_16373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16374", "str_16374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16375", "str_16375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16376", "str_16376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16377", "str_16377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16378", "str_16378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16379", "str_16379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1638", "str_1638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16380", "str_16380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16381", "str_16381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16382", "str_16382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16383", "str_16383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16384", "str_16384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16385", "str_16385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16386", "str_16386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16387", "str_16387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16388", "str_16388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16389", "str_16389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1639", "str_1639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16390", "str_16390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16391", "str_16391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16392", "str_16392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16393", "str_16393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16394", "str_16394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16395", "str_16395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16396", "str_16396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16397", "str_16397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16398", "str_16398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16399", "str_16399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_164", "str_164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1640", "str_1640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16400", "str_16400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16401", "str_16401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16402", "str_16402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16403", "str_16403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16404", "str_16404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16405", "str_16405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16406", "str_16406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16407", "str_16407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16408", "str_16408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16409", "str_16409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1641", "str_1641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16410", "str_16410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16411", "str_16411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16412", "str_16412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16413", "str_16413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16414", "str_16414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16415", "str_16415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16416", "str_16416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16417", "str_16417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16418", "str_16418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16419", "str_16419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1642", "str_1642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16420", "str_16420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16421", "str_16421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16422", "str_16422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16423", "str_16423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16424", "str_16424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16425", "str_16425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16426", "str_16426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16427", "str_16427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16428", "str_16428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16429", "str_16429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1643", "str_1643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16430", "str_16430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16431", "str_16431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16432", "str_16432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16433", "str_16433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16434", "str_16434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16435", "str_16435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16436", "str_16436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16437", "str_16437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16438", "str_16438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16439", "str_16439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1644", "str_1644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16440", "str_16440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16441", "str_16441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16442", "str_16442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16443", "str_16443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16444", "str_16444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16445", "str_16445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16446", "str_16446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16447", "str_16447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16448", "str_16448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16449", "str_16449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1645", "str_1645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16450", "str_16450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16451", "str_16451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16452", "str_16452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16453", "str_16453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16454", "str_16454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16455", "str_16455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16456", "str_16456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16457", "str_16457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16458", "str_16458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16459", "str_16459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1646", "str_1646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16460", "str_16460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16461", "str_16461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16462", "str_16462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16463", "str_16463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16464", "str_16464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16465", "str_16465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16466", "str_16466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16467", "str_16467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16468", "str_16468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16469", "str_16469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1647", "str_1647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16470", "str_16470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16471", "str_16471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16472", "str_16472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16473", "str_16473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16474", "str_16474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16475", "str_16475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16476", "str_16476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16477", "str_16477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16478", "str_16478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16479", "str_16479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1648", "str_1648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16480", "str_16480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16481", "str_16481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16482", "str_16482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16483", "str_16483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16484", "str_16484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16485", "str_16485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16486", "str_16486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16487", "str_16487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16488", "str_16488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16489", "str_16489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1649", "str_1649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16490", "str_16490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16491", "str_16491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16492", "str_16492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16493", "str_16493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16494", "str_16494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16495", "str_16495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16496", "str_16496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16497", "str_16497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16498", "str_16498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16499", "str_16499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_165", "str_165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1650", "str_1650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16500", "str_16500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16501", "str_16501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16502", "str_16502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16503", "str_16503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16504", "str_16504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16505", "str_16505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16506", "str_16506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16507", "str_16507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16508", "str_16508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16509", "str_16509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1651", "str_1651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16510", "str_16510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16511", "str_16511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16512", "str_16512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16513", "str_16513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16514", "str_16514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16515", "str_16515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16516", "str_16516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16517", "str_16517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16518", "str_16518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16519", "str_16519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1652", "str_1652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16520", "str_16520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16521", "str_16521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16522", "str_16522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16523", "str_16523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16524", "str_16524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16525", "str_16525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16526", "str_16526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16527", "str_16527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16528", "str_16528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16529", "str_16529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1653", "str_1653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16530", "str_16530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16531", "str_16531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16532", "str_16532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16533", "str_16533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16534", "str_16534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16535", "str_16535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16536", "str_16536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16537", "str_16537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16538", "str_16538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16539", "str_16539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1654", "str_1654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16540", "str_16540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16541", "str_16541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16542", "str_16542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16543", "str_16543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16544", "str_16544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16545", "str_16545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16546", "str_16546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16547", "str_16547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16548", "str_16548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16549", "str_16549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1655", "str_1655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16550", "str_16550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16551", "str_16551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16552", "str_16552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16553", "str_16553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16554", "str_16554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16555", "str_16555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16556", "str_16556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16557", "str_16557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16558", "str_16558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16559", "str_16559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1656", "str_1656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16560", "str_16560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16561", "str_16561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16562", "str_16562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16563", "str_16563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16564", "str_16564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16565", "str_16565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16566", "str_16566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16567", "str_16567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16568", "str_16568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16569", "str_16569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1657", "str_1657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16570", "str_16570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16571", "str_16571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16572", "str_16572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16573", "str_16573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16574", "str_16574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16575", "str_16575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16576", "str_16576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16577", "str_16577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16578", "str_16578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16579", "str_16579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1658", "str_1658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16580", "str_16580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16581", "str_16581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16582", "str_16582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16583", "str_16583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16584", "str_16584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16585", "str_16585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16586", "str_16586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16587", "str_16587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16588", "str_16588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16589", "str_16589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1659", "str_1659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16590", "str_16590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16591", "str_16591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16592", "str_16592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16593", "str_16593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16594", "str_16594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16595", "str_16595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16596", "str_16596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16597", "str_16597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16598", "str_16598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16599", "str_16599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_166", "str_166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1660", "str_1660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16600", "str_16600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16601", "str_16601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16602", "str_16602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16603", "str_16603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16604", "str_16604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16605", "str_16605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16606", "str_16606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16607", "str_16607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16608", "str_16608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16609", "str_16609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1661", "str_1661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16610", "str_16610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16611", "str_16611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16612", "str_16612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16613", "str_16613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16614", "str_16614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16615", "str_16615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16616", "str_16616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16617", "str_16617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16618", "str_16618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16619", "str_16619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1662", "str_1662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16620", "str_16620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16621", "str_16621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16622", "str_16622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16623", "str_16623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16624", "str_16624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16625", "str_16625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16626", "str_16626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16627", "str_16627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16628", "str_16628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16629", "str_16629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1663", "str_1663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16630", "str_16630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16631", "str_16631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16632", "str_16632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16633", "str_16633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16634", "str_16634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16635", "str_16635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16636", "str_16636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16637", "str_16637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16638", "str_16638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16639", "str_16639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1664", "str_1664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16640", "str_16640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16641", "str_16641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16642", "str_16642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16643", "str_16643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16644", "str_16644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16645", "str_16645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16646", "str_16646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16647", "str_16647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16648", "str_16648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16649", "str_16649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1665", "str_1665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16650", "str_16650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16651", "str_16651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16652", "str_16652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16653", "str_16653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16654", "str_16654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16655", "str_16655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16656", "str_16656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16657", "str_16657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16658", "str_16658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16659", "str_16659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1666", "str_1666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16660", "str_16660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16661", "str_16661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16662", "str_16662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16663", "str_16663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16664", "str_16664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16665", "str_16665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16666", "str_16666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16667", "str_16667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16668", "str_16668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16669", "str_16669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1667", "str_1667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16670", "str_16670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16671", "str_16671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16672", "str_16672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16673", "str_16673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16674", "str_16674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16675", "str_16675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16676", "str_16676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16677", "str_16677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16678", "str_16678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16679", "str_16679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1668", "str_1668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16680", "str_16680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16681", "str_16681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16682", "str_16682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16683", "str_16683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16684", "str_16684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16685", "str_16685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16686", "str_16686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16687", "str_16687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16688", "str_16688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16689", "str_16689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1669", "str_1669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16690", "str_16690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16691", "str_16691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16692", "str_16692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16693", "str_16693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16694", "str_16694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16695", "str_16695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16696", "str_16696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16697", "str_16697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16698", "str_16698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16699", "str_16699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_167", "str_167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1670", "str_1670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16700", "str_16700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16701", "str_16701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16702", "str_16702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16703", "str_16703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16704", "str_16704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16705", "str_16705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16706", "str_16706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16707", "str_16707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16708", "str_16708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16709", "str_16709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1671", "str_1671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16710", "str_16710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16711", "str_16711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16712", "str_16712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16713", "str_16713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16714", "str_16714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16715", "str_16715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16716", "str_16716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16717", "str_16717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16718", "str_16718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16719", "str_16719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1672", "str_1672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16720", "str_16720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16721", "str_16721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16722", "str_16722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16723", "str_16723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16724", "str_16724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16725", "str_16725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16726", "str_16726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16727", "str_16727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16728", "str_16728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16729", "str_16729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1673", "str_1673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16730", "str_16730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16731", "str_16731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16732", "str_16732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16733", "str_16733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16734", "str_16734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16735", "str_16735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16736", "str_16736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16737", "str_16737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16738", "str_16738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16739", "str_16739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1674", "str_1674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16740", "str_16740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16741", "str_16741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16742", "str_16742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16743", "str_16743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16744", "str_16744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16745", "str_16745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16746", "str_16746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16747", "str_16747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_16298: StringResource
+  get() = String14.str_16298
+
+@ExperimentalResourceApi
+internal val Res.string.str_16299: StringResource
+  get() = String14.str_16299
+
+@ExperimentalResourceApi
+internal val Res.string.str_163: StringResource
+  get() = String14.str_163
+
+@ExperimentalResourceApi
+internal val Res.string.str_1630: StringResource
+  get() = String14.str_1630
+
+@ExperimentalResourceApi
+internal val Res.string.str_16300: StringResource
+  get() = String14.str_16300
+
+@ExperimentalResourceApi
+internal val Res.string.str_16301: StringResource
+  get() = String14.str_16301
+
+@ExperimentalResourceApi
+internal val Res.string.str_16302: StringResource
+  get() = String14.str_16302
+
+@ExperimentalResourceApi
+internal val Res.string.str_16303: StringResource
+  get() = String14.str_16303
+
+@ExperimentalResourceApi
+internal val Res.string.str_16304: StringResource
+  get() = String14.str_16304
+
+@ExperimentalResourceApi
+internal val Res.string.str_16305: StringResource
+  get() = String14.str_16305
+
+@ExperimentalResourceApi
+internal val Res.string.str_16306: StringResource
+  get() = String14.str_16306
+
+@ExperimentalResourceApi
+internal val Res.string.str_16307: StringResource
+  get() = String14.str_16307
+
+@ExperimentalResourceApi
+internal val Res.string.str_16308: StringResource
+  get() = String14.str_16308
+
+@ExperimentalResourceApi
+internal val Res.string.str_16309: StringResource
+  get() = String14.str_16309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1631: StringResource
+  get() = String14.str_1631
+
+@ExperimentalResourceApi
+internal val Res.string.str_16310: StringResource
+  get() = String14.str_16310
+
+@ExperimentalResourceApi
+internal val Res.string.str_16311: StringResource
+  get() = String14.str_16311
+
+@ExperimentalResourceApi
+internal val Res.string.str_16312: StringResource
+  get() = String14.str_16312
+
+@ExperimentalResourceApi
+internal val Res.string.str_16313: StringResource
+  get() = String14.str_16313
+
+@ExperimentalResourceApi
+internal val Res.string.str_16314: StringResource
+  get() = String14.str_16314
+
+@ExperimentalResourceApi
+internal val Res.string.str_16315: StringResource
+  get() = String14.str_16315
+
+@ExperimentalResourceApi
+internal val Res.string.str_16316: StringResource
+  get() = String14.str_16316
+
+@ExperimentalResourceApi
+internal val Res.string.str_16317: StringResource
+  get() = String14.str_16317
+
+@ExperimentalResourceApi
+internal val Res.string.str_16318: StringResource
+  get() = String14.str_16318
+
+@ExperimentalResourceApi
+internal val Res.string.str_16319: StringResource
+  get() = String14.str_16319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1632: StringResource
+  get() = String14.str_1632
+
+@ExperimentalResourceApi
+internal val Res.string.str_16320: StringResource
+  get() = String14.str_16320
+
+@ExperimentalResourceApi
+internal val Res.string.str_16321: StringResource
+  get() = String14.str_16321
+
+@ExperimentalResourceApi
+internal val Res.string.str_16322: StringResource
+  get() = String14.str_16322
+
+@ExperimentalResourceApi
+internal val Res.string.str_16323: StringResource
+  get() = String14.str_16323
+
+@ExperimentalResourceApi
+internal val Res.string.str_16324: StringResource
+  get() = String14.str_16324
+
+@ExperimentalResourceApi
+internal val Res.string.str_16325: StringResource
+  get() = String14.str_16325
+
+@ExperimentalResourceApi
+internal val Res.string.str_16326: StringResource
+  get() = String14.str_16326
+
+@ExperimentalResourceApi
+internal val Res.string.str_16327: StringResource
+  get() = String14.str_16327
+
+@ExperimentalResourceApi
+internal val Res.string.str_16328: StringResource
+  get() = String14.str_16328
+
+@ExperimentalResourceApi
+internal val Res.string.str_16329: StringResource
+  get() = String14.str_16329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1633: StringResource
+  get() = String14.str_1633
+
+@ExperimentalResourceApi
+internal val Res.string.str_16330: StringResource
+  get() = String14.str_16330
+
+@ExperimentalResourceApi
+internal val Res.string.str_16331: StringResource
+  get() = String14.str_16331
+
+@ExperimentalResourceApi
+internal val Res.string.str_16332: StringResource
+  get() = String14.str_16332
+
+@ExperimentalResourceApi
+internal val Res.string.str_16333: StringResource
+  get() = String14.str_16333
+
+@ExperimentalResourceApi
+internal val Res.string.str_16334: StringResource
+  get() = String14.str_16334
+
+@ExperimentalResourceApi
+internal val Res.string.str_16335: StringResource
+  get() = String14.str_16335
+
+@ExperimentalResourceApi
+internal val Res.string.str_16336: StringResource
+  get() = String14.str_16336
+
+@ExperimentalResourceApi
+internal val Res.string.str_16337: StringResource
+  get() = String14.str_16337
+
+@ExperimentalResourceApi
+internal val Res.string.str_16338: StringResource
+  get() = String14.str_16338
+
+@ExperimentalResourceApi
+internal val Res.string.str_16339: StringResource
+  get() = String14.str_16339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1634: StringResource
+  get() = String14.str_1634
+
+@ExperimentalResourceApi
+internal val Res.string.str_16340: StringResource
+  get() = String14.str_16340
+
+@ExperimentalResourceApi
+internal val Res.string.str_16341: StringResource
+  get() = String14.str_16341
+
+@ExperimentalResourceApi
+internal val Res.string.str_16342: StringResource
+  get() = String14.str_16342
+
+@ExperimentalResourceApi
+internal val Res.string.str_16343: StringResource
+  get() = String14.str_16343
+
+@ExperimentalResourceApi
+internal val Res.string.str_16344: StringResource
+  get() = String14.str_16344
+
+@ExperimentalResourceApi
+internal val Res.string.str_16345: StringResource
+  get() = String14.str_16345
+
+@ExperimentalResourceApi
+internal val Res.string.str_16346: StringResource
+  get() = String14.str_16346
+
+@ExperimentalResourceApi
+internal val Res.string.str_16347: StringResource
+  get() = String14.str_16347
+
+@ExperimentalResourceApi
+internal val Res.string.str_16348: StringResource
+  get() = String14.str_16348
+
+@ExperimentalResourceApi
+internal val Res.string.str_16349: StringResource
+  get() = String14.str_16349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1635: StringResource
+  get() = String14.str_1635
+
+@ExperimentalResourceApi
+internal val Res.string.str_16350: StringResource
+  get() = String14.str_16350
+
+@ExperimentalResourceApi
+internal val Res.string.str_16351: StringResource
+  get() = String14.str_16351
+
+@ExperimentalResourceApi
+internal val Res.string.str_16352: StringResource
+  get() = String14.str_16352
+
+@ExperimentalResourceApi
+internal val Res.string.str_16353: StringResource
+  get() = String14.str_16353
+
+@ExperimentalResourceApi
+internal val Res.string.str_16354: StringResource
+  get() = String14.str_16354
+
+@ExperimentalResourceApi
+internal val Res.string.str_16355: StringResource
+  get() = String14.str_16355
+
+@ExperimentalResourceApi
+internal val Res.string.str_16356: StringResource
+  get() = String14.str_16356
+
+@ExperimentalResourceApi
+internal val Res.string.str_16357: StringResource
+  get() = String14.str_16357
+
+@ExperimentalResourceApi
+internal val Res.string.str_16358: StringResource
+  get() = String14.str_16358
+
+@ExperimentalResourceApi
+internal val Res.string.str_16359: StringResource
+  get() = String14.str_16359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1636: StringResource
+  get() = String14.str_1636
+
+@ExperimentalResourceApi
+internal val Res.string.str_16360: StringResource
+  get() = String14.str_16360
+
+@ExperimentalResourceApi
+internal val Res.string.str_16361: StringResource
+  get() = String14.str_16361
+
+@ExperimentalResourceApi
+internal val Res.string.str_16362: StringResource
+  get() = String14.str_16362
+
+@ExperimentalResourceApi
+internal val Res.string.str_16363: StringResource
+  get() = String14.str_16363
+
+@ExperimentalResourceApi
+internal val Res.string.str_16364: StringResource
+  get() = String14.str_16364
+
+@ExperimentalResourceApi
+internal val Res.string.str_16365: StringResource
+  get() = String14.str_16365
+
+@ExperimentalResourceApi
+internal val Res.string.str_16366: StringResource
+  get() = String14.str_16366
+
+@ExperimentalResourceApi
+internal val Res.string.str_16367: StringResource
+  get() = String14.str_16367
+
+@ExperimentalResourceApi
+internal val Res.string.str_16368: StringResource
+  get() = String14.str_16368
+
+@ExperimentalResourceApi
+internal val Res.string.str_16369: StringResource
+  get() = String14.str_16369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1637: StringResource
+  get() = String14.str_1637
+
+@ExperimentalResourceApi
+internal val Res.string.str_16370: StringResource
+  get() = String14.str_16370
+
+@ExperimentalResourceApi
+internal val Res.string.str_16371: StringResource
+  get() = String14.str_16371
+
+@ExperimentalResourceApi
+internal val Res.string.str_16372: StringResource
+  get() = String14.str_16372
+
+@ExperimentalResourceApi
+internal val Res.string.str_16373: StringResource
+  get() = String14.str_16373
+
+@ExperimentalResourceApi
+internal val Res.string.str_16374: StringResource
+  get() = String14.str_16374
+
+@ExperimentalResourceApi
+internal val Res.string.str_16375: StringResource
+  get() = String14.str_16375
+
+@ExperimentalResourceApi
+internal val Res.string.str_16376: StringResource
+  get() = String14.str_16376
+
+@ExperimentalResourceApi
+internal val Res.string.str_16377: StringResource
+  get() = String14.str_16377
+
+@ExperimentalResourceApi
+internal val Res.string.str_16378: StringResource
+  get() = String14.str_16378
+
+@ExperimentalResourceApi
+internal val Res.string.str_16379: StringResource
+  get() = String14.str_16379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1638: StringResource
+  get() = String14.str_1638
+
+@ExperimentalResourceApi
+internal val Res.string.str_16380: StringResource
+  get() = String14.str_16380
+
+@ExperimentalResourceApi
+internal val Res.string.str_16381: StringResource
+  get() = String14.str_16381
+
+@ExperimentalResourceApi
+internal val Res.string.str_16382: StringResource
+  get() = String14.str_16382
+
+@ExperimentalResourceApi
+internal val Res.string.str_16383: StringResource
+  get() = String14.str_16383
+
+@ExperimentalResourceApi
+internal val Res.string.str_16384: StringResource
+  get() = String14.str_16384
+
+@ExperimentalResourceApi
+internal val Res.string.str_16385: StringResource
+  get() = String14.str_16385
+
+@ExperimentalResourceApi
+internal val Res.string.str_16386: StringResource
+  get() = String14.str_16386
+
+@ExperimentalResourceApi
+internal val Res.string.str_16387: StringResource
+  get() = String14.str_16387
+
+@ExperimentalResourceApi
+internal val Res.string.str_16388: StringResource
+  get() = String14.str_16388
+
+@ExperimentalResourceApi
+internal val Res.string.str_16389: StringResource
+  get() = String14.str_16389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1639: StringResource
+  get() = String14.str_1639
+
+@ExperimentalResourceApi
+internal val Res.string.str_16390: StringResource
+  get() = String14.str_16390
+
+@ExperimentalResourceApi
+internal val Res.string.str_16391: StringResource
+  get() = String14.str_16391
+
+@ExperimentalResourceApi
+internal val Res.string.str_16392: StringResource
+  get() = String14.str_16392
+
+@ExperimentalResourceApi
+internal val Res.string.str_16393: StringResource
+  get() = String14.str_16393
+
+@ExperimentalResourceApi
+internal val Res.string.str_16394: StringResource
+  get() = String14.str_16394
+
+@ExperimentalResourceApi
+internal val Res.string.str_16395: StringResource
+  get() = String14.str_16395
+
+@ExperimentalResourceApi
+internal val Res.string.str_16396: StringResource
+  get() = String14.str_16396
+
+@ExperimentalResourceApi
+internal val Res.string.str_16397: StringResource
+  get() = String14.str_16397
+
+@ExperimentalResourceApi
+internal val Res.string.str_16398: StringResource
+  get() = String14.str_16398
+
+@ExperimentalResourceApi
+internal val Res.string.str_16399: StringResource
+  get() = String14.str_16399
+
+@ExperimentalResourceApi
+internal val Res.string.str_164: StringResource
+  get() = String14.str_164
+
+@ExperimentalResourceApi
+internal val Res.string.str_1640: StringResource
+  get() = String14.str_1640
+
+@ExperimentalResourceApi
+internal val Res.string.str_16400: StringResource
+  get() = String14.str_16400
+
+@ExperimentalResourceApi
+internal val Res.string.str_16401: StringResource
+  get() = String14.str_16401
+
+@ExperimentalResourceApi
+internal val Res.string.str_16402: StringResource
+  get() = String14.str_16402
+
+@ExperimentalResourceApi
+internal val Res.string.str_16403: StringResource
+  get() = String14.str_16403
+
+@ExperimentalResourceApi
+internal val Res.string.str_16404: StringResource
+  get() = String14.str_16404
+
+@ExperimentalResourceApi
+internal val Res.string.str_16405: StringResource
+  get() = String14.str_16405
+
+@ExperimentalResourceApi
+internal val Res.string.str_16406: StringResource
+  get() = String14.str_16406
+
+@ExperimentalResourceApi
+internal val Res.string.str_16407: StringResource
+  get() = String14.str_16407
+
+@ExperimentalResourceApi
+internal val Res.string.str_16408: StringResource
+  get() = String14.str_16408
+
+@ExperimentalResourceApi
+internal val Res.string.str_16409: StringResource
+  get() = String14.str_16409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1641: StringResource
+  get() = String14.str_1641
+
+@ExperimentalResourceApi
+internal val Res.string.str_16410: StringResource
+  get() = String14.str_16410
+
+@ExperimentalResourceApi
+internal val Res.string.str_16411: StringResource
+  get() = String14.str_16411
+
+@ExperimentalResourceApi
+internal val Res.string.str_16412: StringResource
+  get() = String14.str_16412
+
+@ExperimentalResourceApi
+internal val Res.string.str_16413: StringResource
+  get() = String14.str_16413
+
+@ExperimentalResourceApi
+internal val Res.string.str_16414: StringResource
+  get() = String14.str_16414
+
+@ExperimentalResourceApi
+internal val Res.string.str_16415: StringResource
+  get() = String14.str_16415
+
+@ExperimentalResourceApi
+internal val Res.string.str_16416: StringResource
+  get() = String14.str_16416
+
+@ExperimentalResourceApi
+internal val Res.string.str_16417: StringResource
+  get() = String14.str_16417
+
+@ExperimentalResourceApi
+internal val Res.string.str_16418: StringResource
+  get() = String14.str_16418
+
+@ExperimentalResourceApi
+internal val Res.string.str_16419: StringResource
+  get() = String14.str_16419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1642: StringResource
+  get() = String14.str_1642
+
+@ExperimentalResourceApi
+internal val Res.string.str_16420: StringResource
+  get() = String14.str_16420
+
+@ExperimentalResourceApi
+internal val Res.string.str_16421: StringResource
+  get() = String14.str_16421
+
+@ExperimentalResourceApi
+internal val Res.string.str_16422: StringResource
+  get() = String14.str_16422
+
+@ExperimentalResourceApi
+internal val Res.string.str_16423: StringResource
+  get() = String14.str_16423
+
+@ExperimentalResourceApi
+internal val Res.string.str_16424: StringResource
+  get() = String14.str_16424
+
+@ExperimentalResourceApi
+internal val Res.string.str_16425: StringResource
+  get() = String14.str_16425
+
+@ExperimentalResourceApi
+internal val Res.string.str_16426: StringResource
+  get() = String14.str_16426
+
+@ExperimentalResourceApi
+internal val Res.string.str_16427: StringResource
+  get() = String14.str_16427
+
+@ExperimentalResourceApi
+internal val Res.string.str_16428: StringResource
+  get() = String14.str_16428
+
+@ExperimentalResourceApi
+internal val Res.string.str_16429: StringResource
+  get() = String14.str_16429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1643: StringResource
+  get() = String14.str_1643
+
+@ExperimentalResourceApi
+internal val Res.string.str_16430: StringResource
+  get() = String14.str_16430
+
+@ExperimentalResourceApi
+internal val Res.string.str_16431: StringResource
+  get() = String14.str_16431
+
+@ExperimentalResourceApi
+internal val Res.string.str_16432: StringResource
+  get() = String14.str_16432
+
+@ExperimentalResourceApi
+internal val Res.string.str_16433: StringResource
+  get() = String14.str_16433
+
+@ExperimentalResourceApi
+internal val Res.string.str_16434: StringResource
+  get() = String14.str_16434
+
+@ExperimentalResourceApi
+internal val Res.string.str_16435: StringResource
+  get() = String14.str_16435
+
+@ExperimentalResourceApi
+internal val Res.string.str_16436: StringResource
+  get() = String14.str_16436
+
+@ExperimentalResourceApi
+internal val Res.string.str_16437: StringResource
+  get() = String14.str_16437
+
+@ExperimentalResourceApi
+internal val Res.string.str_16438: StringResource
+  get() = String14.str_16438
+
+@ExperimentalResourceApi
+internal val Res.string.str_16439: StringResource
+  get() = String14.str_16439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1644: StringResource
+  get() = String14.str_1644
+
+@ExperimentalResourceApi
+internal val Res.string.str_16440: StringResource
+  get() = String14.str_16440
+
+@ExperimentalResourceApi
+internal val Res.string.str_16441: StringResource
+  get() = String14.str_16441
+
+@ExperimentalResourceApi
+internal val Res.string.str_16442: StringResource
+  get() = String14.str_16442
+
+@ExperimentalResourceApi
+internal val Res.string.str_16443: StringResource
+  get() = String14.str_16443
+
+@ExperimentalResourceApi
+internal val Res.string.str_16444: StringResource
+  get() = String14.str_16444
+
+@ExperimentalResourceApi
+internal val Res.string.str_16445: StringResource
+  get() = String14.str_16445
+
+@ExperimentalResourceApi
+internal val Res.string.str_16446: StringResource
+  get() = String14.str_16446
+
+@ExperimentalResourceApi
+internal val Res.string.str_16447: StringResource
+  get() = String14.str_16447
+
+@ExperimentalResourceApi
+internal val Res.string.str_16448: StringResource
+  get() = String14.str_16448
+
+@ExperimentalResourceApi
+internal val Res.string.str_16449: StringResource
+  get() = String14.str_16449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1645: StringResource
+  get() = String14.str_1645
+
+@ExperimentalResourceApi
+internal val Res.string.str_16450: StringResource
+  get() = String14.str_16450
+
+@ExperimentalResourceApi
+internal val Res.string.str_16451: StringResource
+  get() = String14.str_16451
+
+@ExperimentalResourceApi
+internal val Res.string.str_16452: StringResource
+  get() = String14.str_16452
+
+@ExperimentalResourceApi
+internal val Res.string.str_16453: StringResource
+  get() = String14.str_16453
+
+@ExperimentalResourceApi
+internal val Res.string.str_16454: StringResource
+  get() = String14.str_16454
+
+@ExperimentalResourceApi
+internal val Res.string.str_16455: StringResource
+  get() = String14.str_16455
+
+@ExperimentalResourceApi
+internal val Res.string.str_16456: StringResource
+  get() = String14.str_16456
+
+@ExperimentalResourceApi
+internal val Res.string.str_16457: StringResource
+  get() = String14.str_16457
+
+@ExperimentalResourceApi
+internal val Res.string.str_16458: StringResource
+  get() = String14.str_16458
+
+@ExperimentalResourceApi
+internal val Res.string.str_16459: StringResource
+  get() = String14.str_16459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1646: StringResource
+  get() = String14.str_1646
+
+@ExperimentalResourceApi
+internal val Res.string.str_16460: StringResource
+  get() = String14.str_16460
+
+@ExperimentalResourceApi
+internal val Res.string.str_16461: StringResource
+  get() = String14.str_16461
+
+@ExperimentalResourceApi
+internal val Res.string.str_16462: StringResource
+  get() = String14.str_16462
+
+@ExperimentalResourceApi
+internal val Res.string.str_16463: StringResource
+  get() = String14.str_16463
+
+@ExperimentalResourceApi
+internal val Res.string.str_16464: StringResource
+  get() = String14.str_16464
+
+@ExperimentalResourceApi
+internal val Res.string.str_16465: StringResource
+  get() = String14.str_16465
+
+@ExperimentalResourceApi
+internal val Res.string.str_16466: StringResource
+  get() = String14.str_16466
+
+@ExperimentalResourceApi
+internal val Res.string.str_16467: StringResource
+  get() = String14.str_16467
+
+@ExperimentalResourceApi
+internal val Res.string.str_16468: StringResource
+  get() = String14.str_16468
+
+@ExperimentalResourceApi
+internal val Res.string.str_16469: StringResource
+  get() = String14.str_16469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1647: StringResource
+  get() = String14.str_1647
+
+@ExperimentalResourceApi
+internal val Res.string.str_16470: StringResource
+  get() = String14.str_16470
+
+@ExperimentalResourceApi
+internal val Res.string.str_16471: StringResource
+  get() = String14.str_16471
+
+@ExperimentalResourceApi
+internal val Res.string.str_16472: StringResource
+  get() = String14.str_16472
+
+@ExperimentalResourceApi
+internal val Res.string.str_16473: StringResource
+  get() = String14.str_16473
+
+@ExperimentalResourceApi
+internal val Res.string.str_16474: StringResource
+  get() = String14.str_16474
+
+@ExperimentalResourceApi
+internal val Res.string.str_16475: StringResource
+  get() = String14.str_16475
+
+@ExperimentalResourceApi
+internal val Res.string.str_16476: StringResource
+  get() = String14.str_16476
+
+@ExperimentalResourceApi
+internal val Res.string.str_16477: StringResource
+  get() = String14.str_16477
+
+@ExperimentalResourceApi
+internal val Res.string.str_16478: StringResource
+  get() = String14.str_16478
+
+@ExperimentalResourceApi
+internal val Res.string.str_16479: StringResource
+  get() = String14.str_16479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1648: StringResource
+  get() = String14.str_1648
+
+@ExperimentalResourceApi
+internal val Res.string.str_16480: StringResource
+  get() = String14.str_16480
+
+@ExperimentalResourceApi
+internal val Res.string.str_16481: StringResource
+  get() = String14.str_16481
+
+@ExperimentalResourceApi
+internal val Res.string.str_16482: StringResource
+  get() = String14.str_16482
+
+@ExperimentalResourceApi
+internal val Res.string.str_16483: StringResource
+  get() = String14.str_16483
+
+@ExperimentalResourceApi
+internal val Res.string.str_16484: StringResource
+  get() = String14.str_16484
+
+@ExperimentalResourceApi
+internal val Res.string.str_16485: StringResource
+  get() = String14.str_16485
+
+@ExperimentalResourceApi
+internal val Res.string.str_16486: StringResource
+  get() = String14.str_16486
+
+@ExperimentalResourceApi
+internal val Res.string.str_16487: StringResource
+  get() = String14.str_16487
+
+@ExperimentalResourceApi
+internal val Res.string.str_16488: StringResource
+  get() = String14.str_16488
+
+@ExperimentalResourceApi
+internal val Res.string.str_16489: StringResource
+  get() = String14.str_16489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1649: StringResource
+  get() = String14.str_1649
+
+@ExperimentalResourceApi
+internal val Res.string.str_16490: StringResource
+  get() = String14.str_16490
+
+@ExperimentalResourceApi
+internal val Res.string.str_16491: StringResource
+  get() = String14.str_16491
+
+@ExperimentalResourceApi
+internal val Res.string.str_16492: StringResource
+  get() = String14.str_16492
+
+@ExperimentalResourceApi
+internal val Res.string.str_16493: StringResource
+  get() = String14.str_16493
+
+@ExperimentalResourceApi
+internal val Res.string.str_16494: StringResource
+  get() = String14.str_16494
+
+@ExperimentalResourceApi
+internal val Res.string.str_16495: StringResource
+  get() = String14.str_16495
+
+@ExperimentalResourceApi
+internal val Res.string.str_16496: StringResource
+  get() = String14.str_16496
+
+@ExperimentalResourceApi
+internal val Res.string.str_16497: StringResource
+  get() = String14.str_16497
+
+@ExperimentalResourceApi
+internal val Res.string.str_16498: StringResource
+  get() = String14.str_16498
+
+@ExperimentalResourceApi
+internal val Res.string.str_16499: StringResource
+  get() = String14.str_16499
+
+@ExperimentalResourceApi
+internal val Res.string.str_165: StringResource
+  get() = String14.str_165
+
+@ExperimentalResourceApi
+internal val Res.string.str_1650: StringResource
+  get() = String14.str_1650
+
+@ExperimentalResourceApi
+internal val Res.string.str_16500: StringResource
+  get() = String14.str_16500
+
+@ExperimentalResourceApi
+internal val Res.string.str_16501: StringResource
+  get() = String14.str_16501
+
+@ExperimentalResourceApi
+internal val Res.string.str_16502: StringResource
+  get() = String14.str_16502
+
+@ExperimentalResourceApi
+internal val Res.string.str_16503: StringResource
+  get() = String14.str_16503
+
+@ExperimentalResourceApi
+internal val Res.string.str_16504: StringResource
+  get() = String14.str_16504
+
+@ExperimentalResourceApi
+internal val Res.string.str_16505: StringResource
+  get() = String14.str_16505
+
+@ExperimentalResourceApi
+internal val Res.string.str_16506: StringResource
+  get() = String14.str_16506
+
+@ExperimentalResourceApi
+internal val Res.string.str_16507: StringResource
+  get() = String14.str_16507
+
+@ExperimentalResourceApi
+internal val Res.string.str_16508: StringResource
+  get() = String14.str_16508
+
+@ExperimentalResourceApi
+internal val Res.string.str_16509: StringResource
+  get() = String14.str_16509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1651: StringResource
+  get() = String14.str_1651
+
+@ExperimentalResourceApi
+internal val Res.string.str_16510: StringResource
+  get() = String14.str_16510
+
+@ExperimentalResourceApi
+internal val Res.string.str_16511: StringResource
+  get() = String14.str_16511
+
+@ExperimentalResourceApi
+internal val Res.string.str_16512: StringResource
+  get() = String14.str_16512
+
+@ExperimentalResourceApi
+internal val Res.string.str_16513: StringResource
+  get() = String14.str_16513
+
+@ExperimentalResourceApi
+internal val Res.string.str_16514: StringResource
+  get() = String14.str_16514
+
+@ExperimentalResourceApi
+internal val Res.string.str_16515: StringResource
+  get() = String14.str_16515
+
+@ExperimentalResourceApi
+internal val Res.string.str_16516: StringResource
+  get() = String14.str_16516
+
+@ExperimentalResourceApi
+internal val Res.string.str_16517: StringResource
+  get() = String14.str_16517
+
+@ExperimentalResourceApi
+internal val Res.string.str_16518: StringResource
+  get() = String14.str_16518
+
+@ExperimentalResourceApi
+internal val Res.string.str_16519: StringResource
+  get() = String14.str_16519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1652: StringResource
+  get() = String14.str_1652
+
+@ExperimentalResourceApi
+internal val Res.string.str_16520: StringResource
+  get() = String14.str_16520
+
+@ExperimentalResourceApi
+internal val Res.string.str_16521: StringResource
+  get() = String14.str_16521
+
+@ExperimentalResourceApi
+internal val Res.string.str_16522: StringResource
+  get() = String14.str_16522
+
+@ExperimentalResourceApi
+internal val Res.string.str_16523: StringResource
+  get() = String14.str_16523
+
+@ExperimentalResourceApi
+internal val Res.string.str_16524: StringResource
+  get() = String14.str_16524
+
+@ExperimentalResourceApi
+internal val Res.string.str_16525: StringResource
+  get() = String14.str_16525
+
+@ExperimentalResourceApi
+internal val Res.string.str_16526: StringResource
+  get() = String14.str_16526
+
+@ExperimentalResourceApi
+internal val Res.string.str_16527: StringResource
+  get() = String14.str_16527
+
+@ExperimentalResourceApi
+internal val Res.string.str_16528: StringResource
+  get() = String14.str_16528
+
+@ExperimentalResourceApi
+internal val Res.string.str_16529: StringResource
+  get() = String14.str_16529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1653: StringResource
+  get() = String14.str_1653
+
+@ExperimentalResourceApi
+internal val Res.string.str_16530: StringResource
+  get() = String14.str_16530
+
+@ExperimentalResourceApi
+internal val Res.string.str_16531: StringResource
+  get() = String14.str_16531
+
+@ExperimentalResourceApi
+internal val Res.string.str_16532: StringResource
+  get() = String14.str_16532
+
+@ExperimentalResourceApi
+internal val Res.string.str_16533: StringResource
+  get() = String14.str_16533
+
+@ExperimentalResourceApi
+internal val Res.string.str_16534: StringResource
+  get() = String14.str_16534
+
+@ExperimentalResourceApi
+internal val Res.string.str_16535: StringResource
+  get() = String14.str_16535
+
+@ExperimentalResourceApi
+internal val Res.string.str_16536: StringResource
+  get() = String14.str_16536
+
+@ExperimentalResourceApi
+internal val Res.string.str_16537: StringResource
+  get() = String14.str_16537
+
+@ExperimentalResourceApi
+internal val Res.string.str_16538: StringResource
+  get() = String14.str_16538
+
+@ExperimentalResourceApi
+internal val Res.string.str_16539: StringResource
+  get() = String14.str_16539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1654: StringResource
+  get() = String14.str_1654
+
+@ExperimentalResourceApi
+internal val Res.string.str_16540: StringResource
+  get() = String14.str_16540
+
+@ExperimentalResourceApi
+internal val Res.string.str_16541: StringResource
+  get() = String14.str_16541
+
+@ExperimentalResourceApi
+internal val Res.string.str_16542: StringResource
+  get() = String14.str_16542
+
+@ExperimentalResourceApi
+internal val Res.string.str_16543: StringResource
+  get() = String14.str_16543
+
+@ExperimentalResourceApi
+internal val Res.string.str_16544: StringResource
+  get() = String14.str_16544
+
+@ExperimentalResourceApi
+internal val Res.string.str_16545: StringResource
+  get() = String14.str_16545
+
+@ExperimentalResourceApi
+internal val Res.string.str_16546: StringResource
+  get() = String14.str_16546
+
+@ExperimentalResourceApi
+internal val Res.string.str_16547: StringResource
+  get() = String14.str_16547
+
+@ExperimentalResourceApi
+internal val Res.string.str_16548: StringResource
+  get() = String14.str_16548
+
+@ExperimentalResourceApi
+internal val Res.string.str_16549: StringResource
+  get() = String14.str_16549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1655: StringResource
+  get() = String14.str_1655
+
+@ExperimentalResourceApi
+internal val Res.string.str_16550: StringResource
+  get() = String14.str_16550
+
+@ExperimentalResourceApi
+internal val Res.string.str_16551: StringResource
+  get() = String14.str_16551
+
+@ExperimentalResourceApi
+internal val Res.string.str_16552: StringResource
+  get() = String14.str_16552
+
+@ExperimentalResourceApi
+internal val Res.string.str_16553: StringResource
+  get() = String14.str_16553
+
+@ExperimentalResourceApi
+internal val Res.string.str_16554: StringResource
+  get() = String14.str_16554
+
+@ExperimentalResourceApi
+internal val Res.string.str_16555: StringResource
+  get() = String14.str_16555
+
+@ExperimentalResourceApi
+internal val Res.string.str_16556: StringResource
+  get() = String14.str_16556
+
+@ExperimentalResourceApi
+internal val Res.string.str_16557: StringResource
+  get() = String14.str_16557
+
+@ExperimentalResourceApi
+internal val Res.string.str_16558: StringResource
+  get() = String14.str_16558
+
+@ExperimentalResourceApi
+internal val Res.string.str_16559: StringResource
+  get() = String14.str_16559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1656: StringResource
+  get() = String14.str_1656
+
+@ExperimentalResourceApi
+internal val Res.string.str_16560: StringResource
+  get() = String14.str_16560
+
+@ExperimentalResourceApi
+internal val Res.string.str_16561: StringResource
+  get() = String14.str_16561
+
+@ExperimentalResourceApi
+internal val Res.string.str_16562: StringResource
+  get() = String14.str_16562
+
+@ExperimentalResourceApi
+internal val Res.string.str_16563: StringResource
+  get() = String14.str_16563
+
+@ExperimentalResourceApi
+internal val Res.string.str_16564: StringResource
+  get() = String14.str_16564
+
+@ExperimentalResourceApi
+internal val Res.string.str_16565: StringResource
+  get() = String14.str_16565
+
+@ExperimentalResourceApi
+internal val Res.string.str_16566: StringResource
+  get() = String14.str_16566
+
+@ExperimentalResourceApi
+internal val Res.string.str_16567: StringResource
+  get() = String14.str_16567
+
+@ExperimentalResourceApi
+internal val Res.string.str_16568: StringResource
+  get() = String14.str_16568
+
+@ExperimentalResourceApi
+internal val Res.string.str_16569: StringResource
+  get() = String14.str_16569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1657: StringResource
+  get() = String14.str_1657
+
+@ExperimentalResourceApi
+internal val Res.string.str_16570: StringResource
+  get() = String14.str_16570
+
+@ExperimentalResourceApi
+internal val Res.string.str_16571: StringResource
+  get() = String14.str_16571
+
+@ExperimentalResourceApi
+internal val Res.string.str_16572: StringResource
+  get() = String14.str_16572
+
+@ExperimentalResourceApi
+internal val Res.string.str_16573: StringResource
+  get() = String14.str_16573
+
+@ExperimentalResourceApi
+internal val Res.string.str_16574: StringResource
+  get() = String14.str_16574
+
+@ExperimentalResourceApi
+internal val Res.string.str_16575: StringResource
+  get() = String14.str_16575
+
+@ExperimentalResourceApi
+internal val Res.string.str_16576: StringResource
+  get() = String14.str_16576
+
+@ExperimentalResourceApi
+internal val Res.string.str_16577: StringResource
+  get() = String14.str_16577
+
+@ExperimentalResourceApi
+internal val Res.string.str_16578: StringResource
+  get() = String14.str_16578
+
+@ExperimentalResourceApi
+internal val Res.string.str_16579: StringResource
+  get() = String14.str_16579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1658: StringResource
+  get() = String14.str_1658
+
+@ExperimentalResourceApi
+internal val Res.string.str_16580: StringResource
+  get() = String14.str_16580
+
+@ExperimentalResourceApi
+internal val Res.string.str_16581: StringResource
+  get() = String14.str_16581
+
+@ExperimentalResourceApi
+internal val Res.string.str_16582: StringResource
+  get() = String14.str_16582
+
+@ExperimentalResourceApi
+internal val Res.string.str_16583: StringResource
+  get() = String14.str_16583
+
+@ExperimentalResourceApi
+internal val Res.string.str_16584: StringResource
+  get() = String14.str_16584
+
+@ExperimentalResourceApi
+internal val Res.string.str_16585: StringResource
+  get() = String14.str_16585
+
+@ExperimentalResourceApi
+internal val Res.string.str_16586: StringResource
+  get() = String14.str_16586
+
+@ExperimentalResourceApi
+internal val Res.string.str_16587: StringResource
+  get() = String14.str_16587
+
+@ExperimentalResourceApi
+internal val Res.string.str_16588: StringResource
+  get() = String14.str_16588
+
+@ExperimentalResourceApi
+internal val Res.string.str_16589: StringResource
+  get() = String14.str_16589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1659: StringResource
+  get() = String14.str_1659
+
+@ExperimentalResourceApi
+internal val Res.string.str_16590: StringResource
+  get() = String14.str_16590
+
+@ExperimentalResourceApi
+internal val Res.string.str_16591: StringResource
+  get() = String14.str_16591
+
+@ExperimentalResourceApi
+internal val Res.string.str_16592: StringResource
+  get() = String14.str_16592
+
+@ExperimentalResourceApi
+internal val Res.string.str_16593: StringResource
+  get() = String14.str_16593
+
+@ExperimentalResourceApi
+internal val Res.string.str_16594: StringResource
+  get() = String14.str_16594
+
+@ExperimentalResourceApi
+internal val Res.string.str_16595: StringResource
+  get() = String14.str_16595
+
+@ExperimentalResourceApi
+internal val Res.string.str_16596: StringResource
+  get() = String14.str_16596
+
+@ExperimentalResourceApi
+internal val Res.string.str_16597: StringResource
+  get() = String14.str_16597
+
+@ExperimentalResourceApi
+internal val Res.string.str_16598: StringResource
+  get() = String14.str_16598
+
+@ExperimentalResourceApi
+internal val Res.string.str_16599: StringResource
+  get() = String14.str_16599
+
+@ExperimentalResourceApi
+internal val Res.string.str_166: StringResource
+  get() = String14.str_166
+
+@ExperimentalResourceApi
+internal val Res.string.str_1660: StringResource
+  get() = String14.str_1660
+
+@ExperimentalResourceApi
+internal val Res.string.str_16600: StringResource
+  get() = String14.str_16600
+
+@ExperimentalResourceApi
+internal val Res.string.str_16601: StringResource
+  get() = String14.str_16601
+
+@ExperimentalResourceApi
+internal val Res.string.str_16602: StringResource
+  get() = String14.str_16602
+
+@ExperimentalResourceApi
+internal val Res.string.str_16603: StringResource
+  get() = String14.str_16603
+
+@ExperimentalResourceApi
+internal val Res.string.str_16604: StringResource
+  get() = String14.str_16604
+
+@ExperimentalResourceApi
+internal val Res.string.str_16605: StringResource
+  get() = String14.str_16605
+
+@ExperimentalResourceApi
+internal val Res.string.str_16606: StringResource
+  get() = String14.str_16606
+
+@ExperimentalResourceApi
+internal val Res.string.str_16607: StringResource
+  get() = String14.str_16607
+
+@ExperimentalResourceApi
+internal val Res.string.str_16608: StringResource
+  get() = String14.str_16608
+
+@ExperimentalResourceApi
+internal val Res.string.str_16609: StringResource
+  get() = String14.str_16609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1661: StringResource
+  get() = String14.str_1661
+
+@ExperimentalResourceApi
+internal val Res.string.str_16610: StringResource
+  get() = String14.str_16610
+
+@ExperimentalResourceApi
+internal val Res.string.str_16611: StringResource
+  get() = String14.str_16611
+
+@ExperimentalResourceApi
+internal val Res.string.str_16612: StringResource
+  get() = String14.str_16612
+
+@ExperimentalResourceApi
+internal val Res.string.str_16613: StringResource
+  get() = String14.str_16613
+
+@ExperimentalResourceApi
+internal val Res.string.str_16614: StringResource
+  get() = String14.str_16614
+
+@ExperimentalResourceApi
+internal val Res.string.str_16615: StringResource
+  get() = String14.str_16615
+
+@ExperimentalResourceApi
+internal val Res.string.str_16616: StringResource
+  get() = String14.str_16616
+
+@ExperimentalResourceApi
+internal val Res.string.str_16617: StringResource
+  get() = String14.str_16617
+
+@ExperimentalResourceApi
+internal val Res.string.str_16618: StringResource
+  get() = String14.str_16618
+
+@ExperimentalResourceApi
+internal val Res.string.str_16619: StringResource
+  get() = String14.str_16619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1662: StringResource
+  get() = String14.str_1662
+
+@ExperimentalResourceApi
+internal val Res.string.str_16620: StringResource
+  get() = String14.str_16620
+
+@ExperimentalResourceApi
+internal val Res.string.str_16621: StringResource
+  get() = String14.str_16621
+
+@ExperimentalResourceApi
+internal val Res.string.str_16622: StringResource
+  get() = String14.str_16622
+
+@ExperimentalResourceApi
+internal val Res.string.str_16623: StringResource
+  get() = String14.str_16623
+
+@ExperimentalResourceApi
+internal val Res.string.str_16624: StringResource
+  get() = String14.str_16624
+
+@ExperimentalResourceApi
+internal val Res.string.str_16625: StringResource
+  get() = String14.str_16625
+
+@ExperimentalResourceApi
+internal val Res.string.str_16626: StringResource
+  get() = String14.str_16626
+
+@ExperimentalResourceApi
+internal val Res.string.str_16627: StringResource
+  get() = String14.str_16627
+
+@ExperimentalResourceApi
+internal val Res.string.str_16628: StringResource
+  get() = String14.str_16628
+
+@ExperimentalResourceApi
+internal val Res.string.str_16629: StringResource
+  get() = String14.str_16629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1663: StringResource
+  get() = String14.str_1663
+
+@ExperimentalResourceApi
+internal val Res.string.str_16630: StringResource
+  get() = String14.str_16630
+
+@ExperimentalResourceApi
+internal val Res.string.str_16631: StringResource
+  get() = String14.str_16631
+
+@ExperimentalResourceApi
+internal val Res.string.str_16632: StringResource
+  get() = String14.str_16632
+
+@ExperimentalResourceApi
+internal val Res.string.str_16633: StringResource
+  get() = String14.str_16633
+
+@ExperimentalResourceApi
+internal val Res.string.str_16634: StringResource
+  get() = String14.str_16634
+
+@ExperimentalResourceApi
+internal val Res.string.str_16635: StringResource
+  get() = String14.str_16635
+
+@ExperimentalResourceApi
+internal val Res.string.str_16636: StringResource
+  get() = String14.str_16636
+
+@ExperimentalResourceApi
+internal val Res.string.str_16637: StringResource
+  get() = String14.str_16637
+
+@ExperimentalResourceApi
+internal val Res.string.str_16638: StringResource
+  get() = String14.str_16638
+
+@ExperimentalResourceApi
+internal val Res.string.str_16639: StringResource
+  get() = String14.str_16639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1664: StringResource
+  get() = String14.str_1664
+
+@ExperimentalResourceApi
+internal val Res.string.str_16640: StringResource
+  get() = String14.str_16640
+
+@ExperimentalResourceApi
+internal val Res.string.str_16641: StringResource
+  get() = String14.str_16641
+
+@ExperimentalResourceApi
+internal val Res.string.str_16642: StringResource
+  get() = String14.str_16642
+
+@ExperimentalResourceApi
+internal val Res.string.str_16643: StringResource
+  get() = String14.str_16643
+
+@ExperimentalResourceApi
+internal val Res.string.str_16644: StringResource
+  get() = String14.str_16644
+
+@ExperimentalResourceApi
+internal val Res.string.str_16645: StringResource
+  get() = String14.str_16645
+
+@ExperimentalResourceApi
+internal val Res.string.str_16646: StringResource
+  get() = String14.str_16646
+
+@ExperimentalResourceApi
+internal val Res.string.str_16647: StringResource
+  get() = String14.str_16647
+
+@ExperimentalResourceApi
+internal val Res.string.str_16648: StringResource
+  get() = String14.str_16648
+
+@ExperimentalResourceApi
+internal val Res.string.str_16649: StringResource
+  get() = String14.str_16649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1665: StringResource
+  get() = String14.str_1665
+
+@ExperimentalResourceApi
+internal val Res.string.str_16650: StringResource
+  get() = String14.str_16650
+
+@ExperimentalResourceApi
+internal val Res.string.str_16651: StringResource
+  get() = String14.str_16651
+
+@ExperimentalResourceApi
+internal val Res.string.str_16652: StringResource
+  get() = String14.str_16652
+
+@ExperimentalResourceApi
+internal val Res.string.str_16653: StringResource
+  get() = String14.str_16653
+
+@ExperimentalResourceApi
+internal val Res.string.str_16654: StringResource
+  get() = String14.str_16654
+
+@ExperimentalResourceApi
+internal val Res.string.str_16655: StringResource
+  get() = String14.str_16655
+
+@ExperimentalResourceApi
+internal val Res.string.str_16656: StringResource
+  get() = String14.str_16656
+
+@ExperimentalResourceApi
+internal val Res.string.str_16657: StringResource
+  get() = String14.str_16657
+
+@ExperimentalResourceApi
+internal val Res.string.str_16658: StringResource
+  get() = String14.str_16658
+
+@ExperimentalResourceApi
+internal val Res.string.str_16659: StringResource
+  get() = String14.str_16659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1666: StringResource
+  get() = String14.str_1666
+
+@ExperimentalResourceApi
+internal val Res.string.str_16660: StringResource
+  get() = String14.str_16660
+
+@ExperimentalResourceApi
+internal val Res.string.str_16661: StringResource
+  get() = String14.str_16661
+
+@ExperimentalResourceApi
+internal val Res.string.str_16662: StringResource
+  get() = String14.str_16662
+
+@ExperimentalResourceApi
+internal val Res.string.str_16663: StringResource
+  get() = String14.str_16663
+
+@ExperimentalResourceApi
+internal val Res.string.str_16664: StringResource
+  get() = String14.str_16664
+
+@ExperimentalResourceApi
+internal val Res.string.str_16665: StringResource
+  get() = String14.str_16665
+
+@ExperimentalResourceApi
+internal val Res.string.str_16666: StringResource
+  get() = String14.str_16666
+
+@ExperimentalResourceApi
+internal val Res.string.str_16667: StringResource
+  get() = String14.str_16667
+
+@ExperimentalResourceApi
+internal val Res.string.str_16668: StringResource
+  get() = String14.str_16668
+
+@ExperimentalResourceApi
+internal val Res.string.str_16669: StringResource
+  get() = String14.str_16669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1667: StringResource
+  get() = String14.str_1667
+
+@ExperimentalResourceApi
+internal val Res.string.str_16670: StringResource
+  get() = String14.str_16670
+
+@ExperimentalResourceApi
+internal val Res.string.str_16671: StringResource
+  get() = String14.str_16671
+
+@ExperimentalResourceApi
+internal val Res.string.str_16672: StringResource
+  get() = String14.str_16672
+
+@ExperimentalResourceApi
+internal val Res.string.str_16673: StringResource
+  get() = String14.str_16673
+
+@ExperimentalResourceApi
+internal val Res.string.str_16674: StringResource
+  get() = String14.str_16674
+
+@ExperimentalResourceApi
+internal val Res.string.str_16675: StringResource
+  get() = String14.str_16675
+
+@ExperimentalResourceApi
+internal val Res.string.str_16676: StringResource
+  get() = String14.str_16676
+
+@ExperimentalResourceApi
+internal val Res.string.str_16677: StringResource
+  get() = String14.str_16677
+
+@ExperimentalResourceApi
+internal val Res.string.str_16678: StringResource
+  get() = String14.str_16678
+
+@ExperimentalResourceApi
+internal val Res.string.str_16679: StringResource
+  get() = String14.str_16679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1668: StringResource
+  get() = String14.str_1668
+
+@ExperimentalResourceApi
+internal val Res.string.str_16680: StringResource
+  get() = String14.str_16680
+
+@ExperimentalResourceApi
+internal val Res.string.str_16681: StringResource
+  get() = String14.str_16681
+
+@ExperimentalResourceApi
+internal val Res.string.str_16682: StringResource
+  get() = String14.str_16682
+
+@ExperimentalResourceApi
+internal val Res.string.str_16683: StringResource
+  get() = String14.str_16683
+
+@ExperimentalResourceApi
+internal val Res.string.str_16684: StringResource
+  get() = String14.str_16684
+
+@ExperimentalResourceApi
+internal val Res.string.str_16685: StringResource
+  get() = String14.str_16685
+
+@ExperimentalResourceApi
+internal val Res.string.str_16686: StringResource
+  get() = String14.str_16686
+
+@ExperimentalResourceApi
+internal val Res.string.str_16687: StringResource
+  get() = String14.str_16687
+
+@ExperimentalResourceApi
+internal val Res.string.str_16688: StringResource
+  get() = String14.str_16688
+
+@ExperimentalResourceApi
+internal val Res.string.str_16689: StringResource
+  get() = String14.str_16689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1669: StringResource
+  get() = String14.str_1669
+
+@ExperimentalResourceApi
+internal val Res.string.str_16690: StringResource
+  get() = String14.str_16690
+
+@ExperimentalResourceApi
+internal val Res.string.str_16691: StringResource
+  get() = String14.str_16691
+
+@ExperimentalResourceApi
+internal val Res.string.str_16692: StringResource
+  get() = String14.str_16692
+
+@ExperimentalResourceApi
+internal val Res.string.str_16693: StringResource
+  get() = String14.str_16693
+
+@ExperimentalResourceApi
+internal val Res.string.str_16694: StringResource
+  get() = String14.str_16694
+
+@ExperimentalResourceApi
+internal val Res.string.str_16695: StringResource
+  get() = String14.str_16695
+
+@ExperimentalResourceApi
+internal val Res.string.str_16696: StringResource
+  get() = String14.str_16696
+
+@ExperimentalResourceApi
+internal val Res.string.str_16697: StringResource
+  get() = String14.str_16697
+
+@ExperimentalResourceApi
+internal val Res.string.str_16698: StringResource
+  get() = String14.str_16698
+
+@ExperimentalResourceApi
+internal val Res.string.str_16699: StringResource
+  get() = String14.str_16699
+
+@ExperimentalResourceApi
+internal val Res.string.str_167: StringResource
+  get() = String14.str_167
+
+@ExperimentalResourceApi
+internal val Res.string.str_1670: StringResource
+  get() = String14.str_1670
+
+@ExperimentalResourceApi
+internal val Res.string.str_16700: StringResource
+  get() = String14.str_16700
+
+@ExperimentalResourceApi
+internal val Res.string.str_16701: StringResource
+  get() = String14.str_16701
+
+@ExperimentalResourceApi
+internal val Res.string.str_16702: StringResource
+  get() = String14.str_16702
+
+@ExperimentalResourceApi
+internal val Res.string.str_16703: StringResource
+  get() = String14.str_16703
+
+@ExperimentalResourceApi
+internal val Res.string.str_16704: StringResource
+  get() = String14.str_16704
+
+@ExperimentalResourceApi
+internal val Res.string.str_16705: StringResource
+  get() = String14.str_16705
+
+@ExperimentalResourceApi
+internal val Res.string.str_16706: StringResource
+  get() = String14.str_16706
+
+@ExperimentalResourceApi
+internal val Res.string.str_16707: StringResource
+  get() = String14.str_16707
+
+@ExperimentalResourceApi
+internal val Res.string.str_16708: StringResource
+  get() = String14.str_16708
+
+@ExperimentalResourceApi
+internal val Res.string.str_16709: StringResource
+  get() = String14.str_16709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1671: StringResource
+  get() = String14.str_1671
+
+@ExperimentalResourceApi
+internal val Res.string.str_16710: StringResource
+  get() = String14.str_16710
+
+@ExperimentalResourceApi
+internal val Res.string.str_16711: StringResource
+  get() = String14.str_16711
+
+@ExperimentalResourceApi
+internal val Res.string.str_16712: StringResource
+  get() = String14.str_16712
+
+@ExperimentalResourceApi
+internal val Res.string.str_16713: StringResource
+  get() = String14.str_16713
+
+@ExperimentalResourceApi
+internal val Res.string.str_16714: StringResource
+  get() = String14.str_16714
+
+@ExperimentalResourceApi
+internal val Res.string.str_16715: StringResource
+  get() = String14.str_16715
+
+@ExperimentalResourceApi
+internal val Res.string.str_16716: StringResource
+  get() = String14.str_16716
+
+@ExperimentalResourceApi
+internal val Res.string.str_16717: StringResource
+  get() = String14.str_16717
+
+@ExperimentalResourceApi
+internal val Res.string.str_16718: StringResource
+  get() = String14.str_16718
+
+@ExperimentalResourceApi
+internal val Res.string.str_16719: StringResource
+  get() = String14.str_16719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1672: StringResource
+  get() = String14.str_1672
+
+@ExperimentalResourceApi
+internal val Res.string.str_16720: StringResource
+  get() = String14.str_16720
+
+@ExperimentalResourceApi
+internal val Res.string.str_16721: StringResource
+  get() = String14.str_16721
+
+@ExperimentalResourceApi
+internal val Res.string.str_16722: StringResource
+  get() = String14.str_16722
+
+@ExperimentalResourceApi
+internal val Res.string.str_16723: StringResource
+  get() = String14.str_16723
+
+@ExperimentalResourceApi
+internal val Res.string.str_16724: StringResource
+  get() = String14.str_16724
+
+@ExperimentalResourceApi
+internal val Res.string.str_16725: StringResource
+  get() = String14.str_16725
+
+@ExperimentalResourceApi
+internal val Res.string.str_16726: StringResource
+  get() = String14.str_16726
+
+@ExperimentalResourceApi
+internal val Res.string.str_16727: StringResource
+  get() = String14.str_16727
+
+@ExperimentalResourceApi
+internal val Res.string.str_16728: StringResource
+  get() = String14.str_16728
+
+@ExperimentalResourceApi
+internal val Res.string.str_16729: StringResource
+  get() = String14.str_16729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1673: StringResource
+  get() = String14.str_1673
+
+@ExperimentalResourceApi
+internal val Res.string.str_16730: StringResource
+  get() = String14.str_16730
+
+@ExperimentalResourceApi
+internal val Res.string.str_16731: StringResource
+  get() = String14.str_16731
+
+@ExperimentalResourceApi
+internal val Res.string.str_16732: StringResource
+  get() = String14.str_16732
+
+@ExperimentalResourceApi
+internal val Res.string.str_16733: StringResource
+  get() = String14.str_16733
+
+@ExperimentalResourceApi
+internal val Res.string.str_16734: StringResource
+  get() = String14.str_16734
+
+@ExperimentalResourceApi
+internal val Res.string.str_16735: StringResource
+  get() = String14.str_16735
+
+@ExperimentalResourceApi
+internal val Res.string.str_16736: StringResource
+  get() = String14.str_16736
+
+@ExperimentalResourceApi
+internal val Res.string.str_16737: StringResource
+  get() = String14.str_16737
+
+@ExperimentalResourceApi
+internal val Res.string.str_16738: StringResource
+  get() = String14.str_16738
+
+@ExperimentalResourceApi
+internal val Res.string.str_16739: StringResource
+  get() = String14.str_16739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1674: StringResource
+  get() = String14.str_1674
+
+@ExperimentalResourceApi
+internal val Res.string.str_16740: StringResource
+  get() = String14.str_16740
+
+@ExperimentalResourceApi
+internal val Res.string.str_16741: StringResource
+  get() = String14.str_16741
+
+@ExperimentalResourceApi
+internal val Res.string.str_16742: StringResource
+  get() = String14.str_16742
+
+@ExperimentalResourceApi
+internal val Res.string.str_16743: StringResource
+  get() = String14.str_16743
+
+@ExperimentalResourceApi
+internal val Res.string.str_16744: StringResource
+  get() = String14.str_16744
+
+@ExperimentalResourceApi
+internal val Res.string.str_16745: StringResource
+  get() = String14.str_16745
+
+@ExperimentalResourceApi
+internal val Res.string.str_16746: StringResource
+  get() = String14.str_16746
+
+@ExperimentalResourceApi
+internal val Res.string.str_16747: StringResource
+  get() = String14.str_16747

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String15.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String15.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String15 {
+  public val str_16748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16748", "str_16748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16749", "str_16749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1675", "str_1675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16750", "str_16750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16751", "str_16751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16752", "str_16752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16753", "str_16753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16754", "str_16754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16755", "str_16755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16756", "str_16756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16757", "str_16757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16758", "str_16758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16759", "str_16759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1676", "str_1676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16760", "str_16760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16761", "str_16761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16762", "str_16762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16763", "str_16763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16764", "str_16764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16765", "str_16765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16766", "str_16766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16767", "str_16767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16768", "str_16768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16769", "str_16769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1677", "str_1677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16770", "str_16770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16771", "str_16771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16772", "str_16772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16773", "str_16773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16774", "str_16774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16775", "str_16775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16776", "str_16776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16777", "str_16777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16778", "str_16778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16779", "str_16779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1678", "str_1678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16780", "str_16780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16781", "str_16781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16782", "str_16782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16783", "str_16783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16784", "str_16784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16785", "str_16785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16786", "str_16786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16787", "str_16787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16788", "str_16788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16789", "str_16789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1679", "str_1679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16790", "str_16790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16791", "str_16791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16792", "str_16792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16793", "str_16793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16794", "str_16794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16795", "str_16795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16796", "str_16796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16797", "str_16797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16798", "str_16798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16799", "str_16799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_168", "str_168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1680", "str_1680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16800", "str_16800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16801", "str_16801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16802", "str_16802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16803", "str_16803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16804", "str_16804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16805", "str_16805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16806", "str_16806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16807", "str_16807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16808", "str_16808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16809", "str_16809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1681", "str_1681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16810", "str_16810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16811", "str_16811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16812", "str_16812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16813", "str_16813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16814", "str_16814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16815", "str_16815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16816", "str_16816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16817", "str_16817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16818", "str_16818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16819", "str_16819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1682", "str_1682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16820", "str_16820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16821", "str_16821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16822", "str_16822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16823", "str_16823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16824", "str_16824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16825", "str_16825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16826", "str_16826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16827", "str_16827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16828", "str_16828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16829", "str_16829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1683", "str_1683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16830", "str_16830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16831", "str_16831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16832", "str_16832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16833", "str_16833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16834", "str_16834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16835", "str_16835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16836", "str_16836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16837", "str_16837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16838", "str_16838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16839", "str_16839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1684", "str_1684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16840", "str_16840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16841", "str_16841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16842", "str_16842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16843", "str_16843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16844", "str_16844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16845", "str_16845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16846", "str_16846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16847", "str_16847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16848", "str_16848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16849", "str_16849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1685", "str_1685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16850", "str_16850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16851", "str_16851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16852", "str_16852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16853", "str_16853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16854", "str_16854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16855", "str_16855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16856", "str_16856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16857", "str_16857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16858", "str_16858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16859", "str_16859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1686", "str_1686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16860", "str_16860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16861", "str_16861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16862", "str_16862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16863", "str_16863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16864", "str_16864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16865", "str_16865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16866", "str_16866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16867", "str_16867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16868", "str_16868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16869", "str_16869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1687", "str_1687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16870", "str_16870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16871", "str_16871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16872", "str_16872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16873", "str_16873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16874", "str_16874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16875", "str_16875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16876", "str_16876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16877", "str_16877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16878", "str_16878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16879", "str_16879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1688", "str_1688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16880", "str_16880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16881", "str_16881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16882", "str_16882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16883", "str_16883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16884", "str_16884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16885", "str_16885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16886", "str_16886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16887", "str_16887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16888", "str_16888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16889", "str_16889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1689", "str_1689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16890", "str_16890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16891", "str_16891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16892", "str_16892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16893", "str_16893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16894", "str_16894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16895", "str_16895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16896", "str_16896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16897", "str_16897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16898", "str_16898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16899", "str_16899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_169", "str_169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1690", "str_1690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16900", "str_16900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16901", "str_16901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16902", "str_16902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16903", "str_16903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16904", "str_16904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16905", "str_16905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16906", "str_16906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16907", "str_16907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16908", "str_16908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16909", "str_16909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1691", "str_1691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16910", "str_16910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16911", "str_16911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16912", "str_16912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16913", "str_16913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16914", "str_16914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16915", "str_16915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16916", "str_16916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16917", "str_16917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16918", "str_16918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16919", "str_16919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1692", "str_1692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16920", "str_16920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16921", "str_16921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16922", "str_16922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16923", "str_16923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16924", "str_16924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16925", "str_16925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16926", "str_16926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16927", "str_16927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16928", "str_16928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16929", "str_16929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1693", "str_1693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16930", "str_16930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16931", "str_16931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16932", "str_16932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16933", "str_16933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16934", "str_16934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16935", "str_16935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16936", "str_16936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16937", "str_16937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16938", "str_16938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16939", "str_16939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1694", "str_1694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16940", "str_16940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16941", "str_16941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16942", "str_16942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16943", "str_16943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16944", "str_16944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16945", "str_16945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16946", "str_16946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16947", "str_16947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16948", "str_16948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16949", "str_16949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1695", "str_1695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16950", "str_16950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16951", "str_16951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16952", "str_16952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16953", "str_16953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16954", "str_16954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16955", "str_16955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16956", "str_16956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16957", "str_16957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16958", "str_16958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16959", "str_16959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1696", "str_1696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16960", "str_16960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16961", "str_16961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16962", "str_16962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16963", "str_16963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16964", "str_16964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16965", "str_16965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16966", "str_16966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16967", "str_16967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16968", "str_16968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16969", "str_16969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1697", "str_1697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16970", "str_16970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16971", "str_16971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16972", "str_16972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16973", "str_16973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16974", "str_16974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16975", "str_16975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16976", "str_16976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16977", "str_16977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16978", "str_16978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16979", "str_16979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1698", "str_1698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16980", "str_16980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16981", "str_16981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16982", "str_16982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16983", "str_16983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16984", "str_16984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16985", "str_16985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16986", "str_16986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16987", "str_16987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16988", "str_16988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16989", "str_16989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1699", "str_1699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16990", "str_16990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16991", "str_16991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16992", "str_16992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16993", "str_16993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16994", "str_16994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16995", "str_16995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16996", "str_16996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16997", "str_16997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16998", "str_16998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_16999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_16999", "str_16999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17", "str_17",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_170", "str_170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1700", "str_1700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17000", "str_17000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17001", "str_17001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17002", "str_17002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17003", "str_17003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17004", "str_17004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17005", "str_17005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17006", "str_17006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17007", "str_17007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17008", "str_17008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17009", "str_17009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1701", "str_1701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17010", "str_17010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17011", "str_17011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17012", "str_17012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17013", "str_17013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17014", "str_17014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17015", "str_17015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17016", "str_17016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17017", "str_17017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17018", "str_17018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17019", "str_17019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1702", "str_1702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17020", "str_17020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17021", "str_17021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17022", "str_17022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17023", "str_17023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17024", "str_17024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17025", "str_17025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17026", "str_17026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17027", "str_17027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17028", "str_17028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17029", "str_17029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1703", "str_1703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17030", "str_17030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17031", "str_17031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17032", "str_17032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17033", "str_17033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17034", "str_17034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17035", "str_17035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17036", "str_17036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17037", "str_17037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17038", "str_17038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17039", "str_17039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1704", "str_1704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17040", "str_17040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17041", "str_17041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17042", "str_17042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17043", "str_17043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17044", "str_17044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17045", "str_17045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17046", "str_17046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17047", "str_17047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17048", "str_17048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17049", "str_17049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1705", "str_1705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17050", "str_17050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17051", "str_17051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17052", "str_17052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17053", "str_17053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17054", "str_17054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17055", "str_17055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17056", "str_17056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17057", "str_17057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17058", "str_17058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17059", "str_17059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1706", "str_1706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17060", "str_17060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17061", "str_17061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17062", "str_17062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17063", "str_17063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17064", "str_17064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17065", "str_17065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17066", "str_17066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17067", "str_17067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17068", "str_17068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17069", "str_17069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1707", "str_1707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17070", "str_17070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17071", "str_17071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17072", "str_17072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17073", "str_17073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17074", "str_17074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17075", "str_17075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17076", "str_17076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17077", "str_17077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17078", "str_17078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17079", "str_17079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1708", "str_1708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17080", "str_17080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17081", "str_17081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17082", "str_17082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17083", "str_17083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17084", "str_17084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17085", "str_17085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17086", "str_17086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17087", "str_17087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17088", "str_17088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17089", "str_17089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1709", "str_1709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17090", "str_17090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17091", "str_17091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17092", "str_17092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17093", "str_17093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17094", "str_17094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17095", "str_17095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17096", "str_17096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17097", "str_17097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17098", "str_17098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17099", "str_17099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_171", "str_171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1710", "str_1710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17100", "str_17100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17101", "str_17101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17102", "str_17102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17103", "str_17103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17104", "str_17104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17105", "str_17105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17106", "str_17106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17107", "str_17107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17108", "str_17108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17109", "str_17109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1711", "str_1711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17110", "str_17110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17111", "str_17111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17112", "str_17112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17113", "str_17113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17114", "str_17114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17115", "str_17115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17116", "str_17116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17117", "str_17117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17118", "str_17118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17119", "str_17119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1712", "str_1712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17120", "str_17120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17121", "str_17121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17122", "str_17122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17123", "str_17123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17124", "str_17124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17125", "str_17125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17126", "str_17126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17127", "str_17127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17128", "str_17128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17129", "str_17129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1713", "str_1713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17130", "str_17130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17131", "str_17131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17132", "str_17132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17133", "str_17133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17134", "str_17134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17135", "str_17135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17136", "str_17136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17137", "str_17137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17138", "str_17138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17139", "str_17139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1714", "str_1714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17140", "str_17140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17141", "str_17141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17142", "str_17142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17143", "str_17143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17144", "str_17144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17145", "str_17145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17146", "str_17146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17147", "str_17147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17148", "str_17148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17149", "str_17149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1715", "str_1715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17150", "str_17150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17151", "str_17151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17152", "str_17152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17153", "str_17153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17154", "str_17154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17155", "str_17155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17156", "str_17156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17157", "str_17157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17158", "str_17158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17159", "str_17159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1716", "str_1716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17160", "str_17160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17161", "str_17161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17162", "str_17162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17163", "str_17163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17164", "str_17164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17165", "str_17165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17166", "str_17166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17167", "str_17167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17168", "str_17168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17169", "str_17169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1717", "str_1717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17170", "str_17170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17171", "str_17171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17172", "str_17172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17173", "str_17173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17174", "str_17174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17175", "str_17175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17176", "str_17176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17177", "str_17177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17178", "str_17178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17179", "str_17179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1718", "str_1718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17180", "str_17180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17181", "str_17181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17182", "str_17182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17183", "str_17183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17184", "str_17184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17185", "str_17185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17186", "str_17186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17187", "str_17187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17188", "str_17188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17189", "str_17189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1719", "str_1719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17190", "str_17190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17191", "str_17191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17192", "str_17192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17193", "str_17193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17194", "str_17194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17195", "str_17195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17196", "str_17196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17197", "str_17197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_16748: StringResource
+  get() = String15.str_16748
+
+@ExperimentalResourceApi
+internal val Res.string.str_16749: StringResource
+  get() = String15.str_16749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1675: StringResource
+  get() = String15.str_1675
+
+@ExperimentalResourceApi
+internal val Res.string.str_16750: StringResource
+  get() = String15.str_16750
+
+@ExperimentalResourceApi
+internal val Res.string.str_16751: StringResource
+  get() = String15.str_16751
+
+@ExperimentalResourceApi
+internal val Res.string.str_16752: StringResource
+  get() = String15.str_16752
+
+@ExperimentalResourceApi
+internal val Res.string.str_16753: StringResource
+  get() = String15.str_16753
+
+@ExperimentalResourceApi
+internal val Res.string.str_16754: StringResource
+  get() = String15.str_16754
+
+@ExperimentalResourceApi
+internal val Res.string.str_16755: StringResource
+  get() = String15.str_16755
+
+@ExperimentalResourceApi
+internal val Res.string.str_16756: StringResource
+  get() = String15.str_16756
+
+@ExperimentalResourceApi
+internal val Res.string.str_16757: StringResource
+  get() = String15.str_16757
+
+@ExperimentalResourceApi
+internal val Res.string.str_16758: StringResource
+  get() = String15.str_16758
+
+@ExperimentalResourceApi
+internal val Res.string.str_16759: StringResource
+  get() = String15.str_16759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1676: StringResource
+  get() = String15.str_1676
+
+@ExperimentalResourceApi
+internal val Res.string.str_16760: StringResource
+  get() = String15.str_16760
+
+@ExperimentalResourceApi
+internal val Res.string.str_16761: StringResource
+  get() = String15.str_16761
+
+@ExperimentalResourceApi
+internal val Res.string.str_16762: StringResource
+  get() = String15.str_16762
+
+@ExperimentalResourceApi
+internal val Res.string.str_16763: StringResource
+  get() = String15.str_16763
+
+@ExperimentalResourceApi
+internal val Res.string.str_16764: StringResource
+  get() = String15.str_16764
+
+@ExperimentalResourceApi
+internal val Res.string.str_16765: StringResource
+  get() = String15.str_16765
+
+@ExperimentalResourceApi
+internal val Res.string.str_16766: StringResource
+  get() = String15.str_16766
+
+@ExperimentalResourceApi
+internal val Res.string.str_16767: StringResource
+  get() = String15.str_16767
+
+@ExperimentalResourceApi
+internal val Res.string.str_16768: StringResource
+  get() = String15.str_16768
+
+@ExperimentalResourceApi
+internal val Res.string.str_16769: StringResource
+  get() = String15.str_16769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1677: StringResource
+  get() = String15.str_1677
+
+@ExperimentalResourceApi
+internal val Res.string.str_16770: StringResource
+  get() = String15.str_16770
+
+@ExperimentalResourceApi
+internal val Res.string.str_16771: StringResource
+  get() = String15.str_16771
+
+@ExperimentalResourceApi
+internal val Res.string.str_16772: StringResource
+  get() = String15.str_16772
+
+@ExperimentalResourceApi
+internal val Res.string.str_16773: StringResource
+  get() = String15.str_16773
+
+@ExperimentalResourceApi
+internal val Res.string.str_16774: StringResource
+  get() = String15.str_16774
+
+@ExperimentalResourceApi
+internal val Res.string.str_16775: StringResource
+  get() = String15.str_16775
+
+@ExperimentalResourceApi
+internal val Res.string.str_16776: StringResource
+  get() = String15.str_16776
+
+@ExperimentalResourceApi
+internal val Res.string.str_16777: StringResource
+  get() = String15.str_16777
+
+@ExperimentalResourceApi
+internal val Res.string.str_16778: StringResource
+  get() = String15.str_16778
+
+@ExperimentalResourceApi
+internal val Res.string.str_16779: StringResource
+  get() = String15.str_16779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1678: StringResource
+  get() = String15.str_1678
+
+@ExperimentalResourceApi
+internal val Res.string.str_16780: StringResource
+  get() = String15.str_16780
+
+@ExperimentalResourceApi
+internal val Res.string.str_16781: StringResource
+  get() = String15.str_16781
+
+@ExperimentalResourceApi
+internal val Res.string.str_16782: StringResource
+  get() = String15.str_16782
+
+@ExperimentalResourceApi
+internal val Res.string.str_16783: StringResource
+  get() = String15.str_16783
+
+@ExperimentalResourceApi
+internal val Res.string.str_16784: StringResource
+  get() = String15.str_16784
+
+@ExperimentalResourceApi
+internal val Res.string.str_16785: StringResource
+  get() = String15.str_16785
+
+@ExperimentalResourceApi
+internal val Res.string.str_16786: StringResource
+  get() = String15.str_16786
+
+@ExperimentalResourceApi
+internal val Res.string.str_16787: StringResource
+  get() = String15.str_16787
+
+@ExperimentalResourceApi
+internal val Res.string.str_16788: StringResource
+  get() = String15.str_16788
+
+@ExperimentalResourceApi
+internal val Res.string.str_16789: StringResource
+  get() = String15.str_16789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1679: StringResource
+  get() = String15.str_1679
+
+@ExperimentalResourceApi
+internal val Res.string.str_16790: StringResource
+  get() = String15.str_16790
+
+@ExperimentalResourceApi
+internal val Res.string.str_16791: StringResource
+  get() = String15.str_16791
+
+@ExperimentalResourceApi
+internal val Res.string.str_16792: StringResource
+  get() = String15.str_16792
+
+@ExperimentalResourceApi
+internal val Res.string.str_16793: StringResource
+  get() = String15.str_16793
+
+@ExperimentalResourceApi
+internal val Res.string.str_16794: StringResource
+  get() = String15.str_16794
+
+@ExperimentalResourceApi
+internal val Res.string.str_16795: StringResource
+  get() = String15.str_16795
+
+@ExperimentalResourceApi
+internal val Res.string.str_16796: StringResource
+  get() = String15.str_16796
+
+@ExperimentalResourceApi
+internal val Res.string.str_16797: StringResource
+  get() = String15.str_16797
+
+@ExperimentalResourceApi
+internal val Res.string.str_16798: StringResource
+  get() = String15.str_16798
+
+@ExperimentalResourceApi
+internal val Res.string.str_16799: StringResource
+  get() = String15.str_16799
+
+@ExperimentalResourceApi
+internal val Res.string.str_168: StringResource
+  get() = String15.str_168
+
+@ExperimentalResourceApi
+internal val Res.string.str_1680: StringResource
+  get() = String15.str_1680
+
+@ExperimentalResourceApi
+internal val Res.string.str_16800: StringResource
+  get() = String15.str_16800
+
+@ExperimentalResourceApi
+internal val Res.string.str_16801: StringResource
+  get() = String15.str_16801
+
+@ExperimentalResourceApi
+internal val Res.string.str_16802: StringResource
+  get() = String15.str_16802
+
+@ExperimentalResourceApi
+internal val Res.string.str_16803: StringResource
+  get() = String15.str_16803
+
+@ExperimentalResourceApi
+internal val Res.string.str_16804: StringResource
+  get() = String15.str_16804
+
+@ExperimentalResourceApi
+internal val Res.string.str_16805: StringResource
+  get() = String15.str_16805
+
+@ExperimentalResourceApi
+internal val Res.string.str_16806: StringResource
+  get() = String15.str_16806
+
+@ExperimentalResourceApi
+internal val Res.string.str_16807: StringResource
+  get() = String15.str_16807
+
+@ExperimentalResourceApi
+internal val Res.string.str_16808: StringResource
+  get() = String15.str_16808
+
+@ExperimentalResourceApi
+internal val Res.string.str_16809: StringResource
+  get() = String15.str_16809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1681: StringResource
+  get() = String15.str_1681
+
+@ExperimentalResourceApi
+internal val Res.string.str_16810: StringResource
+  get() = String15.str_16810
+
+@ExperimentalResourceApi
+internal val Res.string.str_16811: StringResource
+  get() = String15.str_16811
+
+@ExperimentalResourceApi
+internal val Res.string.str_16812: StringResource
+  get() = String15.str_16812
+
+@ExperimentalResourceApi
+internal val Res.string.str_16813: StringResource
+  get() = String15.str_16813
+
+@ExperimentalResourceApi
+internal val Res.string.str_16814: StringResource
+  get() = String15.str_16814
+
+@ExperimentalResourceApi
+internal val Res.string.str_16815: StringResource
+  get() = String15.str_16815
+
+@ExperimentalResourceApi
+internal val Res.string.str_16816: StringResource
+  get() = String15.str_16816
+
+@ExperimentalResourceApi
+internal val Res.string.str_16817: StringResource
+  get() = String15.str_16817
+
+@ExperimentalResourceApi
+internal val Res.string.str_16818: StringResource
+  get() = String15.str_16818
+
+@ExperimentalResourceApi
+internal val Res.string.str_16819: StringResource
+  get() = String15.str_16819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1682: StringResource
+  get() = String15.str_1682
+
+@ExperimentalResourceApi
+internal val Res.string.str_16820: StringResource
+  get() = String15.str_16820
+
+@ExperimentalResourceApi
+internal val Res.string.str_16821: StringResource
+  get() = String15.str_16821
+
+@ExperimentalResourceApi
+internal val Res.string.str_16822: StringResource
+  get() = String15.str_16822
+
+@ExperimentalResourceApi
+internal val Res.string.str_16823: StringResource
+  get() = String15.str_16823
+
+@ExperimentalResourceApi
+internal val Res.string.str_16824: StringResource
+  get() = String15.str_16824
+
+@ExperimentalResourceApi
+internal val Res.string.str_16825: StringResource
+  get() = String15.str_16825
+
+@ExperimentalResourceApi
+internal val Res.string.str_16826: StringResource
+  get() = String15.str_16826
+
+@ExperimentalResourceApi
+internal val Res.string.str_16827: StringResource
+  get() = String15.str_16827
+
+@ExperimentalResourceApi
+internal val Res.string.str_16828: StringResource
+  get() = String15.str_16828
+
+@ExperimentalResourceApi
+internal val Res.string.str_16829: StringResource
+  get() = String15.str_16829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1683: StringResource
+  get() = String15.str_1683
+
+@ExperimentalResourceApi
+internal val Res.string.str_16830: StringResource
+  get() = String15.str_16830
+
+@ExperimentalResourceApi
+internal val Res.string.str_16831: StringResource
+  get() = String15.str_16831
+
+@ExperimentalResourceApi
+internal val Res.string.str_16832: StringResource
+  get() = String15.str_16832
+
+@ExperimentalResourceApi
+internal val Res.string.str_16833: StringResource
+  get() = String15.str_16833
+
+@ExperimentalResourceApi
+internal val Res.string.str_16834: StringResource
+  get() = String15.str_16834
+
+@ExperimentalResourceApi
+internal val Res.string.str_16835: StringResource
+  get() = String15.str_16835
+
+@ExperimentalResourceApi
+internal val Res.string.str_16836: StringResource
+  get() = String15.str_16836
+
+@ExperimentalResourceApi
+internal val Res.string.str_16837: StringResource
+  get() = String15.str_16837
+
+@ExperimentalResourceApi
+internal val Res.string.str_16838: StringResource
+  get() = String15.str_16838
+
+@ExperimentalResourceApi
+internal val Res.string.str_16839: StringResource
+  get() = String15.str_16839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1684: StringResource
+  get() = String15.str_1684
+
+@ExperimentalResourceApi
+internal val Res.string.str_16840: StringResource
+  get() = String15.str_16840
+
+@ExperimentalResourceApi
+internal val Res.string.str_16841: StringResource
+  get() = String15.str_16841
+
+@ExperimentalResourceApi
+internal val Res.string.str_16842: StringResource
+  get() = String15.str_16842
+
+@ExperimentalResourceApi
+internal val Res.string.str_16843: StringResource
+  get() = String15.str_16843
+
+@ExperimentalResourceApi
+internal val Res.string.str_16844: StringResource
+  get() = String15.str_16844
+
+@ExperimentalResourceApi
+internal val Res.string.str_16845: StringResource
+  get() = String15.str_16845
+
+@ExperimentalResourceApi
+internal val Res.string.str_16846: StringResource
+  get() = String15.str_16846
+
+@ExperimentalResourceApi
+internal val Res.string.str_16847: StringResource
+  get() = String15.str_16847
+
+@ExperimentalResourceApi
+internal val Res.string.str_16848: StringResource
+  get() = String15.str_16848
+
+@ExperimentalResourceApi
+internal val Res.string.str_16849: StringResource
+  get() = String15.str_16849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1685: StringResource
+  get() = String15.str_1685
+
+@ExperimentalResourceApi
+internal val Res.string.str_16850: StringResource
+  get() = String15.str_16850
+
+@ExperimentalResourceApi
+internal val Res.string.str_16851: StringResource
+  get() = String15.str_16851
+
+@ExperimentalResourceApi
+internal val Res.string.str_16852: StringResource
+  get() = String15.str_16852
+
+@ExperimentalResourceApi
+internal val Res.string.str_16853: StringResource
+  get() = String15.str_16853
+
+@ExperimentalResourceApi
+internal val Res.string.str_16854: StringResource
+  get() = String15.str_16854
+
+@ExperimentalResourceApi
+internal val Res.string.str_16855: StringResource
+  get() = String15.str_16855
+
+@ExperimentalResourceApi
+internal val Res.string.str_16856: StringResource
+  get() = String15.str_16856
+
+@ExperimentalResourceApi
+internal val Res.string.str_16857: StringResource
+  get() = String15.str_16857
+
+@ExperimentalResourceApi
+internal val Res.string.str_16858: StringResource
+  get() = String15.str_16858
+
+@ExperimentalResourceApi
+internal val Res.string.str_16859: StringResource
+  get() = String15.str_16859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1686: StringResource
+  get() = String15.str_1686
+
+@ExperimentalResourceApi
+internal val Res.string.str_16860: StringResource
+  get() = String15.str_16860
+
+@ExperimentalResourceApi
+internal val Res.string.str_16861: StringResource
+  get() = String15.str_16861
+
+@ExperimentalResourceApi
+internal val Res.string.str_16862: StringResource
+  get() = String15.str_16862
+
+@ExperimentalResourceApi
+internal val Res.string.str_16863: StringResource
+  get() = String15.str_16863
+
+@ExperimentalResourceApi
+internal val Res.string.str_16864: StringResource
+  get() = String15.str_16864
+
+@ExperimentalResourceApi
+internal val Res.string.str_16865: StringResource
+  get() = String15.str_16865
+
+@ExperimentalResourceApi
+internal val Res.string.str_16866: StringResource
+  get() = String15.str_16866
+
+@ExperimentalResourceApi
+internal val Res.string.str_16867: StringResource
+  get() = String15.str_16867
+
+@ExperimentalResourceApi
+internal val Res.string.str_16868: StringResource
+  get() = String15.str_16868
+
+@ExperimentalResourceApi
+internal val Res.string.str_16869: StringResource
+  get() = String15.str_16869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1687: StringResource
+  get() = String15.str_1687
+
+@ExperimentalResourceApi
+internal val Res.string.str_16870: StringResource
+  get() = String15.str_16870
+
+@ExperimentalResourceApi
+internal val Res.string.str_16871: StringResource
+  get() = String15.str_16871
+
+@ExperimentalResourceApi
+internal val Res.string.str_16872: StringResource
+  get() = String15.str_16872
+
+@ExperimentalResourceApi
+internal val Res.string.str_16873: StringResource
+  get() = String15.str_16873
+
+@ExperimentalResourceApi
+internal val Res.string.str_16874: StringResource
+  get() = String15.str_16874
+
+@ExperimentalResourceApi
+internal val Res.string.str_16875: StringResource
+  get() = String15.str_16875
+
+@ExperimentalResourceApi
+internal val Res.string.str_16876: StringResource
+  get() = String15.str_16876
+
+@ExperimentalResourceApi
+internal val Res.string.str_16877: StringResource
+  get() = String15.str_16877
+
+@ExperimentalResourceApi
+internal val Res.string.str_16878: StringResource
+  get() = String15.str_16878
+
+@ExperimentalResourceApi
+internal val Res.string.str_16879: StringResource
+  get() = String15.str_16879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1688: StringResource
+  get() = String15.str_1688
+
+@ExperimentalResourceApi
+internal val Res.string.str_16880: StringResource
+  get() = String15.str_16880
+
+@ExperimentalResourceApi
+internal val Res.string.str_16881: StringResource
+  get() = String15.str_16881
+
+@ExperimentalResourceApi
+internal val Res.string.str_16882: StringResource
+  get() = String15.str_16882
+
+@ExperimentalResourceApi
+internal val Res.string.str_16883: StringResource
+  get() = String15.str_16883
+
+@ExperimentalResourceApi
+internal val Res.string.str_16884: StringResource
+  get() = String15.str_16884
+
+@ExperimentalResourceApi
+internal val Res.string.str_16885: StringResource
+  get() = String15.str_16885
+
+@ExperimentalResourceApi
+internal val Res.string.str_16886: StringResource
+  get() = String15.str_16886
+
+@ExperimentalResourceApi
+internal val Res.string.str_16887: StringResource
+  get() = String15.str_16887
+
+@ExperimentalResourceApi
+internal val Res.string.str_16888: StringResource
+  get() = String15.str_16888
+
+@ExperimentalResourceApi
+internal val Res.string.str_16889: StringResource
+  get() = String15.str_16889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1689: StringResource
+  get() = String15.str_1689
+
+@ExperimentalResourceApi
+internal val Res.string.str_16890: StringResource
+  get() = String15.str_16890
+
+@ExperimentalResourceApi
+internal val Res.string.str_16891: StringResource
+  get() = String15.str_16891
+
+@ExperimentalResourceApi
+internal val Res.string.str_16892: StringResource
+  get() = String15.str_16892
+
+@ExperimentalResourceApi
+internal val Res.string.str_16893: StringResource
+  get() = String15.str_16893
+
+@ExperimentalResourceApi
+internal val Res.string.str_16894: StringResource
+  get() = String15.str_16894
+
+@ExperimentalResourceApi
+internal val Res.string.str_16895: StringResource
+  get() = String15.str_16895
+
+@ExperimentalResourceApi
+internal val Res.string.str_16896: StringResource
+  get() = String15.str_16896
+
+@ExperimentalResourceApi
+internal val Res.string.str_16897: StringResource
+  get() = String15.str_16897
+
+@ExperimentalResourceApi
+internal val Res.string.str_16898: StringResource
+  get() = String15.str_16898
+
+@ExperimentalResourceApi
+internal val Res.string.str_16899: StringResource
+  get() = String15.str_16899
+
+@ExperimentalResourceApi
+internal val Res.string.str_169: StringResource
+  get() = String15.str_169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1690: StringResource
+  get() = String15.str_1690
+
+@ExperimentalResourceApi
+internal val Res.string.str_16900: StringResource
+  get() = String15.str_16900
+
+@ExperimentalResourceApi
+internal val Res.string.str_16901: StringResource
+  get() = String15.str_16901
+
+@ExperimentalResourceApi
+internal val Res.string.str_16902: StringResource
+  get() = String15.str_16902
+
+@ExperimentalResourceApi
+internal val Res.string.str_16903: StringResource
+  get() = String15.str_16903
+
+@ExperimentalResourceApi
+internal val Res.string.str_16904: StringResource
+  get() = String15.str_16904
+
+@ExperimentalResourceApi
+internal val Res.string.str_16905: StringResource
+  get() = String15.str_16905
+
+@ExperimentalResourceApi
+internal val Res.string.str_16906: StringResource
+  get() = String15.str_16906
+
+@ExperimentalResourceApi
+internal val Res.string.str_16907: StringResource
+  get() = String15.str_16907
+
+@ExperimentalResourceApi
+internal val Res.string.str_16908: StringResource
+  get() = String15.str_16908
+
+@ExperimentalResourceApi
+internal val Res.string.str_16909: StringResource
+  get() = String15.str_16909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1691: StringResource
+  get() = String15.str_1691
+
+@ExperimentalResourceApi
+internal val Res.string.str_16910: StringResource
+  get() = String15.str_16910
+
+@ExperimentalResourceApi
+internal val Res.string.str_16911: StringResource
+  get() = String15.str_16911
+
+@ExperimentalResourceApi
+internal val Res.string.str_16912: StringResource
+  get() = String15.str_16912
+
+@ExperimentalResourceApi
+internal val Res.string.str_16913: StringResource
+  get() = String15.str_16913
+
+@ExperimentalResourceApi
+internal val Res.string.str_16914: StringResource
+  get() = String15.str_16914
+
+@ExperimentalResourceApi
+internal val Res.string.str_16915: StringResource
+  get() = String15.str_16915
+
+@ExperimentalResourceApi
+internal val Res.string.str_16916: StringResource
+  get() = String15.str_16916
+
+@ExperimentalResourceApi
+internal val Res.string.str_16917: StringResource
+  get() = String15.str_16917
+
+@ExperimentalResourceApi
+internal val Res.string.str_16918: StringResource
+  get() = String15.str_16918
+
+@ExperimentalResourceApi
+internal val Res.string.str_16919: StringResource
+  get() = String15.str_16919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1692: StringResource
+  get() = String15.str_1692
+
+@ExperimentalResourceApi
+internal val Res.string.str_16920: StringResource
+  get() = String15.str_16920
+
+@ExperimentalResourceApi
+internal val Res.string.str_16921: StringResource
+  get() = String15.str_16921
+
+@ExperimentalResourceApi
+internal val Res.string.str_16922: StringResource
+  get() = String15.str_16922
+
+@ExperimentalResourceApi
+internal val Res.string.str_16923: StringResource
+  get() = String15.str_16923
+
+@ExperimentalResourceApi
+internal val Res.string.str_16924: StringResource
+  get() = String15.str_16924
+
+@ExperimentalResourceApi
+internal val Res.string.str_16925: StringResource
+  get() = String15.str_16925
+
+@ExperimentalResourceApi
+internal val Res.string.str_16926: StringResource
+  get() = String15.str_16926
+
+@ExperimentalResourceApi
+internal val Res.string.str_16927: StringResource
+  get() = String15.str_16927
+
+@ExperimentalResourceApi
+internal val Res.string.str_16928: StringResource
+  get() = String15.str_16928
+
+@ExperimentalResourceApi
+internal val Res.string.str_16929: StringResource
+  get() = String15.str_16929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1693: StringResource
+  get() = String15.str_1693
+
+@ExperimentalResourceApi
+internal val Res.string.str_16930: StringResource
+  get() = String15.str_16930
+
+@ExperimentalResourceApi
+internal val Res.string.str_16931: StringResource
+  get() = String15.str_16931
+
+@ExperimentalResourceApi
+internal val Res.string.str_16932: StringResource
+  get() = String15.str_16932
+
+@ExperimentalResourceApi
+internal val Res.string.str_16933: StringResource
+  get() = String15.str_16933
+
+@ExperimentalResourceApi
+internal val Res.string.str_16934: StringResource
+  get() = String15.str_16934
+
+@ExperimentalResourceApi
+internal val Res.string.str_16935: StringResource
+  get() = String15.str_16935
+
+@ExperimentalResourceApi
+internal val Res.string.str_16936: StringResource
+  get() = String15.str_16936
+
+@ExperimentalResourceApi
+internal val Res.string.str_16937: StringResource
+  get() = String15.str_16937
+
+@ExperimentalResourceApi
+internal val Res.string.str_16938: StringResource
+  get() = String15.str_16938
+
+@ExperimentalResourceApi
+internal val Res.string.str_16939: StringResource
+  get() = String15.str_16939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1694: StringResource
+  get() = String15.str_1694
+
+@ExperimentalResourceApi
+internal val Res.string.str_16940: StringResource
+  get() = String15.str_16940
+
+@ExperimentalResourceApi
+internal val Res.string.str_16941: StringResource
+  get() = String15.str_16941
+
+@ExperimentalResourceApi
+internal val Res.string.str_16942: StringResource
+  get() = String15.str_16942
+
+@ExperimentalResourceApi
+internal val Res.string.str_16943: StringResource
+  get() = String15.str_16943
+
+@ExperimentalResourceApi
+internal val Res.string.str_16944: StringResource
+  get() = String15.str_16944
+
+@ExperimentalResourceApi
+internal val Res.string.str_16945: StringResource
+  get() = String15.str_16945
+
+@ExperimentalResourceApi
+internal val Res.string.str_16946: StringResource
+  get() = String15.str_16946
+
+@ExperimentalResourceApi
+internal val Res.string.str_16947: StringResource
+  get() = String15.str_16947
+
+@ExperimentalResourceApi
+internal val Res.string.str_16948: StringResource
+  get() = String15.str_16948
+
+@ExperimentalResourceApi
+internal val Res.string.str_16949: StringResource
+  get() = String15.str_16949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1695: StringResource
+  get() = String15.str_1695
+
+@ExperimentalResourceApi
+internal val Res.string.str_16950: StringResource
+  get() = String15.str_16950
+
+@ExperimentalResourceApi
+internal val Res.string.str_16951: StringResource
+  get() = String15.str_16951
+
+@ExperimentalResourceApi
+internal val Res.string.str_16952: StringResource
+  get() = String15.str_16952
+
+@ExperimentalResourceApi
+internal val Res.string.str_16953: StringResource
+  get() = String15.str_16953
+
+@ExperimentalResourceApi
+internal val Res.string.str_16954: StringResource
+  get() = String15.str_16954
+
+@ExperimentalResourceApi
+internal val Res.string.str_16955: StringResource
+  get() = String15.str_16955
+
+@ExperimentalResourceApi
+internal val Res.string.str_16956: StringResource
+  get() = String15.str_16956
+
+@ExperimentalResourceApi
+internal val Res.string.str_16957: StringResource
+  get() = String15.str_16957
+
+@ExperimentalResourceApi
+internal val Res.string.str_16958: StringResource
+  get() = String15.str_16958
+
+@ExperimentalResourceApi
+internal val Res.string.str_16959: StringResource
+  get() = String15.str_16959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1696: StringResource
+  get() = String15.str_1696
+
+@ExperimentalResourceApi
+internal val Res.string.str_16960: StringResource
+  get() = String15.str_16960
+
+@ExperimentalResourceApi
+internal val Res.string.str_16961: StringResource
+  get() = String15.str_16961
+
+@ExperimentalResourceApi
+internal val Res.string.str_16962: StringResource
+  get() = String15.str_16962
+
+@ExperimentalResourceApi
+internal val Res.string.str_16963: StringResource
+  get() = String15.str_16963
+
+@ExperimentalResourceApi
+internal val Res.string.str_16964: StringResource
+  get() = String15.str_16964
+
+@ExperimentalResourceApi
+internal val Res.string.str_16965: StringResource
+  get() = String15.str_16965
+
+@ExperimentalResourceApi
+internal val Res.string.str_16966: StringResource
+  get() = String15.str_16966
+
+@ExperimentalResourceApi
+internal val Res.string.str_16967: StringResource
+  get() = String15.str_16967
+
+@ExperimentalResourceApi
+internal val Res.string.str_16968: StringResource
+  get() = String15.str_16968
+
+@ExperimentalResourceApi
+internal val Res.string.str_16969: StringResource
+  get() = String15.str_16969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1697: StringResource
+  get() = String15.str_1697
+
+@ExperimentalResourceApi
+internal val Res.string.str_16970: StringResource
+  get() = String15.str_16970
+
+@ExperimentalResourceApi
+internal val Res.string.str_16971: StringResource
+  get() = String15.str_16971
+
+@ExperimentalResourceApi
+internal val Res.string.str_16972: StringResource
+  get() = String15.str_16972
+
+@ExperimentalResourceApi
+internal val Res.string.str_16973: StringResource
+  get() = String15.str_16973
+
+@ExperimentalResourceApi
+internal val Res.string.str_16974: StringResource
+  get() = String15.str_16974
+
+@ExperimentalResourceApi
+internal val Res.string.str_16975: StringResource
+  get() = String15.str_16975
+
+@ExperimentalResourceApi
+internal val Res.string.str_16976: StringResource
+  get() = String15.str_16976
+
+@ExperimentalResourceApi
+internal val Res.string.str_16977: StringResource
+  get() = String15.str_16977
+
+@ExperimentalResourceApi
+internal val Res.string.str_16978: StringResource
+  get() = String15.str_16978
+
+@ExperimentalResourceApi
+internal val Res.string.str_16979: StringResource
+  get() = String15.str_16979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1698: StringResource
+  get() = String15.str_1698
+
+@ExperimentalResourceApi
+internal val Res.string.str_16980: StringResource
+  get() = String15.str_16980
+
+@ExperimentalResourceApi
+internal val Res.string.str_16981: StringResource
+  get() = String15.str_16981
+
+@ExperimentalResourceApi
+internal val Res.string.str_16982: StringResource
+  get() = String15.str_16982
+
+@ExperimentalResourceApi
+internal val Res.string.str_16983: StringResource
+  get() = String15.str_16983
+
+@ExperimentalResourceApi
+internal val Res.string.str_16984: StringResource
+  get() = String15.str_16984
+
+@ExperimentalResourceApi
+internal val Res.string.str_16985: StringResource
+  get() = String15.str_16985
+
+@ExperimentalResourceApi
+internal val Res.string.str_16986: StringResource
+  get() = String15.str_16986
+
+@ExperimentalResourceApi
+internal val Res.string.str_16987: StringResource
+  get() = String15.str_16987
+
+@ExperimentalResourceApi
+internal val Res.string.str_16988: StringResource
+  get() = String15.str_16988
+
+@ExperimentalResourceApi
+internal val Res.string.str_16989: StringResource
+  get() = String15.str_16989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1699: StringResource
+  get() = String15.str_1699
+
+@ExperimentalResourceApi
+internal val Res.string.str_16990: StringResource
+  get() = String15.str_16990
+
+@ExperimentalResourceApi
+internal val Res.string.str_16991: StringResource
+  get() = String15.str_16991
+
+@ExperimentalResourceApi
+internal val Res.string.str_16992: StringResource
+  get() = String15.str_16992
+
+@ExperimentalResourceApi
+internal val Res.string.str_16993: StringResource
+  get() = String15.str_16993
+
+@ExperimentalResourceApi
+internal val Res.string.str_16994: StringResource
+  get() = String15.str_16994
+
+@ExperimentalResourceApi
+internal val Res.string.str_16995: StringResource
+  get() = String15.str_16995
+
+@ExperimentalResourceApi
+internal val Res.string.str_16996: StringResource
+  get() = String15.str_16996
+
+@ExperimentalResourceApi
+internal val Res.string.str_16997: StringResource
+  get() = String15.str_16997
+
+@ExperimentalResourceApi
+internal val Res.string.str_16998: StringResource
+  get() = String15.str_16998
+
+@ExperimentalResourceApi
+internal val Res.string.str_16999: StringResource
+  get() = String15.str_16999
+
+@ExperimentalResourceApi
+internal val Res.string.str_17: StringResource
+  get() = String15.str_17
+
+@ExperimentalResourceApi
+internal val Res.string.str_170: StringResource
+  get() = String15.str_170
+
+@ExperimentalResourceApi
+internal val Res.string.str_1700: StringResource
+  get() = String15.str_1700
+
+@ExperimentalResourceApi
+internal val Res.string.str_17000: StringResource
+  get() = String15.str_17000
+
+@ExperimentalResourceApi
+internal val Res.string.str_17001: StringResource
+  get() = String15.str_17001
+
+@ExperimentalResourceApi
+internal val Res.string.str_17002: StringResource
+  get() = String15.str_17002
+
+@ExperimentalResourceApi
+internal val Res.string.str_17003: StringResource
+  get() = String15.str_17003
+
+@ExperimentalResourceApi
+internal val Res.string.str_17004: StringResource
+  get() = String15.str_17004
+
+@ExperimentalResourceApi
+internal val Res.string.str_17005: StringResource
+  get() = String15.str_17005
+
+@ExperimentalResourceApi
+internal val Res.string.str_17006: StringResource
+  get() = String15.str_17006
+
+@ExperimentalResourceApi
+internal val Res.string.str_17007: StringResource
+  get() = String15.str_17007
+
+@ExperimentalResourceApi
+internal val Res.string.str_17008: StringResource
+  get() = String15.str_17008
+
+@ExperimentalResourceApi
+internal val Res.string.str_17009: StringResource
+  get() = String15.str_17009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1701: StringResource
+  get() = String15.str_1701
+
+@ExperimentalResourceApi
+internal val Res.string.str_17010: StringResource
+  get() = String15.str_17010
+
+@ExperimentalResourceApi
+internal val Res.string.str_17011: StringResource
+  get() = String15.str_17011
+
+@ExperimentalResourceApi
+internal val Res.string.str_17012: StringResource
+  get() = String15.str_17012
+
+@ExperimentalResourceApi
+internal val Res.string.str_17013: StringResource
+  get() = String15.str_17013
+
+@ExperimentalResourceApi
+internal val Res.string.str_17014: StringResource
+  get() = String15.str_17014
+
+@ExperimentalResourceApi
+internal val Res.string.str_17015: StringResource
+  get() = String15.str_17015
+
+@ExperimentalResourceApi
+internal val Res.string.str_17016: StringResource
+  get() = String15.str_17016
+
+@ExperimentalResourceApi
+internal val Res.string.str_17017: StringResource
+  get() = String15.str_17017
+
+@ExperimentalResourceApi
+internal val Res.string.str_17018: StringResource
+  get() = String15.str_17018
+
+@ExperimentalResourceApi
+internal val Res.string.str_17019: StringResource
+  get() = String15.str_17019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1702: StringResource
+  get() = String15.str_1702
+
+@ExperimentalResourceApi
+internal val Res.string.str_17020: StringResource
+  get() = String15.str_17020
+
+@ExperimentalResourceApi
+internal val Res.string.str_17021: StringResource
+  get() = String15.str_17021
+
+@ExperimentalResourceApi
+internal val Res.string.str_17022: StringResource
+  get() = String15.str_17022
+
+@ExperimentalResourceApi
+internal val Res.string.str_17023: StringResource
+  get() = String15.str_17023
+
+@ExperimentalResourceApi
+internal val Res.string.str_17024: StringResource
+  get() = String15.str_17024
+
+@ExperimentalResourceApi
+internal val Res.string.str_17025: StringResource
+  get() = String15.str_17025
+
+@ExperimentalResourceApi
+internal val Res.string.str_17026: StringResource
+  get() = String15.str_17026
+
+@ExperimentalResourceApi
+internal val Res.string.str_17027: StringResource
+  get() = String15.str_17027
+
+@ExperimentalResourceApi
+internal val Res.string.str_17028: StringResource
+  get() = String15.str_17028
+
+@ExperimentalResourceApi
+internal val Res.string.str_17029: StringResource
+  get() = String15.str_17029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1703: StringResource
+  get() = String15.str_1703
+
+@ExperimentalResourceApi
+internal val Res.string.str_17030: StringResource
+  get() = String15.str_17030
+
+@ExperimentalResourceApi
+internal val Res.string.str_17031: StringResource
+  get() = String15.str_17031
+
+@ExperimentalResourceApi
+internal val Res.string.str_17032: StringResource
+  get() = String15.str_17032
+
+@ExperimentalResourceApi
+internal val Res.string.str_17033: StringResource
+  get() = String15.str_17033
+
+@ExperimentalResourceApi
+internal val Res.string.str_17034: StringResource
+  get() = String15.str_17034
+
+@ExperimentalResourceApi
+internal val Res.string.str_17035: StringResource
+  get() = String15.str_17035
+
+@ExperimentalResourceApi
+internal val Res.string.str_17036: StringResource
+  get() = String15.str_17036
+
+@ExperimentalResourceApi
+internal val Res.string.str_17037: StringResource
+  get() = String15.str_17037
+
+@ExperimentalResourceApi
+internal val Res.string.str_17038: StringResource
+  get() = String15.str_17038
+
+@ExperimentalResourceApi
+internal val Res.string.str_17039: StringResource
+  get() = String15.str_17039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1704: StringResource
+  get() = String15.str_1704
+
+@ExperimentalResourceApi
+internal val Res.string.str_17040: StringResource
+  get() = String15.str_17040
+
+@ExperimentalResourceApi
+internal val Res.string.str_17041: StringResource
+  get() = String15.str_17041
+
+@ExperimentalResourceApi
+internal val Res.string.str_17042: StringResource
+  get() = String15.str_17042
+
+@ExperimentalResourceApi
+internal val Res.string.str_17043: StringResource
+  get() = String15.str_17043
+
+@ExperimentalResourceApi
+internal val Res.string.str_17044: StringResource
+  get() = String15.str_17044
+
+@ExperimentalResourceApi
+internal val Res.string.str_17045: StringResource
+  get() = String15.str_17045
+
+@ExperimentalResourceApi
+internal val Res.string.str_17046: StringResource
+  get() = String15.str_17046
+
+@ExperimentalResourceApi
+internal val Res.string.str_17047: StringResource
+  get() = String15.str_17047
+
+@ExperimentalResourceApi
+internal val Res.string.str_17048: StringResource
+  get() = String15.str_17048
+
+@ExperimentalResourceApi
+internal val Res.string.str_17049: StringResource
+  get() = String15.str_17049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1705: StringResource
+  get() = String15.str_1705
+
+@ExperimentalResourceApi
+internal val Res.string.str_17050: StringResource
+  get() = String15.str_17050
+
+@ExperimentalResourceApi
+internal val Res.string.str_17051: StringResource
+  get() = String15.str_17051
+
+@ExperimentalResourceApi
+internal val Res.string.str_17052: StringResource
+  get() = String15.str_17052
+
+@ExperimentalResourceApi
+internal val Res.string.str_17053: StringResource
+  get() = String15.str_17053
+
+@ExperimentalResourceApi
+internal val Res.string.str_17054: StringResource
+  get() = String15.str_17054
+
+@ExperimentalResourceApi
+internal val Res.string.str_17055: StringResource
+  get() = String15.str_17055
+
+@ExperimentalResourceApi
+internal val Res.string.str_17056: StringResource
+  get() = String15.str_17056
+
+@ExperimentalResourceApi
+internal val Res.string.str_17057: StringResource
+  get() = String15.str_17057
+
+@ExperimentalResourceApi
+internal val Res.string.str_17058: StringResource
+  get() = String15.str_17058
+
+@ExperimentalResourceApi
+internal val Res.string.str_17059: StringResource
+  get() = String15.str_17059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1706: StringResource
+  get() = String15.str_1706
+
+@ExperimentalResourceApi
+internal val Res.string.str_17060: StringResource
+  get() = String15.str_17060
+
+@ExperimentalResourceApi
+internal val Res.string.str_17061: StringResource
+  get() = String15.str_17061
+
+@ExperimentalResourceApi
+internal val Res.string.str_17062: StringResource
+  get() = String15.str_17062
+
+@ExperimentalResourceApi
+internal val Res.string.str_17063: StringResource
+  get() = String15.str_17063
+
+@ExperimentalResourceApi
+internal val Res.string.str_17064: StringResource
+  get() = String15.str_17064
+
+@ExperimentalResourceApi
+internal val Res.string.str_17065: StringResource
+  get() = String15.str_17065
+
+@ExperimentalResourceApi
+internal val Res.string.str_17066: StringResource
+  get() = String15.str_17066
+
+@ExperimentalResourceApi
+internal val Res.string.str_17067: StringResource
+  get() = String15.str_17067
+
+@ExperimentalResourceApi
+internal val Res.string.str_17068: StringResource
+  get() = String15.str_17068
+
+@ExperimentalResourceApi
+internal val Res.string.str_17069: StringResource
+  get() = String15.str_17069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1707: StringResource
+  get() = String15.str_1707
+
+@ExperimentalResourceApi
+internal val Res.string.str_17070: StringResource
+  get() = String15.str_17070
+
+@ExperimentalResourceApi
+internal val Res.string.str_17071: StringResource
+  get() = String15.str_17071
+
+@ExperimentalResourceApi
+internal val Res.string.str_17072: StringResource
+  get() = String15.str_17072
+
+@ExperimentalResourceApi
+internal val Res.string.str_17073: StringResource
+  get() = String15.str_17073
+
+@ExperimentalResourceApi
+internal val Res.string.str_17074: StringResource
+  get() = String15.str_17074
+
+@ExperimentalResourceApi
+internal val Res.string.str_17075: StringResource
+  get() = String15.str_17075
+
+@ExperimentalResourceApi
+internal val Res.string.str_17076: StringResource
+  get() = String15.str_17076
+
+@ExperimentalResourceApi
+internal val Res.string.str_17077: StringResource
+  get() = String15.str_17077
+
+@ExperimentalResourceApi
+internal val Res.string.str_17078: StringResource
+  get() = String15.str_17078
+
+@ExperimentalResourceApi
+internal val Res.string.str_17079: StringResource
+  get() = String15.str_17079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1708: StringResource
+  get() = String15.str_1708
+
+@ExperimentalResourceApi
+internal val Res.string.str_17080: StringResource
+  get() = String15.str_17080
+
+@ExperimentalResourceApi
+internal val Res.string.str_17081: StringResource
+  get() = String15.str_17081
+
+@ExperimentalResourceApi
+internal val Res.string.str_17082: StringResource
+  get() = String15.str_17082
+
+@ExperimentalResourceApi
+internal val Res.string.str_17083: StringResource
+  get() = String15.str_17083
+
+@ExperimentalResourceApi
+internal val Res.string.str_17084: StringResource
+  get() = String15.str_17084
+
+@ExperimentalResourceApi
+internal val Res.string.str_17085: StringResource
+  get() = String15.str_17085
+
+@ExperimentalResourceApi
+internal val Res.string.str_17086: StringResource
+  get() = String15.str_17086
+
+@ExperimentalResourceApi
+internal val Res.string.str_17087: StringResource
+  get() = String15.str_17087
+
+@ExperimentalResourceApi
+internal val Res.string.str_17088: StringResource
+  get() = String15.str_17088
+
+@ExperimentalResourceApi
+internal val Res.string.str_17089: StringResource
+  get() = String15.str_17089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1709: StringResource
+  get() = String15.str_1709
+
+@ExperimentalResourceApi
+internal val Res.string.str_17090: StringResource
+  get() = String15.str_17090
+
+@ExperimentalResourceApi
+internal val Res.string.str_17091: StringResource
+  get() = String15.str_17091
+
+@ExperimentalResourceApi
+internal val Res.string.str_17092: StringResource
+  get() = String15.str_17092
+
+@ExperimentalResourceApi
+internal val Res.string.str_17093: StringResource
+  get() = String15.str_17093
+
+@ExperimentalResourceApi
+internal val Res.string.str_17094: StringResource
+  get() = String15.str_17094
+
+@ExperimentalResourceApi
+internal val Res.string.str_17095: StringResource
+  get() = String15.str_17095
+
+@ExperimentalResourceApi
+internal val Res.string.str_17096: StringResource
+  get() = String15.str_17096
+
+@ExperimentalResourceApi
+internal val Res.string.str_17097: StringResource
+  get() = String15.str_17097
+
+@ExperimentalResourceApi
+internal val Res.string.str_17098: StringResource
+  get() = String15.str_17098
+
+@ExperimentalResourceApi
+internal val Res.string.str_17099: StringResource
+  get() = String15.str_17099
+
+@ExperimentalResourceApi
+internal val Res.string.str_171: StringResource
+  get() = String15.str_171
+
+@ExperimentalResourceApi
+internal val Res.string.str_1710: StringResource
+  get() = String15.str_1710
+
+@ExperimentalResourceApi
+internal val Res.string.str_17100: StringResource
+  get() = String15.str_17100
+
+@ExperimentalResourceApi
+internal val Res.string.str_17101: StringResource
+  get() = String15.str_17101
+
+@ExperimentalResourceApi
+internal val Res.string.str_17102: StringResource
+  get() = String15.str_17102
+
+@ExperimentalResourceApi
+internal val Res.string.str_17103: StringResource
+  get() = String15.str_17103
+
+@ExperimentalResourceApi
+internal val Res.string.str_17104: StringResource
+  get() = String15.str_17104
+
+@ExperimentalResourceApi
+internal val Res.string.str_17105: StringResource
+  get() = String15.str_17105
+
+@ExperimentalResourceApi
+internal val Res.string.str_17106: StringResource
+  get() = String15.str_17106
+
+@ExperimentalResourceApi
+internal val Res.string.str_17107: StringResource
+  get() = String15.str_17107
+
+@ExperimentalResourceApi
+internal val Res.string.str_17108: StringResource
+  get() = String15.str_17108
+
+@ExperimentalResourceApi
+internal val Res.string.str_17109: StringResource
+  get() = String15.str_17109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1711: StringResource
+  get() = String15.str_1711
+
+@ExperimentalResourceApi
+internal val Res.string.str_17110: StringResource
+  get() = String15.str_17110
+
+@ExperimentalResourceApi
+internal val Res.string.str_17111: StringResource
+  get() = String15.str_17111
+
+@ExperimentalResourceApi
+internal val Res.string.str_17112: StringResource
+  get() = String15.str_17112
+
+@ExperimentalResourceApi
+internal val Res.string.str_17113: StringResource
+  get() = String15.str_17113
+
+@ExperimentalResourceApi
+internal val Res.string.str_17114: StringResource
+  get() = String15.str_17114
+
+@ExperimentalResourceApi
+internal val Res.string.str_17115: StringResource
+  get() = String15.str_17115
+
+@ExperimentalResourceApi
+internal val Res.string.str_17116: StringResource
+  get() = String15.str_17116
+
+@ExperimentalResourceApi
+internal val Res.string.str_17117: StringResource
+  get() = String15.str_17117
+
+@ExperimentalResourceApi
+internal val Res.string.str_17118: StringResource
+  get() = String15.str_17118
+
+@ExperimentalResourceApi
+internal val Res.string.str_17119: StringResource
+  get() = String15.str_17119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1712: StringResource
+  get() = String15.str_1712
+
+@ExperimentalResourceApi
+internal val Res.string.str_17120: StringResource
+  get() = String15.str_17120
+
+@ExperimentalResourceApi
+internal val Res.string.str_17121: StringResource
+  get() = String15.str_17121
+
+@ExperimentalResourceApi
+internal val Res.string.str_17122: StringResource
+  get() = String15.str_17122
+
+@ExperimentalResourceApi
+internal val Res.string.str_17123: StringResource
+  get() = String15.str_17123
+
+@ExperimentalResourceApi
+internal val Res.string.str_17124: StringResource
+  get() = String15.str_17124
+
+@ExperimentalResourceApi
+internal val Res.string.str_17125: StringResource
+  get() = String15.str_17125
+
+@ExperimentalResourceApi
+internal val Res.string.str_17126: StringResource
+  get() = String15.str_17126
+
+@ExperimentalResourceApi
+internal val Res.string.str_17127: StringResource
+  get() = String15.str_17127
+
+@ExperimentalResourceApi
+internal val Res.string.str_17128: StringResource
+  get() = String15.str_17128
+
+@ExperimentalResourceApi
+internal val Res.string.str_17129: StringResource
+  get() = String15.str_17129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1713: StringResource
+  get() = String15.str_1713
+
+@ExperimentalResourceApi
+internal val Res.string.str_17130: StringResource
+  get() = String15.str_17130
+
+@ExperimentalResourceApi
+internal val Res.string.str_17131: StringResource
+  get() = String15.str_17131
+
+@ExperimentalResourceApi
+internal val Res.string.str_17132: StringResource
+  get() = String15.str_17132
+
+@ExperimentalResourceApi
+internal val Res.string.str_17133: StringResource
+  get() = String15.str_17133
+
+@ExperimentalResourceApi
+internal val Res.string.str_17134: StringResource
+  get() = String15.str_17134
+
+@ExperimentalResourceApi
+internal val Res.string.str_17135: StringResource
+  get() = String15.str_17135
+
+@ExperimentalResourceApi
+internal val Res.string.str_17136: StringResource
+  get() = String15.str_17136
+
+@ExperimentalResourceApi
+internal val Res.string.str_17137: StringResource
+  get() = String15.str_17137
+
+@ExperimentalResourceApi
+internal val Res.string.str_17138: StringResource
+  get() = String15.str_17138
+
+@ExperimentalResourceApi
+internal val Res.string.str_17139: StringResource
+  get() = String15.str_17139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1714: StringResource
+  get() = String15.str_1714
+
+@ExperimentalResourceApi
+internal val Res.string.str_17140: StringResource
+  get() = String15.str_17140
+
+@ExperimentalResourceApi
+internal val Res.string.str_17141: StringResource
+  get() = String15.str_17141
+
+@ExperimentalResourceApi
+internal val Res.string.str_17142: StringResource
+  get() = String15.str_17142
+
+@ExperimentalResourceApi
+internal val Res.string.str_17143: StringResource
+  get() = String15.str_17143
+
+@ExperimentalResourceApi
+internal val Res.string.str_17144: StringResource
+  get() = String15.str_17144
+
+@ExperimentalResourceApi
+internal val Res.string.str_17145: StringResource
+  get() = String15.str_17145
+
+@ExperimentalResourceApi
+internal val Res.string.str_17146: StringResource
+  get() = String15.str_17146
+
+@ExperimentalResourceApi
+internal val Res.string.str_17147: StringResource
+  get() = String15.str_17147
+
+@ExperimentalResourceApi
+internal val Res.string.str_17148: StringResource
+  get() = String15.str_17148
+
+@ExperimentalResourceApi
+internal val Res.string.str_17149: StringResource
+  get() = String15.str_17149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1715: StringResource
+  get() = String15.str_1715
+
+@ExperimentalResourceApi
+internal val Res.string.str_17150: StringResource
+  get() = String15.str_17150
+
+@ExperimentalResourceApi
+internal val Res.string.str_17151: StringResource
+  get() = String15.str_17151
+
+@ExperimentalResourceApi
+internal val Res.string.str_17152: StringResource
+  get() = String15.str_17152
+
+@ExperimentalResourceApi
+internal val Res.string.str_17153: StringResource
+  get() = String15.str_17153
+
+@ExperimentalResourceApi
+internal val Res.string.str_17154: StringResource
+  get() = String15.str_17154
+
+@ExperimentalResourceApi
+internal val Res.string.str_17155: StringResource
+  get() = String15.str_17155
+
+@ExperimentalResourceApi
+internal val Res.string.str_17156: StringResource
+  get() = String15.str_17156
+
+@ExperimentalResourceApi
+internal val Res.string.str_17157: StringResource
+  get() = String15.str_17157
+
+@ExperimentalResourceApi
+internal val Res.string.str_17158: StringResource
+  get() = String15.str_17158
+
+@ExperimentalResourceApi
+internal val Res.string.str_17159: StringResource
+  get() = String15.str_17159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1716: StringResource
+  get() = String15.str_1716
+
+@ExperimentalResourceApi
+internal val Res.string.str_17160: StringResource
+  get() = String15.str_17160
+
+@ExperimentalResourceApi
+internal val Res.string.str_17161: StringResource
+  get() = String15.str_17161
+
+@ExperimentalResourceApi
+internal val Res.string.str_17162: StringResource
+  get() = String15.str_17162
+
+@ExperimentalResourceApi
+internal val Res.string.str_17163: StringResource
+  get() = String15.str_17163
+
+@ExperimentalResourceApi
+internal val Res.string.str_17164: StringResource
+  get() = String15.str_17164
+
+@ExperimentalResourceApi
+internal val Res.string.str_17165: StringResource
+  get() = String15.str_17165
+
+@ExperimentalResourceApi
+internal val Res.string.str_17166: StringResource
+  get() = String15.str_17166
+
+@ExperimentalResourceApi
+internal val Res.string.str_17167: StringResource
+  get() = String15.str_17167
+
+@ExperimentalResourceApi
+internal val Res.string.str_17168: StringResource
+  get() = String15.str_17168
+
+@ExperimentalResourceApi
+internal val Res.string.str_17169: StringResource
+  get() = String15.str_17169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1717: StringResource
+  get() = String15.str_1717
+
+@ExperimentalResourceApi
+internal val Res.string.str_17170: StringResource
+  get() = String15.str_17170
+
+@ExperimentalResourceApi
+internal val Res.string.str_17171: StringResource
+  get() = String15.str_17171
+
+@ExperimentalResourceApi
+internal val Res.string.str_17172: StringResource
+  get() = String15.str_17172
+
+@ExperimentalResourceApi
+internal val Res.string.str_17173: StringResource
+  get() = String15.str_17173
+
+@ExperimentalResourceApi
+internal val Res.string.str_17174: StringResource
+  get() = String15.str_17174
+
+@ExperimentalResourceApi
+internal val Res.string.str_17175: StringResource
+  get() = String15.str_17175
+
+@ExperimentalResourceApi
+internal val Res.string.str_17176: StringResource
+  get() = String15.str_17176
+
+@ExperimentalResourceApi
+internal val Res.string.str_17177: StringResource
+  get() = String15.str_17177
+
+@ExperimentalResourceApi
+internal val Res.string.str_17178: StringResource
+  get() = String15.str_17178
+
+@ExperimentalResourceApi
+internal val Res.string.str_17179: StringResource
+  get() = String15.str_17179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1718: StringResource
+  get() = String15.str_1718
+
+@ExperimentalResourceApi
+internal val Res.string.str_17180: StringResource
+  get() = String15.str_17180
+
+@ExperimentalResourceApi
+internal val Res.string.str_17181: StringResource
+  get() = String15.str_17181
+
+@ExperimentalResourceApi
+internal val Res.string.str_17182: StringResource
+  get() = String15.str_17182
+
+@ExperimentalResourceApi
+internal val Res.string.str_17183: StringResource
+  get() = String15.str_17183
+
+@ExperimentalResourceApi
+internal val Res.string.str_17184: StringResource
+  get() = String15.str_17184
+
+@ExperimentalResourceApi
+internal val Res.string.str_17185: StringResource
+  get() = String15.str_17185
+
+@ExperimentalResourceApi
+internal val Res.string.str_17186: StringResource
+  get() = String15.str_17186
+
+@ExperimentalResourceApi
+internal val Res.string.str_17187: StringResource
+  get() = String15.str_17187
+
+@ExperimentalResourceApi
+internal val Res.string.str_17188: StringResource
+  get() = String15.str_17188
+
+@ExperimentalResourceApi
+internal val Res.string.str_17189: StringResource
+  get() = String15.str_17189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1719: StringResource
+  get() = String15.str_1719
+
+@ExperimentalResourceApi
+internal val Res.string.str_17190: StringResource
+  get() = String15.str_17190
+
+@ExperimentalResourceApi
+internal val Res.string.str_17191: StringResource
+  get() = String15.str_17191
+
+@ExperimentalResourceApi
+internal val Res.string.str_17192: StringResource
+  get() = String15.str_17192
+
+@ExperimentalResourceApi
+internal val Res.string.str_17193: StringResource
+  get() = String15.str_17193
+
+@ExperimentalResourceApi
+internal val Res.string.str_17194: StringResource
+  get() = String15.str_17194
+
+@ExperimentalResourceApi
+internal val Res.string.str_17195: StringResource
+  get() = String15.str_17195
+
+@ExperimentalResourceApi
+internal val Res.string.str_17196: StringResource
+  get() = String15.str_17196
+
+@ExperimentalResourceApi
+internal val Res.string.str_17197: StringResource
+  get() = String15.str_17197

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String16.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String16.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String16 {
+  public val str_17198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17198", "str_17198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17199", "str_17199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_172", "str_172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1720", "str_1720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17200", "str_17200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17201", "str_17201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17202", "str_17202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17203", "str_17203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17204", "str_17204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17205", "str_17205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17206", "str_17206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17207", "str_17207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17208", "str_17208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17209", "str_17209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1721", "str_1721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17210", "str_17210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17211", "str_17211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17212", "str_17212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17213", "str_17213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17214", "str_17214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17215", "str_17215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17216", "str_17216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17217", "str_17217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17218", "str_17218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17219", "str_17219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1722", "str_1722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17220", "str_17220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17221", "str_17221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17222", "str_17222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17223", "str_17223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17224", "str_17224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17225", "str_17225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17226", "str_17226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17227", "str_17227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17228", "str_17228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17229", "str_17229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1723", "str_1723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17230", "str_17230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17231", "str_17231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17232", "str_17232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17233", "str_17233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17234", "str_17234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17235", "str_17235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17236", "str_17236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17237", "str_17237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17238", "str_17238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17239", "str_17239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1724", "str_1724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17240", "str_17240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17241", "str_17241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17242", "str_17242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17243", "str_17243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17244", "str_17244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17245", "str_17245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17246", "str_17246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17247", "str_17247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17248", "str_17248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17249", "str_17249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1725", "str_1725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17250", "str_17250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17251", "str_17251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17252", "str_17252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17253", "str_17253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17254", "str_17254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17255", "str_17255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17256", "str_17256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17257", "str_17257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17258", "str_17258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17259", "str_17259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1726", "str_1726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17260", "str_17260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17261", "str_17261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17262", "str_17262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17263", "str_17263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17264", "str_17264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17265", "str_17265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17266", "str_17266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17267", "str_17267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17268", "str_17268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17269", "str_17269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1727", "str_1727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17270", "str_17270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17271", "str_17271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17272", "str_17272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17273", "str_17273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17274", "str_17274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17275", "str_17275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17276", "str_17276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17277", "str_17277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17278", "str_17278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17279", "str_17279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1728", "str_1728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17280", "str_17280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17281", "str_17281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17282", "str_17282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17283", "str_17283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17284", "str_17284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17285", "str_17285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17286", "str_17286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17287", "str_17287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17288", "str_17288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17289", "str_17289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1729", "str_1729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17290", "str_17290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17291", "str_17291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17292", "str_17292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17293", "str_17293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17294", "str_17294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17295", "str_17295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17296", "str_17296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17297", "str_17297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17298", "str_17298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17299", "str_17299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_173", "str_173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1730", "str_1730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17300", "str_17300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17301", "str_17301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17302", "str_17302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17303", "str_17303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17304", "str_17304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17305", "str_17305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17306", "str_17306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17307", "str_17307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17308", "str_17308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17309", "str_17309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1731", "str_1731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17310", "str_17310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17311", "str_17311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17312", "str_17312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17313", "str_17313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17314", "str_17314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17315", "str_17315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17316", "str_17316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17317", "str_17317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17318", "str_17318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17319", "str_17319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1732", "str_1732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17320", "str_17320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17321", "str_17321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17322", "str_17322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17323", "str_17323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17324", "str_17324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17325", "str_17325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17326", "str_17326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17327", "str_17327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17328", "str_17328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17329", "str_17329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1733", "str_1733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17330", "str_17330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17331", "str_17331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17332", "str_17332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17333", "str_17333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17334", "str_17334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17335", "str_17335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17336", "str_17336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17337", "str_17337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17338", "str_17338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17339", "str_17339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1734", "str_1734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17340", "str_17340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17341", "str_17341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17342", "str_17342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17343", "str_17343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17344", "str_17344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17345", "str_17345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17346", "str_17346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17347", "str_17347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17348", "str_17348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17349", "str_17349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1735", "str_1735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17350", "str_17350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17351", "str_17351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17352", "str_17352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17353", "str_17353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17354", "str_17354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17355", "str_17355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17356", "str_17356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17357", "str_17357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17358", "str_17358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17359", "str_17359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1736", "str_1736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17360", "str_17360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17361", "str_17361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17362", "str_17362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17363", "str_17363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17364", "str_17364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17365", "str_17365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17366", "str_17366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17367", "str_17367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17368", "str_17368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17369", "str_17369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1737", "str_1737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17370", "str_17370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17371", "str_17371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17372", "str_17372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17373", "str_17373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17374", "str_17374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17375", "str_17375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17376", "str_17376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17377", "str_17377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17378", "str_17378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17379", "str_17379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1738", "str_1738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17380", "str_17380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17381", "str_17381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17382", "str_17382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17383", "str_17383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17384", "str_17384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17385", "str_17385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17386", "str_17386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17387", "str_17387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17388", "str_17388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17389", "str_17389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1739", "str_1739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17390", "str_17390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17391", "str_17391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17392", "str_17392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17393", "str_17393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17394", "str_17394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17395", "str_17395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17396", "str_17396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17397", "str_17397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17398", "str_17398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17399", "str_17399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_174", "str_174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1740", "str_1740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17400", "str_17400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17401", "str_17401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17402", "str_17402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17403", "str_17403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17404", "str_17404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17405", "str_17405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17406", "str_17406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17407", "str_17407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17408", "str_17408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17409", "str_17409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1741", "str_1741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17410", "str_17410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17411", "str_17411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17412", "str_17412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17413", "str_17413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17414", "str_17414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17415", "str_17415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17416", "str_17416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17417", "str_17417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17418", "str_17418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17419", "str_17419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1742", "str_1742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17420", "str_17420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17421", "str_17421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17422", "str_17422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17423", "str_17423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17424", "str_17424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17425", "str_17425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17426", "str_17426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17427", "str_17427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17428", "str_17428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17429", "str_17429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1743", "str_1743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17430", "str_17430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17431", "str_17431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17432", "str_17432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17433", "str_17433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17434", "str_17434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17435", "str_17435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17436", "str_17436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17437", "str_17437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17438", "str_17438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17439", "str_17439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1744", "str_1744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17440", "str_17440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17441", "str_17441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17442", "str_17442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17443", "str_17443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17444", "str_17444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17445", "str_17445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17446", "str_17446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17447", "str_17447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17448", "str_17448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17449", "str_17449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1745", "str_1745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17450", "str_17450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17451", "str_17451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17452", "str_17452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17453", "str_17453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17454", "str_17454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17455", "str_17455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17456", "str_17456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17457", "str_17457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17458", "str_17458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17459", "str_17459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1746", "str_1746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17460", "str_17460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17461", "str_17461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17462", "str_17462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17463", "str_17463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17464", "str_17464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17465", "str_17465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17466", "str_17466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17467", "str_17467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17468", "str_17468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17469", "str_17469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1747", "str_1747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17470", "str_17470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17471", "str_17471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17472", "str_17472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17473", "str_17473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17474", "str_17474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17475", "str_17475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17476", "str_17476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17477", "str_17477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17478", "str_17478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17479", "str_17479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1748", "str_1748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17480", "str_17480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17481", "str_17481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17482", "str_17482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17483", "str_17483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17484", "str_17484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17485", "str_17485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17486", "str_17486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17487", "str_17487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17488", "str_17488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17489", "str_17489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1749", "str_1749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17490", "str_17490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17491", "str_17491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17492", "str_17492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17493", "str_17493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17494", "str_17494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17495", "str_17495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17496", "str_17496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17497", "str_17497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17498", "str_17498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17499", "str_17499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_175", "str_175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1750", "str_1750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17500", "str_17500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17501", "str_17501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17502", "str_17502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17503", "str_17503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17504", "str_17504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17505", "str_17505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17506", "str_17506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17507", "str_17507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17508", "str_17508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17509", "str_17509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1751", "str_1751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17510", "str_17510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17511", "str_17511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17512", "str_17512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17513", "str_17513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17514", "str_17514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17515", "str_17515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17516", "str_17516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17517", "str_17517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17518", "str_17518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17519", "str_17519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1752", "str_1752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17520", "str_17520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17521", "str_17521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17522", "str_17522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17523", "str_17523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17524", "str_17524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17525", "str_17525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17526", "str_17526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17527", "str_17527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17528", "str_17528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17529", "str_17529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1753", "str_1753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17530", "str_17530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17531", "str_17531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17532", "str_17532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17533", "str_17533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17534", "str_17534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17535", "str_17535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17536", "str_17536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17537", "str_17537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17538", "str_17538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17539", "str_17539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1754", "str_1754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17540", "str_17540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17541", "str_17541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17542", "str_17542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17543", "str_17543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17544", "str_17544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17545", "str_17545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17546", "str_17546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17547", "str_17547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17548", "str_17548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17549", "str_17549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1755", "str_1755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17550", "str_17550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17551", "str_17551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17552", "str_17552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17553", "str_17553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17554", "str_17554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17555", "str_17555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17556", "str_17556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17557", "str_17557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17558", "str_17558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17559", "str_17559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1756", "str_1756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17560", "str_17560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17561", "str_17561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17562", "str_17562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17563", "str_17563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17564", "str_17564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17565", "str_17565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17566", "str_17566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17567", "str_17567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17568", "str_17568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17569", "str_17569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1757", "str_1757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17570", "str_17570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17571", "str_17571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17572", "str_17572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17573", "str_17573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17574", "str_17574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17575", "str_17575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17576", "str_17576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17577", "str_17577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17578", "str_17578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17579", "str_17579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1758", "str_1758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17580", "str_17580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17581", "str_17581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17582", "str_17582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17583", "str_17583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17584", "str_17584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17585", "str_17585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17586", "str_17586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17587", "str_17587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17588", "str_17588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17589", "str_17589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1759", "str_1759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17590", "str_17590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17591", "str_17591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17592", "str_17592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17593", "str_17593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17594", "str_17594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17595", "str_17595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17596", "str_17596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17597", "str_17597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17598", "str_17598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17599", "str_17599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_176", "str_176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1760", "str_1760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17600", "str_17600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17601", "str_17601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17602", "str_17602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17603", "str_17603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17604", "str_17604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17605", "str_17605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17606", "str_17606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17607", "str_17607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17608", "str_17608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17609", "str_17609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1761", "str_1761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17610", "str_17610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17611", "str_17611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17612", "str_17612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17613", "str_17613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17614", "str_17614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17615", "str_17615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17616", "str_17616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17617", "str_17617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17618", "str_17618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17619", "str_17619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1762", "str_1762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17620", "str_17620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17621", "str_17621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17622", "str_17622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17623", "str_17623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17624", "str_17624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17625", "str_17625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17626", "str_17626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17627", "str_17627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17628", "str_17628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17629", "str_17629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1763", "str_1763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17630", "str_17630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17631", "str_17631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17632", "str_17632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17633", "str_17633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17634", "str_17634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17635", "str_17635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17636", "str_17636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17637", "str_17637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17638", "str_17638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17639", "str_17639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1764", "str_1764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17640", "str_17640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17641", "str_17641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17642", "str_17642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17643", "str_17643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17644", "str_17644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17645", "str_17645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17646", "str_17646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17647", "str_17647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_17198: StringResource
+  get() = String16.str_17198
+
+@ExperimentalResourceApi
+internal val Res.string.str_17199: StringResource
+  get() = String16.str_17199
+
+@ExperimentalResourceApi
+internal val Res.string.str_172: StringResource
+  get() = String16.str_172
+
+@ExperimentalResourceApi
+internal val Res.string.str_1720: StringResource
+  get() = String16.str_1720
+
+@ExperimentalResourceApi
+internal val Res.string.str_17200: StringResource
+  get() = String16.str_17200
+
+@ExperimentalResourceApi
+internal val Res.string.str_17201: StringResource
+  get() = String16.str_17201
+
+@ExperimentalResourceApi
+internal val Res.string.str_17202: StringResource
+  get() = String16.str_17202
+
+@ExperimentalResourceApi
+internal val Res.string.str_17203: StringResource
+  get() = String16.str_17203
+
+@ExperimentalResourceApi
+internal val Res.string.str_17204: StringResource
+  get() = String16.str_17204
+
+@ExperimentalResourceApi
+internal val Res.string.str_17205: StringResource
+  get() = String16.str_17205
+
+@ExperimentalResourceApi
+internal val Res.string.str_17206: StringResource
+  get() = String16.str_17206
+
+@ExperimentalResourceApi
+internal val Res.string.str_17207: StringResource
+  get() = String16.str_17207
+
+@ExperimentalResourceApi
+internal val Res.string.str_17208: StringResource
+  get() = String16.str_17208
+
+@ExperimentalResourceApi
+internal val Res.string.str_17209: StringResource
+  get() = String16.str_17209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1721: StringResource
+  get() = String16.str_1721
+
+@ExperimentalResourceApi
+internal val Res.string.str_17210: StringResource
+  get() = String16.str_17210
+
+@ExperimentalResourceApi
+internal val Res.string.str_17211: StringResource
+  get() = String16.str_17211
+
+@ExperimentalResourceApi
+internal val Res.string.str_17212: StringResource
+  get() = String16.str_17212
+
+@ExperimentalResourceApi
+internal val Res.string.str_17213: StringResource
+  get() = String16.str_17213
+
+@ExperimentalResourceApi
+internal val Res.string.str_17214: StringResource
+  get() = String16.str_17214
+
+@ExperimentalResourceApi
+internal val Res.string.str_17215: StringResource
+  get() = String16.str_17215
+
+@ExperimentalResourceApi
+internal val Res.string.str_17216: StringResource
+  get() = String16.str_17216
+
+@ExperimentalResourceApi
+internal val Res.string.str_17217: StringResource
+  get() = String16.str_17217
+
+@ExperimentalResourceApi
+internal val Res.string.str_17218: StringResource
+  get() = String16.str_17218
+
+@ExperimentalResourceApi
+internal val Res.string.str_17219: StringResource
+  get() = String16.str_17219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1722: StringResource
+  get() = String16.str_1722
+
+@ExperimentalResourceApi
+internal val Res.string.str_17220: StringResource
+  get() = String16.str_17220
+
+@ExperimentalResourceApi
+internal val Res.string.str_17221: StringResource
+  get() = String16.str_17221
+
+@ExperimentalResourceApi
+internal val Res.string.str_17222: StringResource
+  get() = String16.str_17222
+
+@ExperimentalResourceApi
+internal val Res.string.str_17223: StringResource
+  get() = String16.str_17223
+
+@ExperimentalResourceApi
+internal val Res.string.str_17224: StringResource
+  get() = String16.str_17224
+
+@ExperimentalResourceApi
+internal val Res.string.str_17225: StringResource
+  get() = String16.str_17225
+
+@ExperimentalResourceApi
+internal val Res.string.str_17226: StringResource
+  get() = String16.str_17226
+
+@ExperimentalResourceApi
+internal val Res.string.str_17227: StringResource
+  get() = String16.str_17227
+
+@ExperimentalResourceApi
+internal val Res.string.str_17228: StringResource
+  get() = String16.str_17228
+
+@ExperimentalResourceApi
+internal val Res.string.str_17229: StringResource
+  get() = String16.str_17229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1723: StringResource
+  get() = String16.str_1723
+
+@ExperimentalResourceApi
+internal val Res.string.str_17230: StringResource
+  get() = String16.str_17230
+
+@ExperimentalResourceApi
+internal val Res.string.str_17231: StringResource
+  get() = String16.str_17231
+
+@ExperimentalResourceApi
+internal val Res.string.str_17232: StringResource
+  get() = String16.str_17232
+
+@ExperimentalResourceApi
+internal val Res.string.str_17233: StringResource
+  get() = String16.str_17233
+
+@ExperimentalResourceApi
+internal val Res.string.str_17234: StringResource
+  get() = String16.str_17234
+
+@ExperimentalResourceApi
+internal val Res.string.str_17235: StringResource
+  get() = String16.str_17235
+
+@ExperimentalResourceApi
+internal val Res.string.str_17236: StringResource
+  get() = String16.str_17236
+
+@ExperimentalResourceApi
+internal val Res.string.str_17237: StringResource
+  get() = String16.str_17237
+
+@ExperimentalResourceApi
+internal val Res.string.str_17238: StringResource
+  get() = String16.str_17238
+
+@ExperimentalResourceApi
+internal val Res.string.str_17239: StringResource
+  get() = String16.str_17239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1724: StringResource
+  get() = String16.str_1724
+
+@ExperimentalResourceApi
+internal val Res.string.str_17240: StringResource
+  get() = String16.str_17240
+
+@ExperimentalResourceApi
+internal val Res.string.str_17241: StringResource
+  get() = String16.str_17241
+
+@ExperimentalResourceApi
+internal val Res.string.str_17242: StringResource
+  get() = String16.str_17242
+
+@ExperimentalResourceApi
+internal val Res.string.str_17243: StringResource
+  get() = String16.str_17243
+
+@ExperimentalResourceApi
+internal val Res.string.str_17244: StringResource
+  get() = String16.str_17244
+
+@ExperimentalResourceApi
+internal val Res.string.str_17245: StringResource
+  get() = String16.str_17245
+
+@ExperimentalResourceApi
+internal val Res.string.str_17246: StringResource
+  get() = String16.str_17246
+
+@ExperimentalResourceApi
+internal val Res.string.str_17247: StringResource
+  get() = String16.str_17247
+
+@ExperimentalResourceApi
+internal val Res.string.str_17248: StringResource
+  get() = String16.str_17248
+
+@ExperimentalResourceApi
+internal val Res.string.str_17249: StringResource
+  get() = String16.str_17249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1725: StringResource
+  get() = String16.str_1725
+
+@ExperimentalResourceApi
+internal val Res.string.str_17250: StringResource
+  get() = String16.str_17250
+
+@ExperimentalResourceApi
+internal val Res.string.str_17251: StringResource
+  get() = String16.str_17251
+
+@ExperimentalResourceApi
+internal val Res.string.str_17252: StringResource
+  get() = String16.str_17252
+
+@ExperimentalResourceApi
+internal val Res.string.str_17253: StringResource
+  get() = String16.str_17253
+
+@ExperimentalResourceApi
+internal val Res.string.str_17254: StringResource
+  get() = String16.str_17254
+
+@ExperimentalResourceApi
+internal val Res.string.str_17255: StringResource
+  get() = String16.str_17255
+
+@ExperimentalResourceApi
+internal val Res.string.str_17256: StringResource
+  get() = String16.str_17256
+
+@ExperimentalResourceApi
+internal val Res.string.str_17257: StringResource
+  get() = String16.str_17257
+
+@ExperimentalResourceApi
+internal val Res.string.str_17258: StringResource
+  get() = String16.str_17258
+
+@ExperimentalResourceApi
+internal val Res.string.str_17259: StringResource
+  get() = String16.str_17259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1726: StringResource
+  get() = String16.str_1726
+
+@ExperimentalResourceApi
+internal val Res.string.str_17260: StringResource
+  get() = String16.str_17260
+
+@ExperimentalResourceApi
+internal val Res.string.str_17261: StringResource
+  get() = String16.str_17261
+
+@ExperimentalResourceApi
+internal val Res.string.str_17262: StringResource
+  get() = String16.str_17262
+
+@ExperimentalResourceApi
+internal val Res.string.str_17263: StringResource
+  get() = String16.str_17263
+
+@ExperimentalResourceApi
+internal val Res.string.str_17264: StringResource
+  get() = String16.str_17264
+
+@ExperimentalResourceApi
+internal val Res.string.str_17265: StringResource
+  get() = String16.str_17265
+
+@ExperimentalResourceApi
+internal val Res.string.str_17266: StringResource
+  get() = String16.str_17266
+
+@ExperimentalResourceApi
+internal val Res.string.str_17267: StringResource
+  get() = String16.str_17267
+
+@ExperimentalResourceApi
+internal val Res.string.str_17268: StringResource
+  get() = String16.str_17268
+
+@ExperimentalResourceApi
+internal val Res.string.str_17269: StringResource
+  get() = String16.str_17269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1727: StringResource
+  get() = String16.str_1727
+
+@ExperimentalResourceApi
+internal val Res.string.str_17270: StringResource
+  get() = String16.str_17270
+
+@ExperimentalResourceApi
+internal val Res.string.str_17271: StringResource
+  get() = String16.str_17271
+
+@ExperimentalResourceApi
+internal val Res.string.str_17272: StringResource
+  get() = String16.str_17272
+
+@ExperimentalResourceApi
+internal val Res.string.str_17273: StringResource
+  get() = String16.str_17273
+
+@ExperimentalResourceApi
+internal val Res.string.str_17274: StringResource
+  get() = String16.str_17274
+
+@ExperimentalResourceApi
+internal val Res.string.str_17275: StringResource
+  get() = String16.str_17275
+
+@ExperimentalResourceApi
+internal val Res.string.str_17276: StringResource
+  get() = String16.str_17276
+
+@ExperimentalResourceApi
+internal val Res.string.str_17277: StringResource
+  get() = String16.str_17277
+
+@ExperimentalResourceApi
+internal val Res.string.str_17278: StringResource
+  get() = String16.str_17278
+
+@ExperimentalResourceApi
+internal val Res.string.str_17279: StringResource
+  get() = String16.str_17279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1728: StringResource
+  get() = String16.str_1728
+
+@ExperimentalResourceApi
+internal val Res.string.str_17280: StringResource
+  get() = String16.str_17280
+
+@ExperimentalResourceApi
+internal val Res.string.str_17281: StringResource
+  get() = String16.str_17281
+
+@ExperimentalResourceApi
+internal val Res.string.str_17282: StringResource
+  get() = String16.str_17282
+
+@ExperimentalResourceApi
+internal val Res.string.str_17283: StringResource
+  get() = String16.str_17283
+
+@ExperimentalResourceApi
+internal val Res.string.str_17284: StringResource
+  get() = String16.str_17284
+
+@ExperimentalResourceApi
+internal val Res.string.str_17285: StringResource
+  get() = String16.str_17285
+
+@ExperimentalResourceApi
+internal val Res.string.str_17286: StringResource
+  get() = String16.str_17286
+
+@ExperimentalResourceApi
+internal val Res.string.str_17287: StringResource
+  get() = String16.str_17287
+
+@ExperimentalResourceApi
+internal val Res.string.str_17288: StringResource
+  get() = String16.str_17288
+
+@ExperimentalResourceApi
+internal val Res.string.str_17289: StringResource
+  get() = String16.str_17289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1729: StringResource
+  get() = String16.str_1729
+
+@ExperimentalResourceApi
+internal val Res.string.str_17290: StringResource
+  get() = String16.str_17290
+
+@ExperimentalResourceApi
+internal val Res.string.str_17291: StringResource
+  get() = String16.str_17291
+
+@ExperimentalResourceApi
+internal val Res.string.str_17292: StringResource
+  get() = String16.str_17292
+
+@ExperimentalResourceApi
+internal val Res.string.str_17293: StringResource
+  get() = String16.str_17293
+
+@ExperimentalResourceApi
+internal val Res.string.str_17294: StringResource
+  get() = String16.str_17294
+
+@ExperimentalResourceApi
+internal val Res.string.str_17295: StringResource
+  get() = String16.str_17295
+
+@ExperimentalResourceApi
+internal val Res.string.str_17296: StringResource
+  get() = String16.str_17296
+
+@ExperimentalResourceApi
+internal val Res.string.str_17297: StringResource
+  get() = String16.str_17297
+
+@ExperimentalResourceApi
+internal val Res.string.str_17298: StringResource
+  get() = String16.str_17298
+
+@ExperimentalResourceApi
+internal val Res.string.str_17299: StringResource
+  get() = String16.str_17299
+
+@ExperimentalResourceApi
+internal val Res.string.str_173: StringResource
+  get() = String16.str_173
+
+@ExperimentalResourceApi
+internal val Res.string.str_1730: StringResource
+  get() = String16.str_1730
+
+@ExperimentalResourceApi
+internal val Res.string.str_17300: StringResource
+  get() = String16.str_17300
+
+@ExperimentalResourceApi
+internal val Res.string.str_17301: StringResource
+  get() = String16.str_17301
+
+@ExperimentalResourceApi
+internal val Res.string.str_17302: StringResource
+  get() = String16.str_17302
+
+@ExperimentalResourceApi
+internal val Res.string.str_17303: StringResource
+  get() = String16.str_17303
+
+@ExperimentalResourceApi
+internal val Res.string.str_17304: StringResource
+  get() = String16.str_17304
+
+@ExperimentalResourceApi
+internal val Res.string.str_17305: StringResource
+  get() = String16.str_17305
+
+@ExperimentalResourceApi
+internal val Res.string.str_17306: StringResource
+  get() = String16.str_17306
+
+@ExperimentalResourceApi
+internal val Res.string.str_17307: StringResource
+  get() = String16.str_17307
+
+@ExperimentalResourceApi
+internal val Res.string.str_17308: StringResource
+  get() = String16.str_17308
+
+@ExperimentalResourceApi
+internal val Res.string.str_17309: StringResource
+  get() = String16.str_17309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1731: StringResource
+  get() = String16.str_1731
+
+@ExperimentalResourceApi
+internal val Res.string.str_17310: StringResource
+  get() = String16.str_17310
+
+@ExperimentalResourceApi
+internal val Res.string.str_17311: StringResource
+  get() = String16.str_17311
+
+@ExperimentalResourceApi
+internal val Res.string.str_17312: StringResource
+  get() = String16.str_17312
+
+@ExperimentalResourceApi
+internal val Res.string.str_17313: StringResource
+  get() = String16.str_17313
+
+@ExperimentalResourceApi
+internal val Res.string.str_17314: StringResource
+  get() = String16.str_17314
+
+@ExperimentalResourceApi
+internal val Res.string.str_17315: StringResource
+  get() = String16.str_17315
+
+@ExperimentalResourceApi
+internal val Res.string.str_17316: StringResource
+  get() = String16.str_17316
+
+@ExperimentalResourceApi
+internal val Res.string.str_17317: StringResource
+  get() = String16.str_17317
+
+@ExperimentalResourceApi
+internal val Res.string.str_17318: StringResource
+  get() = String16.str_17318
+
+@ExperimentalResourceApi
+internal val Res.string.str_17319: StringResource
+  get() = String16.str_17319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1732: StringResource
+  get() = String16.str_1732
+
+@ExperimentalResourceApi
+internal val Res.string.str_17320: StringResource
+  get() = String16.str_17320
+
+@ExperimentalResourceApi
+internal val Res.string.str_17321: StringResource
+  get() = String16.str_17321
+
+@ExperimentalResourceApi
+internal val Res.string.str_17322: StringResource
+  get() = String16.str_17322
+
+@ExperimentalResourceApi
+internal val Res.string.str_17323: StringResource
+  get() = String16.str_17323
+
+@ExperimentalResourceApi
+internal val Res.string.str_17324: StringResource
+  get() = String16.str_17324
+
+@ExperimentalResourceApi
+internal val Res.string.str_17325: StringResource
+  get() = String16.str_17325
+
+@ExperimentalResourceApi
+internal val Res.string.str_17326: StringResource
+  get() = String16.str_17326
+
+@ExperimentalResourceApi
+internal val Res.string.str_17327: StringResource
+  get() = String16.str_17327
+
+@ExperimentalResourceApi
+internal val Res.string.str_17328: StringResource
+  get() = String16.str_17328
+
+@ExperimentalResourceApi
+internal val Res.string.str_17329: StringResource
+  get() = String16.str_17329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1733: StringResource
+  get() = String16.str_1733
+
+@ExperimentalResourceApi
+internal val Res.string.str_17330: StringResource
+  get() = String16.str_17330
+
+@ExperimentalResourceApi
+internal val Res.string.str_17331: StringResource
+  get() = String16.str_17331
+
+@ExperimentalResourceApi
+internal val Res.string.str_17332: StringResource
+  get() = String16.str_17332
+
+@ExperimentalResourceApi
+internal val Res.string.str_17333: StringResource
+  get() = String16.str_17333
+
+@ExperimentalResourceApi
+internal val Res.string.str_17334: StringResource
+  get() = String16.str_17334
+
+@ExperimentalResourceApi
+internal val Res.string.str_17335: StringResource
+  get() = String16.str_17335
+
+@ExperimentalResourceApi
+internal val Res.string.str_17336: StringResource
+  get() = String16.str_17336
+
+@ExperimentalResourceApi
+internal val Res.string.str_17337: StringResource
+  get() = String16.str_17337
+
+@ExperimentalResourceApi
+internal val Res.string.str_17338: StringResource
+  get() = String16.str_17338
+
+@ExperimentalResourceApi
+internal val Res.string.str_17339: StringResource
+  get() = String16.str_17339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1734: StringResource
+  get() = String16.str_1734
+
+@ExperimentalResourceApi
+internal val Res.string.str_17340: StringResource
+  get() = String16.str_17340
+
+@ExperimentalResourceApi
+internal val Res.string.str_17341: StringResource
+  get() = String16.str_17341
+
+@ExperimentalResourceApi
+internal val Res.string.str_17342: StringResource
+  get() = String16.str_17342
+
+@ExperimentalResourceApi
+internal val Res.string.str_17343: StringResource
+  get() = String16.str_17343
+
+@ExperimentalResourceApi
+internal val Res.string.str_17344: StringResource
+  get() = String16.str_17344
+
+@ExperimentalResourceApi
+internal val Res.string.str_17345: StringResource
+  get() = String16.str_17345
+
+@ExperimentalResourceApi
+internal val Res.string.str_17346: StringResource
+  get() = String16.str_17346
+
+@ExperimentalResourceApi
+internal val Res.string.str_17347: StringResource
+  get() = String16.str_17347
+
+@ExperimentalResourceApi
+internal val Res.string.str_17348: StringResource
+  get() = String16.str_17348
+
+@ExperimentalResourceApi
+internal val Res.string.str_17349: StringResource
+  get() = String16.str_17349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1735: StringResource
+  get() = String16.str_1735
+
+@ExperimentalResourceApi
+internal val Res.string.str_17350: StringResource
+  get() = String16.str_17350
+
+@ExperimentalResourceApi
+internal val Res.string.str_17351: StringResource
+  get() = String16.str_17351
+
+@ExperimentalResourceApi
+internal val Res.string.str_17352: StringResource
+  get() = String16.str_17352
+
+@ExperimentalResourceApi
+internal val Res.string.str_17353: StringResource
+  get() = String16.str_17353
+
+@ExperimentalResourceApi
+internal val Res.string.str_17354: StringResource
+  get() = String16.str_17354
+
+@ExperimentalResourceApi
+internal val Res.string.str_17355: StringResource
+  get() = String16.str_17355
+
+@ExperimentalResourceApi
+internal val Res.string.str_17356: StringResource
+  get() = String16.str_17356
+
+@ExperimentalResourceApi
+internal val Res.string.str_17357: StringResource
+  get() = String16.str_17357
+
+@ExperimentalResourceApi
+internal val Res.string.str_17358: StringResource
+  get() = String16.str_17358
+
+@ExperimentalResourceApi
+internal val Res.string.str_17359: StringResource
+  get() = String16.str_17359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1736: StringResource
+  get() = String16.str_1736
+
+@ExperimentalResourceApi
+internal val Res.string.str_17360: StringResource
+  get() = String16.str_17360
+
+@ExperimentalResourceApi
+internal val Res.string.str_17361: StringResource
+  get() = String16.str_17361
+
+@ExperimentalResourceApi
+internal val Res.string.str_17362: StringResource
+  get() = String16.str_17362
+
+@ExperimentalResourceApi
+internal val Res.string.str_17363: StringResource
+  get() = String16.str_17363
+
+@ExperimentalResourceApi
+internal val Res.string.str_17364: StringResource
+  get() = String16.str_17364
+
+@ExperimentalResourceApi
+internal val Res.string.str_17365: StringResource
+  get() = String16.str_17365
+
+@ExperimentalResourceApi
+internal val Res.string.str_17366: StringResource
+  get() = String16.str_17366
+
+@ExperimentalResourceApi
+internal val Res.string.str_17367: StringResource
+  get() = String16.str_17367
+
+@ExperimentalResourceApi
+internal val Res.string.str_17368: StringResource
+  get() = String16.str_17368
+
+@ExperimentalResourceApi
+internal val Res.string.str_17369: StringResource
+  get() = String16.str_17369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1737: StringResource
+  get() = String16.str_1737
+
+@ExperimentalResourceApi
+internal val Res.string.str_17370: StringResource
+  get() = String16.str_17370
+
+@ExperimentalResourceApi
+internal val Res.string.str_17371: StringResource
+  get() = String16.str_17371
+
+@ExperimentalResourceApi
+internal val Res.string.str_17372: StringResource
+  get() = String16.str_17372
+
+@ExperimentalResourceApi
+internal val Res.string.str_17373: StringResource
+  get() = String16.str_17373
+
+@ExperimentalResourceApi
+internal val Res.string.str_17374: StringResource
+  get() = String16.str_17374
+
+@ExperimentalResourceApi
+internal val Res.string.str_17375: StringResource
+  get() = String16.str_17375
+
+@ExperimentalResourceApi
+internal val Res.string.str_17376: StringResource
+  get() = String16.str_17376
+
+@ExperimentalResourceApi
+internal val Res.string.str_17377: StringResource
+  get() = String16.str_17377
+
+@ExperimentalResourceApi
+internal val Res.string.str_17378: StringResource
+  get() = String16.str_17378
+
+@ExperimentalResourceApi
+internal val Res.string.str_17379: StringResource
+  get() = String16.str_17379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1738: StringResource
+  get() = String16.str_1738
+
+@ExperimentalResourceApi
+internal val Res.string.str_17380: StringResource
+  get() = String16.str_17380
+
+@ExperimentalResourceApi
+internal val Res.string.str_17381: StringResource
+  get() = String16.str_17381
+
+@ExperimentalResourceApi
+internal val Res.string.str_17382: StringResource
+  get() = String16.str_17382
+
+@ExperimentalResourceApi
+internal val Res.string.str_17383: StringResource
+  get() = String16.str_17383
+
+@ExperimentalResourceApi
+internal val Res.string.str_17384: StringResource
+  get() = String16.str_17384
+
+@ExperimentalResourceApi
+internal val Res.string.str_17385: StringResource
+  get() = String16.str_17385
+
+@ExperimentalResourceApi
+internal val Res.string.str_17386: StringResource
+  get() = String16.str_17386
+
+@ExperimentalResourceApi
+internal val Res.string.str_17387: StringResource
+  get() = String16.str_17387
+
+@ExperimentalResourceApi
+internal val Res.string.str_17388: StringResource
+  get() = String16.str_17388
+
+@ExperimentalResourceApi
+internal val Res.string.str_17389: StringResource
+  get() = String16.str_17389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1739: StringResource
+  get() = String16.str_1739
+
+@ExperimentalResourceApi
+internal val Res.string.str_17390: StringResource
+  get() = String16.str_17390
+
+@ExperimentalResourceApi
+internal val Res.string.str_17391: StringResource
+  get() = String16.str_17391
+
+@ExperimentalResourceApi
+internal val Res.string.str_17392: StringResource
+  get() = String16.str_17392
+
+@ExperimentalResourceApi
+internal val Res.string.str_17393: StringResource
+  get() = String16.str_17393
+
+@ExperimentalResourceApi
+internal val Res.string.str_17394: StringResource
+  get() = String16.str_17394
+
+@ExperimentalResourceApi
+internal val Res.string.str_17395: StringResource
+  get() = String16.str_17395
+
+@ExperimentalResourceApi
+internal val Res.string.str_17396: StringResource
+  get() = String16.str_17396
+
+@ExperimentalResourceApi
+internal val Res.string.str_17397: StringResource
+  get() = String16.str_17397
+
+@ExperimentalResourceApi
+internal val Res.string.str_17398: StringResource
+  get() = String16.str_17398
+
+@ExperimentalResourceApi
+internal val Res.string.str_17399: StringResource
+  get() = String16.str_17399
+
+@ExperimentalResourceApi
+internal val Res.string.str_174: StringResource
+  get() = String16.str_174
+
+@ExperimentalResourceApi
+internal val Res.string.str_1740: StringResource
+  get() = String16.str_1740
+
+@ExperimentalResourceApi
+internal val Res.string.str_17400: StringResource
+  get() = String16.str_17400
+
+@ExperimentalResourceApi
+internal val Res.string.str_17401: StringResource
+  get() = String16.str_17401
+
+@ExperimentalResourceApi
+internal val Res.string.str_17402: StringResource
+  get() = String16.str_17402
+
+@ExperimentalResourceApi
+internal val Res.string.str_17403: StringResource
+  get() = String16.str_17403
+
+@ExperimentalResourceApi
+internal val Res.string.str_17404: StringResource
+  get() = String16.str_17404
+
+@ExperimentalResourceApi
+internal val Res.string.str_17405: StringResource
+  get() = String16.str_17405
+
+@ExperimentalResourceApi
+internal val Res.string.str_17406: StringResource
+  get() = String16.str_17406
+
+@ExperimentalResourceApi
+internal val Res.string.str_17407: StringResource
+  get() = String16.str_17407
+
+@ExperimentalResourceApi
+internal val Res.string.str_17408: StringResource
+  get() = String16.str_17408
+
+@ExperimentalResourceApi
+internal val Res.string.str_17409: StringResource
+  get() = String16.str_17409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1741: StringResource
+  get() = String16.str_1741
+
+@ExperimentalResourceApi
+internal val Res.string.str_17410: StringResource
+  get() = String16.str_17410
+
+@ExperimentalResourceApi
+internal val Res.string.str_17411: StringResource
+  get() = String16.str_17411
+
+@ExperimentalResourceApi
+internal val Res.string.str_17412: StringResource
+  get() = String16.str_17412
+
+@ExperimentalResourceApi
+internal val Res.string.str_17413: StringResource
+  get() = String16.str_17413
+
+@ExperimentalResourceApi
+internal val Res.string.str_17414: StringResource
+  get() = String16.str_17414
+
+@ExperimentalResourceApi
+internal val Res.string.str_17415: StringResource
+  get() = String16.str_17415
+
+@ExperimentalResourceApi
+internal val Res.string.str_17416: StringResource
+  get() = String16.str_17416
+
+@ExperimentalResourceApi
+internal val Res.string.str_17417: StringResource
+  get() = String16.str_17417
+
+@ExperimentalResourceApi
+internal val Res.string.str_17418: StringResource
+  get() = String16.str_17418
+
+@ExperimentalResourceApi
+internal val Res.string.str_17419: StringResource
+  get() = String16.str_17419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1742: StringResource
+  get() = String16.str_1742
+
+@ExperimentalResourceApi
+internal val Res.string.str_17420: StringResource
+  get() = String16.str_17420
+
+@ExperimentalResourceApi
+internal val Res.string.str_17421: StringResource
+  get() = String16.str_17421
+
+@ExperimentalResourceApi
+internal val Res.string.str_17422: StringResource
+  get() = String16.str_17422
+
+@ExperimentalResourceApi
+internal val Res.string.str_17423: StringResource
+  get() = String16.str_17423
+
+@ExperimentalResourceApi
+internal val Res.string.str_17424: StringResource
+  get() = String16.str_17424
+
+@ExperimentalResourceApi
+internal val Res.string.str_17425: StringResource
+  get() = String16.str_17425
+
+@ExperimentalResourceApi
+internal val Res.string.str_17426: StringResource
+  get() = String16.str_17426
+
+@ExperimentalResourceApi
+internal val Res.string.str_17427: StringResource
+  get() = String16.str_17427
+
+@ExperimentalResourceApi
+internal val Res.string.str_17428: StringResource
+  get() = String16.str_17428
+
+@ExperimentalResourceApi
+internal val Res.string.str_17429: StringResource
+  get() = String16.str_17429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1743: StringResource
+  get() = String16.str_1743
+
+@ExperimentalResourceApi
+internal val Res.string.str_17430: StringResource
+  get() = String16.str_17430
+
+@ExperimentalResourceApi
+internal val Res.string.str_17431: StringResource
+  get() = String16.str_17431
+
+@ExperimentalResourceApi
+internal val Res.string.str_17432: StringResource
+  get() = String16.str_17432
+
+@ExperimentalResourceApi
+internal val Res.string.str_17433: StringResource
+  get() = String16.str_17433
+
+@ExperimentalResourceApi
+internal val Res.string.str_17434: StringResource
+  get() = String16.str_17434
+
+@ExperimentalResourceApi
+internal val Res.string.str_17435: StringResource
+  get() = String16.str_17435
+
+@ExperimentalResourceApi
+internal val Res.string.str_17436: StringResource
+  get() = String16.str_17436
+
+@ExperimentalResourceApi
+internal val Res.string.str_17437: StringResource
+  get() = String16.str_17437
+
+@ExperimentalResourceApi
+internal val Res.string.str_17438: StringResource
+  get() = String16.str_17438
+
+@ExperimentalResourceApi
+internal val Res.string.str_17439: StringResource
+  get() = String16.str_17439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1744: StringResource
+  get() = String16.str_1744
+
+@ExperimentalResourceApi
+internal val Res.string.str_17440: StringResource
+  get() = String16.str_17440
+
+@ExperimentalResourceApi
+internal val Res.string.str_17441: StringResource
+  get() = String16.str_17441
+
+@ExperimentalResourceApi
+internal val Res.string.str_17442: StringResource
+  get() = String16.str_17442
+
+@ExperimentalResourceApi
+internal val Res.string.str_17443: StringResource
+  get() = String16.str_17443
+
+@ExperimentalResourceApi
+internal val Res.string.str_17444: StringResource
+  get() = String16.str_17444
+
+@ExperimentalResourceApi
+internal val Res.string.str_17445: StringResource
+  get() = String16.str_17445
+
+@ExperimentalResourceApi
+internal val Res.string.str_17446: StringResource
+  get() = String16.str_17446
+
+@ExperimentalResourceApi
+internal val Res.string.str_17447: StringResource
+  get() = String16.str_17447
+
+@ExperimentalResourceApi
+internal val Res.string.str_17448: StringResource
+  get() = String16.str_17448
+
+@ExperimentalResourceApi
+internal val Res.string.str_17449: StringResource
+  get() = String16.str_17449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1745: StringResource
+  get() = String16.str_1745
+
+@ExperimentalResourceApi
+internal val Res.string.str_17450: StringResource
+  get() = String16.str_17450
+
+@ExperimentalResourceApi
+internal val Res.string.str_17451: StringResource
+  get() = String16.str_17451
+
+@ExperimentalResourceApi
+internal val Res.string.str_17452: StringResource
+  get() = String16.str_17452
+
+@ExperimentalResourceApi
+internal val Res.string.str_17453: StringResource
+  get() = String16.str_17453
+
+@ExperimentalResourceApi
+internal val Res.string.str_17454: StringResource
+  get() = String16.str_17454
+
+@ExperimentalResourceApi
+internal val Res.string.str_17455: StringResource
+  get() = String16.str_17455
+
+@ExperimentalResourceApi
+internal val Res.string.str_17456: StringResource
+  get() = String16.str_17456
+
+@ExperimentalResourceApi
+internal val Res.string.str_17457: StringResource
+  get() = String16.str_17457
+
+@ExperimentalResourceApi
+internal val Res.string.str_17458: StringResource
+  get() = String16.str_17458
+
+@ExperimentalResourceApi
+internal val Res.string.str_17459: StringResource
+  get() = String16.str_17459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1746: StringResource
+  get() = String16.str_1746
+
+@ExperimentalResourceApi
+internal val Res.string.str_17460: StringResource
+  get() = String16.str_17460
+
+@ExperimentalResourceApi
+internal val Res.string.str_17461: StringResource
+  get() = String16.str_17461
+
+@ExperimentalResourceApi
+internal val Res.string.str_17462: StringResource
+  get() = String16.str_17462
+
+@ExperimentalResourceApi
+internal val Res.string.str_17463: StringResource
+  get() = String16.str_17463
+
+@ExperimentalResourceApi
+internal val Res.string.str_17464: StringResource
+  get() = String16.str_17464
+
+@ExperimentalResourceApi
+internal val Res.string.str_17465: StringResource
+  get() = String16.str_17465
+
+@ExperimentalResourceApi
+internal val Res.string.str_17466: StringResource
+  get() = String16.str_17466
+
+@ExperimentalResourceApi
+internal val Res.string.str_17467: StringResource
+  get() = String16.str_17467
+
+@ExperimentalResourceApi
+internal val Res.string.str_17468: StringResource
+  get() = String16.str_17468
+
+@ExperimentalResourceApi
+internal val Res.string.str_17469: StringResource
+  get() = String16.str_17469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1747: StringResource
+  get() = String16.str_1747
+
+@ExperimentalResourceApi
+internal val Res.string.str_17470: StringResource
+  get() = String16.str_17470
+
+@ExperimentalResourceApi
+internal val Res.string.str_17471: StringResource
+  get() = String16.str_17471
+
+@ExperimentalResourceApi
+internal val Res.string.str_17472: StringResource
+  get() = String16.str_17472
+
+@ExperimentalResourceApi
+internal val Res.string.str_17473: StringResource
+  get() = String16.str_17473
+
+@ExperimentalResourceApi
+internal val Res.string.str_17474: StringResource
+  get() = String16.str_17474
+
+@ExperimentalResourceApi
+internal val Res.string.str_17475: StringResource
+  get() = String16.str_17475
+
+@ExperimentalResourceApi
+internal val Res.string.str_17476: StringResource
+  get() = String16.str_17476
+
+@ExperimentalResourceApi
+internal val Res.string.str_17477: StringResource
+  get() = String16.str_17477
+
+@ExperimentalResourceApi
+internal val Res.string.str_17478: StringResource
+  get() = String16.str_17478
+
+@ExperimentalResourceApi
+internal val Res.string.str_17479: StringResource
+  get() = String16.str_17479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1748: StringResource
+  get() = String16.str_1748
+
+@ExperimentalResourceApi
+internal val Res.string.str_17480: StringResource
+  get() = String16.str_17480
+
+@ExperimentalResourceApi
+internal val Res.string.str_17481: StringResource
+  get() = String16.str_17481
+
+@ExperimentalResourceApi
+internal val Res.string.str_17482: StringResource
+  get() = String16.str_17482
+
+@ExperimentalResourceApi
+internal val Res.string.str_17483: StringResource
+  get() = String16.str_17483
+
+@ExperimentalResourceApi
+internal val Res.string.str_17484: StringResource
+  get() = String16.str_17484
+
+@ExperimentalResourceApi
+internal val Res.string.str_17485: StringResource
+  get() = String16.str_17485
+
+@ExperimentalResourceApi
+internal val Res.string.str_17486: StringResource
+  get() = String16.str_17486
+
+@ExperimentalResourceApi
+internal val Res.string.str_17487: StringResource
+  get() = String16.str_17487
+
+@ExperimentalResourceApi
+internal val Res.string.str_17488: StringResource
+  get() = String16.str_17488
+
+@ExperimentalResourceApi
+internal val Res.string.str_17489: StringResource
+  get() = String16.str_17489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1749: StringResource
+  get() = String16.str_1749
+
+@ExperimentalResourceApi
+internal val Res.string.str_17490: StringResource
+  get() = String16.str_17490
+
+@ExperimentalResourceApi
+internal val Res.string.str_17491: StringResource
+  get() = String16.str_17491
+
+@ExperimentalResourceApi
+internal val Res.string.str_17492: StringResource
+  get() = String16.str_17492
+
+@ExperimentalResourceApi
+internal val Res.string.str_17493: StringResource
+  get() = String16.str_17493
+
+@ExperimentalResourceApi
+internal val Res.string.str_17494: StringResource
+  get() = String16.str_17494
+
+@ExperimentalResourceApi
+internal val Res.string.str_17495: StringResource
+  get() = String16.str_17495
+
+@ExperimentalResourceApi
+internal val Res.string.str_17496: StringResource
+  get() = String16.str_17496
+
+@ExperimentalResourceApi
+internal val Res.string.str_17497: StringResource
+  get() = String16.str_17497
+
+@ExperimentalResourceApi
+internal val Res.string.str_17498: StringResource
+  get() = String16.str_17498
+
+@ExperimentalResourceApi
+internal val Res.string.str_17499: StringResource
+  get() = String16.str_17499
+
+@ExperimentalResourceApi
+internal val Res.string.str_175: StringResource
+  get() = String16.str_175
+
+@ExperimentalResourceApi
+internal val Res.string.str_1750: StringResource
+  get() = String16.str_1750
+
+@ExperimentalResourceApi
+internal val Res.string.str_17500: StringResource
+  get() = String16.str_17500
+
+@ExperimentalResourceApi
+internal val Res.string.str_17501: StringResource
+  get() = String16.str_17501
+
+@ExperimentalResourceApi
+internal val Res.string.str_17502: StringResource
+  get() = String16.str_17502
+
+@ExperimentalResourceApi
+internal val Res.string.str_17503: StringResource
+  get() = String16.str_17503
+
+@ExperimentalResourceApi
+internal val Res.string.str_17504: StringResource
+  get() = String16.str_17504
+
+@ExperimentalResourceApi
+internal val Res.string.str_17505: StringResource
+  get() = String16.str_17505
+
+@ExperimentalResourceApi
+internal val Res.string.str_17506: StringResource
+  get() = String16.str_17506
+
+@ExperimentalResourceApi
+internal val Res.string.str_17507: StringResource
+  get() = String16.str_17507
+
+@ExperimentalResourceApi
+internal val Res.string.str_17508: StringResource
+  get() = String16.str_17508
+
+@ExperimentalResourceApi
+internal val Res.string.str_17509: StringResource
+  get() = String16.str_17509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1751: StringResource
+  get() = String16.str_1751
+
+@ExperimentalResourceApi
+internal val Res.string.str_17510: StringResource
+  get() = String16.str_17510
+
+@ExperimentalResourceApi
+internal val Res.string.str_17511: StringResource
+  get() = String16.str_17511
+
+@ExperimentalResourceApi
+internal val Res.string.str_17512: StringResource
+  get() = String16.str_17512
+
+@ExperimentalResourceApi
+internal val Res.string.str_17513: StringResource
+  get() = String16.str_17513
+
+@ExperimentalResourceApi
+internal val Res.string.str_17514: StringResource
+  get() = String16.str_17514
+
+@ExperimentalResourceApi
+internal val Res.string.str_17515: StringResource
+  get() = String16.str_17515
+
+@ExperimentalResourceApi
+internal val Res.string.str_17516: StringResource
+  get() = String16.str_17516
+
+@ExperimentalResourceApi
+internal val Res.string.str_17517: StringResource
+  get() = String16.str_17517
+
+@ExperimentalResourceApi
+internal val Res.string.str_17518: StringResource
+  get() = String16.str_17518
+
+@ExperimentalResourceApi
+internal val Res.string.str_17519: StringResource
+  get() = String16.str_17519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1752: StringResource
+  get() = String16.str_1752
+
+@ExperimentalResourceApi
+internal val Res.string.str_17520: StringResource
+  get() = String16.str_17520
+
+@ExperimentalResourceApi
+internal val Res.string.str_17521: StringResource
+  get() = String16.str_17521
+
+@ExperimentalResourceApi
+internal val Res.string.str_17522: StringResource
+  get() = String16.str_17522
+
+@ExperimentalResourceApi
+internal val Res.string.str_17523: StringResource
+  get() = String16.str_17523
+
+@ExperimentalResourceApi
+internal val Res.string.str_17524: StringResource
+  get() = String16.str_17524
+
+@ExperimentalResourceApi
+internal val Res.string.str_17525: StringResource
+  get() = String16.str_17525
+
+@ExperimentalResourceApi
+internal val Res.string.str_17526: StringResource
+  get() = String16.str_17526
+
+@ExperimentalResourceApi
+internal val Res.string.str_17527: StringResource
+  get() = String16.str_17527
+
+@ExperimentalResourceApi
+internal val Res.string.str_17528: StringResource
+  get() = String16.str_17528
+
+@ExperimentalResourceApi
+internal val Res.string.str_17529: StringResource
+  get() = String16.str_17529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1753: StringResource
+  get() = String16.str_1753
+
+@ExperimentalResourceApi
+internal val Res.string.str_17530: StringResource
+  get() = String16.str_17530
+
+@ExperimentalResourceApi
+internal val Res.string.str_17531: StringResource
+  get() = String16.str_17531
+
+@ExperimentalResourceApi
+internal val Res.string.str_17532: StringResource
+  get() = String16.str_17532
+
+@ExperimentalResourceApi
+internal val Res.string.str_17533: StringResource
+  get() = String16.str_17533
+
+@ExperimentalResourceApi
+internal val Res.string.str_17534: StringResource
+  get() = String16.str_17534
+
+@ExperimentalResourceApi
+internal val Res.string.str_17535: StringResource
+  get() = String16.str_17535
+
+@ExperimentalResourceApi
+internal val Res.string.str_17536: StringResource
+  get() = String16.str_17536
+
+@ExperimentalResourceApi
+internal val Res.string.str_17537: StringResource
+  get() = String16.str_17537
+
+@ExperimentalResourceApi
+internal val Res.string.str_17538: StringResource
+  get() = String16.str_17538
+
+@ExperimentalResourceApi
+internal val Res.string.str_17539: StringResource
+  get() = String16.str_17539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1754: StringResource
+  get() = String16.str_1754
+
+@ExperimentalResourceApi
+internal val Res.string.str_17540: StringResource
+  get() = String16.str_17540
+
+@ExperimentalResourceApi
+internal val Res.string.str_17541: StringResource
+  get() = String16.str_17541
+
+@ExperimentalResourceApi
+internal val Res.string.str_17542: StringResource
+  get() = String16.str_17542
+
+@ExperimentalResourceApi
+internal val Res.string.str_17543: StringResource
+  get() = String16.str_17543
+
+@ExperimentalResourceApi
+internal val Res.string.str_17544: StringResource
+  get() = String16.str_17544
+
+@ExperimentalResourceApi
+internal val Res.string.str_17545: StringResource
+  get() = String16.str_17545
+
+@ExperimentalResourceApi
+internal val Res.string.str_17546: StringResource
+  get() = String16.str_17546
+
+@ExperimentalResourceApi
+internal val Res.string.str_17547: StringResource
+  get() = String16.str_17547
+
+@ExperimentalResourceApi
+internal val Res.string.str_17548: StringResource
+  get() = String16.str_17548
+
+@ExperimentalResourceApi
+internal val Res.string.str_17549: StringResource
+  get() = String16.str_17549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1755: StringResource
+  get() = String16.str_1755
+
+@ExperimentalResourceApi
+internal val Res.string.str_17550: StringResource
+  get() = String16.str_17550
+
+@ExperimentalResourceApi
+internal val Res.string.str_17551: StringResource
+  get() = String16.str_17551
+
+@ExperimentalResourceApi
+internal val Res.string.str_17552: StringResource
+  get() = String16.str_17552
+
+@ExperimentalResourceApi
+internal val Res.string.str_17553: StringResource
+  get() = String16.str_17553
+
+@ExperimentalResourceApi
+internal val Res.string.str_17554: StringResource
+  get() = String16.str_17554
+
+@ExperimentalResourceApi
+internal val Res.string.str_17555: StringResource
+  get() = String16.str_17555
+
+@ExperimentalResourceApi
+internal val Res.string.str_17556: StringResource
+  get() = String16.str_17556
+
+@ExperimentalResourceApi
+internal val Res.string.str_17557: StringResource
+  get() = String16.str_17557
+
+@ExperimentalResourceApi
+internal val Res.string.str_17558: StringResource
+  get() = String16.str_17558
+
+@ExperimentalResourceApi
+internal val Res.string.str_17559: StringResource
+  get() = String16.str_17559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1756: StringResource
+  get() = String16.str_1756
+
+@ExperimentalResourceApi
+internal val Res.string.str_17560: StringResource
+  get() = String16.str_17560
+
+@ExperimentalResourceApi
+internal val Res.string.str_17561: StringResource
+  get() = String16.str_17561
+
+@ExperimentalResourceApi
+internal val Res.string.str_17562: StringResource
+  get() = String16.str_17562
+
+@ExperimentalResourceApi
+internal val Res.string.str_17563: StringResource
+  get() = String16.str_17563
+
+@ExperimentalResourceApi
+internal val Res.string.str_17564: StringResource
+  get() = String16.str_17564
+
+@ExperimentalResourceApi
+internal val Res.string.str_17565: StringResource
+  get() = String16.str_17565
+
+@ExperimentalResourceApi
+internal val Res.string.str_17566: StringResource
+  get() = String16.str_17566
+
+@ExperimentalResourceApi
+internal val Res.string.str_17567: StringResource
+  get() = String16.str_17567
+
+@ExperimentalResourceApi
+internal val Res.string.str_17568: StringResource
+  get() = String16.str_17568
+
+@ExperimentalResourceApi
+internal val Res.string.str_17569: StringResource
+  get() = String16.str_17569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1757: StringResource
+  get() = String16.str_1757
+
+@ExperimentalResourceApi
+internal val Res.string.str_17570: StringResource
+  get() = String16.str_17570
+
+@ExperimentalResourceApi
+internal val Res.string.str_17571: StringResource
+  get() = String16.str_17571
+
+@ExperimentalResourceApi
+internal val Res.string.str_17572: StringResource
+  get() = String16.str_17572
+
+@ExperimentalResourceApi
+internal val Res.string.str_17573: StringResource
+  get() = String16.str_17573
+
+@ExperimentalResourceApi
+internal val Res.string.str_17574: StringResource
+  get() = String16.str_17574
+
+@ExperimentalResourceApi
+internal val Res.string.str_17575: StringResource
+  get() = String16.str_17575
+
+@ExperimentalResourceApi
+internal val Res.string.str_17576: StringResource
+  get() = String16.str_17576
+
+@ExperimentalResourceApi
+internal val Res.string.str_17577: StringResource
+  get() = String16.str_17577
+
+@ExperimentalResourceApi
+internal val Res.string.str_17578: StringResource
+  get() = String16.str_17578
+
+@ExperimentalResourceApi
+internal val Res.string.str_17579: StringResource
+  get() = String16.str_17579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1758: StringResource
+  get() = String16.str_1758
+
+@ExperimentalResourceApi
+internal val Res.string.str_17580: StringResource
+  get() = String16.str_17580
+
+@ExperimentalResourceApi
+internal val Res.string.str_17581: StringResource
+  get() = String16.str_17581
+
+@ExperimentalResourceApi
+internal val Res.string.str_17582: StringResource
+  get() = String16.str_17582
+
+@ExperimentalResourceApi
+internal val Res.string.str_17583: StringResource
+  get() = String16.str_17583
+
+@ExperimentalResourceApi
+internal val Res.string.str_17584: StringResource
+  get() = String16.str_17584
+
+@ExperimentalResourceApi
+internal val Res.string.str_17585: StringResource
+  get() = String16.str_17585
+
+@ExperimentalResourceApi
+internal val Res.string.str_17586: StringResource
+  get() = String16.str_17586
+
+@ExperimentalResourceApi
+internal val Res.string.str_17587: StringResource
+  get() = String16.str_17587
+
+@ExperimentalResourceApi
+internal val Res.string.str_17588: StringResource
+  get() = String16.str_17588
+
+@ExperimentalResourceApi
+internal val Res.string.str_17589: StringResource
+  get() = String16.str_17589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1759: StringResource
+  get() = String16.str_1759
+
+@ExperimentalResourceApi
+internal val Res.string.str_17590: StringResource
+  get() = String16.str_17590
+
+@ExperimentalResourceApi
+internal val Res.string.str_17591: StringResource
+  get() = String16.str_17591
+
+@ExperimentalResourceApi
+internal val Res.string.str_17592: StringResource
+  get() = String16.str_17592
+
+@ExperimentalResourceApi
+internal val Res.string.str_17593: StringResource
+  get() = String16.str_17593
+
+@ExperimentalResourceApi
+internal val Res.string.str_17594: StringResource
+  get() = String16.str_17594
+
+@ExperimentalResourceApi
+internal val Res.string.str_17595: StringResource
+  get() = String16.str_17595
+
+@ExperimentalResourceApi
+internal val Res.string.str_17596: StringResource
+  get() = String16.str_17596
+
+@ExperimentalResourceApi
+internal val Res.string.str_17597: StringResource
+  get() = String16.str_17597
+
+@ExperimentalResourceApi
+internal val Res.string.str_17598: StringResource
+  get() = String16.str_17598
+
+@ExperimentalResourceApi
+internal val Res.string.str_17599: StringResource
+  get() = String16.str_17599
+
+@ExperimentalResourceApi
+internal val Res.string.str_176: StringResource
+  get() = String16.str_176
+
+@ExperimentalResourceApi
+internal val Res.string.str_1760: StringResource
+  get() = String16.str_1760
+
+@ExperimentalResourceApi
+internal val Res.string.str_17600: StringResource
+  get() = String16.str_17600
+
+@ExperimentalResourceApi
+internal val Res.string.str_17601: StringResource
+  get() = String16.str_17601
+
+@ExperimentalResourceApi
+internal val Res.string.str_17602: StringResource
+  get() = String16.str_17602
+
+@ExperimentalResourceApi
+internal val Res.string.str_17603: StringResource
+  get() = String16.str_17603
+
+@ExperimentalResourceApi
+internal val Res.string.str_17604: StringResource
+  get() = String16.str_17604
+
+@ExperimentalResourceApi
+internal val Res.string.str_17605: StringResource
+  get() = String16.str_17605
+
+@ExperimentalResourceApi
+internal val Res.string.str_17606: StringResource
+  get() = String16.str_17606
+
+@ExperimentalResourceApi
+internal val Res.string.str_17607: StringResource
+  get() = String16.str_17607
+
+@ExperimentalResourceApi
+internal val Res.string.str_17608: StringResource
+  get() = String16.str_17608
+
+@ExperimentalResourceApi
+internal val Res.string.str_17609: StringResource
+  get() = String16.str_17609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1761: StringResource
+  get() = String16.str_1761
+
+@ExperimentalResourceApi
+internal val Res.string.str_17610: StringResource
+  get() = String16.str_17610
+
+@ExperimentalResourceApi
+internal val Res.string.str_17611: StringResource
+  get() = String16.str_17611
+
+@ExperimentalResourceApi
+internal val Res.string.str_17612: StringResource
+  get() = String16.str_17612
+
+@ExperimentalResourceApi
+internal val Res.string.str_17613: StringResource
+  get() = String16.str_17613
+
+@ExperimentalResourceApi
+internal val Res.string.str_17614: StringResource
+  get() = String16.str_17614
+
+@ExperimentalResourceApi
+internal val Res.string.str_17615: StringResource
+  get() = String16.str_17615
+
+@ExperimentalResourceApi
+internal val Res.string.str_17616: StringResource
+  get() = String16.str_17616
+
+@ExperimentalResourceApi
+internal val Res.string.str_17617: StringResource
+  get() = String16.str_17617
+
+@ExperimentalResourceApi
+internal val Res.string.str_17618: StringResource
+  get() = String16.str_17618
+
+@ExperimentalResourceApi
+internal val Res.string.str_17619: StringResource
+  get() = String16.str_17619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1762: StringResource
+  get() = String16.str_1762
+
+@ExperimentalResourceApi
+internal val Res.string.str_17620: StringResource
+  get() = String16.str_17620
+
+@ExperimentalResourceApi
+internal val Res.string.str_17621: StringResource
+  get() = String16.str_17621
+
+@ExperimentalResourceApi
+internal val Res.string.str_17622: StringResource
+  get() = String16.str_17622
+
+@ExperimentalResourceApi
+internal val Res.string.str_17623: StringResource
+  get() = String16.str_17623
+
+@ExperimentalResourceApi
+internal val Res.string.str_17624: StringResource
+  get() = String16.str_17624
+
+@ExperimentalResourceApi
+internal val Res.string.str_17625: StringResource
+  get() = String16.str_17625
+
+@ExperimentalResourceApi
+internal val Res.string.str_17626: StringResource
+  get() = String16.str_17626
+
+@ExperimentalResourceApi
+internal val Res.string.str_17627: StringResource
+  get() = String16.str_17627
+
+@ExperimentalResourceApi
+internal val Res.string.str_17628: StringResource
+  get() = String16.str_17628
+
+@ExperimentalResourceApi
+internal val Res.string.str_17629: StringResource
+  get() = String16.str_17629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1763: StringResource
+  get() = String16.str_1763
+
+@ExperimentalResourceApi
+internal val Res.string.str_17630: StringResource
+  get() = String16.str_17630
+
+@ExperimentalResourceApi
+internal val Res.string.str_17631: StringResource
+  get() = String16.str_17631
+
+@ExperimentalResourceApi
+internal val Res.string.str_17632: StringResource
+  get() = String16.str_17632
+
+@ExperimentalResourceApi
+internal val Res.string.str_17633: StringResource
+  get() = String16.str_17633
+
+@ExperimentalResourceApi
+internal val Res.string.str_17634: StringResource
+  get() = String16.str_17634
+
+@ExperimentalResourceApi
+internal val Res.string.str_17635: StringResource
+  get() = String16.str_17635
+
+@ExperimentalResourceApi
+internal val Res.string.str_17636: StringResource
+  get() = String16.str_17636
+
+@ExperimentalResourceApi
+internal val Res.string.str_17637: StringResource
+  get() = String16.str_17637
+
+@ExperimentalResourceApi
+internal val Res.string.str_17638: StringResource
+  get() = String16.str_17638
+
+@ExperimentalResourceApi
+internal val Res.string.str_17639: StringResource
+  get() = String16.str_17639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1764: StringResource
+  get() = String16.str_1764
+
+@ExperimentalResourceApi
+internal val Res.string.str_17640: StringResource
+  get() = String16.str_17640
+
+@ExperimentalResourceApi
+internal val Res.string.str_17641: StringResource
+  get() = String16.str_17641
+
+@ExperimentalResourceApi
+internal val Res.string.str_17642: StringResource
+  get() = String16.str_17642
+
+@ExperimentalResourceApi
+internal val Res.string.str_17643: StringResource
+  get() = String16.str_17643
+
+@ExperimentalResourceApi
+internal val Res.string.str_17644: StringResource
+  get() = String16.str_17644
+
+@ExperimentalResourceApi
+internal val Res.string.str_17645: StringResource
+  get() = String16.str_17645
+
+@ExperimentalResourceApi
+internal val Res.string.str_17646: StringResource
+  get() = String16.str_17646
+
+@ExperimentalResourceApi
+internal val Res.string.str_17647: StringResource
+  get() = String16.str_17647

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String17.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String17.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String17 {
+  public val str_17648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17648", "str_17648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17649", "str_17649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1765", "str_1765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17650", "str_17650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17651", "str_17651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17652", "str_17652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17653", "str_17653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17654", "str_17654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17655", "str_17655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17656", "str_17656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17657", "str_17657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17658", "str_17658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17659", "str_17659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1766", "str_1766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17660", "str_17660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17661", "str_17661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17662", "str_17662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17663", "str_17663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17664", "str_17664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17665", "str_17665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17666", "str_17666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17667", "str_17667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17668", "str_17668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17669", "str_17669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1767", "str_1767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17670", "str_17670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17671", "str_17671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17672", "str_17672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17673", "str_17673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17674", "str_17674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17675", "str_17675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17676", "str_17676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17677", "str_17677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17678", "str_17678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17679", "str_17679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1768", "str_1768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17680", "str_17680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17681", "str_17681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17682", "str_17682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17683", "str_17683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17684", "str_17684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17685", "str_17685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17686", "str_17686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17687", "str_17687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17688", "str_17688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17689", "str_17689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1769", "str_1769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17690", "str_17690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17691", "str_17691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17692", "str_17692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17693", "str_17693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17694", "str_17694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17695", "str_17695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17696", "str_17696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17697", "str_17697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17698", "str_17698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17699", "str_17699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_177", "str_177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1770", "str_1770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17700", "str_17700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17701", "str_17701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17702", "str_17702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17703", "str_17703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17704", "str_17704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17705", "str_17705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17706", "str_17706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17707", "str_17707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17708", "str_17708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17709", "str_17709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1771", "str_1771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17710", "str_17710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17711", "str_17711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17712", "str_17712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17713", "str_17713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17714", "str_17714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17715", "str_17715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17716", "str_17716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17717", "str_17717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17718", "str_17718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17719", "str_17719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1772", "str_1772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17720", "str_17720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17721", "str_17721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17722", "str_17722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17723", "str_17723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17724", "str_17724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17725", "str_17725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17726", "str_17726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17727", "str_17727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17728", "str_17728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17729", "str_17729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1773", "str_1773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17730", "str_17730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17731", "str_17731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17732", "str_17732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17733", "str_17733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17734", "str_17734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17735", "str_17735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17736", "str_17736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17737", "str_17737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17738", "str_17738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17739", "str_17739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1774", "str_1774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17740", "str_17740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17741", "str_17741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17742", "str_17742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17743", "str_17743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17744", "str_17744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17745", "str_17745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17746", "str_17746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17747", "str_17747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17748", "str_17748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17749", "str_17749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1775", "str_1775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17750", "str_17750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17751", "str_17751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17752", "str_17752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17753", "str_17753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17754", "str_17754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17755", "str_17755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17756", "str_17756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17757", "str_17757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17758", "str_17758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17759", "str_17759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1776", "str_1776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17760", "str_17760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17761", "str_17761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17762", "str_17762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17763", "str_17763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17764", "str_17764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17765", "str_17765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17766", "str_17766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17767", "str_17767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17768", "str_17768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17769", "str_17769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1777", "str_1777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17770", "str_17770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17771", "str_17771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17772", "str_17772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17773", "str_17773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17774", "str_17774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17775", "str_17775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17776", "str_17776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17777", "str_17777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17778", "str_17778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17779", "str_17779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1778", "str_1778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17780", "str_17780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17781", "str_17781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17782", "str_17782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17783", "str_17783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17784", "str_17784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17785", "str_17785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17786", "str_17786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17787", "str_17787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17788", "str_17788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17789", "str_17789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1779", "str_1779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17790", "str_17790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17791", "str_17791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17792", "str_17792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17793", "str_17793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17794", "str_17794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17795", "str_17795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17796", "str_17796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17797", "str_17797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17798", "str_17798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17799", "str_17799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_178", "str_178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1780", "str_1780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17800", "str_17800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17801", "str_17801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17802", "str_17802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17803", "str_17803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17804", "str_17804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17805", "str_17805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17806", "str_17806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17807", "str_17807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17808", "str_17808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17809", "str_17809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1781", "str_1781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17810", "str_17810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17811", "str_17811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17812", "str_17812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17813", "str_17813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17814", "str_17814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17815", "str_17815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17816", "str_17816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17817", "str_17817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17818", "str_17818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17819", "str_17819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1782", "str_1782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17820", "str_17820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17821", "str_17821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17822", "str_17822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17823", "str_17823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17824", "str_17824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17825", "str_17825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17826", "str_17826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17827", "str_17827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17828", "str_17828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17829", "str_17829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1783", "str_1783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17830", "str_17830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17831", "str_17831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17832", "str_17832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17833", "str_17833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17834", "str_17834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17835", "str_17835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17836", "str_17836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17837", "str_17837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17838", "str_17838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17839", "str_17839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1784", "str_1784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17840", "str_17840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17841", "str_17841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17842", "str_17842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17843", "str_17843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17844", "str_17844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17845", "str_17845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17846", "str_17846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17847", "str_17847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17848", "str_17848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17849", "str_17849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1785", "str_1785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17850", "str_17850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17851", "str_17851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17852", "str_17852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17853", "str_17853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17854", "str_17854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17855", "str_17855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17856", "str_17856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17857", "str_17857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17858", "str_17858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17859", "str_17859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1786", "str_1786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17860", "str_17860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17861", "str_17861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17862", "str_17862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17863", "str_17863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17864", "str_17864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17865", "str_17865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17866", "str_17866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17867", "str_17867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17868", "str_17868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17869", "str_17869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1787", "str_1787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17870", "str_17870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17871", "str_17871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17872", "str_17872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17873", "str_17873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17874", "str_17874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17875", "str_17875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17876", "str_17876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17877", "str_17877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17878", "str_17878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17879", "str_17879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1788", "str_1788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17880", "str_17880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17881", "str_17881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17882", "str_17882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17883", "str_17883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17884", "str_17884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17885", "str_17885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17886", "str_17886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17887", "str_17887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17888", "str_17888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17889", "str_17889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1789", "str_1789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17890", "str_17890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17891", "str_17891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17892", "str_17892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17893", "str_17893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17894", "str_17894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17895", "str_17895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17896", "str_17896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17897", "str_17897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17898", "str_17898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17899", "str_17899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_179", "str_179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1790", "str_1790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17900", "str_17900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17901", "str_17901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17902", "str_17902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17903", "str_17903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17904", "str_17904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17905", "str_17905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17906", "str_17906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17907", "str_17907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17908", "str_17908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17909", "str_17909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1791", "str_1791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17910", "str_17910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17911", "str_17911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17912", "str_17912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17913", "str_17913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17914", "str_17914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17915", "str_17915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17916", "str_17916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17917", "str_17917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17918", "str_17918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17919", "str_17919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1792", "str_1792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17920", "str_17920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17921", "str_17921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17922", "str_17922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17923", "str_17923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17924", "str_17924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17925", "str_17925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17926", "str_17926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17927", "str_17927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17928", "str_17928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17929", "str_17929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1793", "str_1793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17930", "str_17930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17931", "str_17931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17932", "str_17932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17933", "str_17933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17934", "str_17934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17935", "str_17935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17936", "str_17936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17937", "str_17937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17938", "str_17938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17939", "str_17939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1794", "str_1794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17940", "str_17940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17941", "str_17941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17942", "str_17942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17943", "str_17943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17944", "str_17944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17945", "str_17945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17946", "str_17946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17947", "str_17947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17948", "str_17948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17949", "str_17949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1795", "str_1795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17950", "str_17950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17951", "str_17951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17952", "str_17952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17953", "str_17953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17954", "str_17954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17955", "str_17955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17956", "str_17956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17957", "str_17957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17958", "str_17958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17959", "str_17959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1796", "str_1796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17960", "str_17960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17961", "str_17961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17962", "str_17962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17963", "str_17963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17964", "str_17964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17965", "str_17965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17966", "str_17966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17967", "str_17967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17968", "str_17968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17969", "str_17969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1797", "str_1797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17970", "str_17970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17971", "str_17971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17972", "str_17972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17973", "str_17973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17974", "str_17974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17975", "str_17975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17976", "str_17976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17977", "str_17977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17978", "str_17978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17979", "str_17979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1798", "str_1798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17980", "str_17980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17981", "str_17981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17982", "str_17982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17983", "str_17983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17984", "str_17984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17985", "str_17985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17986", "str_17986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17987", "str_17987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17988", "str_17988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17989", "str_17989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1799", "str_1799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17990", "str_17990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17991", "str_17991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17992", "str_17992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17993", "str_17993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17994", "str_17994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17995", "str_17995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17996", "str_17996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17997", "str_17997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17998", "str_17998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_17999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_17999", "str_17999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18", "str_18",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_180", "str_180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1800", "str_1800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18000", "str_18000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18001", "str_18001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18002", "str_18002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18003", "str_18003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18004", "str_18004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18005", "str_18005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18006", "str_18006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18007", "str_18007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18008", "str_18008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18009", "str_18009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1801", "str_1801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18010", "str_18010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18011", "str_18011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18012", "str_18012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18013", "str_18013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18014", "str_18014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18015", "str_18015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18016", "str_18016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18017", "str_18017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18018", "str_18018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18019", "str_18019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1802", "str_1802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18020", "str_18020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18021", "str_18021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18022", "str_18022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18023", "str_18023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18024", "str_18024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18025", "str_18025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18026", "str_18026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18027", "str_18027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18028", "str_18028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18029", "str_18029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1803", "str_1803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18030", "str_18030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18031", "str_18031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18032", "str_18032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18033", "str_18033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18034", "str_18034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18035", "str_18035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18036", "str_18036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18037", "str_18037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18038", "str_18038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18039", "str_18039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1804", "str_1804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18040", "str_18040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18041", "str_18041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18042", "str_18042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18043", "str_18043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18044", "str_18044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18045", "str_18045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18046", "str_18046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18047", "str_18047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18048", "str_18048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18049", "str_18049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1805", "str_1805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18050", "str_18050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18051", "str_18051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18052", "str_18052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18053", "str_18053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18054", "str_18054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18055", "str_18055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18056", "str_18056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18057", "str_18057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18058", "str_18058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18059", "str_18059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1806", "str_1806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18060", "str_18060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18061", "str_18061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18062", "str_18062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18063", "str_18063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18064", "str_18064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18065", "str_18065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18066", "str_18066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18067", "str_18067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18068", "str_18068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18069", "str_18069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1807", "str_1807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18070", "str_18070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18071", "str_18071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18072", "str_18072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18073", "str_18073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18074", "str_18074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18075", "str_18075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18076", "str_18076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18077", "str_18077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18078", "str_18078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18079", "str_18079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1808", "str_1808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18080", "str_18080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18081", "str_18081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18082", "str_18082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18083", "str_18083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18084", "str_18084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18085", "str_18085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18086", "str_18086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18087", "str_18087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18088", "str_18088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18089", "str_18089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1809", "str_1809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18090", "str_18090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18091", "str_18091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18092", "str_18092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18093", "str_18093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18094", "str_18094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18095", "str_18095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18096", "str_18096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18097", "str_18097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_17648: StringResource
+  get() = String17.str_17648
+
+@ExperimentalResourceApi
+internal val Res.string.str_17649: StringResource
+  get() = String17.str_17649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1765: StringResource
+  get() = String17.str_1765
+
+@ExperimentalResourceApi
+internal val Res.string.str_17650: StringResource
+  get() = String17.str_17650
+
+@ExperimentalResourceApi
+internal val Res.string.str_17651: StringResource
+  get() = String17.str_17651
+
+@ExperimentalResourceApi
+internal val Res.string.str_17652: StringResource
+  get() = String17.str_17652
+
+@ExperimentalResourceApi
+internal val Res.string.str_17653: StringResource
+  get() = String17.str_17653
+
+@ExperimentalResourceApi
+internal val Res.string.str_17654: StringResource
+  get() = String17.str_17654
+
+@ExperimentalResourceApi
+internal val Res.string.str_17655: StringResource
+  get() = String17.str_17655
+
+@ExperimentalResourceApi
+internal val Res.string.str_17656: StringResource
+  get() = String17.str_17656
+
+@ExperimentalResourceApi
+internal val Res.string.str_17657: StringResource
+  get() = String17.str_17657
+
+@ExperimentalResourceApi
+internal val Res.string.str_17658: StringResource
+  get() = String17.str_17658
+
+@ExperimentalResourceApi
+internal val Res.string.str_17659: StringResource
+  get() = String17.str_17659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1766: StringResource
+  get() = String17.str_1766
+
+@ExperimentalResourceApi
+internal val Res.string.str_17660: StringResource
+  get() = String17.str_17660
+
+@ExperimentalResourceApi
+internal val Res.string.str_17661: StringResource
+  get() = String17.str_17661
+
+@ExperimentalResourceApi
+internal val Res.string.str_17662: StringResource
+  get() = String17.str_17662
+
+@ExperimentalResourceApi
+internal val Res.string.str_17663: StringResource
+  get() = String17.str_17663
+
+@ExperimentalResourceApi
+internal val Res.string.str_17664: StringResource
+  get() = String17.str_17664
+
+@ExperimentalResourceApi
+internal val Res.string.str_17665: StringResource
+  get() = String17.str_17665
+
+@ExperimentalResourceApi
+internal val Res.string.str_17666: StringResource
+  get() = String17.str_17666
+
+@ExperimentalResourceApi
+internal val Res.string.str_17667: StringResource
+  get() = String17.str_17667
+
+@ExperimentalResourceApi
+internal val Res.string.str_17668: StringResource
+  get() = String17.str_17668
+
+@ExperimentalResourceApi
+internal val Res.string.str_17669: StringResource
+  get() = String17.str_17669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1767: StringResource
+  get() = String17.str_1767
+
+@ExperimentalResourceApi
+internal val Res.string.str_17670: StringResource
+  get() = String17.str_17670
+
+@ExperimentalResourceApi
+internal val Res.string.str_17671: StringResource
+  get() = String17.str_17671
+
+@ExperimentalResourceApi
+internal val Res.string.str_17672: StringResource
+  get() = String17.str_17672
+
+@ExperimentalResourceApi
+internal val Res.string.str_17673: StringResource
+  get() = String17.str_17673
+
+@ExperimentalResourceApi
+internal val Res.string.str_17674: StringResource
+  get() = String17.str_17674
+
+@ExperimentalResourceApi
+internal val Res.string.str_17675: StringResource
+  get() = String17.str_17675
+
+@ExperimentalResourceApi
+internal val Res.string.str_17676: StringResource
+  get() = String17.str_17676
+
+@ExperimentalResourceApi
+internal val Res.string.str_17677: StringResource
+  get() = String17.str_17677
+
+@ExperimentalResourceApi
+internal val Res.string.str_17678: StringResource
+  get() = String17.str_17678
+
+@ExperimentalResourceApi
+internal val Res.string.str_17679: StringResource
+  get() = String17.str_17679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1768: StringResource
+  get() = String17.str_1768
+
+@ExperimentalResourceApi
+internal val Res.string.str_17680: StringResource
+  get() = String17.str_17680
+
+@ExperimentalResourceApi
+internal val Res.string.str_17681: StringResource
+  get() = String17.str_17681
+
+@ExperimentalResourceApi
+internal val Res.string.str_17682: StringResource
+  get() = String17.str_17682
+
+@ExperimentalResourceApi
+internal val Res.string.str_17683: StringResource
+  get() = String17.str_17683
+
+@ExperimentalResourceApi
+internal val Res.string.str_17684: StringResource
+  get() = String17.str_17684
+
+@ExperimentalResourceApi
+internal val Res.string.str_17685: StringResource
+  get() = String17.str_17685
+
+@ExperimentalResourceApi
+internal val Res.string.str_17686: StringResource
+  get() = String17.str_17686
+
+@ExperimentalResourceApi
+internal val Res.string.str_17687: StringResource
+  get() = String17.str_17687
+
+@ExperimentalResourceApi
+internal val Res.string.str_17688: StringResource
+  get() = String17.str_17688
+
+@ExperimentalResourceApi
+internal val Res.string.str_17689: StringResource
+  get() = String17.str_17689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1769: StringResource
+  get() = String17.str_1769
+
+@ExperimentalResourceApi
+internal val Res.string.str_17690: StringResource
+  get() = String17.str_17690
+
+@ExperimentalResourceApi
+internal val Res.string.str_17691: StringResource
+  get() = String17.str_17691
+
+@ExperimentalResourceApi
+internal val Res.string.str_17692: StringResource
+  get() = String17.str_17692
+
+@ExperimentalResourceApi
+internal val Res.string.str_17693: StringResource
+  get() = String17.str_17693
+
+@ExperimentalResourceApi
+internal val Res.string.str_17694: StringResource
+  get() = String17.str_17694
+
+@ExperimentalResourceApi
+internal val Res.string.str_17695: StringResource
+  get() = String17.str_17695
+
+@ExperimentalResourceApi
+internal val Res.string.str_17696: StringResource
+  get() = String17.str_17696
+
+@ExperimentalResourceApi
+internal val Res.string.str_17697: StringResource
+  get() = String17.str_17697
+
+@ExperimentalResourceApi
+internal val Res.string.str_17698: StringResource
+  get() = String17.str_17698
+
+@ExperimentalResourceApi
+internal val Res.string.str_17699: StringResource
+  get() = String17.str_17699
+
+@ExperimentalResourceApi
+internal val Res.string.str_177: StringResource
+  get() = String17.str_177
+
+@ExperimentalResourceApi
+internal val Res.string.str_1770: StringResource
+  get() = String17.str_1770
+
+@ExperimentalResourceApi
+internal val Res.string.str_17700: StringResource
+  get() = String17.str_17700
+
+@ExperimentalResourceApi
+internal val Res.string.str_17701: StringResource
+  get() = String17.str_17701
+
+@ExperimentalResourceApi
+internal val Res.string.str_17702: StringResource
+  get() = String17.str_17702
+
+@ExperimentalResourceApi
+internal val Res.string.str_17703: StringResource
+  get() = String17.str_17703
+
+@ExperimentalResourceApi
+internal val Res.string.str_17704: StringResource
+  get() = String17.str_17704
+
+@ExperimentalResourceApi
+internal val Res.string.str_17705: StringResource
+  get() = String17.str_17705
+
+@ExperimentalResourceApi
+internal val Res.string.str_17706: StringResource
+  get() = String17.str_17706
+
+@ExperimentalResourceApi
+internal val Res.string.str_17707: StringResource
+  get() = String17.str_17707
+
+@ExperimentalResourceApi
+internal val Res.string.str_17708: StringResource
+  get() = String17.str_17708
+
+@ExperimentalResourceApi
+internal val Res.string.str_17709: StringResource
+  get() = String17.str_17709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1771: StringResource
+  get() = String17.str_1771
+
+@ExperimentalResourceApi
+internal val Res.string.str_17710: StringResource
+  get() = String17.str_17710
+
+@ExperimentalResourceApi
+internal val Res.string.str_17711: StringResource
+  get() = String17.str_17711
+
+@ExperimentalResourceApi
+internal val Res.string.str_17712: StringResource
+  get() = String17.str_17712
+
+@ExperimentalResourceApi
+internal val Res.string.str_17713: StringResource
+  get() = String17.str_17713
+
+@ExperimentalResourceApi
+internal val Res.string.str_17714: StringResource
+  get() = String17.str_17714
+
+@ExperimentalResourceApi
+internal val Res.string.str_17715: StringResource
+  get() = String17.str_17715
+
+@ExperimentalResourceApi
+internal val Res.string.str_17716: StringResource
+  get() = String17.str_17716
+
+@ExperimentalResourceApi
+internal val Res.string.str_17717: StringResource
+  get() = String17.str_17717
+
+@ExperimentalResourceApi
+internal val Res.string.str_17718: StringResource
+  get() = String17.str_17718
+
+@ExperimentalResourceApi
+internal val Res.string.str_17719: StringResource
+  get() = String17.str_17719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1772: StringResource
+  get() = String17.str_1772
+
+@ExperimentalResourceApi
+internal val Res.string.str_17720: StringResource
+  get() = String17.str_17720
+
+@ExperimentalResourceApi
+internal val Res.string.str_17721: StringResource
+  get() = String17.str_17721
+
+@ExperimentalResourceApi
+internal val Res.string.str_17722: StringResource
+  get() = String17.str_17722
+
+@ExperimentalResourceApi
+internal val Res.string.str_17723: StringResource
+  get() = String17.str_17723
+
+@ExperimentalResourceApi
+internal val Res.string.str_17724: StringResource
+  get() = String17.str_17724
+
+@ExperimentalResourceApi
+internal val Res.string.str_17725: StringResource
+  get() = String17.str_17725
+
+@ExperimentalResourceApi
+internal val Res.string.str_17726: StringResource
+  get() = String17.str_17726
+
+@ExperimentalResourceApi
+internal val Res.string.str_17727: StringResource
+  get() = String17.str_17727
+
+@ExperimentalResourceApi
+internal val Res.string.str_17728: StringResource
+  get() = String17.str_17728
+
+@ExperimentalResourceApi
+internal val Res.string.str_17729: StringResource
+  get() = String17.str_17729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1773: StringResource
+  get() = String17.str_1773
+
+@ExperimentalResourceApi
+internal val Res.string.str_17730: StringResource
+  get() = String17.str_17730
+
+@ExperimentalResourceApi
+internal val Res.string.str_17731: StringResource
+  get() = String17.str_17731
+
+@ExperimentalResourceApi
+internal val Res.string.str_17732: StringResource
+  get() = String17.str_17732
+
+@ExperimentalResourceApi
+internal val Res.string.str_17733: StringResource
+  get() = String17.str_17733
+
+@ExperimentalResourceApi
+internal val Res.string.str_17734: StringResource
+  get() = String17.str_17734
+
+@ExperimentalResourceApi
+internal val Res.string.str_17735: StringResource
+  get() = String17.str_17735
+
+@ExperimentalResourceApi
+internal val Res.string.str_17736: StringResource
+  get() = String17.str_17736
+
+@ExperimentalResourceApi
+internal val Res.string.str_17737: StringResource
+  get() = String17.str_17737
+
+@ExperimentalResourceApi
+internal val Res.string.str_17738: StringResource
+  get() = String17.str_17738
+
+@ExperimentalResourceApi
+internal val Res.string.str_17739: StringResource
+  get() = String17.str_17739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1774: StringResource
+  get() = String17.str_1774
+
+@ExperimentalResourceApi
+internal val Res.string.str_17740: StringResource
+  get() = String17.str_17740
+
+@ExperimentalResourceApi
+internal val Res.string.str_17741: StringResource
+  get() = String17.str_17741
+
+@ExperimentalResourceApi
+internal val Res.string.str_17742: StringResource
+  get() = String17.str_17742
+
+@ExperimentalResourceApi
+internal val Res.string.str_17743: StringResource
+  get() = String17.str_17743
+
+@ExperimentalResourceApi
+internal val Res.string.str_17744: StringResource
+  get() = String17.str_17744
+
+@ExperimentalResourceApi
+internal val Res.string.str_17745: StringResource
+  get() = String17.str_17745
+
+@ExperimentalResourceApi
+internal val Res.string.str_17746: StringResource
+  get() = String17.str_17746
+
+@ExperimentalResourceApi
+internal val Res.string.str_17747: StringResource
+  get() = String17.str_17747
+
+@ExperimentalResourceApi
+internal val Res.string.str_17748: StringResource
+  get() = String17.str_17748
+
+@ExperimentalResourceApi
+internal val Res.string.str_17749: StringResource
+  get() = String17.str_17749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1775: StringResource
+  get() = String17.str_1775
+
+@ExperimentalResourceApi
+internal val Res.string.str_17750: StringResource
+  get() = String17.str_17750
+
+@ExperimentalResourceApi
+internal val Res.string.str_17751: StringResource
+  get() = String17.str_17751
+
+@ExperimentalResourceApi
+internal val Res.string.str_17752: StringResource
+  get() = String17.str_17752
+
+@ExperimentalResourceApi
+internal val Res.string.str_17753: StringResource
+  get() = String17.str_17753
+
+@ExperimentalResourceApi
+internal val Res.string.str_17754: StringResource
+  get() = String17.str_17754
+
+@ExperimentalResourceApi
+internal val Res.string.str_17755: StringResource
+  get() = String17.str_17755
+
+@ExperimentalResourceApi
+internal val Res.string.str_17756: StringResource
+  get() = String17.str_17756
+
+@ExperimentalResourceApi
+internal val Res.string.str_17757: StringResource
+  get() = String17.str_17757
+
+@ExperimentalResourceApi
+internal val Res.string.str_17758: StringResource
+  get() = String17.str_17758
+
+@ExperimentalResourceApi
+internal val Res.string.str_17759: StringResource
+  get() = String17.str_17759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1776: StringResource
+  get() = String17.str_1776
+
+@ExperimentalResourceApi
+internal val Res.string.str_17760: StringResource
+  get() = String17.str_17760
+
+@ExperimentalResourceApi
+internal val Res.string.str_17761: StringResource
+  get() = String17.str_17761
+
+@ExperimentalResourceApi
+internal val Res.string.str_17762: StringResource
+  get() = String17.str_17762
+
+@ExperimentalResourceApi
+internal val Res.string.str_17763: StringResource
+  get() = String17.str_17763
+
+@ExperimentalResourceApi
+internal val Res.string.str_17764: StringResource
+  get() = String17.str_17764
+
+@ExperimentalResourceApi
+internal val Res.string.str_17765: StringResource
+  get() = String17.str_17765
+
+@ExperimentalResourceApi
+internal val Res.string.str_17766: StringResource
+  get() = String17.str_17766
+
+@ExperimentalResourceApi
+internal val Res.string.str_17767: StringResource
+  get() = String17.str_17767
+
+@ExperimentalResourceApi
+internal val Res.string.str_17768: StringResource
+  get() = String17.str_17768
+
+@ExperimentalResourceApi
+internal val Res.string.str_17769: StringResource
+  get() = String17.str_17769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1777: StringResource
+  get() = String17.str_1777
+
+@ExperimentalResourceApi
+internal val Res.string.str_17770: StringResource
+  get() = String17.str_17770
+
+@ExperimentalResourceApi
+internal val Res.string.str_17771: StringResource
+  get() = String17.str_17771
+
+@ExperimentalResourceApi
+internal val Res.string.str_17772: StringResource
+  get() = String17.str_17772
+
+@ExperimentalResourceApi
+internal val Res.string.str_17773: StringResource
+  get() = String17.str_17773
+
+@ExperimentalResourceApi
+internal val Res.string.str_17774: StringResource
+  get() = String17.str_17774
+
+@ExperimentalResourceApi
+internal val Res.string.str_17775: StringResource
+  get() = String17.str_17775
+
+@ExperimentalResourceApi
+internal val Res.string.str_17776: StringResource
+  get() = String17.str_17776
+
+@ExperimentalResourceApi
+internal val Res.string.str_17777: StringResource
+  get() = String17.str_17777
+
+@ExperimentalResourceApi
+internal val Res.string.str_17778: StringResource
+  get() = String17.str_17778
+
+@ExperimentalResourceApi
+internal val Res.string.str_17779: StringResource
+  get() = String17.str_17779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1778: StringResource
+  get() = String17.str_1778
+
+@ExperimentalResourceApi
+internal val Res.string.str_17780: StringResource
+  get() = String17.str_17780
+
+@ExperimentalResourceApi
+internal val Res.string.str_17781: StringResource
+  get() = String17.str_17781
+
+@ExperimentalResourceApi
+internal val Res.string.str_17782: StringResource
+  get() = String17.str_17782
+
+@ExperimentalResourceApi
+internal val Res.string.str_17783: StringResource
+  get() = String17.str_17783
+
+@ExperimentalResourceApi
+internal val Res.string.str_17784: StringResource
+  get() = String17.str_17784
+
+@ExperimentalResourceApi
+internal val Res.string.str_17785: StringResource
+  get() = String17.str_17785
+
+@ExperimentalResourceApi
+internal val Res.string.str_17786: StringResource
+  get() = String17.str_17786
+
+@ExperimentalResourceApi
+internal val Res.string.str_17787: StringResource
+  get() = String17.str_17787
+
+@ExperimentalResourceApi
+internal val Res.string.str_17788: StringResource
+  get() = String17.str_17788
+
+@ExperimentalResourceApi
+internal val Res.string.str_17789: StringResource
+  get() = String17.str_17789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1779: StringResource
+  get() = String17.str_1779
+
+@ExperimentalResourceApi
+internal val Res.string.str_17790: StringResource
+  get() = String17.str_17790
+
+@ExperimentalResourceApi
+internal val Res.string.str_17791: StringResource
+  get() = String17.str_17791
+
+@ExperimentalResourceApi
+internal val Res.string.str_17792: StringResource
+  get() = String17.str_17792
+
+@ExperimentalResourceApi
+internal val Res.string.str_17793: StringResource
+  get() = String17.str_17793
+
+@ExperimentalResourceApi
+internal val Res.string.str_17794: StringResource
+  get() = String17.str_17794
+
+@ExperimentalResourceApi
+internal val Res.string.str_17795: StringResource
+  get() = String17.str_17795
+
+@ExperimentalResourceApi
+internal val Res.string.str_17796: StringResource
+  get() = String17.str_17796
+
+@ExperimentalResourceApi
+internal val Res.string.str_17797: StringResource
+  get() = String17.str_17797
+
+@ExperimentalResourceApi
+internal val Res.string.str_17798: StringResource
+  get() = String17.str_17798
+
+@ExperimentalResourceApi
+internal val Res.string.str_17799: StringResource
+  get() = String17.str_17799
+
+@ExperimentalResourceApi
+internal val Res.string.str_178: StringResource
+  get() = String17.str_178
+
+@ExperimentalResourceApi
+internal val Res.string.str_1780: StringResource
+  get() = String17.str_1780
+
+@ExperimentalResourceApi
+internal val Res.string.str_17800: StringResource
+  get() = String17.str_17800
+
+@ExperimentalResourceApi
+internal val Res.string.str_17801: StringResource
+  get() = String17.str_17801
+
+@ExperimentalResourceApi
+internal val Res.string.str_17802: StringResource
+  get() = String17.str_17802
+
+@ExperimentalResourceApi
+internal val Res.string.str_17803: StringResource
+  get() = String17.str_17803
+
+@ExperimentalResourceApi
+internal val Res.string.str_17804: StringResource
+  get() = String17.str_17804
+
+@ExperimentalResourceApi
+internal val Res.string.str_17805: StringResource
+  get() = String17.str_17805
+
+@ExperimentalResourceApi
+internal val Res.string.str_17806: StringResource
+  get() = String17.str_17806
+
+@ExperimentalResourceApi
+internal val Res.string.str_17807: StringResource
+  get() = String17.str_17807
+
+@ExperimentalResourceApi
+internal val Res.string.str_17808: StringResource
+  get() = String17.str_17808
+
+@ExperimentalResourceApi
+internal val Res.string.str_17809: StringResource
+  get() = String17.str_17809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1781: StringResource
+  get() = String17.str_1781
+
+@ExperimentalResourceApi
+internal val Res.string.str_17810: StringResource
+  get() = String17.str_17810
+
+@ExperimentalResourceApi
+internal val Res.string.str_17811: StringResource
+  get() = String17.str_17811
+
+@ExperimentalResourceApi
+internal val Res.string.str_17812: StringResource
+  get() = String17.str_17812
+
+@ExperimentalResourceApi
+internal val Res.string.str_17813: StringResource
+  get() = String17.str_17813
+
+@ExperimentalResourceApi
+internal val Res.string.str_17814: StringResource
+  get() = String17.str_17814
+
+@ExperimentalResourceApi
+internal val Res.string.str_17815: StringResource
+  get() = String17.str_17815
+
+@ExperimentalResourceApi
+internal val Res.string.str_17816: StringResource
+  get() = String17.str_17816
+
+@ExperimentalResourceApi
+internal val Res.string.str_17817: StringResource
+  get() = String17.str_17817
+
+@ExperimentalResourceApi
+internal val Res.string.str_17818: StringResource
+  get() = String17.str_17818
+
+@ExperimentalResourceApi
+internal val Res.string.str_17819: StringResource
+  get() = String17.str_17819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1782: StringResource
+  get() = String17.str_1782
+
+@ExperimentalResourceApi
+internal val Res.string.str_17820: StringResource
+  get() = String17.str_17820
+
+@ExperimentalResourceApi
+internal val Res.string.str_17821: StringResource
+  get() = String17.str_17821
+
+@ExperimentalResourceApi
+internal val Res.string.str_17822: StringResource
+  get() = String17.str_17822
+
+@ExperimentalResourceApi
+internal val Res.string.str_17823: StringResource
+  get() = String17.str_17823
+
+@ExperimentalResourceApi
+internal val Res.string.str_17824: StringResource
+  get() = String17.str_17824
+
+@ExperimentalResourceApi
+internal val Res.string.str_17825: StringResource
+  get() = String17.str_17825
+
+@ExperimentalResourceApi
+internal val Res.string.str_17826: StringResource
+  get() = String17.str_17826
+
+@ExperimentalResourceApi
+internal val Res.string.str_17827: StringResource
+  get() = String17.str_17827
+
+@ExperimentalResourceApi
+internal val Res.string.str_17828: StringResource
+  get() = String17.str_17828
+
+@ExperimentalResourceApi
+internal val Res.string.str_17829: StringResource
+  get() = String17.str_17829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1783: StringResource
+  get() = String17.str_1783
+
+@ExperimentalResourceApi
+internal val Res.string.str_17830: StringResource
+  get() = String17.str_17830
+
+@ExperimentalResourceApi
+internal val Res.string.str_17831: StringResource
+  get() = String17.str_17831
+
+@ExperimentalResourceApi
+internal val Res.string.str_17832: StringResource
+  get() = String17.str_17832
+
+@ExperimentalResourceApi
+internal val Res.string.str_17833: StringResource
+  get() = String17.str_17833
+
+@ExperimentalResourceApi
+internal val Res.string.str_17834: StringResource
+  get() = String17.str_17834
+
+@ExperimentalResourceApi
+internal val Res.string.str_17835: StringResource
+  get() = String17.str_17835
+
+@ExperimentalResourceApi
+internal val Res.string.str_17836: StringResource
+  get() = String17.str_17836
+
+@ExperimentalResourceApi
+internal val Res.string.str_17837: StringResource
+  get() = String17.str_17837
+
+@ExperimentalResourceApi
+internal val Res.string.str_17838: StringResource
+  get() = String17.str_17838
+
+@ExperimentalResourceApi
+internal val Res.string.str_17839: StringResource
+  get() = String17.str_17839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1784: StringResource
+  get() = String17.str_1784
+
+@ExperimentalResourceApi
+internal val Res.string.str_17840: StringResource
+  get() = String17.str_17840
+
+@ExperimentalResourceApi
+internal val Res.string.str_17841: StringResource
+  get() = String17.str_17841
+
+@ExperimentalResourceApi
+internal val Res.string.str_17842: StringResource
+  get() = String17.str_17842
+
+@ExperimentalResourceApi
+internal val Res.string.str_17843: StringResource
+  get() = String17.str_17843
+
+@ExperimentalResourceApi
+internal val Res.string.str_17844: StringResource
+  get() = String17.str_17844
+
+@ExperimentalResourceApi
+internal val Res.string.str_17845: StringResource
+  get() = String17.str_17845
+
+@ExperimentalResourceApi
+internal val Res.string.str_17846: StringResource
+  get() = String17.str_17846
+
+@ExperimentalResourceApi
+internal val Res.string.str_17847: StringResource
+  get() = String17.str_17847
+
+@ExperimentalResourceApi
+internal val Res.string.str_17848: StringResource
+  get() = String17.str_17848
+
+@ExperimentalResourceApi
+internal val Res.string.str_17849: StringResource
+  get() = String17.str_17849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1785: StringResource
+  get() = String17.str_1785
+
+@ExperimentalResourceApi
+internal val Res.string.str_17850: StringResource
+  get() = String17.str_17850
+
+@ExperimentalResourceApi
+internal val Res.string.str_17851: StringResource
+  get() = String17.str_17851
+
+@ExperimentalResourceApi
+internal val Res.string.str_17852: StringResource
+  get() = String17.str_17852
+
+@ExperimentalResourceApi
+internal val Res.string.str_17853: StringResource
+  get() = String17.str_17853
+
+@ExperimentalResourceApi
+internal val Res.string.str_17854: StringResource
+  get() = String17.str_17854
+
+@ExperimentalResourceApi
+internal val Res.string.str_17855: StringResource
+  get() = String17.str_17855
+
+@ExperimentalResourceApi
+internal val Res.string.str_17856: StringResource
+  get() = String17.str_17856
+
+@ExperimentalResourceApi
+internal val Res.string.str_17857: StringResource
+  get() = String17.str_17857
+
+@ExperimentalResourceApi
+internal val Res.string.str_17858: StringResource
+  get() = String17.str_17858
+
+@ExperimentalResourceApi
+internal val Res.string.str_17859: StringResource
+  get() = String17.str_17859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1786: StringResource
+  get() = String17.str_1786
+
+@ExperimentalResourceApi
+internal val Res.string.str_17860: StringResource
+  get() = String17.str_17860
+
+@ExperimentalResourceApi
+internal val Res.string.str_17861: StringResource
+  get() = String17.str_17861
+
+@ExperimentalResourceApi
+internal val Res.string.str_17862: StringResource
+  get() = String17.str_17862
+
+@ExperimentalResourceApi
+internal val Res.string.str_17863: StringResource
+  get() = String17.str_17863
+
+@ExperimentalResourceApi
+internal val Res.string.str_17864: StringResource
+  get() = String17.str_17864
+
+@ExperimentalResourceApi
+internal val Res.string.str_17865: StringResource
+  get() = String17.str_17865
+
+@ExperimentalResourceApi
+internal val Res.string.str_17866: StringResource
+  get() = String17.str_17866
+
+@ExperimentalResourceApi
+internal val Res.string.str_17867: StringResource
+  get() = String17.str_17867
+
+@ExperimentalResourceApi
+internal val Res.string.str_17868: StringResource
+  get() = String17.str_17868
+
+@ExperimentalResourceApi
+internal val Res.string.str_17869: StringResource
+  get() = String17.str_17869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1787: StringResource
+  get() = String17.str_1787
+
+@ExperimentalResourceApi
+internal val Res.string.str_17870: StringResource
+  get() = String17.str_17870
+
+@ExperimentalResourceApi
+internal val Res.string.str_17871: StringResource
+  get() = String17.str_17871
+
+@ExperimentalResourceApi
+internal val Res.string.str_17872: StringResource
+  get() = String17.str_17872
+
+@ExperimentalResourceApi
+internal val Res.string.str_17873: StringResource
+  get() = String17.str_17873
+
+@ExperimentalResourceApi
+internal val Res.string.str_17874: StringResource
+  get() = String17.str_17874
+
+@ExperimentalResourceApi
+internal val Res.string.str_17875: StringResource
+  get() = String17.str_17875
+
+@ExperimentalResourceApi
+internal val Res.string.str_17876: StringResource
+  get() = String17.str_17876
+
+@ExperimentalResourceApi
+internal val Res.string.str_17877: StringResource
+  get() = String17.str_17877
+
+@ExperimentalResourceApi
+internal val Res.string.str_17878: StringResource
+  get() = String17.str_17878
+
+@ExperimentalResourceApi
+internal val Res.string.str_17879: StringResource
+  get() = String17.str_17879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1788: StringResource
+  get() = String17.str_1788
+
+@ExperimentalResourceApi
+internal val Res.string.str_17880: StringResource
+  get() = String17.str_17880
+
+@ExperimentalResourceApi
+internal val Res.string.str_17881: StringResource
+  get() = String17.str_17881
+
+@ExperimentalResourceApi
+internal val Res.string.str_17882: StringResource
+  get() = String17.str_17882
+
+@ExperimentalResourceApi
+internal val Res.string.str_17883: StringResource
+  get() = String17.str_17883
+
+@ExperimentalResourceApi
+internal val Res.string.str_17884: StringResource
+  get() = String17.str_17884
+
+@ExperimentalResourceApi
+internal val Res.string.str_17885: StringResource
+  get() = String17.str_17885
+
+@ExperimentalResourceApi
+internal val Res.string.str_17886: StringResource
+  get() = String17.str_17886
+
+@ExperimentalResourceApi
+internal val Res.string.str_17887: StringResource
+  get() = String17.str_17887
+
+@ExperimentalResourceApi
+internal val Res.string.str_17888: StringResource
+  get() = String17.str_17888
+
+@ExperimentalResourceApi
+internal val Res.string.str_17889: StringResource
+  get() = String17.str_17889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1789: StringResource
+  get() = String17.str_1789
+
+@ExperimentalResourceApi
+internal val Res.string.str_17890: StringResource
+  get() = String17.str_17890
+
+@ExperimentalResourceApi
+internal val Res.string.str_17891: StringResource
+  get() = String17.str_17891
+
+@ExperimentalResourceApi
+internal val Res.string.str_17892: StringResource
+  get() = String17.str_17892
+
+@ExperimentalResourceApi
+internal val Res.string.str_17893: StringResource
+  get() = String17.str_17893
+
+@ExperimentalResourceApi
+internal val Res.string.str_17894: StringResource
+  get() = String17.str_17894
+
+@ExperimentalResourceApi
+internal val Res.string.str_17895: StringResource
+  get() = String17.str_17895
+
+@ExperimentalResourceApi
+internal val Res.string.str_17896: StringResource
+  get() = String17.str_17896
+
+@ExperimentalResourceApi
+internal val Res.string.str_17897: StringResource
+  get() = String17.str_17897
+
+@ExperimentalResourceApi
+internal val Res.string.str_17898: StringResource
+  get() = String17.str_17898
+
+@ExperimentalResourceApi
+internal val Res.string.str_17899: StringResource
+  get() = String17.str_17899
+
+@ExperimentalResourceApi
+internal val Res.string.str_179: StringResource
+  get() = String17.str_179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1790: StringResource
+  get() = String17.str_1790
+
+@ExperimentalResourceApi
+internal val Res.string.str_17900: StringResource
+  get() = String17.str_17900
+
+@ExperimentalResourceApi
+internal val Res.string.str_17901: StringResource
+  get() = String17.str_17901
+
+@ExperimentalResourceApi
+internal val Res.string.str_17902: StringResource
+  get() = String17.str_17902
+
+@ExperimentalResourceApi
+internal val Res.string.str_17903: StringResource
+  get() = String17.str_17903
+
+@ExperimentalResourceApi
+internal val Res.string.str_17904: StringResource
+  get() = String17.str_17904
+
+@ExperimentalResourceApi
+internal val Res.string.str_17905: StringResource
+  get() = String17.str_17905
+
+@ExperimentalResourceApi
+internal val Res.string.str_17906: StringResource
+  get() = String17.str_17906
+
+@ExperimentalResourceApi
+internal val Res.string.str_17907: StringResource
+  get() = String17.str_17907
+
+@ExperimentalResourceApi
+internal val Res.string.str_17908: StringResource
+  get() = String17.str_17908
+
+@ExperimentalResourceApi
+internal val Res.string.str_17909: StringResource
+  get() = String17.str_17909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1791: StringResource
+  get() = String17.str_1791
+
+@ExperimentalResourceApi
+internal val Res.string.str_17910: StringResource
+  get() = String17.str_17910
+
+@ExperimentalResourceApi
+internal val Res.string.str_17911: StringResource
+  get() = String17.str_17911
+
+@ExperimentalResourceApi
+internal val Res.string.str_17912: StringResource
+  get() = String17.str_17912
+
+@ExperimentalResourceApi
+internal val Res.string.str_17913: StringResource
+  get() = String17.str_17913
+
+@ExperimentalResourceApi
+internal val Res.string.str_17914: StringResource
+  get() = String17.str_17914
+
+@ExperimentalResourceApi
+internal val Res.string.str_17915: StringResource
+  get() = String17.str_17915
+
+@ExperimentalResourceApi
+internal val Res.string.str_17916: StringResource
+  get() = String17.str_17916
+
+@ExperimentalResourceApi
+internal val Res.string.str_17917: StringResource
+  get() = String17.str_17917
+
+@ExperimentalResourceApi
+internal val Res.string.str_17918: StringResource
+  get() = String17.str_17918
+
+@ExperimentalResourceApi
+internal val Res.string.str_17919: StringResource
+  get() = String17.str_17919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1792: StringResource
+  get() = String17.str_1792
+
+@ExperimentalResourceApi
+internal val Res.string.str_17920: StringResource
+  get() = String17.str_17920
+
+@ExperimentalResourceApi
+internal val Res.string.str_17921: StringResource
+  get() = String17.str_17921
+
+@ExperimentalResourceApi
+internal val Res.string.str_17922: StringResource
+  get() = String17.str_17922
+
+@ExperimentalResourceApi
+internal val Res.string.str_17923: StringResource
+  get() = String17.str_17923
+
+@ExperimentalResourceApi
+internal val Res.string.str_17924: StringResource
+  get() = String17.str_17924
+
+@ExperimentalResourceApi
+internal val Res.string.str_17925: StringResource
+  get() = String17.str_17925
+
+@ExperimentalResourceApi
+internal val Res.string.str_17926: StringResource
+  get() = String17.str_17926
+
+@ExperimentalResourceApi
+internal val Res.string.str_17927: StringResource
+  get() = String17.str_17927
+
+@ExperimentalResourceApi
+internal val Res.string.str_17928: StringResource
+  get() = String17.str_17928
+
+@ExperimentalResourceApi
+internal val Res.string.str_17929: StringResource
+  get() = String17.str_17929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1793: StringResource
+  get() = String17.str_1793
+
+@ExperimentalResourceApi
+internal val Res.string.str_17930: StringResource
+  get() = String17.str_17930
+
+@ExperimentalResourceApi
+internal val Res.string.str_17931: StringResource
+  get() = String17.str_17931
+
+@ExperimentalResourceApi
+internal val Res.string.str_17932: StringResource
+  get() = String17.str_17932
+
+@ExperimentalResourceApi
+internal val Res.string.str_17933: StringResource
+  get() = String17.str_17933
+
+@ExperimentalResourceApi
+internal val Res.string.str_17934: StringResource
+  get() = String17.str_17934
+
+@ExperimentalResourceApi
+internal val Res.string.str_17935: StringResource
+  get() = String17.str_17935
+
+@ExperimentalResourceApi
+internal val Res.string.str_17936: StringResource
+  get() = String17.str_17936
+
+@ExperimentalResourceApi
+internal val Res.string.str_17937: StringResource
+  get() = String17.str_17937
+
+@ExperimentalResourceApi
+internal val Res.string.str_17938: StringResource
+  get() = String17.str_17938
+
+@ExperimentalResourceApi
+internal val Res.string.str_17939: StringResource
+  get() = String17.str_17939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1794: StringResource
+  get() = String17.str_1794
+
+@ExperimentalResourceApi
+internal val Res.string.str_17940: StringResource
+  get() = String17.str_17940
+
+@ExperimentalResourceApi
+internal val Res.string.str_17941: StringResource
+  get() = String17.str_17941
+
+@ExperimentalResourceApi
+internal val Res.string.str_17942: StringResource
+  get() = String17.str_17942
+
+@ExperimentalResourceApi
+internal val Res.string.str_17943: StringResource
+  get() = String17.str_17943
+
+@ExperimentalResourceApi
+internal val Res.string.str_17944: StringResource
+  get() = String17.str_17944
+
+@ExperimentalResourceApi
+internal val Res.string.str_17945: StringResource
+  get() = String17.str_17945
+
+@ExperimentalResourceApi
+internal val Res.string.str_17946: StringResource
+  get() = String17.str_17946
+
+@ExperimentalResourceApi
+internal val Res.string.str_17947: StringResource
+  get() = String17.str_17947
+
+@ExperimentalResourceApi
+internal val Res.string.str_17948: StringResource
+  get() = String17.str_17948
+
+@ExperimentalResourceApi
+internal val Res.string.str_17949: StringResource
+  get() = String17.str_17949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1795: StringResource
+  get() = String17.str_1795
+
+@ExperimentalResourceApi
+internal val Res.string.str_17950: StringResource
+  get() = String17.str_17950
+
+@ExperimentalResourceApi
+internal val Res.string.str_17951: StringResource
+  get() = String17.str_17951
+
+@ExperimentalResourceApi
+internal val Res.string.str_17952: StringResource
+  get() = String17.str_17952
+
+@ExperimentalResourceApi
+internal val Res.string.str_17953: StringResource
+  get() = String17.str_17953
+
+@ExperimentalResourceApi
+internal val Res.string.str_17954: StringResource
+  get() = String17.str_17954
+
+@ExperimentalResourceApi
+internal val Res.string.str_17955: StringResource
+  get() = String17.str_17955
+
+@ExperimentalResourceApi
+internal val Res.string.str_17956: StringResource
+  get() = String17.str_17956
+
+@ExperimentalResourceApi
+internal val Res.string.str_17957: StringResource
+  get() = String17.str_17957
+
+@ExperimentalResourceApi
+internal val Res.string.str_17958: StringResource
+  get() = String17.str_17958
+
+@ExperimentalResourceApi
+internal val Res.string.str_17959: StringResource
+  get() = String17.str_17959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1796: StringResource
+  get() = String17.str_1796
+
+@ExperimentalResourceApi
+internal val Res.string.str_17960: StringResource
+  get() = String17.str_17960
+
+@ExperimentalResourceApi
+internal val Res.string.str_17961: StringResource
+  get() = String17.str_17961
+
+@ExperimentalResourceApi
+internal val Res.string.str_17962: StringResource
+  get() = String17.str_17962
+
+@ExperimentalResourceApi
+internal val Res.string.str_17963: StringResource
+  get() = String17.str_17963
+
+@ExperimentalResourceApi
+internal val Res.string.str_17964: StringResource
+  get() = String17.str_17964
+
+@ExperimentalResourceApi
+internal val Res.string.str_17965: StringResource
+  get() = String17.str_17965
+
+@ExperimentalResourceApi
+internal val Res.string.str_17966: StringResource
+  get() = String17.str_17966
+
+@ExperimentalResourceApi
+internal val Res.string.str_17967: StringResource
+  get() = String17.str_17967
+
+@ExperimentalResourceApi
+internal val Res.string.str_17968: StringResource
+  get() = String17.str_17968
+
+@ExperimentalResourceApi
+internal val Res.string.str_17969: StringResource
+  get() = String17.str_17969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1797: StringResource
+  get() = String17.str_1797
+
+@ExperimentalResourceApi
+internal val Res.string.str_17970: StringResource
+  get() = String17.str_17970
+
+@ExperimentalResourceApi
+internal val Res.string.str_17971: StringResource
+  get() = String17.str_17971
+
+@ExperimentalResourceApi
+internal val Res.string.str_17972: StringResource
+  get() = String17.str_17972
+
+@ExperimentalResourceApi
+internal val Res.string.str_17973: StringResource
+  get() = String17.str_17973
+
+@ExperimentalResourceApi
+internal val Res.string.str_17974: StringResource
+  get() = String17.str_17974
+
+@ExperimentalResourceApi
+internal val Res.string.str_17975: StringResource
+  get() = String17.str_17975
+
+@ExperimentalResourceApi
+internal val Res.string.str_17976: StringResource
+  get() = String17.str_17976
+
+@ExperimentalResourceApi
+internal val Res.string.str_17977: StringResource
+  get() = String17.str_17977
+
+@ExperimentalResourceApi
+internal val Res.string.str_17978: StringResource
+  get() = String17.str_17978
+
+@ExperimentalResourceApi
+internal val Res.string.str_17979: StringResource
+  get() = String17.str_17979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1798: StringResource
+  get() = String17.str_1798
+
+@ExperimentalResourceApi
+internal val Res.string.str_17980: StringResource
+  get() = String17.str_17980
+
+@ExperimentalResourceApi
+internal val Res.string.str_17981: StringResource
+  get() = String17.str_17981
+
+@ExperimentalResourceApi
+internal val Res.string.str_17982: StringResource
+  get() = String17.str_17982
+
+@ExperimentalResourceApi
+internal val Res.string.str_17983: StringResource
+  get() = String17.str_17983
+
+@ExperimentalResourceApi
+internal val Res.string.str_17984: StringResource
+  get() = String17.str_17984
+
+@ExperimentalResourceApi
+internal val Res.string.str_17985: StringResource
+  get() = String17.str_17985
+
+@ExperimentalResourceApi
+internal val Res.string.str_17986: StringResource
+  get() = String17.str_17986
+
+@ExperimentalResourceApi
+internal val Res.string.str_17987: StringResource
+  get() = String17.str_17987
+
+@ExperimentalResourceApi
+internal val Res.string.str_17988: StringResource
+  get() = String17.str_17988
+
+@ExperimentalResourceApi
+internal val Res.string.str_17989: StringResource
+  get() = String17.str_17989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1799: StringResource
+  get() = String17.str_1799
+
+@ExperimentalResourceApi
+internal val Res.string.str_17990: StringResource
+  get() = String17.str_17990
+
+@ExperimentalResourceApi
+internal val Res.string.str_17991: StringResource
+  get() = String17.str_17991
+
+@ExperimentalResourceApi
+internal val Res.string.str_17992: StringResource
+  get() = String17.str_17992
+
+@ExperimentalResourceApi
+internal val Res.string.str_17993: StringResource
+  get() = String17.str_17993
+
+@ExperimentalResourceApi
+internal val Res.string.str_17994: StringResource
+  get() = String17.str_17994
+
+@ExperimentalResourceApi
+internal val Res.string.str_17995: StringResource
+  get() = String17.str_17995
+
+@ExperimentalResourceApi
+internal val Res.string.str_17996: StringResource
+  get() = String17.str_17996
+
+@ExperimentalResourceApi
+internal val Res.string.str_17997: StringResource
+  get() = String17.str_17997
+
+@ExperimentalResourceApi
+internal val Res.string.str_17998: StringResource
+  get() = String17.str_17998
+
+@ExperimentalResourceApi
+internal val Res.string.str_17999: StringResource
+  get() = String17.str_17999
+
+@ExperimentalResourceApi
+internal val Res.string.str_18: StringResource
+  get() = String17.str_18
+
+@ExperimentalResourceApi
+internal val Res.string.str_180: StringResource
+  get() = String17.str_180
+
+@ExperimentalResourceApi
+internal val Res.string.str_1800: StringResource
+  get() = String17.str_1800
+
+@ExperimentalResourceApi
+internal val Res.string.str_18000: StringResource
+  get() = String17.str_18000
+
+@ExperimentalResourceApi
+internal val Res.string.str_18001: StringResource
+  get() = String17.str_18001
+
+@ExperimentalResourceApi
+internal val Res.string.str_18002: StringResource
+  get() = String17.str_18002
+
+@ExperimentalResourceApi
+internal val Res.string.str_18003: StringResource
+  get() = String17.str_18003
+
+@ExperimentalResourceApi
+internal val Res.string.str_18004: StringResource
+  get() = String17.str_18004
+
+@ExperimentalResourceApi
+internal val Res.string.str_18005: StringResource
+  get() = String17.str_18005
+
+@ExperimentalResourceApi
+internal val Res.string.str_18006: StringResource
+  get() = String17.str_18006
+
+@ExperimentalResourceApi
+internal val Res.string.str_18007: StringResource
+  get() = String17.str_18007
+
+@ExperimentalResourceApi
+internal val Res.string.str_18008: StringResource
+  get() = String17.str_18008
+
+@ExperimentalResourceApi
+internal val Res.string.str_18009: StringResource
+  get() = String17.str_18009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1801: StringResource
+  get() = String17.str_1801
+
+@ExperimentalResourceApi
+internal val Res.string.str_18010: StringResource
+  get() = String17.str_18010
+
+@ExperimentalResourceApi
+internal val Res.string.str_18011: StringResource
+  get() = String17.str_18011
+
+@ExperimentalResourceApi
+internal val Res.string.str_18012: StringResource
+  get() = String17.str_18012
+
+@ExperimentalResourceApi
+internal val Res.string.str_18013: StringResource
+  get() = String17.str_18013
+
+@ExperimentalResourceApi
+internal val Res.string.str_18014: StringResource
+  get() = String17.str_18014
+
+@ExperimentalResourceApi
+internal val Res.string.str_18015: StringResource
+  get() = String17.str_18015
+
+@ExperimentalResourceApi
+internal val Res.string.str_18016: StringResource
+  get() = String17.str_18016
+
+@ExperimentalResourceApi
+internal val Res.string.str_18017: StringResource
+  get() = String17.str_18017
+
+@ExperimentalResourceApi
+internal val Res.string.str_18018: StringResource
+  get() = String17.str_18018
+
+@ExperimentalResourceApi
+internal val Res.string.str_18019: StringResource
+  get() = String17.str_18019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1802: StringResource
+  get() = String17.str_1802
+
+@ExperimentalResourceApi
+internal val Res.string.str_18020: StringResource
+  get() = String17.str_18020
+
+@ExperimentalResourceApi
+internal val Res.string.str_18021: StringResource
+  get() = String17.str_18021
+
+@ExperimentalResourceApi
+internal val Res.string.str_18022: StringResource
+  get() = String17.str_18022
+
+@ExperimentalResourceApi
+internal val Res.string.str_18023: StringResource
+  get() = String17.str_18023
+
+@ExperimentalResourceApi
+internal val Res.string.str_18024: StringResource
+  get() = String17.str_18024
+
+@ExperimentalResourceApi
+internal val Res.string.str_18025: StringResource
+  get() = String17.str_18025
+
+@ExperimentalResourceApi
+internal val Res.string.str_18026: StringResource
+  get() = String17.str_18026
+
+@ExperimentalResourceApi
+internal val Res.string.str_18027: StringResource
+  get() = String17.str_18027
+
+@ExperimentalResourceApi
+internal val Res.string.str_18028: StringResource
+  get() = String17.str_18028
+
+@ExperimentalResourceApi
+internal val Res.string.str_18029: StringResource
+  get() = String17.str_18029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1803: StringResource
+  get() = String17.str_1803
+
+@ExperimentalResourceApi
+internal val Res.string.str_18030: StringResource
+  get() = String17.str_18030
+
+@ExperimentalResourceApi
+internal val Res.string.str_18031: StringResource
+  get() = String17.str_18031
+
+@ExperimentalResourceApi
+internal val Res.string.str_18032: StringResource
+  get() = String17.str_18032
+
+@ExperimentalResourceApi
+internal val Res.string.str_18033: StringResource
+  get() = String17.str_18033
+
+@ExperimentalResourceApi
+internal val Res.string.str_18034: StringResource
+  get() = String17.str_18034
+
+@ExperimentalResourceApi
+internal val Res.string.str_18035: StringResource
+  get() = String17.str_18035
+
+@ExperimentalResourceApi
+internal val Res.string.str_18036: StringResource
+  get() = String17.str_18036
+
+@ExperimentalResourceApi
+internal val Res.string.str_18037: StringResource
+  get() = String17.str_18037
+
+@ExperimentalResourceApi
+internal val Res.string.str_18038: StringResource
+  get() = String17.str_18038
+
+@ExperimentalResourceApi
+internal val Res.string.str_18039: StringResource
+  get() = String17.str_18039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1804: StringResource
+  get() = String17.str_1804
+
+@ExperimentalResourceApi
+internal val Res.string.str_18040: StringResource
+  get() = String17.str_18040
+
+@ExperimentalResourceApi
+internal val Res.string.str_18041: StringResource
+  get() = String17.str_18041
+
+@ExperimentalResourceApi
+internal val Res.string.str_18042: StringResource
+  get() = String17.str_18042
+
+@ExperimentalResourceApi
+internal val Res.string.str_18043: StringResource
+  get() = String17.str_18043
+
+@ExperimentalResourceApi
+internal val Res.string.str_18044: StringResource
+  get() = String17.str_18044
+
+@ExperimentalResourceApi
+internal val Res.string.str_18045: StringResource
+  get() = String17.str_18045
+
+@ExperimentalResourceApi
+internal val Res.string.str_18046: StringResource
+  get() = String17.str_18046
+
+@ExperimentalResourceApi
+internal val Res.string.str_18047: StringResource
+  get() = String17.str_18047
+
+@ExperimentalResourceApi
+internal val Res.string.str_18048: StringResource
+  get() = String17.str_18048
+
+@ExperimentalResourceApi
+internal val Res.string.str_18049: StringResource
+  get() = String17.str_18049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1805: StringResource
+  get() = String17.str_1805
+
+@ExperimentalResourceApi
+internal val Res.string.str_18050: StringResource
+  get() = String17.str_18050
+
+@ExperimentalResourceApi
+internal val Res.string.str_18051: StringResource
+  get() = String17.str_18051
+
+@ExperimentalResourceApi
+internal val Res.string.str_18052: StringResource
+  get() = String17.str_18052
+
+@ExperimentalResourceApi
+internal val Res.string.str_18053: StringResource
+  get() = String17.str_18053
+
+@ExperimentalResourceApi
+internal val Res.string.str_18054: StringResource
+  get() = String17.str_18054
+
+@ExperimentalResourceApi
+internal val Res.string.str_18055: StringResource
+  get() = String17.str_18055
+
+@ExperimentalResourceApi
+internal val Res.string.str_18056: StringResource
+  get() = String17.str_18056
+
+@ExperimentalResourceApi
+internal val Res.string.str_18057: StringResource
+  get() = String17.str_18057
+
+@ExperimentalResourceApi
+internal val Res.string.str_18058: StringResource
+  get() = String17.str_18058
+
+@ExperimentalResourceApi
+internal val Res.string.str_18059: StringResource
+  get() = String17.str_18059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1806: StringResource
+  get() = String17.str_1806
+
+@ExperimentalResourceApi
+internal val Res.string.str_18060: StringResource
+  get() = String17.str_18060
+
+@ExperimentalResourceApi
+internal val Res.string.str_18061: StringResource
+  get() = String17.str_18061
+
+@ExperimentalResourceApi
+internal val Res.string.str_18062: StringResource
+  get() = String17.str_18062
+
+@ExperimentalResourceApi
+internal val Res.string.str_18063: StringResource
+  get() = String17.str_18063
+
+@ExperimentalResourceApi
+internal val Res.string.str_18064: StringResource
+  get() = String17.str_18064
+
+@ExperimentalResourceApi
+internal val Res.string.str_18065: StringResource
+  get() = String17.str_18065
+
+@ExperimentalResourceApi
+internal val Res.string.str_18066: StringResource
+  get() = String17.str_18066
+
+@ExperimentalResourceApi
+internal val Res.string.str_18067: StringResource
+  get() = String17.str_18067
+
+@ExperimentalResourceApi
+internal val Res.string.str_18068: StringResource
+  get() = String17.str_18068
+
+@ExperimentalResourceApi
+internal val Res.string.str_18069: StringResource
+  get() = String17.str_18069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1807: StringResource
+  get() = String17.str_1807
+
+@ExperimentalResourceApi
+internal val Res.string.str_18070: StringResource
+  get() = String17.str_18070
+
+@ExperimentalResourceApi
+internal val Res.string.str_18071: StringResource
+  get() = String17.str_18071
+
+@ExperimentalResourceApi
+internal val Res.string.str_18072: StringResource
+  get() = String17.str_18072
+
+@ExperimentalResourceApi
+internal val Res.string.str_18073: StringResource
+  get() = String17.str_18073
+
+@ExperimentalResourceApi
+internal val Res.string.str_18074: StringResource
+  get() = String17.str_18074
+
+@ExperimentalResourceApi
+internal val Res.string.str_18075: StringResource
+  get() = String17.str_18075
+
+@ExperimentalResourceApi
+internal val Res.string.str_18076: StringResource
+  get() = String17.str_18076
+
+@ExperimentalResourceApi
+internal val Res.string.str_18077: StringResource
+  get() = String17.str_18077
+
+@ExperimentalResourceApi
+internal val Res.string.str_18078: StringResource
+  get() = String17.str_18078
+
+@ExperimentalResourceApi
+internal val Res.string.str_18079: StringResource
+  get() = String17.str_18079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1808: StringResource
+  get() = String17.str_1808
+
+@ExperimentalResourceApi
+internal val Res.string.str_18080: StringResource
+  get() = String17.str_18080
+
+@ExperimentalResourceApi
+internal val Res.string.str_18081: StringResource
+  get() = String17.str_18081
+
+@ExperimentalResourceApi
+internal val Res.string.str_18082: StringResource
+  get() = String17.str_18082
+
+@ExperimentalResourceApi
+internal val Res.string.str_18083: StringResource
+  get() = String17.str_18083
+
+@ExperimentalResourceApi
+internal val Res.string.str_18084: StringResource
+  get() = String17.str_18084
+
+@ExperimentalResourceApi
+internal val Res.string.str_18085: StringResource
+  get() = String17.str_18085
+
+@ExperimentalResourceApi
+internal val Res.string.str_18086: StringResource
+  get() = String17.str_18086
+
+@ExperimentalResourceApi
+internal val Res.string.str_18087: StringResource
+  get() = String17.str_18087
+
+@ExperimentalResourceApi
+internal val Res.string.str_18088: StringResource
+  get() = String17.str_18088
+
+@ExperimentalResourceApi
+internal val Res.string.str_18089: StringResource
+  get() = String17.str_18089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1809: StringResource
+  get() = String17.str_1809
+
+@ExperimentalResourceApi
+internal val Res.string.str_18090: StringResource
+  get() = String17.str_18090
+
+@ExperimentalResourceApi
+internal val Res.string.str_18091: StringResource
+  get() = String17.str_18091
+
+@ExperimentalResourceApi
+internal val Res.string.str_18092: StringResource
+  get() = String17.str_18092
+
+@ExperimentalResourceApi
+internal val Res.string.str_18093: StringResource
+  get() = String17.str_18093
+
+@ExperimentalResourceApi
+internal val Res.string.str_18094: StringResource
+  get() = String17.str_18094
+
+@ExperimentalResourceApi
+internal val Res.string.str_18095: StringResource
+  get() = String17.str_18095
+
+@ExperimentalResourceApi
+internal val Res.string.str_18096: StringResource
+  get() = String17.str_18096
+
+@ExperimentalResourceApi
+internal val Res.string.str_18097: StringResource
+  get() = String17.str_18097

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String18.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String18.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String18 {
+  public val str_18098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18098", "str_18098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18099", "str_18099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_181", "str_181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1810", "str_1810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18100", "str_18100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18101", "str_18101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18102", "str_18102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18103", "str_18103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18104", "str_18104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18105", "str_18105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18106", "str_18106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18107", "str_18107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18108", "str_18108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18109", "str_18109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1811", "str_1811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18110", "str_18110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18111", "str_18111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18112", "str_18112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18113", "str_18113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18114", "str_18114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18115", "str_18115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18116", "str_18116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18117", "str_18117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18118", "str_18118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18119", "str_18119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1812", "str_1812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18120", "str_18120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18121", "str_18121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18122", "str_18122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18123", "str_18123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18124", "str_18124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18125", "str_18125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18126", "str_18126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18127", "str_18127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18128", "str_18128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18129", "str_18129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1813", "str_1813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18130", "str_18130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18131", "str_18131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18132", "str_18132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18133", "str_18133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18134", "str_18134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18135", "str_18135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18136", "str_18136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18137", "str_18137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18138", "str_18138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18139", "str_18139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1814", "str_1814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18140", "str_18140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18141", "str_18141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18142", "str_18142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18143", "str_18143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18144", "str_18144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18145", "str_18145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18146", "str_18146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18147", "str_18147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18148", "str_18148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18149", "str_18149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1815", "str_1815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18150", "str_18150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18151", "str_18151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18152", "str_18152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18153", "str_18153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18154", "str_18154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18155", "str_18155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18156", "str_18156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18157", "str_18157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18158", "str_18158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18159", "str_18159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1816", "str_1816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18160", "str_18160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18161", "str_18161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18162", "str_18162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18163", "str_18163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18164", "str_18164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18165", "str_18165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18166", "str_18166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18167", "str_18167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18168", "str_18168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18169", "str_18169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1817", "str_1817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18170", "str_18170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18171", "str_18171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18172", "str_18172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18173", "str_18173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18174", "str_18174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18175", "str_18175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18176", "str_18176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18177", "str_18177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18178", "str_18178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18179", "str_18179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1818", "str_1818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18180", "str_18180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18181", "str_18181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18182", "str_18182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18183", "str_18183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18184", "str_18184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18185", "str_18185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18186", "str_18186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18187", "str_18187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18188", "str_18188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18189", "str_18189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1819", "str_1819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18190", "str_18190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18191", "str_18191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18192", "str_18192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18193", "str_18193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18194", "str_18194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18195", "str_18195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18196", "str_18196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18197", "str_18197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18198", "str_18198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18199", "str_18199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_182", "str_182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1820", "str_1820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18200", "str_18200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18201", "str_18201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18202", "str_18202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18203", "str_18203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18204", "str_18204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18205", "str_18205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18206", "str_18206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18207", "str_18207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18208", "str_18208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18209", "str_18209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1821", "str_1821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18210", "str_18210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18211", "str_18211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18212", "str_18212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18213", "str_18213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18214", "str_18214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18215", "str_18215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18216", "str_18216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18217", "str_18217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18218", "str_18218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18219", "str_18219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1822", "str_1822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18220", "str_18220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18221", "str_18221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18222", "str_18222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18223", "str_18223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18224", "str_18224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18225", "str_18225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18226", "str_18226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18227", "str_18227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18228", "str_18228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18229", "str_18229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1823", "str_1823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18230", "str_18230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18231", "str_18231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18232", "str_18232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18233", "str_18233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18234", "str_18234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18235", "str_18235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18236", "str_18236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18237", "str_18237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18238", "str_18238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18239", "str_18239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1824", "str_1824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18240", "str_18240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18241", "str_18241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18242", "str_18242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18243", "str_18243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18244", "str_18244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18245", "str_18245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18246", "str_18246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18247", "str_18247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18248", "str_18248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18249", "str_18249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1825", "str_1825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18250", "str_18250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18251", "str_18251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18252", "str_18252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18253", "str_18253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18254", "str_18254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18255", "str_18255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18256", "str_18256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18257", "str_18257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18258", "str_18258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18259", "str_18259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1826", "str_1826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18260", "str_18260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18261", "str_18261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18262", "str_18262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18263", "str_18263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18264", "str_18264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18265", "str_18265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18266", "str_18266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18267", "str_18267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18268", "str_18268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18269", "str_18269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1827", "str_1827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18270", "str_18270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18271", "str_18271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18272", "str_18272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18273", "str_18273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18274", "str_18274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18275", "str_18275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18276", "str_18276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18277", "str_18277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18278", "str_18278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18279", "str_18279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1828", "str_1828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18280", "str_18280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18281", "str_18281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18282", "str_18282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18283", "str_18283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18284", "str_18284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18285", "str_18285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18286", "str_18286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18287", "str_18287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18288", "str_18288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18289", "str_18289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1829", "str_1829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18290", "str_18290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18291", "str_18291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18292", "str_18292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18293", "str_18293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18294", "str_18294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18295", "str_18295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18296", "str_18296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18297", "str_18297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18298", "str_18298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18299", "str_18299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_183", "str_183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1830", "str_1830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18300", "str_18300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18301", "str_18301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18302", "str_18302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18303", "str_18303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18304", "str_18304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18305", "str_18305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18306", "str_18306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18307", "str_18307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18308", "str_18308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18309", "str_18309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1831", "str_1831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18310", "str_18310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18311", "str_18311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18312", "str_18312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18313", "str_18313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18314", "str_18314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18315", "str_18315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18316", "str_18316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18317", "str_18317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18318", "str_18318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18319", "str_18319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1832", "str_1832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18320", "str_18320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18321", "str_18321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18322", "str_18322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18323", "str_18323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18324", "str_18324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18325", "str_18325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18326", "str_18326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18327", "str_18327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18328", "str_18328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18329", "str_18329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1833", "str_1833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18330", "str_18330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18331", "str_18331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18332", "str_18332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18333", "str_18333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18334", "str_18334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18335", "str_18335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18336", "str_18336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18337", "str_18337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18338", "str_18338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18339", "str_18339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1834", "str_1834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18340", "str_18340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18341", "str_18341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18342", "str_18342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18343", "str_18343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18344", "str_18344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18345", "str_18345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18346", "str_18346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18347", "str_18347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18348", "str_18348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18349", "str_18349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1835", "str_1835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18350", "str_18350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18351", "str_18351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18352", "str_18352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18353", "str_18353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18354", "str_18354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18355", "str_18355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18356", "str_18356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18357", "str_18357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18358", "str_18358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18359", "str_18359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1836", "str_1836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18360", "str_18360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18361", "str_18361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18362", "str_18362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18363", "str_18363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18364", "str_18364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18365", "str_18365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18366", "str_18366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18367", "str_18367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18368", "str_18368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18369", "str_18369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1837", "str_1837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18370", "str_18370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18371", "str_18371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18372", "str_18372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18373", "str_18373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18374", "str_18374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18375", "str_18375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18376", "str_18376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18377", "str_18377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18378", "str_18378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18379", "str_18379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1838", "str_1838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18380", "str_18380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18381", "str_18381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18382", "str_18382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18383", "str_18383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18384", "str_18384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18385", "str_18385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18386", "str_18386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18387", "str_18387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18388", "str_18388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18389", "str_18389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1839", "str_1839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18390", "str_18390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18391", "str_18391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18392", "str_18392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18393", "str_18393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18394", "str_18394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18395", "str_18395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18396", "str_18396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18397", "str_18397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18398", "str_18398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18399", "str_18399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_184", "str_184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1840", "str_1840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18400", "str_18400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18401", "str_18401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18402", "str_18402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18403", "str_18403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18404", "str_18404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18405", "str_18405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18406", "str_18406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18407", "str_18407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18408", "str_18408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18409", "str_18409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1841", "str_1841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18410", "str_18410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18411", "str_18411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18412", "str_18412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18413", "str_18413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18414", "str_18414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18415", "str_18415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18416", "str_18416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18417", "str_18417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18418", "str_18418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18419", "str_18419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1842", "str_1842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18420", "str_18420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18421", "str_18421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18422", "str_18422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18423", "str_18423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18424", "str_18424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18425", "str_18425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18426", "str_18426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18427", "str_18427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18428", "str_18428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18429", "str_18429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1843", "str_1843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18430", "str_18430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18431", "str_18431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18432", "str_18432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18433", "str_18433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18434", "str_18434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18435", "str_18435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18436", "str_18436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18437", "str_18437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18438", "str_18438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18439", "str_18439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1844", "str_1844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18440", "str_18440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18441", "str_18441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18442", "str_18442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18443", "str_18443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18444", "str_18444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18445", "str_18445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18446", "str_18446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18447", "str_18447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18448", "str_18448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18449", "str_18449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1845", "str_1845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18450", "str_18450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18451", "str_18451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18452", "str_18452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18453", "str_18453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18454", "str_18454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18455", "str_18455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18456", "str_18456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18457", "str_18457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18458", "str_18458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18459", "str_18459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1846", "str_1846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18460", "str_18460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18461", "str_18461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18462", "str_18462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18463", "str_18463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18464", "str_18464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18465", "str_18465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18466", "str_18466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18467", "str_18467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18468", "str_18468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18469", "str_18469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1847", "str_1847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18470", "str_18470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18471", "str_18471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18472", "str_18472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18473", "str_18473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18474", "str_18474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18475", "str_18475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18476", "str_18476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18477", "str_18477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18478", "str_18478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18479", "str_18479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1848", "str_1848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18480", "str_18480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18481", "str_18481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18482", "str_18482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18483", "str_18483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18484", "str_18484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18485", "str_18485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18486", "str_18486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18487", "str_18487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18488", "str_18488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18489", "str_18489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1849", "str_1849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18490", "str_18490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18491", "str_18491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18492", "str_18492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18493", "str_18493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18494", "str_18494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18495", "str_18495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18496", "str_18496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18497", "str_18497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18498", "str_18498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18499", "str_18499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_185", "str_185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1850", "str_1850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18500", "str_18500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18501", "str_18501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18502", "str_18502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18503", "str_18503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18504", "str_18504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18505", "str_18505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18506", "str_18506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18507", "str_18507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18508", "str_18508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18509", "str_18509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1851", "str_1851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18510", "str_18510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18511", "str_18511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18512", "str_18512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18513", "str_18513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18514", "str_18514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18515", "str_18515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18516", "str_18516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18517", "str_18517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18518", "str_18518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18519", "str_18519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1852", "str_1852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18520", "str_18520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18521", "str_18521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18522", "str_18522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18523", "str_18523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18524", "str_18524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18525", "str_18525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18526", "str_18526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18527", "str_18527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18528", "str_18528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18529", "str_18529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1853", "str_1853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18530", "str_18530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18531", "str_18531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18532", "str_18532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18533", "str_18533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18534", "str_18534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18535", "str_18535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18536", "str_18536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18537", "str_18537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18538", "str_18538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18539", "str_18539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1854", "str_1854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18540", "str_18540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18541", "str_18541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18542", "str_18542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18543", "str_18543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18544", "str_18544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18545", "str_18545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18546", "str_18546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18547", "str_18547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_18098: StringResource
+  get() = String18.str_18098
+
+@ExperimentalResourceApi
+internal val Res.string.str_18099: StringResource
+  get() = String18.str_18099
+
+@ExperimentalResourceApi
+internal val Res.string.str_181: StringResource
+  get() = String18.str_181
+
+@ExperimentalResourceApi
+internal val Res.string.str_1810: StringResource
+  get() = String18.str_1810
+
+@ExperimentalResourceApi
+internal val Res.string.str_18100: StringResource
+  get() = String18.str_18100
+
+@ExperimentalResourceApi
+internal val Res.string.str_18101: StringResource
+  get() = String18.str_18101
+
+@ExperimentalResourceApi
+internal val Res.string.str_18102: StringResource
+  get() = String18.str_18102
+
+@ExperimentalResourceApi
+internal val Res.string.str_18103: StringResource
+  get() = String18.str_18103
+
+@ExperimentalResourceApi
+internal val Res.string.str_18104: StringResource
+  get() = String18.str_18104
+
+@ExperimentalResourceApi
+internal val Res.string.str_18105: StringResource
+  get() = String18.str_18105
+
+@ExperimentalResourceApi
+internal val Res.string.str_18106: StringResource
+  get() = String18.str_18106
+
+@ExperimentalResourceApi
+internal val Res.string.str_18107: StringResource
+  get() = String18.str_18107
+
+@ExperimentalResourceApi
+internal val Res.string.str_18108: StringResource
+  get() = String18.str_18108
+
+@ExperimentalResourceApi
+internal val Res.string.str_18109: StringResource
+  get() = String18.str_18109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1811: StringResource
+  get() = String18.str_1811
+
+@ExperimentalResourceApi
+internal val Res.string.str_18110: StringResource
+  get() = String18.str_18110
+
+@ExperimentalResourceApi
+internal val Res.string.str_18111: StringResource
+  get() = String18.str_18111
+
+@ExperimentalResourceApi
+internal val Res.string.str_18112: StringResource
+  get() = String18.str_18112
+
+@ExperimentalResourceApi
+internal val Res.string.str_18113: StringResource
+  get() = String18.str_18113
+
+@ExperimentalResourceApi
+internal val Res.string.str_18114: StringResource
+  get() = String18.str_18114
+
+@ExperimentalResourceApi
+internal val Res.string.str_18115: StringResource
+  get() = String18.str_18115
+
+@ExperimentalResourceApi
+internal val Res.string.str_18116: StringResource
+  get() = String18.str_18116
+
+@ExperimentalResourceApi
+internal val Res.string.str_18117: StringResource
+  get() = String18.str_18117
+
+@ExperimentalResourceApi
+internal val Res.string.str_18118: StringResource
+  get() = String18.str_18118
+
+@ExperimentalResourceApi
+internal val Res.string.str_18119: StringResource
+  get() = String18.str_18119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1812: StringResource
+  get() = String18.str_1812
+
+@ExperimentalResourceApi
+internal val Res.string.str_18120: StringResource
+  get() = String18.str_18120
+
+@ExperimentalResourceApi
+internal val Res.string.str_18121: StringResource
+  get() = String18.str_18121
+
+@ExperimentalResourceApi
+internal val Res.string.str_18122: StringResource
+  get() = String18.str_18122
+
+@ExperimentalResourceApi
+internal val Res.string.str_18123: StringResource
+  get() = String18.str_18123
+
+@ExperimentalResourceApi
+internal val Res.string.str_18124: StringResource
+  get() = String18.str_18124
+
+@ExperimentalResourceApi
+internal val Res.string.str_18125: StringResource
+  get() = String18.str_18125
+
+@ExperimentalResourceApi
+internal val Res.string.str_18126: StringResource
+  get() = String18.str_18126
+
+@ExperimentalResourceApi
+internal val Res.string.str_18127: StringResource
+  get() = String18.str_18127
+
+@ExperimentalResourceApi
+internal val Res.string.str_18128: StringResource
+  get() = String18.str_18128
+
+@ExperimentalResourceApi
+internal val Res.string.str_18129: StringResource
+  get() = String18.str_18129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1813: StringResource
+  get() = String18.str_1813
+
+@ExperimentalResourceApi
+internal val Res.string.str_18130: StringResource
+  get() = String18.str_18130
+
+@ExperimentalResourceApi
+internal val Res.string.str_18131: StringResource
+  get() = String18.str_18131
+
+@ExperimentalResourceApi
+internal val Res.string.str_18132: StringResource
+  get() = String18.str_18132
+
+@ExperimentalResourceApi
+internal val Res.string.str_18133: StringResource
+  get() = String18.str_18133
+
+@ExperimentalResourceApi
+internal val Res.string.str_18134: StringResource
+  get() = String18.str_18134
+
+@ExperimentalResourceApi
+internal val Res.string.str_18135: StringResource
+  get() = String18.str_18135
+
+@ExperimentalResourceApi
+internal val Res.string.str_18136: StringResource
+  get() = String18.str_18136
+
+@ExperimentalResourceApi
+internal val Res.string.str_18137: StringResource
+  get() = String18.str_18137
+
+@ExperimentalResourceApi
+internal val Res.string.str_18138: StringResource
+  get() = String18.str_18138
+
+@ExperimentalResourceApi
+internal val Res.string.str_18139: StringResource
+  get() = String18.str_18139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1814: StringResource
+  get() = String18.str_1814
+
+@ExperimentalResourceApi
+internal val Res.string.str_18140: StringResource
+  get() = String18.str_18140
+
+@ExperimentalResourceApi
+internal val Res.string.str_18141: StringResource
+  get() = String18.str_18141
+
+@ExperimentalResourceApi
+internal val Res.string.str_18142: StringResource
+  get() = String18.str_18142
+
+@ExperimentalResourceApi
+internal val Res.string.str_18143: StringResource
+  get() = String18.str_18143
+
+@ExperimentalResourceApi
+internal val Res.string.str_18144: StringResource
+  get() = String18.str_18144
+
+@ExperimentalResourceApi
+internal val Res.string.str_18145: StringResource
+  get() = String18.str_18145
+
+@ExperimentalResourceApi
+internal val Res.string.str_18146: StringResource
+  get() = String18.str_18146
+
+@ExperimentalResourceApi
+internal val Res.string.str_18147: StringResource
+  get() = String18.str_18147
+
+@ExperimentalResourceApi
+internal val Res.string.str_18148: StringResource
+  get() = String18.str_18148
+
+@ExperimentalResourceApi
+internal val Res.string.str_18149: StringResource
+  get() = String18.str_18149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1815: StringResource
+  get() = String18.str_1815
+
+@ExperimentalResourceApi
+internal val Res.string.str_18150: StringResource
+  get() = String18.str_18150
+
+@ExperimentalResourceApi
+internal val Res.string.str_18151: StringResource
+  get() = String18.str_18151
+
+@ExperimentalResourceApi
+internal val Res.string.str_18152: StringResource
+  get() = String18.str_18152
+
+@ExperimentalResourceApi
+internal val Res.string.str_18153: StringResource
+  get() = String18.str_18153
+
+@ExperimentalResourceApi
+internal val Res.string.str_18154: StringResource
+  get() = String18.str_18154
+
+@ExperimentalResourceApi
+internal val Res.string.str_18155: StringResource
+  get() = String18.str_18155
+
+@ExperimentalResourceApi
+internal val Res.string.str_18156: StringResource
+  get() = String18.str_18156
+
+@ExperimentalResourceApi
+internal val Res.string.str_18157: StringResource
+  get() = String18.str_18157
+
+@ExperimentalResourceApi
+internal val Res.string.str_18158: StringResource
+  get() = String18.str_18158
+
+@ExperimentalResourceApi
+internal val Res.string.str_18159: StringResource
+  get() = String18.str_18159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1816: StringResource
+  get() = String18.str_1816
+
+@ExperimentalResourceApi
+internal val Res.string.str_18160: StringResource
+  get() = String18.str_18160
+
+@ExperimentalResourceApi
+internal val Res.string.str_18161: StringResource
+  get() = String18.str_18161
+
+@ExperimentalResourceApi
+internal val Res.string.str_18162: StringResource
+  get() = String18.str_18162
+
+@ExperimentalResourceApi
+internal val Res.string.str_18163: StringResource
+  get() = String18.str_18163
+
+@ExperimentalResourceApi
+internal val Res.string.str_18164: StringResource
+  get() = String18.str_18164
+
+@ExperimentalResourceApi
+internal val Res.string.str_18165: StringResource
+  get() = String18.str_18165
+
+@ExperimentalResourceApi
+internal val Res.string.str_18166: StringResource
+  get() = String18.str_18166
+
+@ExperimentalResourceApi
+internal val Res.string.str_18167: StringResource
+  get() = String18.str_18167
+
+@ExperimentalResourceApi
+internal val Res.string.str_18168: StringResource
+  get() = String18.str_18168
+
+@ExperimentalResourceApi
+internal val Res.string.str_18169: StringResource
+  get() = String18.str_18169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1817: StringResource
+  get() = String18.str_1817
+
+@ExperimentalResourceApi
+internal val Res.string.str_18170: StringResource
+  get() = String18.str_18170
+
+@ExperimentalResourceApi
+internal val Res.string.str_18171: StringResource
+  get() = String18.str_18171
+
+@ExperimentalResourceApi
+internal val Res.string.str_18172: StringResource
+  get() = String18.str_18172
+
+@ExperimentalResourceApi
+internal val Res.string.str_18173: StringResource
+  get() = String18.str_18173
+
+@ExperimentalResourceApi
+internal val Res.string.str_18174: StringResource
+  get() = String18.str_18174
+
+@ExperimentalResourceApi
+internal val Res.string.str_18175: StringResource
+  get() = String18.str_18175
+
+@ExperimentalResourceApi
+internal val Res.string.str_18176: StringResource
+  get() = String18.str_18176
+
+@ExperimentalResourceApi
+internal val Res.string.str_18177: StringResource
+  get() = String18.str_18177
+
+@ExperimentalResourceApi
+internal val Res.string.str_18178: StringResource
+  get() = String18.str_18178
+
+@ExperimentalResourceApi
+internal val Res.string.str_18179: StringResource
+  get() = String18.str_18179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1818: StringResource
+  get() = String18.str_1818
+
+@ExperimentalResourceApi
+internal val Res.string.str_18180: StringResource
+  get() = String18.str_18180
+
+@ExperimentalResourceApi
+internal val Res.string.str_18181: StringResource
+  get() = String18.str_18181
+
+@ExperimentalResourceApi
+internal val Res.string.str_18182: StringResource
+  get() = String18.str_18182
+
+@ExperimentalResourceApi
+internal val Res.string.str_18183: StringResource
+  get() = String18.str_18183
+
+@ExperimentalResourceApi
+internal val Res.string.str_18184: StringResource
+  get() = String18.str_18184
+
+@ExperimentalResourceApi
+internal val Res.string.str_18185: StringResource
+  get() = String18.str_18185
+
+@ExperimentalResourceApi
+internal val Res.string.str_18186: StringResource
+  get() = String18.str_18186
+
+@ExperimentalResourceApi
+internal val Res.string.str_18187: StringResource
+  get() = String18.str_18187
+
+@ExperimentalResourceApi
+internal val Res.string.str_18188: StringResource
+  get() = String18.str_18188
+
+@ExperimentalResourceApi
+internal val Res.string.str_18189: StringResource
+  get() = String18.str_18189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1819: StringResource
+  get() = String18.str_1819
+
+@ExperimentalResourceApi
+internal val Res.string.str_18190: StringResource
+  get() = String18.str_18190
+
+@ExperimentalResourceApi
+internal val Res.string.str_18191: StringResource
+  get() = String18.str_18191
+
+@ExperimentalResourceApi
+internal val Res.string.str_18192: StringResource
+  get() = String18.str_18192
+
+@ExperimentalResourceApi
+internal val Res.string.str_18193: StringResource
+  get() = String18.str_18193
+
+@ExperimentalResourceApi
+internal val Res.string.str_18194: StringResource
+  get() = String18.str_18194
+
+@ExperimentalResourceApi
+internal val Res.string.str_18195: StringResource
+  get() = String18.str_18195
+
+@ExperimentalResourceApi
+internal val Res.string.str_18196: StringResource
+  get() = String18.str_18196
+
+@ExperimentalResourceApi
+internal val Res.string.str_18197: StringResource
+  get() = String18.str_18197
+
+@ExperimentalResourceApi
+internal val Res.string.str_18198: StringResource
+  get() = String18.str_18198
+
+@ExperimentalResourceApi
+internal val Res.string.str_18199: StringResource
+  get() = String18.str_18199
+
+@ExperimentalResourceApi
+internal val Res.string.str_182: StringResource
+  get() = String18.str_182
+
+@ExperimentalResourceApi
+internal val Res.string.str_1820: StringResource
+  get() = String18.str_1820
+
+@ExperimentalResourceApi
+internal val Res.string.str_18200: StringResource
+  get() = String18.str_18200
+
+@ExperimentalResourceApi
+internal val Res.string.str_18201: StringResource
+  get() = String18.str_18201
+
+@ExperimentalResourceApi
+internal val Res.string.str_18202: StringResource
+  get() = String18.str_18202
+
+@ExperimentalResourceApi
+internal val Res.string.str_18203: StringResource
+  get() = String18.str_18203
+
+@ExperimentalResourceApi
+internal val Res.string.str_18204: StringResource
+  get() = String18.str_18204
+
+@ExperimentalResourceApi
+internal val Res.string.str_18205: StringResource
+  get() = String18.str_18205
+
+@ExperimentalResourceApi
+internal val Res.string.str_18206: StringResource
+  get() = String18.str_18206
+
+@ExperimentalResourceApi
+internal val Res.string.str_18207: StringResource
+  get() = String18.str_18207
+
+@ExperimentalResourceApi
+internal val Res.string.str_18208: StringResource
+  get() = String18.str_18208
+
+@ExperimentalResourceApi
+internal val Res.string.str_18209: StringResource
+  get() = String18.str_18209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1821: StringResource
+  get() = String18.str_1821
+
+@ExperimentalResourceApi
+internal val Res.string.str_18210: StringResource
+  get() = String18.str_18210
+
+@ExperimentalResourceApi
+internal val Res.string.str_18211: StringResource
+  get() = String18.str_18211
+
+@ExperimentalResourceApi
+internal val Res.string.str_18212: StringResource
+  get() = String18.str_18212
+
+@ExperimentalResourceApi
+internal val Res.string.str_18213: StringResource
+  get() = String18.str_18213
+
+@ExperimentalResourceApi
+internal val Res.string.str_18214: StringResource
+  get() = String18.str_18214
+
+@ExperimentalResourceApi
+internal val Res.string.str_18215: StringResource
+  get() = String18.str_18215
+
+@ExperimentalResourceApi
+internal val Res.string.str_18216: StringResource
+  get() = String18.str_18216
+
+@ExperimentalResourceApi
+internal val Res.string.str_18217: StringResource
+  get() = String18.str_18217
+
+@ExperimentalResourceApi
+internal val Res.string.str_18218: StringResource
+  get() = String18.str_18218
+
+@ExperimentalResourceApi
+internal val Res.string.str_18219: StringResource
+  get() = String18.str_18219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1822: StringResource
+  get() = String18.str_1822
+
+@ExperimentalResourceApi
+internal val Res.string.str_18220: StringResource
+  get() = String18.str_18220
+
+@ExperimentalResourceApi
+internal val Res.string.str_18221: StringResource
+  get() = String18.str_18221
+
+@ExperimentalResourceApi
+internal val Res.string.str_18222: StringResource
+  get() = String18.str_18222
+
+@ExperimentalResourceApi
+internal val Res.string.str_18223: StringResource
+  get() = String18.str_18223
+
+@ExperimentalResourceApi
+internal val Res.string.str_18224: StringResource
+  get() = String18.str_18224
+
+@ExperimentalResourceApi
+internal val Res.string.str_18225: StringResource
+  get() = String18.str_18225
+
+@ExperimentalResourceApi
+internal val Res.string.str_18226: StringResource
+  get() = String18.str_18226
+
+@ExperimentalResourceApi
+internal val Res.string.str_18227: StringResource
+  get() = String18.str_18227
+
+@ExperimentalResourceApi
+internal val Res.string.str_18228: StringResource
+  get() = String18.str_18228
+
+@ExperimentalResourceApi
+internal val Res.string.str_18229: StringResource
+  get() = String18.str_18229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1823: StringResource
+  get() = String18.str_1823
+
+@ExperimentalResourceApi
+internal val Res.string.str_18230: StringResource
+  get() = String18.str_18230
+
+@ExperimentalResourceApi
+internal val Res.string.str_18231: StringResource
+  get() = String18.str_18231
+
+@ExperimentalResourceApi
+internal val Res.string.str_18232: StringResource
+  get() = String18.str_18232
+
+@ExperimentalResourceApi
+internal val Res.string.str_18233: StringResource
+  get() = String18.str_18233
+
+@ExperimentalResourceApi
+internal val Res.string.str_18234: StringResource
+  get() = String18.str_18234
+
+@ExperimentalResourceApi
+internal val Res.string.str_18235: StringResource
+  get() = String18.str_18235
+
+@ExperimentalResourceApi
+internal val Res.string.str_18236: StringResource
+  get() = String18.str_18236
+
+@ExperimentalResourceApi
+internal val Res.string.str_18237: StringResource
+  get() = String18.str_18237
+
+@ExperimentalResourceApi
+internal val Res.string.str_18238: StringResource
+  get() = String18.str_18238
+
+@ExperimentalResourceApi
+internal val Res.string.str_18239: StringResource
+  get() = String18.str_18239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1824: StringResource
+  get() = String18.str_1824
+
+@ExperimentalResourceApi
+internal val Res.string.str_18240: StringResource
+  get() = String18.str_18240
+
+@ExperimentalResourceApi
+internal val Res.string.str_18241: StringResource
+  get() = String18.str_18241
+
+@ExperimentalResourceApi
+internal val Res.string.str_18242: StringResource
+  get() = String18.str_18242
+
+@ExperimentalResourceApi
+internal val Res.string.str_18243: StringResource
+  get() = String18.str_18243
+
+@ExperimentalResourceApi
+internal val Res.string.str_18244: StringResource
+  get() = String18.str_18244
+
+@ExperimentalResourceApi
+internal val Res.string.str_18245: StringResource
+  get() = String18.str_18245
+
+@ExperimentalResourceApi
+internal val Res.string.str_18246: StringResource
+  get() = String18.str_18246
+
+@ExperimentalResourceApi
+internal val Res.string.str_18247: StringResource
+  get() = String18.str_18247
+
+@ExperimentalResourceApi
+internal val Res.string.str_18248: StringResource
+  get() = String18.str_18248
+
+@ExperimentalResourceApi
+internal val Res.string.str_18249: StringResource
+  get() = String18.str_18249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1825: StringResource
+  get() = String18.str_1825
+
+@ExperimentalResourceApi
+internal val Res.string.str_18250: StringResource
+  get() = String18.str_18250
+
+@ExperimentalResourceApi
+internal val Res.string.str_18251: StringResource
+  get() = String18.str_18251
+
+@ExperimentalResourceApi
+internal val Res.string.str_18252: StringResource
+  get() = String18.str_18252
+
+@ExperimentalResourceApi
+internal val Res.string.str_18253: StringResource
+  get() = String18.str_18253
+
+@ExperimentalResourceApi
+internal val Res.string.str_18254: StringResource
+  get() = String18.str_18254
+
+@ExperimentalResourceApi
+internal val Res.string.str_18255: StringResource
+  get() = String18.str_18255
+
+@ExperimentalResourceApi
+internal val Res.string.str_18256: StringResource
+  get() = String18.str_18256
+
+@ExperimentalResourceApi
+internal val Res.string.str_18257: StringResource
+  get() = String18.str_18257
+
+@ExperimentalResourceApi
+internal val Res.string.str_18258: StringResource
+  get() = String18.str_18258
+
+@ExperimentalResourceApi
+internal val Res.string.str_18259: StringResource
+  get() = String18.str_18259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1826: StringResource
+  get() = String18.str_1826
+
+@ExperimentalResourceApi
+internal val Res.string.str_18260: StringResource
+  get() = String18.str_18260
+
+@ExperimentalResourceApi
+internal val Res.string.str_18261: StringResource
+  get() = String18.str_18261
+
+@ExperimentalResourceApi
+internal val Res.string.str_18262: StringResource
+  get() = String18.str_18262
+
+@ExperimentalResourceApi
+internal val Res.string.str_18263: StringResource
+  get() = String18.str_18263
+
+@ExperimentalResourceApi
+internal val Res.string.str_18264: StringResource
+  get() = String18.str_18264
+
+@ExperimentalResourceApi
+internal val Res.string.str_18265: StringResource
+  get() = String18.str_18265
+
+@ExperimentalResourceApi
+internal val Res.string.str_18266: StringResource
+  get() = String18.str_18266
+
+@ExperimentalResourceApi
+internal val Res.string.str_18267: StringResource
+  get() = String18.str_18267
+
+@ExperimentalResourceApi
+internal val Res.string.str_18268: StringResource
+  get() = String18.str_18268
+
+@ExperimentalResourceApi
+internal val Res.string.str_18269: StringResource
+  get() = String18.str_18269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1827: StringResource
+  get() = String18.str_1827
+
+@ExperimentalResourceApi
+internal val Res.string.str_18270: StringResource
+  get() = String18.str_18270
+
+@ExperimentalResourceApi
+internal val Res.string.str_18271: StringResource
+  get() = String18.str_18271
+
+@ExperimentalResourceApi
+internal val Res.string.str_18272: StringResource
+  get() = String18.str_18272
+
+@ExperimentalResourceApi
+internal val Res.string.str_18273: StringResource
+  get() = String18.str_18273
+
+@ExperimentalResourceApi
+internal val Res.string.str_18274: StringResource
+  get() = String18.str_18274
+
+@ExperimentalResourceApi
+internal val Res.string.str_18275: StringResource
+  get() = String18.str_18275
+
+@ExperimentalResourceApi
+internal val Res.string.str_18276: StringResource
+  get() = String18.str_18276
+
+@ExperimentalResourceApi
+internal val Res.string.str_18277: StringResource
+  get() = String18.str_18277
+
+@ExperimentalResourceApi
+internal val Res.string.str_18278: StringResource
+  get() = String18.str_18278
+
+@ExperimentalResourceApi
+internal val Res.string.str_18279: StringResource
+  get() = String18.str_18279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1828: StringResource
+  get() = String18.str_1828
+
+@ExperimentalResourceApi
+internal val Res.string.str_18280: StringResource
+  get() = String18.str_18280
+
+@ExperimentalResourceApi
+internal val Res.string.str_18281: StringResource
+  get() = String18.str_18281
+
+@ExperimentalResourceApi
+internal val Res.string.str_18282: StringResource
+  get() = String18.str_18282
+
+@ExperimentalResourceApi
+internal val Res.string.str_18283: StringResource
+  get() = String18.str_18283
+
+@ExperimentalResourceApi
+internal val Res.string.str_18284: StringResource
+  get() = String18.str_18284
+
+@ExperimentalResourceApi
+internal val Res.string.str_18285: StringResource
+  get() = String18.str_18285
+
+@ExperimentalResourceApi
+internal val Res.string.str_18286: StringResource
+  get() = String18.str_18286
+
+@ExperimentalResourceApi
+internal val Res.string.str_18287: StringResource
+  get() = String18.str_18287
+
+@ExperimentalResourceApi
+internal val Res.string.str_18288: StringResource
+  get() = String18.str_18288
+
+@ExperimentalResourceApi
+internal val Res.string.str_18289: StringResource
+  get() = String18.str_18289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1829: StringResource
+  get() = String18.str_1829
+
+@ExperimentalResourceApi
+internal val Res.string.str_18290: StringResource
+  get() = String18.str_18290
+
+@ExperimentalResourceApi
+internal val Res.string.str_18291: StringResource
+  get() = String18.str_18291
+
+@ExperimentalResourceApi
+internal val Res.string.str_18292: StringResource
+  get() = String18.str_18292
+
+@ExperimentalResourceApi
+internal val Res.string.str_18293: StringResource
+  get() = String18.str_18293
+
+@ExperimentalResourceApi
+internal val Res.string.str_18294: StringResource
+  get() = String18.str_18294
+
+@ExperimentalResourceApi
+internal val Res.string.str_18295: StringResource
+  get() = String18.str_18295
+
+@ExperimentalResourceApi
+internal val Res.string.str_18296: StringResource
+  get() = String18.str_18296
+
+@ExperimentalResourceApi
+internal val Res.string.str_18297: StringResource
+  get() = String18.str_18297
+
+@ExperimentalResourceApi
+internal val Res.string.str_18298: StringResource
+  get() = String18.str_18298
+
+@ExperimentalResourceApi
+internal val Res.string.str_18299: StringResource
+  get() = String18.str_18299
+
+@ExperimentalResourceApi
+internal val Res.string.str_183: StringResource
+  get() = String18.str_183
+
+@ExperimentalResourceApi
+internal val Res.string.str_1830: StringResource
+  get() = String18.str_1830
+
+@ExperimentalResourceApi
+internal val Res.string.str_18300: StringResource
+  get() = String18.str_18300
+
+@ExperimentalResourceApi
+internal val Res.string.str_18301: StringResource
+  get() = String18.str_18301
+
+@ExperimentalResourceApi
+internal val Res.string.str_18302: StringResource
+  get() = String18.str_18302
+
+@ExperimentalResourceApi
+internal val Res.string.str_18303: StringResource
+  get() = String18.str_18303
+
+@ExperimentalResourceApi
+internal val Res.string.str_18304: StringResource
+  get() = String18.str_18304
+
+@ExperimentalResourceApi
+internal val Res.string.str_18305: StringResource
+  get() = String18.str_18305
+
+@ExperimentalResourceApi
+internal val Res.string.str_18306: StringResource
+  get() = String18.str_18306
+
+@ExperimentalResourceApi
+internal val Res.string.str_18307: StringResource
+  get() = String18.str_18307
+
+@ExperimentalResourceApi
+internal val Res.string.str_18308: StringResource
+  get() = String18.str_18308
+
+@ExperimentalResourceApi
+internal val Res.string.str_18309: StringResource
+  get() = String18.str_18309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1831: StringResource
+  get() = String18.str_1831
+
+@ExperimentalResourceApi
+internal val Res.string.str_18310: StringResource
+  get() = String18.str_18310
+
+@ExperimentalResourceApi
+internal val Res.string.str_18311: StringResource
+  get() = String18.str_18311
+
+@ExperimentalResourceApi
+internal val Res.string.str_18312: StringResource
+  get() = String18.str_18312
+
+@ExperimentalResourceApi
+internal val Res.string.str_18313: StringResource
+  get() = String18.str_18313
+
+@ExperimentalResourceApi
+internal val Res.string.str_18314: StringResource
+  get() = String18.str_18314
+
+@ExperimentalResourceApi
+internal val Res.string.str_18315: StringResource
+  get() = String18.str_18315
+
+@ExperimentalResourceApi
+internal val Res.string.str_18316: StringResource
+  get() = String18.str_18316
+
+@ExperimentalResourceApi
+internal val Res.string.str_18317: StringResource
+  get() = String18.str_18317
+
+@ExperimentalResourceApi
+internal val Res.string.str_18318: StringResource
+  get() = String18.str_18318
+
+@ExperimentalResourceApi
+internal val Res.string.str_18319: StringResource
+  get() = String18.str_18319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1832: StringResource
+  get() = String18.str_1832
+
+@ExperimentalResourceApi
+internal val Res.string.str_18320: StringResource
+  get() = String18.str_18320
+
+@ExperimentalResourceApi
+internal val Res.string.str_18321: StringResource
+  get() = String18.str_18321
+
+@ExperimentalResourceApi
+internal val Res.string.str_18322: StringResource
+  get() = String18.str_18322
+
+@ExperimentalResourceApi
+internal val Res.string.str_18323: StringResource
+  get() = String18.str_18323
+
+@ExperimentalResourceApi
+internal val Res.string.str_18324: StringResource
+  get() = String18.str_18324
+
+@ExperimentalResourceApi
+internal val Res.string.str_18325: StringResource
+  get() = String18.str_18325
+
+@ExperimentalResourceApi
+internal val Res.string.str_18326: StringResource
+  get() = String18.str_18326
+
+@ExperimentalResourceApi
+internal val Res.string.str_18327: StringResource
+  get() = String18.str_18327
+
+@ExperimentalResourceApi
+internal val Res.string.str_18328: StringResource
+  get() = String18.str_18328
+
+@ExperimentalResourceApi
+internal val Res.string.str_18329: StringResource
+  get() = String18.str_18329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1833: StringResource
+  get() = String18.str_1833
+
+@ExperimentalResourceApi
+internal val Res.string.str_18330: StringResource
+  get() = String18.str_18330
+
+@ExperimentalResourceApi
+internal val Res.string.str_18331: StringResource
+  get() = String18.str_18331
+
+@ExperimentalResourceApi
+internal val Res.string.str_18332: StringResource
+  get() = String18.str_18332
+
+@ExperimentalResourceApi
+internal val Res.string.str_18333: StringResource
+  get() = String18.str_18333
+
+@ExperimentalResourceApi
+internal val Res.string.str_18334: StringResource
+  get() = String18.str_18334
+
+@ExperimentalResourceApi
+internal val Res.string.str_18335: StringResource
+  get() = String18.str_18335
+
+@ExperimentalResourceApi
+internal val Res.string.str_18336: StringResource
+  get() = String18.str_18336
+
+@ExperimentalResourceApi
+internal val Res.string.str_18337: StringResource
+  get() = String18.str_18337
+
+@ExperimentalResourceApi
+internal val Res.string.str_18338: StringResource
+  get() = String18.str_18338
+
+@ExperimentalResourceApi
+internal val Res.string.str_18339: StringResource
+  get() = String18.str_18339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1834: StringResource
+  get() = String18.str_1834
+
+@ExperimentalResourceApi
+internal val Res.string.str_18340: StringResource
+  get() = String18.str_18340
+
+@ExperimentalResourceApi
+internal val Res.string.str_18341: StringResource
+  get() = String18.str_18341
+
+@ExperimentalResourceApi
+internal val Res.string.str_18342: StringResource
+  get() = String18.str_18342
+
+@ExperimentalResourceApi
+internal val Res.string.str_18343: StringResource
+  get() = String18.str_18343
+
+@ExperimentalResourceApi
+internal val Res.string.str_18344: StringResource
+  get() = String18.str_18344
+
+@ExperimentalResourceApi
+internal val Res.string.str_18345: StringResource
+  get() = String18.str_18345
+
+@ExperimentalResourceApi
+internal val Res.string.str_18346: StringResource
+  get() = String18.str_18346
+
+@ExperimentalResourceApi
+internal val Res.string.str_18347: StringResource
+  get() = String18.str_18347
+
+@ExperimentalResourceApi
+internal val Res.string.str_18348: StringResource
+  get() = String18.str_18348
+
+@ExperimentalResourceApi
+internal val Res.string.str_18349: StringResource
+  get() = String18.str_18349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1835: StringResource
+  get() = String18.str_1835
+
+@ExperimentalResourceApi
+internal val Res.string.str_18350: StringResource
+  get() = String18.str_18350
+
+@ExperimentalResourceApi
+internal val Res.string.str_18351: StringResource
+  get() = String18.str_18351
+
+@ExperimentalResourceApi
+internal val Res.string.str_18352: StringResource
+  get() = String18.str_18352
+
+@ExperimentalResourceApi
+internal val Res.string.str_18353: StringResource
+  get() = String18.str_18353
+
+@ExperimentalResourceApi
+internal val Res.string.str_18354: StringResource
+  get() = String18.str_18354
+
+@ExperimentalResourceApi
+internal val Res.string.str_18355: StringResource
+  get() = String18.str_18355
+
+@ExperimentalResourceApi
+internal val Res.string.str_18356: StringResource
+  get() = String18.str_18356
+
+@ExperimentalResourceApi
+internal val Res.string.str_18357: StringResource
+  get() = String18.str_18357
+
+@ExperimentalResourceApi
+internal val Res.string.str_18358: StringResource
+  get() = String18.str_18358
+
+@ExperimentalResourceApi
+internal val Res.string.str_18359: StringResource
+  get() = String18.str_18359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1836: StringResource
+  get() = String18.str_1836
+
+@ExperimentalResourceApi
+internal val Res.string.str_18360: StringResource
+  get() = String18.str_18360
+
+@ExperimentalResourceApi
+internal val Res.string.str_18361: StringResource
+  get() = String18.str_18361
+
+@ExperimentalResourceApi
+internal val Res.string.str_18362: StringResource
+  get() = String18.str_18362
+
+@ExperimentalResourceApi
+internal val Res.string.str_18363: StringResource
+  get() = String18.str_18363
+
+@ExperimentalResourceApi
+internal val Res.string.str_18364: StringResource
+  get() = String18.str_18364
+
+@ExperimentalResourceApi
+internal val Res.string.str_18365: StringResource
+  get() = String18.str_18365
+
+@ExperimentalResourceApi
+internal val Res.string.str_18366: StringResource
+  get() = String18.str_18366
+
+@ExperimentalResourceApi
+internal val Res.string.str_18367: StringResource
+  get() = String18.str_18367
+
+@ExperimentalResourceApi
+internal val Res.string.str_18368: StringResource
+  get() = String18.str_18368
+
+@ExperimentalResourceApi
+internal val Res.string.str_18369: StringResource
+  get() = String18.str_18369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1837: StringResource
+  get() = String18.str_1837
+
+@ExperimentalResourceApi
+internal val Res.string.str_18370: StringResource
+  get() = String18.str_18370
+
+@ExperimentalResourceApi
+internal val Res.string.str_18371: StringResource
+  get() = String18.str_18371
+
+@ExperimentalResourceApi
+internal val Res.string.str_18372: StringResource
+  get() = String18.str_18372
+
+@ExperimentalResourceApi
+internal val Res.string.str_18373: StringResource
+  get() = String18.str_18373
+
+@ExperimentalResourceApi
+internal val Res.string.str_18374: StringResource
+  get() = String18.str_18374
+
+@ExperimentalResourceApi
+internal val Res.string.str_18375: StringResource
+  get() = String18.str_18375
+
+@ExperimentalResourceApi
+internal val Res.string.str_18376: StringResource
+  get() = String18.str_18376
+
+@ExperimentalResourceApi
+internal val Res.string.str_18377: StringResource
+  get() = String18.str_18377
+
+@ExperimentalResourceApi
+internal val Res.string.str_18378: StringResource
+  get() = String18.str_18378
+
+@ExperimentalResourceApi
+internal val Res.string.str_18379: StringResource
+  get() = String18.str_18379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1838: StringResource
+  get() = String18.str_1838
+
+@ExperimentalResourceApi
+internal val Res.string.str_18380: StringResource
+  get() = String18.str_18380
+
+@ExperimentalResourceApi
+internal val Res.string.str_18381: StringResource
+  get() = String18.str_18381
+
+@ExperimentalResourceApi
+internal val Res.string.str_18382: StringResource
+  get() = String18.str_18382
+
+@ExperimentalResourceApi
+internal val Res.string.str_18383: StringResource
+  get() = String18.str_18383
+
+@ExperimentalResourceApi
+internal val Res.string.str_18384: StringResource
+  get() = String18.str_18384
+
+@ExperimentalResourceApi
+internal val Res.string.str_18385: StringResource
+  get() = String18.str_18385
+
+@ExperimentalResourceApi
+internal val Res.string.str_18386: StringResource
+  get() = String18.str_18386
+
+@ExperimentalResourceApi
+internal val Res.string.str_18387: StringResource
+  get() = String18.str_18387
+
+@ExperimentalResourceApi
+internal val Res.string.str_18388: StringResource
+  get() = String18.str_18388
+
+@ExperimentalResourceApi
+internal val Res.string.str_18389: StringResource
+  get() = String18.str_18389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1839: StringResource
+  get() = String18.str_1839
+
+@ExperimentalResourceApi
+internal val Res.string.str_18390: StringResource
+  get() = String18.str_18390
+
+@ExperimentalResourceApi
+internal val Res.string.str_18391: StringResource
+  get() = String18.str_18391
+
+@ExperimentalResourceApi
+internal val Res.string.str_18392: StringResource
+  get() = String18.str_18392
+
+@ExperimentalResourceApi
+internal val Res.string.str_18393: StringResource
+  get() = String18.str_18393
+
+@ExperimentalResourceApi
+internal val Res.string.str_18394: StringResource
+  get() = String18.str_18394
+
+@ExperimentalResourceApi
+internal val Res.string.str_18395: StringResource
+  get() = String18.str_18395
+
+@ExperimentalResourceApi
+internal val Res.string.str_18396: StringResource
+  get() = String18.str_18396
+
+@ExperimentalResourceApi
+internal val Res.string.str_18397: StringResource
+  get() = String18.str_18397
+
+@ExperimentalResourceApi
+internal val Res.string.str_18398: StringResource
+  get() = String18.str_18398
+
+@ExperimentalResourceApi
+internal val Res.string.str_18399: StringResource
+  get() = String18.str_18399
+
+@ExperimentalResourceApi
+internal val Res.string.str_184: StringResource
+  get() = String18.str_184
+
+@ExperimentalResourceApi
+internal val Res.string.str_1840: StringResource
+  get() = String18.str_1840
+
+@ExperimentalResourceApi
+internal val Res.string.str_18400: StringResource
+  get() = String18.str_18400
+
+@ExperimentalResourceApi
+internal val Res.string.str_18401: StringResource
+  get() = String18.str_18401
+
+@ExperimentalResourceApi
+internal val Res.string.str_18402: StringResource
+  get() = String18.str_18402
+
+@ExperimentalResourceApi
+internal val Res.string.str_18403: StringResource
+  get() = String18.str_18403
+
+@ExperimentalResourceApi
+internal val Res.string.str_18404: StringResource
+  get() = String18.str_18404
+
+@ExperimentalResourceApi
+internal val Res.string.str_18405: StringResource
+  get() = String18.str_18405
+
+@ExperimentalResourceApi
+internal val Res.string.str_18406: StringResource
+  get() = String18.str_18406
+
+@ExperimentalResourceApi
+internal val Res.string.str_18407: StringResource
+  get() = String18.str_18407
+
+@ExperimentalResourceApi
+internal val Res.string.str_18408: StringResource
+  get() = String18.str_18408
+
+@ExperimentalResourceApi
+internal val Res.string.str_18409: StringResource
+  get() = String18.str_18409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1841: StringResource
+  get() = String18.str_1841
+
+@ExperimentalResourceApi
+internal val Res.string.str_18410: StringResource
+  get() = String18.str_18410
+
+@ExperimentalResourceApi
+internal val Res.string.str_18411: StringResource
+  get() = String18.str_18411
+
+@ExperimentalResourceApi
+internal val Res.string.str_18412: StringResource
+  get() = String18.str_18412
+
+@ExperimentalResourceApi
+internal val Res.string.str_18413: StringResource
+  get() = String18.str_18413
+
+@ExperimentalResourceApi
+internal val Res.string.str_18414: StringResource
+  get() = String18.str_18414
+
+@ExperimentalResourceApi
+internal val Res.string.str_18415: StringResource
+  get() = String18.str_18415
+
+@ExperimentalResourceApi
+internal val Res.string.str_18416: StringResource
+  get() = String18.str_18416
+
+@ExperimentalResourceApi
+internal val Res.string.str_18417: StringResource
+  get() = String18.str_18417
+
+@ExperimentalResourceApi
+internal val Res.string.str_18418: StringResource
+  get() = String18.str_18418
+
+@ExperimentalResourceApi
+internal val Res.string.str_18419: StringResource
+  get() = String18.str_18419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1842: StringResource
+  get() = String18.str_1842
+
+@ExperimentalResourceApi
+internal val Res.string.str_18420: StringResource
+  get() = String18.str_18420
+
+@ExperimentalResourceApi
+internal val Res.string.str_18421: StringResource
+  get() = String18.str_18421
+
+@ExperimentalResourceApi
+internal val Res.string.str_18422: StringResource
+  get() = String18.str_18422
+
+@ExperimentalResourceApi
+internal val Res.string.str_18423: StringResource
+  get() = String18.str_18423
+
+@ExperimentalResourceApi
+internal val Res.string.str_18424: StringResource
+  get() = String18.str_18424
+
+@ExperimentalResourceApi
+internal val Res.string.str_18425: StringResource
+  get() = String18.str_18425
+
+@ExperimentalResourceApi
+internal val Res.string.str_18426: StringResource
+  get() = String18.str_18426
+
+@ExperimentalResourceApi
+internal val Res.string.str_18427: StringResource
+  get() = String18.str_18427
+
+@ExperimentalResourceApi
+internal val Res.string.str_18428: StringResource
+  get() = String18.str_18428
+
+@ExperimentalResourceApi
+internal val Res.string.str_18429: StringResource
+  get() = String18.str_18429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1843: StringResource
+  get() = String18.str_1843
+
+@ExperimentalResourceApi
+internal val Res.string.str_18430: StringResource
+  get() = String18.str_18430
+
+@ExperimentalResourceApi
+internal val Res.string.str_18431: StringResource
+  get() = String18.str_18431
+
+@ExperimentalResourceApi
+internal val Res.string.str_18432: StringResource
+  get() = String18.str_18432
+
+@ExperimentalResourceApi
+internal val Res.string.str_18433: StringResource
+  get() = String18.str_18433
+
+@ExperimentalResourceApi
+internal val Res.string.str_18434: StringResource
+  get() = String18.str_18434
+
+@ExperimentalResourceApi
+internal val Res.string.str_18435: StringResource
+  get() = String18.str_18435
+
+@ExperimentalResourceApi
+internal val Res.string.str_18436: StringResource
+  get() = String18.str_18436
+
+@ExperimentalResourceApi
+internal val Res.string.str_18437: StringResource
+  get() = String18.str_18437
+
+@ExperimentalResourceApi
+internal val Res.string.str_18438: StringResource
+  get() = String18.str_18438
+
+@ExperimentalResourceApi
+internal val Res.string.str_18439: StringResource
+  get() = String18.str_18439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1844: StringResource
+  get() = String18.str_1844
+
+@ExperimentalResourceApi
+internal val Res.string.str_18440: StringResource
+  get() = String18.str_18440
+
+@ExperimentalResourceApi
+internal val Res.string.str_18441: StringResource
+  get() = String18.str_18441
+
+@ExperimentalResourceApi
+internal val Res.string.str_18442: StringResource
+  get() = String18.str_18442
+
+@ExperimentalResourceApi
+internal val Res.string.str_18443: StringResource
+  get() = String18.str_18443
+
+@ExperimentalResourceApi
+internal val Res.string.str_18444: StringResource
+  get() = String18.str_18444
+
+@ExperimentalResourceApi
+internal val Res.string.str_18445: StringResource
+  get() = String18.str_18445
+
+@ExperimentalResourceApi
+internal val Res.string.str_18446: StringResource
+  get() = String18.str_18446
+
+@ExperimentalResourceApi
+internal val Res.string.str_18447: StringResource
+  get() = String18.str_18447
+
+@ExperimentalResourceApi
+internal val Res.string.str_18448: StringResource
+  get() = String18.str_18448
+
+@ExperimentalResourceApi
+internal val Res.string.str_18449: StringResource
+  get() = String18.str_18449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1845: StringResource
+  get() = String18.str_1845
+
+@ExperimentalResourceApi
+internal val Res.string.str_18450: StringResource
+  get() = String18.str_18450
+
+@ExperimentalResourceApi
+internal val Res.string.str_18451: StringResource
+  get() = String18.str_18451
+
+@ExperimentalResourceApi
+internal val Res.string.str_18452: StringResource
+  get() = String18.str_18452
+
+@ExperimentalResourceApi
+internal val Res.string.str_18453: StringResource
+  get() = String18.str_18453
+
+@ExperimentalResourceApi
+internal val Res.string.str_18454: StringResource
+  get() = String18.str_18454
+
+@ExperimentalResourceApi
+internal val Res.string.str_18455: StringResource
+  get() = String18.str_18455
+
+@ExperimentalResourceApi
+internal val Res.string.str_18456: StringResource
+  get() = String18.str_18456
+
+@ExperimentalResourceApi
+internal val Res.string.str_18457: StringResource
+  get() = String18.str_18457
+
+@ExperimentalResourceApi
+internal val Res.string.str_18458: StringResource
+  get() = String18.str_18458
+
+@ExperimentalResourceApi
+internal val Res.string.str_18459: StringResource
+  get() = String18.str_18459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1846: StringResource
+  get() = String18.str_1846
+
+@ExperimentalResourceApi
+internal val Res.string.str_18460: StringResource
+  get() = String18.str_18460
+
+@ExperimentalResourceApi
+internal val Res.string.str_18461: StringResource
+  get() = String18.str_18461
+
+@ExperimentalResourceApi
+internal val Res.string.str_18462: StringResource
+  get() = String18.str_18462
+
+@ExperimentalResourceApi
+internal val Res.string.str_18463: StringResource
+  get() = String18.str_18463
+
+@ExperimentalResourceApi
+internal val Res.string.str_18464: StringResource
+  get() = String18.str_18464
+
+@ExperimentalResourceApi
+internal val Res.string.str_18465: StringResource
+  get() = String18.str_18465
+
+@ExperimentalResourceApi
+internal val Res.string.str_18466: StringResource
+  get() = String18.str_18466
+
+@ExperimentalResourceApi
+internal val Res.string.str_18467: StringResource
+  get() = String18.str_18467
+
+@ExperimentalResourceApi
+internal val Res.string.str_18468: StringResource
+  get() = String18.str_18468
+
+@ExperimentalResourceApi
+internal val Res.string.str_18469: StringResource
+  get() = String18.str_18469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1847: StringResource
+  get() = String18.str_1847
+
+@ExperimentalResourceApi
+internal val Res.string.str_18470: StringResource
+  get() = String18.str_18470
+
+@ExperimentalResourceApi
+internal val Res.string.str_18471: StringResource
+  get() = String18.str_18471
+
+@ExperimentalResourceApi
+internal val Res.string.str_18472: StringResource
+  get() = String18.str_18472
+
+@ExperimentalResourceApi
+internal val Res.string.str_18473: StringResource
+  get() = String18.str_18473
+
+@ExperimentalResourceApi
+internal val Res.string.str_18474: StringResource
+  get() = String18.str_18474
+
+@ExperimentalResourceApi
+internal val Res.string.str_18475: StringResource
+  get() = String18.str_18475
+
+@ExperimentalResourceApi
+internal val Res.string.str_18476: StringResource
+  get() = String18.str_18476
+
+@ExperimentalResourceApi
+internal val Res.string.str_18477: StringResource
+  get() = String18.str_18477
+
+@ExperimentalResourceApi
+internal val Res.string.str_18478: StringResource
+  get() = String18.str_18478
+
+@ExperimentalResourceApi
+internal val Res.string.str_18479: StringResource
+  get() = String18.str_18479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1848: StringResource
+  get() = String18.str_1848
+
+@ExperimentalResourceApi
+internal val Res.string.str_18480: StringResource
+  get() = String18.str_18480
+
+@ExperimentalResourceApi
+internal val Res.string.str_18481: StringResource
+  get() = String18.str_18481
+
+@ExperimentalResourceApi
+internal val Res.string.str_18482: StringResource
+  get() = String18.str_18482
+
+@ExperimentalResourceApi
+internal val Res.string.str_18483: StringResource
+  get() = String18.str_18483
+
+@ExperimentalResourceApi
+internal val Res.string.str_18484: StringResource
+  get() = String18.str_18484
+
+@ExperimentalResourceApi
+internal val Res.string.str_18485: StringResource
+  get() = String18.str_18485
+
+@ExperimentalResourceApi
+internal val Res.string.str_18486: StringResource
+  get() = String18.str_18486
+
+@ExperimentalResourceApi
+internal val Res.string.str_18487: StringResource
+  get() = String18.str_18487
+
+@ExperimentalResourceApi
+internal val Res.string.str_18488: StringResource
+  get() = String18.str_18488
+
+@ExperimentalResourceApi
+internal val Res.string.str_18489: StringResource
+  get() = String18.str_18489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1849: StringResource
+  get() = String18.str_1849
+
+@ExperimentalResourceApi
+internal val Res.string.str_18490: StringResource
+  get() = String18.str_18490
+
+@ExperimentalResourceApi
+internal val Res.string.str_18491: StringResource
+  get() = String18.str_18491
+
+@ExperimentalResourceApi
+internal val Res.string.str_18492: StringResource
+  get() = String18.str_18492
+
+@ExperimentalResourceApi
+internal val Res.string.str_18493: StringResource
+  get() = String18.str_18493
+
+@ExperimentalResourceApi
+internal val Res.string.str_18494: StringResource
+  get() = String18.str_18494
+
+@ExperimentalResourceApi
+internal val Res.string.str_18495: StringResource
+  get() = String18.str_18495
+
+@ExperimentalResourceApi
+internal val Res.string.str_18496: StringResource
+  get() = String18.str_18496
+
+@ExperimentalResourceApi
+internal val Res.string.str_18497: StringResource
+  get() = String18.str_18497
+
+@ExperimentalResourceApi
+internal val Res.string.str_18498: StringResource
+  get() = String18.str_18498
+
+@ExperimentalResourceApi
+internal val Res.string.str_18499: StringResource
+  get() = String18.str_18499
+
+@ExperimentalResourceApi
+internal val Res.string.str_185: StringResource
+  get() = String18.str_185
+
+@ExperimentalResourceApi
+internal val Res.string.str_1850: StringResource
+  get() = String18.str_1850
+
+@ExperimentalResourceApi
+internal val Res.string.str_18500: StringResource
+  get() = String18.str_18500
+
+@ExperimentalResourceApi
+internal val Res.string.str_18501: StringResource
+  get() = String18.str_18501
+
+@ExperimentalResourceApi
+internal val Res.string.str_18502: StringResource
+  get() = String18.str_18502
+
+@ExperimentalResourceApi
+internal val Res.string.str_18503: StringResource
+  get() = String18.str_18503
+
+@ExperimentalResourceApi
+internal val Res.string.str_18504: StringResource
+  get() = String18.str_18504
+
+@ExperimentalResourceApi
+internal val Res.string.str_18505: StringResource
+  get() = String18.str_18505
+
+@ExperimentalResourceApi
+internal val Res.string.str_18506: StringResource
+  get() = String18.str_18506
+
+@ExperimentalResourceApi
+internal val Res.string.str_18507: StringResource
+  get() = String18.str_18507
+
+@ExperimentalResourceApi
+internal val Res.string.str_18508: StringResource
+  get() = String18.str_18508
+
+@ExperimentalResourceApi
+internal val Res.string.str_18509: StringResource
+  get() = String18.str_18509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1851: StringResource
+  get() = String18.str_1851
+
+@ExperimentalResourceApi
+internal val Res.string.str_18510: StringResource
+  get() = String18.str_18510
+
+@ExperimentalResourceApi
+internal val Res.string.str_18511: StringResource
+  get() = String18.str_18511
+
+@ExperimentalResourceApi
+internal val Res.string.str_18512: StringResource
+  get() = String18.str_18512
+
+@ExperimentalResourceApi
+internal val Res.string.str_18513: StringResource
+  get() = String18.str_18513
+
+@ExperimentalResourceApi
+internal val Res.string.str_18514: StringResource
+  get() = String18.str_18514
+
+@ExperimentalResourceApi
+internal val Res.string.str_18515: StringResource
+  get() = String18.str_18515
+
+@ExperimentalResourceApi
+internal val Res.string.str_18516: StringResource
+  get() = String18.str_18516
+
+@ExperimentalResourceApi
+internal val Res.string.str_18517: StringResource
+  get() = String18.str_18517
+
+@ExperimentalResourceApi
+internal val Res.string.str_18518: StringResource
+  get() = String18.str_18518
+
+@ExperimentalResourceApi
+internal val Res.string.str_18519: StringResource
+  get() = String18.str_18519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1852: StringResource
+  get() = String18.str_1852
+
+@ExperimentalResourceApi
+internal val Res.string.str_18520: StringResource
+  get() = String18.str_18520
+
+@ExperimentalResourceApi
+internal val Res.string.str_18521: StringResource
+  get() = String18.str_18521
+
+@ExperimentalResourceApi
+internal val Res.string.str_18522: StringResource
+  get() = String18.str_18522
+
+@ExperimentalResourceApi
+internal val Res.string.str_18523: StringResource
+  get() = String18.str_18523
+
+@ExperimentalResourceApi
+internal val Res.string.str_18524: StringResource
+  get() = String18.str_18524
+
+@ExperimentalResourceApi
+internal val Res.string.str_18525: StringResource
+  get() = String18.str_18525
+
+@ExperimentalResourceApi
+internal val Res.string.str_18526: StringResource
+  get() = String18.str_18526
+
+@ExperimentalResourceApi
+internal val Res.string.str_18527: StringResource
+  get() = String18.str_18527
+
+@ExperimentalResourceApi
+internal val Res.string.str_18528: StringResource
+  get() = String18.str_18528
+
+@ExperimentalResourceApi
+internal val Res.string.str_18529: StringResource
+  get() = String18.str_18529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1853: StringResource
+  get() = String18.str_1853
+
+@ExperimentalResourceApi
+internal val Res.string.str_18530: StringResource
+  get() = String18.str_18530
+
+@ExperimentalResourceApi
+internal val Res.string.str_18531: StringResource
+  get() = String18.str_18531
+
+@ExperimentalResourceApi
+internal val Res.string.str_18532: StringResource
+  get() = String18.str_18532
+
+@ExperimentalResourceApi
+internal val Res.string.str_18533: StringResource
+  get() = String18.str_18533
+
+@ExperimentalResourceApi
+internal val Res.string.str_18534: StringResource
+  get() = String18.str_18534
+
+@ExperimentalResourceApi
+internal val Res.string.str_18535: StringResource
+  get() = String18.str_18535
+
+@ExperimentalResourceApi
+internal val Res.string.str_18536: StringResource
+  get() = String18.str_18536
+
+@ExperimentalResourceApi
+internal val Res.string.str_18537: StringResource
+  get() = String18.str_18537
+
+@ExperimentalResourceApi
+internal val Res.string.str_18538: StringResource
+  get() = String18.str_18538
+
+@ExperimentalResourceApi
+internal val Res.string.str_18539: StringResource
+  get() = String18.str_18539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1854: StringResource
+  get() = String18.str_1854
+
+@ExperimentalResourceApi
+internal val Res.string.str_18540: StringResource
+  get() = String18.str_18540
+
+@ExperimentalResourceApi
+internal val Res.string.str_18541: StringResource
+  get() = String18.str_18541
+
+@ExperimentalResourceApi
+internal val Res.string.str_18542: StringResource
+  get() = String18.str_18542
+
+@ExperimentalResourceApi
+internal val Res.string.str_18543: StringResource
+  get() = String18.str_18543
+
+@ExperimentalResourceApi
+internal val Res.string.str_18544: StringResource
+  get() = String18.str_18544
+
+@ExperimentalResourceApi
+internal val Res.string.str_18545: StringResource
+  get() = String18.str_18545
+
+@ExperimentalResourceApi
+internal val Res.string.str_18546: StringResource
+  get() = String18.str_18546
+
+@ExperimentalResourceApi
+internal val Res.string.str_18547: StringResource
+  get() = String18.str_18547

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String19.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String19.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String19 {
+  public val str_18548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18548", "str_18548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18549", "str_18549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1855", "str_1855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18550", "str_18550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18551", "str_18551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18552", "str_18552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18553", "str_18553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18554", "str_18554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18555", "str_18555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18556", "str_18556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18557", "str_18557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18558", "str_18558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18559", "str_18559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1856", "str_1856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18560", "str_18560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18561", "str_18561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18562", "str_18562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18563", "str_18563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18564", "str_18564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18565", "str_18565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18566", "str_18566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18567", "str_18567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18568", "str_18568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18569", "str_18569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1857", "str_1857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18570", "str_18570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18571", "str_18571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18572", "str_18572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18573", "str_18573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18574", "str_18574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18575", "str_18575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18576", "str_18576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18577", "str_18577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18578", "str_18578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18579", "str_18579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1858", "str_1858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18580", "str_18580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18581", "str_18581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18582", "str_18582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18583", "str_18583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18584", "str_18584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18585", "str_18585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18586", "str_18586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18587", "str_18587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18588", "str_18588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18589", "str_18589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1859", "str_1859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18590", "str_18590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18591", "str_18591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18592", "str_18592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18593", "str_18593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18594", "str_18594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18595", "str_18595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18596", "str_18596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18597", "str_18597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18598", "str_18598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18599", "str_18599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_186", "str_186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1860", "str_1860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18600", "str_18600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18601", "str_18601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18602", "str_18602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18603", "str_18603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18604", "str_18604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18605", "str_18605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18606", "str_18606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18607", "str_18607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18608", "str_18608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18609", "str_18609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1861", "str_1861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18610", "str_18610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18611", "str_18611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18612", "str_18612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18613", "str_18613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18614", "str_18614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18615", "str_18615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18616", "str_18616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18617", "str_18617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18618", "str_18618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18619", "str_18619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1862", "str_1862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18620", "str_18620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18621", "str_18621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18622", "str_18622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18623", "str_18623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18624", "str_18624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18625", "str_18625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18626", "str_18626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18627", "str_18627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18628", "str_18628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18629", "str_18629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1863", "str_1863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18630", "str_18630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18631", "str_18631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18632", "str_18632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18633", "str_18633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18634", "str_18634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18635", "str_18635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18636", "str_18636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18637", "str_18637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18638", "str_18638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18639", "str_18639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1864", "str_1864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18640", "str_18640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18641", "str_18641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18642", "str_18642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18643", "str_18643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18644", "str_18644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18645", "str_18645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18646", "str_18646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18647", "str_18647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18648", "str_18648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18649", "str_18649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1865", "str_1865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18650", "str_18650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18651", "str_18651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18652", "str_18652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18653", "str_18653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18654", "str_18654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18655", "str_18655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18656", "str_18656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18657", "str_18657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18658", "str_18658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18659", "str_18659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1866", "str_1866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18660", "str_18660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18661", "str_18661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18662", "str_18662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18663", "str_18663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18664", "str_18664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18665", "str_18665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18666", "str_18666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18667", "str_18667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18668", "str_18668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18669", "str_18669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1867", "str_1867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18670", "str_18670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18671", "str_18671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18672", "str_18672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18673", "str_18673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18674", "str_18674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18675", "str_18675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18676", "str_18676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18677", "str_18677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18678", "str_18678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18679", "str_18679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1868", "str_1868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18680", "str_18680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18681", "str_18681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18682", "str_18682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18683", "str_18683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18684", "str_18684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18685", "str_18685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18686", "str_18686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18687", "str_18687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18688", "str_18688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18689", "str_18689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1869", "str_1869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18690", "str_18690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18691", "str_18691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18692", "str_18692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18693", "str_18693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18694", "str_18694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18695", "str_18695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18696", "str_18696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18697", "str_18697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18698", "str_18698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18699", "str_18699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_187", "str_187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1870", "str_1870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18700", "str_18700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18701", "str_18701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18702", "str_18702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18703", "str_18703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18704", "str_18704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18705", "str_18705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18706", "str_18706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18707", "str_18707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18708", "str_18708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18709", "str_18709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1871", "str_1871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18710", "str_18710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18711", "str_18711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18712", "str_18712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18713", "str_18713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18714", "str_18714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18715", "str_18715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18716", "str_18716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18717", "str_18717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18718", "str_18718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18719", "str_18719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1872", "str_1872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18720", "str_18720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18721", "str_18721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18722", "str_18722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18723", "str_18723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18724", "str_18724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18725", "str_18725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18726", "str_18726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18727", "str_18727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18728", "str_18728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18729", "str_18729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1873", "str_1873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18730", "str_18730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18731", "str_18731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18732", "str_18732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18733", "str_18733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18734", "str_18734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18735", "str_18735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18736", "str_18736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18737", "str_18737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18738", "str_18738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18739", "str_18739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1874", "str_1874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18740", "str_18740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18741", "str_18741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18742", "str_18742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18743", "str_18743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18744", "str_18744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18745", "str_18745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18746", "str_18746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18747", "str_18747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18748", "str_18748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18749", "str_18749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1875", "str_1875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18750", "str_18750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18751", "str_18751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18752", "str_18752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18753", "str_18753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18754", "str_18754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18755", "str_18755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18756", "str_18756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18757", "str_18757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18758", "str_18758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18759", "str_18759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1876", "str_1876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18760", "str_18760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18761", "str_18761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18762", "str_18762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18763", "str_18763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18764", "str_18764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18765", "str_18765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18766", "str_18766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18767", "str_18767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18768", "str_18768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18769", "str_18769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1877", "str_1877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18770", "str_18770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18771", "str_18771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18772", "str_18772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18773", "str_18773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18774", "str_18774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18775", "str_18775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18776", "str_18776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18777", "str_18777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18778", "str_18778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18779", "str_18779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1878", "str_1878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18780", "str_18780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18781", "str_18781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18782", "str_18782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18783", "str_18783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18784", "str_18784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18785", "str_18785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18786", "str_18786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18787", "str_18787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18788", "str_18788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18789", "str_18789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1879", "str_1879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18790", "str_18790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18791", "str_18791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18792", "str_18792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18793", "str_18793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18794", "str_18794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18795", "str_18795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18796", "str_18796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18797", "str_18797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18798", "str_18798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18799", "str_18799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_188", "str_188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1880", "str_1880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18800", "str_18800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18801", "str_18801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18802", "str_18802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18803", "str_18803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18804", "str_18804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18805", "str_18805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18806", "str_18806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18807", "str_18807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18808", "str_18808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18809", "str_18809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1881", "str_1881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18810", "str_18810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18811", "str_18811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18812", "str_18812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18813", "str_18813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18814", "str_18814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18815", "str_18815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18816", "str_18816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18817", "str_18817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18818", "str_18818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18819", "str_18819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1882", "str_1882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18820", "str_18820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18821", "str_18821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18822", "str_18822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18823", "str_18823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18824", "str_18824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18825", "str_18825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18826", "str_18826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18827", "str_18827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18828", "str_18828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18829", "str_18829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1883", "str_1883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18830", "str_18830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18831", "str_18831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18832", "str_18832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18833", "str_18833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18834", "str_18834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18835", "str_18835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18836", "str_18836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18837", "str_18837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18838", "str_18838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18839", "str_18839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1884", "str_1884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18840", "str_18840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18841", "str_18841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18842", "str_18842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18843", "str_18843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18844", "str_18844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18845", "str_18845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18846", "str_18846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18847", "str_18847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18848", "str_18848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18849", "str_18849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1885", "str_1885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18850", "str_18850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18851", "str_18851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18852", "str_18852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18853", "str_18853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18854", "str_18854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18855", "str_18855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18856", "str_18856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18857", "str_18857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18858", "str_18858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18859", "str_18859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1886", "str_1886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18860", "str_18860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18861", "str_18861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18862", "str_18862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18863", "str_18863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18864", "str_18864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18865", "str_18865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18866", "str_18866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18867", "str_18867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18868", "str_18868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18869", "str_18869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1887", "str_1887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18870", "str_18870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18871", "str_18871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18872", "str_18872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18873", "str_18873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18874", "str_18874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18875", "str_18875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18876", "str_18876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18877", "str_18877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18878", "str_18878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18879", "str_18879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1888", "str_1888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18880", "str_18880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18881", "str_18881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18882", "str_18882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18883", "str_18883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18884", "str_18884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18885", "str_18885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18886", "str_18886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18887", "str_18887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18888", "str_18888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18889", "str_18889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1889", "str_1889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18890", "str_18890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18891", "str_18891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18892", "str_18892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18893", "str_18893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18894", "str_18894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18895", "str_18895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18896", "str_18896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18897", "str_18897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18898", "str_18898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18899", "str_18899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_189", "str_189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1890", "str_1890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18900", "str_18900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18901", "str_18901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18902", "str_18902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18903", "str_18903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18904", "str_18904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18905", "str_18905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18906", "str_18906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18907", "str_18907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18908", "str_18908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18909", "str_18909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1891", "str_1891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18910", "str_18910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18911", "str_18911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18912", "str_18912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18913", "str_18913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18914", "str_18914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18915", "str_18915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18916", "str_18916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18917", "str_18917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18918", "str_18918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18919", "str_18919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1892", "str_1892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18920", "str_18920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18921", "str_18921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18922", "str_18922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18923", "str_18923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18924", "str_18924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18925", "str_18925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18926", "str_18926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18927", "str_18927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18928", "str_18928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18929", "str_18929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1893", "str_1893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18930", "str_18930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18931", "str_18931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18932", "str_18932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18933", "str_18933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18934", "str_18934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18935", "str_18935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18936", "str_18936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18937", "str_18937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18938", "str_18938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18939", "str_18939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1894", "str_1894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18940", "str_18940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18941", "str_18941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18942", "str_18942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18943", "str_18943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18944", "str_18944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18945", "str_18945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18946", "str_18946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18947", "str_18947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18948", "str_18948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18949", "str_18949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1895", "str_1895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18950", "str_18950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18951", "str_18951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18952", "str_18952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18953", "str_18953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18954", "str_18954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18955", "str_18955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18956", "str_18956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18957", "str_18957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18958", "str_18958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18959", "str_18959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1896", "str_1896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18960", "str_18960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18961", "str_18961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18962", "str_18962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18963", "str_18963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18964", "str_18964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18965", "str_18965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18966", "str_18966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18967", "str_18967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18968", "str_18968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18969", "str_18969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1897", "str_1897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18970", "str_18970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18971", "str_18971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18972", "str_18972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18973", "str_18973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18974", "str_18974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18975", "str_18975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18976", "str_18976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18977", "str_18977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18978", "str_18978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18979", "str_18979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1898", "str_1898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18980", "str_18980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18981", "str_18981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18982", "str_18982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18983", "str_18983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18984", "str_18984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18985", "str_18985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18986", "str_18986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18987", "str_18987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18988", "str_18988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18989", "str_18989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1899", "str_1899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18990", "str_18990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18991", "str_18991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18992", "str_18992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18993", "str_18993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18994", "str_18994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18995", "str_18995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18996", "str_18996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18997", "str_18997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_18998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18998", "str_18998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_18548: StringResource
+  get() = String19.str_18548
+
+@ExperimentalResourceApi
+internal val Res.string.str_18549: StringResource
+  get() = String19.str_18549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1855: StringResource
+  get() = String19.str_1855
+
+@ExperimentalResourceApi
+internal val Res.string.str_18550: StringResource
+  get() = String19.str_18550
+
+@ExperimentalResourceApi
+internal val Res.string.str_18551: StringResource
+  get() = String19.str_18551
+
+@ExperimentalResourceApi
+internal val Res.string.str_18552: StringResource
+  get() = String19.str_18552
+
+@ExperimentalResourceApi
+internal val Res.string.str_18553: StringResource
+  get() = String19.str_18553
+
+@ExperimentalResourceApi
+internal val Res.string.str_18554: StringResource
+  get() = String19.str_18554
+
+@ExperimentalResourceApi
+internal val Res.string.str_18555: StringResource
+  get() = String19.str_18555
+
+@ExperimentalResourceApi
+internal val Res.string.str_18556: StringResource
+  get() = String19.str_18556
+
+@ExperimentalResourceApi
+internal val Res.string.str_18557: StringResource
+  get() = String19.str_18557
+
+@ExperimentalResourceApi
+internal val Res.string.str_18558: StringResource
+  get() = String19.str_18558
+
+@ExperimentalResourceApi
+internal val Res.string.str_18559: StringResource
+  get() = String19.str_18559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1856: StringResource
+  get() = String19.str_1856
+
+@ExperimentalResourceApi
+internal val Res.string.str_18560: StringResource
+  get() = String19.str_18560
+
+@ExperimentalResourceApi
+internal val Res.string.str_18561: StringResource
+  get() = String19.str_18561
+
+@ExperimentalResourceApi
+internal val Res.string.str_18562: StringResource
+  get() = String19.str_18562
+
+@ExperimentalResourceApi
+internal val Res.string.str_18563: StringResource
+  get() = String19.str_18563
+
+@ExperimentalResourceApi
+internal val Res.string.str_18564: StringResource
+  get() = String19.str_18564
+
+@ExperimentalResourceApi
+internal val Res.string.str_18565: StringResource
+  get() = String19.str_18565
+
+@ExperimentalResourceApi
+internal val Res.string.str_18566: StringResource
+  get() = String19.str_18566
+
+@ExperimentalResourceApi
+internal val Res.string.str_18567: StringResource
+  get() = String19.str_18567
+
+@ExperimentalResourceApi
+internal val Res.string.str_18568: StringResource
+  get() = String19.str_18568
+
+@ExperimentalResourceApi
+internal val Res.string.str_18569: StringResource
+  get() = String19.str_18569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1857: StringResource
+  get() = String19.str_1857
+
+@ExperimentalResourceApi
+internal val Res.string.str_18570: StringResource
+  get() = String19.str_18570
+
+@ExperimentalResourceApi
+internal val Res.string.str_18571: StringResource
+  get() = String19.str_18571
+
+@ExperimentalResourceApi
+internal val Res.string.str_18572: StringResource
+  get() = String19.str_18572
+
+@ExperimentalResourceApi
+internal val Res.string.str_18573: StringResource
+  get() = String19.str_18573
+
+@ExperimentalResourceApi
+internal val Res.string.str_18574: StringResource
+  get() = String19.str_18574
+
+@ExperimentalResourceApi
+internal val Res.string.str_18575: StringResource
+  get() = String19.str_18575
+
+@ExperimentalResourceApi
+internal val Res.string.str_18576: StringResource
+  get() = String19.str_18576
+
+@ExperimentalResourceApi
+internal val Res.string.str_18577: StringResource
+  get() = String19.str_18577
+
+@ExperimentalResourceApi
+internal val Res.string.str_18578: StringResource
+  get() = String19.str_18578
+
+@ExperimentalResourceApi
+internal val Res.string.str_18579: StringResource
+  get() = String19.str_18579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1858: StringResource
+  get() = String19.str_1858
+
+@ExperimentalResourceApi
+internal val Res.string.str_18580: StringResource
+  get() = String19.str_18580
+
+@ExperimentalResourceApi
+internal val Res.string.str_18581: StringResource
+  get() = String19.str_18581
+
+@ExperimentalResourceApi
+internal val Res.string.str_18582: StringResource
+  get() = String19.str_18582
+
+@ExperimentalResourceApi
+internal val Res.string.str_18583: StringResource
+  get() = String19.str_18583
+
+@ExperimentalResourceApi
+internal val Res.string.str_18584: StringResource
+  get() = String19.str_18584
+
+@ExperimentalResourceApi
+internal val Res.string.str_18585: StringResource
+  get() = String19.str_18585
+
+@ExperimentalResourceApi
+internal val Res.string.str_18586: StringResource
+  get() = String19.str_18586
+
+@ExperimentalResourceApi
+internal val Res.string.str_18587: StringResource
+  get() = String19.str_18587
+
+@ExperimentalResourceApi
+internal val Res.string.str_18588: StringResource
+  get() = String19.str_18588
+
+@ExperimentalResourceApi
+internal val Res.string.str_18589: StringResource
+  get() = String19.str_18589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1859: StringResource
+  get() = String19.str_1859
+
+@ExperimentalResourceApi
+internal val Res.string.str_18590: StringResource
+  get() = String19.str_18590
+
+@ExperimentalResourceApi
+internal val Res.string.str_18591: StringResource
+  get() = String19.str_18591
+
+@ExperimentalResourceApi
+internal val Res.string.str_18592: StringResource
+  get() = String19.str_18592
+
+@ExperimentalResourceApi
+internal val Res.string.str_18593: StringResource
+  get() = String19.str_18593
+
+@ExperimentalResourceApi
+internal val Res.string.str_18594: StringResource
+  get() = String19.str_18594
+
+@ExperimentalResourceApi
+internal val Res.string.str_18595: StringResource
+  get() = String19.str_18595
+
+@ExperimentalResourceApi
+internal val Res.string.str_18596: StringResource
+  get() = String19.str_18596
+
+@ExperimentalResourceApi
+internal val Res.string.str_18597: StringResource
+  get() = String19.str_18597
+
+@ExperimentalResourceApi
+internal val Res.string.str_18598: StringResource
+  get() = String19.str_18598
+
+@ExperimentalResourceApi
+internal val Res.string.str_18599: StringResource
+  get() = String19.str_18599
+
+@ExperimentalResourceApi
+internal val Res.string.str_186: StringResource
+  get() = String19.str_186
+
+@ExperimentalResourceApi
+internal val Res.string.str_1860: StringResource
+  get() = String19.str_1860
+
+@ExperimentalResourceApi
+internal val Res.string.str_18600: StringResource
+  get() = String19.str_18600
+
+@ExperimentalResourceApi
+internal val Res.string.str_18601: StringResource
+  get() = String19.str_18601
+
+@ExperimentalResourceApi
+internal val Res.string.str_18602: StringResource
+  get() = String19.str_18602
+
+@ExperimentalResourceApi
+internal val Res.string.str_18603: StringResource
+  get() = String19.str_18603
+
+@ExperimentalResourceApi
+internal val Res.string.str_18604: StringResource
+  get() = String19.str_18604
+
+@ExperimentalResourceApi
+internal val Res.string.str_18605: StringResource
+  get() = String19.str_18605
+
+@ExperimentalResourceApi
+internal val Res.string.str_18606: StringResource
+  get() = String19.str_18606
+
+@ExperimentalResourceApi
+internal val Res.string.str_18607: StringResource
+  get() = String19.str_18607
+
+@ExperimentalResourceApi
+internal val Res.string.str_18608: StringResource
+  get() = String19.str_18608
+
+@ExperimentalResourceApi
+internal val Res.string.str_18609: StringResource
+  get() = String19.str_18609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1861: StringResource
+  get() = String19.str_1861
+
+@ExperimentalResourceApi
+internal val Res.string.str_18610: StringResource
+  get() = String19.str_18610
+
+@ExperimentalResourceApi
+internal val Res.string.str_18611: StringResource
+  get() = String19.str_18611
+
+@ExperimentalResourceApi
+internal val Res.string.str_18612: StringResource
+  get() = String19.str_18612
+
+@ExperimentalResourceApi
+internal val Res.string.str_18613: StringResource
+  get() = String19.str_18613
+
+@ExperimentalResourceApi
+internal val Res.string.str_18614: StringResource
+  get() = String19.str_18614
+
+@ExperimentalResourceApi
+internal val Res.string.str_18615: StringResource
+  get() = String19.str_18615
+
+@ExperimentalResourceApi
+internal val Res.string.str_18616: StringResource
+  get() = String19.str_18616
+
+@ExperimentalResourceApi
+internal val Res.string.str_18617: StringResource
+  get() = String19.str_18617
+
+@ExperimentalResourceApi
+internal val Res.string.str_18618: StringResource
+  get() = String19.str_18618
+
+@ExperimentalResourceApi
+internal val Res.string.str_18619: StringResource
+  get() = String19.str_18619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1862: StringResource
+  get() = String19.str_1862
+
+@ExperimentalResourceApi
+internal val Res.string.str_18620: StringResource
+  get() = String19.str_18620
+
+@ExperimentalResourceApi
+internal val Res.string.str_18621: StringResource
+  get() = String19.str_18621
+
+@ExperimentalResourceApi
+internal val Res.string.str_18622: StringResource
+  get() = String19.str_18622
+
+@ExperimentalResourceApi
+internal val Res.string.str_18623: StringResource
+  get() = String19.str_18623
+
+@ExperimentalResourceApi
+internal val Res.string.str_18624: StringResource
+  get() = String19.str_18624
+
+@ExperimentalResourceApi
+internal val Res.string.str_18625: StringResource
+  get() = String19.str_18625
+
+@ExperimentalResourceApi
+internal val Res.string.str_18626: StringResource
+  get() = String19.str_18626
+
+@ExperimentalResourceApi
+internal val Res.string.str_18627: StringResource
+  get() = String19.str_18627
+
+@ExperimentalResourceApi
+internal val Res.string.str_18628: StringResource
+  get() = String19.str_18628
+
+@ExperimentalResourceApi
+internal val Res.string.str_18629: StringResource
+  get() = String19.str_18629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1863: StringResource
+  get() = String19.str_1863
+
+@ExperimentalResourceApi
+internal val Res.string.str_18630: StringResource
+  get() = String19.str_18630
+
+@ExperimentalResourceApi
+internal val Res.string.str_18631: StringResource
+  get() = String19.str_18631
+
+@ExperimentalResourceApi
+internal val Res.string.str_18632: StringResource
+  get() = String19.str_18632
+
+@ExperimentalResourceApi
+internal val Res.string.str_18633: StringResource
+  get() = String19.str_18633
+
+@ExperimentalResourceApi
+internal val Res.string.str_18634: StringResource
+  get() = String19.str_18634
+
+@ExperimentalResourceApi
+internal val Res.string.str_18635: StringResource
+  get() = String19.str_18635
+
+@ExperimentalResourceApi
+internal val Res.string.str_18636: StringResource
+  get() = String19.str_18636
+
+@ExperimentalResourceApi
+internal val Res.string.str_18637: StringResource
+  get() = String19.str_18637
+
+@ExperimentalResourceApi
+internal val Res.string.str_18638: StringResource
+  get() = String19.str_18638
+
+@ExperimentalResourceApi
+internal val Res.string.str_18639: StringResource
+  get() = String19.str_18639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1864: StringResource
+  get() = String19.str_1864
+
+@ExperimentalResourceApi
+internal val Res.string.str_18640: StringResource
+  get() = String19.str_18640
+
+@ExperimentalResourceApi
+internal val Res.string.str_18641: StringResource
+  get() = String19.str_18641
+
+@ExperimentalResourceApi
+internal val Res.string.str_18642: StringResource
+  get() = String19.str_18642
+
+@ExperimentalResourceApi
+internal val Res.string.str_18643: StringResource
+  get() = String19.str_18643
+
+@ExperimentalResourceApi
+internal val Res.string.str_18644: StringResource
+  get() = String19.str_18644
+
+@ExperimentalResourceApi
+internal val Res.string.str_18645: StringResource
+  get() = String19.str_18645
+
+@ExperimentalResourceApi
+internal val Res.string.str_18646: StringResource
+  get() = String19.str_18646
+
+@ExperimentalResourceApi
+internal val Res.string.str_18647: StringResource
+  get() = String19.str_18647
+
+@ExperimentalResourceApi
+internal val Res.string.str_18648: StringResource
+  get() = String19.str_18648
+
+@ExperimentalResourceApi
+internal val Res.string.str_18649: StringResource
+  get() = String19.str_18649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1865: StringResource
+  get() = String19.str_1865
+
+@ExperimentalResourceApi
+internal val Res.string.str_18650: StringResource
+  get() = String19.str_18650
+
+@ExperimentalResourceApi
+internal val Res.string.str_18651: StringResource
+  get() = String19.str_18651
+
+@ExperimentalResourceApi
+internal val Res.string.str_18652: StringResource
+  get() = String19.str_18652
+
+@ExperimentalResourceApi
+internal val Res.string.str_18653: StringResource
+  get() = String19.str_18653
+
+@ExperimentalResourceApi
+internal val Res.string.str_18654: StringResource
+  get() = String19.str_18654
+
+@ExperimentalResourceApi
+internal val Res.string.str_18655: StringResource
+  get() = String19.str_18655
+
+@ExperimentalResourceApi
+internal val Res.string.str_18656: StringResource
+  get() = String19.str_18656
+
+@ExperimentalResourceApi
+internal val Res.string.str_18657: StringResource
+  get() = String19.str_18657
+
+@ExperimentalResourceApi
+internal val Res.string.str_18658: StringResource
+  get() = String19.str_18658
+
+@ExperimentalResourceApi
+internal val Res.string.str_18659: StringResource
+  get() = String19.str_18659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1866: StringResource
+  get() = String19.str_1866
+
+@ExperimentalResourceApi
+internal val Res.string.str_18660: StringResource
+  get() = String19.str_18660
+
+@ExperimentalResourceApi
+internal val Res.string.str_18661: StringResource
+  get() = String19.str_18661
+
+@ExperimentalResourceApi
+internal val Res.string.str_18662: StringResource
+  get() = String19.str_18662
+
+@ExperimentalResourceApi
+internal val Res.string.str_18663: StringResource
+  get() = String19.str_18663
+
+@ExperimentalResourceApi
+internal val Res.string.str_18664: StringResource
+  get() = String19.str_18664
+
+@ExperimentalResourceApi
+internal val Res.string.str_18665: StringResource
+  get() = String19.str_18665
+
+@ExperimentalResourceApi
+internal val Res.string.str_18666: StringResource
+  get() = String19.str_18666
+
+@ExperimentalResourceApi
+internal val Res.string.str_18667: StringResource
+  get() = String19.str_18667
+
+@ExperimentalResourceApi
+internal val Res.string.str_18668: StringResource
+  get() = String19.str_18668
+
+@ExperimentalResourceApi
+internal val Res.string.str_18669: StringResource
+  get() = String19.str_18669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1867: StringResource
+  get() = String19.str_1867
+
+@ExperimentalResourceApi
+internal val Res.string.str_18670: StringResource
+  get() = String19.str_18670
+
+@ExperimentalResourceApi
+internal val Res.string.str_18671: StringResource
+  get() = String19.str_18671
+
+@ExperimentalResourceApi
+internal val Res.string.str_18672: StringResource
+  get() = String19.str_18672
+
+@ExperimentalResourceApi
+internal val Res.string.str_18673: StringResource
+  get() = String19.str_18673
+
+@ExperimentalResourceApi
+internal val Res.string.str_18674: StringResource
+  get() = String19.str_18674
+
+@ExperimentalResourceApi
+internal val Res.string.str_18675: StringResource
+  get() = String19.str_18675
+
+@ExperimentalResourceApi
+internal val Res.string.str_18676: StringResource
+  get() = String19.str_18676
+
+@ExperimentalResourceApi
+internal val Res.string.str_18677: StringResource
+  get() = String19.str_18677
+
+@ExperimentalResourceApi
+internal val Res.string.str_18678: StringResource
+  get() = String19.str_18678
+
+@ExperimentalResourceApi
+internal val Res.string.str_18679: StringResource
+  get() = String19.str_18679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1868: StringResource
+  get() = String19.str_1868
+
+@ExperimentalResourceApi
+internal val Res.string.str_18680: StringResource
+  get() = String19.str_18680
+
+@ExperimentalResourceApi
+internal val Res.string.str_18681: StringResource
+  get() = String19.str_18681
+
+@ExperimentalResourceApi
+internal val Res.string.str_18682: StringResource
+  get() = String19.str_18682
+
+@ExperimentalResourceApi
+internal val Res.string.str_18683: StringResource
+  get() = String19.str_18683
+
+@ExperimentalResourceApi
+internal val Res.string.str_18684: StringResource
+  get() = String19.str_18684
+
+@ExperimentalResourceApi
+internal val Res.string.str_18685: StringResource
+  get() = String19.str_18685
+
+@ExperimentalResourceApi
+internal val Res.string.str_18686: StringResource
+  get() = String19.str_18686
+
+@ExperimentalResourceApi
+internal val Res.string.str_18687: StringResource
+  get() = String19.str_18687
+
+@ExperimentalResourceApi
+internal val Res.string.str_18688: StringResource
+  get() = String19.str_18688
+
+@ExperimentalResourceApi
+internal val Res.string.str_18689: StringResource
+  get() = String19.str_18689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1869: StringResource
+  get() = String19.str_1869
+
+@ExperimentalResourceApi
+internal val Res.string.str_18690: StringResource
+  get() = String19.str_18690
+
+@ExperimentalResourceApi
+internal val Res.string.str_18691: StringResource
+  get() = String19.str_18691
+
+@ExperimentalResourceApi
+internal val Res.string.str_18692: StringResource
+  get() = String19.str_18692
+
+@ExperimentalResourceApi
+internal val Res.string.str_18693: StringResource
+  get() = String19.str_18693
+
+@ExperimentalResourceApi
+internal val Res.string.str_18694: StringResource
+  get() = String19.str_18694
+
+@ExperimentalResourceApi
+internal val Res.string.str_18695: StringResource
+  get() = String19.str_18695
+
+@ExperimentalResourceApi
+internal val Res.string.str_18696: StringResource
+  get() = String19.str_18696
+
+@ExperimentalResourceApi
+internal val Res.string.str_18697: StringResource
+  get() = String19.str_18697
+
+@ExperimentalResourceApi
+internal val Res.string.str_18698: StringResource
+  get() = String19.str_18698
+
+@ExperimentalResourceApi
+internal val Res.string.str_18699: StringResource
+  get() = String19.str_18699
+
+@ExperimentalResourceApi
+internal val Res.string.str_187: StringResource
+  get() = String19.str_187
+
+@ExperimentalResourceApi
+internal val Res.string.str_1870: StringResource
+  get() = String19.str_1870
+
+@ExperimentalResourceApi
+internal val Res.string.str_18700: StringResource
+  get() = String19.str_18700
+
+@ExperimentalResourceApi
+internal val Res.string.str_18701: StringResource
+  get() = String19.str_18701
+
+@ExperimentalResourceApi
+internal val Res.string.str_18702: StringResource
+  get() = String19.str_18702
+
+@ExperimentalResourceApi
+internal val Res.string.str_18703: StringResource
+  get() = String19.str_18703
+
+@ExperimentalResourceApi
+internal val Res.string.str_18704: StringResource
+  get() = String19.str_18704
+
+@ExperimentalResourceApi
+internal val Res.string.str_18705: StringResource
+  get() = String19.str_18705
+
+@ExperimentalResourceApi
+internal val Res.string.str_18706: StringResource
+  get() = String19.str_18706
+
+@ExperimentalResourceApi
+internal val Res.string.str_18707: StringResource
+  get() = String19.str_18707
+
+@ExperimentalResourceApi
+internal val Res.string.str_18708: StringResource
+  get() = String19.str_18708
+
+@ExperimentalResourceApi
+internal val Res.string.str_18709: StringResource
+  get() = String19.str_18709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1871: StringResource
+  get() = String19.str_1871
+
+@ExperimentalResourceApi
+internal val Res.string.str_18710: StringResource
+  get() = String19.str_18710
+
+@ExperimentalResourceApi
+internal val Res.string.str_18711: StringResource
+  get() = String19.str_18711
+
+@ExperimentalResourceApi
+internal val Res.string.str_18712: StringResource
+  get() = String19.str_18712
+
+@ExperimentalResourceApi
+internal val Res.string.str_18713: StringResource
+  get() = String19.str_18713
+
+@ExperimentalResourceApi
+internal val Res.string.str_18714: StringResource
+  get() = String19.str_18714
+
+@ExperimentalResourceApi
+internal val Res.string.str_18715: StringResource
+  get() = String19.str_18715
+
+@ExperimentalResourceApi
+internal val Res.string.str_18716: StringResource
+  get() = String19.str_18716
+
+@ExperimentalResourceApi
+internal val Res.string.str_18717: StringResource
+  get() = String19.str_18717
+
+@ExperimentalResourceApi
+internal val Res.string.str_18718: StringResource
+  get() = String19.str_18718
+
+@ExperimentalResourceApi
+internal val Res.string.str_18719: StringResource
+  get() = String19.str_18719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1872: StringResource
+  get() = String19.str_1872
+
+@ExperimentalResourceApi
+internal val Res.string.str_18720: StringResource
+  get() = String19.str_18720
+
+@ExperimentalResourceApi
+internal val Res.string.str_18721: StringResource
+  get() = String19.str_18721
+
+@ExperimentalResourceApi
+internal val Res.string.str_18722: StringResource
+  get() = String19.str_18722
+
+@ExperimentalResourceApi
+internal val Res.string.str_18723: StringResource
+  get() = String19.str_18723
+
+@ExperimentalResourceApi
+internal val Res.string.str_18724: StringResource
+  get() = String19.str_18724
+
+@ExperimentalResourceApi
+internal val Res.string.str_18725: StringResource
+  get() = String19.str_18725
+
+@ExperimentalResourceApi
+internal val Res.string.str_18726: StringResource
+  get() = String19.str_18726
+
+@ExperimentalResourceApi
+internal val Res.string.str_18727: StringResource
+  get() = String19.str_18727
+
+@ExperimentalResourceApi
+internal val Res.string.str_18728: StringResource
+  get() = String19.str_18728
+
+@ExperimentalResourceApi
+internal val Res.string.str_18729: StringResource
+  get() = String19.str_18729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1873: StringResource
+  get() = String19.str_1873
+
+@ExperimentalResourceApi
+internal val Res.string.str_18730: StringResource
+  get() = String19.str_18730
+
+@ExperimentalResourceApi
+internal val Res.string.str_18731: StringResource
+  get() = String19.str_18731
+
+@ExperimentalResourceApi
+internal val Res.string.str_18732: StringResource
+  get() = String19.str_18732
+
+@ExperimentalResourceApi
+internal val Res.string.str_18733: StringResource
+  get() = String19.str_18733
+
+@ExperimentalResourceApi
+internal val Res.string.str_18734: StringResource
+  get() = String19.str_18734
+
+@ExperimentalResourceApi
+internal val Res.string.str_18735: StringResource
+  get() = String19.str_18735
+
+@ExperimentalResourceApi
+internal val Res.string.str_18736: StringResource
+  get() = String19.str_18736
+
+@ExperimentalResourceApi
+internal val Res.string.str_18737: StringResource
+  get() = String19.str_18737
+
+@ExperimentalResourceApi
+internal val Res.string.str_18738: StringResource
+  get() = String19.str_18738
+
+@ExperimentalResourceApi
+internal val Res.string.str_18739: StringResource
+  get() = String19.str_18739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1874: StringResource
+  get() = String19.str_1874
+
+@ExperimentalResourceApi
+internal val Res.string.str_18740: StringResource
+  get() = String19.str_18740
+
+@ExperimentalResourceApi
+internal val Res.string.str_18741: StringResource
+  get() = String19.str_18741
+
+@ExperimentalResourceApi
+internal val Res.string.str_18742: StringResource
+  get() = String19.str_18742
+
+@ExperimentalResourceApi
+internal val Res.string.str_18743: StringResource
+  get() = String19.str_18743
+
+@ExperimentalResourceApi
+internal val Res.string.str_18744: StringResource
+  get() = String19.str_18744
+
+@ExperimentalResourceApi
+internal val Res.string.str_18745: StringResource
+  get() = String19.str_18745
+
+@ExperimentalResourceApi
+internal val Res.string.str_18746: StringResource
+  get() = String19.str_18746
+
+@ExperimentalResourceApi
+internal val Res.string.str_18747: StringResource
+  get() = String19.str_18747
+
+@ExperimentalResourceApi
+internal val Res.string.str_18748: StringResource
+  get() = String19.str_18748
+
+@ExperimentalResourceApi
+internal val Res.string.str_18749: StringResource
+  get() = String19.str_18749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1875: StringResource
+  get() = String19.str_1875
+
+@ExperimentalResourceApi
+internal val Res.string.str_18750: StringResource
+  get() = String19.str_18750
+
+@ExperimentalResourceApi
+internal val Res.string.str_18751: StringResource
+  get() = String19.str_18751
+
+@ExperimentalResourceApi
+internal val Res.string.str_18752: StringResource
+  get() = String19.str_18752
+
+@ExperimentalResourceApi
+internal val Res.string.str_18753: StringResource
+  get() = String19.str_18753
+
+@ExperimentalResourceApi
+internal val Res.string.str_18754: StringResource
+  get() = String19.str_18754
+
+@ExperimentalResourceApi
+internal val Res.string.str_18755: StringResource
+  get() = String19.str_18755
+
+@ExperimentalResourceApi
+internal val Res.string.str_18756: StringResource
+  get() = String19.str_18756
+
+@ExperimentalResourceApi
+internal val Res.string.str_18757: StringResource
+  get() = String19.str_18757
+
+@ExperimentalResourceApi
+internal val Res.string.str_18758: StringResource
+  get() = String19.str_18758
+
+@ExperimentalResourceApi
+internal val Res.string.str_18759: StringResource
+  get() = String19.str_18759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1876: StringResource
+  get() = String19.str_1876
+
+@ExperimentalResourceApi
+internal val Res.string.str_18760: StringResource
+  get() = String19.str_18760
+
+@ExperimentalResourceApi
+internal val Res.string.str_18761: StringResource
+  get() = String19.str_18761
+
+@ExperimentalResourceApi
+internal val Res.string.str_18762: StringResource
+  get() = String19.str_18762
+
+@ExperimentalResourceApi
+internal val Res.string.str_18763: StringResource
+  get() = String19.str_18763
+
+@ExperimentalResourceApi
+internal val Res.string.str_18764: StringResource
+  get() = String19.str_18764
+
+@ExperimentalResourceApi
+internal val Res.string.str_18765: StringResource
+  get() = String19.str_18765
+
+@ExperimentalResourceApi
+internal val Res.string.str_18766: StringResource
+  get() = String19.str_18766
+
+@ExperimentalResourceApi
+internal val Res.string.str_18767: StringResource
+  get() = String19.str_18767
+
+@ExperimentalResourceApi
+internal val Res.string.str_18768: StringResource
+  get() = String19.str_18768
+
+@ExperimentalResourceApi
+internal val Res.string.str_18769: StringResource
+  get() = String19.str_18769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1877: StringResource
+  get() = String19.str_1877
+
+@ExperimentalResourceApi
+internal val Res.string.str_18770: StringResource
+  get() = String19.str_18770
+
+@ExperimentalResourceApi
+internal val Res.string.str_18771: StringResource
+  get() = String19.str_18771
+
+@ExperimentalResourceApi
+internal val Res.string.str_18772: StringResource
+  get() = String19.str_18772
+
+@ExperimentalResourceApi
+internal val Res.string.str_18773: StringResource
+  get() = String19.str_18773
+
+@ExperimentalResourceApi
+internal val Res.string.str_18774: StringResource
+  get() = String19.str_18774
+
+@ExperimentalResourceApi
+internal val Res.string.str_18775: StringResource
+  get() = String19.str_18775
+
+@ExperimentalResourceApi
+internal val Res.string.str_18776: StringResource
+  get() = String19.str_18776
+
+@ExperimentalResourceApi
+internal val Res.string.str_18777: StringResource
+  get() = String19.str_18777
+
+@ExperimentalResourceApi
+internal val Res.string.str_18778: StringResource
+  get() = String19.str_18778
+
+@ExperimentalResourceApi
+internal val Res.string.str_18779: StringResource
+  get() = String19.str_18779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1878: StringResource
+  get() = String19.str_1878
+
+@ExperimentalResourceApi
+internal val Res.string.str_18780: StringResource
+  get() = String19.str_18780
+
+@ExperimentalResourceApi
+internal val Res.string.str_18781: StringResource
+  get() = String19.str_18781
+
+@ExperimentalResourceApi
+internal val Res.string.str_18782: StringResource
+  get() = String19.str_18782
+
+@ExperimentalResourceApi
+internal val Res.string.str_18783: StringResource
+  get() = String19.str_18783
+
+@ExperimentalResourceApi
+internal val Res.string.str_18784: StringResource
+  get() = String19.str_18784
+
+@ExperimentalResourceApi
+internal val Res.string.str_18785: StringResource
+  get() = String19.str_18785
+
+@ExperimentalResourceApi
+internal val Res.string.str_18786: StringResource
+  get() = String19.str_18786
+
+@ExperimentalResourceApi
+internal val Res.string.str_18787: StringResource
+  get() = String19.str_18787
+
+@ExperimentalResourceApi
+internal val Res.string.str_18788: StringResource
+  get() = String19.str_18788
+
+@ExperimentalResourceApi
+internal val Res.string.str_18789: StringResource
+  get() = String19.str_18789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1879: StringResource
+  get() = String19.str_1879
+
+@ExperimentalResourceApi
+internal val Res.string.str_18790: StringResource
+  get() = String19.str_18790
+
+@ExperimentalResourceApi
+internal val Res.string.str_18791: StringResource
+  get() = String19.str_18791
+
+@ExperimentalResourceApi
+internal val Res.string.str_18792: StringResource
+  get() = String19.str_18792
+
+@ExperimentalResourceApi
+internal val Res.string.str_18793: StringResource
+  get() = String19.str_18793
+
+@ExperimentalResourceApi
+internal val Res.string.str_18794: StringResource
+  get() = String19.str_18794
+
+@ExperimentalResourceApi
+internal val Res.string.str_18795: StringResource
+  get() = String19.str_18795
+
+@ExperimentalResourceApi
+internal val Res.string.str_18796: StringResource
+  get() = String19.str_18796
+
+@ExperimentalResourceApi
+internal val Res.string.str_18797: StringResource
+  get() = String19.str_18797
+
+@ExperimentalResourceApi
+internal val Res.string.str_18798: StringResource
+  get() = String19.str_18798
+
+@ExperimentalResourceApi
+internal val Res.string.str_18799: StringResource
+  get() = String19.str_18799
+
+@ExperimentalResourceApi
+internal val Res.string.str_188: StringResource
+  get() = String19.str_188
+
+@ExperimentalResourceApi
+internal val Res.string.str_1880: StringResource
+  get() = String19.str_1880
+
+@ExperimentalResourceApi
+internal val Res.string.str_18800: StringResource
+  get() = String19.str_18800
+
+@ExperimentalResourceApi
+internal val Res.string.str_18801: StringResource
+  get() = String19.str_18801
+
+@ExperimentalResourceApi
+internal val Res.string.str_18802: StringResource
+  get() = String19.str_18802
+
+@ExperimentalResourceApi
+internal val Res.string.str_18803: StringResource
+  get() = String19.str_18803
+
+@ExperimentalResourceApi
+internal val Res.string.str_18804: StringResource
+  get() = String19.str_18804
+
+@ExperimentalResourceApi
+internal val Res.string.str_18805: StringResource
+  get() = String19.str_18805
+
+@ExperimentalResourceApi
+internal val Res.string.str_18806: StringResource
+  get() = String19.str_18806
+
+@ExperimentalResourceApi
+internal val Res.string.str_18807: StringResource
+  get() = String19.str_18807
+
+@ExperimentalResourceApi
+internal val Res.string.str_18808: StringResource
+  get() = String19.str_18808
+
+@ExperimentalResourceApi
+internal val Res.string.str_18809: StringResource
+  get() = String19.str_18809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1881: StringResource
+  get() = String19.str_1881
+
+@ExperimentalResourceApi
+internal val Res.string.str_18810: StringResource
+  get() = String19.str_18810
+
+@ExperimentalResourceApi
+internal val Res.string.str_18811: StringResource
+  get() = String19.str_18811
+
+@ExperimentalResourceApi
+internal val Res.string.str_18812: StringResource
+  get() = String19.str_18812
+
+@ExperimentalResourceApi
+internal val Res.string.str_18813: StringResource
+  get() = String19.str_18813
+
+@ExperimentalResourceApi
+internal val Res.string.str_18814: StringResource
+  get() = String19.str_18814
+
+@ExperimentalResourceApi
+internal val Res.string.str_18815: StringResource
+  get() = String19.str_18815
+
+@ExperimentalResourceApi
+internal val Res.string.str_18816: StringResource
+  get() = String19.str_18816
+
+@ExperimentalResourceApi
+internal val Res.string.str_18817: StringResource
+  get() = String19.str_18817
+
+@ExperimentalResourceApi
+internal val Res.string.str_18818: StringResource
+  get() = String19.str_18818
+
+@ExperimentalResourceApi
+internal val Res.string.str_18819: StringResource
+  get() = String19.str_18819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1882: StringResource
+  get() = String19.str_1882
+
+@ExperimentalResourceApi
+internal val Res.string.str_18820: StringResource
+  get() = String19.str_18820
+
+@ExperimentalResourceApi
+internal val Res.string.str_18821: StringResource
+  get() = String19.str_18821
+
+@ExperimentalResourceApi
+internal val Res.string.str_18822: StringResource
+  get() = String19.str_18822
+
+@ExperimentalResourceApi
+internal val Res.string.str_18823: StringResource
+  get() = String19.str_18823
+
+@ExperimentalResourceApi
+internal val Res.string.str_18824: StringResource
+  get() = String19.str_18824
+
+@ExperimentalResourceApi
+internal val Res.string.str_18825: StringResource
+  get() = String19.str_18825
+
+@ExperimentalResourceApi
+internal val Res.string.str_18826: StringResource
+  get() = String19.str_18826
+
+@ExperimentalResourceApi
+internal val Res.string.str_18827: StringResource
+  get() = String19.str_18827
+
+@ExperimentalResourceApi
+internal val Res.string.str_18828: StringResource
+  get() = String19.str_18828
+
+@ExperimentalResourceApi
+internal val Res.string.str_18829: StringResource
+  get() = String19.str_18829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1883: StringResource
+  get() = String19.str_1883
+
+@ExperimentalResourceApi
+internal val Res.string.str_18830: StringResource
+  get() = String19.str_18830
+
+@ExperimentalResourceApi
+internal val Res.string.str_18831: StringResource
+  get() = String19.str_18831
+
+@ExperimentalResourceApi
+internal val Res.string.str_18832: StringResource
+  get() = String19.str_18832
+
+@ExperimentalResourceApi
+internal val Res.string.str_18833: StringResource
+  get() = String19.str_18833
+
+@ExperimentalResourceApi
+internal val Res.string.str_18834: StringResource
+  get() = String19.str_18834
+
+@ExperimentalResourceApi
+internal val Res.string.str_18835: StringResource
+  get() = String19.str_18835
+
+@ExperimentalResourceApi
+internal val Res.string.str_18836: StringResource
+  get() = String19.str_18836
+
+@ExperimentalResourceApi
+internal val Res.string.str_18837: StringResource
+  get() = String19.str_18837
+
+@ExperimentalResourceApi
+internal val Res.string.str_18838: StringResource
+  get() = String19.str_18838
+
+@ExperimentalResourceApi
+internal val Res.string.str_18839: StringResource
+  get() = String19.str_18839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1884: StringResource
+  get() = String19.str_1884
+
+@ExperimentalResourceApi
+internal val Res.string.str_18840: StringResource
+  get() = String19.str_18840
+
+@ExperimentalResourceApi
+internal val Res.string.str_18841: StringResource
+  get() = String19.str_18841
+
+@ExperimentalResourceApi
+internal val Res.string.str_18842: StringResource
+  get() = String19.str_18842
+
+@ExperimentalResourceApi
+internal val Res.string.str_18843: StringResource
+  get() = String19.str_18843
+
+@ExperimentalResourceApi
+internal val Res.string.str_18844: StringResource
+  get() = String19.str_18844
+
+@ExperimentalResourceApi
+internal val Res.string.str_18845: StringResource
+  get() = String19.str_18845
+
+@ExperimentalResourceApi
+internal val Res.string.str_18846: StringResource
+  get() = String19.str_18846
+
+@ExperimentalResourceApi
+internal val Res.string.str_18847: StringResource
+  get() = String19.str_18847
+
+@ExperimentalResourceApi
+internal val Res.string.str_18848: StringResource
+  get() = String19.str_18848
+
+@ExperimentalResourceApi
+internal val Res.string.str_18849: StringResource
+  get() = String19.str_18849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1885: StringResource
+  get() = String19.str_1885
+
+@ExperimentalResourceApi
+internal val Res.string.str_18850: StringResource
+  get() = String19.str_18850
+
+@ExperimentalResourceApi
+internal val Res.string.str_18851: StringResource
+  get() = String19.str_18851
+
+@ExperimentalResourceApi
+internal val Res.string.str_18852: StringResource
+  get() = String19.str_18852
+
+@ExperimentalResourceApi
+internal val Res.string.str_18853: StringResource
+  get() = String19.str_18853
+
+@ExperimentalResourceApi
+internal val Res.string.str_18854: StringResource
+  get() = String19.str_18854
+
+@ExperimentalResourceApi
+internal val Res.string.str_18855: StringResource
+  get() = String19.str_18855
+
+@ExperimentalResourceApi
+internal val Res.string.str_18856: StringResource
+  get() = String19.str_18856
+
+@ExperimentalResourceApi
+internal val Res.string.str_18857: StringResource
+  get() = String19.str_18857
+
+@ExperimentalResourceApi
+internal val Res.string.str_18858: StringResource
+  get() = String19.str_18858
+
+@ExperimentalResourceApi
+internal val Res.string.str_18859: StringResource
+  get() = String19.str_18859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1886: StringResource
+  get() = String19.str_1886
+
+@ExperimentalResourceApi
+internal val Res.string.str_18860: StringResource
+  get() = String19.str_18860
+
+@ExperimentalResourceApi
+internal val Res.string.str_18861: StringResource
+  get() = String19.str_18861
+
+@ExperimentalResourceApi
+internal val Res.string.str_18862: StringResource
+  get() = String19.str_18862
+
+@ExperimentalResourceApi
+internal val Res.string.str_18863: StringResource
+  get() = String19.str_18863
+
+@ExperimentalResourceApi
+internal val Res.string.str_18864: StringResource
+  get() = String19.str_18864
+
+@ExperimentalResourceApi
+internal val Res.string.str_18865: StringResource
+  get() = String19.str_18865
+
+@ExperimentalResourceApi
+internal val Res.string.str_18866: StringResource
+  get() = String19.str_18866
+
+@ExperimentalResourceApi
+internal val Res.string.str_18867: StringResource
+  get() = String19.str_18867
+
+@ExperimentalResourceApi
+internal val Res.string.str_18868: StringResource
+  get() = String19.str_18868
+
+@ExperimentalResourceApi
+internal val Res.string.str_18869: StringResource
+  get() = String19.str_18869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1887: StringResource
+  get() = String19.str_1887
+
+@ExperimentalResourceApi
+internal val Res.string.str_18870: StringResource
+  get() = String19.str_18870
+
+@ExperimentalResourceApi
+internal val Res.string.str_18871: StringResource
+  get() = String19.str_18871
+
+@ExperimentalResourceApi
+internal val Res.string.str_18872: StringResource
+  get() = String19.str_18872
+
+@ExperimentalResourceApi
+internal val Res.string.str_18873: StringResource
+  get() = String19.str_18873
+
+@ExperimentalResourceApi
+internal val Res.string.str_18874: StringResource
+  get() = String19.str_18874
+
+@ExperimentalResourceApi
+internal val Res.string.str_18875: StringResource
+  get() = String19.str_18875
+
+@ExperimentalResourceApi
+internal val Res.string.str_18876: StringResource
+  get() = String19.str_18876
+
+@ExperimentalResourceApi
+internal val Res.string.str_18877: StringResource
+  get() = String19.str_18877
+
+@ExperimentalResourceApi
+internal val Res.string.str_18878: StringResource
+  get() = String19.str_18878
+
+@ExperimentalResourceApi
+internal val Res.string.str_18879: StringResource
+  get() = String19.str_18879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1888: StringResource
+  get() = String19.str_1888
+
+@ExperimentalResourceApi
+internal val Res.string.str_18880: StringResource
+  get() = String19.str_18880
+
+@ExperimentalResourceApi
+internal val Res.string.str_18881: StringResource
+  get() = String19.str_18881
+
+@ExperimentalResourceApi
+internal val Res.string.str_18882: StringResource
+  get() = String19.str_18882
+
+@ExperimentalResourceApi
+internal val Res.string.str_18883: StringResource
+  get() = String19.str_18883
+
+@ExperimentalResourceApi
+internal val Res.string.str_18884: StringResource
+  get() = String19.str_18884
+
+@ExperimentalResourceApi
+internal val Res.string.str_18885: StringResource
+  get() = String19.str_18885
+
+@ExperimentalResourceApi
+internal val Res.string.str_18886: StringResource
+  get() = String19.str_18886
+
+@ExperimentalResourceApi
+internal val Res.string.str_18887: StringResource
+  get() = String19.str_18887
+
+@ExperimentalResourceApi
+internal val Res.string.str_18888: StringResource
+  get() = String19.str_18888
+
+@ExperimentalResourceApi
+internal val Res.string.str_18889: StringResource
+  get() = String19.str_18889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1889: StringResource
+  get() = String19.str_1889
+
+@ExperimentalResourceApi
+internal val Res.string.str_18890: StringResource
+  get() = String19.str_18890
+
+@ExperimentalResourceApi
+internal val Res.string.str_18891: StringResource
+  get() = String19.str_18891
+
+@ExperimentalResourceApi
+internal val Res.string.str_18892: StringResource
+  get() = String19.str_18892
+
+@ExperimentalResourceApi
+internal val Res.string.str_18893: StringResource
+  get() = String19.str_18893
+
+@ExperimentalResourceApi
+internal val Res.string.str_18894: StringResource
+  get() = String19.str_18894
+
+@ExperimentalResourceApi
+internal val Res.string.str_18895: StringResource
+  get() = String19.str_18895
+
+@ExperimentalResourceApi
+internal val Res.string.str_18896: StringResource
+  get() = String19.str_18896
+
+@ExperimentalResourceApi
+internal val Res.string.str_18897: StringResource
+  get() = String19.str_18897
+
+@ExperimentalResourceApi
+internal val Res.string.str_18898: StringResource
+  get() = String19.str_18898
+
+@ExperimentalResourceApi
+internal val Res.string.str_18899: StringResource
+  get() = String19.str_18899
+
+@ExperimentalResourceApi
+internal val Res.string.str_189: StringResource
+  get() = String19.str_189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1890: StringResource
+  get() = String19.str_1890
+
+@ExperimentalResourceApi
+internal val Res.string.str_18900: StringResource
+  get() = String19.str_18900
+
+@ExperimentalResourceApi
+internal val Res.string.str_18901: StringResource
+  get() = String19.str_18901
+
+@ExperimentalResourceApi
+internal val Res.string.str_18902: StringResource
+  get() = String19.str_18902
+
+@ExperimentalResourceApi
+internal val Res.string.str_18903: StringResource
+  get() = String19.str_18903
+
+@ExperimentalResourceApi
+internal val Res.string.str_18904: StringResource
+  get() = String19.str_18904
+
+@ExperimentalResourceApi
+internal val Res.string.str_18905: StringResource
+  get() = String19.str_18905
+
+@ExperimentalResourceApi
+internal val Res.string.str_18906: StringResource
+  get() = String19.str_18906
+
+@ExperimentalResourceApi
+internal val Res.string.str_18907: StringResource
+  get() = String19.str_18907
+
+@ExperimentalResourceApi
+internal val Res.string.str_18908: StringResource
+  get() = String19.str_18908
+
+@ExperimentalResourceApi
+internal val Res.string.str_18909: StringResource
+  get() = String19.str_18909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1891: StringResource
+  get() = String19.str_1891
+
+@ExperimentalResourceApi
+internal val Res.string.str_18910: StringResource
+  get() = String19.str_18910
+
+@ExperimentalResourceApi
+internal val Res.string.str_18911: StringResource
+  get() = String19.str_18911
+
+@ExperimentalResourceApi
+internal val Res.string.str_18912: StringResource
+  get() = String19.str_18912
+
+@ExperimentalResourceApi
+internal val Res.string.str_18913: StringResource
+  get() = String19.str_18913
+
+@ExperimentalResourceApi
+internal val Res.string.str_18914: StringResource
+  get() = String19.str_18914
+
+@ExperimentalResourceApi
+internal val Res.string.str_18915: StringResource
+  get() = String19.str_18915
+
+@ExperimentalResourceApi
+internal val Res.string.str_18916: StringResource
+  get() = String19.str_18916
+
+@ExperimentalResourceApi
+internal val Res.string.str_18917: StringResource
+  get() = String19.str_18917
+
+@ExperimentalResourceApi
+internal val Res.string.str_18918: StringResource
+  get() = String19.str_18918
+
+@ExperimentalResourceApi
+internal val Res.string.str_18919: StringResource
+  get() = String19.str_18919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1892: StringResource
+  get() = String19.str_1892
+
+@ExperimentalResourceApi
+internal val Res.string.str_18920: StringResource
+  get() = String19.str_18920
+
+@ExperimentalResourceApi
+internal val Res.string.str_18921: StringResource
+  get() = String19.str_18921
+
+@ExperimentalResourceApi
+internal val Res.string.str_18922: StringResource
+  get() = String19.str_18922
+
+@ExperimentalResourceApi
+internal val Res.string.str_18923: StringResource
+  get() = String19.str_18923
+
+@ExperimentalResourceApi
+internal val Res.string.str_18924: StringResource
+  get() = String19.str_18924
+
+@ExperimentalResourceApi
+internal val Res.string.str_18925: StringResource
+  get() = String19.str_18925
+
+@ExperimentalResourceApi
+internal val Res.string.str_18926: StringResource
+  get() = String19.str_18926
+
+@ExperimentalResourceApi
+internal val Res.string.str_18927: StringResource
+  get() = String19.str_18927
+
+@ExperimentalResourceApi
+internal val Res.string.str_18928: StringResource
+  get() = String19.str_18928
+
+@ExperimentalResourceApi
+internal val Res.string.str_18929: StringResource
+  get() = String19.str_18929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1893: StringResource
+  get() = String19.str_1893
+
+@ExperimentalResourceApi
+internal val Res.string.str_18930: StringResource
+  get() = String19.str_18930
+
+@ExperimentalResourceApi
+internal val Res.string.str_18931: StringResource
+  get() = String19.str_18931
+
+@ExperimentalResourceApi
+internal val Res.string.str_18932: StringResource
+  get() = String19.str_18932
+
+@ExperimentalResourceApi
+internal val Res.string.str_18933: StringResource
+  get() = String19.str_18933
+
+@ExperimentalResourceApi
+internal val Res.string.str_18934: StringResource
+  get() = String19.str_18934
+
+@ExperimentalResourceApi
+internal val Res.string.str_18935: StringResource
+  get() = String19.str_18935
+
+@ExperimentalResourceApi
+internal val Res.string.str_18936: StringResource
+  get() = String19.str_18936
+
+@ExperimentalResourceApi
+internal val Res.string.str_18937: StringResource
+  get() = String19.str_18937
+
+@ExperimentalResourceApi
+internal val Res.string.str_18938: StringResource
+  get() = String19.str_18938
+
+@ExperimentalResourceApi
+internal val Res.string.str_18939: StringResource
+  get() = String19.str_18939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1894: StringResource
+  get() = String19.str_1894
+
+@ExperimentalResourceApi
+internal val Res.string.str_18940: StringResource
+  get() = String19.str_18940
+
+@ExperimentalResourceApi
+internal val Res.string.str_18941: StringResource
+  get() = String19.str_18941
+
+@ExperimentalResourceApi
+internal val Res.string.str_18942: StringResource
+  get() = String19.str_18942
+
+@ExperimentalResourceApi
+internal val Res.string.str_18943: StringResource
+  get() = String19.str_18943
+
+@ExperimentalResourceApi
+internal val Res.string.str_18944: StringResource
+  get() = String19.str_18944
+
+@ExperimentalResourceApi
+internal val Res.string.str_18945: StringResource
+  get() = String19.str_18945
+
+@ExperimentalResourceApi
+internal val Res.string.str_18946: StringResource
+  get() = String19.str_18946
+
+@ExperimentalResourceApi
+internal val Res.string.str_18947: StringResource
+  get() = String19.str_18947
+
+@ExperimentalResourceApi
+internal val Res.string.str_18948: StringResource
+  get() = String19.str_18948
+
+@ExperimentalResourceApi
+internal val Res.string.str_18949: StringResource
+  get() = String19.str_18949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1895: StringResource
+  get() = String19.str_1895
+
+@ExperimentalResourceApi
+internal val Res.string.str_18950: StringResource
+  get() = String19.str_18950
+
+@ExperimentalResourceApi
+internal val Res.string.str_18951: StringResource
+  get() = String19.str_18951
+
+@ExperimentalResourceApi
+internal val Res.string.str_18952: StringResource
+  get() = String19.str_18952
+
+@ExperimentalResourceApi
+internal val Res.string.str_18953: StringResource
+  get() = String19.str_18953
+
+@ExperimentalResourceApi
+internal val Res.string.str_18954: StringResource
+  get() = String19.str_18954
+
+@ExperimentalResourceApi
+internal val Res.string.str_18955: StringResource
+  get() = String19.str_18955
+
+@ExperimentalResourceApi
+internal val Res.string.str_18956: StringResource
+  get() = String19.str_18956
+
+@ExperimentalResourceApi
+internal val Res.string.str_18957: StringResource
+  get() = String19.str_18957
+
+@ExperimentalResourceApi
+internal val Res.string.str_18958: StringResource
+  get() = String19.str_18958
+
+@ExperimentalResourceApi
+internal val Res.string.str_18959: StringResource
+  get() = String19.str_18959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1896: StringResource
+  get() = String19.str_1896
+
+@ExperimentalResourceApi
+internal val Res.string.str_18960: StringResource
+  get() = String19.str_18960
+
+@ExperimentalResourceApi
+internal val Res.string.str_18961: StringResource
+  get() = String19.str_18961
+
+@ExperimentalResourceApi
+internal val Res.string.str_18962: StringResource
+  get() = String19.str_18962
+
+@ExperimentalResourceApi
+internal val Res.string.str_18963: StringResource
+  get() = String19.str_18963
+
+@ExperimentalResourceApi
+internal val Res.string.str_18964: StringResource
+  get() = String19.str_18964
+
+@ExperimentalResourceApi
+internal val Res.string.str_18965: StringResource
+  get() = String19.str_18965
+
+@ExperimentalResourceApi
+internal val Res.string.str_18966: StringResource
+  get() = String19.str_18966
+
+@ExperimentalResourceApi
+internal val Res.string.str_18967: StringResource
+  get() = String19.str_18967
+
+@ExperimentalResourceApi
+internal val Res.string.str_18968: StringResource
+  get() = String19.str_18968
+
+@ExperimentalResourceApi
+internal val Res.string.str_18969: StringResource
+  get() = String19.str_18969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1897: StringResource
+  get() = String19.str_1897
+
+@ExperimentalResourceApi
+internal val Res.string.str_18970: StringResource
+  get() = String19.str_18970
+
+@ExperimentalResourceApi
+internal val Res.string.str_18971: StringResource
+  get() = String19.str_18971
+
+@ExperimentalResourceApi
+internal val Res.string.str_18972: StringResource
+  get() = String19.str_18972
+
+@ExperimentalResourceApi
+internal val Res.string.str_18973: StringResource
+  get() = String19.str_18973
+
+@ExperimentalResourceApi
+internal val Res.string.str_18974: StringResource
+  get() = String19.str_18974
+
+@ExperimentalResourceApi
+internal val Res.string.str_18975: StringResource
+  get() = String19.str_18975
+
+@ExperimentalResourceApi
+internal val Res.string.str_18976: StringResource
+  get() = String19.str_18976
+
+@ExperimentalResourceApi
+internal val Res.string.str_18977: StringResource
+  get() = String19.str_18977
+
+@ExperimentalResourceApi
+internal val Res.string.str_18978: StringResource
+  get() = String19.str_18978
+
+@ExperimentalResourceApi
+internal val Res.string.str_18979: StringResource
+  get() = String19.str_18979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1898: StringResource
+  get() = String19.str_1898
+
+@ExperimentalResourceApi
+internal val Res.string.str_18980: StringResource
+  get() = String19.str_18980
+
+@ExperimentalResourceApi
+internal val Res.string.str_18981: StringResource
+  get() = String19.str_18981
+
+@ExperimentalResourceApi
+internal val Res.string.str_18982: StringResource
+  get() = String19.str_18982
+
+@ExperimentalResourceApi
+internal val Res.string.str_18983: StringResource
+  get() = String19.str_18983
+
+@ExperimentalResourceApi
+internal val Res.string.str_18984: StringResource
+  get() = String19.str_18984
+
+@ExperimentalResourceApi
+internal val Res.string.str_18985: StringResource
+  get() = String19.str_18985
+
+@ExperimentalResourceApi
+internal val Res.string.str_18986: StringResource
+  get() = String19.str_18986
+
+@ExperimentalResourceApi
+internal val Res.string.str_18987: StringResource
+  get() = String19.str_18987
+
+@ExperimentalResourceApi
+internal val Res.string.str_18988: StringResource
+  get() = String19.str_18988
+
+@ExperimentalResourceApi
+internal val Res.string.str_18989: StringResource
+  get() = String19.str_18989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1899: StringResource
+  get() = String19.str_1899
+
+@ExperimentalResourceApi
+internal val Res.string.str_18990: StringResource
+  get() = String19.str_18990
+
+@ExperimentalResourceApi
+internal val Res.string.str_18991: StringResource
+  get() = String19.str_18991
+
+@ExperimentalResourceApi
+internal val Res.string.str_18992: StringResource
+  get() = String19.str_18992
+
+@ExperimentalResourceApi
+internal val Res.string.str_18993: StringResource
+  get() = String19.str_18993
+
+@ExperimentalResourceApi
+internal val Res.string.str_18994: StringResource
+  get() = String19.str_18994
+
+@ExperimentalResourceApi
+internal val Res.string.str_18995: StringResource
+  get() = String19.str_18995
+
+@ExperimentalResourceApi
+internal val Res.string.str_18996: StringResource
+  get() = String19.str_18996
+
+@ExperimentalResourceApi
+internal val Res.string.str_18997: StringResource
+  get() = String19.str_18997
+
+@ExperimentalResourceApi
+internal val Res.string.str_18998: StringResource
+  get() = String19.str_18998

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String2.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String2.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String2 {
+  public val str_10898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10898", "str_10898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10899", "str_10899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_109", "str_109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1090", "str_1090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10900", "str_10900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10901", "str_10901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10902", "str_10902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10903", "str_10903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10904", "str_10904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10905", "str_10905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10906", "str_10906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10907", "str_10907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10908", "str_10908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10909", "str_10909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1091", "str_1091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10910", "str_10910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10911", "str_10911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10912", "str_10912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10913", "str_10913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10914", "str_10914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10915", "str_10915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10916", "str_10916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10917", "str_10917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10918", "str_10918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10919", "str_10919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1092", "str_1092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10920", "str_10920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10921", "str_10921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10922", "str_10922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10923", "str_10923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10924", "str_10924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10925", "str_10925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10926", "str_10926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10927", "str_10927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10928", "str_10928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10929", "str_10929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1093", "str_1093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10930", "str_10930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10931", "str_10931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10932", "str_10932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10933", "str_10933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10934", "str_10934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10935", "str_10935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10936", "str_10936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10937", "str_10937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10938", "str_10938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10939", "str_10939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1094", "str_1094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10940", "str_10940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10941", "str_10941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10942", "str_10942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10943", "str_10943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10944", "str_10944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10945", "str_10945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10946", "str_10946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10947", "str_10947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10948", "str_10948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10949", "str_10949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1095", "str_1095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10950", "str_10950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10951", "str_10951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10952", "str_10952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10953", "str_10953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10954", "str_10954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10955", "str_10955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10956", "str_10956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10957", "str_10957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10958", "str_10958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10959", "str_10959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1096", "str_1096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10960", "str_10960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10961", "str_10961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10962", "str_10962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10963", "str_10963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10964", "str_10964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10965", "str_10965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10966", "str_10966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10967", "str_10967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10968", "str_10968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10969", "str_10969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1097", "str_1097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10970", "str_10970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10971", "str_10971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10972", "str_10972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10973", "str_10973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10974", "str_10974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10975", "str_10975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10976", "str_10976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10977", "str_10977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10978", "str_10978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10979", "str_10979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1098", "str_1098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10980", "str_10980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10981", "str_10981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10982", "str_10982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10983", "str_10983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10984", "str_10984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10985", "str_10985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10986", "str_10986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10987", "str_10987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10988", "str_10988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10989", "str_10989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1099", "str_1099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10990", "str_10990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10991", "str_10991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10992", "str_10992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10993", "str_10993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10994", "str_10994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10995", "str_10995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10996", "str_10996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10997", "str_10997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10998", "str_10998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_10999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_10999", "str_10999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11", "str_11",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_110", "str_110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1100", "str_1100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11000", "str_11000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11001", "str_11001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11002", "str_11002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11003", "str_11003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11004", "str_11004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11005", "str_11005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11006", "str_11006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11007", "str_11007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11008", "str_11008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11009", "str_11009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1101", "str_1101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11010", "str_11010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11011", "str_11011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11012", "str_11012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11013", "str_11013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11014", "str_11014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11015", "str_11015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11016", "str_11016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11017", "str_11017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11018", "str_11018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11019", "str_11019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1102", "str_1102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11020", "str_11020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11021", "str_11021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11022", "str_11022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11023", "str_11023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11024", "str_11024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11025", "str_11025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11026", "str_11026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11027", "str_11027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11028", "str_11028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11029", "str_11029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1103", "str_1103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11030", "str_11030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11031", "str_11031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11032", "str_11032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11033", "str_11033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11034", "str_11034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11035", "str_11035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11036", "str_11036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11037", "str_11037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11038", "str_11038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11039", "str_11039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1104", "str_1104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11040", "str_11040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11041", "str_11041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11042", "str_11042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11043", "str_11043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11044", "str_11044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11045", "str_11045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11046", "str_11046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11047", "str_11047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11048", "str_11048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11049", "str_11049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1105", "str_1105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11050", "str_11050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11051", "str_11051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11052", "str_11052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11053", "str_11053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11054", "str_11054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11055", "str_11055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11056", "str_11056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11057", "str_11057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11058", "str_11058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11059", "str_11059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1106", "str_1106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11060", "str_11060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11061", "str_11061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11062", "str_11062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11063", "str_11063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11064", "str_11064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11065", "str_11065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11066", "str_11066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11067", "str_11067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11068", "str_11068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11069", "str_11069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1107", "str_1107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11070", "str_11070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11071", "str_11071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11072", "str_11072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11073", "str_11073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11074", "str_11074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11075", "str_11075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11076", "str_11076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11077", "str_11077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11078", "str_11078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11079", "str_11079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1108", "str_1108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11080", "str_11080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11081", "str_11081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11082", "str_11082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11083", "str_11083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11084", "str_11084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11085", "str_11085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11086", "str_11086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11087", "str_11087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11088", "str_11088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11089", "str_11089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1109", "str_1109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11090", "str_11090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11091", "str_11091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11092", "str_11092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11093", "str_11093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11094", "str_11094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11095", "str_11095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11096", "str_11096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11097", "str_11097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11098", "str_11098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11099", "str_11099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_111", "str_111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1110", "str_1110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11100", "str_11100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11101", "str_11101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11102", "str_11102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11103", "str_11103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11104", "str_11104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11105", "str_11105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11106", "str_11106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11107", "str_11107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11108", "str_11108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11109", "str_11109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1111", "str_1111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11110", "str_11110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11111", "str_11111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11112", "str_11112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11113", "str_11113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11114", "str_11114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11115", "str_11115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11116", "str_11116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11117", "str_11117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11118", "str_11118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11119", "str_11119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1112", "str_1112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11120", "str_11120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11121", "str_11121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11122", "str_11122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11123", "str_11123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11124", "str_11124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11125", "str_11125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11126", "str_11126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11127", "str_11127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11128", "str_11128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11129", "str_11129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1113", "str_1113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11130", "str_11130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11131", "str_11131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11132", "str_11132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11133", "str_11133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11134", "str_11134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11135", "str_11135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11136", "str_11136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11137", "str_11137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11138", "str_11138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11139", "str_11139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1114", "str_1114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11140", "str_11140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11141", "str_11141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11142", "str_11142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11143", "str_11143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11144", "str_11144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11145", "str_11145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11146", "str_11146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11147", "str_11147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11148", "str_11148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11149", "str_11149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1115", "str_1115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11150", "str_11150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11151", "str_11151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11152", "str_11152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11153", "str_11153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11154", "str_11154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11155", "str_11155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11156", "str_11156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11157", "str_11157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11158", "str_11158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11159", "str_11159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1116", "str_1116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11160", "str_11160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11161", "str_11161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11162", "str_11162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11163", "str_11163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11164", "str_11164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11165", "str_11165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11166", "str_11166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11167", "str_11167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11168", "str_11168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11169", "str_11169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1117", "str_1117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11170", "str_11170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11171", "str_11171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11172", "str_11172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11173", "str_11173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11174", "str_11174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11175", "str_11175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11176", "str_11176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11177", "str_11177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11178", "str_11178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11179", "str_11179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1118", "str_1118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11180", "str_11180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11181", "str_11181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11182", "str_11182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11183", "str_11183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11184", "str_11184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11185", "str_11185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11186", "str_11186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11187", "str_11187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11188", "str_11188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11189", "str_11189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1119", "str_1119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11190", "str_11190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11191", "str_11191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11192", "str_11192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11193", "str_11193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11194", "str_11194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11195", "str_11195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11196", "str_11196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11197", "str_11197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11198", "str_11198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11199", "str_11199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_112", "str_112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1120", "str_1120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11200", "str_11200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11201", "str_11201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11202", "str_11202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11203", "str_11203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11204", "str_11204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11205", "str_11205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11206", "str_11206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11207", "str_11207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11208", "str_11208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11209", "str_11209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1121", "str_1121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11210", "str_11210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11211", "str_11211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11212", "str_11212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11213", "str_11213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11214", "str_11214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11215", "str_11215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11216", "str_11216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11217", "str_11217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11218", "str_11218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11219", "str_11219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1122", "str_1122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11220", "str_11220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11221", "str_11221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11222", "str_11222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11223", "str_11223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11224", "str_11224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11225", "str_11225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11226", "str_11226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11227", "str_11227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11228", "str_11228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11229", "str_11229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1123", "str_1123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11230", "str_11230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11231", "str_11231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11232", "str_11232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11233", "str_11233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11234", "str_11234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11235", "str_11235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11236", "str_11236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11237", "str_11237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11238", "str_11238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11239", "str_11239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1124", "str_1124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11240", "str_11240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11241", "str_11241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11242", "str_11242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11243", "str_11243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11244", "str_11244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11245", "str_11245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11246", "str_11246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11247", "str_11247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11248", "str_11248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11249", "str_11249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1125", "str_1125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11250", "str_11250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11251", "str_11251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11252", "str_11252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11253", "str_11253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11254", "str_11254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11255", "str_11255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11256", "str_11256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11257", "str_11257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11258", "str_11258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11259", "str_11259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1126", "str_1126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11260", "str_11260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11261", "str_11261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11262", "str_11262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11263", "str_11263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11264", "str_11264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11265", "str_11265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11266", "str_11266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11267", "str_11267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11268", "str_11268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11269", "str_11269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1127", "str_1127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11270", "str_11270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11271", "str_11271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11272", "str_11272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11273", "str_11273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11274", "str_11274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11275", "str_11275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11276", "str_11276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11277", "str_11277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11278", "str_11278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11279", "str_11279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1128", "str_1128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11280", "str_11280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11281", "str_11281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11282", "str_11282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11283", "str_11283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11284", "str_11284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11285", "str_11285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11286", "str_11286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11287", "str_11287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11288", "str_11288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11289", "str_11289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1129", "str_1129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11290", "str_11290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11291", "str_11291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11292", "str_11292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11293", "str_11293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11294", "str_11294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11295", "str_11295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11296", "str_11296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11297", "str_11297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11298", "str_11298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11299", "str_11299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_113", "str_113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1130", "str_1130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11300", "str_11300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11301", "str_11301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11302", "str_11302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11303", "str_11303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11304", "str_11304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11305", "str_11305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11306", "str_11306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11307", "str_11307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11308", "str_11308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11309", "str_11309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1131", "str_1131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11310", "str_11310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11311", "str_11311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11312", "str_11312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11313", "str_11313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11314", "str_11314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11315", "str_11315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11316", "str_11316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11317", "str_11317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11318", "str_11318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11319", "str_11319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1132", "str_1132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11320", "str_11320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11321", "str_11321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11322", "str_11322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11323", "str_11323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11324", "str_11324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11325", "str_11325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11326", "str_11326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11327", "str_11327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11328", "str_11328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11329", "str_11329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1133", "str_1133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11330", "str_11330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11331", "str_11331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11332", "str_11332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11333", "str_11333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11334", "str_11334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11335", "str_11335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11336", "str_11336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11337", "str_11337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11338", "str_11338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11339", "str_11339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1134", "str_1134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11340", "str_11340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11341", "str_11341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11342", "str_11342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11343", "str_11343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11344", "str_11344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11345", "str_11345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11346", "str_11346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_10898: StringResource
+  get() = String2.str_10898
+
+@ExperimentalResourceApi
+internal val Res.string.str_10899: StringResource
+  get() = String2.str_10899
+
+@ExperimentalResourceApi
+internal val Res.string.str_109: StringResource
+  get() = String2.str_109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1090: StringResource
+  get() = String2.str_1090
+
+@ExperimentalResourceApi
+internal val Res.string.str_10900: StringResource
+  get() = String2.str_10900
+
+@ExperimentalResourceApi
+internal val Res.string.str_10901: StringResource
+  get() = String2.str_10901
+
+@ExperimentalResourceApi
+internal val Res.string.str_10902: StringResource
+  get() = String2.str_10902
+
+@ExperimentalResourceApi
+internal val Res.string.str_10903: StringResource
+  get() = String2.str_10903
+
+@ExperimentalResourceApi
+internal val Res.string.str_10904: StringResource
+  get() = String2.str_10904
+
+@ExperimentalResourceApi
+internal val Res.string.str_10905: StringResource
+  get() = String2.str_10905
+
+@ExperimentalResourceApi
+internal val Res.string.str_10906: StringResource
+  get() = String2.str_10906
+
+@ExperimentalResourceApi
+internal val Res.string.str_10907: StringResource
+  get() = String2.str_10907
+
+@ExperimentalResourceApi
+internal val Res.string.str_10908: StringResource
+  get() = String2.str_10908
+
+@ExperimentalResourceApi
+internal val Res.string.str_10909: StringResource
+  get() = String2.str_10909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1091: StringResource
+  get() = String2.str_1091
+
+@ExperimentalResourceApi
+internal val Res.string.str_10910: StringResource
+  get() = String2.str_10910
+
+@ExperimentalResourceApi
+internal val Res.string.str_10911: StringResource
+  get() = String2.str_10911
+
+@ExperimentalResourceApi
+internal val Res.string.str_10912: StringResource
+  get() = String2.str_10912
+
+@ExperimentalResourceApi
+internal val Res.string.str_10913: StringResource
+  get() = String2.str_10913
+
+@ExperimentalResourceApi
+internal val Res.string.str_10914: StringResource
+  get() = String2.str_10914
+
+@ExperimentalResourceApi
+internal val Res.string.str_10915: StringResource
+  get() = String2.str_10915
+
+@ExperimentalResourceApi
+internal val Res.string.str_10916: StringResource
+  get() = String2.str_10916
+
+@ExperimentalResourceApi
+internal val Res.string.str_10917: StringResource
+  get() = String2.str_10917
+
+@ExperimentalResourceApi
+internal val Res.string.str_10918: StringResource
+  get() = String2.str_10918
+
+@ExperimentalResourceApi
+internal val Res.string.str_10919: StringResource
+  get() = String2.str_10919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1092: StringResource
+  get() = String2.str_1092
+
+@ExperimentalResourceApi
+internal val Res.string.str_10920: StringResource
+  get() = String2.str_10920
+
+@ExperimentalResourceApi
+internal val Res.string.str_10921: StringResource
+  get() = String2.str_10921
+
+@ExperimentalResourceApi
+internal val Res.string.str_10922: StringResource
+  get() = String2.str_10922
+
+@ExperimentalResourceApi
+internal val Res.string.str_10923: StringResource
+  get() = String2.str_10923
+
+@ExperimentalResourceApi
+internal val Res.string.str_10924: StringResource
+  get() = String2.str_10924
+
+@ExperimentalResourceApi
+internal val Res.string.str_10925: StringResource
+  get() = String2.str_10925
+
+@ExperimentalResourceApi
+internal val Res.string.str_10926: StringResource
+  get() = String2.str_10926
+
+@ExperimentalResourceApi
+internal val Res.string.str_10927: StringResource
+  get() = String2.str_10927
+
+@ExperimentalResourceApi
+internal val Res.string.str_10928: StringResource
+  get() = String2.str_10928
+
+@ExperimentalResourceApi
+internal val Res.string.str_10929: StringResource
+  get() = String2.str_10929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1093: StringResource
+  get() = String2.str_1093
+
+@ExperimentalResourceApi
+internal val Res.string.str_10930: StringResource
+  get() = String2.str_10930
+
+@ExperimentalResourceApi
+internal val Res.string.str_10931: StringResource
+  get() = String2.str_10931
+
+@ExperimentalResourceApi
+internal val Res.string.str_10932: StringResource
+  get() = String2.str_10932
+
+@ExperimentalResourceApi
+internal val Res.string.str_10933: StringResource
+  get() = String2.str_10933
+
+@ExperimentalResourceApi
+internal val Res.string.str_10934: StringResource
+  get() = String2.str_10934
+
+@ExperimentalResourceApi
+internal val Res.string.str_10935: StringResource
+  get() = String2.str_10935
+
+@ExperimentalResourceApi
+internal val Res.string.str_10936: StringResource
+  get() = String2.str_10936
+
+@ExperimentalResourceApi
+internal val Res.string.str_10937: StringResource
+  get() = String2.str_10937
+
+@ExperimentalResourceApi
+internal val Res.string.str_10938: StringResource
+  get() = String2.str_10938
+
+@ExperimentalResourceApi
+internal val Res.string.str_10939: StringResource
+  get() = String2.str_10939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1094: StringResource
+  get() = String2.str_1094
+
+@ExperimentalResourceApi
+internal val Res.string.str_10940: StringResource
+  get() = String2.str_10940
+
+@ExperimentalResourceApi
+internal val Res.string.str_10941: StringResource
+  get() = String2.str_10941
+
+@ExperimentalResourceApi
+internal val Res.string.str_10942: StringResource
+  get() = String2.str_10942
+
+@ExperimentalResourceApi
+internal val Res.string.str_10943: StringResource
+  get() = String2.str_10943
+
+@ExperimentalResourceApi
+internal val Res.string.str_10944: StringResource
+  get() = String2.str_10944
+
+@ExperimentalResourceApi
+internal val Res.string.str_10945: StringResource
+  get() = String2.str_10945
+
+@ExperimentalResourceApi
+internal val Res.string.str_10946: StringResource
+  get() = String2.str_10946
+
+@ExperimentalResourceApi
+internal val Res.string.str_10947: StringResource
+  get() = String2.str_10947
+
+@ExperimentalResourceApi
+internal val Res.string.str_10948: StringResource
+  get() = String2.str_10948
+
+@ExperimentalResourceApi
+internal val Res.string.str_10949: StringResource
+  get() = String2.str_10949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1095: StringResource
+  get() = String2.str_1095
+
+@ExperimentalResourceApi
+internal val Res.string.str_10950: StringResource
+  get() = String2.str_10950
+
+@ExperimentalResourceApi
+internal val Res.string.str_10951: StringResource
+  get() = String2.str_10951
+
+@ExperimentalResourceApi
+internal val Res.string.str_10952: StringResource
+  get() = String2.str_10952
+
+@ExperimentalResourceApi
+internal val Res.string.str_10953: StringResource
+  get() = String2.str_10953
+
+@ExperimentalResourceApi
+internal val Res.string.str_10954: StringResource
+  get() = String2.str_10954
+
+@ExperimentalResourceApi
+internal val Res.string.str_10955: StringResource
+  get() = String2.str_10955
+
+@ExperimentalResourceApi
+internal val Res.string.str_10956: StringResource
+  get() = String2.str_10956
+
+@ExperimentalResourceApi
+internal val Res.string.str_10957: StringResource
+  get() = String2.str_10957
+
+@ExperimentalResourceApi
+internal val Res.string.str_10958: StringResource
+  get() = String2.str_10958
+
+@ExperimentalResourceApi
+internal val Res.string.str_10959: StringResource
+  get() = String2.str_10959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1096: StringResource
+  get() = String2.str_1096
+
+@ExperimentalResourceApi
+internal val Res.string.str_10960: StringResource
+  get() = String2.str_10960
+
+@ExperimentalResourceApi
+internal val Res.string.str_10961: StringResource
+  get() = String2.str_10961
+
+@ExperimentalResourceApi
+internal val Res.string.str_10962: StringResource
+  get() = String2.str_10962
+
+@ExperimentalResourceApi
+internal val Res.string.str_10963: StringResource
+  get() = String2.str_10963
+
+@ExperimentalResourceApi
+internal val Res.string.str_10964: StringResource
+  get() = String2.str_10964
+
+@ExperimentalResourceApi
+internal val Res.string.str_10965: StringResource
+  get() = String2.str_10965
+
+@ExperimentalResourceApi
+internal val Res.string.str_10966: StringResource
+  get() = String2.str_10966
+
+@ExperimentalResourceApi
+internal val Res.string.str_10967: StringResource
+  get() = String2.str_10967
+
+@ExperimentalResourceApi
+internal val Res.string.str_10968: StringResource
+  get() = String2.str_10968
+
+@ExperimentalResourceApi
+internal val Res.string.str_10969: StringResource
+  get() = String2.str_10969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1097: StringResource
+  get() = String2.str_1097
+
+@ExperimentalResourceApi
+internal val Res.string.str_10970: StringResource
+  get() = String2.str_10970
+
+@ExperimentalResourceApi
+internal val Res.string.str_10971: StringResource
+  get() = String2.str_10971
+
+@ExperimentalResourceApi
+internal val Res.string.str_10972: StringResource
+  get() = String2.str_10972
+
+@ExperimentalResourceApi
+internal val Res.string.str_10973: StringResource
+  get() = String2.str_10973
+
+@ExperimentalResourceApi
+internal val Res.string.str_10974: StringResource
+  get() = String2.str_10974
+
+@ExperimentalResourceApi
+internal val Res.string.str_10975: StringResource
+  get() = String2.str_10975
+
+@ExperimentalResourceApi
+internal val Res.string.str_10976: StringResource
+  get() = String2.str_10976
+
+@ExperimentalResourceApi
+internal val Res.string.str_10977: StringResource
+  get() = String2.str_10977
+
+@ExperimentalResourceApi
+internal val Res.string.str_10978: StringResource
+  get() = String2.str_10978
+
+@ExperimentalResourceApi
+internal val Res.string.str_10979: StringResource
+  get() = String2.str_10979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1098: StringResource
+  get() = String2.str_1098
+
+@ExperimentalResourceApi
+internal val Res.string.str_10980: StringResource
+  get() = String2.str_10980
+
+@ExperimentalResourceApi
+internal val Res.string.str_10981: StringResource
+  get() = String2.str_10981
+
+@ExperimentalResourceApi
+internal val Res.string.str_10982: StringResource
+  get() = String2.str_10982
+
+@ExperimentalResourceApi
+internal val Res.string.str_10983: StringResource
+  get() = String2.str_10983
+
+@ExperimentalResourceApi
+internal val Res.string.str_10984: StringResource
+  get() = String2.str_10984
+
+@ExperimentalResourceApi
+internal val Res.string.str_10985: StringResource
+  get() = String2.str_10985
+
+@ExperimentalResourceApi
+internal val Res.string.str_10986: StringResource
+  get() = String2.str_10986
+
+@ExperimentalResourceApi
+internal val Res.string.str_10987: StringResource
+  get() = String2.str_10987
+
+@ExperimentalResourceApi
+internal val Res.string.str_10988: StringResource
+  get() = String2.str_10988
+
+@ExperimentalResourceApi
+internal val Res.string.str_10989: StringResource
+  get() = String2.str_10989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1099: StringResource
+  get() = String2.str_1099
+
+@ExperimentalResourceApi
+internal val Res.string.str_10990: StringResource
+  get() = String2.str_10990
+
+@ExperimentalResourceApi
+internal val Res.string.str_10991: StringResource
+  get() = String2.str_10991
+
+@ExperimentalResourceApi
+internal val Res.string.str_10992: StringResource
+  get() = String2.str_10992
+
+@ExperimentalResourceApi
+internal val Res.string.str_10993: StringResource
+  get() = String2.str_10993
+
+@ExperimentalResourceApi
+internal val Res.string.str_10994: StringResource
+  get() = String2.str_10994
+
+@ExperimentalResourceApi
+internal val Res.string.str_10995: StringResource
+  get() = String2.str_10995
+
+@ExperimentalResourceApi
+internal val Res.string.str_10996: StringResource
+  get() = String2.str_10996
+
+@ExperimentalResourceApi
+internal val Res.string.str_10997: StringResource
+  get() = String2.str_10997
+
+@ExperimentalResourceApi
+internal val Res.string.str_10998: StringResource
+  get() = String2.str_10998
+
+@ExperimentalResourceApi
+internal val Res.string.str_10999: StringResource
+  get() = String2.str_10999
+
+@ExperimentalResourceApi
+internal val Res.string.str_11: StringResource
+  get() = String2.str_11
+
+@ExperimentalResourceApi
+internal val Res.string.str_110: StringResource
+  get() = String2.str_110
+
+@ExperimentalResourceApi
+internal val Res.string.str_1100: StringResource
+  get() = String2.str_1100
+
+@ExperimentalResourceApi
+internal val Res.string.str_11000: StringResource
+  get() = String2.str_11000
+
+@ExperimentalResourceApi
+internal val Res.string.str_11001: StringResource
+  get() = String2.str_11001
+
+@ExperimentalResourceApi
+internal val Res.string.str_11002: StringResource
+  get() = String2.str_11002
+
+@ExperimentalResourceApi
+internal val Res.string.str_11003: StringResource
+  get() = String2.str_11003
+
+@ExperimentalResourceApi
+internal val Res.string.str_11004: StringResource
+  get() = String2.str_11004
+
+@ExperimentalResourceApi
+internal val Res.string.str_11005: StringResource
+  get() = String2.str_11005
+
+@ExperimentalResourceApi
+internal val Res.string.str_11006: StringResource
+  get() = String2.str_11006
+
+@ExperimentalResourceApi
+internal val Res.string.str_11007: StringResource
+  get() = String2.str_11007
+
+@ExperimentalResourceApi
+internal val Res.string.str_11008: StringResource
+  get() = String2.str_11008
+
+@ExperimentalResourceApi
+internal val Res.string.str_11009: StringResource
+  get() = String2.str_11009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1101: StringResource
+  get() = String2.str_1101
+
+@ExperimentalResourceApi
+internal val Res.string.str_11010: StringResource
+  get() = String2.str_11010
+
+@ExperimentalResourceApi
+internal val Res.string.str_11011: StringResource
+  get() = String2.str_11011
+
+@ExperimentalResourceApi
+internal val Res.string.str_11012: StringResource
+  get() = String2.str_11012
+
+@ExperimentalResourceApi
+internal val Res.string.str_11013: StringResource
+  get() = String2.str_11013
+
+@ExperimentalResourceApi
+internal val Res.string.str_11014: StringResource
+  get() = String2.str_11014
+
+@ExperimentalResourceApi
+internal val Res.string.str_11015: StringResource
+  get() = String2.str_11015
+
+@ExperimentalResourceApi
+internal val Res.string.str_11016: StringResource
+  get() = String2.str_11016
+
+@ExperimentalResourceApi
+internal val Res.string.str_11017: StringResource
+  get() = String2.str_11017
+
+@ExperimentalResourceApi
+internal val Res.string.str_11018: StringResource
+  get() = String2.str_11018
+
+@ExperimentalResourceApi
+internal val Res.string.str_11019: StringResource
+  get() = String2.str_11019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1102: StringResource
+  get() = String2.str_1102
+
+@ExperimentalResourceApi
+internal val Res.string.str_11020: StringResource
+  get() = String2.str_11020
+
+@ExperimentalResourceApi
+internal val Res.string.str_11021: StringResource
+  get() = String2.str_11021
+
+@ExperimentalResourceApi
+internal val Res.string.str_11022: StringResource
+  get() = String2.str_11022
+
+@ExperimentalResourceApi
+internal val Res.string.str_11023: StringResource
+  get() = String2.str_11023
+
+@ExperimentalResourceApi
+internal val Res.string.str_11024: StringResource
+  get() = String2.str_11024
+
+@ExperimentalResourceApi
+internal val Res.string.str_11025: StringResource
+  get() = String2.str_11025
+
+@ExperimentalResourceApi
+internal val Res.string.str_11026: StringResource
+  get() = String2.str_11026
+
+@ExperimentalResourceApi
+internal val Res.string.str_11027: StringResource
+  get() = String2.str_11027
+
+@ExperimentalResourceApi
+internal val Res.string.str_11028: StringResource
+  get() = String2.str_11028
+
+@ExperimentalResourceApi
+internal val Res.string.str_11029: StringResource
+  get() = String2.str_11029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1103: StringResource
+  get() = String2.str_1103
+
+@ExperimentalResourceApi
+internal val Res.string.str_11030: StringResource
+  get() = String2.str_11030
+
+@ExperimentalResourceApi
+internal val Res.string.str_11031: StringResource
+  get() = String2.str_11031
+
+@ExperimentalResourceApi
+internal val Res.string.str_11032: StringResource
+  get() = String2.str_11032
+
+@ExperimentalResourceApi
+internal val Res.string.str_11033: StringResource
+  get() = String2.str_11033
+
+@ExperimentalResourceApi
+internal val Res.string.str_11034: StringResource
+  get() = String2.str_11034
+
+@ExperimentalResourceApi
+internal val Res.string.str_11035: StringResource
+  get() = String2.str_11035
+
+@ExperimentalResourceApi
+internal val Res.string.str_11036: StringResource
+  get() = String2.str_11036
+
+@ExperimentalResourceApi
+internal val Res.string.str_11037: StringResource
+  get() = String2.str_11037
+
+@ExperimentalResourceApi
+internal val Res.string.str_11038: StringResource
+  get() = String2.str_11038
+
+@ExperimentalResourceApi
+internal val Res.string.str_11039: StringResource
+  get() = String2.str_11039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1104: StringResource
+  get() = String2.str_1104
+
+@ExperimentalResourceApi
+internal val Res.string.str_11040: StringResource
+  get() = String2.str_11040
+
+@ExperimentalResourceApi
+internal val Res.string.str_11041: StringResource
+  get() = String2.str_11041
+
+@ExperimentalResourceApi
+internal val Res.string.str_11042: StringResource
+  get() = String2.str_11042
+
+@ExperimentalResourceApi
+internal val Res.string.str_11043: StringResource
+  get() = String2.str_11043
+
+@ExperimentalResourceApi
+internal val Res.string.str_11044: StringResource
+  get() = String2.str_11044
+
+@ExperimentalResourceApi
+internal val Res.string.str_11045: StringResource
+  get() = String2.str_11045
+
+@ExperimentalResourceApi
+internal val Res.string.str_11046: StringResource
+  get() = String2.str_11046
+
+@ExperimentalResourceApi
+internal val Res.string.str_11047: StringResource
+  get() = String2.str_11047
+
+@ExperimentalResourceApi
+internal val Res.string.str_11048: StringResource
+  get() = String2.str_11048
+
+@ExperimentalResourceApi
+internal val Res.string.str_11049: StringResource
+  get() = String2.str_11049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1105: StringResource
+  get() = String2.str_1105
+
+@ExperimentalResourceApi
+internal val Res.string.str_11050: StringResource
+  get() = String2.str_11050
+
+@ExperimentalResourceApi
+internal val Res.string.str_11051: StringResource
+  get() = String2.str_11051
+
+@ExperimentalResourceApi
+internal val Res.string.str_11052: StringResource
+  get() = String2.str_11052
+
+@ExperimentalResourceApi
+internal val Res.string.str_11053: StringResource
+  get() = String2.str_11053
+
+@ExperimentalResourceApi
+internal val Res.string.str_11054: StringResource
+  get() = String2.str_11054
+
+@ExperimentalResourceApi
+internal val Res.string.str_11055: StringResource
+  get() = String2.str_11055
+
+@ExperimentalResourceApi
+internal val Res.string.str_11056: StringResource
+  get() = String2.str_11056
+
+@ExperimentalResourceApi
+internal val Res.string.str_11057: StringResource
+  get() = String2.str_11057
+
+@ExperimentalResourceApi
+internal val Res.string.str_11058: StringResource
+  get() = String2.str_11058
+
+@ExperimentalResourceApi
+internal val Res.string.str_11059: StringResource
+  get() = String2.str_11059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1106: StringResource
+  get() = String2.str_1106
+
+@ExperimentalResourceApi
+internal val Res.string.str_11060: StringResource
+  get() = String2.str_11060
+
+@ExperimentalResourceApi
+internal val Res.string.str_11061: StringResource
+  get() = String2.str_11061
+
+@ExperimentalResourceApi
+internal val Res.string.str_11062: StringResource
+  get() = String2.str_11062
+
+@ExperimentalResourceApi
+internal val Res.string.str_11063: StringResource
+  get() = String2.str_11063
+
+@ExperimentalResourceApi
+internal val Res.string.str_11064: StringResource
+  get() = String2.str_11064
+
+@ExperimentalResourceApi
+internal val Res.string.str_11065: StringResource
+  get() = String2.str_11065
+
+@ExperimentalResourceApi
+internal val Res.string.str_11066: StringResource
+  get() = String2.str_11066
+
+@ExperimentalResourceApi
+internal val Res.string.str_11067: StringResource
+  get() = String2.str_11067
+
+@ExperimentalResourceApi
+internal val Res.string.str_11068: StringResource
+  get() = String2.str_11068
+
+@ExperimentalResourceApi
+internal val Res.string.str_11069: StringResource
+  get() = String2.str_11069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1107: StringResource
+  get() = String2.str_1107
+
+@ExperimentalResourceApi
+internal val Res.string.str_11070: StringResource
+  get() = String2.str_11070
+
+@ExperimentalResourceApi
+internal val Res.string.str_11071: StringResource
+  get() = String2.str_11071
+
+@ExperimentalResourceApi
+internal val Res.string.str_11072: StringResource
+  get() = String2.str_11072
+
+@ExperimentalResourceApi
+internal val Res.string.str_11073: StringResource
+  get() = String2.str_11073
+
+@ExperimentalResourceApi
+internal val Res.string.str_11074: StringResource
+  get() = String2.str_11074
+
+@ExperimentalResourceApi
+internal val Res.string.str_11075: StringResource
+  get() = String2.str_11075
+
+@ExperimentalResourceApi
+internal val Res.string.str_11076: StringResource
+  get() = String2.str_11076
+
+@ExperimentalResourceApi
+internal val Res.string.str_11077: StringResource
+  get() = String2.str_11077
+
+@ExperimentalResourceApi
+internal val Res.string.str_11078: StringResource
+  get() = String2.str_11078
+
+@ExperimentalResourceApi
+internal val Res.string.str_11079: StringResource
+  get() = String2.str_11079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1108: StringResource
+  get() = String2.str_1108
+
+@ExperimentalResourceApi
+internal val Res.string.str_11080: StringResource
+  get() = String2.str_11080
+
+@ExperimentalResourceApi
+internal val Res.string.str_11081: StringResource
+  get() = String2.str_11081
+
+@ExperimentalResourceApi
+internal val Res.string.str_11082: StringResource
+  get() = String2.str_11082
+
+@ExperimentalResourceApi
+internal val Res.string.str_11083: StringResource
+  get() = String2.str_11083
+
+@ExperimentalResourceApi
+internal val Res.string.str_11084: StringResource
+  get() = String2.str_11084
+
+@ExperimentalResourceApi
+internal val Res.string.str_11085: StringResource
+  get() = String2.str_11085
+
+@ExperimentalResourceApi
+internal val Res.string.str_11086: StringResource
+  get() = String2.str_11086
+
+@ExperimentalResourceApi
+internal val Res.string.str_11087: StringResource
+  get() = String2.str_11087
+
+@ExperimentalResourceApi
+internal val Res.string.str_11088: StringResource
+  get() = String2.str_11088
+
+@ExperimentalResourceApi
+internal val Res.string.str_11089: StringResource
+  get() = String2.str_11089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1109: StringResource
+  get() = String2.str_1109
+
+@ExperimentalResourceApi
+internal val Res.string.str_11090: StringResource
+  get() = String2.str_11090
+
+@ExperimentalResourceApi
+internal val Res.string.str_11091: StringResource
+  get() = String2.str_11091
+
+@ExperimentalResourceApi
+internal val Res.string.str_11092: StringResource
+  get() = String2.str_11092
+
+@ExperimentalResourceApi
+internal val Res.string.str_11093: StringResource
+  get() = String2.str_11093
+
+@ExperimentalResourceApi
+internal val Res.string.str_11094: StringResource
+  get() = String2.str_11094
+
+@ExperimentalResourceApi
+internal val Res.string.str_11095: StringResource
+  get() = String2.str_11095
+
+@ExperimentalResourceApi
+internal val Res.string.str_11096: StringResource
+  get() = String2.str_11096
+
+@ExperimentalResourceApi
+internal val Res.string.str_11097: StringResource
+  get() = String2.str_11097
+
+@ExperimentalResourceApi
+internal val Res.string.str_11098: StringResource
+  get() = String2.str_11098
+
+@ExperimentalResourceApi
+internal val Res.string.str_11099: StringResource
+  get() = String2.str_11099
+
+@ExperimentalResourceApi
+internal val Res.string.str_111: StringResource
+  get() = String2.str_111
+
+@ExperimentalResourceApi
+internal val Res.string.str_1110: StringResource
+  get() = String2.str_1110
+
+@ExperimentalResourceApi
+internal val Res.string.str_11100: StringResource
+  get() = String2.str_11100
+
+@ExperimentalResourceApi
+internal val Res.string.str_11101: StringResource
+  get() = String2.str_11101
+
+@ExperimentalResourceApi
+internal val Res.string.str_11102: StringResource
+  get() = String2.str_11102
+
+@ExperimentalResourceApi
+internal val Res.string.str_11103: StringResource
+  get() = String2.str_11103
+
+@ExperimentalResourceApi
+internal val Res.string.str_11104: StringResource
+  get() = String2.str_11104
+
+@ExperimentalResourceApi
+internal val Res.string.str_11105: StringResource
+  get() = String2.str_11105
+
+@ExperimentalResourceApi
+internal val Res.string.str_11106: StringResource
+  get() = String2.str_11106
+
+@ExperimentalResourceApi
+internal val Res.string.str_11107: StringResource
+  get() = String2.str_11107
+
+@ExperimentalResourceApi
+internal val Res.string.str_11108: StringResource
+  get() = String2.str_11108
+
+@ExperimentalResourceApi
+internal val Res.string.str_11109: StringResource
+  get() = String2.str_11109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1111: StringResource
+  get() = String2.str_1111
+
+@ExperimentalResourceApi
+internal val Res.string.str_11110: StringResource
+  get() = String2.str_11110
+
+@ExperimentalResourceApi
+internal val Res.string.str_11111: StringResource
+  get() = String2.str_11111
+
+@ExperimentalResourceApi
+internal val Res.string.str_11112: StringResource
+  get() = String2.str_11112
+
+@ExperimentalResourceApi
+internal val Res.string.str_11113: StringResource
+  get() = String2.str_11113
+
+@ExperimentalResourceApi
+internal val Res.string.str_11114: StringResource
+  get() = String2.str_11114
+
+@ExperimentalResourceApi
+internal val Res.string.str_11115: StringResource
+  get() = String2.str_11115
+
+@ExperimentalResourceApi
+internal val Res.string.str_11116: StringResource
+  get() = String2.str_11116
+
+@ExperimentalResourceApi
+internal val Res.string.str_11117: StringResource
+  get() = String2.str_11117
+
+@ExperimentalResourceApi
+internal val Res.string.str_11118: StringResource
+  get() = String2.str_11118
+
+@ExperimentalResourceApi
+internal val Res.string.str_11119: StringResource
+  get() = String2.str_11119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1112: StringResource
+  get() = String2.str_1112
+
+@ExperimentalResourceApi
+internal val Res.string.str_11120: StringResource
+  get() = String2.str_11120
+
+@ExperimentalResourceApi
+internal val Res.string.str_11121: StringResource
+  get() = String2.str_11121
+
+@ExperimentalResourceApi
+internal val Res.string.str_11122: StringResource
+  get() = String2.str_11122
+
+@ExperimentalResourceApi
+internal val Res.string.str_11123: StringResource
+  get() = String2.str_11123
+
+@ExperimentalResourceApi
+internal val Res.string.str_11124: StringResource
+  get() = String2.str_11124
+
+@ExperimentalResourceApi
+internal val Res.string.str_11125: StringResource
+  get() = String2.str_11125
+
+@ExperimentalResourceApi
+internal val Res.string.str_11126: StringResource
+  get() = String2.str_11126
+
+@ExperimentalResourceApi
+internal val Res.string.str_11127: StringResource
+  get() = String2.str_11127
+
+@ExperimentalResourceApi
+internal val Res.string.str_11128: StringResource
+  get() = String2.str_11128
+
+@ExperimentalResourceApi
+internal val Res.string.str_11129: StringResource
+  get() = String2.str_11129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1113: StringResource
+  get() = String2.str_1113
+
+@ExperimentalResourceApi
+internal val Res.string.str_11130: StringResource
+  get() = String2.str_11130
+
+@ExperimentalResourceApi
+internal val Res.string.str_11131: StringResource
+  get() = String2.str_11131
+
+@ExperimentalResourceApi
+internal val Res.string.str_11132: StringResource
+  get() = String2.str_11132
+
+@ExperimentalResourceApi
+internal val Res.string.str_11133: StringResource
+  get() = String2.str_11133
+
+@ExperimentalResourceApi
+internal val Res.string.str_11134: StringResource
+  get() = String2.str_11134
+
+@ExperimentalResourceApi
+internal val Res.string.str_11135: StringResource
+  get() = String2.str_11135
+
+@ExperimentalResourceApi
+internal val Res.string.str_11136: StringResource
+  get() = String2.str_11136
+
+@ExperimentalResourceApi
+internal val Res.string.str_11137: StringResource
+  get() = String2.str_11137
+
+@ExperimentalResourceApi
+internal val Res.string.str_11138: StringResource
+  get() = String2.str_11138
+
+@ExperimentalResourceApi
+internal val Res.string.str_11139: StringResource
+  get() = String2.str_11139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1114: StringResource
+  get() = String2.str_1114
+
+@ExperimentalResourceApi
+internal val Res.string.str_11140: StringResource
+  get() = String2.str_11140
+
+@ExperimentalResourceApi
+internal val Res.string.str_11141: StringResource
+  get() = String2.str_11141
+
+@ExperimentalResourceApi
+internal val Res.string.str_11142: StringResource
+  get() = String2.str_11142
+
+@ExperimentalResourceApi
+internal val Res.string.str_11143: StringResource
+  get() = String2.str_11143
+
+@ExperimentalResourceApi
+internal val Res.string.str_11144: StringResource
+  get() = String2.str_11144
+
+@ExperimentalResourceApi
+internal val Res.string.str_11145: StringResource
+  get() = String2.str_11145
+
+@ExperimentalResourceApi
+internal val Res.string.str_11146: StringResource
+  get() = String2.str_11146
+
+@ExperimentalResourceApi
+internal val Res.string.str_11147: StringResource
+  get() = String2.str_11147
+
+@ExperimentalResourceApi
+internal val Res.string.str_11148: StringResource
+  get() = String2.str_11148
+
+@ExperimentalResourceApi
+internal val Res.string.str_11149: StringResource
+  get() = String2.str_11149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1115: StringResource
+  get() = String2.str_1115
+
+@ExperimentalResourceApi
+internal val Res.string.str_11150: StringResource
+  get() = String2.str_11150
+
+@ExperimentalResourceApi
+internal val Res.string.str_11151: StringResource
+  get() = String2.str_11151
+
+@ExperimentalResourceApi
+internal val Res.string.str_11152: StringResource
+  get() = String2.str_11152
+
+@ExperimentalResourceApi
+internal val Res.string.str_11153: StringResource
+  get() = String2.str_11153
+
+@ExperimentalResourceApi
+internal val Res.string.str_11154: StringResource
+  get() = String2.str_11154
+
+@ExperimentalResourceApi
+internal val Res.string.str_11155: StringResource
+  get() = String2.str_11155
+
+@ExperimentalResourceApi
+internal val Res.string.str_11156: StringResource
+  get() = String2.str_11156
+
+@ExperimentalResourceApi
+internal val Res.string.str_11157: StringResource
+  get() = String2.str_11157
+
+@ExperimentalResourceApi
+internal val Res.string.str_11158: StringResource
+  get() = String2.str_11158
+
+@ExperimentalResourceApi
+internal val Res.string.str_11159: StringResource
+  get() = String2.str_11159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1116: StringResource
+  get() = String2.str_1116
+
+@ExperimentalResourceApi
+internal val Res.string.str_11160: StringResource
+  get() = String2.str_11160
+
+@ExperimentalResourceApi
+internal val Res.string.str_11161: StringResource
+  get() = String2.str_11161
+
+@ExperimentalResourceApi
+internal val Res.string.str_11162: StringResource
+  get() = String2.str_11162
+
+@ExperimentalResourceApi
+internal val Res.string.str_11163: StringResource
+  get() = String2.str_11163
+
+@ExperimentalResourceApi
+internal val Res.string.str_11164: StringResource
+  get() = String2.str_11164
+
+@ExperimentalResourceApi
+internal val Res.string.str_11165: StringResource
+  get() = String2.str_11165
+
+@ExperimentalResourceApi
+internal val Res.string.str_11166: StringResource
+  get() = String2.str_11166
+
+@ExperimentalResourceApi
+internal val Res.string.str_11167: StringResource
+  get() = String2.str_11167
+
+@ExperimentalResourceApi
+internal val Res.string.str_11168: StringResource
+  get() = String2.str_11168
+
+@ExperimentalResourceApi
+internal val Res.string.str_11169: StringResource
+  get() = String2.str_11169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1117: StringResource
+  get() = String2.str_1117
+
+@ExperimentalResourceApi
+internal val Res.string.str_11170: StringResource
+  get() = String2.str_11170
+
+@ExperimentalResourceApi
+internal val Res.string.str_11171: StringResource
+  get() = String2.str_11171
+
+@ExperimentalResourceApi
+internal val Res.string.str_11172: StringResource
+  get() = String2.str_11172
+
+@ExperimentalResourceApi
+internal val Res.string.str_11173: StringResource
+  get() = String2.str_11173
+
+@ExperimentalResourceApi
+internal val Res.string.str_11174: StringResource
+  get() = String2.str_11174
+
+@ExperimentalResourceApi
+internal val Res.string.str_11175: StringResource
+  get() = String2.str_11175
+
+@ExperimentalResourceApi
+internal val Res.string.str_11176: StringResource
+  get() = String2.str_11176
+
+@ExperimentalResourceApi
+internal val Res.string.str_11177: StringResource
+  get() = String2.str_11177
+
+@ExperimentalResourceApi
+internal val Res.string.str_11178: StringResource
+  get() = String2.str_11178
+
+@ExperimentalResourceApi
+internal val Res.string.str_11179: StringResource
+  get() = String2.str_11179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1118: StringResource
+  get() = String2.str_1118
+
+@ExperimentalResourceApi
+internal val Res.string.str_11180: StringResource
+  get() = String2.str_11180
+
+@ExperimentalResourceApi
+internal val Res.string.str_11181: StringResource
+  get() = String2.str_11181
+
+@ExperimentalResourceApi
+internal val Res.string.str_11182: StringResource
+  get() = String2.str_11182
+
+@ExperimentalResourceApi
+internal val Res.string.str_11183: StringResource
+  get() = String2.str_11183
+
+@ExperimentalResourceApi
+internal val Res.string.str_11184: StringResource
+  get() = String2.str_11184
+
+@ExperimentalResourceApi
+internal val Res.string.str_11185: StringResource
+  get() = String2.str_11185
+
+@ExperimentalResourceApi
+internal val Res.string.str_11186: StringResource
+  get() = String2.str_11186
+
+@ExperimentalResourceApi
+internal val Res.string.str_11187: StringResource
+  get() = String2.str_11187
+
+@ExperimentalResourceApi
+internal val Res.string.str_11188: StringResource
+  get() = String2.str_11188
+
+@ExperimentalResourceApi
+internal val Res.string.str_11189: StringResource
+  get() = String2.str_11189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1119: StringResource
+  get() = String2.str_1119
+
+@ExperimentalResourceApi
+internal val Res.string.str_11190: StringResource
+  get() = String2.str_11190
+
+@ExperimentalResourceApi
+internal val Res.string.str_11191: StringResource
+  get() = String2.str_11191
+
+@ExperimentalResourceApi
+internal val Res.string.str_11192: StringResource
+  get() = String2.str_11192
+
+@ExperimentalResourceApi
+internal val Res.string.str_11193: StringResource
+  get() = String2.str_11193
+
+@ExperimentalResourceApi
+internal val Res.string.str_11194: StringResource
+  get() = String2.str_11194
+
+@ExperimentalResourceApi
+internal val Res.string.str_11195: StringResource
+  get() = String2.str_11195
+
+@ExperimentalResourceApi
+internal val Res.string.str_11196: StringResource
+  get() = String2.str_11196
+
+@ExperimentalResourceApi
+internal val Res.string.str_11197: StringResource
+  get() = String2.str_11197
+
+@ExperimentalResourceApi
+internal val Res.string.str_11198: StringResource
+  get() = String2.str_11198
+
+@ExperimentalResourceApi
+internal val Res.string.str_11199: StringResource
+  get() = String2.str_11199
+
+@ExperimentalResourceApi
+internal val Res.string.str_112: StringResource
+  get() = String2.str_112
+
+@ExperimentalResourceApi
+internal val Res.string.str_1120: StringResource
+  get() = String2.str_1120
+
+@ExperimentalResourceApi
+internal val Res.string.str_11200: StringResource
+  get() = String2.str_11200
+
+@ExperimentalResourceApi
+internal val Res.string.str_11201: StringResource
+  get() = String2.str_11201
+
+@ExperimentalResourceApi
+internal val Res.string.str_11202: StringResource
+  get() = String2.str_11202
+
+@ExperimentalResourceApi
+internal val Res.string.str_11203: StringResource
+  get() = String2.str_11203
+
+@ExperimentalResourceApi
+internal val Res.string.str_11204: StringResource
+  get() = String2.str_11204
+
+@ExperimentalResourceApi
+internal val Res.string.str_11205: StringResource
+  get() = String2.str_11205
+
+@ExperimentalResourceApi
+internal val Res.string.str_11206: StringResource
+  get() = String2.str_11206
+
+@ExperimentalResourceApi
+internal val Res.string.str_11207: StringResource
+  get() = String2.str_11207
+
+@ExperimentalResourceApi
+internal val Res.string.str_11208: StringResource
+  get() = String2.str_11208
+
+@ExperimentalResourceApi
+internal val Res.string.str_11209: StringResource
+  get() = String2.str_11209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1121: StringResource
+  get() = String2.str_1121
+
+@ExperimentalResourceApi
+internal val Res.string.str_11210: StringResource
+  get() = String2.str_11210
+
+@ExperimentalResourceApi
+internal val Res.string.str_11211: StringResource
+  get() = String2.str_11211
+
+@ExperimentalResourceApi
+internal val Res.string.str_11212: StringResource
+  get() = String2.str_11212
+
+@ExperimentalResourceApi
+internal val Res.string.str_11213: StringResource
+  get() = String2.str_11213
+
+@ExperimentalResourceApi
+internal val Res.string.str_11214: StringResource
+  get() = String2.str_11214
+
+@ExperimentalResourceApi
+internal val Res.string.str_11215: StringResource
+  get() = String2.str_11215
+
+@ExperimentalResourceApi
+internal val Res.string.str_11216: StringResource
+  get() = String2.str_11216
+
+@ExperimentalResourceApi
+internal val Res.string.str_11217: StringResource
+  get() = String2.str_11217
+
+@ExperimentalResourceApi
+internal val Res.string.str_11218: StringResource
+  get() = String2.str_11218
+
+@ExperimentalResourceApi
+internal val Res.string.str_11219: StringResource
+  get() = String2.str_11219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1122: StringResource
+  get() = String2.str_1122
+
+@ExperimentalResourceApi
+internal val Res.string.str_11220: StringResource
+  get() = String2.str_11220
+
+@ExperimentalResourceApi
+internal val Res.string.str_11221: StringResource
+  get() = String2.str_11221
+
+@ExperimentalResourceApi
+internal val Res.string.str_11222: StringResource
+  get() = String2.str_11222
+
+@ExperimentalResourceApi
+internal val Res.string.str_11223: StringResource
+  get() = String2.str_11223
+
+@ExperimentalResourceApi
+internal val Res.string.str_11224: StringResource
+  get() = String2.str_11224
+
+@ExperimentalResourceApi
+internal val Res.string.str_11225: StringResource
+  get() = String2.str_11225
+
+@ExperimentalResourceApi
+internal val Res.string.str_11226: StringResource
+  get() = String2.str_11226
+
+@ExperimentalResourceApi
+internal val Res.string.str_11227: StringResource
+  get() = String2.str_11227
+
+@ExperimentalResourceApi
+internal val Res.string.str_11228: StringResource
+  get() = String2.str_11228
+
+@ExperimentalResourceApi
+internal val Res.string.str_11229: StringResource
+  get() = String2.str_11229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1123: StringResource
+  get() = String2.str_1123
+
+@ExperimentalResourceApi
+internal val Res.string.str_11230: StringResource
+  get() = String2.str_11230
+
+@ExperimentalResourceApi
+internal val Res.string.str_11231: StringResource
+  get() = String2.str_11231
+
+@ExperimentalResourceApi
+internal val Res.string.str_11232: StringResource
+  get() = String2.str_11232
+
+@ExperimentalResourceApi
+internal val Res.string.str_11233: StringResource
+  get() = String2.str_11233
+
+@ExperimentalResourceApi
+internal val Res.string.str_11234: StringResource
+  get() = String2.str_11234
+
+@ExperimentalResourceApi
+internal val Res.string.str_11235: StringResource
+  get() = String2.str_11235
+
+@ExperimentalResourceApi
+internal val Res.string.str_11236: StringResource
+  get() = String2.str_11236
+
+@ExperimentalResourceApi
+internal val Res.string.str_11237: StringResource
+  get() = String2.str_11237
+
+@ExperimentalResourceApi
+internal val Res.string.str_11238: StringResource
+  get() = String2.str_11238
+
+@ExperimentalResourceApi
+internal val Res.string.str_11239: StringResource
+  get() = String2.str_11239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1124: StringResource
+  get() = String2.str_1124
+
+@ExperimentalResourceApi
+internal val Res.string.str_11240: StringResource
+  get() = String2.str_11240
+
+@ExperimentalResourceApi
+internal val Res.string.str_11241: StringResource
+  get() = String2.str_11241
+
+@ExperimentalResourceApi
+internal val Res.string.str_11242: StringResource
+  get() = String2.str_11242
+
+@ExperimentalResourceApi
+internal val Res.string.str_11243: StringResource
+  get() = String2.str_11243
+
+@ExperimentalResourceApi
+internal val Res.string.str_11244: StringResource
+  get() = String2.str_11244
+
+@ExperimentalResourceApi
+internal val Res.string.str_11245: StringResource
+  get() = String2.str_11245
+
+@ExperimentalResourceApi
+internal val Res.string.str_11246: StringResource
+  get() = String2.str_11246
+
+@ExperimentalResourceApi
+internal val Res.string.str_11247: StringResource
+  get() = String2.str_11247
+
+@ExperimentalResourceApi
+internal val Res.string.str_11248: StringResource
+  get() = String2.str_11248
+
+@ExperimentalResourceApi
+internal val Res.string.str_11249: StringResource
+  get() = String2.str_11249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1125: StringResource
+  get() = String2.str_1125
+
+@ExperimentalResourceApi
+internal val Res.string.str_11250: StringResource
+  get() = String2.str_11250
+
+@ExperimentalResourceApi
+internal val Res.string.str_11251: StringResource
+  get() = String2.str_11251
+
+@ExperimentalResourceApi
+internal val Res.string.str_11252: StringResource
+  get() = String2.str_11252
+
+@ExperimentalResourceApi
+internal val Res.string.str_11253: StringResource
+  get() = String2.str_11253
+
+@ExperimentalResourceApi
+internal val Res.string.str_11254: StringResource
+  get() = String2.str_11254
+
+@ExperimentalResourceApi
+internal val Res.string.str_11255: StringResource
+  get() = String2.str_11255
+
+@ExperimentalResourceApi
+internal val Res.string.str_11256: StringResource
+  get() = String2.str_11256
+
+@ExperimentalResourceApi
+internal val Res.string.str_11257: StringResource
+  get() = String2.str_11257
+
+@ExperimentalResourceApi
+internal val Res.string.str_11258: StringResource
+  get() = String2.str_11258
+
+@ExperimentalResourceApi
+internal val Res.string.str_11259: StringResource
+  get() = String2.str_11259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1126: StringResource
+  get() = String2.str_1126
+
+@ExperimentalResourceApi
+internal val Res.string.str_11260: StringResource
+  get() = String2.str_11260
+
+@ExperimentalResourceApi
+internal val Res.string.str_11261: StringResource
+  get() = String2.str_11261
+
+@ExperimentalResourceApi
+internal val Res.string.str_11262: StringResource
+  get() = String2.str_11262
+
+@ExperimentalResourceApi
+internal val Res.string.str_11263: StringResource
+  get() = String2.str_11263
+
+@ExperimentalResourceApi
+internal val Res.string.str_11264: StringResource
+  get() = String2.str_11264
+
+@ExperimentalResourceApi
+internal val Res.string.str_11265: StringResource
+  get() = String2.str_11265
+
+@ExperimentalResourceApi
+internal val Res.string.str_11266: StringResource
+  get() = String2.str_11266
+
+@ExperimentalResourceApi
+internal val Res.string.str_11267: StringResource
+  get() = String2.str_11267
+
+@ExperimentalResourceApi
+internal val Res.string.str_11268: StringResource
+  get() = String2.str_11268
+
+@ExperimentalResourceApi
+internal val Res.string.str_11269: StringResource
+  get() = String2.str_11269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1127: StringResource
+  get() = String2.str_1127
+
+@ExperimentalResourceApi
+internal val Res.string.str_11270: StringResource
+  get() = String2.str_11270
+
+@ExperimentalResourceApi
+internal val Res.string.str_11271: StringResource
+  get() = String2.str_11271
+
+@ExperimentalResourceApi
+internal val Res.string.str_11272: StringResource
+  get() = String2.str_11272
+
+@ExperimentalResourceApi
+internal val Res.string.str_11273: StringResource
+  get() = String2.str_11273
+
+@ExperimentalResourceApi
+internal val Res.string.str_11274: StringResource
+  get() = String2.str_11274
+
+@ExperimentalResourceApi
+internal val Res.string.str_11275: StringResource
+  get() = String2.str_11275
+
+@ExperimentalResourceApi
+internal val Res.string.str_11276: StringResource
+  get() = String2.str_11276
+
+@ExperimentalResourceApi
+internal val Res.string.str_11277: StringResource
+  get() = String2.str_11277
+
+@ExperimentalResourceApi
+internal val Res.string.str_11278: StringResource
+  get() = String2.str_11278
+
+@ExperimentalResourceApi
+internal val Res.string.str_11279: StringResource
+  get() = String2.str_11279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1128: StringResource
+  get() = String2.str_1128
+
+@ExperimentalResourceApi
+internal val Res.string.str_11280: StringResource
+  get() = String2.str_11280
+
+@ExperimentalResourceApi
+internal val Res.string.str_11281: StringResource
+  get() = String2.str_11281
+
+@ExperimentalResourceApi
+internal val Res.string.str_11282: StringResource
+  get() = String2.str_11282
+
+@ExperimentalResourceApi
+internal val Res.string.str_11283: StringResource
+  get() = String2.str_11283
+
+@ExperimentalResourceApi
+internal val Res.string.str_11284: StringResource
+  get() = String2.str_11284
+
+@ExperimentalResourceApi
+internal val Res.string.str_11285: StringResource
+  get() = String2.str_11285
+
+@ExperimentalResourceApi
+internal val Res.string.str_11286: StringResource
+  get() = String2.str_11286
+
+@ExperimentalResourceApi
+internal val Res.string.str_11287: StringResource
+  get() = String2.str_11287
+
+@ExperimentalResourceApi
+internal val Res.string.str_11288: StringResource
+  get() = String2.str_11288
+
+@ExperimentalResourceApi
+internal val Res.string.str_11289: StringResource
+  get() = String2.str_11289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1129: StringResource
+  get() = String2.str_1129
+
+@ExperimentalResourceApi
+internal val Res.string.str_11290: StringResource
+  get() = String2.str_11290
+
+@ExperimentalResourceApi
+internal val Res.string.str_11291: StringResource
+  get() = String2.str_11291
+
+@ExperimentalResourceApi
+internal val Res.string.str_11292: StringResource
+  get() = String2.str_11292
+
+@ExperimentalResourceApi
+internal val Res.string.str_11293: StringResource
+  get() = String2.str_11293
+
+@ExperimentalResourceApi
+internal val Res.string.str_11294: StringResource
+  get() = String2.str_11294
+
+@ExperimentalResourceApi
+internal val Res.string.str_11295: StringResource
+  get() = String2.str_11295
+
+@ExperimentalResourceApi
+internal val Res.string.str_11296: StringResource
+  get() = String2.str_11296
+
+@ExperimentalResourceApi
+internal val Res.string.str_11297: StringResource
+  get() = String2.str_11297
+
+@ExperimentalResourceApi
+internal val Res.string.str_11298: StringResource
+  get() = String2.str_11298
+
+@ExperimentalResourceApi
+internal val Res.string.str_11299: StringResource
+  get() = String2.str_11299
+
+@ExperimentalResourceApi
+internal val Res.string.str_113: StringResource
+  get() = String2.str_113
+
+@ExperimentalResourceApi
+internal val Res.string.str_1130: StringResource
+  get() = String2.str_1130
+
+@ExperimentalResourceApi
+internal val Res.string.str_11300: StringResource
+  get() = String2.str_11300
+
+@ExperimentalResourceApi
+internal val Res.string.str_11301: StringResource
+  get() = String2.str_11301
+
+@ExperimentalResourceApi
+internal val Res.string.str_11302: StringResource
+  get() = String2.str_11302
+
+@ExperimentalResourceApi
+internal val Res.string.str_11303: StringResource
+  get() = String2.str_11303
+
+@ExperimentalResourceApi
+internal val Res.string.str_11304: StringResource
+  get() = String2.str_11304
+
+@ExperimentalResourceApi
+internal val Res.string.str_11305: StringResource
+  get() = String2.str_11305
+
+@ExperimentalResourceApi
+internal val Res.string.str_11306: StringResource
+  get() = String2.str_11306
+
+@ExperimentalResourceApi
+internal val Res.string.str_11307: StringResource
+  get() = String2.str_11307
+
+@ExperimentalResourceApi
+internal val Res.string.str_11308: StringResource
+  get() = String2.str_11308
+
+@ExperimentalResourceApi
+internal val Res.string.str_11309: StringResource
+  get() = String2.str_11309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1131: StringResource
+  get() = String2.str_1131
+
+@ExperimentalResourceApi
+internal val Res.string.str_11310: StringResource
+  get() = String2.str_11310
+
+@ExperimentalResourceApi
+internal val Res.string.str_11311: StringResource
+  get() = String2.str_11311
+
+@ExperimentalResourceApi
+internal val Res.string.str_11312: StringResource
+  get() = String2.str_11312
+
+@ExperimentalResourceApi
+internal val Res.string.str_11313: StringResource
+  get() = String2.str_11313
+
+@ExperimentalResourceApi
+internal val Res.string.str_11314: StringResource
+  get() = String2.str_11314
+
+@ExperimentalResourceApi
+internal val Res.string.str_11315: StringResource
+  get() = String2.str_11315
+
+@ExperimentalResourceApi
+internal val Res.string.str_11316: StringResource
+  get() = String2.str_11316
+
+@ExperimentalResourceApi
+internal val Res.string.str_11317: StringResource
+  get() = String2.str_11317
+
+@ExperimentalResourceApi
+internal val Res.string.str_11318: StringResource
+  get() = String2.str_11318
+
+@ExperimentalResourceApi
+internal val Res.string.str_11319: StringResource
+  get() = String2.str_11319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1132: StringResource
+  get() = String2.str_1132
+
+@ExperimentalResourceApi
+internal val Res.string.str_11320: StringResource
+  get() = String2.str_11320
+
+@ExperimentalResourceApi
+internal val Res.string.str_11321: StringResource
+  get() = String2.str_11321
+
+@ExperimentalResourceApi
+internal val Res.string.str_11322: StringResource
+  get() = String2.str_11322
+
+@ExperimentalResourceApi
+internal val Res.string.str_11323: StringResource
+  get() = String2.str_11323
+
+@ExperimentalResourceApi
+internal val Res.string.str_11324: StringResource
+  get() = String2.str_11324
+
+@ExperimentalResourceApi
+internal val Res.string.str_11325: StringResource
+  get() = String2.str_11325
+
+@ExperimentalResourceApi
+internal val Res.string.str_11326: StringResource
+  get() = String2.str_11326
+
+@ExperimentalResourceApi
+internal val Res.string.str_11327: StringResource
+  get() = String2.str_11327
+
+@ExperimentalResourceApi
+internal val Res.string.str_11328: StringResource
+  get() = String2.str_11328
+
+@ExperimentalResourceApi
+internal val Res.string.str_11329: StringResource
+  get() = String2.str_11329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1133: StringResource
+  get() = String2.str_1133
+
+@ExperimentalResourceApi
+internal val Res.string.str_11330: StringResource
+  get() = String2.str_11330
+
+@ExperimentalResourceApi
+internal val Res.string.str_11331: StringResource
+  get() = String2.str_11331
+
+@ExperimentalResourceApi
+internal val Res.string.str_11332: StringResource
+  get() = String2.str_11332
+
+@ExperimentalResourceApi
+internal val Res.string.str_11333: StringResource
+  get() = String2.str_11333
+
+@ExperimentalResourceApi
+internal val Res.string.str_11334: StringResource
+  get() = String2.str_11334
+
+@ExperimentalResourceApi
+internal val Res.string.str_11335: StringResource
+  get() = String2.str_11335
+
+@ExperimentalResourceApi
+internal val Res.string.str_11336: StringResource
+  get() = String2.str_11336
+
+@ExperimentalResourceApi
+internal val Res.string.str_11337: StringResource
+  get() = String2.str_11337
+
+@ExperimentalResourceApi
+internal val Res.string.str_11338: StringResource
+  get() = String2.str_11338
+
+@ExperimentalResourceApi
+internal val Res.string.str_11339: StringResource
+  get() = String2.str_11339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1134: StringResource
+  get() = String2.str_1134
+
+@ExperimentalResourceApi
+internal val Res.string.str_11340: StringResource
+  get() = String2.str_11340
+
+@ExperimentalResourceApi
+internal val Res.string.str_11341: StringResource
+  get() = String2.str_11341
+
+@ExperimentalResourceApi
+internal val Res.string.str_11342: StringResource
+  get() = String2.str_11342
+
+@ExperimentalResourceApi
+internal val Res.string.str_11343: StringResource
+  get() = String2.str_11343
+
+@ExperimentalResourceApi
+internal val Res.string.str_11344: StringResource
+  get() = String2.str_11344
+
+@ExperimentalResourceApi
+internal val Res.string.str_11345: StringResource
+  get() = String2.str_11345
+
+@ExperimentalResourceApi
+internal val Res.string.str_11346: StringResource
+  get() = String2.str_11346

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String20.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String20.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String20 {
+  public val str_18999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_18999", "str_18999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19", "str_19",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_190", "str_190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1900", "str_1900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19000", "str_19000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19001", "str_19001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19002", "str_19002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19003", "str_19003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19004", "str_19004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19005", "str_19005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19006", "str_19006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19007", "str_19007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19008", "str_19008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19009", "str_19009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1901", "str_1901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19010", "str_19010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19011", "str_19011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19012", "str_19012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19013", "str_19013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19014", "str_19014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19015", "str_19015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19016", "str_19016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19017", "str_19017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19018", "str_19018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19019", "str_19019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1902", "str_1902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19020", "str_19020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19021", "str_19021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19022", "str_19022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19023", "str_19023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19024", "str_19024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19025", "str_19025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19026", "str_19026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19027", "str_19027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19028", "str_19028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19029", "str_19029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1903", "str_1903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19030", "str_19030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19031", "str_19031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19032", "str_19032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19033", "str_19033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19034", "str_19034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19035", "str_19035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19036", "str_19036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19037", "str_19037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19038", "str_19038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19039", "str_19039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1904", "str_1904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19040", "str_19040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19041", "str_19041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19042", "str_19042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19043", "str_19043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19044", "str_19044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19045", "str_19045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19046", "str_19046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19047", "str_19047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19048", "str_19048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19049", "str_19049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1905", "str_1905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19050", "str_19050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19051", "str_19051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19052", "str_19052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19053", "str_19053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19054", "str_19054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19055", "str_19055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19056", "str_19056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19057", "str_19057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19058", "str_19058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19059", "str_19059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1906", "str_1906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19060", "str_19060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19061", "str_19061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19062", "str_19062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19063", "str_19063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19064", "str_19064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19065", "str_19065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19066", "str_19066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19067", "str_19067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19068", "str_19068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19069", "str_19069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1907", "str_1907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19070", "str_19070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19071", "str_19071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19072", "str_19072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19073", "str_19073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19074", "str_19074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19075", "str_19075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19076", "str_19076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19077", "str_19077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19078", "str_19078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19079", "str_19079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1908", "str_1908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19080", "str_19080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19081", "str_19081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19082", "str_19082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19083", "str_19083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19084", "str_19084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19085", "str_19085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19086", "str_19086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19087", "str_19087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19088", "str_19088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19089", "str_19089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1909", "str_1909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19090", "str_19090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19091", "str_19091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19092", "str_19092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19093", "str_19093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19094", "str_19094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19095", "str_19095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19096", "str_19096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19097", "str_19097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19098", "str_19098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19099", "str_19099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_191", "str_191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1910", "str_1910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19100", "str_19100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19101", "str_19101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19102", "str_19102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19103", "str_19103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19104", "str_19104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19105", "str_19105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19106", "str_19106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19107", "str_19107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19108", "str_19108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19109", "str_19109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1911", "str_1911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19110", "str_19110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19111", "str_19111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19112", "str_19112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19113", "str_19113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19114", "str_19114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19115", "str_19115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19116", "str_19116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19117", "str_19117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19118", "str_19118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19119", "str_19119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1912", "str_1912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19120", "str_19120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19121", "str_19121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19122", "str_19122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19123", "str_19123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19124", "str_19124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19125", "str_19125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19126", "str_19126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19127", "str_19127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19128", "str_19128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19129", "str_19129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1913", "str_1913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19130", "str_19130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19131", "str_19131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19132", "str_19132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19133", "str_19133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19134", "str_19134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19135", "str_19135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19136", "str_19136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19137", "str_19137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19138", "str_19138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19139", "str_19139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1914", "str_1914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19140", "str_19140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19141", "str_19141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19142", "str_19142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19143", "str_19143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19144", "str_19144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19145", "str_19145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19146", "str_19146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19147", "str_19147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19148", "str_19148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19149", "str_19149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1915", "str_1915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19150", "str_19150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19151", "str_19151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19152", "str_19152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19153", "str_19153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19154", "str_19154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19155", "str_19155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19156", "str_19156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19157", "str_19157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19158", "str_19158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19159", "str_19159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1916", "str_1916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19160", "str_19160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19161", "str_19161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19162", "str_19162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19163", "str_19163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19164", "str_19164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19165", "str_19165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19166", "str_19166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19167", "str_19167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19168", "str_19168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19169", "str_19169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1917", "str_1917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19170", "str_19170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19171", "str_19171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19172", "str_19172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19173", "str_19173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19174", "str_19174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19175", "str_19175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19176", "str_19176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19177", "str_19177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19178", "str_19178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19179", "str_19179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1918", "str_1918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19180", "str_19180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19181", "str_19181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19182", "str_19182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19183", "str_19183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19184", "str_19184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19185", "str_19185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19186", "str_19186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19187", "str_19187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19188", "str_19188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19189", "str_19189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1919", "str_1919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19190", "str_19190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19191", "str_19191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19192", "str_19192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19193", "str_19193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19194", "str_19194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19195", "str_19195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19196", "str_19196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19197", "str_19197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19198", "str_19198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19199", "str_19199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_192", "str_192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1920", "str_1920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19200", "str_19200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19201", "str_19201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19202", "str_19202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19203", "str_19203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19204", "str_19204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19205", "str_19205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19206", "str_19206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19207", "str_19207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19208", "str_19208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19209", "str_19209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1921", "str_1921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19210", "str_19210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19211", "str_19211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19212", "str_19212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19213", "str_19213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19214", "str_19214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19215", "str_19215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19216", "str_19216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19217", "str_19217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19218", "str_19218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19219", "str_19219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1922", "str_1922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19220", "str_19220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19221", "str_19221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19222", "str_19222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19223", "str_19223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19224", "str_19224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19225", "str_19225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19226", "str_19226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19227", "str_19227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19228", "str_19228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19229", "str_19229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1923", "str_1923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19230", "str_19230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19231", "str_19231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19232", "str_19232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19233", "str_19233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19234", "str_19234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19235", "str_19235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19236", "str_19236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19237", "str_19237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19238", "str_19238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19239", "str_19239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1924", "str_1924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19240", "str_19240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19241", "str_19241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19242", "str_19242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19243", "str_19243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19244", "str_19244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19245", "str_19245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19246", "str_19246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19247", "str_19247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19248", "str_19248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19249", "str_19249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1925", "str_1925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19250", "str_19250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19251", "str_19251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19252", "str_19252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19253", "str_19253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19254", "str_19254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19255", "str_19255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19256", "str_19256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19257", "str_19257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19258", "str_19258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19259", "str_19259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1926", "str_1926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19260", "str_19260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19261", "str_19261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19262", "str_19262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19263", "str_19263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19264", "str_19264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19265", "str_19265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19266", "str_19266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19267", "str_19267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19268", "str_19268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19269", "str_19269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1927", "str_1927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19270", "str_19270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19271", "str_19271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19272", "str_19272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19273", "str_19273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19274", "str_19274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19275", "str_19275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19276", "str_19276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19277", "str_19277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19278", "str_19278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19279", "str_19279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1928", "str_1928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19280", "str_19280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19281", "str_19281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19282", "str_19282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19283", "str_19283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19284", "str_19284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19285", "str_19285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19286", "str_19286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19287", "str_19287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19288", "str_19288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19289", "str_19289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1929", "str_1929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19290", "str_19290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19291", "str_19291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19292", "str_19292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19293", "str_19293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19294", "str_19294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19295", "str_19295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19296", "str_19296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19297", "str_19297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19298", "str_19298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19299", "str_19299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_193", "str_193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1930", "str_1930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19300", "str_19300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19301", "str_19301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19302", "str_19302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19303", "str_19303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19304", "str_19304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19305", "str_19305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19306", "str_19306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19307", "str_19307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19308", "str_19308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19309", "str_19309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1931", "str_1931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19310", "str_19310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19311", "str_19311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19312", "str_19312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19313", "str_19313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19314", "str_19314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19315", "str_19315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19316", "str_19316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19317", "str_19317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19318", "str_19318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19319", "str_19319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1932", "str_1932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19320", "str_19320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19321", "str_19321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19322", "str_19322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19323", "str_19323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19324", "str_19324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19325", "str_19325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19326", "str_19326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19327", "str_19327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19328", "str_19328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19329", "str_19329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1933", "str_1933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19330", "str_19330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19331", "str_19331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19332", "str_19332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19333", "str_19333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19334", "str_19334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19335", "str_19335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19336", "str_19336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19337", "str_19337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19338", "str_19338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19339", "str_19339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1934", "str_1934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19340", "str_19340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19341", "str_19341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19342", "str_19342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19343", "str_19343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19344", "str_19344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19345", "str_19345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19346", "str_19346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19347", "str_19347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19348", "str_19348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19349", "str_19349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1935", "str_1935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19350", "str_19350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19351", "str_19351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19352", "str_19352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19353", "str_19353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19354", "str_19354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19355", "str_19355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19356", "str_19356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19357", "str_19357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19358", "str_19358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19359", "str_19359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1936", "str_1936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19360", "str_19360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19361", "str_19361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19362", "str_19362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19363", "str_19363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19364", "str_19364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19365", "str_19365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19366", "str_19366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19367", "str_19367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19368", "str_19368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19369", "str_19369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1937", "str_1937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19370", "str_19370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19371", "str_19371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19372", "str_19372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19373", "str_19373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19374", "str_19374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19375", "str_19375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19376", "str_19376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19377", "str_19377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19378", "str_19378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19379", "str_19379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1938", "str_1938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19380", "str_19380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19381", "str_19381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19382", "str_19382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19383", "str_19383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19384", "str_19384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19385", "str_19385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19386", "str_19386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19387", "str_19387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19388", "str_19388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19389", "str_19389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1939", "str_1939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19390", "str_19390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19391", "str_19391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19392", "str_19392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19393", "str_19393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19394", "str_19394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19395", "str_19395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19396", "str_19396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19397", "str_19397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19398", "str_19398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19399", "str_19399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_194", "str_194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1940", "str_1940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19400", "str_19400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19401", "str_19401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19402", "str_19402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19403", "str_19403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19404", "str_19404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19405", "str_19405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19406", "str_19406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19407", "str_19407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19408", "str_19408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19409", "str_19409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1941", "str_1941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19410", "str_19410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19411", "str_19411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19412", "str_19412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19413", "str_19413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19414", "str_19414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19415", "str_19415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19416", "str_19416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19417", "str_19417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19418", "str_19418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19419", "str_19419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1942", "str_1942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19420", "str_19420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19421", "str_19421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19422", "str_19422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19423", "str_19423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19424", "str_19424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19425", "str_19425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19426", "str_19426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19427", "str_19427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19428", "str_19428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19429", "str_19429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1943", "str_1943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19430", "str_19430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19431", "str_19431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19432", "str_19432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19433", "str_19433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19434", "str_19434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19435", "str_19435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19436", "str_19436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19437", "str_19437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19438", "str_19438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19439", "str_19439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1944", "str_1944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19440", "str_19440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19441", "str_19441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19442", "str_19442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19443", "str_19443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19444", "str_19444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19445", "str_19445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19446", "str_19446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19447", "str_19447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_18999: StringResource
+  get() = String20.str_18999
+
+@ExperimentalResourceApi
+internal val Res.string.str_19: StringResource
+  get() = String20.str_19
+
+@ExperimentalResourceApi
+internal val Res.string.str_190: StringResource
+  get() = String20.str_190
+
+@ExperimentalResourceApi
+internal val Res.string.str_1900: StringResource
+  get() = String20.str_1900
+
+@ExperimentalResourceApi
+internal val Res.string.str_19000: StringResource
+  get() = String20.str_19000
+
+@ExperimentalResourceApi
+internal val Res.string.str_19001: StringResource
+  get() = String20.str_19001
+
+@ExperimentalResourceApi
+internal val Res.string.str_19002: StringResource
+  get() = String20.str_19002
+
+@ExperimentalResourceApi
+internal val Res.string.str_19003: StringResource
+  get() = String20.str_19003
+
+@ExperimentalResourceApi
+internal val Res.string.str_19004: StringResource
+  get() = String20.str_19004
+
+@ExperimentalResourceApi
+internal val Res.string.str_19005: StringResource
+  get() = String20.str_19005
+
+@ExperimentalResourceApi
+internal val Res.string.str_19006: StringResource
+  get() = String20.str_19006
+
+@ExperimentalResourceApi
+internal val Res.string.str_19007: StringResource
+  get() = String20.str_19007
+
+@ExperimentalResourceApi
+internal val Res.string.str_19008: StringResource
+  get() = String20.str_19008
+
+@ExperimentalResourceApi
+internal val Res.string.str_19009: StringResource
+  get() = String20.str_19009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1901: StringResource
+  get() = String20.str_1901
+
+@ExperimentalResourceApi
+internal val Res.string.str_19010: StringResource
+  get() = String20.str_19010
+
+@ExperimentalResourceApi
+internal val Res.string.str_19011: StringResource
+  get() = String20.str_19011
+
+@ExperimentalResourceApi
+internal val Res.string.str_19012: StringResource
+  get() = String20.str_19012
+
+@ExperimentalResourceApi
+internal val Res.string.str_19013: StringResource
+  get() = String20.str_19013
+
+@ExperimentalResourceApi
+internal val Res.string.str_19014: StringResource
+  get() = String20.str_19014
+
+@ExperimentalResourceApi
+internal val Res.string.str_19015: StringResource
+  get() = String20.str_19015
+
+@ExperimentalResourceApi
+internal val Res.string.str_19016: StringResource
+  get() = String20.str_19016
+
+@ExperimentalResourceApi
+internal val Res.string.str_19017: StringResource
+  get() = String20.str_19017
+
+@ExperimentalResourceApi
+internal val Res.string.str_19018: StringResource
+  get() = String20.str_19018
+
+@ExperimentalResourceApi
+internal val Res.string.str_19019: StringResource
+  get() = String20.str_19019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1902: StringResource
+  get() = String20.str_1902
+
+@ExperimentalResourceApi
+internal val Res.string.str_19020: StringResource
+  get() = String20.str_19020
+
+@ExperimentalResourceApi
+internal val Res.string.str_19021: StringResource
+  get() = String20.str_19021
+
+@ExperimentalResourceApi
+internal val Res.string.str_19022: StringResource
+  get() = String20.str_19022
+
+@ExperimentalResourceApi
+internal val Res.string.str_19023: StringResource
+  get() = String20.str_19023
+
+@ExperimentalResourceApi
+internal val Res.string.str_19024: StringResource
+  get() = String20.str_19024
+
+@ExperimentalResourceApi
+internal val Res.string.str_19025: StringResource
+  get() = String20.str_19025
+
+@ExperimentalResourceApi
+internal val Res.string.str_19026: StringResource
+  get() = String20.str_19026
+
+@ExperimentalResourceApi
+internal val Res.string.str_19027: StringResource
+  get() = String20.str_19027
+
+@ExperimentalResourceApi
+internal val Res.string.str_19028: StringResource
+  get() = String20.str_19028
+
+@ExperimentalResourceApi
+internal val Res.string.str_19029: StringResource
+  get() = String20.str_19029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1903: StringResource
+  get() = String20.str_1903
+
+@ExperimentalResourceApi
+internal val Res.string.str_19030: StringResource
+  get() = String20.str_19030
+
+@ExperimentalResourceApi
+internal val Res.string.str_19031: StringResource
+  get() = String20.str_19031
+
+@ExperimentalResourceApi
+internal val Res.string.str_19032: StringResource
+  get() = String20.str_19032
+
+@ExperimentalResourceApi
+internal val Res.string.str_19033: StringResource
+  get() = String20.str_19033
+
+@ExperimentalResourceApi
+internal val Res.string.str_19034: StringResource
+  get() = String20.str_19034
+
+@ExperimentalResourceApi
+internal val Res.string.str_19035: StringResource
+  get() = String20.str_19035
+
+@ExperimentalResourceApi
+internal val Res.string.str_19036: StringResource
+  get() = String20.str_19036
+
+@ExperimentalResourceApi
+internal val Res.string.str_19037: StringResource
+  get() = String20.str_19037
+
+@ExperimentalResourceApi
+internal val Res.string.str_19038: StringResource
+  get() = String20.str_19038
+
+@ExperimentalResourceApi
+internal val Res.string.str_19039: StringResource
+  get() = String20.str_19039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1904: StringResource
+  get() = String20.str_1904
+
+@ExperimentalResourceApi
+internal val Res.string.str_19040: StringResource
+  get() = String20.str_19040
+
+@ExperimentalResourceApi
+internal val Res.string.str_19041: StringResource
+  get() = String20.str_19041
+
+@ExperimentalResourceApi
+internal val Res.string.str_19042: StringResource
+  get() = String20.str_19042
+
+@ExperimentalResourceApi
+internal val Res.string.str_19043: StringResource
+  get() = String20.str_19043
+
+@ExperimentalResourceApi
+internal val Res.string.str_19044: StringResource
+  get() = String20.str_19044
+
+@ExperimentalResourceApi
+internal val Res.string.str_19045: StringResource
+  get() = String20.str_19045
+
+@ExperimentalResourceApi
+internal val Res.string.str_19046: StringResource
+  get() = String20.str_19046
+
+@ExperimentalResourceApi
+internal val Res.string.str_19047: StringResource
+  get() = String20.str_19047
+
+@ExperimentalResourceApi
+internal val Res.string.str_19048: StringResource
+  get() = String20.str_19048
+
+@ExperimentalResourceApi
+internal val Res.string.str_19049: StringResource
+  get() = String20.str_19049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1905: StringResource
+  get() = String20.str_1905
+
+@ExperimentalResourceApi
+internal val Res.string.str_19050: StringResource
+  get() = String20.str_19050
+
+@ExperimentalResourceApi
+internal val Res.string.str_19051: StringResource
+  get() = String20.str_19051
+
+@ExperimentalResourceApi
+internal val Res.string.str_19052: StringResource
+  get() = String20.str_19052
+
+@ExperimentalResourceApi
+internal val Res.string.str_19053: StringResource
+  get() = String20.str_19053
+
+@ExperimentalResourceApi
+internal val Res.string.str_19054: StringResource
+  get() = String20.str_19054
+
+@ExperimentalResourceApi
+internal val Res.string.str_19055: StringResource
+  get() = String20.str_19055
+
+@ExperimentalResourceApi
+internal val Res.string.str_19056: StringResource
+  get() = String20.str_19056
+
+@ExperimentalResourceApi
+internal val Res.string.str_19057: StringResource
+  get() = String20.str_19057
+
+@ExperimentalResourceApi
+internal val Res.string.str_19058: StringResource
+  get() = String20.str_19058
+
+@ExperimentalResourceApi
+internal val Res.string.str_19059: StringResource
+  get() = String20.str_19059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1906: StringResource
+  get() = String20.str_1906
+
+@ExperimentalResourceApi
+internal val Res.string.str_19060: StringResource
+  get() = String20.str_19060
+
+@ExperimentalResourceApi
+internal val Res.string.str_19061: StringResource
+  get() = String20.str_19061
+
+@ExperimentalResourceApi
+internal val Res.string.str_19062: StringResource
+  get() = String20.str_19062
+
+@ExperimentalResourceApi
+internal val Res.string.str_19063: StringResource
+  get() = String20.str_19063
+
+@ExperimentalResourceApi
+internal val Res.string.str_19064: StringResource
+  get() = String20.str_19064
+
+@ExperimentalResourceApi
+internal val Res.string.str_19065: StringResource
+  get() = String20.str_19065
+
+@ExperimentalResourceApi
+internal val Res.string.str_19066: StringResource
+  get() = String20.str_19066
+
+@ExperimentalResourceApi
+internal val Res.string.str_19067: StringResource
+  get() = String20.str_19067
+
+@ExperimentalResourceApi
+internal val Res.string.str_19068: StringResource
+  get() = String20.str_19068
+
+@ExperimentalResourceApi
+internal val Res.string.str_19069: StringResource
+  get() = String20.str_19069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1907: StringResource
+  get() = String20.str_1907
+
+@ExperimentalResourceApi
+internal val Res.string.str_19070: StringResource
+  get() = String20.str_19070
+
+@ExperimentalResourceApi
+internal val Res.string.str_19071: StringResource
+  get() = String20.str_19071
+
+@ExperimentalResourceApi
+internal val Res.string.str_19072: StringResource
+  get() = String20.str_19072
+
+@ExperimentalResourceApi
+internal val Res.string.str_19073: StringResource
+  get() = String20.str_19073
+
+@ExperimentalResourceApi
+internal val Res.string.str_19074: StringResource
+  get() = String20.str_19074
+
+@ExperimentalResourceApi
+internal val Res.string.str_19075: StringResource
+  get() = String20.str_19075
+
+@ExperimentalResourceApi
+internal val Res.string.str_19076: StringResource
+  get() = String20.str_19076
+
+@ExperimentalResourceApi
+internal val Res.string.str_19077: StringResource
+  get() = String20.str_19077
+
+@ExperimentalResourceApi
+internal val Res.string.str_19078: StringResource
+  get() = String20.str_19078
+
+@ExperimentalResourceApi
+internal val Res.string.str_19079: StringResource
+  get() = String20.str_19079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1908: StringResource
+  get() = String20.str_1908
+
+@ExperimentalResourceApi
+internal val Res.string.str_19080: StringResource
+  get() = String20.str_19080
+
+@ExperimentalResourceApi
+internal val Res.string.str_19081: StringResource
+  get() = String20.str_19081
+
+@ExperimentalResourceApi
+internal val Res.string.str_19082: StringResource
+  get() = String20.str_19082
+
+@ExperimentalResourceApi
+internal val Res.string.str_19083: StringResource
+  get() = String20.str_19083
+
+@ExperimentalResourceApi
+internal val Res.string.str_19084: StringResource
+  get() = String20.str_19084
+
+@ExperimentalResourceApi
+internal val Res.string.str_19085: StringResource
+  get() = String20.str_19085
+
+@ExperimentalResourceApi
+internal val Res.string.str_19086: StringResource
+  get() = String20.str_19086
+
+@ExperimentalResourceApi
+internal val Res.string.str_19087: StringResource
+  get() = String20.str_19087
+
+@ExperimentalResourceApi
+internal val Res.string.str_19088: StringResource
+  get() = String20.str_19088
+
+@ExperimentalResourceApi
+internal val Res.string.str_19089: StringResource
+  get() = String20.str_19089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1909: StringResource
+  get() = String20.str_1909
+
+@ExperimentalResourceApi
+internal val Res.string.str_19090: StringResource
+  get() = String20.str_19090
+
+@ExperimentalResourceApi
+internal val Res.string.str_19091: StringResource
+  get() = String20.str_19091
+
+@ExperimentalResourceApi
+internal val Res.string.str_19092: StringResource
+  get() = String20.str_19092
+
+@ExperimentalResourceApi
+internal val Res.string.str_19093: StringResource
+  get() = String20.str_19093
+
+@ExperimentalResourceApi
+internal val Res.string.str_19094: StringResource
+  get() = String20.str_19094
+
+@ExperimentalResourceApi
+internal val Res.string.str_19095: StringResource
+  get() = String20.str_19095
+
+@ExperimentalResourceApi
+internal val Res.string.str_19096: StringResource
+  get() = String20.str_19096
+
+@ExperimentalResourceApi
+internal val Res.string.str_19097: StringResource
+  get() = String20.str_19097
+
+@ExperimentalResourceApi
+internal val Res.string.str_19098: StringResource
+  get() = String20.str_19098
+
+@ExperimentalResourceApi
+internal val Res.string.str_19099: StringResource
+  get() = String20.str_19099
+
+@ExperimentalResourceApi
+internal val Res.string.str_191: StringResource
+  get() = String20.str_191
+
+@ExperimentalResourceApi
+internal val Res.string.str_1910: StringResource
+  get() = String20.str_1910
+
+@ExperimentalResourceApi
+internal val Res.string.str_19100: StringResource
+  get() = String20.str_19100
+
+@ExperimentalResourceApi
+internal val Res.string.str_19101: StringResource
+  get() = String20.str_19101
+
+@ExperimentalResourceApi
+internal val Res.string.str_19102: StringResource
+  get() = String20.str_19102
+
+@ExperimentalResourceApi
+internal val Res.string.str_19103: StringResource
+  get() = String20.str_19103
+
+@ExperimentalResourceApi
+internal val Res.string.str_19104: StringResource
+  get() = String20.str_19104
+
+@ExperimentalResourceApi
+internal val Res.string.str_19105: StringResource
+  get() = String20.str_19105
+
+@ExperimentalResourceApi
+internal val Res.string.str_19106: StringResource
+  get() = String20.str_19106
+
+@ExperimentalResourceApi
+internal val Res.string.str_19107: StringResource
+  get() = String20.str_19107
+
+@ExperimentalResourceApi
+internal val Res.string.str_19108: StringResource
+  get() = String20.str_19108
+
+@ExperimentalResourceApi
+internal val Res.string.str_19109: StringResource
+  get() = String20.str_19109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1911: StringResource
+  get() = String20.str_1911
+
+@ExperimentalResourceApi
+internal val Res.string.str_19110: StringResource
+  get() = String20.str_19110
+
+@ExperimentalResourceApi
+internal val Res.string.str_19111: StringResource
+  get() = String20.str_19111
+
+@ExperimentalResourceApi
+internal val Res.string.str_19112: StringResource
+  get() = String20.str_19112
+
+@ExperimentalResourceApi
+internal val Res.string.str_19113: StringResource
+  get() = String20.str_19113
+
+@ExperimentalResourceApi
+internal val Res.string.str_19114: StringResource
+  get() = String20.str_19114
+
+@ExperimentalResourceApi
+internal val Res.string.str_19115: StringResource
+  get() = String20.str_19115
+
+@ExperimentalResourceApi
+internal val Res.string.str_19116: StringResource
+  get() = String20.str_19116
+
+@ExperimentalResourceApi
+internal val Res.string.str_19117: StringResource
+  get() = String20.str_19117
+
+@ExperimentalResourceApi
+internal val Res.string.str_19118: StringResource
+  get() = String20.str_19118
+
+@ExperimentalResourceApi
+internal val Res.string.str_19119: StringResource
+  get() = String20.str_19119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1912: StringResource
+  get() = String20.str_1912
+
+@ExperimentalResourceApi
+internal val Res.string.str_19120: StringResource
+  get() = String20.str_19120
+
+@ExperimentalResourceApi
+internal val Res.string.str_19121: StringResource
+  get() = String20.str_19121
+
+@ExperimentalResourceApi
+internal val Res.string.str_19122: StringResource
+  get() = String20.str_19122
+
+@ExperimentalResourceApi
+internal val Res.string.str_19123: StringResource
+  get() = String20.str_19123
+
+@ExperimentalResourceApi
+internal val Res.string.str_19124: StringResource
+  get() = String20.str_19124
+
+@ExperimentalResourceApi
+internal val Res.string.str_19125: StringResource
+  get() = String20.str_19125
+
+@ExperimentalResourceApi
+internal val Res.string.str_19126: StringResource
+  get() = String20.str_19126
+
+@ExperimentalResourceApi
+internal val Res.string.str_19127: StringResource
+  get() = String20.str_19127
+
+@ExperimentalResourceApi
+internal val Res.string.str_19128: StringResource
+  get() = String20.str_19128
+
+@ExperimentalResourceApi
+internal val Res.string.str_19129: StringResource
+  get() = String20.str_19129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1913: StringResource
+  get() = String20.str_1913
+
+@ExperimentalResourceApi
+internal val Res.string.str_19130: StringResource
+  get() = String20.str_19130
+
+@ExperimentalResourceApi
+internal val Res.string.str_19131: StringResource
+  get() = String20.str_19131
+
+@ExperimentalResourceApi
+internal val Res.string.str_19132: StringResource
+  get() = String20.str_19132
+
+@ExperimentalResourceApi
+internal val Res.string.str_19133: StringResource
+  get() = String20.str_19133
+
+@ExperimentalResourceApi
+internal val Res.string.str_19134: StringResource
+  get() = String20.str_19134
+
+@ExperimentalResourceApi
+internal val Res.string.str_19135: StringResource
+  get() = String20.str_19135
+
+@ExperimentalResourceApi
+internal val Res.string.str_19136: StringResource
+  get() = String20.str_19136
+
+@ExperimentalResourceApi
+internal val Res.string.str_19137: StringResource
+  get() = String20.str_19137
+
+@ExperimentalResourceApi
+internal val Res.string.str_19138: StringResource
+  get() = String20.str_19138
+
+@ExperimentalResourceApi
+internal val Res.string.str_19139: StringResource
+  get() = String20.str_19139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1914: StringResource
+  get() = String20.str_1914
+
+@ExperimentalResourceApi
+internal val Res.string.str_19140: StringResource
+  get() = String20.str_19140
+
+@ExperimentalResourceApi
+internal val Res.string.str_19141: StringResource
+  get() = String20.str_19141
+
+@ExperimentalResourceApi
+internal val Res.string.str_19142: StringResource
+  get() = String20.str_19142
+
+@ExperimentalResourceApi
+internal val Res.string.str_19143: StringResource
+  get() = String20.str_19143
+
+@ExperimentalResourceApi
+internal val Res.string.str_19144: StringResource
+  get() = String20.str_19144
+
+@ExperimentalResourceApi
+internal val Res.string.str_19145: StringResource
+  get() = String20.str_19145
+
+@ExperimentalResourceApi
+internal val Res.string.str_19146: StringResource
+  get() = String20.str_19146
+
+@ExperimentalResourceApi
+internal val Res.string.str_19147: StringResource
+  get() = String20.str_19147
+
+@ExperimentalResourceApi
+internal val Res.string.str_19148: StringResource
+  get() = String20.str_19148
+
+@ExperimentalResourceApi
+internal val Res.string.str_19149: StringResource
+  get() = String20.str_19149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1915: StringResource
+  get() = String20.str_1915
+
+@ExperimentalResourceApi
+internal val Res.string.str_19150: StringResource
+  get() = String20.str_19150
+
+@ExperimentalResourceApi
+internal val Res.string.str_19151: StringResource
+  get() = String20.str_19151
+
+@ExperimentalResourceApi
+internal val Res.string.str_19152: StringResource
+  get() = String20.str_19152
+
+@ExperimentalResourceApi
+internal val Res.string.str_19153: StringResource
+  get() = String20.str_19153
+
+@ExperimentalResourceApi
+internal val Res.string.str_19154: StringResource
+  get() = String20.str_19154
+
+@ExperimentalResourceApi
+internal val Res.string.str_19155: StringResource
+  get() = String20.str_19155
+
+@ExperimentalResourceApi
+internal val Res.string.str_19156: StringResource
+  get() = String20.str_19156
+
+@ExperimentalResourceApi
+internal val Res.string.str_19157: StringResource
+  get() = String20.str_19157
+
+@ExperimentalResourceApi
+internal val Res.string.str_19158: StringResource
+  get() = String20.str_19158
+
+@ExperimentalResourceApi
+internal val Res.string.str_19159: StringResource
+  get() = String20.str_19159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1916: StringResource
+  get() = String20.str_1916
+
+@ExperimentalResourceApi
+internal val Res.string.str_19160: StringResource
+  get() = String20.str_19160
+
+@ExperimentalResourceApi
+internal val Res.string.str_19161: StringResource
+  get() = String20.str_19161
+
+@ExperimentalResourceApi
+internal val Res.string.str_19162: StringResource
+  get() = String20.str_19162
+
+@ExperimentalResourceApi
+internal val Res.string.str_19163: StringResource
+  get() = String20.str_19163
+
+@ExperimentalResourceApi
+internal val Res.string.str_19164: StringResource
+  get() = String20.str_19164
+
+@ExperimentalResourceApi
+internal val Res.string.str_19165: StringResource
+  get() = String20.str_19165
+
+@ExperimentalResourceApi
+internal val Res.string.str_19166: StringResource
+  get() = String20.str_19166
+
+@ExperimentalResourceApi
+internal val Res.string.str_19167: StringResource
+  get() = String20.str_19167
+
+@ExperimentalResourceApi
+internal val Res.string.str_19168: StringResource
+  get() = String20.str_19168
+
+@ExperimentalResourceApi
+internal val Res.string.str_19169: StringResource
+  get() = String20.str_19169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1917: StringResource
+  get() = String20.str_1917
+
+@ExperimentalResourceApi
+internal val Res.string.str_19170: StringResource
+  get() = String20.str_19170
+
+@ExperimentalResourceApi
+internal val Res.string.str_19171: StringResource
+  get() = String20.str_19171
+
+@ExperimentalResourceApi
+internal val Res.string.str_19172: StringResource
+  get() = String20.str_19172
+
+@ExperimentalResourceApi
+internal val Res.string.str_19173: StringResource
+  get() = String20.str_19173
+
+@ExperimentalResourceApi
+internal val Res.string.str_19174: StringResource
+  get() = String20.str_19174
+
+@ExperimentalResourceApi
+internal val Res.string.str_19175: StringResource
+  get() = String20.str_19175
+
+@ExperimentalResourceApi
+internal val Res.string.str_19176: StringResource
+  get() = String20.str_19176
+
+@ExperimentalResourceApi
+internal val Res.string.str_19177: StringResource
+  get() = String20.str_19177
+
+@ExperimentalResourceApi
+internal val Res.string.str_19178: StringResource
+  get() = String20.str_19178
+
+@ExperimentalResourceApi
+internal val Res.string.str_19179: StringResource
+  get() = String20.str_19179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1918: StringResource
+  get() = String20.str_1918
+
+@ExperimentalResourceApi
+internal val Res.string.str_19180: StringResource
+  get() = String20.str_19180
+
+@ExperimentalResourceApi
+internal val Res.string.str_19181: StringResource
+  get() = String20.str_19181
+
+@ExperimentalResourceApi
+internal val Res.string.str_19182: StringResource
+  get() = String20.str_19182
+
+@ExperimentalResourceApi
+internal val Res.string.str_19183: StringResource
+  get() = String20.str_19183
+
+@ExperimentalResourceApi
+internal val Res.string.str_19184: StringResource
+  get() = String20.str_19184
+
+@ExperimentalResourceApi
+internal val Res.string.str_19185: StringResource
+  get() = String20.str_19185
+
+@ExperimentalResourceApi
+internal val Res.string.str_19186: StringResource
+  get() = String20.str_19186
+
+@ExperimentalResourceApi
+internal val Res.string.str_19187: StringResource
+  get() = String20.str_19187
+
+@ExperimentalResourceApi
+internal val Res.string.str_19188: StringResource
+  get() = String20.str_19188
+
+@ExperimentalResourceApi
+internal val Res.string.str_19189: StringResource
+  get() = String20.str_19189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1919: StringResource
+  get() = String20.str_1919
+
+@ExperimentalResourceApi
+internal val Res.string.str_19190: StringResource
+  get() = String20.str_19190
+
+@ExperimentalResourceApi
+internal val Res.string.str_19191: StringResource
+  get() = String20.str_19191
+
+@ExperimentalResourceApi
+internal val Res.string.str_19192: StringResource
+  get() = String20.str_19192
+
+@ExperimentalResourceApi
+internal val Res.string.str_19193: StringResource
+  get() = String20.str_19193
+
+@ExperimentalResourceApi
+internal val Res.string.str_19194: StringResource
+  get() = String20.str_19194
+
+@ExperimentalResourceApi
+internal val Res.string.str_19195: StringResource
+  get() = String20.str_19195
+
+@ExperimentalResourceApi
+internal val Res.string.str_19196: StringResource
+  get() = String20.str_19196
+
+@ExperimentalResourceApi
+internal val Res.string.str_19197: StringResource
+  get() = String20.str_19197
+
+@ExperimentalResourceApi
+internal val Res.string.str_19198: StringResource
+  get() = String20.str_19198
+
+@ExperimentalResourceApi
+internal val Res.string.str_19199: StringResource
+  get() = String20.str_19199
+
+@ExperimentalResourceApi
+internal val Res.string.str_192: StringResource
+  get() = String20.str_192
+
+@ExperimentalResourceApi
+internal val Res.string.str_1920: StringResource
+  get() = String20.str_1920
+
+@ExperimentalResourceApi
+internal val Res.string.str_19200: StringResource
+  get() = String20.str_19200
+
+@ExperimentalResourceApi
+internal val Res.string.str_19201: StringResource
+  get() = String20.str_19201
+
+@ExperimentalResourceApi
+internal val Res.string.str_19202: StringResource
+  get() = String20.str_19202
+
+@ExperimentalResourceApi
+internal val Res.string.str_19203: StringResource
+  get() = String20.str_19203
+
+@ExperimentalResourceApi
+internal val Res.string.str_19204: StringResource
+  get() = String20.str_19204
+
+@ExperimentalResourceApi
+internal val Res.string.str_19205: StringResource
+  get() = String20.str_19205
+
+@ExperimentalResourceApi
+internal val Res.string.str_19206: StringResource
+  get() = String20.str_19206
+
+@ExperimentalResourceApi
+internal val Res.string.str_19207: StringResource
+  get() = String20.str_19207
+
+@ExperimentalResourceApi
+internal val Res.string.str_19208: StringResource
+  get() = String20.str_19208
+
+@ExperimentalResourceApi
+internal val Res.string.str_19209: StringResource
+  get() = String20.str_19209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1921: StringResource
+  get() = String20.str_1921
+
+@ExperimentalResourceApi
+internal val Res.string.str_19210: StringResource
+  get() = String20.str_19210
+
+@ExperimentalResourceApi
+internal val Res.string.str_19211: StringResource
+  get() = String20.str_19211
+
+@ExperimentalResourceApi
+internal val Res.string.str_19212: StringResource
+  get() = String20.str_19212
+
+@ExperimentalResourceApi
+internal val Res.string.str_19213: StringResource
+  get() = String20.str_19213
+
+@ExperimentalResourceApi
+internal val Res.string.str_19214: StringResource
+  get() = String20.str_19214
+
+@ExperimentalResourceApi
+internal val Res.string.str_19215: StringResource
+  get() = String20.str_19215
+
+@ExperimentalResourceApi
+internal val Res.string.str_19216: StringResource
+  get() = String20.str_19216
+
+@ExperimentalResourceApi
+internal val Res.string.str_19217: StringResource
+  get() = String20.str_19217
+
+@ExperimentalResourceApi
+internal val Res.string.str_19218: StringResource
+  get() = String20.str_19218
+
+@ExperimentalResourceApi
+internal val Res.string.str_19219: StringResource
+  get() = String20.str_19219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1922: StringResource
+  get() = String20.str_1922
+
+@ExperimentalResourceApi
+internal val Res.string.str_19220: StringResource
+  get() = String20.str_19220
+
+@ExperimentalResourceApi
+internal val Res.string.str_19221: StringResource
+  get() = String20.str_19221
+
+@ExperimentalResourceApi
+internal val Res.string.str_19222: StringResource
+  get() = String20.str_19222
+
+@ExperimentalResourceApi
+internal val Res.string.str_19223: StringResource
+  get() = String20.str_19223
+
+@ExperimentalResourceApi
+internal val Res.string.str_19224: StringResource
+  get() = String20.str_19224
+
+@ExperimentalResourceApi
+internal val Res.string.str_19225: StringResource
+  get() = String20.str_19225
+
+@ExperimentalResourceApi
+internal val Res.string.str_19226: StringResource
+  get() = String20.str_19226
+
+@ExperimentalResourceApi
+internal val Res.string.str_19227: StringResource
+  get() = String20.str_19227
+
+@ExperimentalResourceApi
+internal val Res.string.str_19228: StringResource
+  get() = String20.str_19228
+
+@ExperimentalResourceApi
+internal val Res.string.str_19229: StringResource
+  get() = String20.str_19229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1923: StringResource
+  get() = String20.str_1923
+
+@ExperimentalResourceApi
+internal val Res.string.str_19230: StringResource
+  get() = String20.str_19230
+
+@ExperimentalResourceApi
+internal val Res.string.str_19231: StringResource
+  get() = String20.str_19231
+
+@ExperimentalResourceApi
+internal val Res.string.str_19232: StringResource
+  get() = String20.str_19232
+
+@ExperimentalResourceApi
+internal val Res.string.str_19233: StringResource
+  get() = String20.str_19233
+
+@ExperimentalResourceApi
+internal val Res.string.str_19234: StringResource
+  get() = String20.str_19234
+
+@ExperimentalResourceApi
+internal val Res.string.str_19235: StringResource
+  get() = String20.str_19235
+
+@ExperimentalResourceApi
+internal val Res.string.str_19236: StringResource
+  get() = String20.str_19236
+
+@ExperimentalResourceApi
+internal val Res.string.str_19237: StringResource
+  get() = String20.str_19237
+
+@ExperimentalResourceApi
+internal val Res.string.str_19238: StringResource
+  get() = String20.str_19238
+
+@ExperimentalResourceApi
+internal val Res.string.str_19239: StringResource
+  get() = String20.str_19239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1924: StringResource
+  get() = String20.str_1924
+
+@ExperimentalResourceApi
+internal val Res.string.str_19240: StringResource
+  get() = String20.str_19240
+
+@ExperimentalResourceApi
+internal val Res.string.str_19241: StringResource
+  get() = String20.str_19241
+
+@ExperimentalResourceApi
+internal val Res.string.str_19242: StringResource
+  get() = String20.str_19242
+
+@ExperimentalResourceApi
+internal val Res.string.str_19243: StringResource
+  get() = String20.str_19243
+
+@ExperimentalResourceApi
+internal val Res.string.str_19244: StringResource
+  get() = String20.str_19244
+
+@ExperimentalResourceApi
+internal val Res.string.str_19245: StringResource
+  get() = String20.str_19245
+
+@ExperimentalResourceApi
+internal val Res.string.str_19246: StringResource
+  get() = String20.str_19246
+
+@ExperimentalResourceApi
+internal val Res.string.str_19247: StringResource
+  get() = String20.str_19247
+
+@ExperimentalResourceApi
+internal val Res.string.str_19248: StringResource
+  get() = String20.str_19248
+
+@ExperimentalResourceApi
+internal val Res.string.str_19249: StringResource
+  get() = String20.str_19249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1925: StringResource
+  get() = String20.str_1925
+
+@ExperimentalResourceApi
+internal val Res.string.str_19250: StringResource
+  get() = String20.str_19250
+
+@ExperimentalResourceApi
+internal val Res.string.str_19251: StringResource
+  get() = String20.str_19251
+
+@ExperimentalResourceApi
+internal val Res.string.str_19252: StringResource
+  get() = String20.str_19252
+
+@ExperimentalResourceApi
+internal val Res.string.str_19253: StringResource
+  get() = String20.str_19253
+
+@ExperimentalResourceApi
+internal val Res.string.str_19254: StringResource
+  get() = String20.str_19254
+
+@ExperimentalResourceApi
+internal val Res.string.str_19255: StringResource
+  get() = String20.str_19255
+
+@ExperimentalResourceApi
+internal val Res.string.str_19256: StringResource
+  get() = String20.str_19256
+
+@ExperimentalResourceApi
+internal val Res.string.str_19257: StringResource
+  get() = String20.str_19257
+
+@ExperimentalResourceApi
+internal val Res.string.str_19258: StringResource
+  get() = String20.str_19258
+
+@ExperimentalResourceApi
+internal val Res.string.str_19259: StringResource
+  get() = String20.str_19259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1926: StringResource
+  get() = String20.str_1926
+
+@ExperimentalResourceApi
+internal val Res.string.str_19260: StringResource
+  get() = String20.str_19260
+
+@ExperimentalResourceApi
+internal val Res.string.str_19261: StringResource
+  get() = String20.str_19261
+
+@ExperimentalResourceApi
+internal val Res.string.str_19262: StringResource
+  get() = String20.str_19262
+
+@ExperimentalResourceApi
+internal val Res.string.str_19263: StringResource
+  get() = String20.str_19263
+
+@ExperimentalResourceApi
+internal val Res.string.str_19264: StringResource
+  get() = String20.str_19264
+
+@ExperimentalResourceApi
+internal val Res.string.str_19265: StringResource
+  get() = String20.str_19265
+
+@ExperimentalResourceApi
+internal val Res.string.str_19266: StringResource
+  get() = String20.str_19266
+
+@ExperimentalResourceApi
+internal val Res.string.str_19267: StringResource
+  get() = String20.str_19267
+
+@ExperimentalResourceApi
+internal val Res.string.str_19268: StringResource
+  get() = String20.str_19268
+
+@ExperimentalResourceApi
+internal val Res.string.str_19269: StringResource
+  get() = String20.str_19269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1927: StringResource
+  get() = String20.str_1927
+
+@ExperimentalResourceApi
+internal val Res.string.str_19270: StringResource
+  get() = String20.str_19270
+
+@ExperimentalResourceApi
+internal val Res.string.str_19271: StringResource
+  get() = String20.str_19271
+
+@ExperimentalResourceApi
+internal val Res.string.str_19272: StringResource
+  get() = String20.str_19272
+
+@ExperimentalResourceApi
+internal val Res.string.str_19273: StringResource
+  get() = String20.str_19273
+
+@ExperimentalResourceApi
+internal val Res.string.str_19274: StringResource
+  get() = String20.str_19274
+
+@ExperimentalResourceApi
+internal val Res.string.str_19275: StringResource
+  get() = String20.str_19275
+
+@ExperimentalResourceApi
+internal val Res.string.str_19276: StringResource
+  get() = String20.str_19276
+
+@ExperimentalResourceApi
+internal val Res.string.str_19277: StringResource
+  get() = String20.str_19277
+
+@ExperimentalResourceApi
+internal val Res.string.str_19278: StringResource
+  get() = String20.str_19278
+
+@ExperimentalResourceApi
+internal val Res.string.str_19279: StringResource
+  get() = String20.str_19279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1928: StringResource
+  get() = String20.str_1928
+
+@ExperimentalResourceApi
+internal val Res.string.str_19280: StringResource
+  get() = String20.str_19280
+
+@ExperimentalResourceApi
+internal val Res.string.str_19281: StringResource
+  get() = String20.str_19281
+
+@ExperimentalResourceApi
+internal val Res.string.str_19282: StringResource
+  get() = String20.str_19282
+
+@ExperimentalResourceApi
+internal val Res.string.str_19283: StringResource
+  get() = String20.str_19283
+
+@ExperimentalResourceApi
+internal val Res.string.str_19284: StringResource
+  get() = String20.str_19284
+
+@ExperimentalResourceApi
+internal val Res.string.str_19285: StringResource
+  get() = String20.str_19285
+
+@ExperimentalResourceApi
+internal val Res.string.str_19286: StringResource
+  get() = String20.str_19286
+
+@ExperimentalResourceApi
+internal val Res.string.str_19287: StringResource
+  get() = String20.str_19287
+
+@ExperimentalResourceApi
+internal val Res.string.str_19288: StringResource
+  get() = String20.str_19288
+
+@ExperimentalResourceApi
+internal val Res.string.str_19289: StringResource
+  get() = String20.str_19289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1929: StringResource
+  get() = String20.str_1929
+
+@ExperimentalResourceApi
+internal val Res.string.str_19290: StringResource
+  get() = String20.str_19290
+
+@ExperimentalResourceApi
+internal val Res.string.str_19291: StringResource
+  get() = String20.str_19291
+
+@ExperimentalResourceApi
+internal val Res.string.str_19292: StringResource
+  get() = String20.str_19292
+
+@ExperimentalResourceApi
+internal val Res.string.str_19293: StringResource
+  get() = String20.str_19293
+
+@ExperimentalResourceApi
+internal val Res.string.str_19294: StringResource
+  get() = String20.str_19294
+
+@ExperimentalResourceApi
+internal val Res.string.str_19295: StringResource
+  get() = String20.str_19295
+
+@ExperimentalResourceApi
+internal val Res.string.str_19296: StringResource
+  get() = String20.str_19296
+
+@ExperimentalResourceApi
+internal val Res.string.str_19297: StringResource
+  get() = String20.str_19297
+
+@ExperimentalResourceApi
+internal val Res.string.str_19298: StringResource
+  get() = String20.str_19298
+
+@ExperimentalResourceApi
+internal val Res.string.str_19299: StringResource
+  get() = String20.str_19299
+
+@ExperimentalResourceApi
+internal val Res.string.str_193: StringResource
+  get() = String20.str_193
+
+@ExperimentalResourceApi
+internal val Res.string.str_1930: StringResource
+  get() = String20.str_1930
+
+@ExperimentalResourceApi
+internal val Res.string.str_19300: StringResource
+  get() = String20.str_19300
+
+@ExperimentalResourceApi
+internal val Res.string.str_19301: StringResource
+  get() = String20.str_19301
+
+@ExperimentalResourceApi
+internal val Res.string.str_19302: StringResource
+  get() = String20.str_19302
+
+@ExperimentalResourceApi
+internal val Res.string.str_19303: StringResource
+  get() = String20.str_19303
+
+@ExperimentalResourceApi
+internal val Res.string.str_19304: StringResource
+  get() = String20.str_19304
+
+@ExperimentalResourceApi
+internal val Res.string.str_19305: StringResource
+  get() = String20.str_19305
+
+@ExperimentalResourceApi
+internal val Res.string.str_19306: StringResource
+  get() = String20.str_19306
+
+@ExperimentalResourceApi
+internal val Res.string.str_19307: StringResource
+  get() = String20.str_19307
+
+@ExperimentalResourceApi
+internal val Res.string.str_19308: StringResource
+  get() = String20.str_19308
+
+@ExperimentalResourceApi
+internal val Res.string.str_19309: StringResource
+  get() = String20.str_19309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1931: StringResource
+  get() = String20.str_1931
+
+@ExperimentalResourceApi
+internal val Res.string.str_19310: StringResource
+  get() = String20.str_19310
+
+@ExperimentalResourceApi
+internal val Res.string.str_19311: StringResource
+  get() = String20.str_19311
+
+@ExperimentalResourceApi
+internal val Res.string.str_19312: StringResource
+  get() = String20.str_19312
+
+@ExperimentalResourceApi
+internal val Res.string.str_19313: StringResource
+  get() = String20.str_19313
+
+@ExperimentalResourceApi
+internal val Res.string.str_19314: StringResource
+  get() = String20.str_19314
+
+@ExperimentalResourceApi
+internal val Res.string.str_19315: StringResource
+  get() = String20.str_19315
+
+@ExperimentalResourceApi
+internal val Res.string.str_19316: StringResource
+  get() = String20.str_19316
+
+@ExperimentalResourceApi
+internal val Res.string.str_19317: StringResource
+  get() = String20.str_19317
+
+@ExperimentalResourceApi
+internal val Res.string.str_19318: StringResource
+  get() = String20.str_19318
+
+@ExperimentalResourceApi
+internal val Res.string.str_19319: StringResource
+  get() = String20.str_19319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1932: StringResource
+  get() = String20.str_1932
+
+@ExperimentalResourceApi
+internal val Res.string.str_19320: StringResource
+  get() = String20.str_19320
+
+@ExperimentalResourceApi
+internal val Res.string.str_19321: StringResource
+  get() = String20.str_19321
+
+@ExperimentalResourceApi
+internal val Res.string.str_19322: StringResource
+  get() = String20.str_19322
+
+@ExperimentalResourceApi
+internal val Res.string.str_19323: StringResource
+  get() = String20.str_19323
+
+@ExperimentalResourceApi
+internal val Res.string.str_19324: StringResource
+  get() = String20.str_19324
+
+@ExperimentalResourceApi
+internal val Res.string.str_19325: StringResource
+  get() = String20.str_19325
+
+@ExperimentalResourceApi
+internal val Res.string.str_19326: StringResource
+  get() = String20.str_19326
+
+@ExperimentalResourceApi
+internal val Res.string.str_19327: StringResource
+  get() = String20.str_19327
+
+@ExperimentalResourceApi
+internal val Res.string.str_19328: StringResource
+  get() = String20.str_19328
+
+@ExperimentalResourceApi
+internal val Res.string.str_19329: StringResource
+  get() = String20.str_19329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1933: StringResource
+  get() = String20.str_1933
+
+@ExperimentalResourceApi
+internal val Res.string.str_19330: StringResource
+  get() = String20.str_19330
+
+@ExperimentalResourceApi
+internal val Res.string.str_19331: StringResource
+  get() = String20.str_19331
+
+@ExperimentalResourceApi
+internal val Res.string.str_19332: StringResource
+  get() = String20.str_19332
+
+@ExperimentalResourceApi
+internal val Res.string.str_19333: StringResource
+  get() = String20.str_19333
+
+@ExperimentalResourceApi
+internal val Res.string.str_19334: StringResource
+  get() = String20.str_19334
+
+@ExperimentalResourceApi
+internal val Res.string.str_19335: StringResource
+  get() = String20.str_19335
+
+@ExperimentalResourceApi
+internal val Res.string.str_19336: StringResource
+  get() = String20.str_19336
+
+@ExperimentalResourceApi
+internal val Res.string.str_19337: StringResource
+  get() = String20.str_19337
+
+@ExperimentalResourceApi
+internal val Res.string.str_19338: StringResource
+  get() = String20.str_19338
+
+@ExperimentalResourceApi
+internal val Res.string.str_19339: StringResource
+  get() = String20.str_19339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1934: StringResource
+  get() = String20.str_1934
+
+@ExperimentalResourceApi
+internal val Res.string.str_19340: StringResource
+  get() = String20.str_19340
+
+@ExperimentalResourceApi
+internal val Res.string.str_19341: StringResource
+  get() = String20.str_19341
+
+@ExperimentalResourceApi
+internal val Res.string.str_19342: StringResource
+  get() = String20.str_19342
+
+@ExperimentalResourceApi
+internal val Res.string.str_19343: StringResource
+  get() = String20.str_19343
+
+@ExperimentalResourceApi
+internal val Res.string.str_19344: StringResource
+  get() = String20.str_19344
+
+@ExperimentalResourceApi
+internal val Res.string.str_19345: StringResource
+  get() = String20.str_19345
+
+@ExperimentalResourceApi
+internal val Res.string.str_19346: StringResource
+  get() = String20.str_19346
+
+@ExperimentalResourceApi
+internal val Res.string.str_19347: StringResource
+  get() = String20.str_19347
+
+@ExperimentalResourceApi
+internal val Res.string.str_19348: StringResource
+  get() = String20.str_19348
+
+@ExperimentalResourceApi
+internal val Res.string.str_19349: StringResource
+  get() = String20.str_19349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1935: StringResource
+  get() = String20.str_1935
+
+@ExperimentalResourceApi
+internal val Res.string.str_19350: StringResource
+  get() = String20.str_19350
+
+@ExperimentalResourceApi
+internal val Res.string.str_19351: StringResource
+  get() = String20.str_19351
+
+@ExperimentalResourceApi
+internal val Res.string.str_19352: StringResource
+  get() = String20.str_19352
+
+@ExperimentalResourceApi
+internal val Res.string.str_19353: StringResource
+  get() = String20.str_19353
+
+@ExperimentalResourceApi
+internal val Res.string.str_19354: StringResource
+  get() = String20.str_19354
+
+@ExperimentalResourceApi
+internal val Res.string.str_19355: StringResource
+  get() = String20.str_19355
+
+@ExperimentalResourceApi
+internal val Res.string.str_19356: StringResource
+  get() = String20.str_19356
+
+@ExperimentalResourceApi
+internal val Res.string.str_19357: StringResource
+  get() = String20.str_19357
+
+@ExperimentalResourceApi
+internal val Res.string.str_19358: StringResource
+  get() = String20.str_19358
+
+@ExperimentalResourceApi
+internal val Res.string.str_19359: StringResource
+  get() = String20.str_19359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1936: StringResource
+  get() = String20.str_1936
+
+@ExperimentalResourceApi
+internal val Res.string.str_19360: StringResource
+  get() = String20.str_19360
+
+@ExperimentalResourceApi
+internal val Res.string.str_19361: StringResource
+  get() = String20.str_19361
+
+@ExperimentalResourceApi
+internal val Res.string.str_19362: StringResource
+  get() = String20.str_19362
+
+@ExperimentalResourceApi
+internal val Res.string.str_19363: StringResource
+  get() = String20.str_19363
+
+@ExperimentalResourceApi
+internal val Res.string.str_19364: StringResource
+  get() = String20.str_19364
+
+@ExperimentalResourceApi
+internal val Res.string.str_19365: StringResource
+  get() = String20.str_19365
+
+@ExperimentalResourceApi
+internal val Res.string.str_19366: StringResource
+  get() = String20.str_19366
+
+@ExperimentalResourceApi
+internal val Res.string.str_19367: StringResource
+  get() = String20.str_19367
+
+@ExperimentalResourceApi
+internal val Res.string.str_19368: StringResource
+  get() = String20.str_19368
+
+@ExperimentalResourceApi
+internal val Res.string.str_19369: StringResource
+  get() = String20.str_19369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1937: StringResource
+  get() = String20.str_1937
+
+@ExperimentalResourceApi
+internal val Res.string.str_19370: StringResource
+  get() = String20.str_19370
+
+@ExperimentalResourceApi
+internal val Res.string.str_19371: StringResource
+  get() = String20.str_19371
+
+@ExperimentalResourceApi
+internal val Res.string.str_19372: StringResource
+  get() = String20.str_19372
+
+@ExperimentalResourceApi
+internal val Res.string.str_19373: StringResource
+  get() = String20.str_19373
+
+@ExperimentalResourceApi
+internal val Res.string.str_19374: StringResource
+  get() = String20.str_19374
+
+@ExperimentalResourceApi
+internal val Res.string.str_19375: StringResource
+  get() = String20.str_19375
+
+@ExperimentalResourceApi
+internal val Res.string.str_19376: StringResource
+  get() = String20.str_19376
+
+@ExperimentalResourceApi
+internal val Res.string.str_19377: StringResource
+  get() = String20.str_19377
+
+@ExperimentalResourceApi
+internal val Res.string.str_19378: StringResource
+  get() = String20.str_19378
+
+@ExperimentalResourceApi
+internal val Res.string.str_19379: StringResource
+  get() = String20.str_19379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1938: StringResource
+  get() = String20.str_1938
+
+@ExperimentalResourceApi
+internal val Res.string.str_19380: StringResource
+  get() = String20.str_19380
+
+@ExperimentalResourceApi
+internal val Res.string.str_19381: StringResource
+  get() = String20.str_19381
+
+@ExperimentalResourceApi
+internal val Res.string.str_19382: StringResource
+  get() = String20.str_19382
+
+@ExperimentalResourceApi
+internal val Res.string.str_19383: StringResource
+  get() = String20.str_19383
+
+@ExperimentalResourceApi
+internal val Res.string.str_19384: StringResource
+  get() = String20.str_19384
+
+@ExperimentalResourceApi
+internal val Res.string.str_19385: StringResource
+  get() = String20.str_19385
+
+@ExperimentalResourceApi
+internal val Res.string.str_19386: StringResource
+  get() = String20.str_19386
+
+@ExperimentalResourceApi
+internal val Res.string.str_19387: StringResource
+  get() = String20.str_19387
+
+@ExperimentalResourceApi
+internal val Res.string.str_19388: StringResource
+  get() = String20.str_19388
+
+@ExperimentalResourceApi
+internal val Res.string.str_19389: StringResource
+  get() = String20.str_19389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1939: StringResource
+  get() = String20.str_1939
+
+@ExperimentalResourceApi
+internal val Res.string.str_19390: StringResource
+  get() = String20.str_19390
+
+@ExperimentalResourceApi
+internal val Res.string.str_19391: StringResource
+  get() = String20.str_19391
+
+@ExperimentalResourceApi
+internal val Res.string.str_19392: StringResource
+  get() = String20.str_19392
+
+@ExperimentalResourceApi
+internal val Res.string.str_19393: StringResource
+  get() = String20.str_19393
+
+@ExperimentalResourceApi
+internal val Res.string.str_19394: StringResource
+  get() = String20.str_19394
+
+@ExperimentalResourceApi
+internal val Res.string.str_19395: StringResource
+  get() = String20.str_19395
+
+@ExperimentalResourceApi
+internal val Res.string.str_19396: StringResource
+  get() = String20.str_19396
+
+@ExperimentalResourceApi
+internal val Res.string.str_19397: StringResource
+  get() = String20.str_19397
+
+@ExperimentalResourceApi
+internal val Res.string.str_19398: StringResource
+  get() = String20.str_19398
+
+@ExperimentalResourceApi
+internal val Res.string.str_19399: StringResource
+  get() = String20.str_19399
+
+@ExperimentalResourceApi
+internal val Res.string.str_194: StringResource
+  get() = String20.str_194
+
+@ExperimentalResourceApi
+internal val Res.string.str_1940: StringResource
+  get() = String20.str_1940
+
+@ExperimentalResourceApi
+internal val Res.string.str_19400: StringResource
+  get() = String20.str_19400
+
+@ExperimentalResourceApi
+internal val Res.string.str_19401: StringResource
+  get() = String20.str_19401
+
+@ExperimentalResourceApi
+internal val Res.string.str_19402: StringResource
+  get() = String20.str_19402
+
+@ExperimentalResourceApi
+internal val Res.string.str_19403: StringResource
+  get() = String20.str_19403
+
+@ExperimentalResourceApi
+internal val Res.string.str_19404: StringResource
+  get() = String20.str_19404
+
+@ExperimentalResourceApi
+internal val Res.string.str_19405: StringResource
+  get() = String20.str_19405
+
+@ExperimentalResourceApi
+internal val Res.string.str_19406: StringResource
+  get() = String20.str_19406
+
+@ExperimentalResourceApi
+internal val Res.string.str_19407: StringResource
+  get() = String20.str_19407
+
+@ExperimentalResourceApi
+internal val Res.string.str_19408: StringResource
+  get() = String20.str_19408
+
+@ExperimentalResourceApi
+internal val Res.string.str_19409: StringResource
+  get() = String20.str_19409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1941: StringResource
+  get() = String20.str_1941
+
+@ExperimentalResourceApi
+internal val Res.string.str_19410: StringResource
+  get() = String20.str_19410
+
+@ExperimentalResourceApi
+internal val Res.string.str_19411: StringResource
+  get() = String20.str_19411
+
+@ExperimentalResourceApi
+internal val Res.string.str_19412: StringResource
+  get() = String20.str_19412
+
+@ExperimentalResourceApi
+internal val Res.string.str_19413: StringResource
+  get() = String20.str_19413
+
+@ExperimentalResourceApi
+internal val Res.string.str_19414: StringResource
+  get() = String20.str_19414
+
+@ExperimentalResourceApi
+internal val Res.string.str_19415: StringResource
+  get() = String20.str_19415
+
+@ExperimentalResourceApi
+internal val Res.string.str_19416: StringResource
+  get() = String20.str_19416
+
+@ExperimentalResourceApi
+internal val Res.string.str_19417: StringResource
+  get() = String20.str_19417
+
+@ExperimentalResourceApi
+internal val Res.string.str_19418: StringResource
+  get() = String20.str_19418
+
+@ExperimentalResourceApi
+internal val Res.string.str_19419: StringResource
+  get() = String20.str_19419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1942: StringResource
+  get() = String20.str_1942
+
+@ExperimentalResourceApi
+internal val Res.string.str_19420: StringResource
+  get() = String20.str_19420
+
+@ExperimentalResourceApi
+internal val Res.string.str_19421: StringResource
+  get() = String20.str_19421
+
+@ExperimentalResourceApi
+internal val Res.string.str_19422: StringResource
+  get() = String20.str_19422
+
+@ExperimentalResourceApi
+internal val Res.string.str_19423: StringResource
+  get() = String20.str_19423
+
+@ExperimentalResourceApi
+internal val Res.string.str_19424: StringResource
+  get() = String20.str_19424
+
+@ExperimentalResourceApi
+internal val Res.string.str_19425: StringResource
+  get() = String20.str_19425
+
+@ExperimentalResourceApi
+internal val Res.string.str_19426: StringResource
+  get() = String20.str_19426
+
+@ExperimentalResourceApi
+internal val Res.string.str_19427: StringResource
+  get() = String20.str_19427
+
+@ExperimentalResourceApi
+internal val Res.string.str_19428: StringResource
+  get() = String20.str_19428
+
+@ExperimentalResourceApi
+internal val Res.string.str_19429: StringResource
+  get() = String20.str_19429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1943: StringResource
+  get() = String20.str_1943
+
+@ExperimentalResourceApi
+internal val Res.string.str_19430: StringResource
+  get() = String20.str_19430
+
+@ExperimentalResourceApi
+internal val Res.string.str_19431: StringResource
+  get() = String20.str_19431
+
+@ExperimentalResourceApi
+internal val Res.string.str_19432: StringResource
+  get() = String20.str_19432
+
+@ExperimentalResourceApi
+internal val Res.string.str_19433: StringResource
+  get() = String20.str_19433
+
+@ExperimentalResourceApi
+internal val Res.string.str_19434: StringResource
+  get() = String20.str_19434
+
+@ExperimentalResourceApi
+internal val Res.string.str_19435: StringResource
+  get() = String20.str_19435
+
+@ExperimentalResourceApi
+internal val Res.string.str_19436: StringResource
+  get() = String20.str_19436
+
+@ExperimentalResourceApi
+internal val Res.string.str_19437: StringResource
+  get() = String20.str_19437
+
+@ExperimentalResourceApi
+internal val Res.string.str_19438: StringResource
+  get() = String20.str_19438
+
+@ExperimentalResourceApi
+internal val Res.string.str_19439: StringResource
+  get() = String20.str_19439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1944: StringResource
+  get() = String20.str_1944
+
+@ExperimentalResourceApi
+internal val Res.string.str_19440: StringResource
+  get() = String20.str_19440
+
+@ExperimentalResourceApi
+internal val Res.string.str_19441: StringResource
+  get() = String20.str_19441
+
+@ExperimentalResourceApi
+internal val Res.string.str_19442: StringResource
+  get() = String20.str_19442
+
+@ExperimentalResourceApi
+internal val Res.string.str_19443: StringResource
+  get() = String20.str_19443
+
+@ExperimentalResourceApi
+internal val Res.string.str_19444: StringResource
+  get() = String20.str_19444
+
+@ExperimentalResourceApi
+internal val Res.string.str_19445: StringResource
+  get() = String20.str_19445
+
+@ExperimentalResourceApi
+internal val Res.string.str_19446: StringResource
+  get() = String20.str_19446
+
+@ExperimentalResourceApi
+internal val Res.string.str_19447: StringResource
+  get() = String20.str_19447

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String21.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String21.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String21 {
+  public val str_19448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19448", "str_19448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19449", "str_19449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1945", "str_1945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19450", "str_19450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19451", "str_19451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19452", "str_19452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19453", "str_19453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19454", "str_19454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19455", "str_19455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19456", "str_19456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19457", "str_19457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19458", "str_19458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19459", "str_19459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1946", "str_1946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19460", "str_19460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19461", "str_19461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19462", "str_19462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19463", "str_19463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19464", "str_19464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19465", "str_19465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19466", "str_19466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19467", "str_19467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19468", "str_19468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19469", "str_19469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1947", "str_1947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19470", "str_19470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19471", "str_19471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19472", "str_19472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19473", "str_19473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19474", "str_19474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19475", "str_19475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19476", "str_19476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19477", "str_19477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19478", "str_19478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19479", "str_19479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1948", "str_1948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19480", "str_19480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19481", "str_19481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19482", "str_19482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19483", "str_19483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19484", "str_19484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19485", "str_19485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19486", "str_19486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19487", "str_19487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19488", "str_19488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19489", "str_19489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1949", "str_1949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19490", "str_19490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19491", "str_19491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19492", "str_19492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19493", "str_19493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19494", "str_19494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19495", "str_19495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19496", "str_19496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19497", "str_19497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19498", "str_19498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19499", "str_19499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_195", "str_195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1950", "str_1950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19500", "str_19500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19501", "str_19501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19502", "str_19502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19503", "str_19503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19504", "str_19504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19505", "str_19505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19506", "str_19506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19507", "str_19507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19508", "str_19508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19509", "str_19509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1951", "str_1951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19510", "str_19510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19511", "str_19511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19512", "str_19512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19513", "str_19513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19514", "str_19514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19515", "str_19515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19516", "str_19516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19517", "str_19517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19518", "str_19518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19519", "str_19519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1952", "str_1952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19520", "str_19520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19521", "str_19521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19522", "str_19522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19523", "str_19523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19524", "str_19524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19525", "str_19525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19526", "str_19526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19527", "str_19527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19528", "str_19528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19529", "str_19529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1953", "str_1953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19530", "str_19530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19531", "str_19531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19532", "str_19532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19533", "str_19533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19534", "str_19534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19535", "str_19535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19536", "str_19536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19537", "str_19537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19538", "str_19538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19539", "str_19539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1954", "str_1954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19540", "str_19540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19541", "str_19541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19542", "str_19542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19543", "str_19543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19544", "str_19544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19545", "str_19545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19546", "str_19546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19547", "str_19547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19548", "str_19548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19549", "str_19549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1955", "str_1955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19550", "str_19550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19551", "str_19551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19552", "str_19552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19553", "str_19553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19554", "str_19554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19555", "str_19555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19556", "str_19556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19557", "str_19557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19558", "str_19558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19559", "str_19559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1956", "str_1956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19560", "str_19560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19561", "str_19561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19562", "str_19562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19563", "str_19563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19564", "str_19564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19565", "str_19565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19566", "str_19566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19567", "str_19567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19568", "str_19568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19569", "str_19569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1957", "str_1957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19570", "str_19570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19571", "str_19571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19572", "str_19572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19573", "str_19573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19574", "str_19574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19575", "str_19575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19576", "str_19576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19577", "str_19577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19578", "str_19578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19579", "str_19579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1958", "str_1958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19580", "str_19580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19581", "str_19581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19582", "str_19582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19583", "str_19583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19584", "str_19584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19585", "str_19585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19586", "str_19586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19587", "str_19587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19588", "str_19588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19589", "str_19589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1959", "str_1959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19590", "str_19590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19591", "str_19591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19592", "str_19592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19593", "str_19593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19594", "str_19594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19595", "str_19595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19596", "str_19596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19597", "str_19597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19598", "str_19598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19599", "str_19599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_196", "str_196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1960", "str_1960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19600", "str_19600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19601", "str_19601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19602", "str_19602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19603", "str_19603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19604", "str_19604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19605", "str_19605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19606", "str_19606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19607", "str_19607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19608", "str_19608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19609", "str_19609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1961", "str_1961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19610", "str_19610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19611", "str_19611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19612", "str_19612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19613", "str_19613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19614", "str_19614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19615", "str_19615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19616", "str_19616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19617", "str_19617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19618", "str_19618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19619", "str_19619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1962", "str_1962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19620", "str_19620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19621", "str_19621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19622", "str_19622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19623", "str_19623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19624", "str_19624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19625", "str_19625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19626", "str_19626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19627", "str_19627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19628", "str_19628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19629", "str_19629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1963", "str_1963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19630", "str_19630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19631", "str_19631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19632", "str_19632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19633", "str_19633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19634", "str_19634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19635", "str_19635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19636", "str_19636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19637", "str_19637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19638", "str_19638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19639", "str_19639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1964", "str_1964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19640", "str_19640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19641", "str_19641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19642", "str_19642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19643", "str_19643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19644", "str_19644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19645", "str_19645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19646", "str_19646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19647", "str_19647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19648", "str_19648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19649", "str_19649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1965", "str_1965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19650", "str_19650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19651", "str_19651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19652", "str_19652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19653", "str_19653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19654", "str_19654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19655", "str_19655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19656", "str_19656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19657", "str_19657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19658", "str_19658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19659", "str_19659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1966", "str_1966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19660", "str_19660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19661", "str_19661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19662", "str_19662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19663", "str_19663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19664", "str_19664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19665", "str_19665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19666", "str_19666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19667", "str_19667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19668", "str_19668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19669", "str_19669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1967", "str_1967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19670", "str_19670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19671", "str_19671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19672", "str_19672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19673", "str_19673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19674", "str_19674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19675", "str_19675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19676", "str_19676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19677", "str_19677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19678", "str_19678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19679", "str_19679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1968", "str_1968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19680", "str_19680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19681", "str_19681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19682", "str_19682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19683", "str_19683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19684", "str_19684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19685", "str_19685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19686", "str_19686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19687", "str_19687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19688", "str_19688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19689", "str_19689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1969", "str_1969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19690", "str_19690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19691", "str_19691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19692", "str_19692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19693", "str_19693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19694", "str_19694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19695", "str_19695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19696", "str_19696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19697", "str_19697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19698", "str_19698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19699", "str_19699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_197", "str_197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1970", "str_1970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19700", "str_19700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19701", "str_19701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19702", "str_19702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19703", "str_19703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19704", "str_19704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19705", "str_19705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19706", "str_19706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19707", "str_19707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19708", "str_19708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19709", "str_19709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1971", "str_1971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19710", "str_19710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19711", "str_19711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19712", "str_19712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19713", "str_19713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19714", "str_19714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19715", "str_19715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19716", "str_19716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19717", "str_19717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19718", "str_19718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19719", "str_19719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1972", "str_1972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19720", "str_19720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19721", "str_19721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19722", "str_19722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19723", "str_19723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19724", "str_19724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19725", "str_19725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19726", "str_19726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19727", "str_19727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19728", "str_19728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19729", "str_19729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1973", "str_1973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19730", "str_19730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19731", "str_19731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19732", "str_19732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19733", "str_19733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19734", "str_19734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19735", "str_19735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19736", "str_19736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19737", "str_19737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19738", "str_19738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19739", "str_19739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1974", "str_1974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19740", "str_19740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19741", "str_19741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19742", "str_19742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19743", "str_19743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19744", "str_19744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19745", "str_19745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19746", "str_19746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19747", "str_19747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19748", "str_19748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19749", "str_19749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1975", "str_1975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19750", "str_19750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19751", "str_19751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19752", "str_19752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19753", "str_19753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19754", "str_19754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19755", "str_19755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19756", "str_19756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19757", "str_19757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19758", "str_19758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19759", "str_19759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1976", "str_1976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19760", "str_19760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19761", "str_19761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19762", "str_19762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19763", "str_19763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19764", "str_19764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19765", "str_19765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19766", "str_19766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19767", "str_19767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19768", "str_19768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19769", "str_19769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1977", "str_1977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19770", "str_19770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19771", "str_19771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19772", "str_19772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19773", "str_19773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19774", "str_19774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19775", "str_19775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19776", "str_19776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19777", "str_19777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19778", "str_19778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19779", "str_19779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1978", "str_1978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19780", "str_19780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19781", "str_19781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19782", "str_19782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19783", "str_19783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19784", "str_19784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19785", "str_19785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19786", "str_19786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19787", "str_19787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19788", "str_19788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19789", "str_19789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1979", "str_1979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19790", "str_19790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19791", "str_19791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19792", "str_19792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19793", "str_19793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19794", "str_19794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19795", "str_19795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19796", "str_19796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19797", "str_19797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19798", "str_19798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19799", "str_19799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_198", "str_198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1980", "str_1980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19800", "str_19800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19801", "str_19801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19802", "str_19802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19803", "str_19803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19804", "str_19804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19805", "str_19805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19806", "str_19806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19807", "str_19807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19808", "str_19808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19809", "str_19809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1981", "str_1981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19810", "str_19810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19811", "str_19811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19812", "str_19812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19813", "str_19813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19814", "str_19814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19815", "str_19815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19816", "str_19816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19817", "str_19817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19818", "str_19818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19819", "str_19819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1982", "str_1982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19820", "str_19820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19821", "str_19821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19822", "str_19822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19823", "str_19823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19824", "str_19824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19825", "str_19825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19826", "str_19826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19827", "str_19827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19828", "str_19828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19829", "str_19829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1983", "str_1983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19830", "str_19830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19831", "str_19831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19832", "str_19832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19833", "str_19833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19834", "str_19834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19835", "str_19835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19836", "str_19836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19837", "str_19837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19838", "str_19838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19839", "str_19839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1984", "str_1984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19840", "str_19840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19841", "str_19841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19842", "str_19842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19843", "str_19843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19844", "str_19844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19845", "str_19845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19846", "str_19846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19847", "str_19847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19848", "str_19848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19849", "str_19849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1985", "str_1985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19850", "str_19850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19851", "str_19851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19852", "str_19852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19853", "str_19853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19854", "str_19854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19855", "str_19855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19856", "str_19856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19857", "str_19857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19858", "str_19858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19859", "str_19859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1986", "str_1986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19860", "str_19860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19861", "str_19861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19862", "str_19862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19863", "str_19863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19864", "str_19864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19865", "str_19865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19866", "str_19866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19867", "str_19867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19868", "str_19868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19869", "str_19869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1987", "str_1987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19870", "str_19870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19871", "str_19871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19872", "str_19872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19873", "str_19873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19874", "str_19874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19875", "str_19875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19876", "str_19876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19877", "str_19877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19878", "str_19878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19879", "str_19879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1988", "str_1988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19880", "str_19880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19881", "str_19881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19882", "str_19882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19883", "str_19883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19884", "str_19884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19885", "str_19885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19886", "str_19886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19887", "str_19887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19888", "str_19888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19889", "str_19889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1989", "str_1989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19890", "str_19890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19891", "str_19891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19892", "str_19892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19893", "str_19893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19894", "str_19894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19895", "str_19895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19896", "str_19896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19897", "str_19897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19898", "str_19898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_19448: StringResource
+  get() = String21.str_19448
+
+@ExperimentalResourceApi
+internal val Res.string.str_19449: StringResource
+  get() = String21.str_19449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1945: StringResource
+  get() = String21.str_1945
+
+@ExperimentalResourceApi
+internal val Res.string.str_19450: StringResource
+  get() = String21.str_19450
+
+@ExperimentalResourceApi
+internal val Res.string.str_19451: StringResource
+  get() = String21.str_19451
+
+@ExperimentalResourceApi
+internal val Res.string.str_19452: StringResource
+  get() = String21.str_19452
+
+@ExperimentalResourceApi
+internal val Res.string.str_19453: StringResource
+  get() = String21.str_19453
+
+@ExperimentalResourceApi
+internal val Res.string.str_19454: StringResource
+  get() = String21.str_19454
+
+@ExperimentalResourceApi
+internal val Res.string.str_19455: StringResource
+  get() = String21.str_19455
+
+@ExperimentalResourceApi
+internal val Res.string.str_19456: StringResource
+  get() = String21.str_19456
+
+@ExperimentalResourceApi
+internal val Res.string.str_19457: StringResource
+  get() = String21.str_19457
+
+@ExperimentalResourceApi
+internal val Res.string.str_19458: StringResource
+  get() = String21.str_19458
+
+@ExperimentalResourceApi
+internal val Res.string.str_19459: StringResource
+  get() = String21.str_19459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1946: StringResource
+  get() = String21.str_1946
+
+@ExperimentalResourceApi
+internal val Res.string.str_19460: StringResource
+  get() = String21.str_19460
+
+@ExperimentalResourceApi
+internal val Res.string.str_19461: StringResource
+  get() = String21.str_19461
+
+@ExperimentalResourceApi
+internal val Res.string.str_19462: StringResource
+  get() = String21.str_19462
+
+@ExperimentalResourceApi
+internal val Res.string.str_19463: StringResource
+  get() = String21.str_19463
+
+@ExperimentalResourceApi
+internal val Res.string.str_19464: StringResource
+  get() = String21.str_19464
+
+@ExperimentalResourceApi
+internal val Res.string.str_19465: StringResource
+  get() = String21.str_19465
+
+@ExperimentalResourceApi
+internal val Res.string.str_19466: StringResource
+  get() = String21.str_19466
+
+@ExperimentalResourceApi
+internal val Res.string.str_19467: StringResource
+  get() = String21.str_19467
+
+@ExperimentalResourceApi
+internal val Res.string.str_19468: StringResource
+  get() = String21.str_19468
+
+@ExperimentalResourceApi
+internal val Res.string.str_19469: StringResource
+  get() = String21.str_19469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1947: StringResource
+  get() = String21.str_1947
+
+@ExperimentalResourceApi
+internal val Res.string.str_19470: StringResource
+  get() = String21.str_19470
+
+@ExperimentalResourceApi
+internal val Res.string.str_19471: StringResource
+  get() = String21.str_19471
+
+@ExperimentalResourceApi
+internal val Res.string.str_19472: StringResource
+  get() = String21.str_19472
+
+@ExperimentalResourceApi
+internal val Res.string.str_19473: StringResource
+  get() = String21.str_19473
+
+@ExperimentalResourceApi
+internal val Res.string.str_19474: StringResource
+  get() = String21.str_19474
+
+@ExperimentalResourceApi
+internal val Res.string.str_19475: StringResource
+  get() = String21.str_19475
+
+@ExperimentalResourceApi
+internal val Res.string.str_19476: StringResource
+  get() = String21.str_19476
+
+@ExperimentalResourceApi
+internal val Res.string.str_19477: StringResource
+  get() = String21.str_19477
+
+@ExperimentalResourceApi
+internal val Res.string.str_19478: StringResource
+  get() = String21.str_19478
+
+@ExperimentalResourceApi
+internal val Res.string.str_19479: StringResource
+  get() = String21.str_19479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1948: StringResource
+  get() = String21.str_1948
+
+@ExperimentalResourceApi
+internal val Res.string.str_19480: StringResource
+  get() = String21.str_19480
+
+@ExperimentalResourceApi
+internal val Res.string.str_19481: StringResource
+  get() = String21.str_19481
+
+@ExperimentalResourceApi
+internal val Res.string.str_19482: StringResource
+  get() = String21.str_19482
+
+@ExperimentalResourceApi
+internal val Res.string.str_19483: StringResource
+  get() = String21.str_19483
+
+@ExperimentalResourceApi
+internal val Res.string.str_19484: StringResource
+  get() = String21.str_19484
+
+@ExperimentalResourceApi
+internal val Res.string.str_19485: StringResource
+  get() = String21.str_19485
+
+@ExperimentalResourceApi
+internal val Res.string.str_19486: StringResource
+  get() = String21.str_19486
+
+@ExperimentalResourceApi
+internal val Res.string.str_19487: StringResource
+  get() = String21.str_19487
+
+@ExperimentalResourceApi
+internal val Res.string.str_19488: StringResource
+  get() = String21.str_19488
+
+@ExperimentalResourceApi
+internal val Res.string.str_19489: StringResource
+  get() = String21.str_19489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1949: StringResource
+  get() = String21.str_1949
+
+@ExperimentalResourceApi
+internal val Res.string.str_19490: StringResource
+  get() = String21.str_19490
+
+@ExperimentalResourceApi
+internal val Res.string.str_19491: StringResource
+  get() = String21.str_19491
+
+@ExperimentalResourceApi
+internal val Res.string.str_19492: StringResource
+  get() = String21.str_19492
+
+@ExperimentalResourceApi
+internal val Res.string.str_19493: StringResource
+  get() = String21.str_19493
+
+@ExperimentalResourceApi
+internal val Res.string.str_19494: StringResource
+  get() = String21.str_19494
+
+@ExperimentalResourceApi
+internal val Res.string.str_19495: StringResource
+  get() = String21.str_19495
+
+@ExperimentalResourceApi
+internal val Res.string.str_19496: StringResource
+  get() = String21.str_19496
+
+@ExperimentalResourceApi
+internal val Res.string.str_19497: StringResource
+  get() = String21.str_19497
+
+@ExperimentalResourceApi
+internal val Res.string.str_19498: StringResource
+  get() = String21.str_19498
+
+@ExperimentalResourceApi
+internal val Res.string.str_19499: StringResource
+  get() = String21.str_19499
+
+@ExperimentalResourceApi
+internal val Res.string.str_195: StringResource
+  get() = String21.str_195
+
+@ExperimentalResourceApi
+internal val Res.string.str_1950: StringResource
+  get() = String21.str_1950
+
+@ExperimentalResourceApi
+internal val Res.string.str_19500: StringResource
+  get() = String21.str_19500
+
+@ExperimentalResourceApi
+internal val Res.string.str_19501: StringResource
+  get() = String21.str_19501
+
+@ExperimentalResourceApi
+internal val Res.string.str_19502: StringResource
+  get() = String21.str_19502
+
+@ExperimentalResourceApi
+internal val Res.string.str_19503: StringResource
+  get() = String21.str_19503
+
+@ExperimentalResourceApi
+internal val Res.string.str_19504: StringResource
+  get() = String21.str_19504
+
+@ExperimentalResourceApi
+internal val Res.string.str_19505: StringResource
+  get() = String21.str_19505
+
+@ExperimentalResourceApi
+internal val Res.string.str_19506: StringResource
+  get() = String21.str_19506
+
+@ExperimentalResourceApi
+internal val Res.string.str_19507: StringResource
+  get() = String21.str_19507
+
+@ExperimentalResourceApi
+internal val Res.string.str_19508: StringResource
+  get() = String21.str_19508
+
+@ExperimentalResourceApi
+internal val Res.string.str_19509: StringResource
+  get() = String21.str_19509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1951: StringResource
+  get() = String21.str_1951
+
+@ExperimentalResourceApi
+internal val Res.string.str_19510: StringResource
+  get() = String21.str_19510
+
+@ExperimentalResourceApi
+internal val Res.string.str_19511: StringResource
+  get() = String21.str_19511
+
+@ExperimentalResourceApi
+internal val Res.string.str_19512: StringResource
+  get() = String21.str_19512
+
+@ExperimentalResourceApi
+internal val Res.string.str_19513: StringResource
+  get() = String21.str_19513
+
+@ExperimentalResourceApi
+internal val Res.string.str_19514: StringResource
+  get() = String21.str_19514
+
+@ExperimentalResourceApi
+internal val Res.string.str_19515: StringResource
+  get() = String21.str_19515
+
+@ExperimentalResourceApi
+internal val Res.string.str_19516: StringResource
+  get() = String21.str_19516
+
+@ExperimentalResourceApi
+internal val Res.string.str_19517: StringResource
+  get() = String21.str_19517
+
+@ExperimentalResourceApi
+internal val Res.string.str_19518: StringResource
+  get() = String21.str_19518
+
+@ExperimentalResourceApi
+internal val Res.string.str_19519: StringResource
+  get() = String21.str_19519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1952: StringResource
+  get() = String21.str_1952
+
+@ExperimentalResourceApi
+internal val Res.string.str_19520: StringResource
+  get() = String21.str_19520
+
+@ExperimentalResourceApi
+internal val Res.string.str_19521: StringResource
+  get() = String21.str_19521
+
+@ExperimentalResourceApi
+internal val Res.string.str_19522: StringResource
+  get() = String21.str_19522
+
+@ExperimentalResourceApi
+internal val Res.string.str_19523: StringResource
+  get() = String21.str_19523
+
+@ExperimentalResourceApi
+internal val Res.string.str_19524: StringResource
+  get() = String21.str_19524
+
+@ExperimentalResourceApi
+internal val Res.string.str_19525: StringResource
+  get() = String21.str_19525
+
+@ExperimentalResourceApi
+internal val Res.string.str_19526: StringResource
+  get() = String21.str_19526
+
+@ExperimentalResourceApi
+internal val Res.string.str_19527: StringResource
+  get() = String21.str_19527
+
+@ExperimentalResourceApi
+internal val Res.string.str_19528: StringResource
+  get() = String21.str_19528
+
+@ExperimentalResourceApi
+internal val Res.string.str_19529: StringResource
+  get() = String21.str_19529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1953: StringResource
+  get() = String21.str_1953
+
+@ExperimentalResourceApi
+internal val Res.string.str_19530: StringResource
+  get() = String21.str_19530
+
+@ExperimentalResourceApi
+internal val Res.string.str_19531: StringResource
+  get() = String21.str_19531
+
+@ExperimentalResourceApi
+internal val Res.string.str_19532: StringResource
+  get() = String21.str_19532
+
+@ExperimentalResourceApi
+internal val Res.string.str_19533: StringResource
+  get() = String21.str_19533
+
+@ExperimentalResourceApi
+internal val Res.string.str_19534: StringResource
+  get() = String21.str_19534
+
+@ExperimentalResourceApi
+internal val Res.string.str_19535: StringResource
+  get() = String21.str_19535
+
+@ExperimentalResourceApi
+internal val Res.string.str_19536: StringResource
+  get() = String21.str_19536
+
+@ExperimentalResourceApi
+internal val Res.string.str_19537: StringResource
+  get() = String21.str_19537
+
+@ExperimentalResourceApi
+internal val Res.string.str_19538: StringResource
+  get() = String21.str_19538
+
+@ExperimentalResourceApi
+internal val Res.string.str_19539: StringResource
+  get() = String21.str_19539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1954: StringResource
+  get() = String21.str_1954
+
+@ExperimentalResourceApi
+internal val Res.string.str_19540: StringResource
+  get() = String21.str_19540
+
+@ExperimentalResourceApi
+internal val Res.string.str_19541: StringResource
+  get() = String21.str_19541
+
+@ExperimentalResourceApi
+internal val Res.string.str_19542: StringResource
+  get() = String21.str_19542
+
+@ExperimentalResourceApi
+internal val Res.string.str_19543: StringResource
+  get() = String21.str_19543
+
+@ExperimentalResourceApi
+internal val Res.string.str_19544: StringResource
+  get() = String21.str_19544
+
+@ExperimentalResourceApi
+internal val Res.string.str_19545: StringResource
+  get() = String21.str_19545
+
+@ExperimentalResourceApi
+internal val Res.string.str_19546: StringResource
+  get() = String21.str_19546
+
+@ExperimentalResourceApi
+internal val Res.string.str_19547: StringResource
+  get() = String21.str_19547
+
+@ExperimentalResourceApi
+internal val Res.string.str_19548: StringResource
+  get() = String21.str_19548
+
+@ExperimentalResourceApi
+internal val Res.string.str_19549: StringResource
+  get() = String21.str_19549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1955: StringResource
+  get() = String21.str_1955
+
+@ExperimentalResourceApi
+internal val Res.string.str_19550: StringResource
+  get() = String21.str_19550
+
+@ExperimentalResourceApi
+internal val Res.string.str_19551: StringResource
+  get() = String21.str_19551
+
+@ExperimentalResourceApi
+internal val Res.string.str_19552: StringResource
+  get() = String21.str_19552
+
+@ExperimentalResourceApi
+internal val Res.string.str_19553: StringResource
+  get() = String21.str_19553
+
+@ExperimentalResourceApi
+internal val Res.string.str_19554: StringResource
+  get() = String21.str_19554
+
+@ExperimentalResourceApi
+internal val Res.string.str_19555: StringResource
+  get() = String21.str_19555
+
+@ExperimentalResourceApi
+internal val Res.string.str_19556: StringResource
+  get() = String21.str_19556
+
+@ExperimentalResourceApi
+internal val Res.string.str_19557: StringResource
+  get() = String21.str_19557
+
+@ExperimentalResourceApi
+internal val Res.string.str_19558: StringResource
+  get() = String21.str_19558
+
+@ExperimentalResourceApi
+internal val Res.string.str_19559: StringResource
+  get() = String21.str_19559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1956: StringResource
+  get() = String21.str_1956
+
+@ExperimentalResourceApi
+internal val Res.string.str_19560: StringResource
+  get() = String21.str_19560
+
+@ExperimentalResourceApi
+internal val Res.string.str_19561: StringResource
+  get() = String21.str_19561
+
+@ExperimentalResourceApi
+internal val Res.string.str_19562: StringResource
+  get() = String21.str_19562
+
+@ExperimentalResourceApi
+internal val Res.string.str_19563: StringResource
+  get() = String21.str_19563
+
+@ExperimentalResourceApi
+internal val Res.string.str_19564: StringResource
+  get() = String21.str_19564
+
+@ExperimentalResourceApi
+internal val Res.string.str_19565: StringResource
+  get() = String21.str_19565
+
+@ExperimentalResourceApi
+internal val Res.string.str_19566: StringResource
+  get() = String21.str_19566
+
+@ExperimentalResourceApi
+internal val Res.string.str_19567: StringResource
+  get() = String21.str_19567
+
+@ExperimentalResourceApi
+internal val Res.string.str_19568: StringResource
+  get() = String21.str_19568
+
+@ExperimentalResourceApi
+internal val Res.string.str_19569: StringResource
+  get() = String21.str_19569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1957: StringResource
+  get() = String21.str_1957
+
+@ExperimentalResourceApi
+internal val Res.string.str_19570: StringResource
+  get() = String21.str_19570
+
+@ExperimentalResourceApi
+internal val Res.string.str_19571: StringResource
+  get() = String21.str_19571
+
+@ExperimentalResourceApi
+internal val Res.string.str_19572: StringResource
+  get() = String21.str_19572
+
+@ExperimentalResourceApi
+internal val Res.string.str_19573: StringResource
+  get() = String21.str_19573
+
+@ExperimentalResourceApi
+internal val Res.string.str_19574: StringResource
+  get() = String21.str_19574
+
+@ExperimentalResourceApi
+internal val Res.string.str_19575: StringResource
+  get() = String21.str_19575
+
+@ExperimentalResourceApi
+internal val Res.string.str_19576: StringResource
+  get() = String21.str_19576
+
+@ExperimentalResourceApi
+internal val Res.string.str_19577: StringResource
+  get() = String21.str_19577
+
+@ExperimentalResourceApi
+internal val Res.string.str_19578: StringResource
+  get() = String21.str_19578
+
+@ExperimentalResourceApi
+internal val Res.string.str_19579: StringResource
+  get() = String21.str_19579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1958: StringResource
+  get() = String21.str_1958
+
+@ExperimentalResourceApi
+internal val Res.string.str_19580: StringResource
+  get() = String21.str_19580
+
+@ExperimentalResourceApi
+internal val Res.string.str_19581: StringResource
+  get() = String21.str_19581
+
+@ExperimentalResourceApi
+internal val Res.string.str_19582: StringResource
+  get() = String21.str_19582
+
+@ExperimentalResourceApi
+internal val Res.string.str_19583: StringResource
+  get() = String21.str_19583
+
+@ExperimentalResourceApi
+internal val Res.string.str_19584: StringResource
+  get() = String21.str_19584
+
+@ExperimentalResourceApi
+internal val Res.string.str_19585: StringResource
+  get() = String21.str_19585
+
+@ExperimentalResourceApi
+internal val Res.string.str_19586: StringResource
+  get() = String21.str_19586
+
+@ExperimentalResourceApi
+internal val Res.string.str_19587: StringResource
+  get() = String21.str_19587
+
+@ExperimentalResourceApi
+internal val Res.string.str_19588: StringResource
+  get() = String21.str_19588
+
+@ExperimentalResourceApi
+internal val Res.string.str_19589: StringResource
+  get() = String21.str_19589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1959: StringResource
+  get() = String21.str_1959
+
+@ExperimentalResourceApi
+internal val Res.string.str_19590: StringResource
+  get() = String21.str_19590
+
+@ExperimentalResourceApi
+internal val Res.string.str_19591: StringResource
+  get() = String21.str_19591
+
+@ExperimentalResourceApi
+internal val Res.string.str_19592: StringResource
+  get() = String21.str_19592
+
+@ExperimentalResourceApi
+internal val Res.string.str_19593: StringResource
+  get() = String21.str_19593
+
+@ExperimentalResourceApi
+internal val Res.string.str_19594: StringResource
+  get() = String21.str_19594
+
+@ExperimentalResourceApi
+internal val Res.string.str_19595: StringResource
+  get() = String21.str_19595
+
+@ExperimentalResourceApi
+internal val Res.string.str_19596: StringResource
+  get() = String21.str_19596
+
+@ExperimentalResourceApi
+internal val Res.string.str_19597: StringResource
+  get() = String21.str_19597
+
+@ExperimentalResourceApi
+internal val Res.string.str_19598: StringResource
+  get() = String21.str_19598
+
+@ExperimentalResourceApi
+internal val Res.string.str_19599: StringResource
+  get() = String21.str_19599
+
+@ExperimentalResourceApi
+internal val Res.string.str_196: StringResource
+  get() = String21.str_196
+
+@ExperimentalResourceApi
+internal val Res.string.str_1960: StringResource
+  get() = String21.str_1960
+
+@ExperimentalResourceApi
+internal val Res.string.str_19600: StringResource
+  get() = String21.str_19600
+
+@ExperimentalResourceApi
+internal val Res.string.str_19601: StringResource
+  get() = String21.str_19601
+
+@ExperimentalResourceApi
+internal val Res.string.str_19602: StringResource
+  get() = String21.str_19602
+
+@ExperimentalResourceApi
+internal val Res.string.str_19603: StringResource
+  get() = String21.str_19603
+
+@ExperimentalResourceApi
+internal val Res.string.str_19604: StringResource
+  get() = String21.str_19604
+
+@ExperimentalResourceApi
+internal val Res.string.str_19605: StringResource
+  get() = String21.str_19605
+
+@ExperimentalResourceApi
+internal val Res.string.str_19606: StringResource
+  get() = String21.str_19606
+
+@ExperimentalResourceApi
+internal val Res.string.str_19607: StringResource
+  get() = String21.str_19607
+
+@ExperimentalResourceApi
+internal val Res.string.str_19608: StringResource
+  get() = String21.str_19608
+
+@ExperimentalResourceApi
+internal val Res.string.str_19609: StringResource
+  get() = String21.str_19609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1961: StringResource
+  get() = String21.str_1961
+
+@ExperimentalResourceApi
+internal val Res.string.str_19610: StringResource
+  get() = String21.str_19610
+
+@ExperimentalResourceApi
+internal val Res.string.str_19611: StringResource
+  get() = String21.str_19611
+
+@ExperimentalResourceApi
+internal val Res.string.str_19612: StringResource
+  get() = String21.str_19612
+
+@ExperimentalResourceApi
+internal val Res.string.str_19613: StringResource
+  get() = String21.str_19613
+
+@ExperimentalResourceApi
+internal val Res.string.str_19614: StringResource
+  get() = String21.str_19614
+
+@ExperimentalResourceApi
+internal val Res.string.str_19615: StringResource
+  get() = String21.str_19615
+
+@ExperimentalResourceApi
+internal val Res.string.str_19616: StringResource
+  get() = String21.str_19616
+
+@ExperimentalResourceApi
+internal val Res.string.str_19617: StringResource
+  get() = String21.str_19617
+
+@ExperimentalResourceApi
+internal val Res.string.str_19618: StringResource
+  get() = String21.str_19618
+
+@ExperimentalResourceApi
+internal val Res.string.str_19619: StringResource
+  get() = String21.str_19619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1962: StringResource
+  get() = String21.str_1962
+
+@ExperimentalResourceApi
+internal val Res.string.str_19620: StringResource
+  get() = String21.str_19620
+
+@ExperimentalResourceApi
+internal val Res.string.str_19621: StringResource
+  get() = String21.str_19621
+
+@ExperimentalResourceApi
+internal val Res.string.str_19622: StringResource
+  get() = String21.str_19622
+
+@ExperimentalResourceApi
+internal val Res.string.str_19623: StringResource
+  get() = String21.str_19623
+
+@ExperimentalResourceApi
+internal val Res.string.str_19624: StringResource
+  get() = String21.str_19624
+
+@ExperimentalResourceApi
+internal val Res.string.str_19625: StringResource
+  get() = String21.str_19625
+
+@ExperimentalResourceApi
+internal val Res.string.str_19626: StringResource
+  get() = String21.str_19626
+
+@ExperimentalResourceApi
+internal val Res.string.str_19627: StringResource
+  get() = String21.str_19627
+
+@ExperimentalResourceApi
+internal val Res.string.str_19628: StringResource
+  get() = String21.str_19628
+
+@ExperimentalResourceApi
+internal val Res.string.str_19629: StringResource
+  get() = String21.str_19629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1963: StringResource
+  get() = String21.str_1963
+
+@ExperimentalResourceApi
+internal val Res.string.str_19630: StringResource
+  get() = String21.str_19630
+
+@ExperimentalResourceApi
+internal val Res.string.str_19631: StringResource
+  get() = String21.str_19631
+
+@ExperimentalResourceApi
+internal val Res.string.str_19632: StringResource
+  get() = String21.str_19632
+
+@ExperimentalResourceApi
+internal val Res.string.str_19633: StringResource
+  get() = String21.str_19633
+
+@ExperimentalResourceApi
+internal val Res.string.str_19634: StringResource
+  get() = String21.str_19634
+
+@ExperimentalResourceApi
+internal val Res.string.str_19635: StringResource
+  get() = String21.str_19635
+
+@ExperimentalResourceApi
+internal val Res.string.str_19636: StringResource
+  get() = String21.str_19636
+
+@ExperimentalResourceApi
+internal val Res.string.str_19637: StringResource
+  get() = String21.str_19637
+
+@ExperimentalResourceApi
+internal val Res.string.str_19638: StringResource
+  get() = String21.str_19638
+
+@ExperimentalResourceApi
+internal val Res.string.str_19639: StringResource
+  get() = String21.str_19639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1964: StringResource
+  get() = String21.str_1964
+
+@ExperimentalResourceApi
+internal val Res.string.str_19640: StringResource
+  get() = String21.str_19640
+
+@ExperimentalResourceApi
+internal val Res.string.str_19641: StringResource
+  get() = String21.str_19641
+
+@ExperimentalResourceApi
+internal val Res.string.str_19642: StringResource
+  get() = String21.str_19642
+
+@ExperimentalResourceApi
+internal val Res.string.str_19643: StringResource
+  get() = String21.str_19643
+
+@ExperimentalResourceApi
+internal val Res.string.str_19644: StringResource
+  get() = String21.str_19644
+
+@ExperimentalResourceApi
+internal val Res.string.str_19645: StringResource
+  get() = String21.str_19645
+
+@ExperimentalResourceApi
+internal val Res.string.str_19646: StringResource
+  get() = String21.str_19646
+
+@ExperimentalResourceApi
+internal val Res.string.str_19647: StringResource
+  get() = String21.str_19647
+
+@ExperimentalResourceApi
+internal val Res.string.str_19648: StringResource
+  get() = String21.str_19648
+
+@ExperimentalResourceApi
+internal val Res.string.str_19649: StringResource
+  get() = String21.str_19649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1965: StringResource
+  get() = String21.str_1965
+
+@ExperimentalResourceApi
+internal val Res.string.str_19650: StringResource
+  get() = String21.str_19650
+
+@ExperimentalResourceApi
+internal val Res.string.str_19651: StringResource
+  get() = String21.str_19651
+
+@ExperimentalResourceApi
+internal val Res.string.str_19652: StringResource
+  get() = String21.str_19652
+
+@ExperimentalResourceApi
+internal val Res.string.str_19653: StringResource
+  get() = String21.str_19653
+
+@ExperimentalResourceApi
+internal val Res.string.str_19654: StringResource
+  get() = String21.str_19654
+
+@ExperimentalResourceApi
+internal val Res.string.str_19655: StringResource
+  get() = String21.str_19655
+
+@ExperimentalResourceApi
+internal val Res.string.str_19656: StringResource
+  get() = String21.str_19656
+
+@ExperimentalResourceApi
+internal val Res.string.str_19657: StringResource
+  get() = String21.str_19657
+
+@ExperimentalResourceApi
+internal val Res.string.str_19658: StringResource
+  get() = String21.str_19658
+
+@ExperimentalResourceApi
+internal val Res.string.str_19659: StringResource
+  get() = String21.str_19659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1966: StringResource
+  get() = String21.str_1966
+
+@ExperimentalResourceApi
+internal val Res.string.str_19660: StringResource
+  get() = String21.str_19660
+
+@ExperimentalResourceApi
+internal val Res.string.str_19661: StringResource
+  get() = String21.str_19661
+
+@ExperimentalResourceApi
+internal val Res.string.str_19662: StringResource
+  get() = String21.str_19662
+
+@ExperimentalResourceApi
+internal val Res.string.str_19663: StringResource
+  get() = String21.str_19663
+
+@ExperimentalResourceApi
+internal val Res.string.str_19664: StringResource
+  get() = String21.str_19664
+
+@ExperimentalResourceApi
+internal val Res.string.str_19665: StringResource
+  get() = String21.str_19665
+
+@ExperimentalResourceApi
+internal val Res.string.str_19666: StringResource
+  get() = String21.str_19666
+
+@ExperimentalResourceApi
+internal val Res.string.str_19667: StringResource
+  get() = String21.str_19667
+
+@ExperimentalResourceApi
+internal val Res.string.str_19668: StringResource
+  get() = String21.str_19668
+
+@ExperimentalResourceApi
+internal val Res.string.str_19669: StringResource
+  get() = String21.str_19669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1967: StringResource
+  get() = String21.str_1967
+
+@ExperimentalResourceApi
+internal val Res.string.str_19670: StringResource
+  get() = String21.str_19670
+
+@ExperimentalResourceApi
+internal val Res.string.str_19671: StringResource
+  get() = String21.str_19671
+
+@ExperimentalResourceApi
+internal val Res.string.str_19672: StringResource
+  get() = String21.str_19672
+
+@ExperimentalResourceApi
+internal val Res.string.str_19673: StringResource
+  get() = String21.str_19673
+
+@ExperimentalResourceApi
+internal val Res.string.str_19674: StringResource
+  get() = String21.str_19674
+
+@ExperimentalResourceApi
+internal val Res.string.str_19675: StringResource
+  get() = String21.str_19675
+
+@ExperimentalResourceApi
+internal val Res.string.str_19676: StringResource
+  get() = String21.str_19676
+
+@ExperimentalResourceApi
+internal val Res.string.str_19677: StringResource
+  get() = String21.str_19677
+
+@ExperimentalResourceApi
+internal val Res.string.str_19678: StringResource
+  get() = String21.str_19678
+
+@ExperimentalResourceApi
+internal val Res.string.str_19679: StringResource
+  get() = String21.str_19679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1968: StringResource
+  get() = String21.str_1968
+
+@ExperimentalResourceApi
+internal val Res.string.str_19680: StringResource
+  get() = String21.str_19680
+
+@ExperimentalResourceApi
+internal val Res.string.str_19681: StringResource
+  get() = String21.str_19681
+
+@ExperimentalResourceApi
+internal val Res.string.str_19682: StringResource
+  get() = String21.str_19682
+
+@ExperimentalResourceApi
+internal val Res.string.str_19683: StringResource
+  get() = String21.str_19683
+
+@ExperimentalResourceApi
+internal val Res.string.str_19684: StringResource
+  get() = String21.str_19684
+
+@ExperimentalResourceApi
+internal val Res.string.str_19685: StringResource
+  get() = String21.str_19685
+
+@ExperimentalResourceApi
+internal val Res.string.str_19686: StringResource
+  get() = String21.str_19686
+
+@ExperimentalResourceApi
+internal val Res.string.str_19687: StringResource
+  get() = String21.str_19687
+
+@ExperimentalResourceApi
+internal val Res.string.str_19688: StringResource
+  get() = String21.str_19688
+
+@ExperimentalResourceApi
+internal val Res.string.str_19689: StringResource
+  get() = String21.str_19689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1969: StringResource
+  get() = String21.str_1969
+
+@ExperimentalResourceApi
+internal val Res.string.str_19690: StringResource
+  get() = String21.str_19690
+
+@ExperimentalResourceApi
+internal val Res.string.str_19691: StringResource
+  get() = String21.str_19691
+
+@ExperimentalResourceApi
+internal val Res.string.str_19692: StringResource
+  get() = String21.str_19692
+
+@ExperimentalResourceApi
+internal val Res.string.str_19693: StringResource
+  get() = String21.str_19693
+
+@ExperimentalResourceApi
+internal val Res.string.str_19694: StringResource
+  get() = String21.str_19694
+
+@ExperimentalResourceApi
+internal val Res.string.str_19695: StringResource
+  get() = String21.str_19695
+
+@ExperimentalResourceApi
+internal val Res.string.str_19696: StringResource
+  get() = String21.str_19696
+
+@ExperimentalResourceApi
+internal val Res.string.str_19697: StringResource
+  get() = String21.str_19697
+
+@ExperimentalResourceApi
+internal val Res.string.str_19698: StringResource
+  get() = String21.str_19698
+
+@ExperimentalResourceApi
+internal val Res.string.str_19699: StringResource
+  get() = String21.str_19699
+
+@ExperimentalResourceApi
+internal val Res.string.str_197: StringResource
+  get() = String21.str_197
+
+@ExperimentalResourceApi
+internal val Res.string.str_1970: StringResource
+  get() = String21.str_1970
+
+@ExperimentalResourceApi
+internal val Res.string.str_19700: StringResource
+  get() = String21.str_19700
+
+@ExperimentalResourceApi
+internal val Res.string.str_19701: StringResource
+  get() = String21.str_19701
+
+@ExperimentalResourceApi
+internal val Res.string.str_19702: StringResource
+  get() = String21.str_19702
+
+@ExperimentalResourceApi
+internal val Res.string.str_19703: StringResource
+  get() = String21.str_19703
+
+@ExperimentalResourceApi
+internal val Res.string.str_19704: StringResource
+  get() = String21.str_19704
+
+@ExperimentalResourceApi
+internal val Res.string.str_19705: StringResource
+  get() = String21.str_19705
+
+@ExperimentalResourceApi
+internal val Res.string.str_19706: StringResource
+  get() = String21.str_19706
+
+@ExperimentalResourceApi
+internal val Res.string.str_19707: StringResource
+  get() = String21.str_19707
+
+@ExperimentalResourceApi
+internal val Res.string.str_19708: StringResource
+  get() = String21.str_19708
+
+@ExperimentalResourceApi
+internal val Res.string.str_19709: StringResource
+  get() = String21.str_19709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1971: StringResource
+  get() = String21.str_1971
+
+@ExperimentalResourceApi
+internal val Res.string.str_19710: StringResource
+  get() = String21.str_19710
+
+@ExperimentalResourceApi
+internal val Res.string.str_19711: StringResource
+  get() = String21.str_19711
+
+@ExperimentalResourceApi
+internal val Res.string.str_19712: StringResource
+  get() = String21.str_19712
+
+@ExperimentalResourceApi
+internal val Res.string.str_19713: StringResource
+  get() = String21.str_19713
+
+@ExperimentalResourceApi
+internal val Res.string.str_19714: StringResource
+  get() = String21.str_19714
+
+@ExperimentalResourceApi
+internal val Res.string.str_19715: StringResource
+  get() = String21.str_19715
+
+@ExperimentalResourceApi
+internal val Res.string.str_19716: StringResource
+  get() = String21.str_19716
+
+@ExperimentalResourceApi
+internal val Res.string.str_19717: StringResource
+  get() = String21.str_19717
+
+@ExperimentalResourceApi
+internal val Res.string.str_19718: StringResource
+  get() = String21.str_19718
+
+@ExperimentalResourceApi
+internal val Res.string.str_19719: StringResource
+  get() = String21.str_19719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1972: StringResource
+  get() = String21.str_1972
+
+@ExperimentalResourceApi
+internal val Res.string.str_19720: StringResource
+  get() = String21.str_19720
+
+@ExperimentalResourceApi
+internal val Res.string.str_19721: StringResource
+  get() = String21.str_19721
+
+@ExperimentalResourceApi
+internal val Res.string.str_19722: StringResource
+  get() = String21.str_19722
+
+@ExperimentalResourceApi
+internal val Res.string.str_19723: StringResource
+  get() = String21.str_19723
+
+@ExperimentalResourceApi
+internal val Res.string.str_19724: StringResource
+  get() = String21.str_19724
+
+@ExperimentalResourceApi
+internal val Res.string.str_19725: StringResource
+  get() = String21.str_19725
+
+@ExperimentalResourceApi
+internal val Res.string.str_19726: StringResource
+  get() = String21.str_19726
+
+@ExperimentalResourceApi
+internal val Res.string.str_19727: StringResource
+  get() = String21.str_19727
+
+@ExperimentalResourceApi
+internal val Res.string.str_19728: StringResource
+  get() = String21.str_19728
+
+@ExperimentalResourceApi
+internal val Res.string.str_19729: StringResource
+  get() = String21.str_19729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1973: StringResource
+  get() = String21.str_1973
+
+@ExperimentalResourceApi
+internal val Res.string.str_19730: StringResource
+  get() = String21.str_19730
+
+@ExperimentalResourceApi
+internal val Res.string.str_19731: StringResource
+  get() = String21.str_19731
+
+@ExperimentalResourceApi
+internal val Res.string.str_19732: StringResource
+  get() = String21.str_19732
+
+@ExperimentalResourceApi
+internal val Res.string.str_19733: StringResource
+  get() = String21.str_19733
+
+@ExperimentalResourceApi
+internal val Res.string.str_19734: StringResource
+  get() = String21.str_19734
+
+@ExperimentalResourceApi
+internal val Res.string.str_19735: StringResource
+  get() = String21.str_19735
+
+@ExperimentalResourceApi
+internal val Res.string.str_19736: StringResource
+  get() = String21.str_19736
+
+@ExperimentalResourceApi
+internal val Res.string.str_19737: StringResource
+  get() = String21.str_19737
+
+@ExperimentalResourceApi
+internal val Res.string.str_19738: StringResource
+  get() = String21.str_19738
+
+@ExperimentalResourceApi
+internal val Res.string.str_19739: StringResource
+  get() = String21.str_19739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1974: StringResource
+  get() = String21.str_1974
+
+@ExperimentalResourceApi
+internal val Res.string.str_19740: StringResource
+  get() = String21.str_19740
+
+@ExperimentalResourceApi
+internal val Res.string.str_19741: StringResource
+  get() = String21.str_19741
+
+@ExperimentalResourceApi
+internal val Res.string.str_19742: StringResource
+  get() = String21.str_19742
+
+@ExperimentalResourceApi
+internal val Res.string.str_19743: StringResource
+  get() = String21.str_19743
+
+@ExperimentalResourceApi
+internal val Res.string.str_19744: StringResource
+  get() = String21.str_19744
+
+@ExperimentalResourceApi
+internal val Res.string.str_19745: StringResource
+  get() = String21.str_19745
+
+@ExperimentalResourceApi
+internal val Res.string.str_19746: StringResource
+  get() = String21.str_19746
+
+@ExperimentalResourceApi
+internal val Res.string.str_19747: StringResource
+  get() = String21.str_19747
+
+@ExperimentalResourceApi
+internal val Res.string.str_19748: StringResource
+  get() = String21.str_19748
+
+@ExperimentalResourceApi
+internal val Res.string.str_19749: StringResource
+  get() = String21.str_19749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1975: StringResource
+  get() = String21.str_1975
+
+@ExperimentalResourceApi
+internal val Res.string.str_19750: StringResource
+  get() = String21.str_19750
+
+@ExperimentalResourceApi
+internal val Res.string.str_19751: StringResource
+  get() = String21.str_19751
+
+@ExperimentalResourceApi
+internal val Res.string.str_19752: StringResource
+  get() = String21.str_19752
+
+@ExperimentalResourceApi
+internal val Res.string.str_19753: StringResource
+  get() = String21.str_19753
+
+@ExperimentalResourceApi
+internal val Res.string.str_19754: StringResource
+  get() = String21.str_19754
+
+@ExperimentalResourceApi
+internal val Res.string.str_19755: StringResource
+  get() = String21.str_19755
+
+@ExperimentalResourceApi
+internal val Res.string.str_19756: StringResource
+  get() = String21.str_19756
+
+@ExperimentalResourceApi
+internal val Res.string.str_19757: StringResource
+  get() = String21.str_19757
+
+@ExperimentalResourceApi
+internal val Res.string.str_19758: StringResource
+  get() = String21.str_19758
+
+@ExperimentalResourceApi
+internal val Res.string.str_19759: StringResource
+  get() = String21.str_19759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1976: StringResource
+  get() = String21.str_1976
+
+@ExperimentalResourceApi
+internal val Res.string.str_19760: StringResource
+  get() = String21.str_19760
+
+@ExperimentalResourceApi
+internal val Res.string.str_19761: StringResource
+  get() = String21.str_19761
+
+@ExperimentalResourceApi
+internal val Res.string.str_19762: StringResource
+  get() = String21.str_19762
+
+@ExperimentalResourceApi
+internal val Res.string.str_19763: StringResource
+  get() = String21.str_19763
+
+@ExperimentalResourceApi
+internal val Res.string.str_19764: StringResource
+  get() = String21.str_19764
+
+@ExperimentalResourceApi
+internal val Res.string.str_19765: StringResource
+  get() = String21.str_19765
+
+@ExperimentalResourceApi
+internal val Res.string.str_19766: StringResource
+  get() = String21.str_19766
+
+@ExperimentalResourceApi
+internal val Res.string.str_19767: StringResource
+  get() = String21.str_19767
+
+@ExperimentalResourceApi
+internal val Res.string.str_19768: StringResource
+  get() = String21.str_19768
+
+@ExperimentalResourceApi
+internal val Res.string.str_19769: StringResource
+  get() = String21.str_19769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1977: StringResource
+  get() = String21.str_1977
+
+@ExperimentalResourceApi
+internal val Res.string.str_19770: StringResource
+  get() = String21.str_19770
+
+@ExperimentalResourceApi
+internal val Res.string.str_19771: StringResource
+  get() = String21.str_19771
+
+@ExperimentalResourceApi
+internal val Res.string.str_19772: StringResource
+  get() = String21.str_19772
+
+@ExperimentalResourceApi
+internal val Res.string.str_19773: StringResource
+  get() = String21.str_19773
+
+@ExperimentalResourceApi
+internal val Res.string.str_19774: StringResource
+  get() = String21.str_19774
+
+@ExperimentalResourceApi
+internal val Res.string.str_19775: StringResource
+  get() = String21.str_19775
+
+@ExperimentalResourceApi
+internal val Res.string.str_19776: StringResource
+  get() = String21.str_19776
+
+@ExperimentalResourceApi
+internal val Res.string.str_19777: StringResource
+  get() = String21.str_19777
+
+@ExperimentalResourceApi
+internal val Res.string.str_19778: StringResource
+  get() = String21.str_19778
+
+@ExperimentalResourceApi
+internal val Res.string.str_19779: StringResource
+  get() = String21.str_19779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1978: StringResource
+  get() = String21.str_1978
+
+@ExperimentalResourceApi
+internal val Res.string.str_19780: StringResource
+  get() = String21.str_19780
+
+@ExperimentalResourceApi
+internal val Res.string.str_19781: StringResource
+  get() = String21.str_19781
+
+@ExperimentalResourceApi
+internal val Res.string.str_19782: StringResource
+  get() = String21.str_19782
+
+@ExperimentalResourceApi
+internal val Res.string.str_19783: StringResource
+  get() = String21.str_19783
+
+@ExperimentalResourceApi
+internal val Res.string.str_19784: StringResource
+  get() = String21.str_19784
+
+@ExperimentalResourceApi
+internal val Res.string.str_19785: StringResource
+  get() = String21.str_19785
+
+@ExperimentalResourceApi
+internal val Res.string.str_19786: StringResource
+  get() = String21.str_19786
+
+@ExperimentalResourceApi
+internal val Res.string.str_19787: StringResource
+  get() = String21.str_19787
+
+@ExperimentalResourceApi
+internal val Res.string.str_19788: StringResource
+  get() = String21.str_19788
+
+@ExperimentalResourceApi
+internal val Res.string.str_19789: StringResource
+  get() = String21.str_19789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1979: StringResource
+  get() = String21.str_1979
+
+@ExperimentalResourceApi
+internal val Res.string.str_19790: StringResource
+  get() = String21.str_19790
+
+@ExperimentalResourceApi
+internal val Res.string.str_19791: StringResource
+  get() = String21.str_19791
+
+@ExperimentalResourceApi
+internal val Res.string.str_19792: StringResource
+  get() = String21.str_19792
+
+@ExperimentalResourceApi
+internal val Res.string.str_19793: StringResource
+  get() = String21.str_19793
+
+@ExperimentalResourceApi
+internal val Res.string.str_19794: StringResource
+  get() = String21.str_19794
+
+@ExperimentalResourceApi
+internal val Res.string.str_19795: StringResource
+  get() = String21.str_19795
+
+@ExperimentalResourceApi
+internal val Res.string.str_19796: StringResource
+  get() = String21.str_19796
+
+@ExperimentalResourceApi
+internal val Res.string.str_19797: StringResource
+  get() = String21.str_19797
+
+@ExperimentalResourceApi
+internal val Res.string.str_19798: StringResource
+  get() = String21.str_19798
+
+@ExperimentalResourceApi
+internal val Res.string.str_19799: StringResource
+  get() = String21.str_19799
+
+@ExperimentalResourceApi
+internal val Res.string.str_198: StringResource
+  get() = String21.str_198
+
+@ExperimentalResourceApi
+internal val Res.string.str_1980: StringResource
+  get() = String21.str_1980
+
+@ExperimentalResourceApi
+internal val Res.string.str_19800: StringResource
+  get() = String21.str_19800
+
+@ExperimentalResourceApi
+internal val Res.string.str_19801: StringResource
+  get() = String21.str_19801
+
+@ExperimentalResourceApi
+internal val Res.string.str_19802: StringResource
+  get() = String21.str_19802
+
+@ExperimentalResourceApi
+internal val Res.string.str_19803: StringResource
+  get() = String21.str_19803
+
+@ExperimentalResourceApi
+internal val Res.string.str_19804: StringResource
+  get() = String21.str_19804
+
+@ExperimentalResourceApi
+internal val Res.string.str_19805: StringResource
+  get() = String21.str_19805
+
+@ExperimentalResourceApi
+internal val Res.string.str_19806: StringResource
+  get() = String21.str_19806
+
+@ExperimentalResourceApi
+internal val Res.string.str_19807: StringResource
+  get() = String21.str_19807
+
+@ExperimentalResourceApi
+internal val Res.string.str_19808: StringResource
+  get() = String21.str_19808
+
+@ExperimentalResourceApi
+internal val Res.string.str_19809: StringResource
+  get() = String21.str_19809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1981: StringResource
+  get() = String21.str_1981
+
+@ExperimentalResourceApi
+internal val Res.string.str_19810: StringResource
+  get() = String21.str_19810
+
+@ExperimentalResourceApi
+internal val Res.string.str_19811: StringResource
+  get() = String21.str_19811
+
+@ExperimentalResourceApi
+internal val Res.string.str_19812: StringResource
+  get() = String21.str_19812
+
+@ExperimentalResourceApi
+internal val Res.string.str_19813: StringResource
+  get() = String21.str_19813
+
+@ExperimentalResourceApi
+internal val Res.string.str_19814: StringResource
+  get() = String21.str_19814
+
+@ExperimentalResourceApi
+internal val Res.string.str_19815: StringResource
+  get() = String21.str_19815
+
+@ExperimentalResourceApi
+internal val Res.string.str_19816: StringResource
+  get() = String21.str_19816
+
+@ExperimentalResourceApi
+internal val Res.string.str_19817: StringResource
+  get() = String21.str_19817
+
+@ExperimentalResourceApi
+internal val Res.string.str_19818: StringResource
+  get() = String21.str_19818
+
+@ExperimentalResourceApi
+internal val Res.string.str_19819: StringResource
+  get() = String21.str_19819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1982: StringResource
+  get() = String21.str_1982
+
+@ExperimentalResourceApi
+internal val Res.string.str_19820: StringResource
+  get() = String21.str_19820
+
+@ExperimentalResourceApi
+internal val Res.string.str_19821: StringResource
+  get() = String21.str_19821
+
+@ExperimentalResourceApi
+internal val Res.string.str_19822: StringResource
+  get() = String21.str_19822
+
+@ExperimentalResourceApi
+internal val Res.string.str_19823: StringResource
+  get() = String21.str_19823
+
+@ExperimentalResourceApi
+internal val Res.string.str_19824: StringResource
+  get() = String21.str_19824
+
+@ExperimentalResourceApi
+internal val Res.string.str_19825: StringResource
+  get() = String21.str_19825
+
+@ExperimentalResourceApi
+internal val Res.string.str_19826: StringResource
+  get() = String21.str_19826
+
+@ExperimentalResourceApi
+internal val Res.string.str_19827: StringResource
+  get() = String21.str_19827
+
+@ExperimentalResourceApi
+internal val Res.string.str_19828: StringResource
+  get() = String21.str_19828
+
+@ExperimentalResourceApi
+internal val Res.string.str_19829: StringResource
+  get() = String21.str_19829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1983: StringResource
+  get() = String21.str_1983
+
+@ExperimentalResourceApi
+internal val Res.string.str_19830: StringResource
+  get() = String21.str_19830
+
+@ExperimentalResourceApi
+internal val Res.string.str_19831: StringResource
+  get() = String21.str_19831
+
+@ExperimentalResourceApi
+internal val Res.string.str_19832: StringResource
+  get() = String21.str_19832
+
+@ExperimentalResourceApi
+internal val Res.string.str_19833: StringResource
+  get() = String21.str_19833
+
+@ExperimentalResourceApi
+internal val Res.string.str_19834: StringResource
+  get() = String21.str_19834
+
+@ExperimentalResourceApi
+internal val Res.string.str_19835: StringResource
+  get() = String21.str_19835
+
+@ExperimentalResourceApi
+internal val Res.string.str_19836: StringResource
+  get() = String21.str_19836
+
+@ExperimentalResourceApi
+internal val Res.string.str_19837: StringResource
+  get() = String21.str_19837
+
+@ExperimentalResourceApi
+internal val Res.string.str_19838: StringResource
+  get() = String21.str_19838
+
+@ExperimentalResourceApi
+internal val Res.string.str_19839: StringResource
+  get() = String21.str_19839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1984: StringResource
+  get() = String21.str_1984
+
+@ExperimentalResourceApi
+internal val Res.string.str_19840: StringResource
+  get() = String21.str_19840
+
+@ExperimentalResourceApi
+internal val Res.string.str_19841: StringResource
+  get() = String21.str_19841
+
+@ExperimentalResourceApi
+internal val Res.string.str_19842: StringResource
+  get() = String21.str_19842
+
+@ExperimentalResourceApi
+internal val Res.string.str_19843: StringResource
+  get() = String21.str_19843
+
+@ExperimentalResourceApi
+internal val Res.string.str_19844: StringResource
+  get() = String21.str_19844
+
+@ExperimentalResourceApi
+internal val Res.string.str_19845: StringResource
+  get() = String21.str_19845
+
+@ExperimentalResourceApi
+internal val Res.string.str_19846: StringResource
+  get() = String21.str_19846
+
+@ExperimentalResourceApi
+internal val Res.string.str_19847: StringResource
+  get() = String21.str_19847
+
+@ExperimentalResourceApi
+internal val Res.string.str_19848: StringResource
+  get() = String21.str_19848
+
+@ExperimentalResourceApi
+internal val Res.string.str_19849: StringResource
+  get() = String21.str_19849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1985: StringResource
+  get() = String21.str_1985
+
+@ExperimentalResourceApi
+internal val Res.string.str_19850: StringResource
+  get() = String21.str_19850
+
+@ExperimentalResourceApi
+internal val Res.string.str_19851: StringResource
+  get() = String21.str_19851
+
+@ExperimentalResourceApi
+internal val Res.string.str_19852: StringResource
+  get() = String21.str_19852
+
+@ExperimentalResourceApi
+internal val Res.string.str_19853: StringResource
+  get() = String21.str_19853
+
+@ExperimentalResourceApi
+internal val Res.string.str_19854: StringResource
+  get() = String21.str_19854
+
+@ExperimentalResourceApi
+internal val Res.string.str_19855: StringResource
+  get() = String21.str_19855
+
+@ExperimentalResourceApi
+internal val Res.string.str_19856: StringResource
+  get() = String21.str_19856
+
+@ExperimentalResourceApi
+internal val Res.string.str_19857: StringResource
+  get() = String21.str_19857
+
+@ExperimentalResourceApi
+internal val Res.string.str_19858: StringResource
+  get() = String21.str_19858
+
+@ExperimentalResourceApi
+internal val Res.string.str_19859: StringResource
+  get() = String21.str_19859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1986: StringResource
+  get() = String21.str_1986
+
+@ExperimentalResourceApi
+internal val Res.string.str_19860: StringResource
+  get() = String21.str_19860
+
+@ExperimentalResourceApi
+internal val Res.string.str_19861: StringResource
+  get() = String21.str_19861
+
+@ExperimentalResourceApi
+internal val Res.string.str_19862: StringResource
+  get() = String21.str_19862
+
+@ExperimentalResourceApi
+internal val Res.string.str_19863: StringResource
+  get() = String21.str_19863
+
+@ExperimentalResourceApi
+internal val Res.string.str_19864: StringResource
+  get() = String21.str_19864
+
+@ExperimentalResourceApi
+internal val Res.string.str_19865: StringResource
+  get() = String21.str_19865
+
+@ExperimentalResourceApi
+internal val Res.string.str_19866: StringResource
+  get() = String21.str_19866
+
+@ExperimentalResourceApi
+internal val Res.string.str_19867: StringResource
+  get() = String21.str_19867
+
+@ExperimentalResourceApi
+internal val Res.string.str_19868: StringResource
+  get() = String21.str_19868
+
+@ExperimentalResourceApi
+internal val Res.string.str_19869: StringResource
+  get() = String21.str_19869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1987: StringResource
+  get() = String21.str_1987
+
+@ExperimentalResourceApi
+internal val Res.string.str_19870: StringResource
+  get() = String21.str_19870
+
+@ExperimentalResourceApi
+internal val Res.string.str_19871: StringResource
+  get() = String21.str_19871
+
+@ExperimentalResourceApi
+internal val Res.string.str_19872: StringResource
+  get() = String21.str_19872
+
+@ExperimentalResourceApi
+internal val Res.string.str_19873: StringResource
+  get() = String21.str_19873
+
+@ExperimentalResourceApi
+internal val Res.string.str_19874: StringResource
+  get() = String21.str_19874
+
+@ExperimentalResourceApi
+internal val Res.string.str_19875: StringResource
+  get() = String21.str_19875
+
+@ExperimentalResourceApi
+internal val Res.string.str_19876: StringResource
+  get() = String21.str_19876
+
+@ExperimentalResourceApi
+internal val Res.string.str_19877: StringResource
+  get() = String21.str_19877
+
+@ExperimentalResourceApi
+internal val Res.string.str_19878: StringResource
+  get() = String21.str_19878
+
+@ExperimentalResourceApi
+internal val Res.string.str_19879: StringResource
+  get() = String21.str_19879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1988: StringResource
+  get() = String21.str_1988
+
+@ExperimentalResourceApi
+internal val Res.string.str_19880: StringResource
+  get() = String21.str_19880
+
+@ExperimentalResourceApi
+internal val Res.string.str_19881: StringResource
+  get() = String21.str_19881
+
+@ExperimentalResourceApi
+internal val Res.string.str_19882: StringResource
+  get() = String21.str_19882
+
+@ExperimentalResourceApi
+internal val Res.string.str_19883: StringResource
+  get() = String21.str_19883
+
+@ExperimentalResourceApi
+internal val Res.string.str_19884: StringResource
+  get() = String21.str_19884
+
+@ExperimentalResourceApi
+internal val Res.string.str_19885: StringResource
+  get() = String21.str_19885
+
+@ExperimentalResourceApi
+internal val Res.string.str_19886: StringResource
+  get() = String21.str_19886
+
+@ExperimentalResourceApi
+internal val Res.string.str_19887: StringResource
+  get() = String21.str_19887
+
+@ExperimentalResourceApi
+internal val Res.string.str_19888: StringResource
+  get() = String21.str_19888
+
+@ExperimentalResourceApi
+internal val Res.string.str_19889: StringResource
+  get() = String21.str_19889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1989: StringResource
+  get() = String21.str_1989
+
+@ExperimentalResourceApi
+internal val Res.string.str_19890: StringResource
+  get() = String21.str_19890
+
+@ExperimentalResourceApi
+internal val Res.string.str_19891: StringResource
+  get() = String21.str_19891
+
+@ExperimentalResourceApi
+internal val Res.string.str_19892: StringResource
+  get() = String21.str_19892
+
+@ExperimentalResourceApi
+internal val Res.string.str_19893: StringResource
+  get() = String21.str_19893
+
+@ExperimentalResourceApi
+internal val Res.string.str_19894: StringResource
+  get() = String21.str_19894
+
+@ExperimentalResourceApi
+internal val Res.string.str_19895: StringResource
+  get() = String21.str_19895
+
+@ExperimentalResourceApi
+internal val Res.string.str_19896: StringResource
+  get() = String21.str_19896
+
+@ExperimentalResourceApi
+internal val Res.string.str_19897: StringResource
+  get() = String21.str_19897
+
+@ExperimentalResourceApi
+internal val Res.string.str_19898: StringResource
+  get() = String21.str_19898

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String22.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String22.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String22 {
+  public val str_19899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19899", "str_19899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_199", "str_199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1990", "str_1990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19900", "str_19900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19901", "str_19901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19902", "str_19902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19903", "str_19903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19904", "str_19904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19905", "str_19905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19906", "str_19906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19907", "str_19907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19908", "str_19908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19909", "str_19909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1991", "str_1991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19910", "str_19910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19911", "str_19911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19912", "str_19912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19913", "str_19913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19914", "str_19914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19915", "str_19915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19916", "str_19916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19917", "str_19917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19918", "str_19918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19919", "str_19919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1992", "str_1992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19920", "str_19920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19921", "str_19921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19922", "str_19922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19923", "str_19923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19924", "str_19924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19925", "str_19925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19926", "str_19926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19927", "str_19927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19928", "str_19928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19929", "str_19929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1993", "str_1993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19930", "str_19930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19931", "str_19931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19932", "str_19932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19933", "str_19933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19934", "str_19934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19935", "str_19935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19936", "str_19936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19937", "str_19937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19938", "str_19938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19939", "str_19939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1994", "str_1994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19940", "str_19940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19941", "str_19941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19942", "str_19942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19943", "str_19943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19944", "str_19944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19945", "str_19945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19946", "str_19946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19947", "str_19947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19948", "str_19948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19949", "str_19949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1995", "str_1995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19950", "str_19950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19951", "str_19951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19952", "str_19952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19953", "str_19953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19954", "str_19954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19955", "str_19955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19956", "str_19956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19957", "str_19957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19958", "str_19958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19959", "str_19959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1996", "str_1996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19960", "str_19960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19961", "str_19961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19962", "str_19962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19963", "str_19963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19964", "str_19964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19965", "str_19965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19966", "str_19966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19967", "str_19967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19968", "str_19968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19969", "str_19969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1997", "str_1997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19970", "str_19970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19971", "str_19971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19972", "str_19972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19973", "str_19973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19974", "str_19974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19975", "str_19975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19976", "str_19976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19977", "str_19977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19978", "str_19978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19979", "str_19979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1998", "str_1998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19980", "str_19980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19981", "str_19981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19982", "str_19982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19983", "str_19983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19984", "str_19984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19985", "str_19985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19986", "str_19986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19987", "str_19987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19988", "str_19988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19989", "str_19989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1999", "str_1999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19990", "str_19990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19991", "str_19991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19992", "str_19992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19993", "str_19993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19994", "str_19994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19995", "str_19995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19996", "str_19996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19997", "str_19997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19998", "str_19998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_19999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_19999", "str_19999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2", "str_2",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20", "str_20",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_200", "str_200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2000", "str_2000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20000", "str_20000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20001", "str_20001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20002", "str_20002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20003", "str_20003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20004", "str_20004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20005", "str_20005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20006", "str_20006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20007", "str_20007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20008", "str_20008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20009", "str_20009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2001", "str_2001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20010", "str_20010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20011", "str_20011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20012", "str_20012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20013", "str_20013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20014", "str_20014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20015", "str_20015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20016", "str_20016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20017", "str_20017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20018", "str_20018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20019", "str_20019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2002", "str_2002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20020", "str_20020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20021", "str_20021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20022", "str_20022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20023", "str_20023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20024", "str_20024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20025", "str_20025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20026", "str_20026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20027", "str_20027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20028", "str_20028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20029", "str_20029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2003", "str_2003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20030", "str_20030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20031", "str_20031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20032", "str_20032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20033", "str_20033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20034", "str_20034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20035", "str_20035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20036", "str_20036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20037", "str_20037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20038", "str_20038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20039", "str_20039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2004", "str_2004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20040", "str_20040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20041", "str_20041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20042", "str_20042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20043", "str_20043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20044", "str_20044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20045", "str_20045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20046", "str_20046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20047", "str_20047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20048", "str_20048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20049", "str_20049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2005", "str_2005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20050", "str_20050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20051", "str_20051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20052", "str_20052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20053", "str_20053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20054", "str_20054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20055", "str_20055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20056", "str_20056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20057", "str_20057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20058", "str_20058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20059", "str_20059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2006", "str_2006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20060", "str_20060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20061", "str_20061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20062", "str_20062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20063", "str_20063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20064", "str_20064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20065", "str_20065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20066", "str_20066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20067", "str_20067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20068", "str_20068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20069", "str_20069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2007", "str_2007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20070", "str_20070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20071", "str_20071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20072", "str_20072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20073", "str_20073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20074", "str_20074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20075", "str_20075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20076", "str_20076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20077", "str_20077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20078", "str_20078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20079", "str_20079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2008", "str_2008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20080", "str_20080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20081", "str_20081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20082", "str_20082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20083", "str_20083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20084", "str_20084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20085", "str_20085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20086", "str_20086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20087", "str_20087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20088", "str_20088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20089", "str_20089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2009", "str_2009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20090", "str_20090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20091", "str_20091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20092", "str_20092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20093", "str_20093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20094", "str_20094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20095", "str_20095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20096", "str_20096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20097", "str_20097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20098", "str_20098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20099", "str_20099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_201", "str_201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2010", "str_2010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20100", "str_20100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20101", "str_20101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20102", "str_20102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20103", "str_20103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20104", "str_20104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20105", "str_20105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20106", "str_20106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20107", "str_20107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20108", "str_20108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20109", "str_20109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2011", "str_2011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20110", "str_20110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20111", "str_20111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20112", "str_20112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20113", "str_20113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20114", "str_20114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20115", "str_20115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20116", "str_20116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20117", "str_20117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20118", "str_20118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20119", "str_20119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2012", "str_2012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20120", "str_20120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20121", "str_20121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20122", "str_20122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20123", "str_20123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20124", "str_20124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20125", "str_20125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20126", "str_20126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20127", "str_20127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20128", "str_20128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20129", "str_20129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2013", "str_2013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20130", "str_20130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20131", "str_20131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20132", "str_20132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20133", "str_20133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20134", "str_20134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20135", "str_20135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20136", "str_20136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20137", "str_20137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20138", "str_20138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20139", "str_20139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2014", "str_2014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20140", "str_20140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20141", "str_20141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20142", "str_20142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20143", "str_20143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20144", "str_20144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20145", "str_20145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20146", "str_20146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20147", "str_20147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20148", "str_20148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20149", "str_20149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2015", "str_2015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20150", "str_20150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20151", "str_20151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20152", "str_20152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20153", "str_20153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20154", "str_20154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20155", "str_20155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20156", "str_20156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20157", "str_20157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20158", "str_20158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20159", "str_20159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2016", "str_2016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20160", "str_20160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20161", "str_20161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20162", "str_20162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20163", "str_20163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20164", "str_20164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20165", "str_20165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20166", "str_20166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20167", "str_20167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20168", "str_20168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20169", "str_20169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2017", "str_2017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20170", "str_20170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20171", "str_20171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20172", "str_20172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20173", "str_20173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20174", "str_20174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20175", "str_20175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20176", "str_20176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20177", "str_20177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20178", "str_20178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20179", "str_20179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2018", "str_2018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20180", "str_20180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20181", "str_20181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20182", "str_20182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20183", "str_20183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20184", "str_20184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20185", "str_20185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20186", "str_20186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20187", "str_20187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20188", "str_20188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20189", "str_20189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2019", "str_2019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20190", "str_20190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20191", "str_20191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20192", "str_20192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20193", "str_20193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20194", "str_20194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20195", "str_20195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20196", "str_20196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20197", "str_20197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20198", "str_20198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20199", "str_20199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_202", "str_202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2020", "str_2020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20200", "str_20200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20201", "str_20201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20202", "str_20202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20203", "str_20203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20204", "str_20204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20205", "str_20205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20206", "str_20206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20207", "str_20207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20208", "str_20208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20209", "str_20209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2021", "str_2021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20210", "str_20210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20211", "str_20211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20212", "str_20212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20213", "str_20213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20214", "str_20214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20215", "str_20215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20216", "str_20216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20217", "str_20217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20218", "str_20218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20219", "str_20219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2022", "str_2022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20220", "str_20220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20221", "str_20221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20222", "str_20222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20223", "str_20223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20224", "str_20224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20225", "str_20225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20226", "str_20226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20227", "str_20227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20228", "str_20228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20229", "str_20229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2023", "str_2023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20230", "str_20230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20231", "str_20231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20232", "str_20232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20233", "str_20233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20234", "str_20234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20235", "str_20235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20236", "str_20236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20237", "str_20237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20238", "str_20238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20239", "str_20239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2024", "str_2024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20240", "str_20240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20241", "str_20241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20242", "str_20242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20243", "str_20243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20244", "str_20244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20245", "str_20245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20246", "str_20246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20247", "str_20247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20248", "str_20248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20249", "str_20249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2025", "str_2025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20250", "str_20250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20251", "str_20251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20252", "str_20252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20253", "str_20253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20254", "str_20254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20255", "str_20255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20256", "str_20256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20257", "str_20257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20258", "str_20258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20259", "str_20259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2026", "str_2026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20260", "str_20260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20261", "str_20261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20262", "str_20262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20263", "str_20263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20264", "str_20264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20265", "str_20265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20266", "str_20266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20267", "str_20267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20268", "str_20268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20269", "str_20269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2027", "str_2027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20270", "str_20270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20271", "str_20271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20272", "str_20272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20273", "str_20273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20274", "str_20274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20275", "str_20275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20276", "str_20276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20277", "str_20277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20278", "str_20278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20279", "str_20279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2028", "str_2028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20280", "str_20280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20281", "str_20281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20282", "str_20282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20283", "str_20283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20284", "str_20284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20285", "str_20285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20286", "str_20286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20287", "str_20287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20288", "str_20288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20289", "str_20289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2029", "str_2029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20290", "str_20290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20291", "str_20291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20292", "str_20292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20293", "str_20293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20294", "str_20294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20295", "str_20295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20296", "str_20296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20297", "str_20297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20298", "str_20298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20299", "str_20299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_203", "str_203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2030", "str_2030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20300", "str_20300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20301", "str_20301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20302", "str_20302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20303", "str_20303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20304", "str_20304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20305", "str_20305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20306", "str_20306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20307", "str_20307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20308", "str_20308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20309", "str_20309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2031", "str_2031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20310", "str_20310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20311", "str_20311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20312", "str_20312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20313", "str_20313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20314", "str_20314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20315", "str_20315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20316", "str_20316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20317", "str_20317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20318", "str_20318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20319", "str_20319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2032", "str_2032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20320", "str_20320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20321", "str_20321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20322", "str_20322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20323", "str_20323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20324", "str_20324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20325", "str_20325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20326", "str_20326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20327", "str_20327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20328", "str_20328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20329", "str_20329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2033", "str_2033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20330", "str_20330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20331", "str_20331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20332", "str_20332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20333", "str_20333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20334", "str_20334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20335", "str_20335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20336", "str_20336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20337", "str_20337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20338", "str_20338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20339", "str_20339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2034", "str_2034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20340", "str_20340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20341", "str_20341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20342", "str_20342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20343", "str_20343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20344", "str_20344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20345", "str_20345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20346", "str_20346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_19899: StringResource
+  get() = String22.str_19899
+
+@ExperimentalResourceApi
+internal val Res.string.str_199: StringResource
+  get() = String22.str_199
+
+@ExperimentalResourceApi
+internal val Res.string.str_1990: StringResource
+  get() = String22.str_1990
+
+@ExperimentalResourceApi
+internal val Res.string.str_19900: StringResource
+  get() = String22.str_19900
+
+@ExperimentalResourceApi
+internal val Res.string.str_19901: StringResource
+  get() = String22.str_19901
+
+@ExperimentalResourceApi
+internal val Res.string.str_19902: StringResource
+  get() = String22.str_19902
+
+@ExperimentalResourceApi
+internal val Res.string.str_19903: StringResource
+  get() = String22.str_19903
+
+@ExperimentalResourceApi
+internal val Res.string.str_19904: StringResource
+  get() = String22.str_19904
+
+@ExperimentalResourceApi
+internal val Res.string.str_19905: StringResource
+  get() = String22.str_19905
+
+@ExperimentalResourceApi
+internal val Res.string.str_19906: StringResource
+  get() = String22.str_19906
+
+@ExperimentalResourceApi
+internal val Res.string.str_19907: StringResource
+  get() = String22.str_19907
+
+@ExperimentalResourceApi
+internal val Res.string.str_19908: StringResource
+  get() = String22.str_19908
+
+@ExperimentalResourceApi
+internal val Res.string.str_19909: StringResource
+  get() = String22.str_19909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1991: StringResource
+  get() = String22.str_1991
+
+@ExperimentalResourceApi
+internal val Res.string.str_19910: StringResource
+  get() = String22.str_19910
+
+@ExperimentalResourceApi
+internal val Res.string.str_19911: StringResource
+  get() = String22.str_19911
+
+@ExperimentalResourceApi
+internal val Res.string.str_19912: StringResource
+  get() = String22.str_19912
+
+@ExperimentalResourceApi
+internal val Res.string.str_19913: StringResource
+  get() = String22.str_19913
+
+@ExperimentalResourceApi
+internal val Res.string.str_19914: StringResource
+  get() = String22.str_19914
+
+@ExperimentalResourceApi
+internal val Res.string.str_19915: StringResource
+  get() = String22.str_19915
+
+@ExperimentalResourceApi
+internal val Res.string.str_19916: StringResource
+  get() = String22.str_19916
+
+@ExperimentalResourceApi
+internal val Res.string.str_19917: StringResource
+  get() = String22.str_19917
+
+@ExperimentalResourceApi
+internal val Res.string.str_19918: StringResource
+  get() = String22.str_19918
+
+@ExperimentalResourceApi
+internal val Res.string.str_19919: StringResource
+  get() = String22.str_19919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1992: StringResource
+  get() = String22.str_1992
+
+@ExperimentalResourceApi
+internal val Res.string.str_19920: StringResource
+  get() = String22.str_19920
+
+@ExperimentalResourceApi
+internal val Res.string.str_19921: StringResource
+  get() = String22.str_19921
+
+@ExperimentalResourceApi
+internal val Res.string.str_19922: StringResource
+  get() = String22.str_19922
+
+@ExperimentalResourceApi
+internal val Res.string.str_19923: StringResource
+  get() = String22.str_19923
+
+@ExperimentalResourceApi
+internal val Res.string.str_19924: StringResource
+  get() = String22.str_19924
+
+@ExperimentalResourceApi
+internal val Res.string.str_19925: StringResource
+  get() = String22.str_19925
+
+@ExperimentalResourceApi
+internal val Res.string.str_19926: StringResource
+  get() = String22.str_19926
+
+@ExperimentalResourceApi
+internal val Res.string.str_19927: StringResource
+  get() = String22.str_19927
+
+@ExperimentalResourceApi
+internal val Res.string.str_19928: StringResource
+  get() = String22.str_19928
+
+@ExperimentalResourceApi
+internal val Res.string.str_19929: StringResource
+  get() = String22.str_19929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1993: StringResource
+  get() = String22.str_1993
+
+@ExperimentalResourceApi
+internal val Res.string.str_19930: StringResource
+  get() = String22.str_19930
+
+@ExperimentalResourceApi
+internal val Res.string.str_19931: StringResource
+  get() = String22.str_19931
+
+@ExperimentalResourceApi
+internal val Res.string.str_19932: StringResource
+  get() = String22.str_19932
+
+@ExperimentalResourceApi
+internal val Res.string.str_19933: StringResource
+  get() = String22.str_19933
+
+@ExperimentalResourceApi
+internal val Res.string.str_19934: StringResource
+  get() = String22.str_19934
+
+@ExperimentalResourceApi
+internal val Res.string.str_19935: StringResource
+  get() = String22.str_19935
+
+@ExperimentalResourceApi
+internal val Res.string.str_19936: StringResource
+  get() = String22.str_19936
+
+@ExperimentalResourceApi
+internal val Res.string.str_19937: StringResource
+  get() = String22.str_19937
+
+@ExperimentalResourceApi
+internal val Res.string.str_19938: StringResource
+  get() = String22.str_19938
+
+@ExperimentalResourceApi
+internal val Res.string.str_19939: StringResource
+  get() = String22.str_19939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1994: StringResource
+  get() = String22.str_1994
+
+@ExperimentalResourceApi
+internal val Res.string.str_19940: StringResource
+  get() = String22.str_19940
+
+@ExperimentalResourceApi
+internal val Res.string.str_19941: StringResource
+  get() = String22.str_19941
+
+@ExperimentalResourceApi
+internal val Res.string.str_19942: StringResource
+  get() = String22.str_19942
+
+@ExperimentalResourceApi
+internal val Res.string.str_19943: StringResource
+  get() = String22.str_19943
+
+@ExperimentalResourceApi
+internal val Res.string.str_19944: StringResource
+  get() = String22.str_19944
+
+@ExperimentalResourceApi
+internal val Res.string.str_19945: StringResource
+  get() = String22.str_19945
+
+@ExperimentalResourceApi
+internal val Res.string.str_19946: StringResource
+  get() = String22.str_19946
+
+@ExperimentalResourceApi
+internal val Res.string.str_19947: StringResource
+  get() = String22.str_19947
+
+@ExperimentalResourceApi
+internal val Res.string.str_19948: StringResource
+  get() = String22.str_19948
+
+@ExperimentalResourceApi
+internal val Res.string.str_19949: StringResource
+  get() = String22.str_19949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1995: StringResource
+  get() = String22.str_1995
+
+@ExperimentalResourceApi
+internal val Res.string.str_19950: StringResource
+  get() = String22.str_19950
+
+@ExperimentalResourceApi
+internal val Res.string.str_19951: StringResource
+  get() = String22.str_19951
+
+@ExperimentalResourceApi
+internal val Res.string.str_19952: StringResource
+  get() = String22.str_19952
+
+@ExperimentalResourceApi
+internal val Res.string.str_19953: StringResource
+  get() = String22.str_19953
+
+@ExperimentalResourceApi
+internal val Res.string.str_19954: StringResource
+  get() = String22.str_19954
+
+@ExperimentalResourceApi
+internal val Res.string.str_19955: StringResource
+  get() = String22.str_19955
+
+@ExperimentalResourceApi
+internal val Res.string.str_19956: StringResource
+  get() = String22.str_19956
+
+@ExperimentalResourceApi
+internal val Res.string.str_19957: StringResource
+  get() = String22.str_19957
+
+@ExperimentalResourceApi
+internal val Res.string.str_19958: StringResource
+  get() = String22.str_19958
+
+@ExperimentalResourceApi
+internal val Res.string.str_19959: StringResource
+  get() = String22.str_19959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1996: StringResource
+  get() = String22.str_1996
+
+@ExperimentalResourceApi
+internal val Res.string.str_19960: StringResource
+  get() = String22.str_19960
+
+@ExperimentalResourceApi
+internal val Res.string.str_19961: StringResource
+  get() = String22.str_19961
+
+@ExperimentalResourceApi
+internal val Res.string.str_19962: StringResource
+  get() = String22.str_19962
+
+@ExperimentalResourceApi
+internal val Res.string.str_19963: StringResource
+  get() = String22.str_19963
+
+@ExperimentalResourceApi
+internal val Res.string.str_19964: StringResource
+  get() = String22.str_19964
+
+@ExperimentalResourceApi
+internal val Res.string.str_19965: StringResource
+  get() = String22.str_19965
+
+@ExperimentalResourceApi
+internal val Res.string.str_19966: StringResource
+  get() = String22.str_19966
+
+@ExperimentalResourceApi
+internal val Res.string.str_19967: StringResource
+  get() = String22.str_19967
+
+@ExperimentalResourceApi
+internal val Res.string.str_19968: StringResource
+  get() = String22.str_19968
+
+@ExperimentalResourceApi
+internal val Res.string.str_19969: StringResource
+  get() = String22.str_19969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1997: StringResource
+  get() = String22.str_1997
+
+@ExperimentalResourceApi
+internal val Res.string.str_19970: StringResource
+  get() = String22.str_19970
+
+@ExperimentalResourceApi
+internal val Res.string.str_19971: StringResource
+  get() = String22.str_19971
+
+@ExperimentalResourceApi
+internal val Res.string.str_19972: StringResource
+  get() = String22.str_19972
+
+@ExperimentalResourceApi
+internal val Res.string.str_19973: StringResource
+  get() = String22.str_19973
+
+@ExperimentalResourceApi
+internal val Res.string.str_19974: StringResource
+  get() = String22.str_19974
+
+@ExperimentalResourceApi
+internal val Res.string.str_19975: StringResource
+  get() = String22.str_19975
+
+@ExperimentalResourceApi
+internal val Res.string.str_19976: StringResource
+  get() = String22.str_19976
+
+@ExperimentalResourceApi
+internal val Res.string.str_19977: StringResource
+  get() = String22.str_19977
+
+@ExperimentalResourceApi
+internal val Res.string.str_19978: StringResource
+  get() = String22.str_19978
+
+@ExperimentalResourceApi
+internal val Res.string.str_19979: StringResource
+  get() = String22.str_19979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1998: StringResource
+  get() = String22.str_1998
+
+@ExperimentalResourceApi
+internal val Res.string.str_19980: StringResource
+  get() = String22.str_19980
+
+@ExperimentalResourceApi
+internal val Res.string.str_19981: StringResource
+  get() = String22.str_19981
+
+@ExperimentalResourceApi
+internal val Res.string.str_19982: StringResource
+  get() = String22.str_19982
+
+@ExperimentalResourceApi
+internal val Res.string.str_19983: StringResource
+  get() = String22.str_19983
+
+@ExperimentalResourceApi
+internal val Res.string.str_19984: StringResource
+  get() = String22.str_19984
+
+@ExperimentalResourceApi
+internal val Res.string.str_19985: StringResource
+  get() = String22.str_19985
+
+@ExperimentalResourceApi
+internal val Res.string.str_19986: StringResource
+  get() = String22.str_19986
+
+@ExperimentalResourceApi
+internal val Res.string.str_19987: StringResource
+  get() = String22.str_19987
+
+@ExperimentalResourceApi
+internal val Res.string.str_19988: StringResource
+  get() = String22.str_19988
+
+@ExperimentalResourceApi
+internal val Res.string.str_19989: StringResource
+  get() = String22.str_19989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1999: StringResource
+  get() = String22.str_1999
+
+@ExperimentalResourceApi
+internal val Res.string.str_19990: StringResource
+  get() = String22.str_19990
+
+@ExperimentalResourceApi
+internal val Res.string.str_19991: StringResource
+  get() = String22.str_19991
+
+@ExperimentalResourceApi
+internal val Res.string.str_19992: StringResource
+  get() = String22.str_19992
+
+@ExperimentalResourceApi
+internal val Res.string.str_19993: StringResource
+  get() = String22.str_19993
+
+@ExperimentalResourceApi
+internal val Res.string.str_19994: StringResource
+  get() = String22.str_19994
+
+@ExperimentalResourceApi
+internal val Res.string.str_19995: StringResource
+  get() = String22.str_19995
+
+@ExperimentalResourceApi
+internal val Res.string.str_19996: StringResource
+  get() = String22.str_19996
+
+@ExperimentalResourceApi
+internal val Res.string.str_19997: StringResource
+  get() = String22.str_19997
+
+@ExperimentalResourceApi
+internal val Res.string.str_19998: StringResource
+  get() = String22.str_19998
+
+@ExperimentalResourceApi
+internal val Res.string.str_19999: StringResource
+  get() = String22.str_19999
+
+@ExperimentalResourceApi
+internal val Res.string.str_2: StringResource
+  get() = String22.str_2
+
+@ExperimentalResourceApi
+internal val Res.string.str_20: StringResource
+  get() = String22.str_20
+
+@ExperimentalResourceApi
+internal val Res.string.str_200: StringResource
+  get() = String22.str_200
+
+@ExperimentalResourceApi
+internal val Res.string.str_2000: StringResource
+  get() = String22.str_2000
+
+@ExperimentalResourceApi
+internal val Res.string.str_20000: StringResource
+  get() = String22.str_20000
+
+@ExperimentalResourceApi
+internal val Res.string.str_20001: StringResource
+  get() = String22.str_20001
+
+@ExperimentalResourceApi
+internal val Res.string.str_20002: StringResource
+  get() = String22.str_20002
+
+@ExperimentalResourceApi
+internal val Res.string.str_20003: StringResource
+  get() = String22.str_20003
+
+@ExperimentalResourceApi
+internal val Res.string.str_20004: StringResource
+  get() = String22.str_20004
+
+@ExperimentalResourceApi
+internal val Res.string.str_20005: StringResource
+  get() = String22.str_20005
+
+@ExperimentalResourceApi
+internal val Res.string.str_20006: StringResource
+  get() = String22.str_20006
+
+@ExperimentalResourceApi
+internal val Res.string.str_20007: StringResource
+  get() = String22.str_20007
+
+@ExperimentalResourceApi
+internal val Res.string.str_20008: StringResource
+  get() = String22.str_20008
+
+@ExperimentalResourceApi
+internal val Res.string.str_20009: StringResource
+  get() = String22.str_20009
+
+@ExperimentalResourceApi
+internal val Res.string.str_2001: StringResource
+  get() = String22.str_2001
+
+@ExperimentalResourceApi
+internal val Res.string.str_20010: StringResource
+  get() = String22.str_20010
+
+@ExperimentalResourceApi
+internal val Res.string.str_20011: StringResource
+  get() = String22.str_20011
+
+@ExperimentalResourceApi
+internal val Res.string.str_20012: StringResource
+  get() = String22.str_20012
+
+@ExperimentalResourceApi
+internal val Res.string.str_20013: StringResource
+  get() = String22.str_20013
+
+@ExperimentalResourceApi
+internal val Res.string.str_20014: StringResource
+  get() = String22.str_20014
+
+@ExperimentalResourceApi
+internal val Res.string.str_20015: StringResource
+  get() = String22.str_20015
+
+@ExperimentalResourceApi
+internal val Res.string.str_20016: StringResource
+  get() = String22.str_20016
+
+@ExperimentalResourceApi
+internal val Res.string.str_20017: StringResource
+  get() = String22.str_20017
+
+@ExperimentalResourceApi
+internal val Res.string.str_20018: StringResource
+  get() = String22.str_20018
+
+@ExperimentalResourceApi
+internal val Res.string.str_20019: StringResource
+  get() = String22.str_20019
+
+@ExperimentalResourceApi
+internal val Res.string.str_2002: StringResource
+  get() = String22.str_2002
+
+@ExperimentalResourceApi
+internal val Res.string.str_20020: StringResource
+  get() = String22.str_20020
+
+@ExperimentalResourceApi
+internal val Res.string.str_20021: StringResource
+  get() = String22.str_20021
+
+@ExperimentalResourceApi
+internal val Res.string.str_20022: StringResource
+  get() = String22.str_20022
+
+@ExperimentalResourceApi
+internal val Res.string.str_20023: StringResource
+  get() = String22.str_20023
+
+@ExperimentalResourceApi
+internal val Res.string.str_20024: StringResource
+  get() = String22.str_20024
+
+@ExperimentalResourceApi
+internal val Res.string.str_20025: StringResource
+  get() = String22.str_20025
+
+@ExperimentalResourceApi
+internal val Res.string.str_20026: StringResource
+  get() = String22.str_20026
+
+@ExperimentalResourceApi
+internal val Res.string.str_20027: StringResource
+  get() = String22.str_20027
+
+@ExperimentalResourceApi
+internal val Res.string.str_20028: StringResource
+  get() = String22.str_20028
+
+@ExperimentalResourceApi
+internal val Res.string.str_20029: StringResource
+  get() = String22.str_20029
+
+@ExperimentalResourceApi
+internal val Res.string.str_2003: StringResource
+  get() = String22.str_2003
+
+@ExperimentalResourceApi
+internal val Res.string.str_20030: StringResource
+  get() = String22.str_20030
+
+@ExperimentalResourceApi
+internal val Res.string.str_20031: StringResource
+  get() = String22.str_20031
+
+@ExperimentalResourceApi
+internal val Res.string.str_20032: StringResource
+  get() = String22.str_20032
+
+@ExperimentalResourceApi
+internal val Res.string.str_20033: StringResource
+  get() = String22.str_20033
+
+@ExperimentalResourceApi
+internal val Res.string.str_20034: StringResource
+  get() = String22.str_20034
+
+@ExperimentalResourceApi
+internal val Res.string.str_20035: StringResource
+  get() = String22.str_20035
+
+@ExperimentalResourceApi
+internal val Res.string.str_20036: StringResource
+  get() = String22.str_20036
+
+@ExperimentalResourceApi
+internal val Res.string.str_20037: StringResource
+  get() = String22.str_20037
+
+@ExperimentalResourceApi
+internal val Res.string.str_20038: StringResource
+  get() = String22.str_20038
+
+@ExperimentalResourceApi
+internal val Res.string.str_20039: StringResource
+  get() = String22.str_20039
+
+@ExperimentalResourceApi
+internal val Res.string.str_2004: StringResource
+  get() = String22.str_2004
+
+@ExperimentalResourceApi
+internal val Res.string.str_20040: StringResource
+  get() = String22.str_20040
+
+@ExperimentalResourceApi
+internal val Res.string.str_20041: StringResource
+  get() = String22.str_20041
+
+@ExperimentalResourceApi
+internal val Res.string.str_20042: StringResource
+  get() = String22.str_20042
+
+@ExperimentalResourceApi
+internal val Res.string.str_20043: StringResource
+  get() = String22.str_20043
+
+@ExperimentalResourceApi
+internal val Res.string.str_20044: StringResource
+  get() = String22.str_20044
+
+@ExperimentalResourceApi
+internal val Res.string.str_20045: StringResource
+  get() = String22.str_20045
+
+@ExperimentalResourceApi
+internal val Res.string.str_20046: StringResource
+  get() = String22.str_20046
+
+@ExperimentalResourceApi
+internal val Res.string.str_20047: StringResource
+  get() = String22.str_20047
+
+@ExperimentalResourceApi
+internal val Res.string.str_20048: StringResource
+  get() = String22.str_20048
+
+@ExperimentalResourceApi
+internal val Res.string.str_20049: StringResource
+  get() = String22.str_20049
+
+@ExperimentalResourceApi
+internal val Res.string.str_2005: StringResource
+  get() = String22.str_2005
+
+@ExperimentalResourceApi
+internal val Res.string.str_20050: StringResource
+  get() = String22.str_20050
+
+@ExperimentalResourceApi
+internal val Res.string.str_20051: StringResource
+  get() = String22.str_20051
+
+@ExperimentalResourceApi
+internal val Res.string.str_20052: StringResource
+  get() = String22.str_20052
+
+@ExperimentalResourceApi
+internal val Res.string.str_20053: StringResource
+  get() = String22.str_20053
+
+@ExperimentalResourceApi
+internal val Res.string.str_20054: StringResource
+  get() = String22.str_20054
+
+@ExperimentalResourceApi
+internal val Res.string.str_20055: StringResource
+  get() = String22.str_20055
+
+@ExperimentalResourceApi
+internal val Res.string.str_20056: StringResource
+  get() = String22.str_20056
+
+@ExperimentalResourceApi
+internal val Res.string.str_20057: StringResource
+  get() = String22.str_20057
+
+@ExperimentalResourceApi
+internal val Res.string.str_20058: StringResource
+  get() = String22.str_20058
+
+@ExperimentalResourceApi
+internal val Res.string.str_20059: StringResource
+  get() = String22.str_20059
+
+@ExperimentalResourceApi
+internal val Res.string.str_2006: StringResource
+  get() = String22.str_2006
+
+@ExperimentalResourceApi
+internal val Res.string.str_20060: StringResource
+  get() = String22.str_20060
+
+@ExperimentalResourceApi
+internal val Res.string.str_20061: StringResource
+  get() = String22.str_20061
+
+@ExperimentalResourceApi
+internal val Res.string.str_20062: StringResource
+  get() = String22.str_20062
+
+@ExperimentalResourceApi
+internal val Res.string.str_20063: StringResource
+  get() = String22.str_20063
+
+@ExperimentalResourceApi
+internal val Res.string.str_20064: StringResource
+  get() = String22.str_20064
+
+@ExperimentalResourceApi
+internal val Res.string.str_20065: StringResource
+  get() = String22.str_20065
+
+@ExperimentalResourceApi
+internal val Res.string.str_20066: StringResource
+  get() = String22.str_20066
+
+@ExperimentalResourceApi
+internal val Res.string.str_20067: StringResource
+  get() = String22.str_20067
+
+@ExperimentalResourceApi
+internal val Res.string.str_20068: StringResource
+  get() = String22.str_20068
+
+@ExperimentalResourceApi
+internal val Res.string.str_20069: StringResource
+  get() = String22.str_20069
+
+@ExperimentalResourceApi
+internal val Res.string.str_2007: StringResource
+  get() = String22.str_2007
+
+@ExperimentalResourceApi
+internal val Res.string.str_20070: StringResource
+  get() = String22.str_20070
+
+@ExperimentalResourceApi
+internal val Res.string.str_20071: StringResource
+  get() = String22.str_20071
+
+@ExperimentalResourceApi
+internal val Res.string.str_20072: StringResource
+  get() = String22.str_20072
+
+@ExperimentalResourceApi
+internal val Res.string.str_20073: StringResource
+  get() = String22.str_20073
+
+@ExperimentalResourceApi
+internal val Res.string.str_20074: StringResource
+  get() = String22.str_20074
+
+@ExperimentalResourceApi
+internal val Res.string.str_20075: StringResource
+  get() = String22.str_20075
+
+@ExperimentalResourceApi
+internal val Res.string.str_20076: StringResource
+  get() = String22.str_20076
+
+@ExperimentalResourceApi
+internal val Res.string.str_20077: StringResource
+  get() = String22.str_20077
+
+@ExperimentalResourceApi
+internal val Res.string.str_20078: StringResource
+  get() = String22.str_20078
+
+@ExperimentalResourceApi
+internal val Res.string.str_20079: StringResource
+  get() = String22.str_20079
+
+@ExperimentalResourceApi
+internal val Res.string.str_2008: StringResource
+  get() = String22.str_2008
+
+@ExperimentalResourceApi
+internal val Res.string.str_20080: StringResource
+  get() = String22.str_20080
+
+@ExperimentalResourceApi
+internal val Res.string.str_20081: StringResource
+  get() = String22.str_20081
+
+@ExperimentalResourceApi
+internal val Res.string.str_20082: StringResource
+  get() = String22.str_20082
+
+@ExperimentalResourceApi
+internal val Res.string.str_20083: StringResource
+  get() = String22.str_20083
+
+@ExperimentalResourceApi
+internal val Res.string.str_20084: StringResource
+  get() = String22.str_20084
+
+@ExperimentalResourceApi
+internal val Res.string.str_20085: StringResource
+  get() = String22.str_20085
+
+@ExperimentalResourceApi
+internal val Res.string.str_20086: StringResource
+  get() = String22.str_20086
+
+@ExperimentalResourceApi
+internal val Res.string.str_20087: StringResource
+  get() = String22.str_20087
+
+@ExperimentalResourceApi
+internal val Res.string.str_20088: StringResource
+  get() = String22.str_20088
+
+@ExperimentalResourceApi
+internal val Res.string.str_20089: StringResource
+  get() = String22.str_20089
+
+@ExperimentalResourceApi
+internal val Res.string.str_2009: StringResource
+  get() = String22.str_2009
+
+@ExperimentalResourceApi
+internal val Res.string.str_20090: StringResource
+  get() = String22.str_20090
+
+@ExperimentalResourceApi
+internal val Res.string.str_20091: StringResource
+  get() = String22.str_20091
+
+@ExperimentalResourceApi
+internal val Res.string.str_20092: StringResource
+  get() = String22.str_20092
+
+@ExperimentalResourceApi
+internal val Res.string.str_20093: StringResource
+  get() = String22.str_20093
+
+@ExperimentalResourceApi
+internal val Res.string.str_20094: StringResource
+  get() = String22.str_20094
+
+@ExperimentalResourceApi
+internal val Res.string.str_20095: StringResource
+  get() = String22.str_20095
+
+@ExperimentalResourceApi
+internal val Res.string.str_20096: StringResource
+  get() = String22.str_20096
+
+@ExperimentalResourceApi
+internal val Res.string.str_20097: StringResource
+  get() = String22.str_20097
+
+@ExperimentalResourceApi
+internal val Res.string.str_20098: StringResource
+  get() = String22.str_20098
+
+@ExperimentalResourceApi
+internal val Res.string.str_20099: StringResource
+  get() = String22.str_20099
+
+@ExperimentalResourceApi
+internal val Res.string.str_201: StringResource
+  get() = String22.str_201
+
+@ExperimentalResourceApi
+internal val Res.string.str_2010: StringResource
+  get() = String22.str_2010
+
+@ExperimentalResourceApi
+internal val Res.string.str_20100: StringResource
+  get() = String22.str_20100
+
+@ExperimentalResourceApi
+internal val Res.string.str_20101: StringResource
+  get() = String22.str_20101
+
+@ExperimentalResourceApi
+internal val Res.string.str_20102: StringResource
+  get() = String22.str_20102
+
+@ExperimentalResourceApi
+internal val Res.string.str_20103: StringResource
+  get() = String22.str_20103
+
+@ExperimentalResourceApi
+internal val Res.string.str_20104: StringResource
+  get() = String22.str_20104
+
+@ExperimentalResourceApi
+internal val Res.string.str_20105: StringResource
+  get() = String22.str_20105
+
+@ExperimentalResourceApi
+internal val Res.string.str_20106: StringResource
+  get() = String22.str_20106
+
+@ExperimentalResourceApi
+internal val Res.string.str_20107: StringResource
+  get() = String22.str_20107
+
+@ExperimentalResourceApi
+internal val Res.string.str_20108: StringResource
+  get() = String22.str_20108
+
+@ExperimentalResourceApi
+internal val Res.string.str_20109: StringResource
+  get() = String22.str_20109
+
+@ExperimentalResourceApi
+internal val Res.string.str_2011: StringResource
+  get() = String22.str_2011
+
+@ExperimentalResourceApi
+internal val Res.string.str_20110: StringResource
+  get() = String22.str_20110
+
+@ExperimentalResourceApi
+internal val Res.string.str_20111: StringResource
+  get() = String22.str_20111
+
+@ExperimentalResourceApi
+internal val Res.string.str_20112: StringResource
+  get() = String22.str_20112
+
+@ExperimentalResourceApi
+internal val Res.string.str_20113: StringResource
+  get() = String22.str_20113
+
+@ExperimentalResourceApi
+internal val Res.string.str_20114: StringResource
+  get() = String22.str_20114
+
+@ExperimentalResourceApi
+internal val Res.string.str_20115: StringResource
+  get() = String22.str_20115
+
+@ExperimentalResourceApi
+internal val Res.string.str_20116: StringResource
+  get() = String22.str_20116
+
+@ExperimentalResourceApi
+internal val Res.string.str_20117: StringResource
+  get() = String22.str_20117
+
+@ExperimentalResourceApi
+internal val Res.string.str_20118: StringResource
+  get() = String22.str_20118
+
+@ExperimentalResourceApi
+internal val Res.string.str_20119: StringResource
+  get() = String22.str_20119
+
+@ExperimentalResourceApi
+internal val Res.string.str_2012: StringResource
+  get() = String22.str_2012
+
+@ExperimentalResourceApi
+internal val Res.string.str_20120: StringResource
+  get() = String22.str_20120
+
+@ExperimentalResourceApi
+internal val Res.string.str_20121: StringResource
+  get() = String22.str_20121
+
+@ExperimentalResourceApi
+internal val Res.string.str_20122: StringResource
+  get() = String22.str_20122
+
+@ExperimentalResourceApi
+internal val Res.string.str_20123: StringResource
+  get() = String22.str_20123
+
+@ExperimentalResourceApi
+internal val Res.string.str_20124: StringResource
+  get() = String22.str_20124
+
+@ExperimentalResourceApi
+internal val Res.string.str_20125: StringResource
+  get() = String22.str_20125
+
+@ExperimentalResourceApi
+internal val Res.string.str_20126: StringResource
+  get() = String22.str_20126
+
+@ExperimentalResourceApi
+internal val Res.string.str_20127: StringResource
+  get() = String22.str_20127
+
+@ExperimentalResourceApi
+internal val Res.string.str_20128: StringResource
+  get() = String22.str_20128
+
+@ExperimentalResourceApi
+internal val Res.string.str_20129: StringResource
+  get() = String22.str_20129
+
+@ExperimentalResourceApi
+internal val Res.string.str_2013: StringResource
+  get() = String22.str_2013
+
+@ExperimentalResourceApi
+internal val Res.string.str_20130: StringResource
+  get() = String22.str_20130
+
+@ExperimentalResourceApi
+internal val Res.string.str_20131: StringResource
+  get() = String22.str_20131
+
+@ExperimentalResourceApi
+internal val Res.string.str_20132: StringResource
+  get() = String22.str_20132
+
+@ExperimentalResourceApi
+internal val Res.string.str_20133: StringResource
+  get() = String22.str_20133
+
+@ExperimentalResourceApi
+internal val Res.string.str_20134: StringResource
+  get() = String22.str_20134
+
+@ExperimentalResourceApi
+internal val Res.string.str_20135: StringResource
+  get() = String22.str_20135
+
+@ExperimentalResourceApi
+internal val Res.string.str_20136: StringResource
+  get() = String22.str_20136
+
+@ExperimentalResourceApi
+internal val Res.string.str_20137: StringResource
+  get() = String22.str_20137
+
+@ExperimentalResourceApi
+internal val Res.string.str_20138: StringResource
+  get() = String22.str_20138
+
+@ExperimentalResourceApi
+internal val Res.string.str_20139: StringResource
+  get() = String22.str_20139
+
+@ExperimentalResourceApi
+internal val Res.string.str_2014: StringResource
+  get() = String22.str_2014
+
+@ExperimentalResourceApi
+internal val Res.string.str_20140: StringResource
+  get() = String22.str_20140
+
+@ExperimentalResourceApi
+internal val Res.string.str_20141: StringResource
+  get() = String22.str_20141
+
+@ExperimentalResourceApi
+internal val Res.string.str_20142: StringResource
+  get() = String22.str_20142
+
+@ExperimentalResourceApi
+internal val Res.string.str_20143: StringResource
+  get() = String22.str_20143
+
+@ExperimentalResourceApi
+internal val Res.string.str_20144: StringResource
+  get() = String22.str_20144
+
+@ExperimentalResourceApi
+internal val Res.string.str_20145: StringResource
+  get() = String22.str_20145
+
+@ExperimentalResourceApi
+internal val Res.string.str_20146: StringResource
+  get() = String22.str_20146
+
+@ExperimentalResourceApi
+internal val Res.string.str_20147: StringResource
+  get() = String22.str_20147
+
+@ExperimentalResourceApi
+internal val Res.string.str_20148: StringResource
+  get() = String22.str_20148
+
+@ExperimentalResourceApi
+internal val Res.string.str_20149: StringResource
+  get() = String22.str_20149
+
+@ExperimentalResourceApi
+internal val Res.string.str_2015: StringResource
+  get() = String22.str_2015
+
+@ExperimentalResourceApi
+internal val Res.string.str_20150: StringResource
+  get() = String22.str_20150
+
+@ExperimentalResourceApi
+internal val Res.string.str_20151: StringResource
+  get() = String22.str_20151
+
+@ExperimentalResourceApi
+internal val Res.string.str_20152: StringResource
+  get() = String22.str_20152
+
+@ExperimentalResourceApi
+internal val Res.string.str_20153: StringResource
+  get() = String22.str_20153
+
+@ExperimentalResourceApi
+internal val Res.string.str_20154: StringResource
+  get() = String22.str_20154
+
+@ExperimentalResourceApi
+internal val Res.string.str_20155: StringResource
+  get() = String22.str_20155
+
+@ExperimentalResourceApi
+internal val Res.string.str_20156: StringResource
+  get() = String22.str_20156
+
+@ExperimentalResourceApi
+internal val Res.string.str_20157: StringResource
+  get() = String22.str_20157
+
+@ExperimentalResourceApi
+internal val Res.string.str_20158: StringResource
+  get() = String22.str_20158
+
+@ExperimentalResourceApi
+internal val Res.string.str_20159: StringResource
+  get() = String22.str_20159
+
+@ExperimentalResourceApi
+internal val Res.string.str_2016: StringResource
+  get() = String22.str_2016
+
+@ExperimentalResourceApi
+internal val Res.string.str_20160: StringResource
+  get() = String22.str_20160
+
+@ExperimentalResourceApi
+internal val Res.string.str_20161: StringResource
+  get() = String22.str_20161
+
+@ExperimentalResourceApi
+internal val Res.string.str_20162: StringResource
+  get() = String22.str_20162
+
+@ExperimentalResourceApi
+internal val Res.string.str_20163: StringResource
+  get() = String22.str_20163
+
+@ExperimentalResourceApi
+internal val Res.string.str_20164: StringResource
+  get() = String22.str_20164
+
+@ExperimentalResourceApi
+internal val Res.string.str_20165: StringResource
+  get() = String22.str_20165
+
+@ExperimentalResourceApi
+internal val Res.string.str_20166: StringResource
+  get() = String22.str_20166
+
+@ExperimentalResourceApi
+internal val Res.string.str_20167: StringResource
+  get() = String22.str_20167
+
+@ExperimentalResourceApi
+internal val Res.string.str_20168: StringResource
+  get() = String22.str_20168
+
+@ExperimentalResourceApi
+internal val Res.string.str_20169: StringResource
+  get() = String22.str_20169
+
+@ExperimentalResourceApi
+internal val Res.string.str_2017: StringResource
+  get() = String22.str_2017
+
+@ExperimentalResourceApi
+internal val Res.string.str_20170: StringResource
+  get() = String22.str_20170
+
+@ExperimentalResourceApi
+internal val Res.string.str_20171: StringResource
+  get() = String22.str_20171
+
+@ExperimentalResourceApi
+internal val Res.string.str_20172: StringResource
+  get() = String22.str_20172
+
+@ExperimentalResourceApi
+internal val Res.string.str_20173: StringResource
+  get() = String22.str_20173
+
+@ExperimentalResourceApi
+internal val Res.string.str_20174: StringResource
+  get() = String22.str_20174
+
+@ExperimentalResourceApi
+internal val Res.string.str_20175: StringResource
+  get() = String22.str_20175
+
+@ExperimentalResourceApi
+internal val Res.string.str_20176: StringResource
+  get() = String22.str_20176
+
+@ExperimentalResourceApi
+internal val Res.string.str_20177: StringResource
+  get() = String22.str_20177
+
+@ExperimentalResourceApi
+internal val Res.string.str_20178: StringResource
+  get() = String22.str_20178
+
+@ExperimentalResourceApi
+internal val Res.string.str_20179: StringResource
+  get() = String22.str_20179
+
+@ExperimentalResourceApi
+internal val Res.string.str_2018: StringResource
+  get() = String22.str_2018
+
+@ExperimentalResourceApi
+internal val Res.string.str_20180: StringResource
+  get() = String22.str_20180
+
+@ExperimentalResourceApi
+internal val Res.string.str_20181: StringResource
+  get() = String22.str_20181
+
+@ExperimentalResourceApi
+internal val Res.string.str_20182: StringResource
+  get() = String22.str_20182
+
+@ExperimentalResourceApi
+internal val Res.string.str_20183: StringResource
+  get() = String22.str_20183
+
+@ExperimentalResourceApi
+internal val Res.string.str_20184: StringResource
+  get() = String22.str_20184
+
+@ExperimentalResourceApi
+internal val Res.string.str_20185: StringResource
+  get() = String22.str_20185
+
+@ExperimentalResourceApi
+internal val Res.string.str_20186: StringResource
+  get() = String22.str_20186
+
+@ExperimentalResourceApi
+internal val Res.string.str_20187: StringResource
+  get() = String22.str_20187
+
+@ExperimentalResourceApi
+internal val Res.string.str_20188: StringResource
+  get() = String22.str_20188
+
+@ExperimentalResourceApi
+internal val Res.string.str_20189: StringResource
+  get() = String22.str_20189
+
+@ExperimentalResourceApi
+internal val Res.string.str_2019: StringResource
+  get() = String22.str_2019
+
+@ExperimentalResourceApi
+internal val Res.string.str_20190: StringResource
+  get() = String22.str_20190
+
+@ExperimentalResourceApi
+internal val Res.string.str_20191: StringResource
+  get() = String22.str_20191
+
+@ExperimentalResourceApi
+internal val Res.string.str_20192: StringResource
+  get() = String22.str_20192
+
+@ExperimentalResourceApi
+internal val Res.string.str_20193: StringResource
+  get() = String22.str_20193
+
+@ExperimentalResourceApi
+internal val Res.string.str_20194: StringResource
+  get() = String22.str_20194
+
+@ExperimentalResourceApi
+internal val Res.string.str_20195: StringResource
+  get() = String22.str_20195
+
+@ExperimentalResourceApi
+internal val Res.string.str_20196: StringResource
+  get() = String22.str_20196
+
+@ExperimentalResourceApi
+internal val Res.string.str_20197: StringResource
+  get() = String22.str_20197
+
+@ExperimentalResourceApi
+internal val Res.string.str_20198: StringResource
+  get() = String22.str_20198
+
+@ExperimentalResourceApi
+internal val Res.string.str_20199: StringResource
+  get() = String22.str_20199
+
+@ExperimentalResourceApi
+internal val Res.string.str_202: StringResource
+  get() = String22.str_202
+
+@ExperimentalResourceApi
+internal val Res.string.str_2020: StringResource
+  get() = String22.str_2020
+
+@ExperimentalResourceApi
+internal val Res.string.str_20200: StringResource
+  get() = String22.str_20200
+
+@ExperimentalResourceApi
+internal val Res.string.str_20201: StringResource
+  get() = String22.str_20201
+
+@ExperimentalResourceApi
+internal val Res.string.str_20202: StringResource
+  get() = String22.str_20202
+
+@ExperimentalResourceApi
+internal val Res.string.str_20203: StringResource
+  get() = String22.str_20203
+
+@ExperimentalResourceApi
+internal val Res.string.str_20204: StringResource
+  get() = String22.str_20204
+
+@ExperimentalResourceApi
+internal val Res.string.str_20205: StringResource
+  get() = String22.str_20205
+
+@ExperimentalResourceApi
+internal val Res.string.str_20206: StringResource
+  get() = String22.str_20206
+
+@ExperimentalResourceApi
+internal val Res.string.str_20207: StringResource
+  get() = String22.str_20207
+
+@ExperimentalResourceApi
+internal val Res.string.str_20208: StringResource
+  get() = String22.str_20208
+
+@ExperimentalResourceApi
+internal val Res.string.str_20209: StringResource
+  get() = String22.str_20209
+
+@ExperimentalResourceApi
+internal val Res.string.str_2021: StringResource
+  get() = String22.str_2021
+
+@ExperimentalResourceApi
+internal val Res.string.str_20210: StringResource
+  get() = String22.str_20210
+
+@ExperimentalResourceApi
+internal val Res.string.str_20211: StringResource
+  get() = String22.str_20211
+
+@ExperimentalResourceApi
+internal val Res.string.str_20212: StringResource
+  get() = String22.str_20212
+
+@ExperimentalResourceApi
+internal val Res.string.str_20213: StringResource
+  get() = String22.str_20213
+
+@ExperimentalResourceApi
+internal val Res.string.str_20214: StringResource
+  get() = String22.str_20214
+
+@ExperimentalResourceApi
+internal val Res.string.str_20215: StringResource
+  get() = String22.str_20215
+
+@ExperimentalResourceApi
+internal val Res.string.str_20216: StringResource
+  get() = String22.str_20216
+
+@ExperimentalResourceApi
+internal val Res.string.str_20217: StringResource
+  get() = String22.str_20217
+
+@ExperimentalResourceApi
+internal val Res.string.str_20218: StringResource
+  get() = String22.str_20218
+
+@ExperimentalResourceApi
+internal val Res.string.str_20219: StringResource
+  get() = String22.str_20219
+
+@ExperimentalResourceApi
+internal val Res.string.str_2022: StringResource
+  get() = String22.str_2022
+
+@ExperimentalResourceApi
+internal val Res.string.str_20220: StringResource
+  get() = String22.str_20220
+
+@ExperimentalResourceApi
+internal val Res.string.str_20221: StringResource
+  get() = String22.str_20221
+
+@ExperimentalResourceApi
+internal val Res.string.str_20222: StringResource
+  get() = String22.str_20222
+
+@ExperimentalResourceApi
+internal val Res.string.str_20223: StringResource
+  get() = String22.str_20223
+
+@ExperimentalResourceApi
+internal val Res.string.str_20224: StringResource
+  get() = String22.str_20224
+
+@ExperimentalResourceApi
+internal val Res.string.str_20225: StringResource
+  get() = String22.str_20225
+
+@ExperimentalResourceApi
+internal val Res.string.str_20226: StringResource
+  get() = String22.str_20226
+
+@ExperimentalResourceApi
+internal val Res.string.str_20227: StringResource
+  get() = String22.str_20227
+
+@ExperimentalResourceApi
+internal val Res.string.str_20228: StringResource
+  get() = String22.str_20228
+
+@ExperimentalResourceApi
+internal val Res.string.str_20229: StringResource
+  get() = String22.str_20229
+
+@ExperimentalResourceApi
+internal val Res.string.str_2023: StringResource
+  get() = String22.str_2023
+
+@ExperimentalResourceApi
+internal val Res.string.str_20230: StringResource
+  get() = String22.str_20230
+
+@ExperimentalResourceApi
+internal val Res.string.str_20231: StringResource
+  get() = String22.str_20231
+
+@ExperimentalResourceApi
+internal val Res.string.str_20232: StringResource
+  get() = String22.str_20232
+
+@ExperimentalResourceApi
+internal val Res.string.str_20233: StringResource
+  get() = String22.str_20233
+
+@ExperimentalResourceApi
+internal val Res.string.str_20234: StringResource
+  get() = String22.str_20234
+
+@ExperimentalResourceApi
+internal val Res.string.str_20235: StringResource
+  get() = String22.str_20235
+
+@ExperimentalResourceApi
+internal val Res.string.str_20236: StringResource
+  get() = String22.str_20236
+
+@ExperimentalResourceApi
+internal val Res.string.str_20237: StringResource
+  get() = String22.str_20237
+
+@ExperimentalResourceApi
+internal val Res.string.str_20238: StringResource
+  get() = String22.str_20238
+
+@ExperimentalResourceApi
+internal val Res.string.str_20239: StringResource
+  get() = String22.str_20239
+
+@ExperimentalResourceApi
+internal val Res.string.str_2024: StringResource
+  get() = String22.str_2024
+
+@ExperimentalResourceApi
+internal val Res.string.str_20240: StringResource
+  get() = String22.str_20240
+
+@ExperimentalResourceApi
+internal val Res.string.str_20241: StringResource
+  get() = String22.str_20241
+
+@ExperimentalResourceApi
+internal val Res.string.str_20242: StringResource
+  get() = String22.str_20242
+
+@ExperimentalResourceApi
+internal val Res.string.str_20243: StringResource
+  get() = String22.str_20243
+
+@ExperimentalResourceApi
+internal val Res.string.str_20244: StringResource
+  get() = String22.str_20244
+
+@ExperimentalResourceApi
+internal val Res.string.str_20245: StringResource
+  get() = String22.str_20245
+
+@ExperimentalResourceApi
+internal val Res.string.str_20246: StringResource
+  get() = String22.str_20246
+
+@ExperimentalResourceApi
+internal val Res.string.str_20247: StringResource
+  get() = String22.str_20247
+
+@ExperimentalResourceApi
+internal val Res.string.str_20248: StringResource
+  get() = String22.str_20248
+
+@ExperimentalResourceApi
+internal val Res.string.str_20249: StringResource
+  get() = String22.str_20249
+
+@ExperimentalResourceApi
+internal val Res.string.str_2025: StringResource
+  get() = String22.str_2025
+
+@ExperimentalResourceApi
+internal val Res.string.str_20250: StringResource
+  get() = String22.str_20250
+
+@ExperimentalResourceApi
+internal val Res.string.str_20251: StringResource
+  get() = String22.str_20251
+
+@ExperimentalResourceApi
+internal val Res.string.str_20252: StringResource
+  get() = String22.str_20252
+
+@ExperimentalResourceApi
+internal val Res.string.str_20253: StringResource
+  get() = String22.str_20253
+
+@ExperimentalResourceApi
+internal val Res.string.str_20254: StringResource
+  get() = String22.str_20254
+
+@ExperimentalResourceApi
+internal val Res.string.str_20255: StringResource
+  get() = String22.str_20255
+
+@ExperimentalResourceApi
+internal val Res.string.str_20256: StringResource
+  get() = String22.str_20256
+
+@ExperimentalResourceApi
+internal val Res.string.str_20257: StringResource
+  get() = String22.str_20257
+
+@ExperimentalResourceApi
+internal val Res.string.str_20258: StringResource
+  get() = String22.str_20258
+
+@ExperimentalResourceApi
+internal val Res.string.str_20259: StringResource
+  get() = String22.str_20259
+
+@ExperimentalResourceApi
+internal val Res.string.str_2026: StringResource
+  get() = String22.str_2026
+
+@ExperimentalResourceApi
+internal val Res.string.str_20260: StringResource
+  get() = String22.str_20260
+
+@ExperimentalResourceApi
+internal val Res.string.str_20261: StringResource
+  get() = String22.str_20261
+
+@ExperimentalResourceApi
+internal val Res.string.str_20262: StringResource
+  get() = String22.str_20262
+
+@ExperimentalResourceApi
+internal val Res.string.str_20263: StringResource
+  get() = String22.str_20263
+
+@ExperimentalResourceApi
+internal val Res.string.str_20264: StringResource
+  get() = String22.str_20264
+
+@ExperimentalResourceApi
+internal val Res.string.str_20265: StringResource
+  get() = String22.str_20265
+
+@ExperimentalResourceApi
+internal val Res.string.str_20266: StringResource
+  get() = String22.str_20266
+
+@ExperimentalResourceApi
+internal val Res.string.str_20267: StringResource
+  get() = String22.str_20267
+
+@ExperimentalResourceApi
+internal val Res.string.str_20268: StringResource
+  get() = String22.str_20268
+
+@ExperimentalResourceApi
+internal val Res.string.str_20269: StringResource
+  get() = String22.str_20269
+
+@ExperimentalResourceApi
+internal val Res.string.str_2027: StringResource
+  get() = String22.str_2027
+
+@ExperimentalResourceApi
+internal val Res.string.str_20270: StringResource
+  get() = String22.str_20270
+
+@ExperimentalResourceApi
+internal val Res.string.str_20271: StringResource
+  get() = String22.str_20271
+
+@ExperimentalResourceApi
+internal val Res.string.str_20272: StringResource
+  get() = String22.str_20272
+
+@ExperimentalResourceApi
+internal val Res.string.str_20273: StringResource
+  get() = String22.str_20273
+
+@ExperimentalResourceApi
+internal val Res.string.str_20274: StringResource
+  get() = String22.str_20274
+
+@ExperimentalResourceApi
+internal val Res.string.str_20275: StringResource
+  get() = String22.str_20275
+
+@ExperimentalResourceApi
+internal val Res.string.str_20276: StringResource
+  get() = String22.str_20276
+
+@ExperimentalResourceApi
+internal val Res.string.str_20277: StringResource
+  get() = String22.str_20277
+
+@ExperimentalResourceApi
+internal val Res.string.str_20278: StringResource
+  get() = String22.str_20278
+
+@ExperimentalResourceApi
+internal val Res.string.str_20279: StringResource
+  get() = String22.str_20279
+
+@ExperimentalResourceApi
+internal val Res.string.str_2028: StringResource
+  get() = String22.str_2028
+
+@ExperimentalResourceApi
+internal val Res.string.str_20280: StringResource
+  get() = String22.str_20280
+
+@ExperimentalResourceApi
+internal val Res.string.str_20281: StringResource
+  get() = String22.str_20281
+
+@ExperimentalResourceApi
+internal val Res.string.str_20282: StringResource
+  get() = String22.str_20282
+
+@ExperimentalResourceApi
+internal val Res.string.str_20283: StringResource
+  get() = String22.str_20283
+
+@ExperimentalResourceApi
+internal val Res.string.str_20284: StringResource
+  get() = String22.str_20284
+
+@ExperimentalResourceApi
+internal val Res.string.str_20285: StringResource
+  get() = String22.str_20285
+
+@ExperimentalResourceApi
+internal val Res.string.str_20286: StringResource
+  get() = String22.str_20286
+
+@ExperimentalResourceApi
+internal val Res.string.str_20287: StringResource
+  get() = String22.str_20287
+
+@ExperimentalResourceApi
+internal val Res.string.str_20288: StringResource
+  get() = String22.str_20288
+
+@ExperimentalResourceApi
+internal val Res.string.str_20289: StringResource
+  get() = String22.str_20289
+
+@ExperimentalResourceApi
+internal val Res.string.str_2029: StringResource
+  get() = String22.str_2029
+
+@ExperimentalResourceApi
+internal val Res.string.str_20290: StringResource
+  get() = String22.str_20290
+
+@ExperimentalResourceApi
+internal val Res.string.str_20291: StringResource
+  get() = String22.str_20291
+
+@ExperimentalResourceApi
+internal val Res.string.str_20292: StringResource
+  get() = String22.str_20292
+
+@ExperimentalResourceApi
+internal val Res.string.str_20293: StringResource
+  get() = String22.str_20293
+
+@ExperimentalResourceApi
+internal val Res.string.str_20294: StringResource
+  get() = String22.str_20294
+
+@ExperimentalResourceApi
+internal val Res.string.str_20295: StringResource
+  get() = String22.str_20295
+
+@ExperimentalResourceApi
+internal val Res.string.str_20296: StringResource
+  get() = String22.str_20296
+
+@ExperimentalResourceApi
+internal val Res.string.str_20297: StringResource
+  get() = String22.str_20297
+
+@ExperimentalResourceApi
+internal val Res.string.str_20298: StringResource
+  get() = String22.str_20298
+
+@ExperimentalResourceApi
+internal val Res.string.str_20299: StringResource
+  get() = String22.str_20299
+
+@ExperimentalResourceApi
+internal val Res.string.str_203: StringResource
+  get() = String22.str_203
+
+@ExperimentalResourceApi
+internal val Res.string.str_2030: StringResource
+  get() = String22.str_2030
+
+@ExperimentalResourceApi
+internal val Res.string.str_20300: StringResource
+  get() = String22.str_20300
+
+@ExperimentalResourceApi
+internal val Res.string.str_20301: StringResource
+  get() = String22.str_20301
+
+@ExperimentalResourceApi
+internal val Res.string.str_20302: StringResource
+  get() = String22.str_20302
+
+@ExperimentalResourceApi
+internal val Res.string.str_20303: StringResource
+  get() = String22.str_20303
+
+@ExperimentalResourceApi
+internal val Res.string.str_20304: StringResource
+  get() = String22.str_20304
+
+@ExperimentalResourceApi
+internal val Res.string.str_20305: StringResource
+  get() = String22.str_20305
+
+@ExperimentalResourceApi
+internal val Res.string.str_20306: StringResource
+  get() = String22.str_20306
+
+@ExperimentalResourceApi
+internal val Res.string.str_20307: StringResource
+  get() = String22.str_20307
+
+@ExperimentalResourceApi
+internal val Res.string.str_20308: StringResource
+  get() = String22.str_20308
+
+@ExperimentalResourceApi
+internal val Res.string.str_20309: StringResource
+  get() = String22.str_20309
+
+@ExperimentalResourceApi
+internal val Res.string.str_2031: StringResource
+  get() = String22.str_2031
+
+@ExperimentalResourceApi
+internal val Res.string.str_20310: StringResource
+  get() = String22.str_20310
+
+@ExperimentalResourceApi
+internal val Res.string.str_20311: StringResource
+  get() = String22.str_20311
+
+@ExperimentalResourceApi
+internal val Res.string.str_20312: StringResource
+  get() = String22.str_20312
+
+@ExperimentalResourceApi
+internal val Res.string.str_20313: StringResource
+  get() = String22.str_20313
+
+@ExperimentalResourceApi
+internal val Res.string.str_20314: StringResource
+  get() = String22.str_20314
+
+@ExperimentalResourceApi
+internal val Res.string.str_20315: StringResource
+  get() = String22.str_20315
+
+@ExperimentalResourceApi
+internal val Res.string.str_20316: StringResource
+  get() = String22.str_20316
+
+@ExperimentalResourceApi
+internal val Res.string.str_20317: StringResource
+  get() = String22.str_20317
+
+@ExperimentalResourceApi
+internal val Res.string.str_20318: StringResource
+  get() = String22.str_20318
+
+@ExperimentalResourceApi
+internal val Res.string.str_20319: StringResource
+  get() = String22.str_20319
+
+@ExperimentalResourceApi
+internal val Res.string.str_2032: StringResource
+  get() = String22.str_2032
+
+@ExperimentalResourceApi
+internal val Res.string.str_20320: StringResource
+  get() = String22.str_20320
+
+@ExperimentalResourceApi
+internal val Res.string.str_20321: StringResource
+  get() = String22.str_20321
+
+@ExperimentalResourceApi
+internal val Res.string.str_20322: StringResource
+  get() = String22.str_20322
+
+@ExperimentalResourceApi
+internal val Res.string.str_20323: StringResource
+  get() = String22.str_20323
+
+@ExperimentalResourceApi
+internal val Res.string.str_20324: StringResource
+  get() = String22.str_20324
+
+@ExperimentalResourceApi
+internal val Res.string.str_20325: StringResource
+  get() = String22.str_20325
+
+@ExperimentalResourceApi
+internal val Res.string.str_20326: StringResource
+  get() = String22.str_20326
+
+@ExperimentalResourceApi
+internal val Res.string.str_20327: StringResource
+  get() = String22.str_20327
+
+@ExperimentalResourceApi
+internal val Res.string.str_20328: StringResource
+  get() = String22.str_20328
+
+@ExperimentalResourceApi
+internal val Res.string.str_20329: StringResource
+  get() = String22.str_20329
+
+@ExperimentalResourceApi
+internal val Res.string.str_2033: StringResource
+  get() = String22.str_2033
+
+@ExperimentalResourceApi
+internal val Res.string.str_20330: StringResource
+  get() = String22.str_20330
+
+@ExperimentalResourceApi
+internal val Res.string.str_20331: StringResource
+  get() = String22.str_20331
+
+@ExperimentalResourceApi
+internal val Res.string.str_20332: StringResource
+  get() = String22.str_20332
+
+@ExperimentalResourceApi
+internal val Res.string.str_20333: StringResource
+  get() = String22.str_20333
+
+@ExperimentalResourceApi
+internal val Res.string.str_20334: StringResource
+  get() = String22.str_20334
+
+@ExperimentalResourceApi
+internal val Res.string.str_20335: StringResource
+  get() = String22.str_20335
+
+@ExperimentalResourceApi
+internal val Res.string.str_20336: StringResource
+  get() = String22.str_20336
+
+@ExperimentalResourceApi
+internal val Res.string.str_20337: StringResource
+  get() = String22.str_20337
+
+@ExperimentalResourceApi
+internal val Res.string.str_20338: StringResource
+  get() = String22.str_20338
+
+@ExperimentalResourceApi
+internal val Res.string.str_20339: StringResource
+  get() = String22.str_20339
+
+@ExperimentalResourceApi
+internal val Res.string.str_2034: StringResource
+  get() = String22.str_2034
+
+@ExperimentalResourceApi
+internal val Res.string.str_20340: StringResource
+  get() = String22.str_20340
+
+@ExperimentalResourceApi
+internal val Res.string.str_20341: StringResource
+  get() = String22.str_20341
+
+@ExperimentalResourceApi
+internal val Res.string.str_20342: StringResource
+  get() = String22.str_20342
+
+@ExperimentalResourceApi
+internal val Res.string.str_20343: StringResource
+  get() = String22.str_20343
+
+@ExperimentalResourceApi
+internal val Res.string.str_20344: StringResource
+  get() = String22.str_20344
+
+@ExperimentalResourceApi
+internal val Res.string.str_20345: StringResource
+  get() = String22.str_20345
+
+@ExperimentalResourceApi
+internal val Res.string.str_20346: StringResource
+  get() = String22.str_20346

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String23.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String23.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String23 {
+  public val str_20347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20347", "str_20347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20348", "str_20348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20349", "str_20349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2035", "str_2035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20350", "str_20350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20351", "str_20351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20352", "str_20352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20353", "str_20353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20354", "str_20354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20355", "str_20355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20356", "str_20356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20357", "str_20357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20358", "str_20358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20359", "str_20359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2036", "str_2036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20360", "str_20360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20361", "str_20361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20362", "str_20362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20363", "str_20363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20364", "str_20364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20365", "str_20365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20366", "str_20366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20367", "str_20367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20368", "str_20368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20369", "str_20369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2037", "str_2037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20370", "str_20370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20371", "str_20371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20372", "str_20372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20373", "str_20373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20374", "str_20374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20375", "str_20375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20376", "str_20376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20377", "str_20377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20378", "str_20378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20379", "str_20379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2038", "str_2038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20380", "str_20380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20381", "str_20381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20382", "str_20382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20383", "str_20383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20384", "str_20384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20385", "str_20385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20386", "str_20386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20387", "str_20387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20388", "str_20388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20389", "str_20389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2039", "str_2039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20390", "str_20390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20391", "str_20391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20392", "str_20392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20393", "str_20393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20394", "str_20394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20395", "str_20395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20396", "str_20396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20397", "str_20397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20398", "str_20398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20399", "str_20399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_204", "str_204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2040", "str_2040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20400", "str_20400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20401", "str_20401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20402", "str_20402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20403", "str_20403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20404", "str_20404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20405", "str_20405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20406", "str_20406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20407", "str_20407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20408", "str_20408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20409", "str_20409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2041", "str_2041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20410", "str_20410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20411", "str_20411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20412", "str_20412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20413", "str_20413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20414", "str_20414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20415", "str_20415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20416", "str_20416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20417", "str_20417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20418", "str_20418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20419", "str_20419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2042", "str_2042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20420", "str_20420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20421", "str_20421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20422", "str_20422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20423", "str_20423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20424", "str_20424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20425", "str_20425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20426", "str_20426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20427", "str_20427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20428", "str_20428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20429", "str_20429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2043", "str_2043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20430", "str_20430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20431", "str_20431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20432", "str_20432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20433", "str_20433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20434", "str_20434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20435", "str_20435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20436", "str_20436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20437", "str_20437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20438", "str_20438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20439", "str_20439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2044", "str_2044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20440", "str_20440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20441", "str_20441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20442", "str_20442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20443", "str_20443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20444", "str_20444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20445", "str_20445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20446", "str_20446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20447", "str_20447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20448", "str_20448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20449", "str_20449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2045", "str_2045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20450", "str_20450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20451", "str_20451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20452", "str_20452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20453", "str_20453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20454", "str_20454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20455", "str_20455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20456", "str_20456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20457", "str_20457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20458", "str_20458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20459", "str_20459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2046", "str_2046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20460", "str_20460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20461", "str_20461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20462", "str_20462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20463", "str_20463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20464", "str_20464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20465", "str_20465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20466", "str_20466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20467", "str_20467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20468", "str_20468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20469", "str_20469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2047", "str_2047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20470", "str_20470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20471", "str_20471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20472", "str_20472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20473", "str_20473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20474", "str_20474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20475", "str_20475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20476", "str_20476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20477", "str_20477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20478", "str_20478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20479", "str_20479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2048", "str_2048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20480", "str_20480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20481", "str_20481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20482", "str_20482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20483", "str_20483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20484", "str_20484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20485", "str_20485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20486", "str_20486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20487", "str_20487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20488", "str_20488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20489", "str_20489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2049", "str_2049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20490", "str_20490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20491", "str_20491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20492", "str_20492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20493", "str_20493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20494", "str_20494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20495", "str_20495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20496", "str_20496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20497", "str_20497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20498", "str_20498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20499", "str_20499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_205", "str_205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2050", "str_2050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20500", "str_20500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20501", "str_20501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20502", "str_20502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20503", "str_20503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20504", "str_20504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20505", "str_20505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20506", "str_20506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20507", "str_20507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20508", "str_20508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20509", "str_20509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2051", "str_2051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20510", "str_20510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20511", "str_20511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20512", "str_20512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20513", "str_20513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20514", "str_20514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20515", "str_20515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20516", "str_20516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20517", "str_20517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20518", "str_20518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20519", "str_20519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2052", "str_2052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20520", "str_20520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20521", "str_20521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20522", "str_20522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20523", "str_20523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20524", "str_20524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20525", "str_20525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20526", "str_20526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20527", "str_20527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20528", "str_20528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20529", "str_20529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2053", "str_2053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20530", "str_20530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20531", "str_20531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20532", "str_20532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20533", "str_20533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20534", "str_20534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20535", "str_20535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20536", "str_20536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20537", "str_20537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20538", "str_20538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20539", "str_20539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2054", "str_2054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20540", "str_20540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20541", "str_20541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20542", "str_20542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20543", "str_20543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20544", "str_20544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20545", "str_20545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20546", "str_20546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20547", "str_20547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20548", "str_20548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20549", "str_20549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2055", "str_2055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20550", "str_20550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20551", "str_20551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20552", "str_20552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20553", "str_20553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20554", "str_20554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20555", "str_20555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20556", "str_20556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20557", "str_20557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20558", "str_20558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20559", "str_20559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2056", "str_2056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20560", "str_20560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20561", "str_20561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20562", "str_20562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20563", "str_20563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20564", "str_20564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20565", "str_20565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20566", "str_20566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20567", "str_20567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20568", "str_20568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20569", "str_20569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2057", "str_2057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20570", "str_20570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20571", "str_20571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20572", "str_20572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20573", "str_20573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20574", "str_20574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20575", "str_20575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20576", "str_20576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20577", "str_20577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20578", "str_20578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20579", "str_20579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2058", "str_2058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20580", "str_20580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20581", "str_20581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20582", "str_20582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20583", "str_20583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20584", "str_20584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20585", "str_20585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20586", "str_20586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20587", "str_20587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20588", "str_20588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20589", "str_20589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2059", "str_2059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20590", "str_20590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20591", "str_20591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20592", "str_20592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20593", "str_20593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20594", "str_20594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20595", "str_20595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20596", "str_20596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20597", "str_20597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20598", "str_20598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20599", "str_20599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_206", "str_206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2060", "str_2060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20600", "str_20600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20601", "str_20601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20602", "str_20602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20603", "str_20603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20604", "str_20604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20605", "str_20605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20606", "str_20606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20607", "str_20607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20608", "str_20608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20609", "str_20609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2061", "str_2061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20610", "str_20610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20611", "str_20611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20612", "str_20612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20613", "str_20613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20614", "str_20614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20615", "str_20615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20616", "str_20616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20617", "str_20617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20618", "str_20618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20619", "str_20619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2062", "str_2062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20620", "str_20620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20621", "str_20621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20622", "str_20622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20623", "str_20623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20624", "str_20624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20625", "str_20625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20626", "str_20626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20627", "str_20627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20628", "str_20628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20629", "str_20629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2063", "str_2063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20630", "str_20630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20631", "str_20631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20632", "str_20632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20633", "str_20633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20634", "str_20634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20635", "str_20635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20636", "str_20636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20637", "str_20637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20638", "str_20638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20639", "str_20639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2064", "str_2064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20640", "str_20640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20641", "str_20641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20642", "str_20642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20643", "str_20643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20644", "str_20644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20645", "str_20645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20646", "str_20646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20647", "str_20647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20648", "str_20648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20649", "str_20649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2065", "str_2065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20650", "str_20650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20651", "str_20651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20652", "str_20652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20653", "str_20653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20654", "str_20654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20655", "str_20655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20656", "str_20656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20657", "str_20657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20658", "str_20658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20659", "str_20659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2066", "str_2066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20660", "str_20660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20661", "str_20661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20662", "str_20662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20663", "str_20663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20664", "str_20664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20665", "str_20665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20666", "str_20666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20667", "str_20667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20668", "str_20668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20669", "str_20669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2067", "str_2067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20670", "str_20670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20671", "str_20671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20672", "str_20672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20673", "str_20673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20674", "str_20674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20675", "str_20675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20676", "str_20676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20677", "str_20677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20678", "str_20678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20679", "str_20679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2068", "str_2068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20680", "str_20680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20681", "str_20681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20682", "str_20682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20683", "str_20683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20684", "str_20684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20685", "str_20685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20686", "str_20686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20687", "str_20687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20688", "str_20688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20689", "str_20689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2069", "str_2069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20690", "str_20690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20691", "str_20691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20692", "str_20692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20693", "str_20693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20694", "str_20694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20695", "str_20695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20696", "str_20696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20697", "str_20697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20698", "str_20698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20699", "str_20699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_207", "str_207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2070", "str_2070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20700", "str_20700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20701", "str_20701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20702", "str_20702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20703", "str_20703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20704", "str_20704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20705", "str_20705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20706", "str_20706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20707", "str_20707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20708", "str_20708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20709", "str_20709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2071", "str_2071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20710", "str_20710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20711", "str_20711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20712", "str_20712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20713", "str_20713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20714", "str_20714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20715", "str_20715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20716", "str_20716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20717", "str_20717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20718", "str_20718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20719", "str_20719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2072", "str_2072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20720", "str_20720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20721", "str_20721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20722", "str_20722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20723", "str_20723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20724", "str_20724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20725", "str_20725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20726", "str_20726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20727", "str_20727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20728", "str_20728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20729", "str_20729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2073", "str_2073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20730", "str_20730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20731", "str_20731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20732", "str_20732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20733", "str_20733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20734", "str_20734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20735", "str_20735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20736", "str_20736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20737", "str_20737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20738", "str_20738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20739", "str_20739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2074", "str_2074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20740", "str_20740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20741", "str_20741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20742", "str_20742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20743", "str_20743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20744", "str_20744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20745", "str_20745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20746", "str_20746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20747", "str_20747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20748", "str_20748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20749", "str_20749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2075", "str_2075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20750", "str_20750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20751", "str_20751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20752", "str_20752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20753", "str_20753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20754", "str_20754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20755", "str_20755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20756", "str_20756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20757", "str_20757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20758", "str_20758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20759", "str_20759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2076", "str_2076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20760", "str_20760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20761", "str_20761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20762", "str_20762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20763", "str_20763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20764", "str_20764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20765", "str_20765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20766", "str_20766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20767", "str_20767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20768", "str_20768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20769", "str_20769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2077", "str_2077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20770", "str_20770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20771", "str_20771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20772", "str_20772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20773", "str_20773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20774", "str_20774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20775", "str_20775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20776", "str_20776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20777", "str_20777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20778", "str_20778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20779", "str_20779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2078", "str_2078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20780", "str_20780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20781", "str_20781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20782", "str_20782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20783", "str_20783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20784", "str_20784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20785", "str_20785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20786", "str_20786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20787", "str_20787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20788", "str_20788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20789", "str_20789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2079", "str_2079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20790", "str_20790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20791", "str_20791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20792", "str_20792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20793", "str_20793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20794", "str_20794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20795", "str_20795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20796", "str_20796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20797", "str_20797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_20347: StringResource
+  get() = String23.str_20347
+
+@ExperimentalResourceApi
+internal val Res.string.str_20348: StringResource
+  get() = String23.str_20348
+
+@ExperimentalResourceApi
+internal val Res.string.str_20349: StringResource
+  get() = String23.str_20349
+
+@ExperimentalResourceApi
+internal val Res.string.str_2035: StringResource
+  get() = String23.str_2035
+
+@ExperimentalResourceApi
+internal val Res.string.str_20350: StringResource
+  get() = String23.str_20350
+
+@ExperimentalResourceApi
+internal val Res.string.str_20351: StringResource
+  get() = String23.str_20351
+
+@ExperimentalResourceApi
+internal val Res.string.str_20352: StringResource
+  get() = String23.str_20352
+
+@ExperimentalResourceApi
+internal val Res.string.str_20353: StringResource
+  get() = String23.str_20353
+
+@ExperimentalResourceApi
+internal val Res.string.str_20354: StringResource
+  get() = String23.str_20354
+
+@ExperimentalResourceApi
+internal val Res.string.str_20355: StringResource
+  get() = String23.str_20355
+
+@ExperimentalResourceApi
+internal val Res.string.str_20356: StringResource
+  get() = String23.str_20356
+
+@ExperimentalResourceApi
+internal val Res.string.str_20357: StringResource
+  get() = String23.str_20357
+
+@ExperimentalResourceApi
+internal val Res.string.str_20358: StringResource
+  get() = String23.str_20358
+
+@ExperimentalResourceApi
+internal val Res.string.str_20359: StringResource
+  get() = String23.str_20359
+
+@ExperimentalResourceApi
+internal val Res.string.str_2036: StringResource
+  get() = String23.str_2036
+
+@ExperimentalResourceApi
+internal val Res.string.str_20360: StringResource
+  get() = String23.str_20360
+
+@ExperimentalResourceApi
+internal val Res.string.str_20361: StringResource
+  get() = String23.str_20361
+
+@ExperimentalResourceApi
+internal val Res.string.str_20362: StringResource
+  get() = String23.str_20362
+
+@ExperimentalResourceApi
+internal val Res.string.str_20363: StringResource
+  get() = String23.str_20363
+
+@ExperimentalResourceApi
+internal val Res.string.str_20364: StringResource
+  get() = String23.str_20364
+
+@ExperimentalResourceApi
+internal val Res.string.str_20365: StringResource
+  get() = String23.str_20365
+
+@ExperimentalResourceApi
+internal val Res.string.str_20366: StringResource
+  get() = String23.str_20366
+
+@ExperimentalResourceApi
+internal val Res.string.str_20367: StringResource
+  get() = String23.str_20367
+
+@ExperimentalResourceApi
+internal val Res.string.str_20368: StringResource
+  get() = String23.str_20368
+
+@ExperimentalResourceApi
+internal val Res.string.str_20369: StringResource
+  get() = String23.str_20369
+
+@ExperimentalResourceApi
+internal val Res.string.str_2037: StringResource
+  get() = String23.str_2037
+
+@ExperimentalResourceApi
+internal val Res.string.str_20370: StringResource
+  get() = String23.str_20370
+
+@ExperimentalResourceApi
+internal val Res.string.str_20371: StringResource
+  get() = String23.str_20371
+
+@ExperimentalResourceApi
+internal val Res.string.str_20372: StringResource
+  get() = String23.str_20372
+
+@ExperimentalResourceApi
+internal val Res.string.str_20373: StringResource
+  get() = String23.str_20373
+
+@ExperimentalResourceApi
+internal val Res.string.str_20374: StringResource
+  get() = String23.str_20374
+
+@ExperimentalResourceApi
+internal val Res.string.str_20375: StringResource
+  get() = String23.str_20375
+
+@ExperimentalResourceApi
+internal val Res.string.str_20376: StringResource
+  get() = String23.str_20376
+
+@ExperimentalResourceApi
+internal val Res.string.str_20377: StringResource
+  get() = String23.str_20377
+
+@ExperimentalResourceApi
+internal val Res.string.str_20378: StringResource
+  get() = String23.str_20378
+
+@ExperimentalResourceApi
+internal val Res.string.str_20379: StringResource
+  get() = String23.str_20379
+
+@ExperimentalResourceApi
+internal val Res.string.str_2038: StringResource
+  get() = String23.str_2038
+
+@ExperimentalResourceApi
+internal val Res.string.str_20380: StringResource
+  get() = String23.str_20380
+
+@ExperimentalResourceApi
+internal val Res.string.str_20381: StringResource
+  get() = String23.str_20381
+
+@ExperimentalResourceApi
+internal val Res.string.str_20382: StringResource
+  get() = String23.str_20382
+
+@ExperimentalResourceApi
+internal val Res.string.str_20383: StringResource
+  get() = String23.str_20383
+
+@ExperimentalResourceApi
+internal val Res.string.str_20384: StringResource
+  get() = String23.str_20384
+
+@ExperimentalResourceApi
+internal val Res.string.str_20385: StringResource
+  get() = String23.str_20385
+
+@ExperimentalResourceApi
+internal val Res.string.str_20386: StringResource
+  get() = String23.str_20386
+
+@ExperimentalResourceApi
+internal val Res.string.str_20387: StringResource
+  get() = String23.str_20387
+
+@ExperimentalResourceApi
+internal val Res.string.str_20388: StringResource
+  get() = String23.str_20388
+
+@ExperimentalResourceApi
+internal val Res.string.str_20389: StringResource
+  get() = String23.str_20389
+
+@ExperimentalResourceApi
+internal val Res.string.str_2039: StringResource
+  get() = String23.str_2039
+
+@ExperimentalResourceApi
+internal val Res.string.str_20390: StringResource
+  get() = String23.str_20390
+
+@ExperimentalResourceApi
+internal val Res.string.str_20391: StringResource
+  get() = String23.str_20391
+
+@ExperimentalResourceApi
+internal val Res.string.str_20392: StringResource
+  get() = String23.str_20392
+
+@ExperimentalResourceApi
+internal val Res.string.str_20393: StringResource
+  get() = String23.str_20393
+
+@ExperimentalResourceApi
+internal val Res.string.str_20394: StringResource
+  get() = String23.str_20394
+
+@ExperimentalResourceApi
+internal val Res.string.str_20395: StringResource
+  get() = String23.str_20395
+
+@ExperimentalResourceApi
+internal val Res.string.str_20396: StringResource
+  get() = String23.str_20396
+
+@ExperimentalResourceApi
+internal val Res.string.str_20397: StringResource
+  get() = String23.str_20397
+
+@ExperimentalResourceApi
+internal val Res.string.str_20398: StringResource
+  get() = String23.str_20398
+
+@ExperimentalResourceApi
+internal val Res.string.str_20399: StringResource
+  get() = String23.str_20399
+
+@ExperimentalResourceApi
+internal val Res.string.str_204: StringResource
+  get() = String23.str_204
+
+@ExperimentalResourceApi
+internal val Res.string.str_2040: StringResource
+  get() = String23.str_2040
+
+@ExperimentalResourceApi
+internal val Res.string.str_20400: StringResource
+  get() = String23.str_20400
+
+@ExperimentalResourceApi
+internal val Res.string.str_20401: StringResource
+  get() = String23.str_20401
+
+@ExperimentalResourceApi
+internal val Res.string.str_20402: StringResource
+  get() = String23.str_20402
+
+@ExperimentalResourceApi
+internal val Res.string.str_20403: StringResource
+  get() = String23.str_20403
+
+@ExperimentalResourceApi
+internal val Res.string.str_20404: StringResource
+  get() = String23.str_20404
+
+@ExperimentalResourceApi
+internal val Res.string.str_20405: StringResource
+  get() = String23.str_20405
+
+@ExperimentalResourceApi
+internal val Res.string.str_20406: StringResource
+  get() = String23.str_20406
+
+@ExperimentalResourceApi
+internal val Res.string.str_20407: StringResource
+  get() = String23.str_20407
+
+@ExperimentalResourceApi
+internal val Res.string.str_20408: StringResource
+  get() = String23.str_20408
+
+@ExperimentalResourceApi
+internal val Res.string.str_20409: StringResource
+  get() = String23.str_20409
+
+@ExperimentalResourceApi
+internal val Res.string.str_2041: StringResource
+  get() = String23.str_2041
+
+@ExperimentalResourceApi
+internal val Res.string.str_20410: StringResource
+  get() = String23.str_20410
+
+@ExperimentalResourceApi
+internal val Res.string.str_20411: StringResource
+  get() = String23.str_20411
+
+@ExperimentalResourceApi
+internal val Res.string.str_20412: StringResource
+  get() = String23.str_20412
+
+@ExperimentalResourceApi
+internal val Res.string.str_20413: StringResource
+  get() = String23.str_20413
+
+@ExperimentalResourceApi
+internal val Res.string.str_20414: StringResource
+  get() = String23.str_20414
+
+@ExperimentalResourceApi
+internal val Res.string.str_20415: StringResource
+  get() = String23.str_20415
+
+@ExperimentalResourceApi
+internal val Res.string.str_20416: StringResource
+  get() = String23.str_20416
+
+@ExperimentalResourceApi
+internal val Res.string.str_20417: StringResource
+  get() = String23.str_20417
+
+@ExperimentalResourceApi
+internal val Res.string.str_20418: StringResource
+  get() = String23.str_20418
+
+@ExperimentalResourceApi
+internal val Res.string.str_20419: StringResource
+  get() = String23.str_20419
+
+@ExperimentalResourceApi
+internal val Res.string.str_2042: StringResource
+  get() = String23.str_2042
+
+@ExperimentalResourceApi
+internal val Res.string.str_20420: StringResource
+  get() = String23.str_20420
+
+@ExperimentalResourceApi
+internal val Res.string.str_20421: StringResource
+  get() = String23.str_20421
+
+@ExperimentalResourceApi
+internal val Res.string.str_20422: StringResource
+  get() = String23.str_20422
+
+@ExperimentalResourceApi
+internal val Res.string.str_20423: StringResource
+  get() = String23.str_20423
+
+@ExperimentalResourceApi
+internal val Res.string.str_20424: StringResource
+  get() = String23.str_20424
+
+@ExperimentalResourceApi
+internal val Res.string.str_20425: StringResource
+  get() = String23.str_20425
+
+@ExperimentalResourceApi
+internal val Res.string.str_20426: StringResource
+  get() = String23.str_20426
+
+@ExperimentalResourceApi
+internal val Res.string.str_20427: StringResource
+  get() = String23.str_20427
+
+@ExperimentalResourceApi
+internal val Res.string.str_20428: StringResource
+  get() = String23.str_20428
+
+@ExperimentalResourceApi
+internal val Res.string.str_20429: StringResource
+  get() = String23.str_20429
+
+@ExperimentalResourceApi
+internal val Res.string.str_2043: StringResource
+  get() = String23.str_2043
+
+@ExperimentalResourceApi
+internal val Res.string.str_20430: StringResource
+  get() = String23.str_20430
+
+@ExperimentalResourceApi
+internal val Res.string.str_20431: StringResource
+  get() = String23.str_20431
+
+@ExperimentalResourceApi
+internal val Res.string.str_20432: StringResource
+  get() = String23.str_20432
+
+@ExperimentalResourceApi
+internal val Res.string.str_20433: StringResource
+  get() = String23.str_20433
+
+@ExperimentalResourceApi
+internal val Res.string.str_20434: StringResource
+  get() = String23.str_20434
+
+@ExperimentalResourceApi
+internal val Res.string.str_20435: StringResource
+  get() = String23.str_20435
+
+@ExperimentalResourceApi
+internal val Res.string.str_20436: StringResource
+  get() = String23.str_20436
+
+@ExperimentalResourceApi
+internal val Res.string.str_20437: StringResource
+  get() = String23.str_20437
+
+@ExperimentalResourceApi
+internal val Res.string.str_20438: StringResource
+  get() = String23.str_20438
+
+@ExperimentalResourceApi
+internal val Res.string.str_20439: StringResource
+  get() = String23.str_20439
+
+@ExperimentalResourceApi
+internal val Res.string.str_2044: StringResource
+  get() = String23.str_2044
+
+@ExperimentalResourceApi
+internal val Res.string.str_20440: StringResource
+  get() = String23.str_20440
+
+@ExperimentalResourceApi
+internal val Res.string.str_20441: StringResource
+  get() = String23.str_20441
+
+@ExperimentalResourceApi
+internal val Res.string.str_20442: StringResource
+  get() = String23.str_20442
+
+@ExperimentalResourceApi
+internal val Res.string.str_20443: StringResource
+  get() = String23.str_20443
+
+@ExperimentalResourceApi
+internal val Res.string.str_20444: StringResource
+  get() = String23.str_20444
+
+@ExperimentalResourceApi
+internal val Res.string.str_20445: StringResource
+  get() = String23.str_20445
+
+@ExperimentalResourceApi
+internal val Res.string.str_20446: StringResource
+  get() = String23.str_20446
+
+@ExperimentalResourceApi
+internal val Res.string.str_20447: StringResource
+  get() = String23.str_20447
+
+@ExperimentalResourceApi
+internal val Res.string.str_20448: StringResource
+  get() = String23.str_20448
+
+@ExperimentalResourceApi
+internal val Res.string.str_20449: StringResource
+  get() = String23.str_20449
+
+@ExperimentalResourceApi
+internal val Res.string.str_2045: StringResource
+  get() = String23.str_2045
+
+@ExperimentalResourceApi
+internal val Res.string.str_20450: StringResource
+  get() = String23.str_20450
+
+@ExperimentalResourceApi
+internal val Res.string.str_20451: StringResource
+  get() = String23.str_20451
+
+@ExperimentalResourceApi
+internal val Res.string.str_20452: StringResource
+  get() = String23.str_20452
+
+@ExperimentalResourceApi
+internal val Res.string.str_20453: StringResource
+  get() = String23.str_20453
+
+@ExperimentalResourceApi
+internal val Res.string.str_20454: StringResource
+  get() = String23.str_20454
+
+@ExperimentalResourceApi
+internal val Res.string.str_20455: StringResource
+  get() = String23.str_20455
+
+@ExperimentalResourceApi
+internal val Res.string.str_20456: StringResource
+  get() = String23.str_20456
+
+@ExperimentalResourceApi
+internal val Res.string.str_20457: StringResource
+  get() = String23.str_20457
+
+@ExperimentalResourceApi
+internal val Res.string.str_20458: StringResource
+  get() = String23.str_20458
+
+@ExperimentalResourceApi
+internal val Res.string.str_20459: StringResource
+  get() = String23.str_20459
+
+@ExperimentalResourceApi
+internal val Res.string.str_2046: StringResource
+  get() = String23.str_2046
+
+@ExperimentalResourceApi
+internal val Res.string.str_20460: StringResource
+  get() = String23.str_20460
+
+@ExperimentalResourceApi
+internal val Res.string.str_20461: StringResource
+  get() = String23.str_20461
+
+@ExperimentalResourceApi
+internal val Res.string.str_20462: StringResource
+  get() = String23.str_20462
+
+@ExperimentalResourceApi
+internal val Res.string.str_20463: StringResource
+  get() = String23.str_20463
+
+@ExperimentalResourceApi
+internal val Res.string.str_20464: StringResource
+  get() = String23.str_20464
+
+@ExperimentalResourceApi
+internal val Res.string.str_20465: StringResource
+  get() = String23.str_20465
+
+@ExperimentalResourceApi
+internal val Res.string.str_20466: StringResource
+  get() = String23.str_20466
+
+@ExperimentalResourceApi
+internal val Res.string.str_20467: StringResource
+  get() = String23.str_20467
+
+@ExperimentalResourceApi
+internal val Res.string.str_20468: StringResource
+  get() = String23.str_20468
+
+@ExperimentalResourceApi
+internal val Res.string.str_20469: StringResource
+  get() = String23.str_20469
+
+@ExperimentalResourceApi
+internal val Res.string.str_2047: StringResource
+  get() = String23.str_2047
+
+@ExperimentalResourceApi
+internal val Res.string.str_20470: StringResource
+  get() = String23.str_20470
+
+@ExperimentalResourceApi
+internal val Res.string.str_20471: StringResource
+  get() = String23.str_20471
+
+@ExperimentalResourceApi
+internal val Res.string.str_20472: StringResource
+  get() = String23.str_20472
+
+@ExperimentalResourceApi
+internal val Res.string.str_20473: StringResource
+  get() = String23.str_20473
+
+@ExperimentalResourceApi
+internal val Res.string.str_20474: StringResource
+  get() = String23.str_20474
+
+@ExperimentalResourceApi
+internal val Res.string.str_20475: StringResource
+  get() = String23.str_20475
+
+@ExperimentalResourceApi
+internal val Res.string.str_20476: StringResource
+  get() = String23.str_20476
+
+@ExperimentalResourceApi
+internal val Res.string.str_20477: StringResource
+  get() = String23.str_20477
+
+@ExperimentalResourceApi
+internal val Res.string.str_20478: StringResource
+  get() = String23.str_20478
+
+@ExperimentalResourceApi
+internal val Res.string.str_20479: StringResource
+  get() = String23.str_20479
+
+@ExperimentalResourceApi
+internal val Res.string.str_2048: StringResource
+  get() = String23.str_2048
+
+@ExperimentalResourceApi
+internal val Res.string.str_20480: StringResource
+  get() = String23.str_20480
+
+@ExperimentalResourceApi
+internal val Res.string.str_20481: StringResource
+  get() = String23.str_20481
+
+@ExperimentalResourceApi
+internal val Res.string.str_20482: StringResource
+  get() = String23.str_20482
+
+@ExperimentalResourceApi
+internal val Res.string.str_20483: StringResource
+  get() = String23.str_20483
+
+@ExperimentalResourceApi
+internal val Res.string.str_20484: StringResource
+  get() = String23.str_20484
+
+@ExperimentalResourceApi
+internal val Res.string.str_20485: StringResource
+  get() = String23.str_20485
+
+@ExperimentalResourceApi
+internal val Res.string.str_20486: StringResource
+  get() = String23.str_20486
+
+@ExperimentalResourceApi
+internal val Res.string.str_20487: StringResource
+  get() = String23.str_20487
+
+@ExperimentalResourceApi
+internal val Res.string.str_20488: StringResource
+  get() = String23.str_20488
+
+@ExperimentalResourceApi
+internal val Res.string.str_20489: StringResource
+  get() = String23.str_20489
+
+@ExperimentalResourceApi
+internal val Res.string.str_2049: StringResource
+  get() = String23.str_2049
+
+@ExperimentalResourceApi
+internal val Res.string.str_20490: StringResource
+  get() = String23.str_20490
+
+@ExperimentalResourceApi
+internal val Res.string.str_20491: StringResource
+  get() = String23.str_20491
+
+@ExperimentalResourceApi
+internal val Res.string.str_20492: StringResource
+  get() = String23.str_20492
+
+@ExperimentalResourceApi
+internal val Res.string.str_20493: StringResource
+  get() = String23.str_20493
+
+@ExperimentalResourceApi
+internal val Res.string.str_20494: StringResource
+  get() = String23.str_20494
+
+@ExperimentalResourceApi
+internal val Res.string.str_20495: StringResource
+  get() = String23.str_20495
+
+@ExperimentalResourceApi
+internal val Res.string.str_20496: StringResource
+  get() = String23.str_20496
+
+@ExperimentalResourceApi
+internal val Res.string.str_20497: StringResource
+  get() = String23.str_20497
+
+@ExperimentalResourceApi
+internal val Res.string.str_20498: StringResource
+  get() = String23.str_20498
+
+@ExperimentalResourceApi
+internal val Res.string.str_20499: StringResource
+  get() = String23.str_20499
+
+@ExperimentalResourceApi
+internal val Res.string.str_205: StringResource
+  get() = String23.str_205
+
+@ExperimentalResourceApi
+internal val Res.string.str_2050: StringResource
+  get() = String23.str_2050
+
+@ExperimentalResourceApi
+internal val Res.string.str_20500: StringResource
+  get() = String23.str_20500
+
+@ExperimentalResourceApi
+internal val Res.string.str_20501: StringResource
+  get() = String23.str_20501
+
+@ExperimentalResourceApi
+internal val Res.string.str_20502: StringResource
+  get() = String23.str_20502
+
+@ExperimentalResourceApi
+internal val Res.string.str_20503: StringResource
+  get() = String23.str_20503
+
+@ExperimentalResourceApi
+internal val Res.string.str_20504: StringResource
+  get() = String23.str_20504
+
+@ExperimentalResourceApi
+internal val Res.string.str_20505: StringResource
+  get() = String23.str_20505
+
+@ExperimentalResourceApi
+internal val Res.string.str_20506: StringResource
+  get() = String23.str_20506
+
+@ExperimentalResourceApi
+internal val Res.string.str_20507: StringResource
+  get() = String23.str_20507
+
+@ExperimentalResourceApi
+internal val Res.string.str_20508: StringResource
+  get() = String23.str_20508
+
+@ExperimentalResourceApi
+internal val Res.string.str_20509: StringResource
+  get() = String23.str_20509
+
+@ExperimentalResourceApi
+internal val Res.string.str_2051: StringResource
+  get() = String23.str_2051
+
+@ExperimentalResourceApi
+internal val Res.string.str_20510: StringResource
+  get() = String23.str_20510
+
+@ExperimentalResourceApi
+internal val Res.string.str_20511: StringResource
+  get() = String23.str_20511
+
+@ExperimentalResourceApi
+internal val Res.string.str_20512: StringResource
+  get() = String23.str_20512
+
+@ExperimentalResourceApi
+internal val Res.string.str_20513: StringResource
+  get() = String23.str_20513
+
+@ExperimentalResourceApi
+internal val Res.string.str_20514: StringResource
+  get() = String23.str_20514
+
+@ExperimentalResourceApi
+internal val Res.string.str_20515: StringResource
+  get() = String23.str_20515
+
+@ExperimentalResourceApi
+internal val Res.string.str_20516: StringResource
+  get() = String23.str_20516
+
+@ExperimentalResourceApi
+internal val Res.string.str_20517: StringResource
+  get() = String23.str_20517
+
+@ExperimentalResourceApi
+internal val Res.string.str_20518: StringResource
+  get() = String23.str_20518
+
+@ExperimentalResourceApi
+internal val Res.string.str_20519: StringResource
+  get() = String23.str_20519
+
+@ExperimentalResourceApi
+internal val Res.string.str_2052: StringResource
+  get() = String23.str_2052
+
+@ExperimentalResourceApi
+internal val Res.string.str_20520: StringResource
+  get() = String23.str_20520
+
+@ExperimentalResourceApi
+internal val Res.string.str_20521: StringResource
+  get() = String23.str_20521
+
+@ExperimentalResourceApi
+internal val Res.string.str_20522: StringResource
+  get() = String23.str_20522
+
+@ExperimentalResourceApi
+internal val Res.string.str_20523: StringResource
+  get() = String23.str_20523
+
+@ExperimentalResourceApi
+internal val Res.string.str_20524: StringResource
+  get() = String23.str_20524
+
+@ExperimentalResourceApi
+internal val Res.string.str_20525: StringResource
+  get() = String23.str_20525
+
+@ExperimentalResourceApi
+internal val Res.string.str_20526: StringResource
+  get() = String23.str_20526
+
+@ExperimentalResourceApi
+internal val Res.string.str_20527: StringResource
+  get() = String23.str_20527
+
+@ExperimentalResourceApi
+internal val Res.string.str_20528: StringResource
+  get() = String23.str_20528
+
+@ExperimentalResourceApi
+internal val Res.string.str_20529: StringResource
+  get() = String23.str_20529
+
+@ExperimentalResourceApi
+internal val Res.string.str_2053: StringResource
+  get() = String23.str_2053
+
+@ExperimentalResourceApi
+internal val Res.string.str_20530: StringResource
+  get() = String23.str_20530
+
+@ExperimentalResourceApi
+internal val Res.string.str_20531: StringResource
+  get() = String23.str_20531
+
+@ExperimentalResourceApi
+internal val Res.string.str_20532: StringResource
+  get() = String23.str_20532
+
+@ExperimentalResourceApi
+internal val Res.string.str_20533: StringResource
+  get() = String23.str_20533
+
+@ExperimentalResourceApi
+internal val Res.string.str_20534: StringResource
+  get() = String23.str_20534
+
+@ExperimentalResourceApi
+internal val Res.string.str_20535: StringResource
+  get() = String23.str_20535
+
+@ExperimentalResourceApi
+internal val Res.string.str_20536: StringResource
+  get() = String23.str_20536
+
+@ExperimentalResourceApi
+internal val Res.string.str_20537: StringResource
+  get() = String23.str_20537
+
+@ExperimentalResourceApi
+internal val Res.string.str_20538: StringResource
+  get() = String23.str_20538
+
+@ExperimentalResourceApi
+internal val Res.string.str_20539: StringResource
+  get() = String23.str_20539
+
+@ExperimentalResourceApi
+internal val Res.string.str_2054: StringResource
+  get() = String23.str_2054
+
+@ExperimentalResourceApi
+internal val Res.string.str_20540: StringResource
+  get() = String23.str_20540
+
+@ExperimentalResourceApi
+internal val Res.string.str_20541: StringResource
+  get() = String23.str_20541
+
+@ExperimentalResourceApi
+internal val Res.string.str_20542: StringResource
+  get() = String23.str_20542
+
+@ExperimentalResourceApi
+internal val Res.string.str_20543: StringResource
+  get() = String23.str_20543
+
+@ExperimentalResourceApi
+internal val Res.string.str_20544: StringResource
+  get() = String23.str_20544
+
+@ExperimentalResourceApi
+internal val Res.string.str_20545: StringResource
+  get() = String23.str_20545
+
+@ExperimentalResourceApi
+internal val Res.string.str_20546: StringResource
+  get() = String23.str_20546
+
+@ExperimentalResourceApi
+internal val Res.string.str_20547: StringResource
+  get() = String23.str_20547
+
+@ExperimentalResourceApi
+internal val Res.string.str_20548: StringResource
+  get() = String23.str_20548
+
+@ExperimentalResourceApi
+internal val Res.string.str_20549: StringResource
+  get() = String23.str_20549
+
+@ExperimentalResourceApi
+internal val Res.string.str_2055: StringResource
+  get() = String23.str_2055
+
+@ExperimentalResourceApi
+internal val Res.string.str_20550: StringResource
+  get() = String23.str_20550
+
+@ExperimentalResourceApi
+internal val Res.string.str_20551: StringResource
+  get() = String23.str_20551
+
+@ExperimentalResourceApi
+internal val Res.string.str_20552: StringResource
+  get() = String23.str_20552
+
+@ExperimentalResourceApi
+internal val Res.string.str_20553: StringResource
+  get() = String23.str_20553
+
+@ExperimentalResourceApi
+internal val Res.string.str_20554: StringResource
+  get() = String23.str_20554
+
+@ExperimentalResourceApi
+internal val Res.string.str_20555: StringResource
+  get() = String23.str_20555
+
+@ExperimentalResourceApi
+internal val Res.string.str_20556: StringResource
+  get() = String23.str_20556
+
+@ExperimentalResourceApi
+internal val Res.string.str_20557: StringResource
+  get() = String23.str_20557
+
+@ExperimentalResourceApi
+internal val Res.string.str_20558: StringResource
+  get() = String23.str_20558
+
+@ExperimentalResourceApi
+internal val Res.string.str_20559: StringResource
+  get() = String23.str_20559
+
+@ExperimentalResourceApi
+internal val Res.string.str_2056: StringResource
+  get() = String23.str_2056
+
+@ExperimentalResourceApi
+internal val Res.string.str_20560: StringResource
+  get() = String23.str_20560
+
+@ExperimentalResourceApi
+internal val Res.string.str_20561: StringResource
+  get() = String23.str_20561
+
+@ExperimentalResourceApi
+internal val Res.string.str_20562: StringResource
+  get() = String23.str_20562
+
+@ExperimentalResourceApi
+internal val Res.string.str_20563: StringResource
+  get() = String23.str_20563
+
+@ExperimentalResourceApi
+internal val Res.string.str_20564: StringResource
+  get() = String23.str_20564
+
+@ExperimentalResourceApi
+internal val Res.string.str_20565: StringResource
+  get() = String23.str_20565
+
+@ExperimentalResourceApi
+internal val Res.string.str_20566: StringResource
+  get() = String23.str_20566
+
+@ExperimentalResourceApi
+internal val Res.string.str_20567: StringResource
+  get() = String23.str_20567
+
+@ExperimentalResourceApi
+internal val Res.string.str_20568: StringResource
+  get() = String23.str_20568
+
+@ExperimentalResourceApi
+internal val Res.string.str_20569: StringResource
+  get() = String23.str_20569
+
+@ExperimentalResourceApi
+internal val Res.string.str_2057: StringResource
+  get() = String23.str_2057
+
+@ExperimentalResourceApi
+internal val Res.string.str_20570: StringResource
+  get() = String23.str_20570
+
+@ExperimentalResourceApi
+internal val Res.string.str_20571: StringResource
+  get() = String23.str_20571
+
+@ExperimentalResourceApi
+internal val Res.string.str_20572: StringResource
+  get() = String23.str_20572
+
+@ExperimentalResourceApi
+internal val Res.string.str_20573: StringResource
+  get() = String23.str_20573
+
+@ExperimentalResourceApi
+internal val Res.string.str_20574: StringResource
+  get() = String23.str_20574
+
+@ExperimentalResourceApi
+internal val Res.string.str_20575: StringResource
+  get() = String23.str_20575
+
+@ExperimentalResourceApi
+internal val Res.string.str_20576: StringResource
+  get() = String23.str_20576
+
+@ExperimentalResourceApi
+internal val Res.string.str_20577: StringResource
+  get() = String23.str_20577
+
+@ExperimentalResourceApi
+internal val Res.string.str_20578: StringResource
+  get() = String23.str_20578
+
+@ExperimentalResourceApi
+internal val Res.string.str_20579: StringResource
+  get() = String23.str_20579
+
+@ExperimentalResourceApi
+internal val Res.string.str_2058: StringResource
+  get() = String23.str_2058
+
+@ExperimentalResourceApi
+internal val Res.string.str_20580: StringResource
+  get() = String23.str_20580
+
+@ExperimentalResourceApi
+internal val Res.string.str_20581: StringResource
+  get() = String23.str_20581
+
+@ExperimentalResourceApi
+internal val Res.string.str_20582: StringResource
+  get() = String23.str_20582
+
+@ExperimentalResourceApi
+internal val Res.string.str_20583: StringResource
+  get() = String23.str_20583
+
+@ExperimentalResourceApi
+internal val Res.string.str_20584: StringResource
+  get() = String23.str_20584
+
+@ExperimentalResourceApi
+internal val Res.string.str_20585: StringResource
+  get() = String23.str_20585
+
+@ExperimentalResourceApi
+internal val Res.string.str_20586: StringResource
+  get() = String23.str_20586
+
+@ExperimentalResourceApi
+internal val Res.string.str_20587: StringResource
+  get() = String23.str_20587
+
+@ExperimentalResourceApi
+internal val Res.string.str_20588: StringResource
+  get() = String23.str_20588
+
+@ExperimentalResourceApi
+internal val Res.string.str_20589: StringResource
+  get() = String23.str_20589
+
+@ExperimentalResourceApi
+internal val Res.string.str_2059: StringResource
+  get() = String23.str_2059
+
+@ExperimentalResourceApi
+internal val Res.string.str_20590: StringResource
+  get() = String23.str_20590
+
+@ExperimentalResourceApi
+internal val Res.string.str_20591: StringResource
+  get() = String23.str_20591
+
+@ExperimentalResourceApi
+internal val Res.string.str_20592: StringResource
+  get() = String23.str_20592
+
+@ExperimentalResourceApi
+internal val Res.string.str_20593: StringResource
+  get() = String23.str_20593
+
+@ExperimentalResourceApi
+internal val Res.string.str_20594: StringResource
+  get() = String23.str_20594
+
+@ExperimentalResourceApi
+internal val Res.string.str_20595: StringResource
+  get() = String23.str_20595
+
+@ExperimentalResourceApi
+internal val Res.string.str_20596: StringResource
+  get() = String23.str_20596
+
+@ExperimentalResourceApi
+internal val Res.string.str_20597: StringResource
+  get() = String23.str_20597
+
+@ExperimentalResourceApi
+internal val Res.string.str_20598: StringResource
+  get() = String23.str_20598
+
+@ExperimentalResourceApi
+internal val Res.string.str_20599: StringResource
+  get() = String23.str_20599
+
+@ExperimentalResourceApi
+internal val Res.string.str_206: StringResource
+  get() = String23.str_206
+
+@ExperimentalResourceApi
+internal val Res.string.str_2060: StringResource
+  get() = String23.str_2060
+
+@ExperimentalResourceApi
+internal val Res.string.str_20600: StringResource
+  get() = String23.str_20600
+
+@ExperimentalResourceApi
+internal val Res.string.str_20601: StringResource
+  get() = String23.str_20601
+
+@ExperimentalResourceApi
+internal val Res.string.str_20602: StringResource
+  get() = String23.str_20602
+
+@ExperimentalResourceApi
+internal val Res.string.str_20603: StringResource
+  get() = String23.str_20603
+
+@ExperimentalResourceApi
+internal val Res.string.str_20604: StringResource
+  get() = String23.str_20604
+
+@ExperimentalResourceApi
+internal val Res.string.str_20605: StringResource
+  get() = String23.str_20605
+
+@ExperimentalResourceApi
+internal val Res.string.str_20606: StringResource
+  get() = String23.str_20606
+
+@ExperimentalResourceApi
+internal val Res.string.str_20607: StringResource
+  get() = String23.str_20607
+
+@ExperimentalResourceApi
+internal val Res.string.str_20608: StringResource
+  get() = String23.str_20608
+
+@ExperimentalResourceApi
+internal val Res.string.str_20609: StringResource
+  get() = String23.str_20609
+
+@ExperimentalResourceApi
+internal val Res.string.str_2061: StringResource
+  get() = String23.str_2061
+
+@ExperimentalResourceApi
+internal val Res.string.str_20610: StringResource
+  get() = String23.str_20610
+
+@ExperimentalResourceApi
+internal val Res.string.str_20611: StringResource
+  get() = String23.str_20611
+
+@ExperimentalResourceApi
+internal val Res.string.str_20612: StringResource
+  get() = String23.str_20612
+
+@ExperimentalResourceApi
+internal val Res.string.str_20613: StringResource
+  get() = String23.str_20613
+
+@ExperimentalResourceApi
+internal val Res.string.str_20614: StringResource
+  get() = String23.str_20614
+
+@ExperimentalResourceApi
+internal val Res.string.str_20615: StringResource
+  get() = String23.str_20615
+
+@ExperimentalResourceApi
+internal val Res.string.str_20616: StringResource
+  get() = String23.str_20616
+
+@ExperimentalResourceApi
+internal val Res.string.str_20617: StringResource
+  get() = String23.str_20617
+
+@ExperimentalResourceApi
+internal val Res.string.str_20618: StringResource
+  get() = String23.str_20618
+
+@ExperimentalResourceApi
+internal val Res.string.str_20619: StringResource
+  get() = String23.str_20619
+
+@ExperimentalResourceApi
+internal val Res.string.str_2062: StringResource
+  get() = String23.str_2062
+
+@ExperimentalResourceApi
+internal val Res.string.str_20620: StringResource
+  get() = String23.str_20620
+
+@ExperimentalResourceApi
+internal val Res.string.str_20621: StringResource
+  get() = String23.str_20621
+
+@ExperimentalResourceApi
+internal val Res.string.str_20622: StringResource
+  get() = String23.str_20622
+
+@ExperimentalResourceApi
+internal val Res.string.str_20623: StringResource
+  get() = String23.str_20623
+
+@ExperimentalResourceApi
+internal val Res.string.str_20624: StringResource
+  get() = String23.str_20624
+
+@ExperimentalResourceApi
+internal val Res.string.str_20625: StringResource
+  get() = String23.str_20625
+
+@ExperimentalResourceApi
+internal val Res.string.str_20626: StringResource
+  get() = String23.str_20626
+
+@ExperimentalResourceApi
+internal val Res.string.str_20627: StringResource
+  get() = String23.str_20627
+
+@ExperimentalResourceApi
+internal val Res.string.str_20628: StringResource
+  get() = String23.str_20628
+
+@ExperimentalResourceApi
+internal val Res.string.str_20629: StringResource
+  get() = String23.str_20629
+
+@ExperimentalResourceApi
+internal val Res.string.str_2063: StringResource
+  get() = String23.str_2063
+
+@ExperimentalResourceApi
+internal val Res.string.str_20630: StringResource
+  get() = String23.str_20630
+
+@ExperimentalResourceApi
+internal val Res.string.str_20631: StringResource
+  get() = String23.str_20631
+
+@ExperimentalResourceApi
+internal val Res.string.str_20632: StringResource
+  get() = String23.str_20632
+
+@ExperimentalResourceApi
+internal val Res.string.str_20633: StringResource
+  get() = String23.str_20633
+
+@ExperimentalResourceApi
+internal val Res.string.str_20634: StringResource
+  get() = String23.str_20634
+
+@ExperimentalResourceApi
+internal val Res.string.str_20635: StringResource
+  get() = String23.str_20635
+
+@ExperimentalResourceApi
+internal val Res.string.str_20636: StringResource
+  get() = String23.str_20636
+
+@ExperimentalResourceApi
+internal val Res.string.str_20637: StringResource
+  get() = String23.str_20637
+
+@ExperimentalResourceApi
+internal val Res.string.str_20638: StringResource
+  get() = String23.str_20638
+
+@ExperimentalResourceApi
+internal val Res.string.str_20639: StringResource
+  get() = String23.str_20639
+
+@ExperimentalResourceApi
+internal val Res.string.str_2064: StringResource
+  get() = String23.str_2064
+
+@ExperimentalResourceApi
+internal val Res.string.str_20640: StringResource
+  get() = String23.str_20640
+
+@ExperimentalResourceApi
+internal val Res.string.str_20641: StringResource
+  get() = String23.str_20641
+
+@ExperimentalResourceApi
+internal val Res.string.str_20642: StringResource
+  get() = String23.str_20642
+
+@ExperimentalResourceApi
+internal val Res.string.str_20643: StringResource
+  get() = String23.str_20643
+
+@ExperimentalResourceApi
+internal val Res.string.str_20644: StringResource
+  get() = String23.str_20644
+
+@ExperimentalResourceApi
+internal val Res.string.str_20645: StringResource
+  get() = String23.str_20645
+
+@ExperimentalResourceApi
+internal val Res.string.str_20646: StringResource
+  get() = String23.str_20646
+
+@ExperimentalResourceApi
+internal val Res.string.str_20647: StringResource
+  get() = String23.str_20647
+
+@ExperimentalResourceApi
+internal val Res.string.str_20648: StringResource
+  get() = String23.str_20648
+
+@ExperimentalResourceApi
+internal val Res.string.str_20649: StringResource
+  get() = String23.str_20649
+
+@ExperimentalResourceApi
+internal val Res.string.str_2065: StringResource
+  get() = String23.str_2065
+
+@ExperimentalResourceApi
+internal val Res.string.str_20650: StringResource
+  get() = String23.str_20650
+
+@ExperimentalResourceApi
+internal val Res.string.str_20651: StringResource
+  get() = String23.str_20651
+
+@ExperimentalResourceApi
+internal val Res.string.str_20652: StringResource
+  get() = String23.str_20652
+
+@ExperimentalResourceApi
+internal val Res.string.str_20653: StringResource
+  get() = String23.str_20653
+
+@ExperimentalResourceApi
+internal val Res.string.str_20654: StringResource
+  get() = String23.str_20654
+
+@ExperimentalResourceApi
+internal val Res.string.str_20655: StringResource
+  get() = String23.str_20655
+
+@ExperimentalResourceApi
+internal val Res.string.str_20656: StringResource
+  get() = String23.str_20656
+
+@ExperimentalResourceApi
+internal val Res.string.str_20657: StringResource
+  get() = String23.str_20657
+
+@ExperimentalResourceApi
+internal val Res.string.str_20658: StringResource
+  get() = String23.str_20658
+
+@ExperimentalResourceApi
+internal val Res.string.str_20659: StringResource
+  get() = String23.str_20659
+
+@ExperimentalResourceApi
+internal val Res.string.str_2066: StringResource
+  get() = String23.str_2066
+
+@ExperimentalResourceApi
+internal val Res.string.str_20660: StringResource
+  get() = String23.str_20660
+
+@ExperimentalResourceApi
+internal val Res.string.str_20661: StringResource
+  get() = String23.str_20661
+
+@ExperimentalResourceApi
+internal val Res.string.str_20662: StringResource
+  get() = String23.str_20662
+
+@ExperimentalResourceApi
+internal val Res.string.str_20663: StringResource
+  get() = String23.str_20663
+
+@ExperimentalResourceApi
+internal val Res.string.str_20664: StringResource
+  get() = String23.str_20664
+
+@ExperimentalResourceApi
+internal val Res.string.str_20665: StringResource
+  get() = String23.str_20665
+
+@ExperimentalResourceApi
+internal val Res.string.str_20666: StringResource
+  get() = String23.str_20666
+
+@ExperimentalResourceApi
+internal val Res.string.str_20667: StringResource
+  get() = String23.str_20667
+
+@ExperimentalResourceApi
+internal val Res.string.str_20668: StringResource
+  get() = String23.str_20668
+
+@ExperimentalResourceApi
+internal val Res.string.str_20669: StringResource
+  get() = String23.str_20669
+
+@ExperimentalResourceApi
+internal val Res.string.str_2067: StringResource
+  get() = String23.str_2067
+
+@ExperimentalResourceApi
+internal val Res.string.str_20670: StringResource
+  get() = String23.str_20670
+
+@ExperimentalResourceApi
+internal val Res.string.str_20671: StringResource
+  get() = String23.str_20671
+
+@ExperimentalResourceApi
+internal val Res.string.str_20672: StringResource
+  get() = String23.str_20672
+
+@ExperimentalResourceApi
+internal val Res.string.str_20673: StringResource
+  get() = String23.str_20673
+
+@ExperimentalResourceApi
+internal val Res.string.str_20674: StringResource
+  get() = String23.str_20674
+
+@ExperimentalResourceApi
+internal val Res.string.str_20675: StringResource
+  get() = String23.str_20675
+
+@ExperimentalResourceApi
+internal val Res.string.str_20676: StringResource
+  get() = String23.str_20676
+
+@ExperimentalResourceApi
+internal val Res.string.str_20677: StringResource
+  get() = String23.str_20677
+
+@ExperimentalResourceApi
+internal val Res.string.str_20678: StringResource
+  get() = String23.str_20678
+
+@ExperimentalResourceApi
+internal val Res.string.str_20679: StringResource
+  get() = String23.str_20679
+
+@ExperimentalResourceApi
+internal val Res.string.str_2068: StringResource
+  get() = String23.str_2068
+
+@ExperimentalResourceApi
+internal val Res.string.str_20680: StringResource
+  get() = String23.str_20680
+
+@ExperimentalResourceApi
+internal val Res.string.str_20681: StringResource
+  get() = String23.str_20681
+
+@ExperimentalResourceApi
+internal val Res.string.str_20682: StringResource
+  get() = String23.str_20682
+
+@ExperimentalResourceApi
+internal val Res.string.str_20683: StringResource
+  get() = String23.str_20683
+
+@ExperimentalResourceApi
+internal val Res.string.str_20684: StringResource
+  get() = String23.str_20684
+
+@ExperimentalResourceApi
+internal val Res.string.str_20685: StringResource
+  get() = String23.str_20685
+
+@ExperimentalResourceApi
+internal val Res.string.str_20686: StringResource
+  get() = String23.str_20686
+
+@ExperimentalResourceApi
+internal val Res.string.str_20687: StringResource
+  get() = String23.str_20687
+
+@ExperimentalResourceApi
+internal val Res.string.str_20688: StringResource
+  get() = String23.str_20688
+
+@ExperimentalResourceApi
+internal val Res.string.str_20689: StringResource
+  get() = String23.str_20689
+
+@ExperimentalResourceApi
+internal val Res.string.str_2069: StringResource
+  get() = String23.str_2069
+
+@ExperimentalResourceApi
+internal val Res.string.str_20690: StringResource
+  get() = String23.str_20690
+
+@ExperimentalResourceApi
+internal val Res.string.str_20691: StringResource
+  get() = String23.str_20691
+
+@ExperimentalResourceApi
+internal val Res.string.str_20692: StringResource
+  get() = String23.str_20692
+
+@ExperimentalResourceApi
+internal val Res.string.str_20693: StringResource
+  get() = String23.str_20693
+
+@ExperimentalResourceApi
+internal val Res.string.str_20694: StringResource
+  get() = String23.str_20694
+
+@ExperimentalResourceApi
+internal val Res.string.str_20695: StringResource
+  get() = String23.str_20695
+
+@ExperimentalResourceApi
+internal val Res.string.str_20696: StringResource
+  get() = String23.str_20696
+
+@ExperimentalResourceApi
+internal val Res.string.str_20697: StringResource
+  get() = String23.str_20697
+
+@ExperimentalResourceApi
+internal val Res.string.str_20698: StringResource
+  get() = String23.str_20698
+
+@ExperimentalResourceApi
+internal val Res.string.str_20699: StringResource
+  get() = String23.str_20699
+
+@ExperimentalResourceApi
+internal val Res.string.str_207: StringResource
+  get() = String23.str_207
+
+@ExperimentalResourceApi
+internal val Res.string.str_2070: StringResource
+  get() = String23.str_2070
+
+@ExperimentalResourceApi
+internal val Res.string.str_20700: StringResource
+  get() = String23.str_20700
+
+@ExperimentalResourceApi
+internal val Res.string.str_20701: StringResource
+  get() = String23.str_20701
+
+@ExperimentalResourceApi
+internal val Res.string.str_20702: StringResource
+  get() = String23.str_20702
+
+@ExperimentalResourceApi
+internal val Res.string.str_20703: StringResource
+  get() = String23.str_20703
+
+@ExperimentalResourceApi
+internal val Res.string.str_20704: StringResource
+  get() = String23.str_20704
+
+@ExperimentalResourceApi
+internal val Res.string.str_20705: StringResource
+  get() = String23.str_20705
+
+@ExperimentalResourceApi
+internal val Res.string.str_20706: StringResource
+  get() = String23.str_20706
+
+@ExperimentalResourceApi
+internal val Res.string.str_20707: StringResource
+  get() = String23.str_20707
+
+@ExperimentalResourceApi
+internal val Res.string.str_20708: StringResource
+  get() = String23.str_20708
+
+@ExperimentalResourceApi
+internal val Res.string.str_20709: StringResource
+  get() = String23.str_20709
+
+@ExperimentalResourceApi
+internal val Res.string.str_2071: StringResource
+  get() = String23.str_2071
+
+@ExperimentalResourceApi
+internal val Res.string.str_20710: StringResource
+  get() = String23.str_20710
+
+@ExperimentalResourceApi
+internal val Res.string.str_20711: StringResource
+  get() = String23.str_20711
+
+@ExperimentalResourceApi
+internal val Res.string.str_20712: StringResource
+  get() = String23.str_20712
+
+@ExperimentalResourceApi
+internal val Res.string.str_20713: StringResource
+  get() = String23.str_20713
+
+@ExperimentalResourceApi
+internal val Res.string.str_20714: StringResource
+  get() = String23.str_20714
+
+@ExperimentalResourceApi
+internal val Res.string.str_20715: StringResource
+  get() = String23.str_20715
+
+@ExperimentalResourceApi
+internal val Res.string.str_20716: StringResource
+  get() = String23.str_20716
+
+@ExperimentalResourceApi
+internal val Res.string.str_20717: StringResource
+  get() = String23.str_20717
+
+@ExperimentalResourceApi
+internal val Res.string.str_20718: StringResource
+  get() = String23.str_20718
+
+@ExperimentalResourceApi
+internal val Res.string.str_20719: StringResource
+  get() = String23.str_20719
+
+@ExperimentalResourceApi
+internal val Res.string.str_2072: StringResource
+  get() = String23.str_2072
+
+@ExperimentalResourceApi
+internal val Res.string.str_20720: StringResource
+  get() = String23.str_20720
+
+@ExperimentalResourceApi
+internal val Res.string.str_20721: StringResource
+  get() = String23.str_20721
+
+@ExperimentalResourceApi
+internal val Res.string.str_20722: StringResource
+  get() = String23.str_20722
+
+@ExperimentalResourceApi
+internal val Res.string.str_20723: StringResource
+  get() = String23.str_20723
+
+@ExperimentalResourceApi
+internal val Res.string.str_20724: StringResource
+  get() = String23.str_20724
+
+@ExperimentalResourceApi
+internal val Res.string.str_20725: StringResource
+  get() = String23.str_20725
+
+@ExperimentalResourceApi
+internal val Res.string.str_20726: StringResource
+  get() = String23.str_20726
+
+@ExperimentalResourceApi
+internal val Res.string.str_20727: StringResource
+  get() = String23.str_20727
+
+@ExperimentalResourceApi
+internal val Res.string.str_20728: StringResource
+  get() = String23.str_20728
+
+@ExperimentalResourceApi
+internal val Res.string.str_20729: StringResource
+  get() = String23.str_20729
+
+@ExperimentalResourceApi
+internal val Res.string.str_2073: StringResource
+  get() = String23.str_2073
+
+@ExperimentalResourceApi
+internal val Res.string.str_20730: StringResource
+  get() = String23.str_20730
+
+@ExperimentalResourceApi
+internal val Res.string.str_20731: StringResource
+  get() = String23.str_20731
+
+@ExperimentalResourceApi
+internal val Res.string.str_20732: StringResource
+  get() = String23.str_20732
+
+@ExperimentalResourceApi
+internal val Res.string.str_20733: StringResource
+  get() = String23.str_20733
+
+@ExperimentalResourceApi
+internal val Res.string.str_20734: StringResource
+  get() = String23.str_20734
+
+@ExperimentalResourceApi
+internal val Res.string.str_20735: StringResource
+  get() = String23.str_20735
+
+@ExperimentalResourceApi
+internal val Res.string.str_20736: StringResource
+  get() = String23.str_20736
+
+@ExperimentalResourceApi
+internal val Res.string.str_20737: StringResource
+  get() = String23.str_20737
+
+@ExperimentalResourceApi
+internal val Res.string.str_20738: StringResource
+  get() = String23.str_20738
+
+@ExperimentalResourceApi
+internal val Res.string.str_20739: StringResource
+  get() = String23.str_20739
+
+@ExperimentalResourceApi
+internal val Res.string.str_2074: StringResource
+  get() = String23.str_2074
+
+@ExperimentalResourceApi
+internal val Res.string.str_20740: StringResource
+  get() = String23.str_20740
+
+@ExperimentalResourceApi
+internal val Res.string.str_20741: StringResource
+  get() = String23.str_20741
+
+@ExperimentalResourceApi
+internal val Res.string.str_20742: StringResource
+  get() = String23.str_20742
+
+@ExperimentalResourceApi
+internal val Res.string.str_20743: StringResource
+  get() = String23.str_20743
+
+@ExperimentalResourceApi
+internal val Res.string.str_20744: StringResource
+  get() = String23.str_20744
+
+@ExperimentalResourceApi
+internal val Res.string.str_20745: StringResource
+  get() = String23.str_20745
+
+@ExperimentalResourceApi
+internal val Res.string.str_20746: StringResource
+  get() = String23.str_20746
+
+@ExperimentalResourceApi
+internal val Res.string.str_20747: StringResource
+  get() = String23.str_20747
+
+@ExperimentalResourceApi
+internal val Res.string.str_20748: StringResource
+  get() = String23.str_20748
+
+@ExperimentalResourceApi
+internal val Res.string.str_20749: StringResource
+  get() = String23.str_20749
+
+@ExperimentalResourceApi
+internal val Res.string.str_2075: StringResource
+  get() = String23.str_2075
+
+@ExperimentalResourceApi
+internal val Res.string.str_20750: StringResource
+  get() = String23.str_20750
+
+@ExperimentalResourceApi
+internal val Res.string.str_20751: StringResource
+  get() = String23.str_20751
+
+@ExperimentalResourceApi
+internal val Res.string.str_20752: StringResource
+  get() = String23.str_20752
+
+@ExperimentalResourceApi
+internal val Res.string.str_20753: StringResource
+  get() = String23.str_20753
+
+@ExperimentalResourceApi
+internal val Res.string.str_20754: StringResource
+  get() = String23.str_20754
+
+@ExperimentalResourceApi
+internal val Res.string.str_20755: StringResource
+  get() = String23.str_20755
+
+@ExperimentalResourceApi
+internal val Res.string.str_20756: StringResource
+  get() = String23.str_20756
+
+@ExperimentalResourceApi
+internal val Res.string.str_20757: StringResource
+  get() = String23.str_20757
+
+@ExperimentalResourceApi
+internal val Res.string.str_20758: StringResource
+  get() = String23.str_20758
+
+@ExperimentalResourceApi
+internal val Res.string.str_20759: StringResource
+  get() = String23.str_20759
+
+@ExperimentalResourceApi
+internal val Res.string.str_2076: StringResource
+  get() = String23.str_2076
+
+@ExperimentalResourceApi
+internal val Res.string.str_20760: StringResource
+  get() = String23.str_20760
+
+@ExperimentalResourceApi
+internal val Res.string.str_20761: StringResource
+  get() = String23.str_20761
+
+@ExperimentalResourceApi
+internal val Res.string.str_20762: StringResource
+  get() = String23.str_20762
+
+@ExperimentalResourceApi
+internal val Res.string.str_20763: StringResource
+  get() = String23.str_20763
+
+@ExperimentalResourceApi
+internal val Res.string.str_20764: StringResource
+  get() = String23.str_20764
+
+@ExperimentalResourceApi
+internal val Res.string.str_20765: StringResource
+  get() = String23.str_20765
+
+@ExperimentalResourceApi
+internal val Res.string.str_20766: StringResource
+  get() = String23.str_20766
+
+@ExperimentalResourceApi
+internal val Res.string.str_20767: StringResource
+  get() = String23.str_20767
+
+@ExperimentalResourceApi
+internal val Res.string.str_20768: StringResource
+  get() = String23.str_20768
+
+@ExperimentalResourceApi
+internal val Res.string.str_20769: StringResource
+  get() = String23.str_20769
+
+@ExperimentalResourceApi
+internal val Res.string.str_2077: StringResource
+  get() = String23.str_2077
+
+@ExperimentalResourceApi
+internal val Res.string.str_20770: StringResource
+  get() = String23.str_20770
+
+@ExperimentalResourceApi
+internal val Res.string.str_20771: StringResource
+  get() = String23.str_20771
+
+@ExperimentalResourceApi
+internal val Res.string.str_20772: StringResource
+  get() = String23.str_20772
+
+@ExperimentalResourceApi
+internal val Res.string.str_20773: StringResource
+  get() = String23.str_20773
+
+@ExperimentalResourceApi
+internal val Res.string.str_20774: StringResource
+  get() = String23.str_20774
+
+@ExperimentalResourceApi
+internal val Res.string.str_20775: StringResource
+  get() = String23.str_20775
+
+@ExperimentalResourceApi
+internal val Res.string.str_20776: StringResource
+  get() = String23.str_20776
+
+@ExperimentalResourceApi
+internal val Res.string.str_20777: StringResource
+  get() = String23.str_20777
+
+@ExperimentalResourceApi
+internal val Res.string.str_20778: StringResource
+  get() = String23.str_20778
+
+@ExperimentalResourceApi
+internal val Res.string.str_20779: StringResource
+  get() = String23.str_20779
+
+@ExperimentalResourceApi
+internal val Res.string.str_2078: StringResource
+  get() = String23.str_2078
+
+@ExperimentalResourceApi
+internal val Res.string.str_20780: StringResource
+  get() = String23.str_20780
+
+@ExperimentalResourceApi
+internal val Res.string.str_20781: StringResource
+  get() = String23.str_20781
+
+@ExperimentalResourceApi
+internal val Res.string.str_20782: StringResource
+  get() = String23.str_20782
+
+@ExperimentalResourceApi
+internal val Res.string.str_20783: StringResource
+  get() = String23.str_20783
+
+@ExperimentalResourceApi
+internal val Res.string.str_20784: StringResource
+  get() = String23.str_20784
+
+@ExperimentalResourceApi
+internal val Res.string.str_20785: StringResource
+  get() = String23.str_20785
+
+@ExperimentalResourceApi
+internal val Res.string.str_20786: StringResource
+  get() = String23.str_20786
+
+@ExperimentalResourceApi
+internal val Res.string.str_20787: StringResource
+  get() = String23.str_20787
+
+@ExperimentalResourceApi
+internal val Res.string.str_20788: StringResource
+  get() = String23.str_20788
+
+@ExperimentalResourceApi
+internal val Res.string.str_20789: StringResource
+  get() = String23.str_20789
+
+@ExperimentalResourceApi
+internal val Res.string.str_2079: StringResource
+  get() = String23.str_2079
+
+@ExperimentalResourceApi
+internal val Res.string.str_20790: StringResource
+  get() = String23.str_20790
+
+@ExperimentalResourceApi
+internal val Res.string.str_20791: StringResource
+  get() = String23.str_20791
+
+@ExperimentalResourceApi
+internal val Res.string.str_20792: StringResource
+  get() = String23.str_20792
+
+@ExperimentalResourceApi
+internal val Res.string.str_20793: StringResource
+  get() = String23.str_20793
+
+@ExperimentalResourceApi
+internal val Res.string.str_20794: StringResource
+  get() = String23.str_20794
+
+@ExperimentalResourceApi
+internal val Res.string.str_20795: StringResource
+  get() = String23.str_20795
+
+@ExperimentalResourceApi
+internal val Res.string.str_20796: StringResource
+  get() = String23.str_20796
+
+@ExperimentalResourceApi
+internal val Res.string.str_20797: StringResource
+  get() = String23.str_20797

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String24.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String24.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String24 {
+  public val str_20798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20798", "str_20798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20799", "str_20799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_208", "str_208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2080", "str_2080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20800", "str_20800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20801", "str_20801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20802", "str_20802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20803", "str_20803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20804", "str_20804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20805", "str_20805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20806", "str_20806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20807", "str_20807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20808", "str_20808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20809", "str_20809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2081", "str_2081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20810", "str_20810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20811", "str_20811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20812", "str_20812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20813", "str_20813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20814", "str_20814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20815", "str_20815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20816", "str_20816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20817", "str_20817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20818", "str_20818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20819", "str_20819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2082", "str_2082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20820", "str_20820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20821", "str_20821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20822", "str_20822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20823", "str_20823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20824", "str_20824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20825", "str_20825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20826", "str_20826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20827", "str_20827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20828", "str_20828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20829", "str_20829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2083", "str_2083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20830", "str_20830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20831", "str_20831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20832", "str_20832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20833", "str_20833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20834", "str_20834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20835", "str_20835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20836", "str_20836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20837", "str_20837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20838", "str_20838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20839", "str_20839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2084", "str_2084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20840", "str_20840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20841", "str_20841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20842", "str_20842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20843", "str_20843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20844", "str_20844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20845", "str_20845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20846", "str_20846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20847", "str_20847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20848", "str_20848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20849", "str_20849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2085", "str_2085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20850", "str_20850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20851", "str_20851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20852", "str_20852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20853", "str_20853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20854", "str_20854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20855", "str_20855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20856", "str_20856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20857", "str_20857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20858", "str_20858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20859", "str_20859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2086", "str_2086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20860", "str_20860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20861", "str_20861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20862", "str_20862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20863", "str_20863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20864", "str_20864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20865", "str_20865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20866", "str_20866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20867", "str_20867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20868", "str_20868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20869", "str_20869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2087", "str_2087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20870", "str_20870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20871", "str_20871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20872", "str_20872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20873", "str_20873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20874", "str_20874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20875", "str_20875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20876", "str_20876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20877", "str_20877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20878", "str_20878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20879", "str_20879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2088", "str_2088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20880", "str_20880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20881", "str_20881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20882", "str_20882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20883", "str_20883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20884", "str_20884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20885", "str_20885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20886", "str_20886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20887", "str_20887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20888", "str_20888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20889", "str_20889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2089", "str_2089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20890", "str_20890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20891", "str_20891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20892", "str_20892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20893", "str_20893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20894", "str_20894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20895", "str_20895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20896", "str_20896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20897", "str_20897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20898", "str_20898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20899", "str_20899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_209", "str_209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2090", "str_2090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20900", "str_20900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20901", "str_20901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20902", "str_20902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20903", "str_20903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20904", "str_20904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20905", "str_20905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20906", "str_20906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20907", "str_20907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20908", "str_20908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20909", "str_20909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2091", "str_2091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20910", "str_20910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20911", "str_20911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20912", "str_20912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20913", "str_20913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20914", "str_20914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20915", "str_20915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20916", "str_20916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20917", "str_20917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20918", "str_20918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20919", "str_20919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2092", "str_2092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20920", "str_20920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20921", "str_20921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20922", "str_20922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20923", "str_20923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20924", "str_20924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20925", "str_20925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20926", "str_20926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20927", "str_20927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20928", "str_20928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20929", "str_20929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2093", "str_2093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20930", "str_20930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20931", "str_20931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20932", "str_20932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20933", "str_20933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20934", "str_20934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20935", "str_20935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20936", "str_20936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20937", "str_20937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20938", "str_20938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20939", "str_20939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2094", "str_2094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20940", "str_20940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20941", "str_20941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20942", "str_20942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20943", "str_20943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20944", "str_20944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20945", "str_20945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20946", "str_20946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20947", "str_20947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20948", "str_20948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20949", "str_20949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2095", "str_2095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20950", "str_20950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20951", "str_20951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20952", "str_20952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20953", "str_20953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20954", "str_20954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20955", "str_20955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20956", "str_20956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20957", "str_20957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20958", "str_20958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20959", "str_20959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2096", "str_2096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20960", "str_20960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20961", "str_20961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20962", "str_20962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20963", "str_20963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20964", "str_20964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20965", "str_20965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20966", "str_20966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20967", "str_20967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20968", "str_20968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20969", "str_20969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2097", "str_2097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20970", "str_20970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20971", "str_20971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20972", "str_20972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20973", "str_20973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20974", "str_20974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20975", "str_20975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20976", "str_20976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20977", "str_20977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20978", "str_20978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20979", "str_20979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2098", "str_2098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20980", "str_20980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20981", "str_20981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20982", "str_20982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20983", "str_20983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20984", "str_20984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20985", "str_20985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20986", "str_20986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20987", "str_20987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20988", "str_20988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20989", "str_20989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2099", "str_2099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20990", "str_20990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20991", "str_20991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20992", "str_20992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20993", "str_20993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20994", "str_20994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20995", "str_20995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20996", "str_20996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20997", "str_20997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20998", "str_20998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_20999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_20999", "str_20999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21", "str_21",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_210", "str_210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2100", "str_2100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21000", "str_21000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21001", "str_21001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21002", "str_21002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21003", "str_21003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21004", "str_21004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21005", "str_21005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21006", "str_21006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21007", "str_21007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21008", "str_21008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21009", "str_21009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2101", "str_2101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21010", "str_21010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21011", "str_21011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21012", "str_21012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21013", "str_21013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21014", "str_21014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21015", "str_21015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21016", "str_21016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21017", "str_21017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21018", "str_21018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21019", "str_21019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2102", "str_2102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21020", "str_21020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21021", "str_21021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21022", "str_21022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21023", "str_21023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21024", "str_21024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21025", "str_21025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21026", "str_21026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21027", "str_21027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21028", "str_21028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21029", "str_21029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2103", "str_2103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21030", "str_21030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21031", "str_21031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21032", "str_21032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21033", "str_21033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21034", "str_21034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21035", "str_21035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21036", "str_21036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21037", "str_21037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21038", "str_21038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21039", "str_21039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2104", "str_2104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21040", "str_21040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21041", "str_21041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21042", "str_21042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21043", "str_21043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21044", "str_21044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21045", "str_21045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21046", "str_21046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21047", "str_21047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21048", "str_21048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21049", "str_21049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2105", "str_2105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21050", "str_21050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21051", "str_21051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21052", "str_21052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21053", "str_21053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21054", "str_21054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21055", "str_21055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21056", "str_21056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21057", "str_21057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21058", "str_21058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21059", "str_21059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2106", "str_2106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21060", "str_21060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21061", "str_21061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21062", "str_21062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21063", "str_21063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21064", "str_21064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21065", "str_21065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21066", "str_21066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21067", "str_21067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21068", "str_21068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21069", "str_21069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2107", "str_2107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21070", "str_21070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21071", "str_21071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21072", "str_21072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21073", "str_21073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21074", "str_21074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21075", "str_21075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21076", "str_21076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21077", "str_21077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21078", "str_21078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21079", "str_21079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2108", "str_2108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21080", "str_21080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21081", "str_21081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21082", "str_21082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21083", "str_21083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21084", "str_21084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21085", "str_21085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21086", "str_21086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21087", "str_21087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21088", "str_21088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21089", "str_21089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2109", "str_2109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21090", "str_21090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21091", "str_21091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21092", "str_21092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21093", "str_21093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21094", "str_21094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21095", "str_21095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21096", "str_21096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21097", "str_21097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21098", "str_21098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21099", "str_21099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_211", "str_211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2110", "str_2110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21100", "str_21100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21101", "str_21101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21102", "str_21102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21103", "str_21103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21104", "str_21104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21105", "str_21105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21106", "str_21106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21107", "str_21107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21108", "str_21108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21109", "str_21109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2111", "str_2111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21110", "str_21110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21111", "str_21111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21112", "str_21112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21113", "str_21113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21114", "str_21114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21115", "str_21115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21116", "str_21116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21117", "str_21117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21118", "str_21118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21119", "str_21119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2112", "str_2112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21120", "str_21120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21121", "str_21121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21122", "str_21122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21123", "str_21123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21124", "str_21124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21125", "str_21125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21126", "str_21126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21127", "str_21127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21128", "str_21128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21129", "str_21129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2113", "str_2113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21130", "str_21130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21131", "str_21131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21132", "str_21132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21133", "str_21133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21134", "str_21134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21135", "str_21135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21136", "str_21136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21137", "str_21137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21138", "str_21138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21139", "str_21139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2114", "str_2114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21140", "str_21140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21141", "str_21141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21142", "str_21142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21143", "str_21143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21144", "str_21144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21145", "str_21145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21146", "str_21146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21147", "str_21147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21148", "str_21148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21149", "str_21149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2115", "str_2115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21150", "str_21150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21151", "str_21151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21152", "str_21152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21153", "str_21153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21154", "str_21154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21155", "str_21155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21156", "str_21156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21157", "str_21157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21158", "str_21158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21159", "str_21159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2116", "str_2116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21160", "str_21160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21161", "str_21161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21162", "str_21162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21163", "str_21163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21164", "str_21164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21165", "str_21165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21166", "str_21166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21167", "str_21167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21168", "str_21168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21169", "str_21169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2117", "str_2117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21170", "str_21170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21171", "str_21171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21172", "str_21172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21173", "str_21173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21174", "str_21174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21175", "str_21175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21176", "str_21176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21177", "str_21177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21178", "str_21178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21179", "str_21179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2118", "str_2118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21180", "str_21180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21181", "str_21181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21182", "str_21182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21183", "str_21183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21184", "str_21184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21185", "str_21185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21186", "str_21186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21187", "str_21187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21188", "str_21188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21189", "str_21189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2119", "str_2119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21190", "str_21190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21191", "str_21191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21192", "str_21192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21193", "str_21193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21194", "str_21194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21195", "str_21195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21196", "str_21196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21197", "str_21197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21198", "str_21198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21199", "str_21199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_212", "str_212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2120", "str_2120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21200", "str_21200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21201", "str_21201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21202", "str_21202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21203", "str_21203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21204", "str_21204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21205", "str_21205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21206", "str_21206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21207", "str_21207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21208", "str_21208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21209", "str_21209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2121", "str_2121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21210", "str_21210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21211", "str_21211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21212", "str_21212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21213", "str_21213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21214", "str_21214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21215", "str_21215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21216", "str_21216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21217", "str_21217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21218", "str_21218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21219", "str_21219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2122", "str_2122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21220", "str_21220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21221", "str_21221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21222", "str_21222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21223", "str_21223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21224", "str_21224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21225", "str_21225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21226", "str_21226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21227", "str_21227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21228", "str_21228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21229", "str_21229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2123", "str_2123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21230", "str_21230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21231", "str_21231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21232", "str_21232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21233", "str_21233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21234", "str_21234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21235", "str_21235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21236", "str_21236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21237", "str_21237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21238", "str_21238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21239", "str_21239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2124", "str_2124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21240", "str_21240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21241", "str_21241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21242", "str_21242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21243", "str_21243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21244", "str_21244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21245", "str_21245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21246", "str_21246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_20798: StringResource
+  get() = String24.str_20798
+
+@ExperimentalResourceApi
+internal val Res.string.str_20799: StringResource
+  get() = String24.str_20799
+
+@ExperimentalResourceApi
+internal val Res.string.str_208: StringResource
+  get() = String24.str_208
+
+@ExperimentalResourceApi
+internal val Res.string.str_2080: StringResource
+  get() = String24.str_2080
+
+@ExperimentalResourceApi
+internal val Res.string.str_20800: StringResource
+  get() = String24.str_20800
+
+@ExperimentalResourceApi
+internal val Res.string.str_20801: StringResource
+  get() = String24.str_20801
+
+@ExperimentalResourceApi
+internal val Res.string.str_20802: StringResource
+  get() = String24.str_20802
+
+@ExperimentalResourceApi
+internal val Res.string.str_20803: StringResource
+  get() = String24.str_20803
+
+@ExperimentalResourceApi
+internal val Res.string.str_20804: StringResource
+  get() = String24.str_20804
+
+@ExperimentalResourceApi
+internal val Res.string.str_20805: StringResource
+  get() = String24.str_20805
+
+@ExperimentalResourceApi
+internal val Res.string.str_20806: StringResource
+  get() = String24.str_20806
+
+@ExperimentalResourceApi
+internal val Res.string.str_20807: StringResource
+  get() = String24.str_20807
+
+@ExperimentalResourceApi
+internal val Res.string.str_20808: StringResource
+  get() = String24.str_20808
+
+@ExperimentalResourceApi
+internal val Res.string.str_20809: StringResource
+  get() = String24.str_20809
+
+@ExperimentalResourceApi
+internal val Res.string.str_2081: StringResource
+  get() = String24.str_2081
+
+@ExperimentalResourceApi
+internal val Res.string.str_20810: StringResource
+  get() = String24.str_20810
+
+@ExperimentalResourceApi
+internal val Res.string.str_20811: StringResource
+  get() = String24.str_20811
+
+@ExperimentalResourceApi
+internal val Res.string.str_20812: StringResource
+  get() = String24.str_20812
+
+@ExperimentalResourceApi
+internal val Res.string.str_20813: StringResource
+  get() = String24.str_20813
+
+@ExperimentalResourceApi
+internal val Res.string.str_20814: StringResource
+  get() = String24.str_20814
+
+@ExperimentalResourceApi
+internal val Res.string.str_20815: StringResource
+  get() = String24.str_20815
+
+@ExperimentalResourceApi
+internal val Res.string.str_20816: StringResource
+  get() = String24.str_20816
+
+@ExperimentalResourceApi
+internal val Res.string.str_20817: StringResource
+  get() = String24.str_20817
+
+@ExperimentalResourceApi
+internal val Res.string.str_20818: StringResource
+  get() = String24.str_20818
+
+@ExperimentalResourceApi
+internal val Res.string.str_20819: StringResource
+  get() = String24.str_20819
+
+@ExperimentalResourceApi
+internal val Res.string.str_2082: StringResource
+  get() = String24.str_2082
+
+@ExperimentalResourceApi
+internal val Res.string.str_20820: StringResource
+  get() = String24.str_20820
+
+@ExperimentalResourceApi
+internal val Res.string.str_20821: StringResource
+  get() = String24.str_20821
+
+@ExperimentalResourceApi
+internal val Res.string.str_20822: StringResource
+  get() = String24.str_20822
+
+@ExperimentalResourceApi
+internal val Res.string.str_20823: StringResource
+  get() = String24.str_20823
+
+@ExperimentalResourceApi
+internal val Res.string.str_20824: StringResource
+  get() = String24.str_20824
+
+@ExperimentalResourceApi
+internal val Res.string.str_20825: StringResource
+  get() = String24.str_20825
+
+@ExperimentalResourceApi
+internal val Res.string.str_20826: StringResource
+  get() = String24.str_20826
+
+@ExperimentalResourceApi
+internal val Res.string.str_20827: StringResource
+  get() = String24.str_20827
+
+@ExperimentalResourceApi
+internal val Res.string.str_20828: StringResource
+  get() = String24.str_20828
+
+@ExperimentalResourceApi
+internal val Res.string.str_20829: StringResource
+  get() = String24.str_20829
+
+@ExperimentalResourceApi
+internal val Res.string.str_2083: StringResource
+  get() = String24.str_2083
+
+@ExperimentalResourceApi
+internal val Res.string.str_20830: StringResource
+  get() = String24.str_20830
+
+@ExperimentalResourceApi
+internal val Res.string.str_20831: StringResource
+  get() = String24.str_20831
+
+@ExperimentalResourceApi
+internal val Res.string.str_20832: StringResource
+  get() = String24.str_20832
+
+@ExperimentalResourceApi
+internal val Res.string.str_20833: StringResource
+  get() = String24.str_20833
+
+@ExperimentalResourceApi
+internal val Res.string.str_20834: StringResource
+  get() = String24.str_20834
+
+@ExperimentalResourceApi
+internal val Res.string.str_20835: StringResource
+  get() = String24.str_20835
+
+@ExperimentalResourceApi
+internal val Res.string.str_20836: StringResource
+  get() = String24.str_20836
+
+@ExperimentalResourceApi
+internal val Res.string.str_20837: StringResource
+  get() = String24.str_20837
+
+@ExperimentalResourceApi
+internal val Res.string.str_20838: StringResource
+  get() = String24.str_20838
+
+@ExperimentalResourceApi
+internal val Res.string.str_20839: StringResource
+  get() = String24.str_20839
+
+@ExperimentalResourceApi
+internal val Res.string.str_2084: StringResource
+  get() = String24.str_2084
+
+@ExperimentalResourceApi
+internal val Res.string.str_20840: StringResource
+  get() = String24.str_20840
+
+@ExperimentalResourceApi
+internal val Res.string.str_20841: StringResource
+  get() = String24.str_20841
+
+@ExperimentalResourceApi
+internal val Res.string.str_20842: StringResource
+  get() = String24.str_20842
+
+@ExperimentalResourceApi
+internal val Res.string.str_20843: StringResource
+  get() = String24.str_20843
+
+@ExperimentalResourceApi
+internal val Res.string.str_20844: StringResource
+  get() = String24.str_20844
+
+@ExperimentalResourceApi
+internal val Res.string.str_20845: StringResource
+  get() = String24.str_20845
+
+@ExperimentalResourceApi
+internal val Res.string.str_20846: StringResource
+  get() = String24.str_20846
+
+@ExperimentalResourceApi
+internal val Res.string.str_20847: StringResource
+  get() = String24.str_20847
+
+@ExperimentalResourceApi
+internal val Res.string.str_20848: StringResource
+  get() = String24.str_20848
+
+@ExperimentalResourceApi
+internal val Res.string.str_20849: StringResource
+  get() = String24.str_20849
+
+@ExperimentalResourceApi
+internal val Res.string.str_2085: StringResource
+  get() = String24.str_2085
+
+@ExperimentalResourceApi
+internal val Res.string.str_20850: StringResource
+  get() = String24.str_20850
+
+@ExperimentalResourceApi
+internal val Res.string.str_20851: StringResource
+  get() = String24.str_20851
+
+@ExperimentalResourceApi
+internal val Res.string.str_20852: StringResource
+  get() = String24.str_20852
+
+@ExperimentalResourceApi
+internal val Res.string.str_20853: StringResource
+  get() = String24.str_20853
+
+@ExperimentalResourceApi
+internal val Res.string.str_20854: StringResource
+  get() = String24.str_20854
+
+@ExperimentalResourceApi
+internal val Res.string.str_20855: StringResource
+  get() = String24.str_20855
+
+@ExperimentalResourceApi
+internal val Res.string.str_20856: StringResource
+  get() = String24.str_20856
+
+@ExperimentalResourceApi
+internal val Res.string.str_20857: StringResource
+  get() = String24.str_20857
+
+@ExperimentalResourceApi
+internal val Res.string.str_20858: StringResource
+  get() = String24.str_20858
+
+@ExperimentalResourceApi
+internal val Res.string.str_20859: StringResource
+  get() = String24.str_20859
+
+@ExperimentalResourceApi
+internal val Res.string.str_2086: StringResource
+  get() = String24.str_2086
+
+@ExperimentalResourceApi
+internal val Res.string.str_20860: StringResource
+  get() = String24.str_20860
+
+@ExperimentalResourceApi
+internal val Res.string.str_20861: StringResource
+  get() = String24.str_20861
+
+@ExperimentalResourceApi
+internal val Res.string.str_20862: StringResource
+  get() = String24.str_20862
+
+@ExperimentalResourceApi
+internal val Res.string.str_20863: StringResource
+  get() = String24.str_20863
+
+@ExperimentalResourceApi
+internal val Res.string.str_20864: StringResource
+  get() = String24.str_20864
+
+@ExperimentalResourceApi
+internal val Res.string.str_20865: StringResource
+  get() = String24.str_20865
+
+@ExperimentalResourceApi
+internal val Res.string.str_20866: StringResource
+  get() = String24.str_20866
+
+@ExperimentalResourceApi
+internal val Res.string.str_20867: StringResource
+  get() = String24.str_20867
+
+@ExperimentalResourceApi
+internal val Res.string.str_20868: StringResource
+  get() = String24.str_20868
+
+@ExperimentalResourceApi
+internal val Res.string.str_20869: StringResource
+  get() = String24.str_20869
+
+@ExperimentalResourceApi
+internal val Res.string.str_2087: StringResource
+  get() = String24.str_2087
+
+@ExperimentalResourceApi
+internal val Res.string.str_20870: StringResource
+  get() = String24.str_20870
+
+@ExperimentalResourceApi
+internal val Res.string.str_20871: StringResource
+  get() = String24.str_20871
+
+@ExperimentalResourceApi
+internal val Res.string.str_20872: StringResource
+  get() = String24.str_20872
+
+@ExperimentalResourceApi
+internal val Res.string.str_20873: StringResource
+  get() = String24.str_20873
+
+@ExperimentalResourceApi
+internal val Res.string.str_20874: StringResource
+  get() = String24.str_20874
+
+@ExperimentalResourceApi
+internal val Res.string.str_20875: StringResource
+  get() = String24.str_20875
+
+@ExperimentalResourceApi
+internal val Res.string.str_20876: StringResource
+  get() = String24.str_20876
+
+@ExperimentalResourceApi
+internal val Res.string.str_20877: StringResource
+  get() = String24.str_20877
+
+@ExperimentalResourceApi
+internal val Res.string.str_20878: StringResource
+  get() = String24.str_20878
+
+@ExperimentalResourceApi
+internal val Res.string.str_20879: StringResource
+  get() = String24.str_20879
+
+@ExperimentalResourceApi
+internal val Res.string.str_2088: StringResource
+  get() = String24.str_2088
+
+@ExperimentalResourceApi
+internal val Res.string.str_20880: StringResource
+  get() = String24.str_20880
+
+@ExperimentalResourceApi
+internal val Res.string.str_20881: StringResource
+  get() = String24.str_20881
+
+@ExperimentalResourceApi
+internal val Res.string.str_20882: StringResource
+  get() = String24.str_20882
+
+@ExperimentalResourceApi
+internal val Res.string.str_20883: StringResource
+  get() = String24.str_20883
+
+@ExperimentalResourceApi
+internal val Res.string.str_20884: StringResource
+  get() = String24.str_20884
+
+@ExperimentalResourceApi
+internal val Res.string.str_20885: StringResource
+  get() = String24.str_20885
+
+@ExperimentalResourceApi
+internal val Res.string.str_20886: StringResource
+  get() = String24.str_20886
+
+@ExperimentalResourceApi
+internal val Res.string.str_20887: StringResource
+  get() = String24.str_20887
+
+@ExperimentalResourceApi
+internal val Res.string.str_20888: StringResource
+  get() = String24.str_20888
+
+@ExperimentalResourceApi
+internal val Res.string.str_20889: StringResource
+  get() = String24.str_20889
+
+@ExperimentalResourceApi
+internal val Res.string.str_2089: StringResource
+  get() = String24.str_2089
+
+@ExperimentalResourceApi
+internal val Res.string.str_20890: StringResource
+  get() = String24.str_20890
+
+@ExperimentalResourceApi
+internal val Res.string.str_20891: StringResource
+  get() = String24.str_20891
+
+@ExperimentalResourceApi
+internal val Res.string.str_20892: StringResource
+  get() = String24.str_20892
+
+@ExperimentalResourceApi
+internal val Res.string.str_20893: StringResource
+  get() = String24.str_20893
+
+@ExperimentalResourceApi
+internal val Res.string.str_20894: StringResource
+  get() = String24.str_20894
+
+@ExperimentalResourceApi
+internal val Res.string.str_20895: StringResource
+  get() = String24.str_20895
+
+@ExperimentalResourceApi
+internal val Res.string.str_20896: StringResource
+  get() = String24.str_20896
+
+@ExperimentalResourceApi
+internal val Res.string.str_20897: StringResource
+  get() = String24.str_20897
+
+@ExperimentalResourceApi
+internal val Res.string.str_20898: StringResource
+  get() = String24.str_20898
+
+@ExperimentalResourceApi
+internal val Res.string.str_20899: StringResource
+  get() = String24.str_20899
+
+@ExperimentalResourceApi
+internal val Res.string.str_209: StringResource
+  get() = String24.str_209
+
+@ExperimentalResourceApi
+internal val Res.string.str_2090: StringResource
+  get() = String24.str_2090
+
+@ExperimentalResourceApi
+internal val Res.string.str_20900: StringResource
+  get() = String24.str_20900
+
+@ExperimentalResourceApi
+internal val Res.string.str_20901: StringResource
+  get() = String24.str_20901
+
+@ExperimentalResourceApi
+internal val Res.string.str_20902: StringResource
+  get() = String24.str_20902
+
+@ExperimentalResourceApi
+internal val Res.string.str_20903: StringResource
+  get() = String24.str_20903
+
+@ExperimentalResourceApi
+internal val Res.string.str_20904: StringResource
+  get() = String24.str_20904
+
+@ExperimentalResourceApi
+internal val Res.string.str_20905: StringResource
+  get() = String24.str_20905
+
+@ExperimentalResourceApi
+internal val Res.string.str_20906: StringResource
+  get() = String24.str_20906
+
+@ExperimentalResourceApi
+internal val Res.string.str_20907: StringResource
+  get() = String24.str_20907
+
+@ExperimentalResourceApi
+internal val Res.string.str_20908: StringResource
+  get() = String24.str_20908
+
+@ExperimentalResourceApi
+internal val Res.string.str_20909: StringResource
+  get() = String24.str_20909
+
+@ExperimentalResourceApi
+internal val Res.string.str_2091: StringResource
+  get() = String24.str_2091
+
+@ExperimentalResourceApi
+internal val Res.string.str_20910: StringResource
+  get() = String24.str_20910
+
+@ExperimentalResourceApi
+internal val Res.string.str_20911: StringResource
+  get() = String24.str_20911
+
+@ExperimentalResourceApi
+internal val Res.string.str_20912: StringResource
+  get() = String24.str_20912
+
+@ExperimentalResourceApi
+internal val Res.string.str_20913: StringResource
+  get() = String24.str_20913
+
+@ExperimentalResourceApi
+internal val Res.string.str_20914: StringResource
+  get() = String24.str_20914
+
+@ExperimentalResourceApi
+internal val Res.string.str_20915: StringResource
+  get() = String24.str_20915
+
+@ExperimentalResourceApi
+internal val Res.string.str_20916: StringResource
+  get() = String24.str_20916
+
+@ExperimentalResourceApi
+internal val Res.string.str_20917: StringResource
+  get() = String24.str_20917
+
+@ExperimentalResourceApi
+internal val Res.string.str_20918: StringResource
+  get() = String24.str_20918
+
+@ExperimentalResourceApi
+internal val Res.string.str_20919: StringResource
+  get() = String24.str_20919
+
+@ExperimentalResourceApi
+internal val Res.string.str_2092: StringResource
+  get() = String24.str_2092
+
+@ExperimentalResourceApi
+internal val Res.string.str_20920: StringResource
+  get() = String24.str_20920
+
+@ExperimentalResourceApi
+internal val Res.string.str_20921: StringResource
+  get() = String24.str_20921
+
+@ExperimentalResourceApi
+internal val Res.string.str_20922: StringResource
+  get() = String24.str_20922
+
+@ExperimentalResourceApi
+internal val Res.string.str_20923: StringResource
+  get() = String24.str_20923
+
+@ExperimentalResourceApi
+internal val Res.string.str_20924: StringResource
+  get() = String24.str_20924
+
+@ExperimentalResourceApi
+internal val Res.string.str_20925: StringResource
+  get() = String24.str_20925
+
+@ExperimentalResourceApi
+internal val Res.string.str_20926: StringResource
+  get() = String24.str_20926
+
+@ExperimentalResourceApi
+internal val Res.string.str_20927: StringResource
+  get() = String24.str_20927
+
+@ExperimentalResourceApi
+internal val Res.string.str_20928: StringResource
+  get() = String24.str_20928
+
+@ExperimentalResourceApi
+internal val Res.string.str_20929: StringResource
+  get() = String24.str_20929
+
+@ExperimentalResourceApi
+internal val Res.string.str_2093: StringResource
+  get() = String24.str_2093
+
+@ExperimentalResourceApi
+internal val Res.string.str_20930: StringResource
+  get() = String24.str_20930
+
+@ExperimentalResourceApi
+internal val Res.string.str_20931: StringResource
+  get() = String24.str_20931
+
+@ExperimentalResourceApi
+internal val Res.string.str_20932: StringResource
+  get() = String24.str_20932
+
+@ExperimentalResourceApi
+internal val Res.string.str_20933: StringResource
+  get() = String24.str_20933
+
+@ExperimentalResourceApi
+internal val Res.string.str_20934: StringResource
+  get() = String24.str_20934
+
+@ExperimentalResourceApi
+internal val Res.string.str_20935: StringResource
+  get() = String24.str_20935
+
+@ExperimentalResourceApi
+internal val Res.string.str_20936: StringResource
+  get() = String24.str_20936
+
+@ExperimentalResourceApi
+internal val Res.string.str_20937: StringResource
+  get() = String24.str_20937
+
+@ExperimentalResourceApi
+internal val Res.string.str_20938: StringResource
+  get() = String24.str_20938
+
+@ExperimentalResourceApi
+internal val Res.string.str_20939: StringResource
+  get() = String24.str_20939
+
+@ExperimentalResourceApi
+internal val Res.string.str_2094: StringResource
+  get() = String24.str_2094
+
+@ExperimentalResourceApi
+internal val Res.string.str_20940: StringResource
+  get() = String24.str_20940
+
+@ExperimentalResourceApi
+internal val Res.string.str_20941: StringResource
+  get() = String24.str_20941
+
+@ExperimentalResourceApi
+internal val Res.string.str_20942: StringResource
+  get() = String24.str_20942
+
+@ExperimentalResourceApi
+internal val Res.string.str_20943: StringResource
+  get() = String24.str_20943
+
+@ExperimentalResourceApi
+internal val Res.string.str_20944: StringResource
+  get() = String24.str_20944
+
+@ExperimentalResourceApi
+internal val Res.string.str_20945: StringResource
+  get() = String24.str_20945
+
+@ExperimentalResourceApi
+internal val Res.string.str_20946: StringResource
+  get() = String24.str_20946
+
+@ExperimentalResourceApi
+internal val Res.string.str_20947: StringResource
+  get() = String24.str_20947
+
+@ExperimentalResourceApi
+internal val Res.string.str_20948: StringResource
+  get() = String24.str_20948
+
+@ExperimentalResourceApi
+internal val Res.string.str_20949: StringResource
+  get() = String24.str_20949
+
+@ExperimentalResourceApi
+internal val Res.string.str_2095: StringResource
+  get() = String24.str_2095
+
+@ExperimentalResourceApi
+internal val Res.string.str_20950: StringResource
+  get() = String24.str_20950
+
+@ExperimentalResourceApi
+internal val Res.string.str_20951: StringResource
+  get() = String24.str_20951
+
+@ExperimentalResourceApi
+internal val Res.string.str_20952: StringResource
+  get() = String24.str_20952
+
+@ExperimentalResourceApi
+internal val Res.string.str_20953: StringResource
+  get() = String24.str_20953
+
+@ExperimentalResourceApi
+internal val Res.string.str_20954: StringResource
+  get() = String24.str_20954
+
+@ExperimentalResourceApi
+internal val Res.string.str_20955: StringResource
+  get() = String24.str_20955
+
+@ExperimentalResourceApi
+internal val Res.string.str_20956: StringResource
+  get() = String24.str_20956
+
+@ExperimentalResourceApi
+internal val Res.string.str_20957: StringResource
+  get() = String24.str_20957
+
+@ExperimentalResourceApi
+internal val Res.string.str_20958: StringResource
+  get() = String24.str_20958
+
+@ExperimentalResourceApi
+internal val Res.string.str_20959: StringResource
+  get() = String24.str_20959
+
+@ExperimentalResourceApi
+internal val Res.string.str_2096: StringResource
+  get() = String24.str_2096
+
+@ExperimentalResourceApi
+internal val Res.string.str_20960: StringResource
+  get() = String24.str_20960
+
+@ExperimentalResourceApi
+internal val Res.string.str_20961: StringResource
+  get() = String24.str_20961
+
+@ExperimentalResourceApi
+internal val Res.string.str_20962: StringResource
+  get() = String24.str_20962
+
+@ExperimentalResourceApi
+internal val Res.string.str_20963: StringResource
+  get() = String24.str_20963
+
+@ExperimentalResourceApi
+internal val Res.string.str_20964: StringResource
+  get() = String24.str_20964
+
+@ExperimentalResourceApi
+internal val Res.string.str_20965: StringResource
+  get() = String24.str_20965
+
+@ExperimentalResourceApi
+internal val Res.string.str_20966: StringResource
+  get() = String24.str_20966
+
+@ExperimentalResourceApi
+internal val Res.string.str_20967: StringResource
+  get() = String24.str_20967
+
+@ExperimentalResourceApi
+internal val Res.string.str_20968: StringResource
+  get() = String24.str_20968
+
+@ExperimentalResourceApi
+internal val Res.string.str_20969: StringResource
+  get() = String24.str_20969
+
+@ExperimentalResourceApi
+internal val Res.string.str_2097: StringResource
+  get() = String24.str_2097
+
+@ExperimentalResourceApi
+internal val Res.string.str_20970: StringResource
+  get() = String24.str_20970
+
+@ExperimentalResourceApi
+internal val Res.string.str_20971: StringResource
+  get() = String24.str_20971
+
+@ExperimentalResourceApi
+internal val Res.string.str_20972: StringResource
+  get() = String24.str_20972
+
+@ExperimentalResourceApi
+internal val Res.string.str_20973: StringResource
+  get() = String24.str_20973
+
+@ExperimentalResourceApi
+internal val Res.string.str_20974: StringResource
+  get() = String24.str_20974
+
+@ExperimentalResourceApi
+internal val Res.string.str_20975: StringResource
+  get() = String24.str_20975
+
+@ExperimentalResourceApi
+internal val Res.string.str_20976: StringResource
+  get() = String24.str_20976
+
+@ExperimentalResourceApi
+internal val Res.string.str_20977: StringResource
+  get() = String24.str_20977
+
+@ExperimentalResourceApi
+internal val Res.string.str_20978: StringResource
+  get() = String24.str_20978
+
+@ExperimentalResourceApi
+internal val Res.string.str_20979: StringResource
+  get() = String24.str_20979
+
+@ExperimentalResourceApi
+internal val Res.string.str_2098: StringResource
+  get() = String24.str_2098
+
+@ExperimentalResourceApi
+internal val Res.string.str_20980: StringResource
+  get() = String24.str_20980
+
+@ExperimentalResourceApi
+internal val Res.string.str_20981: StringResource
+  get() = String24.str_20981
+
+@ExperimentalResourceApi
+internal val Res.string.str_20982: StringResource
+  get() = String24.str_20982
+
+@ExperimentalResourceApi
+internal val Res.string.str_20983: StringResource
+  get() = String24.str_20983
+
+@ExperimentalResourceApi
+internal val Res.string.str_20984: StringResource
+  get() = String24.str_20984
+
+@ExperimentalResourceApi
+internal val Res.string.str_20985: StringResource
+  get() = String24.str_20985
+
+@ExperimentalResourceApi
+internal val Res.string.str_20986: StringResource
+  get() = String24.str_20986
+
+@ExperimentalResourceApi
+internal val Res.string.str_20987: StringResource
+  get() = String24.str_20987
+
+@ExperimentalResourceApi
+internal val Res.string.str_20988: StringResource
+  get() = String24.str_20988
+
+@ExperimentalResourceApi
+internal val Res.string.str_20989: StringResource
+  get() = String24.str_20989
+
+@ExperimentalResourceApi
+internal val Res.string.str_2099: StringResource
+  get() = String24.str_2099
+
+@ExperimentalResourceApi
+internal val Res.string.str_20990: StringResource
+  get() = String24.str_20990
+
+@ExperimentalResourceApi
+internal val Res.string.str_20991: StringResource
+  get() = String24.str_20991
+
+@ExperimentalResourceApi
+internal val Res.string.str_20992: StringResource
+  get() = String24.str_20992
+
+@ExperimentalResourceApi
+internal val Res.string.str_20993: StringResource
+  get() = String24.str_20993
+
+@ExperimentalResourceApi
+internal val Res.string.str_20994: StringResource
+  get() = String24.str_20994
+
+@ExperimentalResourceApi
+internal val Res.string.str_20995: StringResource
+  get() = String24.str_20995
+
+@ExperimentalResourceApi
+internal val Res.string.str_20996: StringResource
+  get() = String24.str_20996
+
+@ExperimentalResourceApi
+internal val Res.string.str_20997: StringResource
+  get() = String24.str_20997
+
+@ExperimentalResourceApi
+internal val Res.string.str_20998: StringResource
+  get() = String24.str_20998
+
+@ExperimentalResourceApi
+internal val Res.string.str_20999: StringResource
+  get() = String24.str_20999
+
+@ExperimentalResourceApi
+internal val Res.string.str_21: StringResource
+  get() = String24.str_21
+
+@ExperimentalResourceApi
+internal val Res.string.str_210: StringResource
+  get() = String24.str_210
+
+@ExperimentalResourceApi
+internal val Res.string.str_2100: StringResource
+  get() = String24.str_2100
+
+@ExperimentalResourceApi
+internal val Res.string.str_21000: StringResource
+  get() = String24.str_21000
+
+@ExperimentalResourceApi
+internal val Res.string.str_21001: StringResource
+  get() = String24.str_21001
+
+@ExperimentalResourceApi
+internal val Res.string.str_21002: StringResource
+  get() = String24.str_21002
+
+@ExperimentalResourceApi
+internal val Res.string.str_21003: StringResource
+  get() = String24.str_21003
+
+@ExperimentalResourceApi
+internal val Res.string.str_21004: StringResource
+  get() = String24.str_21004
+
+@ExperimentalResourceApi
+internal val Res.string.str_21005: StringResource
+  get() = String24.str_21005
+
+@ExperimentalResourceApi
+internal val Res.string.str_21006: StringResource
+  get() = String24.str_21006
+
+@ExperimentalResourceApi
+internal val Res.string.str_21007: StringResource
+  get() = String24.str_21007
+
+@ExperimentalResourceApi
+internal val Res.string.str_21008: StringResource
+  get() = String24.str_21008
+
+@ExperimentalResourceApi
+internal val Res.string.str_21009: StringResource
+  get() = String24.str_21009
+
+@ExperimentalResourceApi
+internal val Res.string.str_2101: StringResource
+  get() = String24.str_2101
+
+@ExperimentalResourceApi
+internal val Res.string.str_21010: StringResource
+  get() = String24.str_21010
+
+@ExperimentalResourceApi
+internal val Res.string.str_21011: StringResource
+  get() = String24.str_21011
+
+@ExperimentalResourceApi
+internal val Res.string.str_21012: StringResource
+  get() = String24.str_21012
+
+@ExperimentalResourceApi
+internal val Res.string.str_21013: StringResource
+  get() = String24.str_21013
+
+@ExperimentalResourceApi
+internal val Res.string.str_21014: StringResource
+  get() = String24.str_21014
+
+@ExperimentalResourceApi
+internal val Res.string.str_21015: StringResource
+  get() = String24.str_21015
+
+@ExperimentalResourceApi
+internal val Res.string.str_21016: StringResource
+  get() = String24.str_21016
+
+@ExperimentalResourceApi
+internal val Res.string.str_21017: StringResource
+  get() = String24.str_21017
+
+@ExperimentalResourceApi
+internal val Res.string.str_21018: StringResource
+  get() = String24.str_21018
+
+@ExperimentalResourceApi
+internal val Res.string.str_21019: StringResource
+  get() = String24.str_21019
+
+@ExperimentalResourceApi
+internal val Res.string.str_2102: StringResource
+  get() = String24.str_2102
+
+@ExperimentalResourceApi
+internal val Res.string.str_21020: StringResource
+  get() = String24.str_21020
+
+@ExperimentalResourceApi
+internal val Res.string.str_21021: StringResource
+  get() = String24.str_21021
+
+@ExperimentalResourceApi
+internal val Res.string.str_21022: StringResource
+  get() = String24.str_21022
+
+@ExperimentalResourceApi
+internal val Res.string.str_21023: StringResource
+  get() = String24.str_21023
+
+@ExperimentalResourceApi
+internal val Res.string.str_21024: StringResource
+  get() = String24.str_21024
+
+@ExperimentalResourceApi
+internal val Res.string.str_21025: StringResource
+  get() = String24.str_21025
+
+@ExperimentalResourceApi
+internal val Res.string.str_21026: StringResource
+  get() = String24.str_21026
+
+@ExperimentalResourceApi
+internal val Res.string.str_21027: StringResource
+  get() = String24.str_21027
+
+@ExperimentalResourceApi
+internal val Res.string.str_21028: StringResource
+  get() = String24.str_21028
+
+@ExperimentalResourceApi
+internal val Res.string.str_21029: StringResource
+  get() = String24.str_21029
+
+@ExperimentalResourceApi
+internal val Res.string.str_2103: StringResource
+  get() = String24.str_2103
+
+@ExperimentalResourceApi
+internal val Res.string.str_21030: StringResource
+  get() = String24.str_21030
+
+@ExperimentalResourceApi
+internal val Res.string.str_21031: StringResource
+  get() = String24.str_21031
+
+@ExperimentalResourceApi
+internal val Res.string.str_21032: StringResource
+  get() = String24.str_21032
+
+@ExperimentalResourceApi
+internal val Res.string.str_21033: StringResource
+  get() = String24.str_21033
+
+@ExperimentalResourceApi
+internal val Res.string.str_21034: StringResource
+  get() = String24.str_21034
+
+@ExperimentalResourceApi
+internal val Res.string.str_21035: StringResource
+  get() = String24.str_21035
+
+@ExperimentalResourceApi
+internal val Res.string.str_21036: StringResource
+  get() = String24.str_21036
+
+@ExperimentalResourceApi
+internal val Res.string.str_21037: StringResource
+  get() = String24.str_21037
+
+@ExperimentalResourceApi
+internal val Res.string.str_21038: StringResource
+  get() = String24.str_21038
+
+@ExperimentalResourceApi
+internal val Res.string.str_21039: StringResource
+  get() = String24.str_21039
+
+@ExperimentalResourceApi
+internal val Res.string.str_2104: StringResource
+  get() = String24.str_2104
+
+@ExperimentalResourceApi
+internal val Res.string.str_21040: StringResource
+  get() = String24.str_21040
+
+@ExperimentalResourceApi
+internal val Res.string.str_21041: StringResource
+  get() = String24.str_21041
+
+@ExperimentalResourceApi
+internal val Res.string.str_21042: StringResource
+  get() = String24.str_21042
+
+@ExperimentalResourceApi
+internal val Res.string.str_21043: StringResource
+  get() = String24.str_21043
+
+@ExperimentalResourceApi
+internal val Res.string.str_21044: StringResource
+  get() = String24.str_21044
+
+@ExperimentalResourceApi
+internal val Res.string.str_21045: StringResource
+  get() = String24.str_21045
+
+@ExperimentalResourceApi
+internal val Res.string.str_21046: StringResource
+  get() = String24.str_21046
+
+@ExperimentalResourceApi
+internal val Res.string.str_21047: StringResource
+  get() = String24.str_21047
+
+@ExperimentalResourceApi
+internal val Res.string.str_21048: StringResource
+  get() = String24.str_21048
+
+@ExperimentalResourceApi
+internal val Res.string.str_21049: StringResource
+  get() = String24.str_21049
+
+@ExperimentalResourceApi
+internal val Res.string.str_2105: StringResource
+  get() = String24.str_2105
+
+@ExperimentalResourceApi
+internal val Res.string.str_21050: StringResource
+  get() = String24.str_21050
+
+@ExperimentalResourceApi
+internal val Res.string.str_21051: StringResource
+  get() = String24.str_21051
+
+@ExperimentalResourceApi
+internal val Res.string.str_21052: StringResource
+  get() = String24.str_21052
+
+@ExperimentalResourceApi
+internal val Res.string.str_21053: StringResource
+  get() = String24.str_21053
+
+@ExperimentalResourceApi
+internal val Res.string.str_21054: StringResource
+  get() = String24.str_21054
+
+@ExperimentalResourceApi
+internal val Res.string.str_21055: StringResource
+  get() = String24.str_21055
+
+@ExperimentalResourceApi
+internal val Res.string.str_21056: StringResource
+  get() = String24.str_21056
+
+@ExperimentalResourceApi
+internal val Res.string.str_21057: StringResource
+  get() = String24.str_21057
+
+@ExperimentalResourceApi
+internal val Res.string.str_21058: StringResource
+  get() = String24.str_21058
+
+@ExperimentalResourceApi
+internal val Res.string.str_21059: StringResource
+  get() = String24.str_21059
+
+@ExperimentalResourceApi
+internal val Res.string.str_2106: StringResource
+  get() = String24.str_2106
+
+@ExperimentalResourceApi
+internal val Res.string.str_21060: StringResource
+  get() = String24.str_21060
+
+@ExperimentalResourceApi
+internal val Res.string.str_21061: StringResource
+  get() = String24.str_21061
+
+@ExperimentalResourceApi
+internal val Res.string.str_21062: StringResource
+  get() = String24.str_21062
+
+@ExperimentalResourceApi
+internal val Res.string.str_21063: StringResource
+  get() = String24.str_21063
+
+@ExperimentalResourceApi
+internal val Res.string.str_21064: StringResource
+  get() = String24.str_21064
+
+@ExperimentalResourceApi
+internal val Res.string.str_21065: StringResource
+  get() = String24.str_21065
+
+@ExperimentalResourceApi
+internal val Res.string.str_21066: StringResource
+  get() = String24.str_21066
+
+@ExperimentalResourceApi
+internal val Res.string.str_21067: StringResource
+  get() = String24.str_21067
+
+@ExperimentalResourceApi
+internal val Res.string.str_21068: StringResource
+  get() = String24.str_21068
+
+@ExperimentalResourceApi
+internal val Res.string.str_21069: StringResource
+  get() = String24.str_21069
+
+@ExperimentalResourceApi
+internal val Res.string.str_2107: StringResource
+  get() = String24.str_2107
+
+@ExperimentalResourceApi
+internal val Res.string.str_21070: StringResource
+  get() = String24.str_21070
+
+@ExperimentalResourceApi
+internal val Res.string.str_21071: StringResource
+  get() = String24.str_21071
+
+@ExperimentalResourceApi
+internal val Res.string.str_21072: StringResource
+  get() = String24.str_21072
+
+@ExperimentalResourceApi
+internal val Res.string.str_21073: StringResource
+  get() = String24.str_21073
+
+@ExperimentalResourceApi
+internal val Res.string.str_21074: StringResource
+  get() = String24.str_21074
+
+@ExperimentalResourceApi
+internal val Res.string.str_21075: StringResource
+  get() = String24.str_21075
+
+@ExperimentalResourceApi
+internal val Res.string.str_21076: StringResource
+  get() = String24.str_21076
+
+@ExperimentalResourceApi
+internal val Res.string.str_21077: StringResource
+  get() = String24.str_21077
+
+@ExperimentalResourceApi
+internal val Res.string.str_21078: StringResource
+  get() = String24.str_21078
+
+@ExperimentalResourceApi
+internal val Res.string.str_21079: StringResource
+  get() = String24.str_21079
+
+@ExperimentalResourceApi
+internal val Res.string.str_2108: StringResource
+  get() = String24.str_2108
+
+@ExperimentalResourceApi
+internal val Res.string.str_21080: StringResource
+  get() = String24.str_21080
+
+@ExperimentalResourceApi
+internal val Res.string.str_21081: StringResource
+  get() = String24.str_21081
+
+@ExperimentalResourceApi
+internal val Res.string.str_21082: StringResource
+  get() = String24.str_21082
+
+@ExperimentalResourceApi
+internal val Res.string.str_21083: StringResource
+  get() = String24.str_21083
+
+@ExperimentalResourceApi
+internal val Res.string.str_21084: StringResource
+  get() = String24.str_21084
+
+@ExperimentalResourceApi
+internal val Res.string.str_21085: StringResource
+  get() = String24.str_21085
+
+@ExperimentalResourceApi
+internal val Res.string.str_21086: StringResource
+  get() = String24.str_21086
+
+@ExperimentalResourceApi
+internal val Res.string.str_21087: StringResource
+  get() = String24.str_21087
+
+@ExperimentalResourceApi
+internal val Res.string.str_21088: StringResource
+  get() = String24.str_21088
+
+@ExperimentalResourceApi
+internal val Res.string.str_21089: StringResource
+  get() = String24.str_21089
+
+@ExperimentalResourceApi
+internal val Res.string.str_2109: StringResource
+  get() = String24.str_2109
+
+@ExperimentalResourceApi
+internal val Res.string.str_21090: StringResource
+  get() = String24.str_21090
+
+@ExperimentalResourceApi
+internal val Res.string.str_21091: StringResource
+  get() = String24.str_21091
+
+@ExperimentalResourceApi
+internal val Res.string.str_21092: StringResource
+  get() = String24.str_21092
+
+@ExperimentalResourceApi
+internal val Res.string.str_21093: StringResource
+  get() = String24.str_21093
+
+@ExperimentalResourceApi
+internal val Res.string.str_21094: StringResource
+  get() = String24.str_21094
+
+@ExperimentalResourceApi
+internal val Res.string.str_21095: StringResource
+  get() = String24.str_21095
+
+@ExperimentalResourceApi
+internal val Res.string.str_21096: StringResource
+  get() = String24.str_21096
+
+@ExperimentalResourceApi
+internal val Res.string.str_21097: StringResource
+  get() = String24.str_21097
+
+@ExperimentalResourceApi
+internal val Res.string.str_21098: StringResource
+  get() = String24.str_21098
+
+@ExperimentalResourceApi
+internal val Res.string.str_21099: StringResource
+  get() = String24.str_21099
+
+@ExperimentalResourceApi
+internal val Res.string.str_211: StringResource
+  get() = String24.str_211
+
+@ExperimentalResourceApi
+internal val Res.string.str_2110: StringResource
+  get() = String24.str_2110
+
+@ExperimentalResourceApi
+internal val Res.string.str_21100: StringResource
+  get() = String24.str_21100
+
+@ExperimentalResourceApi
+internal val Res.string.str_21101: StringResource
+  get() = String24.str_21101
+
+@ExperimentalResourceApi
+internal val Res.string.str_21102: StringResource
+  get() = String24.str_21102
+
+@ExperimentalResourceApi
+internal val Res.string.str_21103: StringResource
+  get() = String24.str_21103
+
+@ExperimentalResourceApi
+internal val Res.string.str_21104: StringResource
+  get() = String24.str_21104
+
+@ExperimentalResourceApi
+internal val Res.string.str_21105: StringResource
+  get() = String24.str_21105
+
+@ExperimentalResourceApi
+internal val Res.string.str_21106: StringResource
+  get() = String24.str_21106
+
+@ExperimentalResourceApi
+internal val Res.string.str_21107: StringResource
+  get() = String24.str_21107
+
+@ExperimentalResourceApi
+internal val Res.string.str_21108: StringResource
+  get() = String24.str_21108
+
+@ExperimentalResourceApi
+internal val Res.string.str_21109: StringResource
+  get() = String24.str_21109
+
+@ExperimentalResourceApi
+internal val Res.string.str_2111: StringResource
+  get() = String24.str_2111
+
+@ExperimentalResourceApi
+internal val Res.string.str_21110: StringResource
+  get() = String24.str_21110
+
+@ExperimentalResourceApi
+internal val Res.string.str_21111: StringResource
+  get() = String24.str_21111
+
+@ExperimentalResourceApi
+internal val Res.string.str_21112: StringResource
+  get() = String24.str_21112
+
+@ExperimentalResourceApi
+internal val Res.string.str_21113: StringResource
+  get() = String24.str_21113
+
+@ExperimentalResourceApi
+internal val Res.string.str_21114: StringResource
+  get() = String24.str_21114
+
+@ExperimentalResourceApi
+internal val Res.string.str_21115: StringResource
+  get() = String24.str_21115
+
+@ExperimentalResourceApi
+internal val Res.string.str_21116: StringResource
+  get() = String24.str_21116
+
+@ExperimentalResourceApi
+internal val Res.string.str_21117: StringResource
+  get() = String24.str_21117
+
+@ExperimentalResourceApi
+internal val Res.string.str_21118: StringResource
+  get() = String24.str_21118
+
+@ExperimentalResourceApi
+internal val Res.string.str_21119: StringResource
+  get() = String24.str_21119
+
+@ExperimentalResourceApi
+internal val Res.string.str_2112: StringResource
+  get() = String24.str_2112
+
+@ExperimentalResourceApi
+internal val Res.string.str_21120: StringResource
+  get() = String24.str_21120
+
+@ExperimentalResourceApi
+internal val Res.string.str_21121: StringResource
+  get() = String24.str_21121
+
+@ExperimentalResourceApi
+internal val Res.string.str_21122: StringResource
+  get() = String24.str_21122
+
+@ExperimentalResourceApi
+internal val Res.string.str_21123: StringResource
+  get() = String24.str_21123
+
+@ExperimentalResourceApi
+internal val Res.string.str_21124: StringResource
+  get() = String24.str_21124
+
+@ExperimentalResourceApi
+internal val Res.string.str_21125: StringResource
+  get() = String24.str_21125
+
+@ExperimentalResourceApi
+internal val Res.string.str_21126: StringResource
+  get() = String24.str_21126
+
+@ExperimentalResourceApi
+internal val Res.string.str_21127: StringResource
+  get() = String24.str_21127
+
+@ExperimentalResourceApi
+internal val Res.string.str_21128: StringResource
+  get() = String24.str_21128
+
+@ExperimentalResourceApi
+internal val Res.string.str_21129: StringResource
+  get() = String24.str_21129
+
+@ExperimentalResourceApi
+internal val Res.string.str_2113: StringResource
+  get() = String24.str_2113
+
+@ExperimentalResourceApi
+internal val Res.string.str_21130: StringResource
+  get() = String24.str_21130
+
+@ExperimentalResourceApi
+internal val Res.string.str_21131: StringResource
+  get() = String24.str_21131
+
+@ExperimentalResourceApi
+internal val Res.string.str_21132: StringResource
+  get() = String24.str_21132
+
+@ExperimentalResourceApi
+internal val Res.string.str_21133: StringResource
+  get() = String24.str_21133
+
+@ExperimentalResourceApi
+internal val Res.string.str_21134: StringResource
+  get() = String24.str_21134
+
+@ExperimentalResourceApi
+internal val Res.string.str_21135: StringResource
+  get() = String24.str_21135
+
+@ExperimentalResourceApi
+internal val Res.string.str_21136: StringResource
+  get() = String24.str_21136
+
+@ExperimentalResourceApi
+internal val Res.string.str_21137: StringResource
+  get() = String24.str_21137
+
+@ExperimentalResourceApi
+internal val Res.string.str_21138: StringResource
+  get() = String24.str_21138
+
+@ExperimentalResourceApi
+internal val Res.string.str_21139: StringResource
+  get() = String24.str_21139
+
+@ExperimentalResourceApi
+internal val Res.string.str_2114: StringResource
+  get() = String24.str_2114
+
+@ExperimentalResourceApi
+internal val Res.string.str_21140: StringResource
+  get() = String24.str_21140
+
+@ExperimentalResourceApi
+internal val Res.string.str_21141: StringResource
+  get() = String24.str_21141
+
+@ExperimentalResourceApi
+internal val Res.string.str_21142: StringResource
+  get() = String24.str_21142
+
+@ExperimentalResourceApi
+internal val Res.string.str_21143: StringResource
+  get() = String24.str_21143
+
+@ExperimentalResourceApi
+internal val Res.string.str_21144: StringResource
+  get() = String24.str_21144
+
+@ExperimentalResourceApi
+internal val Res.string.str_21145: StringResource
+  get() = String24.str_21145
+
+@ExperimentalResourceApi
+internal val Res.string.str_21146: StringResource
+  get() = String24.str_21146
+
+@ExperimentalResourceApi
+internal val Res.string.str_21147: StringResource
+  get() = String24.str_21147
+
+@ExperimentalResourceApi
+internal val Res.string.str_21148: StringResource
+  get() = String24.str_21148
+
+@ExperimentalResourceApi
+internal val Res.string.str_21149: StringResource
+  get() = String24.str_21149
+
+@ExperimentalResourceApi
+internal val Res.string.str_2115: StringResource
+  get() = String24.str_2115
+
+@ExperimentalResourceApi
+internal val Res.string.str_21150: StringResource
+  get() = String24.str_21150
+
+@ExperimentalResourceApi
+internal val Res.string.str_21151: StringResource
+  get() = String24.str_21151
+
+@ExperimentalResourceApi
+internal val Res.string.str_21152: StringResource
+  get() = String24.str_21152
+
+@ExperimentalResourceApi
+internal val Res.string.str_21153: StringResource
+  get() = String24.str_21153
+
+@ExperimentalResourceApi
+internal val Res.string.str_21154: StringResource
+  get() = String24.str_21154
+
+@ExperimentalResourceApi
+internal val Res.string.str_21155: StringResource
+  get() = String24.str_21155
+
+@ExperimentalResourceApi
+internal val Res.string.str_21156: StringResource
+  get() = String24.str_21156
+
+@ExperimentalResourceApi
+internal val Res.string.str_21157: StringResource
+  get() = String24.str_21157
+
+@ExperimentalResourceApi
+internal val Res.string.str_21158: StringResource
+  get() = String24.str_21158
+
+@ExperimentalResourceApi
+internal val Res.string.str_21159: StringResource
+  get() = String24.str_21159
+
+@ExperimentalResourceApi
+internal val Res.string.str_2116: StringResource
+  get() = String24.str_2116
+
+@ExperimentalResourceApi
+internal val Res.string.str_21160: StringResource
+  get() = String24.str_21160
+
+@ExperimentalResourceApi
+internal val Res.string.str_21161: StringResource
+  get() = String24.str_21161
+
+@ExperimentalResourceApi
+internal val Res.string.str_21162: StringResource
+  get() = String24.str_21162
+
+@ExperimentalResourceApi
+internal val Res.string.str_21163: StringResource
+  get() = String24.str_21163
+
+@ExperimentalResourceApi
+internal val Res.string.str_21164: StringResource
+  get() = String24.str_21164
+
+@ExperimentalResourceApi
+internal val Res.string.str_21165: StringResource
+  get() = String24.str_21165
+
+@ExperimentalResourceApi
+internal val Res.string.str_21166: StringResource
+  get() = String24.str_21166
+
+@ExperimentalResourceApi
+internal val Res.string.str_21167: StringResource
+  get() = String24.str_21167
+
+@ExperimentalResourceApi
+internal val Res.string.str_21168: StringResource
+  get() = String24.str_21168
+
+@ExperimentalResourceApi
+internal val Res.string.str_21169: StringResource
+  get() = String24.str_21169
+
+@ExperimentalResourceApi
+internal val Res.string.str_2117: StringResource
+  get() = String24.str_2117
+
+@ExperimentalResourceApi
+internal val Res.string.str_21170: StringResource
+  get() = String24.str_21170
+
+@ExperimentalResourceApi
+internal val Res.string.str_21171: StringResource
+  get() = String24.str_21171
+
+@ExperimentalResourceApi
+internal val Res.string.str_21172: StringResource
+  get() = String24.str_21172
+
+@ExperimentalResourceApi
+internal val Res.string.str_21173: StringResource
+  get() = String24.str_21173
+
+@ExperimentalResourceApi
+internal val Res.string.str_21174: StringResource
+  get() = String24.str_21174
+
+@ExperimentalResourceApi
+internal val Res.string.str_21175: StringResource
+  get() = String24.str_21175
+
+@ExperimentalResourceApi
+internal val Res.string.str_21176: StringResource
+  get() = String24.str_21176
+
+@ExperimentalResourceApi
+internal val Res.string.str_21177: StringResource
+  get() = String24.str_21177
+
+@ExperimentalResourceApi
+internal val Res.string.str_21178: StringResource
+  get() = String24.str_21178
+
+@ExperimentalResourceApi
+internal val Res.string.str_21179: StringResource
+  get() = String24.str_21179
+
+@ExperimentalResourceApi
+internal val Res.string.str_2118: StringResource
+  get() = String24.str_2118
+
+@ExperimentalResourceApi
+internal val Res.string.str_21180: StringResource
+  get() = String24.str_21180
+
+@ExperimentalResourceApi
+internal val Res.string.str_21181: StringResource
+  get() = String24.str_21181
+
+@ExperimentalResourceApi
+internal val Res.string.str_21182: StringResource
+  get() = String24.str_21182
+
+@ExperimentalResourceApi
+internal val Res.string.str_21183: StringResource
+  get() = String24.str_21183
+
+@ExperimentalResourceApi
+internal val Res.string.str_21184: StringResource
+  get() = String24.str_21184
+
+@ExperimentalResourceApi
+internal val Res.string.str_21185: StringResource
+  get() = String24.str_21185
+
+@ExperimentalResourceApi
+internal val Res.string.str_21186: StringResource
+  get() = String24.str_21186
+
+@ExperimentalResourceApi
+internal val Res.string.str_21187: StringResource
+  get() = String24.str_21187
+
+@ExperimentalResourceApi
+internal val Res.string.str_21188: StringResource
+  get() = String24.str_21188
+
+@ExperimentalResourceApi
+internal val Res.string.str_21189: StringResource
+  get() = String24.str_21189
+
+@ExperimentalResourceApi
+internal val Res.string.str_2119: StringResource
+  get() = String24.str_2119
+
+@ExperimentalResourceApi
+internal val Res.string.str_21190: StringResource
+  get() = String24.str_21190
+
+@ExperimentalResourceApi
+internal val Res.string.str_21191: StringResource
+  get() = String24.str_21191
+
+@ExperimentalResourceApi
+internal val Res.string.str_21192: StringResource
+  get() = String24.str_21192
+
+@ExperimentalResourceApi
+internal val Res.string.str_21193: StringResource
+  get() = String24.str_21193
+
+@ExperimentalResourceApi
+internal val Res.string.str_21194: StringResource
+  get() = String24.str_21194
+
+@ExperimentalResourceApi
+internal val Res.string.str_21195: StringResource
+  get() = String24.str_21195
+
+@ExperimentalResourceApi
+internal val Res.string.str_21196: StringResource
+  get() = String24.str_21196
+
+@ExperimentalResourceApi
+internal val Res.string.str_21197: StringResource
+  get() = String24.str_21197
+
+@ExperimentalResourceApi
+internal val Res.string.str_21198: StringResource
+  get() = String24.str_21198
+
+@ExperimentalResourceApi
+internal val Res.string.str_21199: StringResource
+  get() = String24.str_21199
+
+@ExperimentalResourceApi
+internal val Res.string.str_212: StringResource
+  get() = String24.str_212
+
+@ExperimentalResourceApi
+internal val Res.string.str_2120: StringResource
+  get() = String24.str_2120
+
+@ExperimentalResourceApi
+internal val Res.string.str_21200: StringResource
+  get() = String24.str_21200
+
+@ExperimentalResourceApi
+internal val Res.string.str_21201: StringResource
+  get() = String24.str_21201
+
+@ExperimentalResourceApi
+internal val Res.string.str_21202: StringResource
+  get() = String24.str_21202
+
+@ExperimentalResourceApi
+internal val Res.string.str_21203: StringResource
+  get() = String24.str_21203
+
+@ExperimentalResourceApi
+internal val Res.string.str_21204: StringResource
+  get() = String24.str_21204
+
+@ExperimentalResourceApi
+internal val Res.string.str_21205: StringResource
+  get() = String24.str_21205
+
+@ExperimentalResourceApi
+internal val Res.string.str_21206: StringResource
+  get() = String24.str_21206
+
+@ExperimentalResourceApi
+internal val Res.string.str_21207: StringResource
+  get() = String24.str_21207
+
+@ExperimentalResourceApi
+internal val Res.string.str_21208: StringResource
+  get() = String24.str_21208
+
+@ExperimentalResourceApi
+internal val Res.string.str_21209: StringResource
+  get() = String24.str_21209
+
+@ExperimentalResourceApi
+internal val Res.string.str_2121: StringResource
+  get() = String24.str_2121
+
+@ExperimentalResourceApi
+internal val Res.string.str_21210: StringResource
+  get() = String24.str_21210
+
+@ExperimentalResourceApi
+internal val Res.string.str_21211: StringResource
+  get() = String24.str_21211
+
+@ExperimentalResourceApi
+internal val Res.string.str_21212: StringResource
+  get() = String24.str_21212
+
+@ExperimentalResourceApi
+internal val Res.string.str_21213: StringResource
+  get() = String24.str_21213
+
+@ExperimentalResourceApi
+internal val Res.string.str_21214: StringResource
+  get() = String24.str_21214
+
+@ExperimentalResourceApi
+internal val Res.string.str_21215: StringResource
+  get() = String24.str_21215
+
+@ExperimentalResourceApi
+internal val Res.string.str_21216: StringResource
+  get() = String24.str_21216
+
+@ExperimentalResourceApi
+internal val Res.string.str_21217: StringResource
+  get() = String24.str_21217
+
+@ExperimentalResourceApi
+internal val Res.string.str_21218: StringResource
+  get() = String24.str_21218
+
+@ExperimentalResourceApi
+internal val Res.string.str_21219: StringResource
+  get() = String24.str_21219
+
+@ExperimentalResourceApi
+internal val Res.string.str_2122: StringResource
+  get() = String24.str_2122
+
+@ExperimentalResourceApi
+internal val Res.string.str_21220: StringResource
+  get() = String24.str_21220
+
+@ExperimentalResourceApi
+internal val Res.string.str_21221: StringResource
+  get() = String24.str_21221
+
+@ExperimentalResourceApi
+internal val Res.string.str_21222: StringResource
+  get() = String24.str_21222
+
+@ExperimentalResourceApi
+internal val Res.string.str_21223: StringResource
+  get() = String24.str_21223
+
+@ExperimentalResourceApi
+internal val Res.string.str_21224: StringResource
+  get() = String24.str_21224
+
+@ExperimentalResourceApi
+internal val Res.string.str_21225: StringResource
+  get() = String24.str_21225
+
+@ExperimentalResourceApi
+internal val Res.string.str_21226: StringResource
+  get() = String24.str_21226
+
+@ExperimentalResourceApi
+internal val Res.string.str_21227: StringResource
+  get() = String24.str_21227
+
+@ExperimentalResourceApi
+internal val Res.string.str_21228: StringResource
+  get() = String24.str_21228
+
+@ExperimentalResourceApi
+internal val Res.string.str_21229: StringResource
+  get() = String24.str_21229
+
+@ExperimentalResourceApi
+internal val Res.string.str_2123: StringResource
+  get() = String24.str_2123
+
+@ExperimentalResourceApi
+internal val Res.string.str_21230: StringResource
+  get() = String24.str_21230
+
+@ExperimentalResourceApi
+internal val Res.string.str_21231: StringResource
+  get() = String24.str_21231
+
+@ExperimentalResourceApi
+internal val Res.string.str_21232: StringResource
+  get() = String24.str_21232
+
+@ExperimentalResourceApi
+internal val Res.string.str_21233: StringResource
+  get() = String24.str_21233
+
+@ExperimentalResourceApi
+internal val Res.string.str_21234: StringResource
+  get() = String24.str_21234
+
+@ExperimentalResourceApi
+internal val Res.string.str_21235: StringResource
+  get() = String24.str_21235
+
+@ExperimentalResourceApi
+internal val Res.string.str_21236: StringResource
+  get() = String24.str_21236
+
+@ExperimentalResourceApi
+internal val Res.string.str_21237: StringResource
+  get() = String24.str_21237
+
+@ExperimentalResourceApi
+internal val Res.string.str_21238: StringResource
+  get() = String24.str_21238
+
+@ExperimentalResourceApi
+internal val Res.string.str_21239: StringResource
+  get() = String24.str_21239
+
+@ExperimentalResourceApi
+internal val Res.string.str_2124: StringResource
+  get() = String24.str_2124
+
+@ExperimentalResourceApi
+internal val Res.string.str_21240: StringResource
+  get() = String24.str_21240
+
+@ExperimentalResourceApi
+internal val Res.string.str_21241: StringResource
+  get() = String24.str_21241
+
+@ExperimentalResourceApi
+internal val Res.string.str_21242: StringResource
+  get() = String24.str_21242
+
+@ExperimentalResourceApi
+internal val Res.string.str_21243: StringResource
+  get() = String24.str_21243
+
+@ExperimentalResourceApi
+internal val Res.string.str_21244: StringResource
+  get() = String24.str_21244
+
+@ExperimentalResourceApi
+internal val Res.string.str_21245: StringResource
+  get() = String24.str_21245
+
+@ExperimentalResourceApi
+internal val Res.string.str_21246: StringResource
+  get() = String24.str_21246

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String25.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String25.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String25 {
+  public val str_21247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21247", "str_21247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21248", "str_21248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21249", "str_21249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2125", "str_2125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21250", "str_21250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21251", "str_21251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21252", "str_21252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21253", "str_21253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21254", "str_21254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21255", "str_21255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21256", "str_21256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21257", "str_21257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21258", "str_21258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21259", "str_21259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2126", "str_2126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21260", "str_21260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21261", "str_21261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21262", "str_21262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21263", "str_21263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21264", "str_21264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21265", "str_21265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21266", "str_21266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21267", "str_21267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21268", "str_21268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21269", "str_21269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2127", "str_2127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21270", "str_21270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21271", "str_21271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21272", "str_21272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21273", "str_21273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21274", "str_21274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21275", "str_21275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21276", "str_21276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21277", "str_21277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21278", "str_21278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21279", "str_21279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2128", "str_2128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21280", "str_21280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21281", "str_21281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21282", "str_21282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21283", "str_21283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21284", "str_21284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21285", "str_21285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21286", "str_21286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21287", "str_21287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21288", "str_21288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21289", "str_21289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2129", "str_2129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21290", "str_21290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21291", "str_21291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21292", "str_21292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21293", "str_21293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21294", "str_21294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21295", "str_21295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21296", "str_21296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21297", "str_21297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21298", "str_21298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21299", "str_21299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_213", "str_213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2130", "str_2130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21300", "str_21300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21301", "str_21301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21302", "str_21302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21303", "str_21303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21304", "str_21304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21305", "str_21305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21306", "str_21306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21307", "str_21307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21308", "str_21308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21309", "str_21309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2131", "str_2131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21310", "str_21310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21311", "str_21311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21312", "str_21312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21313", "str_21313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21314", "str_21314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21315", "str_21315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21316", "str_21316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21317", "str_21317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21318", "str_21318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21319", "str_21319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2132", "str_2132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21320", "str_21320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21321", "str_21321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21322", "str_21322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21323", "str_21323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21324", "str_21324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21325", "str_21325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21326", "str_21326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21327", "str_21327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21328", "str_21328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21329", "str_21329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2133", "str_2133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21330", "str_21330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21331", "str_21331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21332", "str_21332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21333", "str_21333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21334", "str_21334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21335", "str_21335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21336", "str_21336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21337", "str_21337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21338", "str_21338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21339", "str_21339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2134", "str_2134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21340", "str_21340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21341", "str_21341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21342", "str_21342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21343", "str_21343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21344", "str_21344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21345", "str_21345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21346", "str_21346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21347", "str_21347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21348", "str_21348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21349", "str_21349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2135", "str_2135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21350", "str_21350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21351", "str_21351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21352", "str_21352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21353", "str_21353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21354", "str_21354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21355", "str_21355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21356", "str_21356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21357", "str_21357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21358", "str_21358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21359", "str_21359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2136", "str_2136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21360", "str_21360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21361", "str_21361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21362", "str_21362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21363", "str_21363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21364", "str_21364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21365", "str_21365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21366", "str_21366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21367", "str_21367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21368", "str_21368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21369", "str_21369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2137", "str_2137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21370", "str_21370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21371", "str_21371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21372", "str_21372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21373", "str_21373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21374", "str_21374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21375", "str_21375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21376", "str_21376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21377", "str_21377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21378", "str_21378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21379", "str_21379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2138", "str_2138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21380", "str_21380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21381", "str_21381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21382", "str_21382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21383", "str_21383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21384", "str_21384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21385", "str_21385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21386", "str_21386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21387", "str_21387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21388", "str_21388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21389", "str_21389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2139", "str_2139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21390", "str_21390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21391", "str_21391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21392", "str_21392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21393", "str_21393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21394", "str_21394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21395", "str_21395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21396", "str_21396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21397", "str_21397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21398", "str_21398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21399", "str_21399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_214", "str_214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2140", "str_2140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21400", "str_21400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21401", "str_21401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21402", "str_21402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21403", "str_21403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21404", "str_21404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21405", "str_21405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21406", "str_21406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21407", "str_21407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21408", "str_21408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21409", "str_21409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2141", "str_2141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21410", "str_21410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21411", "str_21411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21412", "str_21412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21413", "str_21413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21414", "str_21414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21415", "str_21415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21416", "str_21416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21417", "str_21417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21418", "str_21418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21419", "str_21419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2142", "str_2142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21420", "str_21420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21421", "str_21421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21422", "str_21422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21423", "str_21423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21424", "str_21424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21425", "str_21425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21426", "str_21426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21427", "str_21427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21428", "str_21428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21429", "str_21429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2143", "str_2143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21430", "str_21430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21431", "str_21431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21432", "str_21432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21433", "str_21433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21434", "str_21434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21435", "str_21435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21436", "str_21436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21437", "str_21437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21438", "str_21438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21439", "str_21439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2144", "str_2144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21440", "str_21440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21441", "str_21441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21442", "str_21442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21443", "str_21443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21444", "str_21444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21445", "str_21445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21446", "str_21446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21447", "str_21447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21448", "str_21448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21449", "str_21449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2145", "str_2145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21450", "str_21450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21451", "str_21451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21452", "str_21452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21453", "str_21453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21454", "str_21454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21455", "str_21455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21456", "str_21456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21457", "str_21457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21458", "str_21458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21459", "str_21459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2146", "str_2146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21460", "str_21460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21461", "str_21461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21462", "str_21462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21463", "str_21463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21464", "str_21464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21465", "str_21465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21466", "str_21466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21467", "str_21467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21468", "str_21468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21469", "str_21469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2147", "str_2147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21470", "str_21470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21471", "str_21471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21472", "str_21472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21473", "str_21473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21474", "str_21474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21475", "str_21475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21476", "str_21476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21477", "str_21477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21478", "str_21478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21479", "str_21479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2148", "str_2148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21480", "str_21480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21481", "str_21481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21482", "str_21482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21483", "str_21483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21484", "str_21484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21485", "str_21485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21486", "str_21486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21487", "str_21487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21488", "str_21488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21489", "str_21489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2149", "str_2149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21490", "str_21490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21491", "str_21491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21492", "str_21492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21493", "str_21493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21494", "str_21494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21495", "str_21495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21496", "str_21496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21497", "str_21497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21498", "str_21498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21499", "str_21499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_215", "str_215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2150", "str_2150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21500", "str_21500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21501", "str_21501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21502", "str_21502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21503", "str_21503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21504", "str_21504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21505", "str_21505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21506", "str_21506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21507", "str_21507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21508", "str_21508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21509", "str_21509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2151", "str_2151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21510", "str_21510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21511", "str_21511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21512", "str_21512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21513", "str_21513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21514", "str_21514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21515", "str_21515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21516", "str_21516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21517", "str_21517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21518", "str_21518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21519", "str_21519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2152", "str_2152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21520", "str_21520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21521", "str_21521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21522", "str_21522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21523", "str_21523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21524", "str_21524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21525", "str_21525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21526", "str_21526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21527", "str_21527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21528", "str_21528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21529", "str_21529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2153", "str_2153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21530", "str_21530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21531", "str_21531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21532", "str_21532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21533", "str_21533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21534", "str_21534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21535", "str_21535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21536", "str_21536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21537", "str_21537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21538", "str_21538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21539", "str_21539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2154", "str_2154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21540", "str_21540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21541", "str_21541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21542", "str_21542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21543", "str_21543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21544", "str_21544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21545", "str_21545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21546", "str_21546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21547", "str_21547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21548", "str_21548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21549", "str_21549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2155", "str_2155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21550", "str_21550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21551", "str_21551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21552", "str_21552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21553", "str_21553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21554", "str_21554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21555", "str_21555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21556", "str_21556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21557", "str_21557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21558", "str_21558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21559", "str_21559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2156", "str_2156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21560", "str_21560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21561", "str_21561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21562", "str_21562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21563", "str_21563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21564", "str_21564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21565", "str_21565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21566", "str_21566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21567", "str_21567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21568", "str_21568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21569", "str_21569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2157", "str_2157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21570", "str_21570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21571", "str_21571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21572", "str_21572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21573", "str_21573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21574", "str_21574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21575", "str_21575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21576", "str_21576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21577", "str_21577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21578", "str_21578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21579", "str_21579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2158", "str_2158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21580", "str_21580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21581", "str_21581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21582", "str_21582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21583", "str_21583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21584", "str_21584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21585", "str_21585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21586", "str_21586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21587", "str_21587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21588", "str_21588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21589", "str_21589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2159", "str_2159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21590", "str_21590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21591", "str_21591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21592", "str_21592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21593", "str_21593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21594", "str_21594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21595", "str_21595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21596", "str_21596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21597", "str_21597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21598", "str_21598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21599", "str_21599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_216", "str_216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2160", "str_2160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21600", "str_21600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21601", "str_21601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21602", "str_21602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21603", "str_21603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21604", "str_21604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21605", "str_21605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21606", "str_21606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21607", "str_21607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21608", "str_21608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21609", "str_21609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2161", "str_2161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21610", "str_21610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21611", "str_21611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21612", "str_21612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21613", "str_21613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21614", "str_21614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21615", "str_21615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21616", "str_21616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21617", "str_21617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21618", "str_21618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21619", "str_21619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2162", "str_2162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21620", "str_21620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21621", "str_21621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21622", "str_21622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21623", "str_21623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21624", "str_21624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21625", "str_21625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21626", "str_21626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21627", "str_21627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21628", "str_21628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21629", "str_21629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2163", "str_2163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21630", "str_21630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21631", "str_21631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21632", "str_21632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21633", "str_21633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21634", "str_21634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21635", "str_21635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21636", "str_21636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21637", "str_21637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21638", "str_21638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21639", "str_21639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2164", "str_2164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21640", "str_21640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21641", "str_21641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21642", "str_21642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21643", "str_21643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21644", "str_21644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21645", "str_21645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21646", "str_21646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21647", "str_21647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21648", "str_21648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21649", "str_21649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2165", "str_2165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21650", "str_21650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21651", "str_21651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21652", "str_21652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21653", "str_21653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21654", "str_21654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21655", "str_21655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21656", "str_21656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21657", "str_21657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21658", "str_21658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21659", "str_21659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2166", "str_2166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21660", "str_21660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21661", "str_21661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21662", "str_21662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21663", "str_21663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21664", "str_21664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21665", "str_21665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21666", "str_21666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21667", "str_21667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21668", "str_21668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21669", "str_21669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2167", "str_2167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21670", "str_21670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21671", "str_21671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21672", "str_21672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21673", "str_21673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21674", "str_21674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21675", "str_21675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21676", "str_21676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21677", "str_21677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21678", "str_21678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21679", "str_21679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2168", "str_2168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21680", "str_21680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21681", "str_21681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21682", "str_21682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21683", "str_21683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21684", "str_21684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21685", "str_21685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21686", "str_21686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21687", "str_21687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21688", "str_21688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21689", "str_21689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2169", "str_2169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21690", "str_21690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21691", "str_21691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21692", "str_21692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21693", "str_21693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21694", "str_21694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21695", "str_21695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21696", "str_21696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21697", "str_21697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_21247: StringResource
+  get() = String25.str_21247
+
+@ExperimentalResourceApi
+internal val Res.string.str_21248: StringResource
+  get() = String25.str_21248
+
+@ExperimentalResourceApi
+internal val Res.string.str_21249: StringResource
+  get() = String25.str_21249
+
+@ExperimentalResourceApi
+internal val Res.string.str_2125: StringResource
+  get() = String25.str_2125
+
+@ExperimentalResourceApi
+internal val Res.string.str_21250: StringResource
+  get() = String25.str_21250
+
+@ExperimentalResourceApi
+internal val Res.string.str_21251: StringResource
+  get() = String25.str_21251
+
+@ExperimentalResourceApi
+internal val Res.string.str_21252: StringResource
+  get() = String25.str_21252
+
+@ExperimentalResourceApi
+internal val Res.string.str_21253: StringResource
+  get() = String25.str_21253
+
+@ExperimentalResourceApi
+internal val Res.string.str_21254: StringResource
+  get() = String25.str_21254
+
+@ExperimentalResourceApi
+internal val Res.string.str_21255: StringResource
+  get() = String25.str_21255
+
+@ExperimentalResourceApi
+internal val Res.string.str_21256: StringResource
+  get() = String25.str_21256
+
+@ExperimentalResourceApi
+internal val Res.string.str_21257: StringResource
+  get() = String25.str_21257
+
+@ExperimentalResourceApi
+internal val Res.string.str_21258: StringResource
+  get() = String25.str_21258
+
+@ExperimentalResourceApi
+internal val Res.string.str_21259: StringResource
+  get() = String25.str_21259
+
+@ExperimentalResourceApi
+internal val Res.string.str_2126: StringResource
+  get() = String25.str_2126
+
+@ExperimentalResourceApi
+internal val Res.string.str_21260: StringResource
+  get() = String25.str_21260
+
+@ExperimentalResourceApi
+internal val Res.string.str_21261: StringResource
+  get() = String25.str_21261
+
+@ExperimentalResourceApi
+internal val Res.string.str_21262: StringResource
+  get() = String25.str_21262
+
+@ExperimentalResourceApi
+internal val Res.string.str_21263: StringResource
+  get() = String25.str_21263
+
+@ExperimentalResourceApi
+internal val Res.string.str_21264: StringResource
+  get() = String25.str_21264
+
+@ExperimentalResourceApi
+internal val Res.string.str_21265: StringResource
+  get() = String25.str_21265
+
+@ExperimentalResourceApi
+internal val Res.string.str_21266: StringResource
+  get() = String25.str_21266
+
+@ExperimentalResourceApi
+internal val Res.string.str_21267: StringResource
+  get() = String25.str_21267
+
+@ExperimentalResourceApi
+internal val Res.string.str_21268: StringResource
+  get() = String25.str_21268
+
+@ExperimentalResourceApi
+internal val Res.string.str_21269: StringResource
+  get() = String25.str_21269
+
+@ExperimentalResourceApi
+internal val Res.string.str_2127: StringResource
+  get() = String25.str_2127
+
+@ExperimentalResourceApi
+internal val Res.string.str_21270: StringResource
+  get() = String25.str_21270
+
+@ExperimentalResourceApi
+internal val Res.string.str_21271: StringResource
+  get() = String25.str_21271
+
+@ExperimentalResourceApi
+internal val Res.string.str_21272: StringResource
+  get() = String25.str_21272
+
+@ExperimentalResourceApi
+internal val Res.string.str_21273: StringResource
+  get() = String25.str_21273
+
+@ExperimentalResourceApi
+internal val Res.string.str_21274: StringResource
+  get() = String25.str_21274
+
+@ExperimentalResourceApi
+internal val Res.string.str_21275: StringResource
+  get() = String25.str_21275
+
+@ExperimentalResourceApi
+internal val Res.string.str_21276: StringResource
+  get() = String25.str_21276
+
+@ExperimentalResourceApi
+internal val Res.string.str_21277: StringResource
+  get() = String25.str_21277
+
+@ExperimentalResourceApi
+internal val Res.string.str_21278: StringResource
+  get() = String25.str_21278
+
+@ExperimentalResourceApi
+internal val Res.string.str_21279: StringResource
+  get() = String25.str_21279
+
+@ExperimentalResourceApi
+internal val Res.string.str_2128: StringResource
+  get() = String25.str_2128
+
+@ExperimentalResourceApi
+internal val Res.string.str_21280: StringResource
+  get() = String25.str_21280
+
+@ExperimentalResourceApi
+internal val Res.string.str_21281: StringResource
+  get() = String25.str_21281
+
+@ExperimentalResourceApi
+internal val Res.string.str_21282: StringResource
+  get() = String25.str_21282
+
+@ExperimentalResourceApi
+internal val Res.string.str_21283: StringResource
+  get() = String25.str_21283
+
+@ExperimentalResourceApi
+internal val Res.string.str_21284: StringResource
+  get() = String25.str_21284
+
+@ExperimentalResourceApi
+internal val Res.string.str_21285: StringResource
+  get() = String25.str_21285
+
+@ExperimentalResourceApi
+internal val Res.string.str_21286: StringResource
+  get() = String25.str_21286
+
+@ExperimentalResourceApi
+internal val Res.string.str_21287: StringResource
+  get() = String25.str_21287
+
+@ExperimentalResourceApi
+internal val Res.string.str_21288: StringResource
+  get() = String25.str_21288
+
+@ExperimentalResourceApi
+internal val Res.string.str_21289: StringResource
+  get() = String25.str_21289
+
+@ExperimentalResourceApi
+internal val Res.string.str_2129: StringResource
+  get() = String25.str_2129
+
+@ExperimentalResourceApi
+internal val Res.string.str_21290: StringResource
+  get() = String25.str_21290
+
+@ExperimentalResourceApi
+internal val Res.string.str_21291: StringResource
+  get() = String25.str_21291
+
+@ExperimentalResourceApi
+internal val Res.string.str_21292: StringResource
+  get() = String25.str_21292
+
+@ExperimentalResourceApi
+internal val Res.string.str_21293: StringResource
+  get() = String25.str_21293
+
+@ExperimentalResourceApi
+internal val Res.string.str_21294: StringResource
+  get() = String25.str_21294
+
+@ExperimentalResourceApi
+internal val Res.string.str_21295: StringResource
+  get() = String25.str_21295
+
+@ExperimentalResourceApi
+internal val Res.string.str_21296: StringResource
+  get() = String25.str_21296
+
+@ExperimentalResourceApi
+internal val Res.string.str_21297: StringResource
+  get() = String25.str_21297
+
+@ExperimentalResourceApi
+internal val Res.string.str_21298: StringResource
+  get() = String25.str_21298
+
+@ExperimentalResourceApi
+internal val Res.string.str_21299: StringResource
+  get() = String25.str_21299
+
+@ExperimentalResourceApi
+internal val Res.string.str_213: StringResource
+  get() = String25.str_213
+
+@ExperimentalResourceApi
+internal val Res.string.str_2130: StringResource
+  get() = String25.str_2130
+
+@ExperimentalResourceApi
+internal val Res.string.str_21300: StringResource
+  get() = String25.str_21300
+
+@ExperimentalResourceApi
+internal val Res.string.str_21301: StringResource
+  get() = String25.str_21301
+
+@ExperimentalResourceApi
+internal val Res.string.str_21302: StringResource
+  get() = String25.str_21302
+
+@ExperimentalResourceApi
+internal val Res.string.str_21303: StringResource
+  get() = String25.str_21303
+
+@ExperimentalResourceApi
+internal val Res.string.str_21304: StringResource
+  get() = String25.str_21304
+
+@ExperimentalResourceApi
+internal val Res.string.str_21305: StringResource
+  get() = String25.str_21305
+
+@ExperimentalResourceApi
+internal val Res.string.str_21306: StringResource
+  get() = String25.str_21306
+
+@ExperimentalResourceApi
+internal val Res.string.str_21307: StringResource
+  get() = String25.str_21307
+
+@ExperimentalResourceApi
+internal val Res.string.str_21308: StringResource
+  get() = String25.str_21308
+
+@ExperimentalResourceApi
+internal val Res.string.str_21309: StringResource
+  get() = String25.str_21309
+
+@ExperimentalResourceApi
+internal val Res.string.str_2131: StringResource
+  get() = String25.str_2131
+
+@ExperimentalResourceApi
+internal val Res.string.str_21310: StringResource
+  get() = String25.str_21310
+
+@ExperimentalResourceApi
+internal val Res.string.str_21311: StringResource
+  get() = String25.str_21311
+
+@ExperimentalResourceApi
+internal val Res.string.str_21312: StringResource
+  get() = String25.str_21312
+
+@ExperimentalResourceApi
+internal val Res.string.str_21313: StringResource
+  get() = String25.str_21313
+
+@ExperimentalResourceApi
+internal val Res.string.str_21314: StringResource
+  get() = String25.str_21314
+
+@ExperimentalResourceApi
+internal val Res.string.str_21315: StringResource
+  get() = String25.str_21315
+
+@ExperimentalResourceApi
+internal val Res.string.str_21316: StringResource
+  get() = String25.str_21316
+
+@ExperimentalResourceApi
+internal val Res.string.str_21317: StringResource
+  get() = String25.str_21317
+
+@ExperimentalResourceApi
+internal val Res.string.str_21318: StringResource
+  get() = String25.str_21318
+
+@ExperimentalResourceApi
+internal val Res.string.str_21319: StringResource
+  get() = String25.str_21319
+
+@ExperimentalResourceApi
+internal val Res.string.str_2132: StringResource
+  get() = String25.str_2132
+
+@ExperimentalResourceApi
+internal val Res.string.str_21320: StringResource
+  get() = String25.str_21320
+
+@ExperimentalResourceApi
+internal val Res.string.str_21321: StringResource
+  get() = String25.str_21321
+
+@ExperimentalResourceApi
+internal val Res.string.str_21322: StringResource
+  get() = String25.str_21322
+
+@ExperimentalResourceApi
+internal val Res.string.str_21323: StringResource
+  get() = String25.str_21323
+
+@ExperimentalResourceApi
+internal val Res.string.str_21324: StringResource
+  get() = String25.str_21324
+
+@ExperimentalResourceApi
+internal val Res.string.str_21325: StringResource
+  get() = String25.str_21325
+
+@ExperimentalResourceApi
+internal val Res.string.str_21326: StringResource
+  get() = String25.str_21326
+
+@ExperimentalResourceApi
+internal val Res.string.str_21327: StringResource
+  get() = String25.str_21327
+
+@ExperimentalResourceApi
+internal val Res.string.str_21328: StringResource
+  get() = String25.str_21328
+
+@ExperimentalResourceApi
+internal val Res.string.str_21329: StringResource
+  get() = String25.str_21329
+
+@ExperimentalResourceApi
+internal val Res.string.str_2133: StringResource
+  get() = String25.str_2133
+
+@ExperimentalResourceApi
+internal val Res.string.str_21330: StringResource
+  get() = String25.str_21330
+
+@ExperimentalResourceApi
+internal val Res.string.str_21331: StringResource
+  get() = String25.str_21331
+
+@ExperimentalResourceApi
+internal val Res.string.str_21332: StringResource
+  get() = String25.str_21332
+
+@ExperimentalResourceApi
+internal val Res.string.str_21333: StringResource
+  get() = String25.str_21333
+
+@ExperimentalResourceApi
+internal val Res.string.str_21334: StringResource
+  get() = String25.str_21334
+
+@ExperimentalResourceApi
+internal val Res.string.str_21335: StringResource
+  get() = String25.str_21335
+
+@ExperimentalResourceApi
+internal val Res.string.str_21336: StringResource
+  get() = String25.str_21336
+
+@ExperimentalResourceApi
+internal val Res.string.str_21337: StringResource
+  get() = String25.str_21337
+
+@ExperimentalResourceApi
+internal val Res.string.str_21338: StringResource
+  get() = String25.str_21338
+
+@ExperimentalResourceApi
+internal val Res.string.str_21339: StringResource
+  get() = String25.str_21339
+
+@ExperimentalResourceApi
+internal val Res.string.str_2134: StringResource
+  get() = String25.str_2134
+
+@ExperimentalResourceApi
+internal val Res.string.str_21340: StringResource
+  get() = String25.str_21340
+
+@ExperimentalResourceApi
+internal val Res.string.str_21341: StringResource
+  get() = String25.str_21341
+
+@ExperimentalResourceApi
+internal val Res.string.str_21342: StringResource
+  get() = String25.str_21342
+
+@ExperimentalResourceApi
+internal val Res.string.str_21343: StringResource
+  get() = String25.str_21343
+
+@ExperimentalResourceApi
+internal val Res.string.str_21344: StringResource
+  get() = String25.str_21344
+
+@ExperimentalResourceApi
+internal val Res.string.str_21345: StringResource
+  get() = String25.str_21345
+
+@ExperimentalResourceApi
+internal val Res.string.str_21346: StringResource
+  get() = String25.str_21346
+
+@ExperimentalResourceApi
+internal val Res.string.str_21347: StringResource
+  get() = String25.str_21347
+
+@ExperimentalResourceApi
+internal val Res.string.str_21348: StringResource
+  get() = String25.str_21348
+
+@ExperimentalResourceApi
+internal val Res.string.str_21349: StringResource
+  get() = String25.str_21349
+
+@ExperimentalResourceApi
+internal val Res.string.str_2135: StringResource
+  get() = String25.str_2135
+
+@ExperimentalResourceApi
+internal val Res.string.str_21350: StringResource
+  get() = String25.str_21350
+
+@ExperimentalResourceApi
+internal val Res.string.str_21351: StringResource
+  get() = String25.str_21351
+
+@ExperimentalResourceApi
+internal val Res.string.str_21352: StringResource
+  get() = String25.str_21352
+
+@ExperimentalResourceApi
+internal val Res.string.str_21353: StringResource
+  get() = String25.str_21353
+
+@ExperimentalResourceApi
+internal val Res.string.str_21354: StringResource
+  get() = String25.str_21354
+
+@ExperimentalResourceApi
+internal val Res.string.str_21355: StringResource
+  get() = String25.str_21355
+
+@ExperimentalResourceApi
+internal val Res.string.str_21356: StringResource
+  get() = String25.str_21356
+
+@ExperimentalResourceApi
+internal val Res.string.str_21357: StringResource
+  get() = String25.str_21357
+
+@ExperimentalResourceApi
+internal val Res.string.str_21358: StringResource
+  get() = String25.str_21358
+
+@ExperimentalResourceApi
+internal val Res.string.str_21359: StringResource
+  get() = String25.str_21359
+
+@ExperimentalResourceApi
+internal val Res.string.str_2136: StringResource
+  get() = String25.str_2136
+
+@ExperimentalResourceApi
+internal val Res.string.str_21360: StringResource
+  get() = String25.str_21360
+
+@ExperimentalResourceApi
+internal val Res.string.str_21361: StringResource
+  get() = String25.str_21361
+
+@ExperimentalResourceApi
+internal val Res.string.str_21362: StringResource
+  get() = String25.str_21362
+
+@ExperimentalResourceApi
+internal val Res.string.str_21363: StringResource
+  get() = String25.str_21363
+
+@ExperimentalResourceApi
+internal val Res.string.str_21364: StringResource
+  get() = String25.str_21364
+
+@ExperimentalResourceApi
+internal val Res.string.str_21365: StringResource
+  get() = String25.str_21365
+
+@ExperimentalResourceApi
+internal val Res.string.str_21366: StringResource
+  get() = String25.str_21366
+
+@ExperimentalResourceApi
+internal val Res.string.str_21367: StringResource
+  get() = String25.str_21367
+
+@ExperimentalResourceApi
+internal val Res.string.str_21368: StringResource
+  get() = String25.str_21368
+
+@ExperimentalResourceApi
+internal val Res.string.str_21369: StringResource
+  get() = String25.str_21369
+
+@ExperimentalResourceApi
+internal val Res.string.str_2137: StringResource
+  get() = String25.str_2137
+
+@ExperimentalResourceApi
+internal val Res.string.str_21370: StringResource
+  get() = String25.str_21370
+
+@ExperimentalResourceApi
+internal val Res.string.str_21371: StringResource
+  get() = String25.str_21371
+
+@ExperimentalResourceApi
+internal val Res.string.str_21372: StringResource
+  get() = String25.str_21372
+
+@ExperimentalResourceApi
+internal val Res.string.str_21373: StringResource
+  get() = String25.str_21373
+
+@ExperimentalResourceApi
+internal val Res.string.str_21374: StringResource
+  get() = String25.str_21374
+
+@ExperimentalResourceApi
+internal val Res.string.str_21375: StringResource
+  get() = String25.str_21375
+
+@ExperimentalResourceApi
+internal val Res.string.str_21376: StringResource
+  get() = String25.str_21376
+
+@ExperimentalResourceApi
+internal val Res.string.str_21377: StringResource
+  get() = String25.str_21377
+
+@ExperimentalResourceApi
+internal val Res.string.str_21378: StringResource
+  get() = String25.str_21378
+
+@ExperimentalResourceApi
+internal val Res.string.str_21379: StringResource
+  get() = String25.str_21379
+
+@ExperimentalResourceApi
+internal val Res.string.str_2138: StringResource
+  get() = String25.str_2138
+
+@ExperimentalResourceApi
+internal val Res.string.str_21380: StringResource
+  get() = String25.str_21380
+
+@ExperimentalResourceApi
+internal val Res.string.str_21381: StringResource
+  get() = String25.str_21381
+
+@ExperimentalResourceApi
+internal val Res.string.str_21382: StringResource
+  get() = String25.str_21382
+
+@ExperimentalResourceApi
+internal val Res.string.str_21383: StringResource
+  get() = String25.str_21383
+
+@ExperimentalResourceApi
+internal val Res.string.str_21384: StringResource
+  get() = String25.str_21384
+
+@ExperimentalResourceApi
+internal val Res.string.str_21385: StringResource
+  get() = String25.str_21385
+
+@ExperimentalResourceApi
+internal val Res.string.str_21386: StringResource
+  get() = String25.str_21386
+
+@ExperimentalResourceApi
+internal val Res.string.str_21387: StringResource
+  get() = String25.str_21387
+
+@ExperimentalResourceApi
+internal val Res.string.str_21388: StringResource
+  get() = String25.str_21388
+
+@ExperimentalResourceApi
+internal val Res.string.str_21389: StringResource
+  get() = String25.str_21389
+
+@ExperimentalResourceApi
+internal val Res.string.str_2139: StringResource
+  get() = String25.str_2139
+
+@ExperimentalResourceApi
+internal val Res.string.str_21390: StringResource
+  get() = String25.str_21390
+
+@ExperimentalResourceApi
+internal val Res.string.str_21391: StringResource
+  get() = String25.str_21391
+
+@ExperimentalResourceApi
+internal val Res.string.str_21392: StringResource
+  get() = String25.str_21392
+
+@ExperimentalResourceApi
+internal val Res.string.str_21393: StringResource
+  get() = String25.str_21393
+
+@ExperimentalResourceApi
+internal val Res.string.str_21394: StringResource
+  get() = String25.str_21394
+
+@ExperimentalResourceApi
+internal val Res.string.str_21395: StringResource
+  get() = String25.str_21395
+
+@ExperimentalResourceApi
+internal val Res.string.str_21396: StringResource
+  get() = String25.str_21396
+
+@ExperimentalResourceApi
+internal val Res.string.str_21397: StringResource
+  get() = String25.str_21397
+
+@ExperimentalResourceApi
+internal val Res.string.str_21398: StringResource
+  get() = String25.str_21398
+
+@ExperimentalResourceApi
+internal val Res.string.str_21399: StringResource
+  get() = String25.str_21399
+
+@ExperimentalResourceApi
+internal val Res.string.str_214: StringResource
+  get() = String25.str_214
+
+@ExperimentalResourceApi
+internal val Res.string.str_2140: StringResource
+  get() = String25.str_2140
+
+@ExperimentalResourceApi
+internal val Res.string.str_21400: StringResource
+  get() = String25.str_21400
+
+@ExperimentalResourceApi
+internal val Res.string.str_21401: StringResource
+  get() = String25.str_21401
+
+@ExperimentalResourceApi
+internal val Res.string.str_21402: StringResource
+  get() = String25.str_21402
+
+@ExperimentalResourceApi
+internal val Res.string.str_21403: StringResource
+  get() = String25.str_21403
+
+@ExperimentalResourceApi
+internal val Res.string.str_21404: StringResource
+  get() = String25.str_21404
+
+@ExperimentalResourceApi
+internal val Res.string.str_21405: StringResource
+  get() = String25.str_21405
+
+@ExperimentalResourceApi
+internal val Res.string.str_21406: StringResource
+  get() = String25.str_21406
+
+@ExperimentalResourceApi
+internal val Res.string.str_21407: StringResource
+  get() = String25.str_21407
+
+@ExperimentalResourceApi
+internal val Res.string.str_21408: StringResource
+  get() = String25.str_21408
+
+@ExperimentalResourceApi
+internal val Res.string.str_21409: StringResource
+  get() = String25.str_21409
+
+@ExperimentalResourceApi
+internal val Res.string.str_2141: StringResource
+  get() = String25.str_2141
+
+@ExperimentalResourceApi
+internal val Res.string.str_21410: StringResource
+  get() = String25.str_21410
+
+@ExperimentalResourceApi
+internal val Res.string.str_21411: StringResource
+  get() = String25.str_21411
+
+@ExperimentalResourceApi
+internal val Res.string.str_21412: StringResource
+  get() = String25.str_21412
+
+@ExperimentalResourceApi
+internal val Res.string.str_21413: StringResource
+  get() = String25.str_21413
+
+@ExperimentalResourceApi
+internal val Res.string.str_21414: StringResource
+  get() = String25.str_21414
+
+@ExperimentalResourceApi
+internal val Res.string.str_21415: StringResource
+  get() = String25.str_21415
+
+@ExperimentalResourceApi
+internal val Res.string.str_21416: StringResource
+  get() = String25.str_21416
+
+@ExperimentalResourceApi
+internal val Res.string.str_21417: StringResource
+  get() = String25.str_21417
+
+@ExperimentalResourceApi
+internal val Res.string.str_21418: StringResource
+  get() = String25.str_21418
+
+@ExperimentalResourceApi
+internal val Res.string.str_21419: StringResource
+  get() = String25.str_21419
+
+@ExperimentalResourceApi
+internal val Res.string.str_2142: StringResource
+  get() = String25.str_2142
+
+@ExperimentalResourceApi
+internal val Res.string.str_21420: StringResource
+  get() = String25.str_21420
+
+@ExperimentalResourceApi
+internal val Res.string.str_21421: StringResource
+  get() = String25.str_21421
+
+@ExperimentalResourceApi
+internal val Res.string.str_21422: StringResource
+  get() = String25.str_21422
+
+@ExperimentalResourceApi
+internal val Res.string.str_21423: StringResource
+  get() = String25.str_21423
+
+@ExperimentalResourceApi
+internal val Res.string.str_21424: StringResource
+  get() = String25.str_21424
+
+@ExperimentalResourceApi
+internal val Res.string.str_21425: StringResource
+  get() = String25.str_21425
+
+@ExperimentalResourceApi
+internal val Res.string.str_21426: StringResource
+  get() = String25.str_21426
+
+@ExperimentalResourceApi
+internal val Res.string.str_21427: StringResource
+  get() = String25.str_21427
+
+@ExperimentalResourceApi
+internal val Res.string.str_21428: StringResource
+  get() = String25.str_21428
+
+@ExperimentalResourceApi
+internal val Res.string.str_21429: StringResource
+  get() = String25.str_21429
+
+@ExperimentalResourceApi
+internal val Res.string.str_2143: StringResource
+  get() = String25.str_2143
+
+@ExperimentalResourceApi
+internal val Res.string.str_21430: StringResource
+  get() = String25.str_21430
+
+@ExperimentalResourceApi
+internal val Res.string.str_21431: StringResource
+  get() = String25.str_21431
+
+@ExperimentalResourceApi
+internal val Res.string.str_21432: StringResource
+  get() = String25.str_21432
+
+@ExperimentalResourceApi
+internal val Res.string.str_21433: StringResource
+  get() = String25.str_21433
+
+@ExperimentalResourceApi
+internal val Res.string.str_21434: StringResource
+  get() = String25.str_21434
+
+@ExperimentalResourceApi
+internal val Res.string.str_21435: StringResource
+  get() = String25.str_21435
+
+@ExperimentalResourceApi
+internal val Res.string.str_21436: StringResource
+  get() = String25.str_21436
+
+@ExperimentalResourceApi
+internal val Res.string.str_21437: StringResource
+  get() = String25.str_21437
+
+@ExperimentalResourceApi
+internal val Res.string.str_21438: StringResource
+  get() = String25.str_21438
+
+@ExperimentalResourceApi
+internal val Res.string.str_21439: StringResource
+  get() = String25.str_21439
+
+@ExperimentalResourceApi
+internal val Res.string.str_2144: StringResource
+  get() = String25.str_2144
+
+@ExperimentalResourceApi
+internal val Res.string.str_21440: StringResource
+  get() = String25.str_21440
+
+@ExperimentalResourceApi
+internal val Res.string.str_21441: StringResource
+  get() = String25.str_21441
+
+@ExperimentalResourceApi
+internal val Res.string.str_21442: StringResource
+  get() = String25.str_21442
+
+@ExperimentalResourceApi
+internal val Res.string.str_21443: StringResource
+  get() = String25.str_21443
+
+@ExperimentalResourceApi
+internal val Res.string.str_21444: StringResource
+  get() = String25.str_21444
+
+@ExperimentalResourceApi
+internal val Res.string.str_21445: StringResource
+  get() = String25.str_21445
+
+@ExperimentalResourceApi
+internal val Res.string.str_21446: StringResource
+  get() = String25.str_21446
+
+@ExperimentalResourceApi
+internal val Res.string.str_21447: StringResource
+  get() = String25.str_21447
+
+@ExperimentalResourceApi
+internal val Res.string.str_21448: StringResource
+  get() = String25.str_21448
+
+@ExperimentalResourceApi
+internal val Res.string.str_21449: StringResource
+  get() = String25.str_21449
+
+@ExperimentalResourceApi
+internal val Res.string.str_2145: StringResource
+  get() = String25.str_2145
+
+@ExperimentalResourceApi
+internal val Res.string.str_21450: StringResource
+  get() = String25.str_21450
+
+@ExperimentalResourceApi
+internal val Res.string.str_21451: StringResource
+  get() = String25.str_21451
+
+@ExperimentalResourceApi
+internal val Res.string.str_21452: StringResource
+  get() = String25.str_21452
+
+@ExperimentalResourceApi
+internal val Res.string.str_21453: StringResource
+  get() = String25.str_21453
+
+@ExperimentalResourceApi
+internal val Res.string.str_21454: StringResource
+  get() = String25.str_21454
+
+@ExperimentalResourceApi
+internal val Res.string.str_21455: StringResource
+  get() = String25.str_21455
+
+@ExperimentalResourceApi
+internal val Res.string.str_21456: StringResource
+  get() = String25.str_21456
+
+@ExperimentalResourceApi
+internal val Res.string.str_21457: StringResource
+  get() = String25.str_21457
+
+@ExperimentalResourceApi
+internal val Res.string.str_21458: StringResource
+  get() = String25.str_21458
+
+@ExperimentalResourceApi
+internal val Res.string.str_21459: StringResource
+  get() = String25.str_21459
+
+@ExperimentalResourceApi
+internal val Res.string.str_2146: StringResource
+  get() = String25.str_2146
+
+@ExperimentalResourceApi
+internal val Res.string.str_21460: StringResource
+  get() = String25.str_21460
+
+@ExperimentalResourceApi
+internal val Res.string.str_21461: StringResource
+  get() = String25.str_21461
+
+@ExperimentalResourceApi
+internal val Res.string.str_21462: StringResource
+  get() = String25.str_21462
+
+@ExperimentalResourceApi
+internal val Res.string.str_21463: StringResource
+  get() = String25.str_21463
+
+@ExperimentalResourceApi
+internal val Res.string.str_21464: StringResource
+  get() = String25.str_21464
+
+@ExperimentalResourceApi
+internal val Res.string.str_21465: StringResource
+  get() = String25.str_21465
+
+@ExperimentalResourceApi
+internal val Res.string.str_21466: StringResource
+  get() = String25.str_21466
+
+@ExperimentalResourceApi
+internal val Res.string.str_21467: StringResource
+  get() = String25.str_21467
+
+@ExperimentalResourceApi
+internal val Res.string.str_21468: StringResource
+  get() = String25.str_21468
+
+@ExperimentalResourceApi
+internal val Res.string.str_21469: StringResource
+  get() = String25.str_21469
+
+@ExperimentalResourceApi
+internal val Res.string.str_2147: StringResource
+  get() = String25.str_2147
+
+@ExperimentalResourceApi
+internal val Res.string.str_21470: StringResource
+  get() = String25.str_21470
+
+@ExperimentalResourceApi
+internal val Res.string.str_21471: StringResource
+  get() = String25.str_21471
+
+@ExperimentalResourceApi
+internal val Res.string.str_21472: StringResource
+  get() = String25.str_21472
+
+@ExperimentalResourceApi
+internal val Res.string.str_21473: StringResource
+  get() = String25.str_21473
+
+@ExperimentalResourceApi
+internal val Res.string.str_21474: StringResource
+  get() = String25.str_21474
+
+@ExperimentalResourceApi
+internal val Res.string.str_21475: StringResource
+  get() = String25.str_21475
+
+@ExperimentalResourceApi
+internal val Res.string.str_21476: StringResource
+  get() = String25.str_21476
+
+@ExperimentalResourceApi
+internal val Res.string.str_21477: StringResource
+  get() = String25.str_21477
+
+@ExperimentalResourceApi
+internal val Res.string.str_21478: StringResource
+  get() = String25.str_21478
+
+@ExperimentalResourceApi
+internal val Res.string.str_21479: StringResource
+  get() = String25.str_21479
+
+@ExperimentalResourceApi
+internal val Res.string.str_2148: StringResource
+  get() = String25.str_2148
+
+@ExperimentalResourceApi
+internal val Res.string.str_21480: StringResource
+  get() = String25.str_21480
+
+@ExperimentalResourceApi
+internal val Res.string.str_21481: StringResource
+  get() = String25.str_21481
+
+@ExperimentalResourceApi
+internal val Res.string.str_21482: StringResource
+  get() = String25.str_21482
+
+@ExperimentalResourceApi
+internal val Res.string.str_21483: StringResource
+  get() = String25.str_21483
+
+@ExperimentalResourceApi
+internal val Res.string.str_21484: StringResource
+  get() = String25.str_21484
+
+@ExperimentalResourceApi
+internal val Res.string.str_21485: StringResource
+  get() = String25.str_21485
+
+@ExperimentalResourceApi
+internal val Res.string.str_21486: StringResource
+  get() = String25.str_21486
+
+@ExperimentalResourceApi
+internal val Res.string.str_21487: StringResource
+  get() = String25.str_21487
+
+@ExperimentalResourceApi
+internal val Res.string.str_21488: StringResource
+  get() = String25.str_21488
+
+@ExperimentalResourceApi
+internal val Res.string.str_21489: StringResource
+  get() = String25.str_21489
+
+@ExperimentalResourceApi
+internal val Res.string.str_2149: StringResource
+  get() = String25.str_2149
+
+@ExperimentalResourceApi
+internal val Res.string.str_21490: StringResource
+  get() = String25.str_21490
+
+@ExperimentalResourceApi
+internal val Res.string.str_21491: StringResource
+  get() = String25.str_21491
+
+@ExperimentalResourceApi
+internal val Res.string.str_21492: StringResource
+  get() = String25.str_21492
+
+@ExperimentalResourceApi
+internal val Res.string.str_21493: StringResource
+  get() = String25.str_21493
+
+@ExperimentalResourceApi
+internal val Res.string.str_21494: StringResource
+  get() = String25.str_21494
+
+@ExperimentalResourceApi
+internal val Res.string.str_21495: StringResource
+  get() = String25.str_21495
+
+@ExperimentalResourceApi
+internal val Res.string.str_21496: StringResource
+  get() = String25.str_21496
+
+@ExperimentalResourceApi
+internal val Res.string.str_21497: StringResource
+  get() = String25.str_21497
+
+@ExperimentalResourceApi
+internal val Res.string.str_21498: StringResource
+  get() = String25.str_21498
+
+@ExperimentalResourceApi
+internal val Res.string.str_21499: StringResource
+  get() = String25.str_21499
+
+@ExperimentalResourceApi
+internal val Res.string.str_215: StringResource
+  get() = String25.str_215
+
+@ExperimentalResourceApi
+internal val Res.string.str_2150: StringResource
+  get() = String25.str_2150
+
+@ExperimentalResourceApi
+internal val Res.string.str_21500: StringResource
+  get() = String25.str_21500
+
+@ExperimentalResourceApi
+internal val Res.string.str_21501: StringResource
+  get() = String25.str_21501
+
+@ExperimentalResourceApi
+internal val Res.string.str_21502: StringResource
+  get() = String25.str_21502
+
+@ExperimentalResourceApi
+internal val Res.string.str_21503: StringResource
+  get() = String25.str_21503
+
+@ExperimentalResourceApi
+internal val Res.string.str_21504: StringResource
+  get() = String25.str_21504
+
+@ExperimentalResourceApi
+internal val Res.string.str_21505: StringResource
+  get() = String25.str_21505
+
+@ExperimentalResourceApi
+internal val Res.string.str_21506: StringResource
+  get() = String25.str_21506
+
+@ExperimentalResourceApi
+internal val Res.string.str_21507: StringResource
+  get() = String25.str_21507
+
+@ExperimentalResourceApi
+internal val Res.string.str_21508: StringResource
+  get() = String25.str_21508
+
+@ExperimentalResourceApi
+internal val Res.string.str_21509: StringResource
+  get() = String25.str_21509
+
+@ExperimentalResourceApi
+internal val Res.string.str_2151: StringResource
+  get() = String25.str_2151
+
+@ExperimentalResourceApi
+internal val Res.string.str_21510: StringResource
+  get() = String25.str_21510
+
+@ExperimentalResourceApi
+internal val Res.string.str_21511: StringResource
+  get() = String25.str_21511
+
+@ExperimentalResourceApi
+internal val Res.string.str_21512: StringResource
+  get() = String25.str_21512
+
+@ExperimentalResourceApi
+internal val Res.string.str_21513: StringResource
+  get() = String25.str_21513
+
+@ExperimentalResourceApi
+internal val Res.string.str_21514: StringResource
+  get() = String25.str_21514
+
+@ExperimentalResourceApi
+internal val Res.string.str_21515: StringResource
+  get() = String25.str_21515
+
+@ExperimentalResourceApi
+internal val Res.string.str_21516: StringResource
+  get() = String25.str_21516
+
+@ExperimentalResourceApi
+internal val Res.string.str_21517: StringResource
+  get() = String25.str_21517
+
+@ExperimentalResourceApi
+internal val Res.string.str_21518: StringResource
+  get() = String25.str_21518
+
+@ExperimentalResourceApi
+internal val Res.string.str_21519: StringResource
+  get() = String25.str_21519
+
+@ExperimentalResourceApi
+internal val Res.string.str_2152: StringResource
+  get() = String25.str_2152
+
+@ExperimentalResourceApi
+internal val Res.string.str_21520: StringResource
+  get() = String25.str_21520
+
+@ExperimentalResourceApi
+internal val Res.string.str_21521: StringResource
+  get() = String25.str_21521
+
+@ExperimentalResourceApi
+internal val Res.string.str_21522: StringResource
+  get() = String25.str_21522
+
+@ExperimentalResourceApi
+internal val Res.string.str_21523: StringResource
+  get() = String25.str_21523
+
+@ExperimentalResourceApi
+internal val Res.string.str_21524: StringResource
+  get() = String25.str_21524
+
+@ExperimentalResourceApi
+internal val Res.string.str_21525: StringResource
+  get() = String25.str_21525
+
+@ExperimentalResourceApi
+internal val Res.string.str_21526: StringResource
+  get() = String25.str_21526
+
+@ExperimentalResourceApi
+internal val Res.string.str_21527: StringResource
+  get() = String25.str_21527
+
+@ExperimentalResourceApi
+internal val Res.string.str_21528: StringResource
+  get() = String25.str_21528
+
+@ExperimentalResourceApi
+internal val Res.string.str_21529: StringResource
+  get() = String25.str_21529
+
+@ExperimentalResourceApi
+internal val Res.string.str_2153: StringResource
+  get() = String25.str_2153
+
+@ExperimentalResourceApi
+internal val Res.string.str_21530: StringResource
+  get() = String25.str_21530
+
+@ExperimentalResourceApi
+internal val Res.string.str_21531: StringResource
+  get() = String25.str_21531
+
+@ExperimentalResourceApi
+internal val Res.string.str_21532: StringResource
+  get() = String25.str_21532
+
+@ExperimentalResourceApi
+internal val Res.string.str_21533: StringResource
+  get() = String25.str_21533
+
+@ExperimentalResourceApi
+internal val Res.string.str_21534: StringResource
+  get() = String25.str_21534
+
+@ExperimentalResourceApi
+internal val Res.string.str_21535: StringResource
+  get() = String25.str_21535
+
+@ExperimentalResourceApi
+internal val Res.string.str_21536: StringResource
+  get() = String25.str_21536
+
+@ExperimentalResourceApi
+internal val Res.string.str_21537: StringResource
+  get() = String25.str_21537
+
+@ExperimentalResourceApi
+internal val Res.string.str_21538: StringResource
+  get() = String25.str_21538
+
+@ExperimentalResourceApi
+internal val Res.string.str_21539: StringResource
+  get() = String25.str_21539
+
+@ExperimentalResourceApi
+internal val Res.string.str_2154: StringResource
+  get() = String25.str_2154
+
+@ExperimentalResourceApi
+internal val Res.string.str_21540: StringResource
+  get() = String25.str_21540
+
+@ExperimentalResourceApi
+internal val Res.string.str_21541: StringResource
+  get() = String25.str_21541
+
+@ExperimentalResourceApi
+internal val Res.string.str_21542: StringResource
+  get() = String25.str_21542
+
+@ExperimentalResourceApi
+internal val Res.string.str_21543: StringResource
+  get() = String25.str_21543
+
+@ExperimentalResourceApi
+internal val Res.string.str_21544: StringResource
+  get() = String25.str_21544
+
+@ExperimentalResourceApi
+internal val Res.string.str_21545: StringResource
+  get() = String25.str_21545
+
+@ExperimentalResourceApi
+internal val Res.string.str_21546: StringResource
+  get() = String25.str_21546
+
+@ExperimentalResourceApi
+internal val Res.string.str_21547: StringResource
+  get() = String25.str_21547
+
+@ExperimentalResourceApi
+internal val Res.string.str_21548: StringResource
+  get() = String25.str_21548
+
+@ExperimentalResourceApi
+internal val Res.string.str_21549: StringResource
+  get() = String25.str_21549
+
+@ExperimentalResourceApi
+internal val Res.string.str_2155: StringResource
+  get() = String25.str_2155
+
+@ExperimentalResourceApi
+internal val Res.string.str_21550: StringResource
+  get() = String25.str_21550
+
+@ExperimentalResourceApi
+internal val Res.string.str_21551: StringResource
+  get() = String25.str_21551
+
+@ExperimentalResourceApi
+internal val Res.string.str_21552: StringResource
+  get() = String25.str_21552
+
+@ExperimentalResourceApi
+internal val Res.string.str_21553: StringResource
+  get() = String25.str_21553
+
+@ExperimentalResourceApi
+internal val Res.string.str_21554: StringResource
+  get() = String25.str_21554
+
+@ExperimentalResourceApi
+internal val Res.string.str_21555: StringResource
+  get() = String25.str_21555
+
+@ExperimentalResourceApi
+internal val Res.string.str_21556: StringResource
+  get() = String25.str_21556
+
+@ExperimentalResourceApi
+internal val Res.string.str_21557: StringResource
+  get() = String25.str_21557
+
+@ExperimentalResourceApi
+internal val Res.string.str_21558: StringResource
+  get() = String25.str_21558
+
+@ExperimentalResourceApi
+internal val Res.string.str_21559: StringResource
+  get() = String25.str_21559
+
+@ExperimentalResourceApi
+internal val Res.string.str_2156: StringResource
+  get() = String25.str_2156
+
+@ExperimentalResourceApi
+internal val Res.string.str_21560: StringResource
+  get() = String25.str_21560
+
+@ExperimentalResourceApi
+internal val Res.string.str_21561: StringResource
+  get() = String25.str_21561
+
+@ExperimentalResourceApi
+internal val Res.string.str_21562: StringResource
+  get() = String25.str_21562
+
+@ExperimentalResourceApi
+internal val Res.string.str_21563: StringResource
+  get() = String25.str_21563
+
+@ExperimentalResourceApi
+internal val Res.string.str_21564: StringResource
+  get() = String25.str_21564
+
+@ExperimentalResourceApi
+internal val Res.string.str_21565: StringResource
+  get() = String25.str_21565
+
+@ExperimentalResourceApi
+internal val Res.string.str_21566: StringResource
+  get() = String25.str_21566
+
+@ExperimentalResourceApi
+internal val Res.string.str_21567: StringResource
+  get() = String25.str_21567
+
+@ExperimentalResourceApi
+internal val Res.string.str_21568: StringResource
+  get() = String25.str_21568
+
+@ExperimentalResourceApi
+internal val Res.string.str_21569: StringResource
+  get() = String25.str_21569
+
+@ExperimentalResourceApi
+internal val Res.string.str_2157: StringResource
+  get() = String25.str_2157
+
+@ExperimentalResourceApi
+internal val Res.string.str_21570: StringResource
+  get() = String25.str_21570
+
+@ExperimentalResourceApi
+internal val Res.string.str_21571: StringResource
+  get() = String25.str_21571
+
+@ExperimentalResourceApi
+internal val Res.string.str_21572: StringResource
+  get() = String25.str_21572
+
+@ExperimentalResourceApi
+internal val Res.string.str_21573: StringResource
+  get() = String25.str_21573
+
+@ExperimentalResourceApi
+internal val Res.string.str_21574: StringResource
+  get() = String25.str_21574
+
+@ExperimentalResourceApi
+internal val Res.string.str_21575: StringResource
+  get() = String25.str_21575
+
+@ExperimentalResourceApi
+internal val Res.string.str_21576: StringResource
+  get() = String25.str_21576
+
+@ExperimentalResourceApi
+internal val Res.string.str_21577: StringResource
+  get() = String25.str_21577
+
+@ExperimentalResourceApi
+internal val Res.string.str_21578: StringResource
+  get() = String25.str_21578
+
+@ExperimentalResourceApi
+internal val Res.string.str_21579: StringResource
+  get() = String25.str_21579
+
+@ExperimentalResourceApi
+internal val Res.string.str_2158: StringResource
+  get() = String25.str_2158
+
+@ExperimentalResourceApi
+internal val Res.string.str_21580: StringResource
+  get() = String25.str_21580
+
+@ExperimentalResourceApi
+internal val Res.string.str_21581: StringResource
+  get() = String25.str_21581
+
+@ExperimentalResourceApi
+internal val Res.string.str_21582: StringResource
+  get() = String25.str_21582
+
+@ExperimentalResourceApi
+internal val Res.string.str_21583: StringResource
+  get() = String25.str_21583
+
+@ExperimentalResourceApi
+internal val Res.string.str_21584: StringResource
+  get() = String25.str_21584
+
+@ExperimentalResourceApi
+internal val Res.string.str_21585: StringResource
+  get() = String25.str_21585
+
+@ExperimentalResourceApi
+internal val Res.string.str_21586: StringResource
+  get() = String25.str_21586
+
+@ExperimentalResourceApi
+internal val Res.string.str_21587: StringResource
+  get() = String25.str_21587
+
+@ExperimentalResourceApi
+internal val Res.string.str_21588: StringResource
+  get() = String25.str_21588
+
+@ExperimentalResourceApi
+internal val Res.string.str_21589: StringResource
+  get() = String25.str_21589
+
+@ExperimentalResourceApi
+internal val Res.string.str_2159: StringResource
+  get() = String25.str_2159
+
+@ExperimentalResourceApi
+internal val Res.string.str_21590: StringResource
+  get() = String25.str_21590
+
+@ExperimentalResourceApi
+internal val Res.string.str_21591: StringResource
+  get() = String25.str_21591
+
+@ExperimentalResourceApi
+internal val Res.string.str_21592: StringResource
+  get() = String25.str_21592
+
+@ExperimentalResourceApi
+internal val Res.string.str_21593: StringResource
+  get() = String25.str_21593
+
+@ExperimentalResourceApi
+internal val Res.string.str_21594: StringResource
+  get() = String25.str_21594
+
+@ExperimentalResourceApi
+internal val Res.string.str_21595: StringResource
+  get() = String25.str_21595
+
+@ExperimentalResourceApi
+internal val Res.string.str_21596: StringResource
+  get() = String25.str_21596
+
+@ExperimentalResourceApi
+internal val Res.string.str_21597: StringResource
+  get() = String25.str_21597
+
+@ExperimentalResourceApi
+internal val Res.string.str_21598: StringResource
+  get() = String25.str_21598
+
+@ExperimentalResourceApi
+internal val Res.string.str_21599: StringResource
+  get() = String25.str_21599
+
+@ExperimentalResourceApi
+internal val Res.string.str_216: StringResource
+  get() = String25.str_216
+
+@ExperimentalResourceApi
+internal val Res.string.str_2160: StringResource
+  get() = String25.str_2160
+
+@ExperimentalResourceApi
+internal val Res.string.str_21600: StringResource
+  get() = String25.str_21600
+
+@ExperimentalResourceApi
+internal val Res.string.str_21601: StringResource
+  get() = String25.str_21601
+
+@ExperimentalResourceApi
+internal val Res.string.str_21602: StringResource
+  get() = String25.str_21602
+
+@ExperimentalResourceApi
+internal val Res.string.str_21603: StringResource
+  get() = String25.str_21603
+
+@ExperimentalResourceApi
+internal val Res.string.str_21604: StringResource
+  get() = String25.str_21604
+
+@ExperimentalResourceApi
+internal val Res.string.str_21605: StringResource
+  get() = String25.str_21605
+
+@ExperimentalResourceApi
+internal val Res.string.str_21606: StringResource
+  get() = String25.str_21606
+
+@ExperimentalResourceApi
+internal val Res.string.str_21607: StringResource
+  get() = String25.str_21607
+
+@ExperimentalResourceApi
+internal val Res.string.str_21608: StringResource
+  get() = String25.str_21608
+
+@ExperimentalResourceApi
+internal val Res.string.str_21609: StringResource
+  get() = String25.str_21609
+
+@ExperimentalResourceApi
+internal val Res.string.str_2161: StringResource
+  get() = String25.str_2161
+
+@ExperimentalResourceApi
+internal val Res.string.str_21610: StringResource
+  get() = String25.str_21610
+
+@ExperimentalResourceApi
+internal val Res.string.str_21611: StringResource
+  get() = String25.str_21611
+
+@ExperimentalResourceApi
+internal val Res.string.str_21612: StringResource
+  get() = String25.str_21612
+
+@ExperimentalResourceApi
+internal val Res.string.str_21613: StringResource
+  get() = String25.str_21613
+
+@ExperimentalResourceApi
+internal val Res.string.str_21614: StringResource
+  get() = String25.str_21614
+
+@ExperimentalResourceApi
+internal val Res.string.str_21615: StringResource
+  get() = String25.str_21615
+
+@ExperimentalResourceApi
+internal val Res.string.str_21616: StringResource
+  get() = String25.str_21616
+
+@ExperimentalResourceApi
+internal val Res.string.str_21617: StringResource
+  get() = String25.str_21617
+
+@ExperimentalResourceApi
+internal val Res.string.str_21618: StringResource
+  get() = String25.str_21618
+
+@ExperimentalResourceApi
+internal val Res.string.str_21619: StringResource
+  get() = String25.str_21619
+
+@ExperimentalResourceApi
+internal val Res.string.str_2162: StringResource
+  get() = String25.str_2162
+
+@ExperimentalResourceApi
+internal val Res.string.str_21620: StringResource
+  get() = String25.str_21620
+
+@ExperimentalResourceApi
+internal val Res.string.str_21621: StringResource
+  get() = String25.str_21621
+
+@ExperimentalResourceApi
+internal val Res.string.str_21622: StringResource
+  get() = String25.str_21622
+
+@ExperimentalResourceApi
+internal val Res.string.str_21623: StringResource
+  get() = String25.str_21623
+
+@ExperimentalResourceApi
+internal val Res.string.str_21624: StringResource
+  get() = String25.str_21624
+
+@ExperimentalResourceApi
+internal val Res.string.str_21625: StringResource
+  get() = String25.str_21625
+
+@ExperimentalResourceApi
+internal val Res.string.str_21626: StringResource
+  get() = String25.str_21626
+
+@ExperimentalResourceApi
+internal val Res.string.str_21627: StringResource
+  get() = String25.str_21627
+
+@ExperimentalResourceApi
+internal val Res.string.str_21628: StringResource
+  get() = String25.str_21628
+
+@ExperimentalResourceApi
+internal val Res.string.str_21629: StringResource
+  get() = String25.str_21629
+
+@ExperimentalResourceApi
+internal val Res.string.str_2163: StringResource
+  get() = String25.str_2163
+
+@ExperimentalResourceApi
+internal val Res.string.str_21630: StringResource
+  get() = String25.str_21630
+
+@ExperimentalResourceApi
+internal val Res.string.str_21631: StringResource
+  get() = String25.str_21631
+
+@ExperimentalResourceApi
+internal val Res.string.str_21632: StringResource
+  get() = String25.str_21632
+
+@ExperimentalResourceApi
+internal val Res.string.str_21633: StringResource
+  get() = String25.str_21633
+
+@ExperimentalResourceApi
+internal val Res.string.str_21634: StringResource
+  get() = String25.str_21634
+
+@ExperimentalResourceApi
+internal val Res.string.str_21635: StringResource
+  get() = String25.str_21635
+
+@ExperimentalResourceApi
+internal val Res.string.str_21636: StringResource
+  get() = String25.str_21636
+
+@ExperimentalResourceApi
+internal val Res.string.str_21637: StringResource
+  get() = String25.str_21637
+
+@ExperimentalResourceApi
+internal val Res.string.str_21638: StringResource
+  get() = String25.str_21638
+
+@ExperimentalResourceApi
+internal val Res.string.str_21639: StringResource
+  get() = String25.str_21639
+
+@ExperimentalResourceApi
+internal val Res.string.str_2164: StringResource
+  get() = String25.str_2164
+
+@ExperimentalResourceApi
+internal val Res.string.str_21640: StringResource
+  get() = String25.str_21640
+
+@ExperimentalResourceApi
+internal val Res.string.str_21641: StringResource
+  get() = String25.str_21641
+
+@ExperimentalResourceApi
+internal val Res.string.str_21642: StringResource
+  get() = String25.str_21642
+
+@ExperimentalResourceApi
+internal val Res.string.str_21643: StringResource
+  get() = String25.str_21643
+
+@ExperimentalResourceApi
+internal val Res.string.str_21644: StringResource
+  get() = String25.str_21644
+
+@ExperimentalResourceApi
+internal val Res.string.str_21645: StringResource
+  get() = String25.str_21645
+
+@ExperimentalResourceApi
+internal val Res.string.str_21646: StringResource
+  get() = String25.str_21646
+
+@ExperimentalResourceApi
+internal val Res.string.str_21647: StringResource
+  get() = String25.str_21647
+
+@ExperimentalResourceApi
+internal val Res.string.str_21648: StringResource
+  get() = String25.str_21648
+
+@ExperimentalResourceApi
+internal val Res.string.str_21649: StringResource
+  get() = String25.str_21649
+
+@ExperimentalResourceApi
+internal val Res.string.str_2165: StringResource
+  get() = String25.str_2165
+
+@ExperimentalResourceApi
+internal val Res.string.str_21650: StringResource
+  get() = String25.str_21650
+
+@ExperimentalResourceApi
+internal val Res.string.str_21651: StringResource
+  get() = String25.str_21651
+
+@ExperimentalResourceApi
+internal val Res.string.str_21652: StringResource
+  get() = String25.str_21652
+
+@ExperimentalResourceApi
+internal val Res.string.str_21653: StringResource
+  get() = String25.str_21653
+
+@ExperimentalResourceApi
+internal val Res.string.str_21654: StringResource
+  get() = String25.str_21654
+
+@ExperimentalResourceApi
+internal val Res.string.str_21655: StringResource
+  get() = String25.str_21655
+
+@ExperimentalResourceApi
+internal val Res.string.str_21656: StringResource
+  get() = String25.str_21656
+
+@ExperimentalResourceApi
+internal val Res.string.str_21657: StringResource
+  get() = String25.str_21657
+
+@ExperimentalResourceApi
+internal val Res.string.str_21658: StringResource
+  get() = String25.str_21658
+
+@ExperimentalResourceApi
+internal val Res.string.str_21659: StringResource
+  get() = String25.str_21659
+
+@ExperimentalResourceApi
+internal val Res.string.str_2166: StringResource
+  get() = String25.str_2166
+
+@ExperimentalResourceApi
+internal val Res.string.str_21660: StringResource
+  get() = String25.str_21660
+
+@ExperimentalResourceApi
+internal val Res.string.str_21661: StringResource
+  get() = String25.str_21661
+
+@ExperimentalResourceApi
+internal val Res.string.str_21662: StringResource
+  get() = String25.str_21662
+
+@ExperimentalResourceApi
+internal val Res.string.str_21663: StringResource
+  get() = String25.str_21663
+
+@ExperimentalResourceApi
+internal val Res.string.str_21664: StringResource
+  get() = String25.str_21664
+
+@ExperimentalResourceApi
+internal val Res.string.str_21665: StringResource
+  get() = String25.str_21665
+
+@ExperimentalResourceApi
+internal val Res.string.str_21666: StringResource
+  get() = String25.str_21666
+
+@ExperimentalResourceApi
+internal val Res.string.str_21667: StringResource
+  get() = String25.str_21667
+
+@ExperimentalResourceApi
+internal val Res.string.str_21668: StringResource
+  get() = String25.str_21668
+
+@ExperimentalResourceApi
+internal val Res.string.str_21669: StringResource
+  get() = String25.str_21669
+
+@ExperimentalResourceApi
+internal val Res.string.str_2167: StringResource
+  get() = String25.str_2167
+
+@ExperimentalResourceApi
+internal val Res.string.str_21670: StringResource
+  get() = String25.str_21670
+
+@ExperimentalResourceApi
+internal val Res.string.str_21671: StringResource
+  get() = String25.str_21671
+
+@ExperimentalResourceApi
+internal val Res.string.str_21672: StringResource
+  get() = String25.str_21672
+
+@ExperimentalResourceApi
+internal val Res.string.str_21673: StringResource
+  get() = String25.str_21673
+
+@ExperimentalResourceApi
+internal val Res.string.str_21674: StringResource
+  get() = String25.str_21674
+
+@ExperimentalResourceApi
+internal val Res.string.str_21675: StringResource
+  get() = String25.str_21675
+
+@ExperimentalResourceApi
+internal val Res.string.str_21676: StringResource
+  get() = String25.str_21676
+
+@ExperimentalResourceApi
+internal val Res.string.str_21677: StringResource
+  get() = String25.str_21677
+
+@ExperimentalResourceApi
+internal val Res.string.str_21678: StringResource
+  get() = String25.str_21678
+
+@ExperimentalResourceApi
+internal val Res.string.str_21679: StringResource
+  get() = String25.str_21679
+
+@ExperimentalResourceApi
+internal val Res.string.str_2168: StringResource
+  get() = String25.str_2168
+
+@ExperimentalResourceApi
+internal val Res.string.str_21680: StringResource
+  get() = String25.str_21680
+
+@ExperimentalResourceApi
+internal val Res.string.str_21681: StringResource
+  get() = String25.str_21681
+
+@ExperimentalResourceApi
+internal val Res.string.str_21682: StringResource
+  get() = String25.str_21682
+
+@ExperimentalResourceApi
+internal val Res.string.str_21683: StringResource
+  get() = String25.str_21683
+
+@ExperimentalResourceApi
+internal val Res.string.str_21684: StringResource
+  get() = String25.str_21684
+
+@ExperimentalResourceApi
+internal val Res.string.str_21685: StringResource
+  get() = String25.str_21685
+
+@ExperimentalResourceApi
+internal val Res.string.str_21686: StringResource
+  get() = String25.str_21686
+
+@ExperimentalResourceApi
+internal val Res.string.str_21687: StringResource
+  get() = String25.str_21687
+
+@ExperimentalResourceApi
+internal val Res.string.str_21688: StringResource
+  get() = String25.str_21688
+
+@ExperimentalResourceApi
+internal val Res.string.str_21689: StringResource
+  get() = String25.str_21689
+
+@ExperimentalResourceApi
+internal val Res.string.str_2169: StringResource
+  get() = String25.str_2169
+
+@ExperimentalResourceApi
+internal val Res.string.str_21690: StringResource
+  get() = String25.str_21690
+
+@ExperimentalResourceApi
+internal val Res.string.str_21691: StringResource
+  get() = String25.str_21691
+
+@ExperimentalResourceApi
+internal val Res.string.str_21692: StringResource
+  get() = String25.str_21692
+
+@ExperimentalResourceApi
+internal val Res.string.str_21693: StringResource
+  get() = String25.str_21693
+
+@ExperimentalResourceApi
+internal val Res.string.str_21694: StringResource
+  get() = String25.str_21694
+
+@ExperimentalResourceApi
+internal val Res.string.str_21695: StringResource
+  get() = String25.str_21695
+
+@ExperimentalResourceApi
+internal val Res.string.str_21696: StringResource
+  get() = String25.str_21696
+
+@ExperimentalResourceApi
+internal val Res.string.str_21697: StringResource
+  get() = String25.str_21697

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String26.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String26.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String26 {
+  public val str_21698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21698", "str_21698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21699", "str_21699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_217", "str_217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2170", "str_2170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21700", "str_21700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21701", "str_21701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21702", "str_21702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21703", "str_21703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21704", "str_21704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21705", "str_21705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21706", "str_21706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21707", "str_21707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21708", "str_21708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21709", "str_21709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2171", "str_2171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21710", "str_21710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21711", "str_21711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21712", "str_21712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21713", "str_21713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21714", "str_21714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21715", "str_21715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21716", "str_21716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21717", "str_21717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21718", "str_21718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21719", "str_21719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2172", "str_2172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21720", "str_21720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21721", "str_21721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21722", "str_21722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21723", "str_21723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21724", "str_21724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21725", "str_21725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21726", "str_21726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21727", "str_21727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21728", "str_21728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21729", "str_21729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2173", "str_2173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21730", "str_21730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21731", "str_21731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21732", "str_21732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21733", "str_21733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21734", "str_21734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21735", "str_21735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21736", "str_21736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21737", "str_21737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21738", "str_21738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21739", "str_21739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2174", "str_2174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21740", "str_21740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21741", "str_21741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21742", "str_21742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21743", "str_21743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21744", "str_21744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21745", "str_21745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21746", "str_21746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21747", "str_21747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21748", "str_21748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21749", "str_21749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2175", "str_2175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21750", "str_21750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21751", "str_21751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21752", "str_21752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21753", "str_21753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21754", "str_21754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21755", "str_21755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21756", "str_21756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21757", "str_21757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21758", "str_21758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21759", "str_21759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2176", "str_2176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21760", "str_21760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21761", "str_21761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21762", "str_21762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21763", "str_21763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21764", "str_21764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21765", "str_21765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21766", "str_21766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21767", "str_21767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21768", "str_21768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21769", "str_21769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2177", "str_2177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21770", "str_21770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21771", "str_21771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21772", "str_21772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21773", "str_21773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21774", "str_21774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21775", "str_21775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21776", "str_21776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21777", "str_21777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21778", "str_21778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21779", "str_21779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2178", "str_2178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21780", "str_21780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21781", "str_21781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21782", "str_21782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21783", "str_21783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21784", "str_21784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21785", "str_21785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21786", "str_21786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21787", "str_21787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21788", "str_21788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21789", "str_21789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2179", "str_2179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21790", "str_21790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21791", "str_21791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21792", "str_21792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21793", "str_21793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21794", "str_21794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21795", "str_21795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21796", "str_21796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21797", "str_21797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21798", "str_21798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21799", "str_21799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_218", "str_218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2180", "str_2180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21800", "str_21800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21801", "str_21801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21802", "str_21802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21803", "str_21803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21804", "str_21804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21805", "str_21805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21806", "str_21806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21807", "str_21807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21808", "str_21808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21809", "str_21809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2181", "str_2181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21810", "str_21810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21811", "str_21811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21812", "str_21812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21813", "str_21813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21814", "str_21814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21815", "str_21815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21816", "str_21816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21817", "str_21817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21818", "str_21818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21819", "str_21819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2182", "str_2182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21820", "str_21820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21821", "str_21821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21822", "str_21822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21823", "str_21823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21824", "str_21824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21825", "str_21825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21826", "str_21826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21827", "str_21827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21828", "str_21828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21829", "str_21829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2183", "str_2183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21830", "str_21830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21831", "str_21831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21832", "str_21832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21833", "str_21833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21834", "str_21834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21835", "str_21835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21836", "str_21836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21837", "str_21837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21838", "str_21838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21839", "str_21839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2184", "str_2184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21840", "str_21840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21841", "str_21841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21842", "str_21842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21843", "str_21843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21844", "str_21844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21845", "str_21845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21846", "str_21846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21847", "str_21847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21848", "str_21848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21849", "str_21849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2185", "str_2185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21850", "str_21850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21851", "str_21851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21852", "str_21852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21853", "str_21853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21854", "str_21854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21855", "str_21855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21856", "str_21856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21857", "str_21857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21858", "str_21858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21859", "str_21859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2186", "str_2186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21860", "str_21860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21861", "str_21861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21862", "str_21862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21863", "str_21863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21864", "str_21864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21865", "str_21865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21866", "str_21866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21867", "str_21867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21868", "str_21868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21869", "str_21869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2187", "str_2187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21870", "str_21870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21871", "str_21871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21872", "str_21872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21873", "str_21873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21874", "str_21874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21875", "str_21875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21876", "str_21876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21877", "str_21877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21878", "str_21878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21879", "str_21879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2188", "str_2188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21880", "str_21880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21881", "str_21881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21882", "str_21882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21883", "str_21883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21884", "str_21884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21885", "str_21885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21886", "str_21886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21887", "str_21887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21888", "str_21888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21889", "str_21889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2189", "str_2189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21890", "str_21890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21891", "str_21891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21892", "str_21892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21893", "str_21893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21894", "str_21894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21895", "str_21895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21896", "str_21896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21897", "str_21897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21898", "str_21898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21899", "str_21899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_219", "str_219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2190", "str_2190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21900", "str_21900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21901", "str_21901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21902", "str_21902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21903", "str_21903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21904", "str_21904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21905", "str_21905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21906", "str_21906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21907", "str_21907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21908", "str_21908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21909", "str_21909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2191", "str_2191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21910", "str_21910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21911", "str_21911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21912", "str_21912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21913", "str_21913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21914", "str_21914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21915", "str_21915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21916", "str_21916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21917", "str_21917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21918", "str_21918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21919", "str_21919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2192", "str_2192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21920", "str_21920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21921", "str_21921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21922", "str_21922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21923", "str_21923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21924", "str_21924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21925", "str_21925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21926", "str_21926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21927", "str_21927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21928", "str_21928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21929", "str_21929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2193", "str_2193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21930", "str_21930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21931", "str_21931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21932", "str_21932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21933", "str_21933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21934", "str_21934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21935", "str_21935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21936", "str_21936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21937", "str_21937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21938", "str_21938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21939", "str_21939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2194", "str_2194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21940", "str_21940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21941", "str_21941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21942", "str_21942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21943", "str_21943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21944", "str_21944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21945", "str_21945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21946", "str_21946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21947", "str_21947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21948", "str_21948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21949", "str_21949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2195", "str_2195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21950", "str_21950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21951", "str_21951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21952", "str_21952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21953", "str_21953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21954", "str_21954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21955", "str_21955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21956", "str_21956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21957", "str_21957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21958", "str_21958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21959", "str_21959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2196", "str_2196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21960", "str_21960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21961", "str_21961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21962", "str_21962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21963", "str_21963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21964", "str_21964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21965", "str_21965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21966", "str_21966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21967", "str_21967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21968", "str_21968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21969", "str_21969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2197", "str_2197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21970", "str_21970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21971", "str_21971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21972", "str_21972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21973", "str_21973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21974", "str_21974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21975", "str_21975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21976", "str_21976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21977", "str_21977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21978", "str_21978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21979", "str_21979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2198", "str_2198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21980", "str_21980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21981", "str_21981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21982", "str_21982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21983", "str_21983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21984", "str_21984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21985", "str_21985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21986", "str_21986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21987", "str_21987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21988", "str_21988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21989", "str_21989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2199", "str_2199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21990", "str_21990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21991", "str_21991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21992", "str_21992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21993", "str_21993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21994", "str_21994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21995", "str_21995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21996", "str_21996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21997", "str_21997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21998", "str_21998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_21999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_21999", "str_21999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22", "str_22",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_220", "str_220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2200", "str_2200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22000", "str_22000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22001", "str_22001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22002", "str_22002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22003", "str_22003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22004", "str_22004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22005", "str_22005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22006", "str_22006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22007", "str_22007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22008", "str_22008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22009", "str_22009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2201", "str_2201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22010", "str_22010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22011", "str_22011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22012", "str_22012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22013", "str_22013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22014", "str_22014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22015", "str_22015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22016", "str_22016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22017", "str_22017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22018", "str_22018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22019", "str_22019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2202", "str_2202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22020", "str_22020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22021", "str_22021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22022", "str_22022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22023", "str_22023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22024", "str_22024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22025", "str_22025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22026", "str_22026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22027", "str_22027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22028", "str_22028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22029", "str_22029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2203", "str_2203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22030", "str_22030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22031", "str_22031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22032", "str_22032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22033", "str_22033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22034", "str_22034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22035", "str_22035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22036", "str_22036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22037", "str_22037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22038", "str_22038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22039", "str_22039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2204", "str_2204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22040", "str_22040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22041", "str_22041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22042", "str_22042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22043", "str_22043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22044", "str_22044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22045", "str_22045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22046", "str_22046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22047", "str_22047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22048", "str_22048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22049", "str_22049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2205", "str_2205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22050", "str_22050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22051", "str_22051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22052", "str_22052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22053", "str_22053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22054", "str_22054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22055", "str_22055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22056", "str_22056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22057", "str_22057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22058", "str_22058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22059", "str_22059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2206", "str_2206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22060", "str_22060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22061", "str_22061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22062", "str_22062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22063", "str_22063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22064", "str_22064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22065", "str_22065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22066", "str_22066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22067", "str_22067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22068", "str_22068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22069", "str_22069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2207", "str_2207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22070", "str_22070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22071", "str_22071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22072", "str_22072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22073", "str_22073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22074", "str_22074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22075", "str_22075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22076", "str_22076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22077", "str_22077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22078", "str_22078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22079", "str_22079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2208", "str_2208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22080", "str_22080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22081", "str_22081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22082", "str_22082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22083", "str_22083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22084", "str_22084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22085", "str_22085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22086", "str_22086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22087", "str_22087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22088", "str_22088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22089", "str_22089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2209", "str_2209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22090", "str_22090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22091", "str_22091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22092", "str_22092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22093", "str_22093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22094", "str_22094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22095", "str_22095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22096", "str_22096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22097", "str_22097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22098", "str_22098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22099", "str_22099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_221", "str_221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2210", "str_2210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22100", "str_22100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22101", "str_22101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22102", "str_22102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22103", "str_22103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22104", "str_22104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22105", "str_22105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22106", "str_22106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22107", "str_22107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22108", "str_22108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22109", "str_22109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2211", "str_2211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22110", "str_22110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22111", "str_22111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22112", "str_22112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22113", "str_22113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22114", "str_22114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22115", "str_22115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22116", "str_22116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22117", "str_22117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22118", "str_22118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22119", "str_22119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2212", "str_2212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22120", "str_22120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22121", "str_22121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22122", "str_22122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22123", "str_22123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22124", "str_22124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22125", "str_22125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22126", "str_22126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22127", "str_22127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22128", "str_22128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22129", "str_22129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2213", "str_2213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22130", "str_22130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22131", "str_22131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22132", "str_22132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22133", "str_22133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22134", "str_22134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22135", "str_22135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22136", "str_22136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22137", "str_22137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22138", "str_22138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22139", "str_22139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2214", "str_2214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22140", "str_22140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22141", "str_22141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22142", "str_22142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22143", "str_22143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22144", "str_22144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22145", "str_22145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22146", "str_22146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_21698: StringResource
+  get() = String26.str_21698
+
+@ExperimentalResourceApi
+internal val Res.string.str_21699: StringResource
+  get() = String26.str_21699
+
+@ExperimentalResourceApi
+internal val Res.string.str_217: StringResource
+  get() = String26.str_217
+
+@ExperimentalResourceApi
+internal val Res.string.str_2170: StringResource
+  get() = String26.str_2170
+
+@ExperimentalResourceApi
+internal val Res.string.str_21700: StringResource
+  get() = String26.str_21700
+
+@ExperimentalResourceApi
+internal val Res.string.str_21701: StringResource
+  get() = String26.str_21701
+
+@ExperimentalResourceApi
+internal val Res.string.str_21702: StringResource
+  get() = String26.str_21702
+
+@ExperimentalResourceApi
+internal val Res.string.str_21703: StringResource
+  get() = String26.str_21703
+
+@ExperimentalResourceApi
+internal val Res.string.str_21704: StringResource
+  get() = String26.str_21704
+
+@ExperimentalResourceApi
+internal val Res.string.str_21705: StringResource
+  get() = String26.str_21705
+
+@ExperimentalResourceApi
+internal val Res.string.str_21706: StringResource
+  get() = String26.str_21706
+
+@ExperimentalResourceApi
+internal val Res.string.str_21707: StringResource
+  get() = String26.str_21707
+
+@ExperimentalResourceApi
+internal val Res.string.str_21708: StringResource
+  get() = String26.str_21708
+
+@ExperimentalResourceApi
+internal val Res.string.str_21709: StringResource
+  get() = String26.str_21709
+
+@ExperimentalResourceApi
+internal val Res.string.str_2171: StringResource
+  get() = String26.str_2171
+
+@ExperimentalResourceApi
+internal val Res.string.str_21710: StringResource
+  get() = String26.str_21710
+
+@ExperimentalResourceApi
+internal val Res.string.str_21711: StringResource
+  get() = String26.str_21711
+
+@ExperimentalResourceApi
+internal val Res.string.str_21712: StringResource
+  get() = String26.str_21712
+
+@ExperimentalResourceApi
+internal val Res.string.str_21713: StringResource
+  get() = String26.str_21713
+
+@ExperimentalResourceApi
+internal val Res.string.str_21714: StringResource
+  get() = String26.str_21714
+
+@ExperimentalResourceApi
+internal val Res.string.str_21715: StringResource
+  get() = String26.str_21715
+
+@ExperimentalResourceApi
+internal val Res.string.str_21716: StringResource
+  get() = String26.str_21716
+
+@ExperimentalResourceApi
+internal val Res.string.str_21717: StringResource
+  get() = String26.str_21717
+
+@ExperimentalResourceApi
+internal val Res.string.str_21718: StringResource
+  get() = String26.str_21718
+
+@ExperimentalResourceApi
+internal val Res.string.str_21719: StringResource
+  get() = String26.str_21719
+
+@ExperimentalResourceApi
+internal val Res.string.str_2172: StringResource
+  get() = String26.str_2172
+
+@ExperimentalResourceApi
+internal val Res.string.str_21720: StringResource
+  get() = String26.str_21720
+
+@ExperimentalResourceApi
+internal val Res.string.str_21721: StringResource
+  get() = String26.str_21721
+
+@ExperimentalResourceApi
+internal val Res.string.str_21722: StringResource
+  get() = String26.str_21722
+
+@ExperimentalResourceApi
+internal val Res.string.str_21723: StringResource
+  get() = String26.str_21723
+
+@ExperimentalResourceApi
+internal val Res.string.str_21724: StringResource
+  get() = String26.str_21724
+
+@ExperimentalResourceApi
+internal val Res.string.str_21725: StringResource
+  get() = String26.str_21725
+
+@ExperimentalResourceApi
+internal val Res.string.str_21726: StringResource
+  get() = String26.str_21726
+
+@ExperimentalResourceApi
+internal val Res.string.str_21727: StringResource
+  get() = String26.str_21727
+
+@ExperimentalResourceApi
+internal val Res.string.str_21728: StringResource
+  get() = String26.str_21728
+
+@ExperimentalResourceApi
+internal val Res.string.str_21729: StringResource
+  get() = String26.str_21729
+
+@ExperimentalResourceApi
+internal val Res.string.str_2173: StringResource
+  get() = String26.str_2173
+
+@ExperimentalResourceApi
+internal val Res.string.str_21730: StringResource
+  get() = String26.str_21730
+
+@ExperimentalResourceApi
+internal val Res.string.str_21731: StringResource
+  get() = String26.str_21731
+
+@ExperimentalResourceApi
+internal val Res.string.str_21732: StringResource
+  get() = String26.str_21732
+
+@ExperimentalResourceApi
+internal val Res.string.str_21733: StringResource
+  get() = String26.str_21733
+
+@ExperimentalResourceApi
+internal val Res.string.str_21734: StringResource
+  get() = String26.str_21734
+
+@ExperimentalResourceApi
+internal val Res.string.str_21735: StringResource
+  get() = String26.str_21735
+
+@ExperimentalResourceApi
+internal val Res.string.str_21736: StringResource
+  get() = String26.str_21736
+
+@ExperimentalResourceApi
+internal val Res.string.str_21737: StringResource
+  get() = String26.str_21737
+
+@ExperimentalResourceApi
+internal val Res.string.str_21738: StringResource
+  get() = String26.str_21738
+
+@ExperimentalResourceApi
+internal val Res.string.str_21739: StringResource
+  get() = String26.str_21739
+
+@ExperimentalResourceApi
+internal val Res.string.str_2174: StringResource
+  get() = String26.str_2174
+
+@ExperimentalResourceApi
+internal val Res.string.str_21740: StringResource
+  get() = String26.str_21740
+
+@ExperimentalResourceApi
+internal val Res.string.str_21741: StringResource
+  get() = String26.str_21741
+
+@ExperimentalResourceApi
+internal val Res.string.str_21742: StringResource
+  get() = String26.str_21742
+
+@ExperimentalResourceApi
+internal val Res.string.str_21743: StringResource
+  get() = String26.str_21743
+
+@ExperimentalResourceApi
+internal val Res.string.str_21744: StringResource
+  get() = String26.str_21744
+
+@ExperimentalResourceApi
+internal val Res.string.str_21745: StringResource
+  get() = String26.str_21745
+
+@ExperimentalResourceApi
+internal val Res.string.str_21746: StringResource
+  get() = String26.str_21746
+
+@ExperimentalResourceApi
+internal val Res.string.str_21747: StringResource
+  get() = String26.str_21747
+
+@ExperimentalResourceApi
+internal val Res.string.str_21748: StringResource
+  get() = String26.str_21748
+
+@ExperimentalResourceApi
+internal val Res.string.str_21749: StringResource
+  get() = String26.str_21749
+
+@ExperimentalResourceApi
+internal val Res.string.str_2175: StringResource
+  get() = String26.str_2175
+
+@ExperimentalResourceApi
+internal val Res.string.str_21750: StringResource
+  get() = String26.str_21750
+
+@ExperimentalResourceApi
+internal val Res.string.str_21751: StringResource
+  get() = String26.str_21751
+
+@ExperimentalResourceApi
+internal val Res.string.str_21752: StringResource
+  get() = String26.str_21752
+
+@ExperimentalResourceApi
+internal val Res.string.str_21753: StringResource
+  get() = String26.str_21753
+
+@ExperimentalResourceApi
+internal val Res.string.str_21754: StringResource
+  get() = String26.str_21754
+
+@ExperimentalResourceApi
+internal val Res.string.str_21755: StringResource
+  get() = String26.str_21755
+
+@ExperimentalResourceApi
+internal val Res.string.str_21756: StringResource
+  get() = String26.str_21756
+
+@ExperimentalResourceApi
+internal val Res.string.str_21757: StringResource
+  get() = String26.str_21757
+
+@ExperimentalResourceApi
+internal val Res.string.str_21758: StringResource
+  get() = String26.str_21758
+
+@ExperimentalResourceApi
+internal val Res.string.str_21759: StringResource
+  get() = String26.str_21759
+
+@ExperimentalResourceApi
+internal val Res.string.str_2176: StringResource
+  get() = String26.str_2176
+
+@ExperimentalResourceApi
+internal val Res.string.str_21760: StringResource
+  get() = String26.str_21760
+
+@ExperimentalResourceApi
+internal val Res.string.str_21761: StringResource
+  get() = String26.str_21761
+
+@ExperimentalResourceApi
+internal val Res.string.str_21762: StringResource
+  get() = String26.str_21762
+
+@ExperimentalResourceApi
+internal val Res.string.str_21763: StringResource
+  get() = String26.str_21763
+
+@ExperimentalResourceApi
+internal val Res.string.str_21764: StringResource
+  get() = String26.str_21764
+
+@ExperimentalResourceApi
+internal val Res.string.str_21765: StringResource
+  get() = String26.str_21765
+
+@ExperimentalResourceApi
+internal val Res.string.str_21766: StringResource
+  get() = String26.str_21766
+
+@ExperimentalResourceApi
+internal val Res.string.str_21767: StringResource
+  get() = String26.str_21767
+
+@ExperimentalResourceApi
+internal val Res.string.str_21768: StringResource
+  get() = String26.str_21768
+
+@ExperimentalResourceApi
+internal val Res.string.str_21769: StringResource
+  get() = String26.str_21769
+
+@ExperimentalResourceApi
+internal val Res.string.str_2177: StringResource
+  get() = String26.str_2177
+
+@ExperimentalResourceApi
+internal val Res.string.str_21770: StringResource
+  get() = String26.str_21770
+
+@ExperimentalResourceApi
+internal val Res.string.str_21771: StringResource
+  get() = String26.str_21771
+
+@ExperimentalResourceApi
+internal val Res.string.str_21772: StringResource
+  get() = String26.str_21772
+
+@ExperimentalResourceApi
+internal val Res.string.str_21773: StringResource
+  get() = String26.str_21773
+
+@ExperimentalResourceApi
+internal val Res.string.str_21774: StringResource
+  get() = String26.str_21774
+
+@ExperimentalResourceApi
+internal val Res.string.str_21775: StringResource
+  get() = String26.str_21775
+
+@ExperimentalResourceApi
+internal val Res.string.str_21776: StringResource
+  get() = String26.str_21776
+
+@ExperimentalResourceApi
+internal val Res.string.str_21777: StringResource
+  get() = String26.str_21777
+
+@ExperimentalResourceApi
+internal val Res.string.str_21778: StringResource
+  get() = String26.str_21778
+
+@ExperimentalResourceApi
+internal val Res.string.str_21779: StringResource
+  get() = String26.str_21779
+
+@ExperimentalResourceApi
+internal val Res.string.str_2178: StringResource
+  get() = String26.str_2178
+
+@ExperimentalResourceApi
+internal val Res.string.str_21780: StringResource
+  get() = String26.str_21780
+
+@ExperimentalResourceApi
+internal val Res.string.str_21781: StringResource
+  get() = String26.str_21781
+
+@ExperimentalResourceApi
+internal val Res.string.str_21782: StringResource
+  get() = String26.str_21782
+
+@ExperimentalResourceApi
+internal val Res.string.str_21783: StringResource
+  get() = String26.str_21783
+
+@ExperimentalResourceApi
+internal val Res.string.str_21784: StringResource
+  get() = String26.str_21784
+
+@ExperimentalResourceApi
+internal val Res.string.str_21785: StringResource
+  get() = String26.str_21785
+
+@ExperimentalResourceApi
+internal val Res.string.str_21786: StringResource
+  get() = String26.str_21786
+
+@ExperimentalResourceApi
+internal val Res.string.str_21787: StringResource
+  get() = String26.str_21787
+
+@ExperimentalResourceApi
+internal val Res.string.str_21788: StringResource
+  get() = String26.str_21788
+
+@ExperimentalResourceApi
+internal val Res.string.str_21789: StringResource
+  get() = String26.str_21789
+
+@ExperimentalResourceApi
+internal val Res.string.str_2179: StringResource
+  get() = String26.str_2179
+
+@ExperimentalResourceApi
+internal val Res.string.str_21790: StringResource
+  get() = String26.str_21790
+
+@ExperimentalResourceApi
+internal val Res.string.str_21791: StringResource
+  get() = String26.str_21791
+
+@ExperimentalResourceApi
+internal val Res.string.str_21792: StringResource
+  get() = String26.str_21792
+
+@ExperimentalResourceApi
+internal val Res.string.str_21793: StringResource
+  get() = String26.str_21793
+
+@ExperimentalResourceApi
+internal val Res.string.str_21794: StringResource
+  get() = String26.str_21794
+
+@ExperimentalResourceApi
+internal val Res.string.str_21795: StringResource
+  get() = String26.str_21795
+
+@ExperimentalResourceApi
+internal val Res.string.str_21796: StringResource
+  get() = String26.str_21796
+
+@ExperimentalResourceApi
+internal val Res.string.str_21797: StringResource
+  get() = String26.str_21797
+
+@ExperimentalResourceApi
+internal val Res.string.str_21798: StringResource
+  get() = String26.str_21798
+
+@ExperimentalResourceApi
+internal val Res.string.str_21799: StringResource
+  get() = String26.str_21799
+
+@ExperimentalResourceApi
+internal val Res.string.str_218: StringResource
+  get() = String26.str_218
+
+@ExperimentalResourceApi
+internal val Res.string.str_2180: StringResource
+  get() = String26.str_2180
+
+@ExperimentalResourceApi
+internal val Res.string.str_21800: StringResource
+  get() = String26.str_21800
+
+@ExperimentalResourceApi
+internal val Res.string.str_21801: StringResource
+  get() = String26.str_21801
+
+@ExperimentalResourceApi
+internal val Res.string.str_21802: StringResource
+  get() = String26.str_21802
+
+@ExperimentalResourceApi
+internal val Res.string.str_21803: StringResource
+  get() = String26.str_21803
+
+@ExperimentalResourceApi
+internal val Res.string.str_21804: StringResource
+  get() = String26.str_21804
+
+@ExperimentalResourceApi
+internal val Res.string.str_21805: StringResource
+  get() = String26.str_21805
+
+@ExperimentalResourceApi
+internal val Res.string.str_21806: StringResource
+  get() = String26.str_21806
+
+@ExperimentalResourceApi
+internal val Res.string.str_21807: StringResource
+  get() = String26.str_21807
+
+@ExperimentalResourceApi
+internal val Res.string.str_21808: StringResource
+  get() = String26.str_21808
+
+@ExperimentalResourceApi
+internal val Res.string.str_21809: StringResource
+  get() = String26.str_21809
+
+@ExperimentalResourceApi
+internal val Res.string.str_2181: StringResource
+  get() = String26.str_2181
+
+@ExperimentalResourceApi
+internal val Res.string.str_21810: StringResource
+  get() = String26.str_21810
+
+@ExperimentalResourceApi
+internal val Res.string.str_21811: StringResource
+  get() = String26.str_21811
+
+@ExperimentalResourceApi
+internal val Res.string.str_21812: StringResource
+  get() = String26.str_21812
+
+@ExperimentalResourceApi
+internal val Res.string.str_21813: StringResource
+  get() = String26.str_21813
+
+@ExperimentalResourceApi
+internal val Res.string.str_21814: StringResource
+  get() = String26.str_21814
+
+@ExperimentalResourceApi
+internal val Res.string.str_21815: StringResource
+  get() = String26.str_21815
+
+@ExperimentalResourceApi
+internal val Res.string.str_21816: StringResource
+  get() = String26.str_21816
+
+@ExperimentalResourceApi
+internal val Res.string.str_21817: StringResource
+  get() = String26.str_21817
+
+@ExperimentalResourceApi
+internal val Res.string.str_21818: StringResource
+  get() = String26.str_21818
+
+@ExperimentalResourceApi
+internal val Res.string.str_21819: StringResource
+  get() = String26.str_21819
+
+@ExperimentalResourceApi
+internal val Res.string.str_2182: StringResource
+  get() = String26.str_2182
+
+@ExperimentalResourceApi
+internal val Res.string.str_21820: StringResource
+  get() = String26.str_21820
+
+@ExperimentalResourceApi
+internal val Res.string.str_21821: StringResource
+  get() = String26.str_21821
+
+@ExperimentalResourceApi
+internal val Res.string.str_21822: StringResource
+  get() = String26.str_21822
+
+@ExperimentalResourceApi
+internal val Res.string.str_21823: StringResource
+  get() = String26.str_21823
+
+@ExperimentalResourceApi
+internal val Res.string.str_21824: StringResource
+  get() = String26.str_21824
+
+@ExperimentalResourceApi
+internal val Res.string.str_21825: StringResource
+  get() = String26.str_21825
+
+@ExperimentalResourceApi
+internal val Res.string.str_21826: StringResource
+  get() = String26.str_21826
+
+@ExperimentalResourceApi
+internal val Res.string.str_21827: StringResource
+  get() = String26.str_21827
+
+@ExperimentalResourceApi
+internal val Res.string.str_21828: StringResource
+  get() = String26.str_21828
+
+@ExperimentalResourceApi
+internal val Res.string.str_21829: StringResource
+  get() = String26.str_21829
+
+@ExperimentalResourceApi
+internal val Res.string.str_2183: StringResource
+  get() = String26.str_2183
+
+@ExperimentalResourceApi
+internal val Res.string.str_21830: StringResource
+  get() = String26.str_21830
+
+@ExperimentalResourceApi
+internal val Res.string.str_21831: StringResource
+  get() = String26.str_21831
+
+@ExperimentalResourceApi
+internal val Res.string.str_21832: StringResource
+  get() = String26.str_21832
+
+@ExperimentalResourceApi
+internal val Res.string.str_21833: StringResource
+  get() = String26.str_21833
+
+@ExperimentalResourceApi
+internal val Res.string.str_21834: StringResource
+  get() = String26.str_21834
+
+@ExperimentalResourceApi
+internal val Res.string.str_21835: StringResource
+  get() = String26.str_21835
+
+@ExperimentalResourceApi
+internal val Res.string.str_21836: StringResource
+  get() = String26.str_21836
+
+@ExperimentalResourceApi
+internal val Res.string.str_21837: StringResource
+  get() = String26.str_21837
+
+@ExperimentalResourceApi
+internal val Res.string.str_21838: StringResource
+  get() = String26.str_21838
+
+@ExperimentalResourceApi
+internal val Res.string.str_21839: StringResource
+  get() = String26.str_21839
+
+@ExperimentalResourceApi
+internal val Res.string.str_2184: StringResource
+  get() = String26.str_2184
+
+@ExperimentalResourceApi
+internal val Res.string.str_21840: StringResource
+  get() = String26.str_21840
+
+@ExperimentalResourceApi
+internal val Res.string.str_21841: StringResource
+  get() = String26.str_21841
+
+@ExperimentalResourceApi
+internal val Res.string.str_21842: StringResource
+  get() = String26.str_21842
+
+@ExperimentalResourceApi
+internal val Res.string.str_21843: StringResource
+  get() = String26.str_21843
+
+@ExperimentalResourceApi
+internal val Res.string.str_21844: StringResource
+  get() = String26.str_21844
+
+@ExperimentalResourceApi
+internal val Res.string.str_21845: StringResource
+  get() = String26.str_21845
+
+@ExperimentalResourceApi
+internal val Res.string.str_21846: StringResource
+  get() = String26.str_21846
+
+@ExperimentalResourceApi
+internal val Res.string.str_21847: StringResource
+  get() = String26.str_21847
+
+@ExperimentalResourceApi
+internal val Res.string.str_21848: StringResource
+  get() = String26.str_21848
+
+@ExperimentalResourceApi
+internal val Res.string.str_21849: StringResource
+  get() = String26.str_21849
+
+@ExperimentalResourceApi
+internal val Res.string.str_2185: StringResource
+  get() = String26.str_2185
+
+@ExperimentalResourceApi
+internal val Res.string.str_21850: StringResource
+  get() = String26.str_21850
+
+@ExperimentalResourceApi
+internal val Res.string.str_21851: StringResource
+  get() = String26.str_21851
+
+@ExperimentalResourceApi
+internal val Res.string.str_21852: StringResource
+  get() = String26.str_21852
+
+@ExperimentalResourceApi
+internal val Res.string.str_21853: StringResource
+  get() = String26.str_21853
+
+@ExperimentalResourceApi
+internal val Res.string.str_21854: StringResource
+  get() = String26.str_21854
+
+@ExperimentalResourceApi
+internal val Res.string.str_21855: StringResource
+  get() = String26.str_21855
+
+@ExperimentalResourceApi
+internal val Res.string.str_21856: StringResource
+  get() = String26.str_21856
+
+@ExperimentalResourceApi
+internal val Res.string.str_21857: StringResource
+  get() = String26.str_21857
+
+@ExperimentalResourceApi
+internal val Res.string.str_21858: StringResource
+  get() = String26.str_21858
+
+@ExperimentalResourceApi
+internal val Res.string.str_21859: StringResource
+  get() = String26.str_21859
+
+@ExperimentalResourceApi
+internal val Res.string.str_2186: StringResource
+  get() = String26.str_2186
+
+@ExperimentalResourceApi
+internal val Res.string.str_21860: StringResource
+  get() = String26.str_21860
+
+@ExperimentalResourceApi
+internal val Res.string.str_21861: StringResource
+  get() = String26.str_21861
+
+@ExperimentalResourceApi
+internal val Res.string.str_21862: StringResource
+  get() = String26.str_21862
+
+@ExperimentalResourceApi
+internal val Res.string.str_21863: StringResource
+  get() = String26.str_21863
+
+@ExperimentalResourceApi
+internal val Res.string.str_21864: StringResource
+  get() = String26.str_21864
+
+@ExperimentalResourceApi
+internal val Res.string.str_21865: StringResource
+  get() = String26.str_21865
+
+@ExperimentalResourceApi
+internal val Res.string.str_21866: StringResource
+  get() = String26.str_21866
+
+@ExperimentalResourceApi
+internal val Res.string.str_21867: StringResource
+  get() = String26.str_21867
+
+@ExperimentalResourceApi
+internal val Res.string.str_21868: StringResource
+  get() = String26.str_21868
+
+@ExperimentalResourceApi
+internal val Res.string.str_21869: StringResource
+  get() = String26.str_21869
+
+@ExperimentalResourceApi
+internal val Res.string.str_2187: StringResource
+  get() = String26.str_2187
+
+@ExperimentalResourceApi
+internal val Res.string.str_21870: StringResource
+  get() = String26.str_21870
+
+@ExperimentalResourceApi
+internal val Res.string.str_21871: StringResource
+  get() = String26.str_21871
+
+@ExperimentalResourceApi
+internal val Res.string.str_21872: StringResource
+  get() = String26.str_21872
+
+@ExperimentalResourceApi
+internal val Res.string.str_21873: StringResource
+  get() = String26.str_21873
+
+@ExperimentalResourceApi
+internal val Res.string.str_21874: StringResource
+  get() = String26.str_21874
+
+@ExperimentalResourceApi
+internal val Res.string.str_21875: StringResource
+  get() = String26.str_21875
+
+@ExperimentalResourceApi
+internal val Res.string.str_21876: StringResource
+  get() = String26.str_21876
+
+@ExperimentalResourceApi
+internal val Res.string.str_21877: StringResource
+  get() = String26.str_21877
+
+@ExperimentalResourceApi
+internal val Res.string.str_21878: StringResource
+  get() = String26.str_21878
+
+@ExperimentalResourceApi
+internal val Res.string.str_21879: StringResource
+  get() = String26.str_21879
+
+@ExperimentalResourceApi
+internal val Res.string.str_2188: StringResource
+  get() = String26.str_2188
+
+@ExperimentalResourceApi
+internal val Res.string.str_21880: StringResource
+  get() = String26.str_21880
+
+@ExperimentalResourceApi
+internal val Res.string.str_21881: StringResource
+  get() = String26.str_21881
+
+@ExperimentalResourceApi
+internal val Res.string.str_21882: StringResource
+  get() = String26.str_21882
+
+@ExperimentalResourceApi
+internal val Res.string.str_21883: StringResource
+  get() = String26.str_21883
+
+@ExperimentalResourceApi
+internal val Res.string.str_21884: StringResource
+  get() = String26.str_21884
+
+@ExperimentalResourceApi
+internal val Res.string.str_21885: StringResource
+  get() = String26.str_21885
+
+@ExperimentalResourceApi
+internal val Res.string.str_21886: StringResource
+  get() = String26.str_21886
+
+@ExperimentalResourceApi
+internal val Res.string.str_21887: StringResource
+  get() = String26.str_21887
+
+@ExperimentalResourceApi
+internal val Res.string.str_21888: StringResource
+  get() = String26.str_21888
+
+@ExperimentalResourceApi
+internal val Res.string.str_21889: StringResource
+  get() = String26.str_21889
+
+@ExperimentalResourceApi
+internal val Res.string.str_2189: StringResource
+  get() = String26.str_2189
+
+@ExperimentalResourceApi
+internal val Res.string.str_21890: StringResource
+  get() = String26.str_21890
+
+@ExperimentalResourceApi
+internal val Res.string.str_21891: StringResource
+  get() = String26.str_21891
+
+@ExperimentalResourceApi
+internal val Res.string.str_21892: StringResource
+  get() = String26.str_21892
+
+@ExperimentalResourceApi
+internal val Res.string.str_21893: StringResource
+  get() = String26.str_21893
+
+@ExperimentalResourceApi
+internal val Res.string.str_21894: StringResource
+  get() = String26.str_21894
+
+@ExperimentalResourceApi
+internal val Res.string.str_21895: StringResource
+  get() = String26.str_21895
+
+@ExperimentalResourceApi
+internal val Res.string.str_21896: StringResource
+  get() = String26.str_21896
+
+@ExperimentalResourceApi
+internal val Res.string.str_21897: StringResource
+  get() = String26.str_21897
+
+@ExperimentalResourceApi
+internal val Res.string.str_21898: StringResource
+  get() = String26.str_21898
+
+@ExperimentalResourceApi
+internal val Res.string.str_21899: StringResource
+  get() = String26.str_21899
+
+@ExperimentalResourceApi
+internal val Res.string.str_219: StringResource
+  get() = String26.str_219
+
+@ExperimentalResourceApi
+internal val Res.string.str_2190: StringResource
+  get() = String26.str_2190
+
+@ExperimentalResourceApi
+internal val Res.string.str_21900: StringResource
+  get() = String26.str_21900
+
+@ExperimentalResourceApi
+internal val Res.string.str_21901: StringResource
+  get() = String26.str_21901
+
+@ExperimentalResourceApi
+internal val Res.string.str_21902: StringResource
+  get() = String26.str_21902
+
+@ExperimentalResourceApi
+internal val Res.string.str_21903: StringResource
+  get() = String26.str_21903
+
+@ExperimentalResourceApi
+internal val Res.string.str_21904: StringResource
+  get() = String26.str_21904
+
+@ExperimentalResourceApi
+internal val Res.string.str_21905: StringResource
+  get() = String26.str_21905
+
+@ExperimentalResourceApi
+internal val Res.string.str_21906: StringResource
+  get() = String26.str_21906
+
+@ExperimentalResourceApi
+internal val Res.string.str_21907: StringResource
+  get() = String26.str_21907
+
+@ExperimentalResourceApi
+internal val Res.string.str_21908: StringResource
+  get() = String26.str_21908
+
+@ExperimentalResourceApi
+internal val Res.string.str_21909: StringResource
+  get() = String26.str_21909
+
+@ExperimentalResourceApi
+internal val Res.string.str_2191: StringResource
+  get() = String26.str_2191
+
+@ExperimentalResourceApi
+internal val Res.string.str_21910: StringResource
+  get() = String26.str_21910
+
+@ExperimentalResourceApi
+internal val Res.string.str_21911: StringResource
+  get() = String26.str_21911
+
+@ExperimentalResourceApi
+internal val Res.string.str_21912: StringResource
+  get() = String26.str_21912
+
+@ExperimentalResourceApi
+internal val Res.string.str_21913: StringResource
+  get() = String26.str_21913
+
+@ExperimentalResourceApi
+internal val Res.string.str_21914: StringResource
+  get() = String26.str_21914
+
+@ExperimentalResourceApi
+internal val Res.string.str_21915: StringResource
+  get() = String26.str_21915
+
+@ExperimentalResourceApi
+internal val Res.string.str_21916: StringResource
+  get() = String26.str_21916
+
+@ExperimentalResourceApi
+internal val Res.string.str_21917: StringResource
+  get() = String26.str_21917
+
+@ExperimentalResourceApi
+internal val Res.string.str_21918: StringResource
+  get() = String26.str_21918
+
+@ExperimentalResourceApi
+internal val Res.string.str_21919: StringResource
+  get() = String26.str_21919
+
+@ExperimentalResourceApi
+internal val Res.string.str_2192: StringResource
+  get() = String26.str_2192
+
+@ExperimentalResourceApi
+internal val Res.string.str_21920: StringResource
+  get() = String26.str_21920
+
+@ExperimentalResourceApi
+internal val Res.string.str_21921: StringResource
+  get() = String26.str_21921
+
+@ExperimentalResourceApi
+internal val Res.string.str_21922: StringResource
+  get() = String26.str_21922
+
+@ExperimentalResourceApi
+internal val Res.string.str_21923: StringResource
+  get() = String26.str_21923
+
+@ExperimentalResourceApi
+internal val Res.string.str_21924: StringResource
+  get() = String26.str_21924
+
+@ExperimentalResourceApi
+internal val Res.string.str_21925: StringResource
+  get() = String26.str_21925
+
+@ExperimentalResourceApi
+internal val Res.string.str_21926: StringResource
+  get() = String26.str_21926
+
+@ExperimentalResourceApi
+internal val Res.string.str_21927: StringResource
+  get() = String26.str_21927
+
+@ExperimentalResourceApi
+internal val Res.string.str_21928: StringResource
+  get() = String26.str_21928
+
+@ExperimentalResourceApi
+internal val Res.string.str_21929: StringResource
+  get() = String26.str_21929
+
+@ExperimentalResourceApi
+internal val Res.string.str_2193: StringResource
+  get() = String26.str_2193
+
+@ExperimentalResourceApi
+internal val Res.string.str_21930: StringResource
+  get() = String26.str_21930
+
+@ExperimentalResourceApi
+internal val Res.string.str_21931: StringResource
+  get() = String26.str_21931
+
+@ExperimentalResourceApi
+internal val Res.string.str_21932: StringResource
+  get() = String26.str_21932
+
+@ExperimentalResourceApi
+internal val Res.string.str_21933: StringResource
+  get() = String26.str_21933
+
+@ExperimentalResourceApi
+internal val Res.string.str_21934: StringResource
+  get() = String26.str_21934
+
+@ExperimentalResourceApi
+internal val Res.string.str_21935: StringResource
+  get() = String26.str_21935
+
+@ExperimentalResourceApi
+internal val Res.string.str_21936: StringResource
+  get() = String26.str_21936
+
+@ExperimentalResourceApi
+internal val Res.string.str_21937: StringResource
+  get() = String26.str_21937
+
+@ExperimentalResourceApi
+internal val Res.string.str_21938: StringResource
+  get() = String26.str_21938
+
+@ExperimentalResourceApi
+internal val Res.string.str_21939: StringResource
+  get() = String26.str_21939
+
+@ExperimentalResourceApi
+internal val Res.string.str_2194: StringResource
+  get() = String26.str_2194
+
+@ExperimentalResourceApi
+internal val Res.string.str_21940: StringResource
+  get() = String26.str_21940
+
+@ExperimentalResourceApi
+internal val Res.string.str_21941: StringResource
+  get() = String26.str_21941
+
+@ExperimentalResourceApi
+internal val Res.string.str_21942: StringResource
+  get() = String26.str_21942
+
+@ExperimentalResourceApi
+internal val Res.string.str_21943: StringResource
+  get() = String26.str_21943
+
+@ExperimentalResourceApi
+internal val Res.string.str_21944: StringResource
+  get() = String26.str_21944
+
+@ExperimentalResourceApi
+internal val Res.string.str_21945: StringResource
+  get() = String26.str_21945
+
+@ExperimentalResourceApi
+internal val Res.string.str_21946: StringResource
+  get() = String26.str_21946
+
+@ExperimentalResourceApi
+internal val Res.string.str_21947: StringResource
+  get() = String26.str_21947
+
+@ExperimentalResourceApi
+internal val Res.string.str_21948: StringResource
+  get() = String26.str_21948
+
+@ExperimentalResourceApi
+internal val Res.string.str_21949: StringResource
+  get() = String26.str_21949
+
+@ExperimentalResourceApi
+internal val Res.string.str_2195: StringResource
+  get() = String26.str_2195
+
+@ExperimentalResourceApi
+internal val Res.string.str_21950: StringResource
+  get() = String26.str_21950
+
+@ExperimentalResourceApi
+internal val Res.string.str_21951: StringResource
+  get() = String26.str_21951
+
+@ExperimentalResourceApi
+internal val Res.string.str_21952: StringResource
+  get() = String26.str_21952
+
+@ExperimentalResourceApi
+internal val Res.string.str_21953: StringResource
+  get() = String26.str_21953
+
+@ExperimentalResourceApi
+internal val Res.string.str_21954: StringResource
+  get() = String26.str_21954
+
+@ExperimentalResourceApi
+internal val Res.string.str_21955: StringResource
+  get() = String26.str_21955
+
+@ExperimentalResourceApi
+internal val Res.string.str_21956: StringResource
+  get() = String26.str_21956
+
+@ExperimentalResourceApi
+internal val Res.string.str_21957: StringResource
+  get() = String26.str_21957
+
+@ExperimentalResourceApi
+internal val Res.string.str_21958: StringResource
+  get() = String26.str_21958
+
+@ExperimentalResourceApi
+internal val Res.string.str_21959: StringResource
+  get() = String26.str_21959
+
+@ExperimentalResourceApi
+internal val Res.string.str_2196: StringResource
+  get() = String26.str_2196
+
+@ExperimentalResourceApi
+internal val Res.string.str_21960: StringResource
+  get() = String26.str_21960
+
+@ExperimentalResourceApi
+internal val Res.string.str_21961: StringResource
+  get() = String26.str_21961
+
+@ExperimentalResourceApi
+internal val Res.string.str_21962: StringResource
+  get() = String26.str_21962
+
+@ExperimentalResourceApi
+internal val Res.string.str_21963: StringResource
+  get() = String26.str_21963
+
+@ExperimentalResourceApi
+internal val Res.string.str_21964: StringResource
+  get() = String26.str_21964
+
+@ExperimentalResourceApi
+internal val Res.string.str_21965: StringResource
+  get() = String26.str_21965
+
+@ExperimentalResourceApi
+internal val Res.string.str_21966: StringResource
+  get() = String26.str_21966
+
+@ExperimentalResourceApi
+internal val Res.string.str_21967: StringResource
+  get() = String26.str_21967
+
+@ExperimentalResourceApi
+internal val Res.string.str_21968: StringResource
+  get() = String26.str_21968
+
+@ExperimentalResourceApi
+internal val Res.string.str_21969: StringResource
+  get() = String26.str_21969
+
+@ExperimentalResourceApi
+internal val Res.string.str_2197: StringResource
+  get() = String26.str_2197
+
+@ExperimentalResourceApi
+internal val Res.string.str_21970: StringResource
+  get() = String26.str_21970
+
+@ExperimentalResourceApi
+internal val Res.string.str_21971: StringResource
+  get() = String26.str_21971
+
+@ExperimentalResourceApi
+internal val Res.string.str_21972: StringResource
+  get() = String26.str_21972
+
+@ExperimentalResourceApi
+internal val Res.string.str_21973: StringResource
+  get() = String26.str_21973
+
+@ExperimentalResourceApi
+internal val Res.string.str_21974: StringResource
+  get() = String26.str_21974
+
+@ExperimentalResourceApi
+internal val Res.string.str_21975: StringResource
+  get() = String26.str_21975
+
+@ExperimentalResourceApi
+internal val Res.string.str_21976: StringResource
+  get() = String26.str_21976
+
+@ExperimentalResourceApi
+internal val Res.string.str_21977: StringResource
+  get() = String26.str_21977
+
+@ExperimentalResourceApi
+internal val Res.string.str_21978: StringResource
+  get() = String26.str_21978
+
+@ExperimentalResourceApi
+internal val Res.string.str_21979: StringResource
+  get() = String26.str_21979
+
+@ExperimentalResourceApi
+internal val Res.string.str_2198: StringResource
+  get() = String26.str_2198
+
+@ExperimentalResourceApi
+internal val Res.string.str_21980: StringResource
+  get() = String26.str_21980
+
+@ExperimentalResourceApi
+internal val Res.string.str_21981: StringResource
+  get() = String26.str_21981
+
+@ExperimentalResourceApi
+internal val Res.string.str_21982: StringResource
+  get() = String26.str_21982
+
+@ExperimentalResourceApi
+internal val Res.string.str_21983: StringResource
+  get() = String26.str_21983
+
+@ExperimentalResourceApi
+internal val Res.string.str_21984: StringResource
+  get() = String26.str_21984
+
+@ExperimentalResourceApi
+internal val Res.string.str_21985: StringResource
+  get() = String26.str_21985
+
+@ExperimentalResourceApi
+internal val Res.string.str_21986: StringResource
+  get() = String26.str_21986
+
+@ExperimentalResourceApi
+internal val Res.string.str_21987: StringResource
+  get() = String26.str_21987
+
+@ExperimentalResourceApi
+internal val Res.string.str_21988: StringResource
+  get() = String26.str_21988
+
+@ExperimentalResourceApi
+internal val Res.string.str_21989: StringResource
+  get() = String26.str_21989
+
+@ExperimentalResourceApi
+internal val Res.string.str_2199: StringResource
+  get() = String26.str_2199
+
+@ExperimentalResourceApi
+internal val Res.string.str_21990: StringResource
+  get() = String26.str_21990
+
+@ExperimentalResourceApi
+internal val Res.string.str_21991: StringResource
+  get() = String26.str_21991
+
+@ExperimentalResourceApi
+internal val Res.string.str_21992: StringResource
+  get() = String26.str_21992
+
+@ExperimentalResourceApi
+internal val Res.string.str_21993: StringResource
+  get() = String26.str_21993
+
+@ExperimentalResourceApi
+internal val Res.string.str_21994: StringResource
+  get() = String26.str_21994
+
+@ExperimentalResourceApi
+internal val Res.string.str_21995: StringResource
+  get() = String26.str_21995
+
+@ExperimentalResourceApi
+internal val Res.string.str_21996: StringResource
+  get() = String26.str_21996
+
+@ExperimentalResourceApi
+internal val Res.string.str_21997: StringResource
+  get() = String26.str_21997
+
+@ExperimentalResourceApi
+internal val Res.string.str_21998: StringResource
+  get() = String26.str_21998
+
+@ExperimentalResourceApi
+internal val Res.string.str_21999: StringResource
+  get() = String26.str_21999
+
+@ExperimentalResourceApi
+internal val Res.string.str_22: StringResource
+  get() = String26.str_22
+
+@ExperimentalResourceApi
+internal val Res.string.str_220: StringResource
+  get() = String26.str_220
+
+@ExperimentalResourceApi
+internal val Res.string.str_2200: StringResource
+  get() = String26.str_2200
+
+@ExperimentalResourceApi
+internal val Res.string.str_22000: StringResource
+  get() = String26.str_22000
+
+@ExperimentalResourceApi
+internal val Res.string.str_22001: StringResource
+  get() = String26.str_22001
+
+@ExperimentalResourceApi
+internal val Res.string.str_22002: StringResource
+  get() = String26.str_22002
+
+@ExperimentalResourceApi
+internal val Res.string.str_22003: StringResource
+  get() = String26.str_22003
+
+@ExperimentalResourceApi
+internal val Res.string.str_22004: StringResource
+  get() = String26.str_22004
+
+@ExperimentalResourceApi
+internal val Res.string.str_22005: StringResource
+  get() = String26.str_22005
+
+@ExperimentalResourceApi
+internal val Res.string.str_22006: StringResource
+  get() = String26.str_22006
+
+@ExperimentalResourceApi
+internal val Res.string.str_22007: StringResource
+  get() = String26.str_22007
+
+@ExperimentalResourceApi
+internal val Res.string.str_22008: StringResource
+  get() = String26.str_22008
+
+@ExperimentalResourceApi
+internal val Res.string.str_22009: StringResource
+  get() = String26.str_22009
+
+@ExperimentalResourceApi
+internal val Res.string.str_2201: StringResource
+  get() = String26.str_2201
+
+@ExperimentalResourceApi
+internal val Res.string.str_22010: StringResource
+  get() = String26.str_22010
+
+@ExperimentalResourceApi
+internal val Res.string.str_22011: StringResource
+  get() = String26.str_22011
+
+@ExperimentalResourceApi
+internal val Res.string.str_22012: StringResource
+  get() = String26.str_22012
+
+@ExperimentalResourceApi
+internal val Res.string.str_22013: StringResource
+  get() = String26.str_22013
+
+@ExperimentalResourceApi
+internal val Res.string.str_22014: StringResource
+  get() = String26.str_22014
+
+@ExperimentalResourceApi
+internal val Res.string.str_22015: StringResource
+  get() = String26.str_22015
+
+@ExperimentalResourceApi
+internal val Res.string.str_22016: StringResource
+  get() = String26.str_22016
+
+@ExperimentalResourceApi
+internal val Res.string.str_22017: StringResource
+  get() = String26.str_22017
+
+@ExperimentalResourceApi
+internal val Res.string.str_22018: StringResource
+  get() = String26.str_22018
+
+@ExperimentalResourceApi
+internal val Res.string.str_22019: StringResource
+  get() = String26.str_22019
+
+@ExperimentalResourceApi
+internal val Res.string.str_2202: StringResource
+  get() = String26.str_2202
+
+@ExperimentalResourceApi
+internal val Res.string.str_22020: StringResource
+  get() = String26.str_22020
+
+@ExperimentalResourceApi
+internal val Res.string.str_22021: StringResource
+  get() = String26.str_22021
+
+@ExperimentalResourceApi
+internal val Res.string.str_22022: StringResource
+  get() = String26.str_22022
+
+@ExperimentalResourceApi
+internal val Res.string.str_22023: StringResource
+  get() = String26.str_22023
+
+@ExperimentalResourceApi
+internal val Res.string.str_22024: StringResource
+  get() = String26.str_22024
+
+@ExperimentalResourceApi
+internal val Res.string.str_22025: StringResource
+  get() = String26.str_22025
+
+@ExperimentalResourceApi
+internal val Res.string.str_22026: StringResource
+  get() = String26.str_22026
+
+@ExperimentalResourceApi
+internal val Res.string.str_22027: StringResource
+  get() = String26.str_22027
+
+@ExperimentalResourceApi
+internal val Res.string.str_22028: StringResource
+  get() = String26.str_22028
+
+@ExperimentalResourceApi
+internal val Res.string.str_22029: StringResource
+  get() = String26.str_22029
+
+@ExperimentalResourceApi
+internal val Res.string.str_2203: StringResource
+  get() = String26.str_2203
+
+@ExperimentalResourceApi
+internal val Res.string.str_22030: StringResource
+  get() = String26.str_22030
+
+@ExperimentalResourceApi
+internal val Res.string.str_22031: StringResource
+  get() = String26.str_22031
+
+@ExperimentalResourceApi
+internal val Res.string.str_22032: StringResource
+  get() = String26.str_22032
+
+@ExperimentalResourceApi
+internal val Res.string.str_22033: StringResource
+  get() = String26.str_22033
+
+@ExperimentalResourceApi
+internal val Res.string.str_22034: StringResource
+  get() = String26.str_22034
+
+@ExperimentalResourceApi
+internal val Res.string.str_22035: StringResource
+  get() = String26.str_22035
+
+@ExperimentalResourceApi
+internal val Res.string.str_22036: StringResource
+  get() = String26.str_22036
+
+@ExperimentalResourceApi
+internal val Res.string.str_22037: StringResource
+  get() = String26.str_22037
+
+@ExperimentalResourceApi
+internal val Res.string.str_22038: StringResource
+  get() = String26.str_22038
+
+@ExperimentalResourceApi
+internal val Res.string.str_22039: StringResource
+  get() = String26.str_22039
+
+@ExperimentalResourceApi
+internal val Res.string.str_2204: StringResource
+  get() = String26.str_2204
+
+@ExperimentalResourceApi
+internal val Res.string.str_22040: StringResource
+  get() = String26.str_22040
+
+@ExperimentalResourceApi
+internal val Res.string.str_22041: StringResource
+  get() = String26.str_22041
+
+@ExperimentalResourceApi
+internal val Res.string.str_22042: StringResource
+  get() = String26.str_22042
+
+@ExperimentalResourceApi
+internal val Res.string.str_22043: StringResource
+  get() = String26.str_22043
+
+@ExperimentalResourceApi
+internal val Res.string.str_22044: StringResource
+  get() = String26.str_22044
+
+@ExperimentalResourceApi
+internal val Res.string.str_22045: StringResource
+  get() = String26.str_22045
+
+@ExperimentalResourceApi
+internal val Res.string.str_22046: StringResource
+  get() = String26.str_22046
+
+@ExperimentalResourceApi
+internal val Res.string.str_22047: StringResource
+  get() = String26.str_22047
+
+@ExperimentalResourceApi
+internal val Res.string.str_22048: StringResource
+  get() = String26.str_22048
+
+@ExperimentalResourceApi
+internal val Res.string.str_22049: StringResource
+  get() = String26.str_22049
+
+@ExperimentalResourceApi
+internal val Res.string.str_2205: StringResource
+  get() = String26.str_2205
+
+@ExperimentalResourceApi
+internal val Res.string.str_22050: StringResource
+  get() = String26.str_22050
+
+@ExperimentalResourceApi
+internal val Res.string.str_22051: StringResource
+  get() = String26.str_22051
+
+@ExperimentalResourceApi
+internal val Res.string.str_22052: StringResource
+  get() = String26.str_22052
+
+@ExperimentalResourceApi
+internal val Res.string.str_22053: StringResource
+  get() = String26.str_22053
+
+@ExperimentalResourceApi
+internal val Res.string.str_22054: StringResource
+  get() = String26.str_22054
+
+@ExperimentalResourceApi
+internal val Res.string.str_22055: StringResource
+  get() = String26.str_22055
+
+@ExperimentalResourceApi
+internal val Res.string.str_22056: StringResource
+  get() = String26.str_22056
+
+@ExperimentalResourceApi
+internal val Res.string.str_22057: StringResource
+  get() = String26.str_22057
+
+@ExperimentalResourceApi
+internal val Res.string.str_22058: StringResource
+  get() = String26.str_22058
+
+@ExperimentalResourceApi
+internal val Res.string.str_22059: StringResource
+  get() = String26.str_22059
+
+@ExperimentalResourceApi
+internal val Res.string.str_2206: StringResource
+  get() = String26.str_2206
+
+@ExperimentalResourceApi
+internal val Res.string.str_22060: StringResource
+  get() = String26.str_22060
+
+@ExperimentalResourceApi
+internal val Res.string.str_22061: StringResource
+  get() = String26.str_22061
+
+@ExperimentalResourceApi
+internal val Res.string.str_22062: StringResource
+  get() = String26.str_22062
+
+@ExperimentalResourceApi
+internal val Res.string.str_22063: StringResource
+  get() = String26.str_22063
+
+@ExperimentalResourceApi
+internal val Res.string.str_22064: StringResource
+  get() = String26.str_22064
+
+@ExperimentalResourceApi
+internal val Res.string.str_22065: StringResource
+  get() = String26.str_22065
+
+@ExperimentalResourceApi
+internal val Res.string.str_22066: StringResource
+  get() = String26.str_22066
+
+@ExperimentalResourceApi
+internal val Res.string.str_22067: StringResource
+  get() = String26.str_22067
+
+@ExperimentalResourceApi
+internal val Res.string.str_22068: StringResource
+  get() = String26.str_22068
+
+@ExperimentalResourceApi
+internal val Res.string.str_22069: StringResource
+  get() = String26.str_22069
+
+@ExperimentalResourceApi
+internal val Res.string.str_2207: StringResource
+  get() = String26.str_2207
+
+@ExperimentalResourceApi
+internal val Res.string.str_22070: StringResource
+  get() = String26.str_22070
+
+@ExperimentalResourceApi
+internal val Res.string.str_22071: StringResource
+  get() = String26.str_22071
+
+@ExperimentalResourceApi
+internal val Res.string.str_22072: StringResource
+  get() = String26.str_22072
+
+@ExperimentalResourceApi
+internal val Res.string.str_22073: StringResource
+  get() = String26.str_22073
+
+@ExperimentalResourceApi
+internal val Res.string.str_22074: StringResource
+  get() = String26.str_22074
+
+@ExperimentalResourceApi
+internal val Res.string.str_22075: StringResource
+  get() = String26.str_22075
+
+@ExperimentalResourceApi
+internal val Res.string.str_22076: StringResource
+  get() = String26.str_22076
+
+@ExperimentalResourceApi
+internal val Res.string.str_22077: StringResource
+  get() = String26.str_22077
+
+@ExperimentalResourceApi
+internal val Res.string.str_22078: StringResource
+  get() = String26.str_22078
+
+@ExperimentalResourceApi
+internal val Res.string.str_22079: StringResource
+  get() = String26.str_22079
+
+@ExperimentalResourceApi
+internal val Res.string.str_2208: StringResource
+  get() = String26.str_2208
+
+@ExperimentalResourceApi
+internal val Res.string.str_22080: StringResource
+  get() = String26.str_22080
+
+@ExperimentalResourceApi
+internal val Res.string.str_22081: StringResource
+  get() = String26.str_22081
+
+@ExperimentalResourceApi
+internal val Res.string.str_22082: StringResource
+  get() = String26.str_22082
+
+@ExperimentalResourceApi
+internal val Res.string.str_22083: StringResource
+  get() = String26.str_22083
+
+@ExperimentalResourceApi
+internal val Res.string.str_22084: StringResource
+  get() = String26.str_22084
+
+@ExperimentalResourceApi
+internal val Res.string.str_22085: StringResource
+  get() = String26.str_22085
+
+@ExperimentalResourceApi
+internal val Res.string.str_22086: StringResource
+  get() = String26.str_22086
+
+@ExperimentalResourceApi
+internal val Res.string.str_22087: StringResource
+  get() = String26.str_22087
+
+@ExperimentalResourceApi
+internal val Res.string.str_22088: StringResource
+  get() = String26.str_22088
+
+@ExperimentalResourceApi
+internal val Res.string.str_22089: StringResource
+  get() = String26.str_22089
+
+@ExperimentalResourceApi
+internal val Res.string.str_2209: StringResource
+  get() = String26.str_2209
+
+@ExperimentalResourceApi
+internal val Res.string.str_22090: StringResource
+  get() = String26.str_22090
+
+@ExperimentalResourceApi
+internal val Res.string.str_22091: StringResource
+  get() = String26.str_22091
+
+@ExperimentalResourceApi
+internal val Res.string.str_22092: StringResource
+  get() = String26.str_22092
+
+@ExperimentalResourceApi
+internal val Res.string.str_22093: StringResource
+  get() = String26.str_22093
+
+@ExperimentalResourceApi
+internal val Res.string.str_22094: StringResource
+  get() = String26.str_22094
+
+@ExperimentalResourceApi
+internal val Res.string.str_22095: StringResource
+  get() = String26.str_22095
+
+@ExperimentalResourceApi
+internal val Res.string.str_22096: StringResource
+  get() = String26.str_22096
+
+@ExperimentalResourceApi
+internal val Res.string.str_22097: StringResource
+  get() = String26.str_22097
+
+@ExperimentalResourceApi
+internal val Res.string.str_22098: StringResource
+  get() = String26.str_22098
+
+@ExperimentalResourceApi
+internal val Res.string.str_22099: StringResource
+  get() = String26.str_22099
+
+@ExperimentalResourceApi
+internal val Res.string.str_221: StringResource
+  get() = String26.str_221
+
+@ExperimentalResourceApi
+internal val Res.string.str_2210: StringResource
+  get() = String26.str_2210
+
+@ExperimentalResourceApi
+internal val Res.string.str_22100: StringResource
+  get() = String26.str_22100
+
+@ExperimentalResourceApi
+internal val Res.string.str_22101: StringResource
+  get() = String26.str_22101
+
+@ExperimentalResourceApi
+internal val Res.string.str_22102: StringResource
+  get() = String26.str_22102
+
+@ExperimentalResourceApi
+internal val Res.string.str_22103: StringResource
+  get() = String26.str_22103
+
+@ExperimentalResourceApi
+internal val Res.string.str_22104: StringResource
+  get() = String26.str_22104
+
+@ExperimentalResourceApi
+internal val Res.string.str_22105: StringResource
+  get() = String26.str_22105
+
+@ExperimentalResourceApi
+internal val Res.string.str_22106: StringResource
+  get() = String26.str_22106
+
+@ExperimentalResourceApi
+internal val Res.string.str_22107: StringResource
+  get() = String26.str_22107
+
+@ExperimentalResourceApi
+internal val Res.string.str_22108: StringResource
+  get() = String26.str_22108
+
+@ExperimentalResourceApi
+internal val Res.string.str_22109: StringResource
+  get() = String26.str_22109
+
+@ExperimentalResourceApi
+internal val Res.string.str_2211: StringResource
+  get() = String26.str_2211
+
+@ExperimentalResourceApi
+internal val Res.string.str_22110: StringResource
+  get() = String26.str_22110
+
+@ExperimentalResourceApi
+internal val Res.string.str_22111: StringResource
+  get() = String26.str_22111
+
+@ExperimentalResourceApi
+internal val Res.string.str_22112: StringResource
+  get() = String26.str_22112
+
+@ExperimentalResourceApi
+internal val Res.string.str_22113: StringResource
+  get() = String26.str_22113
+
+@ExperimentalResourceApi
+internal val Res.string.str_22114: StringResource
+  get() = String26.str_22114
+
+@ExperimentalResourceApi
+internal val Res.string.str_22115: StringResource
+  get() = String26.str_22115
+
+@ExperimentalResourceApi
+internal val Res.string.str_22116: StringResource
+  get() = String26.str_22116
+
+@ExperimentalResourceApi
+internal val Res.string.str_22117: StringResource
+  get() = String26.str_22117
+
+@ExperimentalResourceApi
+internal val Res.string.str_22118: StringResource
+  get() = String26.str_22118
+
+@ExperimentalResourceApi
+internal val Res.string.str_22119: StringResource
+  get() = String26.str_22119
+
+@ExperimentalResourceApi
+internal val Res.string.str_2212: StringResource
+  get() = String26.str_2212
+
+@ExperimentalResourceApi
+internal val Res.string.str_22120: StringResource
+  get() = String26.str_22120
+
+@ExperimentalResourceApi
+internal val Res.string.str_22121: StringResource
+  get() = String26.str_22121
+
+@ExperimentalResourceApi
+internal val Res.string.str_22122: StringResource
+  get() = String26.str_22122
+
+@ExperimentalResourceApi
+internal val Res.string.str_22123: StringResource
+  get() = String26.str_22123
+
+@ExperimentalResourceApi
+internal val Res.string.str_22124: StringResource
+  get() = String26.str_22124
+
+@ExperimentalResourceApi
+internal val Res.string.str_22125: StringResource
+  get() = String26.str_22125
+
+@ExperimentalResourceApi
+internal val Res.string.str_22126: StringResource
+  get() = String26.str_22126
+
+@ExperimentalResourceApi
+internal val Res.string.str_22127: StringResource
+  get() = String26.str_22127
+
+@ExperimentalResourceApi
+internal val Res.string.str_22128: StringResource
+  get() = String26.str_22128
+
+@ExperimentalResourceApi
+internal val Res.string.str_22129: StringResource
+  get() = String26.str_22129
+
+@ExperimentalResourceApi
+internal val Res.string.str_2213: StringResource
+  get() = String26.str_2213
+
+@ExperimentalResourceApi
+internal val Res.string.str_22130: StringResource
+  get() = String26.str_22130
+
+@ExperimentalResourceApi
+internal val Res.string.str_22131: StringResource
+  get() = String26.str_22131
+
+@ExperimentalResourceApi
+internal val Res.string.str_22132: StringResource
+  get() = String26.str_22132
+
+@ExperimentalResourceApi
+internal val Res.string.str_22133: StringResource
+  get() = String26.str_22133
+
+@ExperimentalResourceApi
+internal val Res.string.str_22134: StringResource
+  get() = String26.str_22134
+
+@ExperimentalResourceApi
+internal val Res.string.str_22135: StringResource
+  get() = String26.str_22135
+
+@ExperimentalResourceApi
+internal val Res.string.str_22136: StringResource
+  get() = String26.str_22136
+
+@ExperimentalResourceApi
+internal val Res.string.str_22137: StringResource
+  get() = String26.str_22137
+
+@ExperimentalResourceApi
+internal val Res.string.str_22138: StringResource
+  get() = String26.str_22138
+
+@ExperimentalResourceApi
+internal val Res.string.str_22139: StringResource
+  get() = String26.str_22139
+
+@ExperimentalResourceApi
+internal val Res.string.str_2214: StringResource
+  get() = String26.str_2214
+
+@ExperimentalResourceApi
+internal val Res.string.str_22140: StringResource
+  get() = String26.str_22140
+
+@ExperimentalResourceApi
+internal val Res.string.str_22141: StringResource
+  get() = String26.str_22141
+
+@ExperimentalResourceApi
+internal val Res.string.str_22142: StringResource
+  get() = String26.str_22142
+
+@ExperimentalResourceApi
+internal val Res.string.str_22143: StringResource
+  get() = String26.str_22143
+
+@ExperimentalResourceApi
+internal val Res.string.str_22144: StringResource
+  get() = String26.str_22144
+
+@ExperimentalResourceApi
+internal val Res.string.str_22145: StringResource
+  get() = String26.str_22145
+
+@ExperimentalResourceApi
+internal val Res.string.str_22146: StringResource
+  get() = String26.str_22146

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String27.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String27.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String27 {
+  public val str_22147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22147", "str_22147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22148", "str_22148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22149", "str_22149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2215", "str_2215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22150", "str_22150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22151", "str_22151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22152", "str_22152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22153", "str_22153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22154", "str_22154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22155", "str_22155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22156", "str_22156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22157", "str_22157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22158", "str_22158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22159", "str_22159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2216", "str_2216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22160", "str_22160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22161", "str_22161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22162", "str_22162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22163", "str_22163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22164", "str_22164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22165", "str_22165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22166", "str_22166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22167", "str_22167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22168", "str_22168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22169", "str_22169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2217", "str_2217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22170", "str_22170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22171", "str_22171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22172", "str_22172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22173", "str_22173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22174", "str_22174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22175", "str_22175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22176", "str_22176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22177", "str_22177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22178", "str_22178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22179", "str_22179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2218", "str_2218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22180", "str_22180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22181", "str_22181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22182", "str_22182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22183", "str_22183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22184", "str_22184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22185", "str_22185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22186", "str_22186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22187", "str_22187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22188", "str_22188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22189", "str_22189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2219", "str_2219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22190", "str_22190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22191", "str_22191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22192", "str_22192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22193", "str_22193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22194", "str_22194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22195", "str_22195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22196", "str_22196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22197", "str_22197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22198", "str_22198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22199", "str_22199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_222", "str_222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2220", "str_2220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22200", "str_22200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22201", "str_22201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22202", "str_22202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22203", "str_22203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22204", "str_22204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22205", "str_22205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22206", "str_22206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22207", "str_22207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22208", "str_22208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22209", "str_22209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2221", "str_2221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22210", "str_22210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22211", "str_22211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22212", "str_22212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22213", "str_22213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22214", "str_22214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22215", "str_22215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22216", "str_22216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22217", "str_22217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22218", "str_22218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22219", "str_22219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2222", "str_2222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22220", "str_22220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22221", "str_22221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22222", "str_22222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22223", "str_22223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22224", "str_22224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22225", "str_22225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22226", "str_22226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22227", "str_22227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22228", "str_22228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22229", "str_22229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2223", "str_2223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22230", "str_22230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22231", "str_22231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22232", "str_22232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22233", "str_22233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22234", "str_22234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22235", "str_22235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22236", "str_22236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22237", "str_22237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22238", "str_22238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22239", "str_22239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2224", "str_2224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22240", "str_22240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22241", "str_22241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22242", "str_22242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22243", "str_22243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22244", "str_22244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22245", "str_22245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22246", "str_22246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22247", "str_22247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22248", "str_22248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22249", "str_22249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2225", "str_2225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22250", "str_22250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22251", "str_22251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22252", "str_22252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22253", "str_22253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22254", "str_22254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22255", "str_22255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22256", "str_22256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22257", "str_22257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22258", "str_22258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22259", "str_22259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2226", "str_2226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22260", "str_22260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22261", "str_22261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22262", "str_22262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22263", "str_22263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22264", "str_22264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22265", "str_22265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22266", "str_22266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22267", "str_22267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22268", "str_22268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22269", "str_22269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2227", "str_2227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22270", "str_22270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22271", "str_22271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22272", "str_22272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22273", "str_22273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22274", "str_22274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22275", "str_22275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22276", "str_22276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22277", "str_22277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22278", "str_22278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22279", "str_22279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2228", "str_2228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22280", "str_22280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22281", "str_22281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22282", "str_22282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22283", "str_22283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22284", "str_22284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22285", "str_22285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22286", "str_22286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22287", "str_22287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22288", "str_22288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22289", "str_22289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2229", "str_2229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22290", "str_22290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22291", "str_22291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22292", "str_22292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22293", "str_22293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22294", "str_22294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22295", "str_22295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22296", "str_22296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22297", "str_22297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22298", "str_22298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22299", "str_22299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_223", "str_223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2230", "str_2230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22300", "str_22300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22301", "str_22301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22302", "str_22302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22303", "str_22303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22304", "str_22304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22305", "str_22305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22306", "str_22306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22307", "str_22307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22308", "str_22308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22309", "str_22309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2231", "str_2231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22310", "str_22310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22311", "str_22311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22312", "str_22312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22313", "str_22313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22314", "str_22314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22315", "str_22315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22316", "str_22316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22317", "str_22317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22318", "str_22318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22319", "str_22319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2232", "str_2232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22320", "str_22320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22321", "str_22321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22322", "str_22322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22323", "str_22323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22324", "str_22324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22325", "str_22325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22326", "str_22326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22327", "str_22327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22328", "str_22328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22329", "str_22329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2233", "str_2233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22330", "str_22330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22331", "str_22331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22332", "str_22332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22333", "str_22333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22334", "str_22334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22335", "str_22335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22336", "str_22336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22337", "str_22337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22338", "str_22338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22339", "str_22339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2234", "str_2234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22340", "str_22340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22341", "str_22341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22342", "str_22342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22343", "str_22343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22344", "str_22344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22345", "str_22345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22346", "str_22346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22347", "str_22347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22348", "str_22348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22349", "str_22349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2235", "str_2235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22350", "str_22350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22351", "str_22351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22352", "str_22352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22353", "str_22353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22354", "str_22354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22355", "str_22355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22356", "str_22356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22357", "str_22357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22358", "str_22358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22359", "str_22359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2236", "str_2236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22360", "str_22360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22361", "str_22361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22362", "str_22362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22363", "str_22363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22364", "str_22364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22365", "str_22365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22366", "str_22366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22367", "str_22367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22368", "str_22368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22369", "str_22369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2237", "str_2237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22370", "str_22370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22371", "str_22371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22372", "str_22372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22373", "str_22373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22374", "str_22374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22375", "str_22375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22376", "str_22376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22377", "str_22377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22378", "str_22378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22379", "str_22379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2238", "str_2238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22380", "str_22380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22381", "str_22381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22382", "str_22382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22383", "str_22383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22384", "str_22384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22385", "str_22385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22386", "str_22386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22387", "str_22387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22388", "str_22388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22389", "str_22389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2239", "str_2239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22390", "str_22390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22391", "str_22391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22392", "str_22392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22393", "str_22393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22394", "str_22394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22395", "str_22395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22396", "str_22396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22397", "str_22397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22398", "str_22398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22399", "str_22399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_224", "str_224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2240", "str_2240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22400", "str_22400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22401", "str_22401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22402", "str_22402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22403", "str_22403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22404", "str_22404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22405", "str_22405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22406", "str_22406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22407", "str_22407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22408", "str_22408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22409", "str_22409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2241", "str_2241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22410", "str_22410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22411", "str_22411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22412", "str_22412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22413", "str_22413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22414", "str_22414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22415", "str_22415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22416", "str_22416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22417", "str_22417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22418", "str_22418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22419", "str_22419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2242", "str_2242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22420", "str_22420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22421", "str_22421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22422", "str_22422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22423", "str_22423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22424", "str_22424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22425", "str_22425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22426", "str_22426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22427", "str_22427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22428", "str_22428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22429", "str_22429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2243", "str_2243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22430", "str_22430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22431", "str_22431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22432", "str_22432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22433", "str_22433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22434", "str_22434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22435", "str_22435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22436", "str_22436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22437", "str_22437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22438", "str_22438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22439", "str_22439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2244", "str_2244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22440", "str_22440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22441", "str_22441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22442", "str_22442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22443", "str_22443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22444", "str_22444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22445", "str_22445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22446", "str_22446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22447", "str_22447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22448", "str_22448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22449", "str_22449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2245", "str_2245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22450", "str_22450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22451", "str_22451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22452", "str_22452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22453", "str_22453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22454", "str_22454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22455", "str_22455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22456", "str_22456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22457", "str_22457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22458", "str_22458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22459", "str_22459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2246", "str_2246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22460", "str_22460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22461", "str_22461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22462", "str_22462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22463", "str_22463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22464", "str_22464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22465", "str_22465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22466", "str_22466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22467", "str_22467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22468", "str_22468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22469", "str_22469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2247", "str_2247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22470", "str_22470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22471", "str_22471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22472", "str_22472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22473", "str_22473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22474", "str_22474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22475", "str_22475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22476", "str_22476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22477", "str_22477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22478", "str_22478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22479", "str_22479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2248", "str_2248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22480", "str_22480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22481", "str_22481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22482", "str_22482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22483", "str_22483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22484", "str_22484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22485", "str_22485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22486", "str_22486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22487", "str_22487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22488", "str_22488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22489", "str_22489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2249", "str_2249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22490", "str_22490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22491", "str_22491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22492", "str_22492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22493", "str_22493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22494", "str_22494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22495", "str_22495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22496", "str_22496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22497", "str_22497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22498", "str_22498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22499", "str_22499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_225", "str_225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2250", "str_2250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22500", "str_22500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22501", "str_22501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22502", "str_22502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22503", "str_22503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22504", "str_22504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22505", "str_22505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22506", "str_22506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22507", "str_22507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22508", "str_22508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22509", "str_22509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2251", "str_2251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22510", "str_22510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22511", "str_22511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22512", "str_22512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22513", "str_22513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22514", "str_22514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22515", "str_22515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22516", "str_22516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22517", "str_22517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22518", "str_22518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22519", "str_22519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2252", "str_2252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22520", "str_22520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22521", "str_22521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22522", "str_22522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22523", "str_22523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22524", "str_22524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22525", "str_22525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22526", "str_22526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22527", "str_22527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22528", "str_22528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22529", "str_22529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2253", "str_2253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22530", "str_22530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22531", "str_22531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22532", "str_22532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22533", "str_22533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22534", "str_22534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22535", "str_22535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22536", "str_22536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22537", "str_22537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22538", "str_22538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22539", "str_22539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2254", "str_2254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22540", "str_22540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22541", "str_22541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22542", "str_22542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22543", "str_22543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22544", "str_22544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22545", "str_22545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22546", "str_22546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22547", "str_22547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22548", "str_22548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22549", "str_22549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2255", "str_2255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22550", "str_22550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22551", "str_22551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22552", "str_22552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22553", "str_22553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22554", "str_22554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22555", "str_22555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22556", "str_22556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22557", "str_22557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22558", "str_22558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22559", "str_22559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2256", "str_2256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22560", "str_22560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22561", "str_22561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22562", "str_22562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22563", "str_22563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22564", "str_22564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22565", "str_22565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22566", "str_22566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22567", "str_22567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22568", "str_22568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22569", "str_22569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2257", "str_2257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22570", "str_22570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22571", "str_22571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22572", "str_22572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22573", "str_22573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22574", "str_22574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22575", "str_22575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22576", "str_22576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22577", "str_22577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22578", "str_22578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22579", "str_22579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2258", "str_2258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22580", "str_22580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22581", "str_22581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22582", "str_22582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22583", "str_22583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22584", "str_22584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22585", "str_22585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22586", "str_22586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22587", "str_22587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22588", "str_22588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22589", "str_22589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2259", "str_2259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22590", "str_22590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22591", "str_22591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22592", "str_22592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22593", "str_22593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22594", "str_22594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22595", "str_22595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22596", "str_22596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22597", "str_22597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_22147: StringResource
+  get() = String27.str_22147
+
+@ExperimentalResourceApi
+internal val Res.string.str_22148: StringResource
+  get() = String27.str_22148
+
+@ExperimentalResourceApi
+internal val Res.string.str_22149: StringResource
+  get() = String27.str_22149
+
+@ExperimentalResourceApi
+internal val Res.string.str_2215: StringResource
+  get() = String27.str_2215
+
+@ExperimentalResourceApi
+internal val Res.string.str_22150: StringResource
+  get() = String27.str_22150
+
+@ExperimentalResourceApi
+internal val Res.string.str_22151: StringResource
+  get() = String27.str_22151
+
+@ExperimentalResourceApi
+internal val Res.string.str_22152: StringResource
+  get() = String27.str_22152
+
+@ExperimentalResourceApi
+internal val Res.string.str_22153: StringResource
+  get() = String27.str_22153
+
+@ExperimentalResourceApi
+internal val Res.string.str_22154: StringResource
+  get() = String27.str_22154
+
+@ExperimentalResourceApi
+internal val Res.string.str_22155: StringResource
+  get() = String27.str_22155
+
+@ExperimentalResourceApi
+internal val Res.string.str_22156: StringResource
+  get() = String27.str_22156
+
+@ExperimentalResourceApi
+internal val Res.string.str_22157: StringResource
+  get() = String27.str_22157
+
+@ExperimentalResourceApi
+internal val Res.string.str_22158: StringResource
+  get() = String27.str_22158
+
+@ExperimentalResourceApi
+internal val Res.string.str_22159: StringResource
+  get() = String27.str_22159
+
+@ExperimentalResourceApi
+internal val Res.string.str_2216: StringResource
+  get() = String27.str_2216
+
+@ExperimentalResourceApi
+internal val Res.string.str_22160: StringResource
+  get() = String27.str_22160
+
+@ExperimentalResourceApi
+internal val Res.string.str_22161: StringResource
+  get() = String27.str_22161
+
+@ExperimentalResourceApi
+internal val Res.string.str_22162: StringResource
+  get() = String27.str_22162
+
+@ExperimentalResourceApi
+internal val Res.string.str_22163: StringResource
+  get() = String27.str_22163
+
+@ExperimentalResourceApi
+internal val Res.string.str_22164: StringResource
+  get() = String27.str_22164
+
+@ExperimentalResourceApi
+internal val Res.string.str_22165: StringResource
+  get() = String27.str_22165
+
+@ExperimentalResourceApi
+internal val Res.string.str_22166: StringResource
+  get() = String27.str_22166
+
+@ExperimentalResourceApi
+internal val Res.string.str_22167: StringResource
+  get() = String27.str_22167
+
+@ExperimentalResourceApi
+internal val Res.string.str_22168: StringResource
+  get() = String27.str_22168
+
+@ExperimentalResourceApi
+internal val Res.string.str_22169: StringResource
+  get() = String27.str_22169
+
+@ExperimentalResourceApi
+internal val Res.string.str_2217: StringResource
+  get() = String27.str_2217
+
+@ExperimentalResourceApi
+internal val Res.string.str_22170: StringResource
+  get() = String27.str_22170
+
+@ExperimentalResourceApi
+internal val Res.string.str_22171: StringResource
+  get() = String27.str_22171
+
+@ExperimentalResourceApi
+internal val Res.string.str_22172: StringResource
+  get() = String27.str_22172
+
+@ExperimentalResourceApi
+internal val Res.string.str_22173: StringResource
+  get() = String27.str_22173
+
+@ExperimentalResourceApi
+internal val Res.string.str_22174: StringResource
+  get() = String27.str_22174
+
+@ExperimentalResourceApi
+internal val Res.string.str_22175: StringResource
+  get() = String27.str_22175
+
+@ExperimentalResourceApi
+internal val Res.string.str_22176: StringResource
+  get() = String27.str_22176
+
+@ExperimentalResourceApi
+internal val Res.string.str_22177: StringResource
+  get() = String27.str_22177
+
+@ExperimentalResourceApi
+internal val Res.string.str_22178: StringResource
+  get() = String27.str_22178
+
+@ExperimentalResourceApi
+internal val Res.string.str_22179: StringResource
+  get() = String27.str_22179
+
+@ExperimentalResourceApi
+internal val Res.string.str_2218: StringResource
+  get() = String27.str_2218
+
+@ExperimentalResourceApi
+internal val Res.string.str_22180: StringResource
+  get() = String27.str_22180
+
+@ExperimentalResourceApi
+internal val Res.string.str_22181: StringResource
+  get() = String27.str_22181
+
+@ExperimentalResourceApi
+internal val Res.string.str_22182: StringResource
+  get() = String27.str_22182
+
+@ExperimentalResourceApi
+internal val Res.string.str_22183: StringResource
+  get() = String27.str_22183
+
+@ExperimentalResourceApi
+internal val Res.string.str_22184: StringResource
+  get() = String27.str_22184
+
+@ExperimentalResourceApi
+internal val Res.string.str_22185: StringResource
+  get() = String27.str_22185
+
+@ExperimentalResourceApi
+internal val Res.string.str_22186: StringResource
+  get() = String27.str_22186
+
+@ExperimentalResourceApi
+internal val Res.string.str_22187: StringResource
+  get() = String27.str_22187
+
+@ExperimentalResourceApi
+internal val Res.string.str_22188: StringResource
+  get() = String27.str_22188
+
+@ExperimentalResourceApi
+internal val Res.string.str_22189: StringResource
+  get() = String27.str_22189
+
+@ExperimentalResourceApi
+internal val Res.string.str_2219: StringResource
+  get() = String27.str_2219
+
+@ExperimentalResourceApi
+internal val Res.string.str_22190: StringResource
+  get() = String27.str_22190
+
+@ExperimentalResourceApi
+internal val Res.string.str_22191: StringResource
+  get() = String27.str_22191
+
+@ExperimentalResourceApi
+internal val Res.string.str_22192: StringResource
+  get() = String27.str_22192
+
+@ExperimentalResourceApi
+internal val Res.string.str_22193: StringResource
+  get() = String27.str_22193
+
+@ExperimentalResourceApi
+internal val Res.string.str_22194: StringResource
+  get() = String27.str_22194
+
+@ExperimentalResourceApi
+internal val Res.string.str_22195: StringResource
+  get() = String27.str_22195
+
+@ExperimentalResourceApi
+internal val Res.string.str_22196: StringResource
+  get() = String27.str_22196
+
+@ExperimentalResourceApi
+internal val Res.string.str_22197: StringResource
+  get() = String27.str_22197
+
+@ExperimentalResourceApi
+internal val Res.string.str_22198: StringResource
+  get() = String27.str_22198
+
+@ExperimentalResourceApi
+internal val Res.string.str_22199: StringResource
+  get() = String27.str_22199
+
+@ExperimentalResourceApi
+internal val Res.string.str_222: StringResource
+  get() = String27.str_222
+
+@ExperimentalResourceApi
+internal val Res.string.str_2220: StringResource
+  get() = String27.str_2220
+
+@ExperimentalResourceApi
+internal val Res.string.str_22200: StringResource
+  get() = String27.str_22200
+
+@ExperimentalResourceApi
+internal val Res.string.str_22201: StringResource
+  get() = String27.str_22201
+
+@ExperimentalResourceApi
+internal val Res.string.str_22202: StringResource
+  get() = String27.str_22202
+
+@ExperimentalResourceApi
+internal val Res.string.str_22203: StringResource
+  get() = String27.str_22203
+
+@ExperimentalResourceApi
+internal val Res.string.str_22204: StringResource
+  get() = String27.str_22204
+
+@ExperimentalResourceApi
+internal val Res.string.str_22205: StringResource
+  get() = String27.str_22205
+
+@ExperimentalResourceApi
+internal val Res.string.str_22206: StringResource
+  get() = String27.str_22206
+
+@ExperimentalResourceApi
+internal val Res.string.str_22207: StringResource
+  get() = String27.str_22207
+
+@ExperimentalResourceApi
+internal val Res.string.str_22208: StringResource
+  get() = String27.str_22208
+
+@ExperimentalResourceApi
+internal val Res.string.str_22209: StringResource
+  get() = String27.str_22209
+
+@ExperimentalResourceApi
+internal val Res.string.str_2221: StringResource
+  get() = String27.str_2221
+
+@ExperimentalResourceApi
+internal val Res.string.str_22210: StringResource
+  get() = String27.str_22210
+
+@ExperimentalResourceApi
+internal val Res.string.str_22211: StringResource
+  get() = String27.str_22211
+
+@ExperimentalResourceApi
+internal val Res.string.str_22212: StringResource
+  get() = String27.str_22212
+
+@ExperimentalResourceApi
+internal val Res.string.str_22213: StringResource
+  get() = String27.str_22213
+
+@ExperimentalResourceApi
+internal val Res.string.str_22214: StringResource
+  get() = String27.str_22214
+
+@ExperimentalResourceApi
+internal val Res.string.str_22215: StringResource
+  get() = String27.str_22215
+
+@ExperimentalResourceApi
+internal val Res.string.str_22216: StringResource
+  get() = String27.str_22216
+
+@ExperimentalResourceApi
+internal val Res.string.str_22217: StringResource
+  get() = String27.str_22217
+
+@ExperimentalResourceApi
+internal val Res.string.str_22218: StringResource
+  get() = String27.str_22218
+
+@ExperimentalResourceApi
+internal val Res.string.str_22219: StringResource
+  get() = String27.str_22219
+
+@ExperimentalResourceApi
+internal val Res.string.str_2222: StringResource
+  get() = String27.str_2222
+
+@ExperimentalResourceApi
+internal val Res.string.str_22220: StringResource
+  get() = String27.str_22220
+
+@ExperimentalResourceApi
+internal val Res.string.str_22221: StringResource
+  get() = String27.str_22221
+
+@ExperimentalResourceApi
+internal val Res.string.str_22222: StringResource
+  get() = String27.str_22222
+
+@ExperimentalResourceApi
+internal val Res.string.str_22223: StringResource
+  get() = String27.str_22223
+
+@ExperimentalResourceApi
+internal val Res.string.str_22224: StringResource
+  get() = String27.str_22224
+
+@ExperimentalResourceApi
+internal val Res.string.str_22225: StringResource
+  get() = String27.str_22225
+
+@ExperimentalResourceApi
+internal val Res.string.str_22226: StringResource
+  get() = String27.str_22226
+
+@ExperimentalResourceApi
+internal val Res.string.str_22227: StringResource
+  get() = String27.str_22227
+
+@ExperimentalResourceApi
+internal val Res.string.str_22228: StringResource
+  get() = String27.str_22228
+
+@ExperimentalResourceApi
+internal val Res.string.str_22229: StringResource
+  get() = String27.str_22229
+
+@ExperimentalResourceApi
+internal val Res.string.str_2223: StringResource
+  get() = String27.str_2223
+
+@ExperimentalResourceApi
+internal val Res.string.str_22230: StringResource
+  get() = String27.str_22230
+
+@ExperimentalResourceApi
+internal val Res.string.str_22231: StringResource
+  get() = String27.str_22231
+
+@ExperimentalResourceApi
+internal val Res.string.str_22232: StringResource
+  get() = String27.str_22232
+
+@ExperimentalResourceApi
+internal val Res.string.str_22233: StringResource
+  get() = String27.str_22233
+
+@ExperimentalResourceApi
+internal val Res.string.str_22234: StringResource
+  get() = String27.str_22234
+
+@ExperimentalResourceApi
+internal val Res.string.str_22235: StringResource
+  get() = String27.str_22235
+
+@ExperimentalResourceApi
+internal val Res.string.str_22236: StringResource
+  get() = String27.str_22236
+
+@ExperimentalResourceApi
+internal val Res.string.str_22237: StringResource
+  get() = String27.str_22237
+
+@ExperimentalResourceApi
+internal val Res.string.str_22238: StringResource
+  get() = String27.str_22238
+
+@ExperimentalResourceApi
+internal val Res.string.str_22239: StringResource
+  get() = String27.str_22239
+
+@ExperimentalResourceApi
+internal val Res.string.str_2224: StringResource
+  get() = String27.str_2224
+
+@ExperimentalResourceApi
+internal val Res.string.str_22240: StringResource
+  get() = String27.str_22240
+
+@ExperimentalResourceApi
+internal val Res.string.str_22241: StringResource
+  get() = String27.str_22241
+
+@ExperimentalResourceApi
+internal val Res.string.str_22242: StringResource
+  get() = String27.str_22242
+
+@ExperimentalResourceApi
+internal val Res.string.str_22243: StringResource
+  get() = String27.str_22243
+
+@ExperimentalResourceApi
+internal val Res.string.str_22244: StringResource
+  get() = String27.str_22244
+
+@ExperimentalResourceApi
+internal val Res.string.str_22245: StringResource
+  get() = String27.str_22245
+
+@ExperimentalResourceApi
+internal val Res.string.str_22246: StringResource
+  get() = String27.str_22246
+
+@ExperimentalResourceApi
+internal val Res.string.str_22247: StringResource
+  get() = String27.str_22247
+
+@ExperimentalResourceApi
+internal val Res.string.str_22248: StringResource
+  get() = String27.str_22248
+
+@ExperimentalResourceApi
+internal val Res.string.str_22249: StringResource
+  get() = String27.str_22249
+
+@ExperimentalResourceApi
+internal val Res.string.str_2225: StringResource
+  get() = String27.str_2225
+
+@ExperimentalResourceApi
+internal val Res.string.str_22250: StringResource
+  get() = String27.str_22250
+
+@ExperimentalResourceApi
+internal val Res.string.str_22251: StringResource
+  get() = String27.str_22251
+
+@ExperimentalResourceApi
+internal val Res.string.str_22252: StringResource
+  get() = String27.str_22252
+
+@ExperimentalResourceApi
+internal val Res.string.str_22253: StringResource
+  get() = String27.str_22253
+
+@ExperimentalResourceApi
+internal val Res.string.str_22254: StringResource
+  get() = String27.str_22254
+
+@ExperimentalResourceApi
+internal val Res.string.str_22255: StringResource
+  get() = String27.str_22255
+
+@ExperimentalResourceApi
+internal val Res.string.str_22256: StringResource
+  get() = String27.str_22256
+
+@ExperimentalResourceApi
+internal val Res.string.str_22257: StringResource
+  get() = String27.str_22257
+
+@ExperimentalResourceApi
+internal val Res.string.str_22258: StringResource
+  get() = String27.str_22258
+
+@ExperimentalResourceApi
+internal val Res.string.str_22259: StringResource
+  get() = String27.str_22259
+
+@ExperimentalResourceApi
+internal val Res.string.str_2226: StringResource
+  get() = String27.str_2226
+
+@ExperimentalResourceApi
+internal val Res.string.str_22260: StringResource
+  get() = String27.str_22260
+
+@ExperimentalResourceApi
+internal val Res.string.str_22261: StringResource
+  get() = String27.str_22261
+
+@ExperimentalResourceApi
+internal val Res.string.str_22262: StringResource
+  get() = String27.str_22262
+
+@ExperimentalResourceApi
+internal val Res.string.str_22263: StringResource
+  get() = String27.str_22263
+
+@ExperimentalResourceApi
+internal val Res.string.str_22264: StringResource
+  get() = String27.str_22264
+
+@ExperimentalResourceApi
+internal val Res.string.str_22265: StringResource
+  get() = String27.str_22265
+
+@ExperimentalResourceApi
+internal val Res.string.str_22266: StringResource
+  get() = String27.str_22266
+
+@ExperimentalResourceApi
+internal val Res.string.str_22267: StringResource
+  get() = String27.str_22267
+
+@ExperimentalResourceApi
+internal val Res.string.str_22268: StringResource
+  get() = String27.str_22268
+
+@ExperimentalResourceApi
+internal val Res.string.str_22269: StringResource
+  get() = String27.str_22269
+
+@ExperimentalResourceApi
+internal val Res.string.str_2227: StringResource
+  get() = String27.str_2227
+
+@ExperimentalResourceApi
+internal val Res.string.str_22270: StringResource
+  get() = String27.str_22270
+
+@ExperimentalResourceApi
+internal val Res.string.str_22271: StringResource
+  get() = String27.str_22271
+
+@ExperimentalResourceApi
+internal val Res.string.str_22272: StringResource
+  get() = String27.str_22272
+
+@ExperimentalResourceApi
+internal val Res.string.str_22273: StringResource
+  get() = String27.str_22273
+
+@ExperimentalResourceApi
+internal val Res.string.str_22274: StringResource
+  get() = String27.str_22274
+
+@ExperimentalResourceApi
+internal val Res.string.str_22275: StringResource
+  get() = String27.str_22275
+
+@ExperimentalResourceApi
+internal val Res.string.str_22276: StringResource
+  get() = String27.str_22276
+
+@ExperimentalResourceApi
+internal val Res.string.str_22277: StringResource
+  get() = String27.str_22277
+
+@ExperimentalResourceApi
+internal val Res.string.str_22278: StringResource
+  get() = String27.str_22278
+
+@ExperimentalResourceApi
+internal val Res.string.str_22279: StringResource
+  get() = String27.str_22279
+
+@ExperimentalResourceApi
+internal val Res.string.str_2228: StringResource
+  get() = String27.str_2228
+
+@ExperimentalResourceApi
+internal val Res.string.str_22280: StringResource
+  get() = String27.str_22280
+
+@ExperimentalResourceApi
+internal val Res.string.str_22281: StringResource
+  get() = String27.str_22281
+
+@ExperimentalResourceApi
+internal val Res.string.str_22282: StringResource
+  get() = String27.str_22282
+
+@ExperimentalResourceApi
+internal val Res.string.str_22283: StringResource
+  get() = String27.str_22283
+
+@ExperimentalResourceApi
+internal val Res.string.str_22284: StringResource
+  get() = String27.str_22284
+
+@ExperimentalResourceApi
+internal val Res.string.str_22285: StringResource
+  get() = String27.str_22285
+
+@ExperimentalResourceApi
+internal val Res.string.str_22286: StringResource
+  get() = String27.str_22286
+
+@ExperimentalResourceApi
+internal val Res.string.str_22287: StringResource
+  get() = String27.str_22287
+
+@ExperimentalResourceApi
+internal val Res.string.str_22288: StringResource
+  get() = String27.str_22288
+
+@ExperimentalResourceApi
+internal val Res.string.str_22289: StringResource
+  get() = String27.str_22289
+
+@ExperimentalResourceApi
+internal val Res.string.str_2229: StringResource
+  get() = String27.str_2229
+
+@ExperimentalResourceApi
+internal val Res.string.str_22290: StringResource
+  get() = String27.str_22290
+
+@ExperimentalResourceApi
+internal val Res.string.str_22291: StringResource
+  get() = String27.str_22291
+
+@ExperimentalResourceApi
+internal val Res.string.str_22292: StringResource
+  get() = String27.str_22292
+
+@ExperimentalResourceApi
+internal val Res.string.str_22293: StringResource
+  get() = String27.str_22293
+
+@ExperimentalResourceApi
+internal val Res.string.str_22294: StringResource
+  get() = String27.str_22294
+
+@ExperimentalResourceApi
+internal val Res.string.str_22295: StringResource
+  get() = String27.str_22295
+
+@ExperimentalResourceApi
+internal val Res.string.str_22296: StringResource
+  get() = String27.str_22296
+
+@ExperimentalResourceApi
+internal val Res.string.str_22297: StringResource
+  get() = String27.str_22297
+
+@ExperimentalResourceApi
+internal val Res.string.str_22298: StringResource
+  get() = String27.str_22298
+
+@ExperimentalResourceApi
+internal val Res.string.str_22299: StringResource
+  get() = String27.str_22299
+
+@ExperimentalResourceApi
+internal val Res.string.str_223: StringResource
+  get() = String27.str_223
+
+@ExperimentalResourceApi
+internal val Res.string.str_2230: StringResource
+  get() = String27.str_2230
+
+@ExperimentalResourceApi
+internal val Res.string.str_22300: StringResource
+  get() = String27.str_22300
+
+@ExperimentalResourceApi
+internal val Res.string.str_22301: StringResource
+  get() = String27.str_22301
+
+@ExperimentalResourceApi
+internal val Res.string.str_22302: StringResource
+  get() = String27.str_22302
+
+@ExperimentalResourceApi
+internal val Res.string.str_22303: StringResource
+  get() = String27.str_22303
+
+@ExperimentalResourceApi
+internal val Res.string.str_22304: StringResource
+  get() = String27.str_22304
+
+@ExperimentalResourceApi
+internal val Res.string.str_22305: StringResource
+  get() = String27.str_22305
+
+@ExperimentalResourceApi
+internal val Res.string.str_22306: StringResource
+  get() = String27.str_22306
+
+@ExperimentalResourceApi
+internal val Res.string.str_22307: StringResource
+  get() = String27.str_22307
+
+@ExperimentalResourceApi
+internal val Res.string.str_22308: StringResource
+  get() = String27.str_22308
+
+@ExperimentalResourceApi
+internal val Res.string.str_22309: StringResource
+  get() = String27.str_22309
+
+@ExperimentalResourceApi
+internal val Res.string.str_2231: StringResource
+  get() = String27.str_2231
+
+@ExperimentalResourceApi
+internal val Res.string.str_22310: StringResource
+  get() = String27.str_22310
+
+@ExperimentalResourceApi
+internal val Res.string.str_22311: StringResource
+  get() = String27.str_22311
+
+@ExperimentalResourceApi
+internal val Res.string.str_22312: StringResource
+  get() = String27.str_22312
+
+@ExperimentalResourceApi
+internal val Res.string.str_22313: StringResource
+  get() = String27.str_22313
+
+@ExperimentalResourceApi
+internal val Res.string.str_22314: StringResource
+  get() = String27.str_22314
+
+@ExperimentalResourceApi
+internal val Res.string.str_22315: StringResource
+  get() = String27.str_22315
+
+@ExperimentalResourceApi
+internal val Res.string.str_22316: StringResource
+  get() = String27.str_22316
+
+@ExperimentalResourceApi
+internal val Res.string.str_22317: StringResource
+  get() = String27.str_22317
+
+@ExperimentalResourceApi
+internal val Res.string.str_22318: StringResource
+  get() = String27.str_22318
+
+@ExperimentalResourceApi
+internal val Res.string.str_22319: StringResource
+  get() = String27.str_22319
+
+@ExperimentalResourceApi
+internal val Res.string.str_2232: StringResource
+  get() = String27.str_2232
+
+@ExperimentalResourceApi
+internal val Res.string.str_22320: StringResource
+  get() = String27.str_22320
+
+@ExperimentalResourceApi
+internal val Res.string.str_22321: StringResource
+  get() = String27.str_22321
+
+@ExperimentalResourceApi
+internal val Res.string.str_22322: StringResource
+  get() = String27.str_22322
+
+@ExperimentalResourceApi
+internal val Res.string.str_22323: StringResource
+  get() = String27.str_22323
+
+@ExperimentalResourceApi
+internal val Res.string.str_22324: StringResource
+  get() = String27.str_22324
+
+@ExperimentalResourceApi
+internal val Res.string.str_22325: StringResource
+  get() = String27.str_22325
+
+@ExperimentalResourceApi
+internal val Res.string.str_22326: StringResource
+  get() = String27.str_22326
+
+@ExperimentalResourceApi
+internal val Res.string.str_22327: StringResource
+  get() = String27.str_22327
+
+@ExperimentalResourceApi
+internal val Res.string.str_22328: StringResource
+  get() = String27.str_22328
+
+@ExperimentalResourceApi
+internal val Res.string.str_22329: StringResource
+  get() = String27.str_22329
+
+@ExperimentalResourceApi
+internal val Res.string.str_2233: StringResource
+  get() = String27.str_2233
+
+@ExperimentalResourceApi
+internal val Res.string.str_22330: StringResource
+  get() = String27.str_22330
+
+@ExperimentalResourceApi
+internal val Res.string.str_22331: StringResource
+  get() = String27.str_22331
+
+@ExperimentalResourceApi
+internal val Res.string.str_22332: StringResource
+  get() = String27.str_22332
+
+@ExperimentalResourceApi
+internal val Res.string.str_22333: StringResource
+  get() = String27.str_22333
+
+@ExperimentalResourceApi
+internal val Res.string.str_22334: StringResource
+  get() = String27.str_22334
+
+@ExperimentalResourceApi
+internal val Res.string.str_22335: StringResource
+  get() = String27.str_22335
+
+@ExperimentalResourceApi
+internal val Res.string.str_22336: StringResource
+  get() = String27.str_22336
+
+@ExperimentalResourceApi
+internal val Res.string.str_22337: StringResource
+  get() = String27.str_22337
+
+@ExperimentalResourceApi
+internal val Res.string.str_22338: StringResource
+  get() = String27.str_22338
+
+@ExperimentalResourceApi
+internal val Res.string.str_22339: StringResource
+  get() = String27.str_22339
+
+@ExperimentalResourceApi
+internal val Res.string.str_2234: StringResource
+  get() = String27.str_2234
+
+@ExperimentalResourceApi
+internal val Res.string.str_22340: StringResource
+  get() = String27.str_22340
+
+@ExperimentalResourceApi
+internal val Res.string.str_22341: StringResource
+  get() = String27.str_22341
+
+@ExperimentalResourceApi
+internal val Res.string.str_22342: StringResource
+  get() = String27.str_22342
+
+@ExperimentalResourceApi
+internal val Res.string.str_22343: StringResource
+  get() = String27.str_22343
+
+@ExperimentalResourceApi
+internal val Res.string.str_22344: StringResource
+  get() = String27.str_22344
+
+@ExperimentalResourceApi
+internal val Res.string.str_22345: StringResource
+  get() = String27.str_22345
+
+@ExperimentalResourceApi
+internal val Res.string.str_22346: StringResource
+  get() = String27.str_22346
+
+@ExperimentalResourceApi
+internal val Res.string.str_22347: StringResource
+  get() = String27.str_22347
+
+@ExperimentalResourceApi
+internal val Res.string.str_22348: StringResource
+  get() = String27.str_22348
+
+@ExperimentalResourceApi
+internal val Res.string.str_22349: StringResource
+  get() = String27.str_22349
+
+@ExperimentalResourceApi
+internal val Res.string.str_2235: StringResource
+  get() = String27.str_2235
+
+@ExperimentalResourceApi
+internal val Res.string.str_22350: StringResource
+  get() = String27.str_22350
+
+@ExperimentalResourceApi
+internal val Res.string.str_22351: StringResource
+  get() = String27.str_22351
+
+@ExperimentalResourceApi
+internal val Res.string.str_22352: StringResource
+  get() = String27.str_22352
+
+@ExperimentalResourceApi
+internal val Res.string.str_22353: StringResource
+  get() = String27.str_22353
+
+@ExperimentalResourceApi
+internal val Res.string.str_22354: StringResource
+  get() = String27.str_22354
+
+@ExperimentalResourceApi
+internal val Res.string.str_22355: StringResource
+  get() = String27.str_22355
+
+@ExperimentalResourceApi
+internal val Res.string.str_22356: StringResource
+  get() = String27.str_22356
+
+@ExperimentalResourceApi
+internal val Res.string.str_22357: StringResource
+  get() = String27.str_22357
+
+@ExperimentalResourceApi
+internal val Res.string.str_22358: StringResource
+  get() = String27.str_22358
+
+@ExperimentalResourceApi
+internal val Res.string.str_22359: StringResource
+  get() = String27.str_22359
+
+@ExperimentalResourceApi
+internal val Res.string.str_2236: StringResource
+  get() = String27.str_2236
+
+@ExperimentalResourceApi
+internal val Res.string.str_22360: StringResource
+  get() = String27.str_22360
+
+@ExperimentalResourceApi
+internal val Res.string.str_22361: StringResource
+  get() = String27.str_22361
+
+@ExperimentalResourceApi
+internal val Res.string.str_22362: StringResource
+  get() = String27.str_22362
+
+@ExperimentalResourceApi
+internal val Res.string.str_22363: StringResource
+  get() = String27.str_22363
+
+@ExperimentalResourceApi
+internal val Res.string.str_22364: StringResource
+  get() = String27.str_22364
+
+@ExperimentalResourceApi
+internal val Res.string.str_22365: StringResource
+  get() = String27.str_22365
+
+@ExperimentalResourceApi
+internal val Res.string.str_22366: StringResource
+  get() = String27.str_22366
+
+@ExperimentalResourceApi
+internal val Res.string.str_22367: StringResource
+  get() = String27.str_22367
+
+@ExperimentalResourceApi
+internal val Res.string.str_22368: StringResource
+  get() = String27.str_22368
+
+@ExperimentalResourceApi
+internal val Res.string.str_22369: StringResource
+  get() = String27.str_22369
+
+@ExperimentalResourceApi
+internal val Res.string.str_2237: StringResource
+  get() = String27.str_2237
+
+@ExperimentalResourceApi
+internal val Res.string.str_22370: StringResource
+  get() = String27.str_22370
+
+@ExperimentalResourceApi
+internal val Res.string.str_22371: StringResource
+  get() = String27.str_22371
+
+@ExperimentalResourceApi
+internal val Res.string.str_22372: StringResource
+  get() = String27.str_22372
+
+@ExperimentalResourceApi
+internal val Res.string.str_22373: StringResource
+  get() = String27.str_22373
+
+@ExperimentalResourceApi
+internal val Res.string.str_22374: StringResource
+  get() = String27.str_22374
+
+@ExperimentalResourceApi
+internal val Res.string.str_22375: StringResource
+  get() = String27.str_22375
+
+@ExperimentalResourceApi
+internal val Res.string.str_22376: StringResource
+  get() = String27.str_22376
+
+@ExperimentalResourceApi
+internal val Res.string.str_22377: StringResource
+  get() = String27.str_22377
+
+@ExperimentalResourceApi
+internal val Res.string.str_22378: StringResource
+  get() = String27.str_22378
+
+@ExperimentalResourceApi
+internal val Res.string.str_22379: StringResource
+  get() = String27.str_22379
+
+@ExperimentalResourceApi
+internal val Res.string.str_2238: StringResource
+  get() = String27.str_2238
+
+@ExperimentalResourceApi
+internal val Res.string.str_22380: StringResource
+  get() = String27.str_22380
+
+@ExperimentalResourceApi
+internal val Res.string.str_22381: StringResource
+  get() = String27.str_22381
+
+@ExperimentalResourceApi
+internal val Res.string.str_22382: StringResource
+  get() = String27.str_22382
+
+@ExperimentalResourceApi
+internal val Res.string.str_22383: StringResource
+  get() = String27.str_22383
+
+@ExperimentalResourceApi
+internal val Res.string.str_22384: StringResource
+  get() = String27.str_22384
+
+@ExperimentalResourceApi
+internal val Res.string.str_22385: StringResource
+  get() = String27.str_22385
+
+@ExperimentalResourceApi
+internal val Res.string.str_22386: StringResource
+  get() = String27.str_22386
+
+@ExperimentalResourceApi
+internal val Res.string.str_22387: StringResource
+  get() = String27.str_22387
+
+@ExperimentalResourceApi
+internal val Res.string.str_22388: StringResource
+  get() = String27.str_22388
+
+@ExperimentalResourceApi
+internal val Res.string.str_22389: StringResource
+  get() = String27.str_22389
+
+@ExperimentalResourceApi
+internal val Res.string.str_2239: StringResource
+  get() = String27.str_2239
+
+@ExperimentalResourceApi
+internal val Res.string.str_22390: StringResource
+  get() = String27.str_22390
+
+@ExperimentalResourceApi
+internal val Res.string.str_22391: StringResource
+  get() = String27.str_22391
+
+@ExperimentalResourceApi
+internal val Res.string.str_22392: StringResource
+  get() = String27.str_22392
+
+@ExperimentalResourceApi
+internal val Res.string.str_22393: StringResource
+  get() = String27.str_22393
+
+@ExperimentalResourceApi
+internal val Res.string.str_22394: StringResource
+  get() = String27.str_22394
+
+@ExperimentalResourceApi
+internal val Res.string.str_22395: StringResource
+  get() = String27.str_22395
+
+@ExperimentalResourceApi
+internal val Res.string.str_22396: StringResource
+  get() = String27.str_22396
+
+@ExperimentalResourceApi
+internal val Res.string.str_22397: StringResource
+  get() = String27.str_22397
+
+@ExperimentalResourceApi
+internal val Res.string.str_22398: StringResource
+  get() = String27.str_22398
+
+@ExperimentalResourceApi
+internal val Res.string.str_22399: StringResource
+  get() = String27.str_22399
+
+@ExperimentalResourceApi
+internal val Res.string.str_224: StringResource
+  get() = String27.str_224
+
+@ExperimentalResourceApi
+internal val Res.string.str_2240: StringResource
+  get() = String27.str_2240
+
+@ExperimentalResourceApi
+internal val Res.string.str_22400: StringResource
+  get() = String27.str_22400
+
+@ExperimentalResourceApi
+internal val Res.string.str_22401: StringResource
+  get() = String27.str_22401
+
+@ExperimentalResourceApi
+internal val Res.string.str_22402: StringResource
+  get() = String27.str_22402
+
+@ExperimentalResourceApi
+internal val Res.string.str_22403: StringResource
+  get() = String27.str_22403
+
+@ExperimentalResourceApi
+internal val Res.string.str_22404: StringResource
+  get() = String27.str_22404
+
+@ExperimentalResourceApi
+internal val Res.string.str_22405: StringResource
+  get() = String27.str_22405
+
+@ExperimentalResourceApi
+internal val Res.string.str_22406: StringResource
+  get() = String27.str_22406
+
+@ExperimentalResourceApi
+internal val Res.string.str_22407: StringResource
+  get() = String27.str_22407
+
+@ExperimentalResourceApi
+internal val Res.string.str_22408: StringResource
+  get() = String27.str_22408
+
+@ExperimentalResourceApi
+internal val Res.string.str_22409: StringResource
+  get() = String27.str_22409
+
+@ExperimentalResourceApi
+internal val Res.string.str_2241: StringResource
+  get() = String27.str_2241
+
+@ExperimentalResourceApi
+internal val Res.string.str_22410: StringResource
+  get() = String27.str_22410
+
+@ExperimentalResourceApi
+internal val Res.string.str_22411: StringResource
+  get() = String27.str_22411
+
+@ExperimentalResourceApi
+internal val Res.string.str_22412: StringResource
+  get() = String27.str_22412
+
+@ExperimentalResourceApi
+internal val Res.string.str_22413: StringResource
+  get() = String27.str_22413
+
+@ExperimentalResourceApi
+internal val Res.string.str_22414: StringResource
+  get() = String27.str_22414
+
+@ExperimentalResourceApi
+internal val Res.string.str_22415: StringResource
+  get() = String27.str_22415
+
+@ExperimentalResourceApi
+internal val Res.string.str_22416: StringResource
+  get() = String27.str_22416
+
+@ExperimentalResourceApi
+internal val Res.string.str_22417: StringResource
+  get() = String27.str_22417
+
+@ExperimentalResourceApi
+internal val Res.string.str_22418: StringResource
+  get() = String27.str_22418
+
+@ExperimentalResourceApi
+internal val Res.string.str_22419: StringResource
+  get() = String27.str_22419
+
+@ExperimentalResourceApi
+internal val Res.string.str_2242: StringResource
+  get() = String27.str_2242
+
+@ExperimentalResourceApi
+internal val Res.string.str_22420: StringResource
+  get() = String27.str_22420
+
+@ExperimentalResourceApi
+internal val Res.string.str_22421: StringResource
+  get() = String27.str_22421
+
+@ExperimentalResourceApi
+internal val Res.string.str_22422: StringResource
+  get() = String27.str_22422
+
+@ExperimentalResourceApi
+internal val Res.string.str_22423: StringResource
+  get() = String27.str_22423
+
+@ExperimentalResourceApi
+internal val Res.string.str_22424: StringResource
+  get() = String27.str_22424
+
+@ExperimentalResourceApi
+internal val Res.string.str_22425: StringResource
+  get() = String27.str_22425
+
+@ExperimentalResourceApi
+internal val Res.string.str_22426: StringResource
+  get() = String27.str_22426
+
+@ExperimentalResourceApi
+internal val Res.string.str_22427: StringResource
+  get() = String27.str_22427
+
+@ExperimentalResourceApi
+internal val Res.string.str_22428: StringResource
+  get() = String27.str_22428
+
+@ExperimentalResourceApi
+internal val Res.string.str_22429: StringResource
+  get() = String27.str_22429
+
+@ExperimentalResourceApi
+internal val Res.string.str_2243: StringResource
+  get() = String27.str_2243
+
+@ExperimentalResourceApi
+internal val Res.string.str_22430: StringResource
+  get() = String27.str_22430
+
+@ExperimentalResourceApi
+internal val Res.string.str_22431: StringResource
+  get() = String27.str_22431
+
+@ExperimentalResourceApi
+internal val Res.string.str_22432: StringResource
+  get() = String27.str_22432
+
+@ExperimentalResourceApi
+internal val Res.string.str_22433: StringResource
+  get() = String27.str_22433
+
+@ExperimentalResourceApi
+internal val Res.string.str_22434: StringResource
+  get() = String27.str_22434
+
+@ExperimentalResourceApi
+internal val Res.string.str_22435: StringResource
+  get() = String27.str_22435
+
+@ExperimentalResourceApi
+internal val Res.string.str_22436: StringResource
+  get() = String27.str_22436
+
+@ExperimentalResourceApi
+internal val Res.string.str_22437: StringResource
+  get() = String27.str_22437
+
+@ExperimentalResourceApi
+internal val Res.string.str_22438: StringResource
+  get() = String27.str_22438
+
+@ExperimentalResourceApi
+internal val Res.string.str_22439: StringResource
+  get() = String27.str_22439
+
+@ExperimentalResourceApi
+internal val Res.string.str_2244: StringResource
+  get() = String27.str_2244
+
+@ExperimentalResourceApi
+internal val Res.string.str_22440: StringResource
+  get() = String27.str_22440
+
+@ExperimentalResourceApi
+internal val Res.string.str_22441: StringResource
+  get() = String27.str_22441
+
+@ExperimentalResourceApi
+internal val Res.string.str_22442: StringResource
+  get() = String27.str_22442
+
+@ExperimentalResourceApi
+internal val Res.string.str_22443: StringResource
+  get() = String27.str_22443
+
+@ExperimentalResourceApi
+internal val Res.string.str_22444: StringResource
+  get() = String27.str_22444
+
+@ExperimentalResourceApi
+internal val Res.string.str_22445: StringResource
+  get() = String27.str_22445
+
+@ExperimentalResourceApi
+internal val Res.string.str_22446: StringResource
+  get() = String27.str_22446
+
+@ExperimentalResourceApi
+internal val Res.string.str_22447: StringResource
+  get() = String27.str_22447
+
+@ExperimentalResourceApi
+internal val Res.string.str_22448: StringResource
+  get() = String27.str_22448
+
+@ExperimentalResourceApi
+internal val Res.string.str_22449: StringResource
+  get() = String27.str_22449
+
+@ExperimentalResourceApi
+internal val Res.string.str_2245: StringResource
+  get() = String27.str_2245
+
+@ExperimentalResourceApi
+internal val Res.string.str_22450: StringResource
+  get() = String27.str_22450
+
+@ExperimentalResourceApi
+internal val Res.string.str_22451: StringResource
+  get() = String27.str_22451
+
+@ExperimentalResourceApi
+internal val Res.string.str_22452: StringResource
+  get() = String27.str_22452
+
+@ExperimentalResourceApi
+internal val Res.string.str_22453: StringResource
+  get() = String27.str_22453
+
+@ExperimentalResourceApi
+internal val Res.string.str_22454: StringResource
+  get() = String27.str_22454
+
+@ExperimentalResourceApi
+internal val Res.string.str_22455: StringResource
+  get() = String27.str_22455
+
+@ExperimentalResourceApi
+internal val Res.string.str_22456: StringResource
+  get() = String27.str_22456
+
+@ExperimentalResourceApi
+internal val Res.string.str_22457: StringResource
+  get() = String27.str_22457
+
+@ExperimentalResourceApi
+internal val Res.string.str_22458: StringResource
+  get() = String27.str_22458
+
+@ExperimentalResourceApi
+internal val Res.string.str_22459: StringResource
+  get() = String27.str_22459
+
+@ExperimentalResourceApi
+internal val Res.string.str_2246: StringResource
+  get() = String27.str_2246
+
+@ExperimentalResourceApi
+internal val Res.string.str_22460: StringResource
+  get() = String27.str_22460
+
+@ExperimentalResourceApi
+internal val Res.string.str_22461: StringResource
+  get() = String27.str_22461
+
+@ExperimentalResourceApi
+internal val Res.string.str_22462: StringResource
+  get() = String27.str_22462
+
+@ExperimentalResourceApi
+internal val Res.string.str_22463: StringResource
+  get() = String27.str_22463
+
+@ExperimentalResourceApi
+internal val Res.string.str_22464: StringResource
+  get() = String27.str_22464
+
+@ExperimentalResourceApi
+internal val Res.string.str_22465: StringResource
+  get() = String27.str_22465
+
+@ExperimentalResourceApi
+internal val Res.string.str_22466: StringResource
+  get() = String27.str_22466
+
+@ExperimentalResourceApi
+internal val Res.string.str_22467: StringResource
+  get() = String27.str_22467
+
+@ExperimentalResourceApi
+internal val Res.string.str_22468: StringResource
+  get() = String27.str_22468
+
+@ExperimentalResourceApi
+internal val Res.string.str_22469: StringResource
+  get() = String27.str_22469
+
+@ExperimentalResourceApi
+internal val Res.string.str_2247: StringResource
+  get() = String27.str_2247
+
+@ExperimentalResourceApi
+internal val Res.string.str_22470: StringResource
+  get() = String27.str_22470
+
+@ExperimentalResourceApi
+internal val Res.string.str_22471: StringResource
+  get() = String27.str_22471
+
+@ExperimentalResourceApi
+internal val Res.string.str_22472: StringResource
+  get() = String27.str_22472
+
+@ExperimentalResourceApi
+internal val Res.string.str_22473: StringResource
+  get() = String27.str_22473
+
+@ExperimentalResourceApi
+internal val Res.string.str_22474: StringResource
+  get() = String27.str_22474
+
+@ExperimentalResourceApi
+internal val Res.string.str_22475: StringResource
+  get() = String27.str_22475
+
+@ExperimentalResourceApi
+internal val Res.string.str_22476: StringResource
+  get() = String27.str_22476
+
+@ExperimentalResourceApi
+internal val Res.string.str_22477: StringResource
+  get() = String27.str_22477
+
+@ExperimentalResourceApi
+internal val Res.string.str_22478: StringResource
+  get() = String27.str_22478
+
+@ExperimentalResourceApi
+internal val Res.string.str_22479: StringResource
+  get() = String27.str_22479
+
+@ExperimentalResourceApi
+internal val Res.string.str_2248: StringResource
+  get() = String27.str_2248
+
+@ExperimentalResourceApi
+internal val Res.string.str_22480: StringResource
+  get() = String27.str_22480
+
+@ExperimentalResourceApi
+internal val Res.string.str_22481: StringResource
+  get() = String27.str_22481
+
+@ExperimentalResourceApi
+internal val Res.string.str_22482: StringResource
+  get() = String27.str_22482
+
+@ExperimentalResourceApi
+internal val Res.string.str_22483: StringResource
+  get() = String27.str_22483
+
+@ExperimentalResourceApi
+internal val Res.string.str_22484: StringResource
+  get() = String27.str_22484
+
+@ExperimentalResourceApi
+internal val Res.string.str_22485: StringResource
+  get() = String27.str_22485
+
+@ExperimentalResourceApi
+internal val Res.string.str_22486: StringResource
+  get() = String27.str_22486
+
+@ExperimentalResourceApi
+internal val Res.string.str_22487: StringResource
+  get() = String27.str_22487
+
+@ExperimentalResourceApi
+internal val Res.string.str_22488: StringResource
+  get() = String27.str_22488
+
+@ExperimentalResourceApi
+internal val Res.string.str_22489: StringResource
+  get() = String27.str_22489
+
+@ExperimentalResourceApi
+internal val Res.string.str_2249: StringResource
+  get() = String27.str_2249
+
+@ExperimentalResourceApi
+internal val Res.string.str_22490: StringResource
+  get() = String27.str_22490
+
+@ExperimentalResourceApi
+internal val Res.string.str_22491: StringResource
+  get() = String27.str_22491
+
+@ExperimentalResourceApi
+internal val Res.string.str_22492: StringResource
+  get() = String27.str_22492
+
+@ExperimentalResourceApi
+internal val Res.string.str_22493: StringResource
+  get() = String27.str_22493
+
+@ExperimentalResourceApi
+internal val Res.string.str_22494: StringResource
+  get() = String27.str_22494
+
+@ExperimentalResourceApi
+internal val Res.string.str_22495: StringResource
+  get() = String27.str_22495
+
+@ExperimentalResourceApi
+internal val Res.string.str_22496: StringResource
+  get() = String27.str_22496
+
+@ExperimentalResourceApi
+internal val Res.string.str_22497: StringResource
+  get() = String27.str_22497
+
+@ExperimentalResourceApi
+internal val Res.string.str_22498: StringResource
+  get() = String27.str_22498
+
+@ExperimentalResourceApi
+internal val Res.string.str_22499: StringResource
+  get() = String27.str_22499
+
+@ExperimentalResourceApi
+internal val Res.string.str_225: StringResource
+  get() = String27.str_225
+
+@ExperimentalResourceApi
+internal val Res.string.str_2250: StringResource
+  get() = String27.str_2250
+
+@ExperimentalResourceApi
+internal val Res.string.str_22500: StringResource
+  get() = String27.str_22500
+
+@ExperimentalResourceApi
+internal val Res.string.str_22501: StringResource
+  get() = String27.str_22501
+
+@ExperimentalResourceApi
+internal val Res.string.str_22502: StringResource
+  get() = String27.str_22502
+
+@ExperimentalResourceApi
+internal val Res.string.str_22503: StringResource
+  get() = String27.str_22503
+
+@ExperimentalResourceApi
+internal val Res.string.str_22504: StringResource
+  get() = String27.str_22504
+
+@ExperimentalResourceApi
+internal val Res.string.str_22505: StringResource
+  get() = String27.str_22505
+
+@ExperimentalResourceApi
+internal val Res.string.str_22506: StringResource
+  get() = String27.str_22506
+
+@ExperimentalResourceApi
+internal val Res.string.str_22507: StringResource
+  get() = String27.str_22507
+
+@ExperimentalResourceApi
+internal val Res.string.str_22508: StringResource
+  get() = String27.str_22508
+
+@ExperimentalResourceApi
+internal val Res.string.str_22509: StringResource
+  get() = String27.str_22509
+
+@ExperimentalResourceApi
+internal val Res.string.str_2251: StringResource
+  get() = String27.str_2251
+
+@ExperimentalResourceApi
+internal val Res.string.str_22510: StringResource
+  get() = String27.str_22510
+
+@ExperimentalResourceApi
+internal val Res.string.str_22511: StringResource
+  get() = String27.str_22511
+
+@ExperimentalResourceApi
+internal val Res.string.str_22512: StringResource
+  get() = String27.str_22512
+
+@ExperimentalResourceApi
+internal val Res.string.str_22513: StringResource
+  get() = String27.str_22513
+
+@ExperimentalResourceApi
+internal val Res.string.str_22514: StringResource
+  get() = String27.str_22514
+
+@ExperimentalResourceApi
+internal val Res.string.str_22515: StringResource
+  get() = String27.str_22515
+
+@ExperimentalResourceApi
+internal val Res.string.str_22516: StringResource
+  get() = String27.str_22516
+
+@ExperimentalResourceApi
+internal val Res.string.str_22517: StringResource
+  get() = String27.str_22517
+
+@ExperimentalResourceApi
+internal val Res.string.str_22518: StringResource
+  get() = String27.str_22518
+
+@ExperimentalResourceApi
+internal val Res.string.str_22519: StringResource
+  get() = String27.str_22519
+
+@ExperimentalResourceApi
+internal val Res.string.str_2252: StringResource
+  get() = String27.str_2252
+
+@ExperimentalResourceApi
+internal val Res.string.str_22520: StringResource
+  get() = String27.str_22520
+
+@ExperimentalResourceApi
+internal val Res.string.str_22521: StringResource
+  get() = String27.str_22521
+
+@ExperimentalResourceApi
+internal val Res.string.str_22522: StringResource
+  get() = String27.str_22522
+
+@ExperimentalResourceApi
+internal val Res.string.str_22523: StringResource
+  get() = String27.str_22523
+
+@ExperimentalResourceApi
+internal val Res.string.str_22524: StringResource
+  get() = String27.str_22524
+
+@ExperimentalResourceApi
+internal val Res.string.str_22525: StringResource
+  get() = String27.str_22525
+
+@ExperimentalResourceApi
+internal val Res.string.str_22526: StringResource
+  get() = String27.str_22526
+
+@ExperimentalResourceApi
+internal val Res.string.str_22527: StringResource
+  get() = String27.str_22527
+
+@ExperimentalResourceApi
+internal val Res.string.str_22528: StringResource
+  get() = String27.str_22528
+
+@ExperimentalResourceApi
+internal val Res.string.str_22529: StringResource
+  get() = String27.str_22529
+
+@ExperimentalResourceApi
+internal val Res.string.str_2253: StringResource
+  get() = String27.str_2253
+
+@ExperimentalResourceApi
+internal val Res.string.str_22530: StringResource
+  get() = String27.str_22530
+
+@ExperimentalResourceApi
+internal val Res.string.str_22531: StringResource
+  get() = String27.str_22531
+
+@ExperimentalResourceApi
+internal val Res.string.str_22532: StringResource
+  get() = String27.str_22532
+
+@ExperimentalResourceApi
+internal val Res.string.str_22533: StringResource
+  get() = String27.str_22533
+
+@ExperimentalResourceApi
+internal val Res.string.str_22534: StringResource
+  get() = String27.str_22534
+
+@ExperimentalResourceApi
+internal val Res.string.str_22535: StringResource
+  get() = String27.str_22535
+
+@ExperimentalResourceApi
+internal val Res.string.str_22536: StringResource
+  get() = String27.str_22536
+
+@ExperimentalResourceApi
+internal val Res.string.str_22537: StringResource
+  get() = String27.str_22537
+
+@ExperimentalResourceApi
+internal val Res.string.str_22538: StringResource
+  get() = String27.str_22538
+
+@ExperimentalResourceApi
+internal val Res.string.str_22539: StringResource
+  get() = String27.str_22539
+
+@ExperimentalResourceApi
+internal val Res.string.str_2254: StringResource
+  get() = String27.str_2254
+
+@ExperimentalResourceApi
+internal val Res.string.str_22540: StringResource
+  get() = String27.str_22540
+
+@ExperimentalResourceApi
+internal val Res.string.str_22541: StringResource
+  get() = String27.str_22541
+
+@ExperimentalResourceApi
+internal val Res.string.str_22542: StringResource
+  get() = String27.str_22542
+
+@ExperimentalResourceApi
+internal val Res.string.str_22543: StringResource
+  get() = String27.str_22543
+
+@ExperimentalResourceApi
+internal val Res.string.str_22544: StringResource
+  get() = String27.str_22544
+
+@ExperimentalResourceApi
+internal val Res.string.str_22545: StringResource
+  get() = String27.str_22545
+
+@ExperimentalResourceApi
+internal val Res.string.str_22546: StringResource
+  get() = String27.str_22546
+
+@ExperimentalResourceApi
+internal val Res.string.str_22547: StringResource
+  get() = String27.str_22547
+
+@ExperimentalResourceApi
+internal val Res.string.str_22548: StringResource
+  get() = String27.str_22548
+
+@ExperimentalResourceApi
+internal val Res.string.str_22549: StringResource
+  get() = String27.str_22549
+
+@ExperimentalResourceApi
+internal val Res.string.str_2255: StringResource
+  get() = String27.str_2255
+
+@ExperimentalResourceApi
+internal val Res.string.str_22550: StringResource
+  get() = String27.str_22550
+
+@ExperimentalResourceApi
+internal val Res.string.str_22551: StringResource
+  get() = String27.str_22551
+
+@ExperimentalResourceApi
+internal val Res.string.str_22552: StringResource
+  get() = String27.str_22552
+
+@ExperimentalResourceApi
+internal val Res.string.str_22553: StringResource
+  get() = String27.str_22553
+
+@ExperimentalResourceApi
+internal val Res.string.str_22554: StringResource
+  get() = String27.str_22554
+
+@ExperimentalResourceApi
+internal val Res.string.str_22555: StringResource
+  get() = String27.str_22555
+
+@ExperimentalResourceApi
+internal val Res.string.str_22556: StringResource
+  get() = String27.str_22556
+
+@ExperimentalResourceApi
+internal val Res.string.str_22557: StringResource
+  get() = String27.str_22557
+
+@ExperimentalResourceApi
+internal val Res.string.str_22558: StringResource
+  get() = String27.str_22558
+
+@ExperimentalResourceApi
+internal val Res.string.str_22559: StringResource
+  get() = String27.str_22559
+
+@ExperimentalResourceApi
+internal val Res.string.str_2256: StringResource
+  get() = String27.str_2256
+
+@ExperimentalResourceApi
+internal val Res.string.str_22560: StringResource
+  get() = String27.str_22560
+
+@ExperimentalResourceApi
+internal val Res.string.str_22561: StringResource
+  get() = String27.str_22561
+
+@ExperimentalResourceApi
+internal val Res.string.str_22562: StringResource
+  get() = String27.str_22562
+
+@ExperimentalResourceApi
+internal val Res.string.str_22563: StringResource
+  get() = String27.str_22563
+
+@ExperimentalResourceApi
+internal val Res.string.str_22564: StringResource
+  get() = String27.str_22564
+
+@ExperimentalResourceApi
+internal val Res.string.str_22565: StringResource
+  get() = String27.str_22565
+
+@ExperimentalResourceApi
+internal val Res.string.str_22566: StringResource
+  get() = String27.str_22566
+
+@ExperimentalResourceApi
+internal val Res.string.str_22567: StringResource
+  get() = String27.str_22567
+
+@ExperimentalResourceApi
+internal val Res.string.str_22568: StringResource
+  get() = String27.str_22568
+
+@ExperimentalResourceApi
+internal val Res.string.str_22569: StringResource
+  get() = String27.str_22569
+
+@ExperimentalResourceApi
+internal val Res.string.str_2257: StringResource
+  get() = String27.str_2257
+
+@ExperimentalResourceApi
+internal val Res.string.str_22570: StringResource
+  get() = String27.str_22570
+
+@ExperimentalResourceApi
+internal val Res.string.str_22571: StringResource
+  get() = String27.str_22571
+
+@ExperimentalResourceApi
+internal val Res.string.str_22572: StringResource
+  get() = String27.str_22572
+
+@ExperimentalResourceApi
+internal val Res.string.str_22573: StringResource
+  get() = String27.str_22573
+
+@ExperimentalResourceApi
+internal val Res.string.str_22574: StringResource
+  get() = String27.str_22574
+
+@ExperimentalResourceApi
+internal val Res.string.str_22575: StringResource
+  get() = String27.str_22575
+
+@ExperimentalResourceApi
+internal val Res.string.str_22576: StringResource
+  get() = String27.str_22576
+
+@ExperimentalResourceApi
+internal val Res.string.str_22577: StringResource
+  get() = String27.str_22577
+
+@ExperimentalResourceApi
+internal val Res.string.str_22578: StringResource
+  get() = String27.str_22578
+
+@ExperimentalResourceApi
+internal val Res.string.str_22579: StringResource
+  get() = String27.str_22579
+
+@ExperimentalResourceApi
+internal val Res.string.str_2258: StringResource
+  get() = String27.str_2258
+
+@ExperimentalResourceApi
+internal val Res.string.str_22580: StringResource
+  get() = String27.str_22580
+
+@ExperimentalResourceApi
+internal val Res.string.str_22581: StringResource
+  get() = String27.str_22581
+
+@ExperimentalResourceApi
+internal val Res.string.str_22582: StringResource
+  get() = String27.str_22582
+
+@ExperimentalResourceApi
+internal val Res.string.str_22583: StringResource
+  get() = String27.str_22583
+
+@ExperimentalResourceApi
+internal val Res.string.str_22584: StringResource
+  get() = String27.str_22584
+
+@ExperimentalResourceApi
+internal val Res.string.str_22585: StringResource
+  get() = String27.str_22585
+
+@ExperimentalResourceApi
+internal val Res.string.str_22586: StringResource
+  get() = String27.str_22586
+
+@ExperimentalResourceApi
+internal val Res.string.str_22587: StringResource
+  get() = String27.str_22587
+
+@ExperimentalResourceApi
+internal val Res.string.str_22588: StringResource
+  get() = String27.str_22588
+
+@ExperimentalResourceApi
+internal val Res.string.str_22589: StringResource
+  get() = String27.str_22589
+
+@ExperimentalResourceApi
+internal val Res.string.str_2259: StringResource
+  get() = String27.str_2259
+
+@ExperimentalResourceApi
+internal val Res.string.str_22590: StringResource
+  get() = String27.str_22590
+
+@ExperimentalResourceApi
+internal val Res.string.str_22591: StringResource
+  get() = String27.str_22591
+
+@ExperimentalResourceApi
+internal val Res.string.str_22592: StringResource
+  get() = String27.str_22592
+
+@ExperimentalResourceApi
+internal val Res.string.str_22593: StringResource
+  get() = String27.str_22593
+
+@ExperimentalResourceApi
+internal val Res.string.str_22594: StringResource
+  get() = String27.str_22594
+
+@ExperimentalResourceApi
+internal val Res.string.str_22595: StringResource
+  get() = String27.str_22595
+
+@ExperimentalResourceApi
+internal val Res.string.str_22596: StringResource
+  get() = String27.str_22596
+
+@ExperimentalResourceApi
+internal val Res.string.str_22597: StringResource
+  get() = String27.str_22597

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String28.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String28.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String28 {
+  public val str_22598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22598", "str_22598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22599", "str_22599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_226", "str_226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2260", "str_2260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22600", "str_22600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22601", "str_22601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22602", "str_22602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22603", "str_22603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22604", "str_22604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22605", "str_22605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22606", "str_22606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22607", "str_22607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22608", "str_22608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22609", "str_22609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2261", "str_2261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22610", "str_22610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22611", "str_22611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22612", "str_22612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22613", "str_22613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22614", "str_22614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22615", "str_22615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22616", "str_22616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22617", "str_22617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22618", "str_22618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22619", "str_22619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2262", "str_2262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22620", "str_22620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22621", "str_22621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22622", "str_22622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22623", "str_22623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22624", "str_22624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22625", "str_22625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22626", "str_22626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22627", "str_22627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22628", "str_22628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22629", "str_22629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2263", "str_2263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22630", "str_22630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22631", "str_22631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22632", "str_22632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22633", "str_22633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22634", "str_22634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22635", "str_22635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22636", "str_22636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22637", "str_22637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22638", "str_22638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22639", "str_22639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2264", "str_2264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22640", "str_22640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22641", "str_22641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22642", "str_22642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22643", "str_22643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22644", "str_22644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22645", "str_22645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22646", "str_22646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22647", "str_22647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22648", "str_22648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22649", "str_22649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2265", "str_2265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22650", "str_22650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22651", "str_22651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22652", "str_22652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22653", "str_22653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22654", "str_22654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22655", "str_22655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22656", "str_22656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22657", "str_22657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22658", "str_22658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22659", "str_22659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2266", "str_2266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22660", "str_22660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22661", "str_22661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22662", "str_22662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22663", "str_22663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22664", "str_22664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22665", "str_22665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22666", "str_22666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22667", "str_22667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22668", "str_22668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22669", "str_22669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2267", "str_2267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22670", "str_22670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22671", "str_22671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22672", "str_22672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22673", "str_22673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22674", "str_22674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22675", "str_22675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22676", "str_22676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22677", "str_22677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22678", "str_22678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22679", "str_22679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2268", "str_2268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22680", "str_22680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22681", "str_22681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22682", "str_22682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22683", "str_22683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22684", "str_22684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22685", "str_22685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22686", "str_22686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22687", "str_22687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22688", "str_22688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22689", "str_22689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2269", "str_2269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22690", "str_22690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22691", "str_22691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22692", "str_22692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22693", "str_22693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22694", "str_22694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22695", "str_22695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22696", "str_22696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22697", "str_22697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22698", "str_22698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22699", "str_22699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_227", "str_227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2270", "str_2270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22700", "str_22700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22701", "str_22701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22702", "str_22702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22703", "str_22703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22704", "str_22704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22705", "str_22705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22706", "str_22706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22707", "str_22707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22708", "str_22708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22709", "str_22709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2271", "str_2271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22710", "str_22710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22711", "str_22711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22712", "str_22712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22713", "str_22713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22714", "str_22714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22715", "str_22715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22716", "str_22716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22717", "str_22717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22718", "str_22718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22719", "str_22719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2272", "str_2272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22720", "str_22720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22721", "str_22721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22722", "str_22722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22723", "str_22723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22724", "str_22724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22725", "str_22725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22726", "str_22726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22727", "str_22727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22728", "str_22728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22729", "str_22729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2273", "str_2273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22730", "str_22730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22731", "str_22731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22732", "str_22732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22733", "str_22733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22734", "str_22734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22735", "str_22735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22736", "str_22736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22737", "str_22737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22738", "str_22738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22739", "str_22739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2274", "str_2274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22740", "str_22740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22741", "str_22741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22742", "str_22742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22743", "str_22743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22744", "str_22744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22745", "str_22745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22746", "str_22746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22747", "str_22747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22748", "str_22748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22749", "str_22749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2275", "str_2275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22750", "str_22750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22751", "str_22751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22752", "str_22752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22753", "str_22753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22754", "str_22754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22755", "str_22755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22756", "str_22756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22757", "str_22757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22758", "str_22758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22759", "str_22759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2276", "str_2276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22760", "str_22760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22761", "str_22761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22762", "str_22762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22763", "str_22763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22764", "str_22764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22765", "str_22765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22766", "str_22766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22767", "str_22767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22768", "str_22768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22769", "str_22769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2277", "str_2277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22770", "str_22770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22771", "str_22771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22772", "str_22772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22773", "str_22773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22774", "str_22774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22775", "str_22775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22776", "str_22776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22777", "str_22777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22778", "str_22778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22779", "str_22779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2278", "str_2278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22780", "str_22780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22781", "str_22781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22782", "str_22782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22783", "str_22783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22784", "str_22784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22785", "str_22785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22786", "str_22786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22787", "str_22787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22788", "str_22788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22789", "str_22789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2279", "str_2279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22790", "str_22790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22791", "str_22791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22792", "str_22792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22793", "str_22793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22794", "str_22794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22795", "str_22795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22796", "str_22796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22797", "str_22797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22798", "str_22798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22799", "str_22799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_228", "str_228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2280", "str_2280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22800", "str_22800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22801", "str_22801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22802", "str_22802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22803", "str_22803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22804", "str_22804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22805", "str_22805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22806", "str_22806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22807", "str_22807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22808", "str_22808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22809", "str_22809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2281", "str_2281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22810", "str_22810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22811", "str_22811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22812", "str_22812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22813", "str_22813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22814", "str_22814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22815", "str_22815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22816", "str_22816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22817", "str_22817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22818", "str_22818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22819", "str_22819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2282", "str_2282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22820", "str_22820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22821", "str_22821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22822", "str_22822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22823", "str_22823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22824", "str_22824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22825", "str_22825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22826", "str_22826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22827", "str_22827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22828", "str_22828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22829", "str_22829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2283", "str_2283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22830", "str_22830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22831", "str_22831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22832", "str_22832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22833", "str_22833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22834", "str_22834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22835", "str_22835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22836", "str_22836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22837", "str_22837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22838", "str_22838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22839", "str_22839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2284", "str_2284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22840", "str_22840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22841", "str_22841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22842", "str_22842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22843", "str_22843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22844", "str_22844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22845", "str_22845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22846", "str_22846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22847", "str_22847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22848", "str_22848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22849", "str_22849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2285", "str_2285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22850", "str_22850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22851", "str_22851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22852", "str_22852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22853", "str_22853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22854", "str_22854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22855", "str_22855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22856", "str_22856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22857", "str_22857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22858", "str_22858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22859", "str_22859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2286", "str_2286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22860", "str_22860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22861", "str_22861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22862", "str_22862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22863", "str_22863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22864", "str_22864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22865", "str_22865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22866", "str_22866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22867", "str_22867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22868", "str_22868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22869", "str_22869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2287", "str_2287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22870", "str_22870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22871", "str_22871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22872", "str_22872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22873", "str_22873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22874", "str_22874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22875", "str_22875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22876", "str_22876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22877", "str_22877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22878", "str_22878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22879", "str_22879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2288", "str_2288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22880", "str_22880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22881", "str_22881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22882", "str_22882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22883", "str_22883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22884", "str_22884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22885", "str_22885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22886", "str_22886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22887", "str_22887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22888", "str_22888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22889", "str_22889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2289", "str_2289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22890", "str_22890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22891", "str_22891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22892", "str_22892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22893", "str_22893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22894", "str_22894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22895", "str_22895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22896", "str_22896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22897", "str_22897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22898", "str_22898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22899", "str_22899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_229", "str_229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2290", "str_2290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22900", "str_22900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22901", "str_22901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22902", "str_22902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22903", "str_22903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22904", "str_22904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22905", "str_22905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22906", "str_22906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22907", "str_22907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22908", "str_22908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22909", "str_22909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2291", "str_2291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22910", "str_22910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22911", "str_22911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22912", "str_22912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22913", "str_22913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22914", "str_22914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22915", "str_22915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22916", "str_22916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22917", "str_22917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22918", "str_22918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22919", "str_22919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2292", "str_2292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22920", "str_22920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22921", "str_22921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22922", "str_22922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22923", "str_22923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22924", "str_22924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22925", "str_22925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22926", "str_22926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22927", "str_22927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22928", "str_22928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22929", "str_22929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2293", "str_2293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22930", "str_22930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22931", "str_22931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22932", "str_22932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22933", "str_22933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22934", "str_22934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22935", "str_22935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22936", "str_22936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22937", "str_22937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22938", "str_22938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22939", "str_22939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2294", "str_2294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22940", "str_22940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22941", "str_22941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22942", "str_22942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22943", "str_22943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22944", "str_22944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22945", "str_22945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22946", "str_22946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22947", "str_22947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22948", "str_22948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22949", "str_22949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2295", "str_2295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22950", "str_22950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22951", "str_22951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22952", "str_22952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22953", "str_22953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22954", "str_22954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22955", "str_22955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22956", "str_22956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22957", "str_22957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22958", "str_22958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22959", "str_22959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2296", "str_2296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22960", "str_22960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22961", "str_22961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22962", "str_22962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22963", "str_22963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22964", "str_22964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22965", "str_22965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22966", "str_22966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22967", "str_22967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22968", "str_22968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22969", "str_22969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2297", "str_2297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22970", "str_22970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22971", "str_22971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22972", "str_22972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22973", "str_22973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22974", "str_22974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22975", "str_22975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22976", "str_22976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22977", "str_22977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22978", "str_22978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22979", "str_22979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2298", "str_2298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22980", "str_22980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22981", "str_22981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22982", "str_22982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22983", "str_22983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22984", "str_22984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22985", "str_22985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22986", "str_22986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22987", "str_22987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22988", "str_22988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22989", "str_22989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2299", "str_2299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22990", "str_22990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22991", "str_22991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22992", "str_22992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22993", "str_22993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22994", "str_22994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22995", "str_22995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22996", "str_22996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22997", "str_22997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22998", "str_22998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_22999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_22999", "str_22999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23", "str_23",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_230", "str_230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2300", "str_2300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23000", "str_23000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23001", "str_23001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23002", "str_23002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23003", "str_23003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23004", "str_23004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23005", "str_23005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23006", "str_23006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23007", "str_23007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23008", "str_23008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23009", "str_23009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2301", "str_2301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23010", "str_23010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23011", "str_23011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23012", "str_23012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23013", "str_23013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23014", "str_23014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23015", "str_23015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23016", "str_23016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23017", "str_23017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23018", "str_23018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23019", "str_23019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2302", "str_2302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23020", "str_23020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23021", "str_23021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23022", "str_23022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23023", "str_23023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23024", "str_23024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23025", "str_23025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23026", "str_23026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23027", "str_23027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23028", "str_23028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23029", "str_23029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2303", "str_2303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23030", "str_23030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23031", "str_23031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23032", "str_23032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23033", "str_23033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23034", "str_23034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23035", "str_23035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23036", "str_23036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23037", "str_23037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23038", "str_23038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23039", "str_23039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2304", "str_2304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23040", "str_23040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23041", "str_23041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23042", "str_23042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23043", "str_23043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23044", "str_23044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23045", "str_23045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23046", "str_23046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_22598: StringResource
+  get() = String28.str_22598
+
+@ExperimentalResourceApi
+internal val Res.string.str_22599: StringResource
+  get() = String28.str_22599
+
+@ExperimentalResourceApi
+internal val Res.string.str_226: StringResource
+  get() = String28.str_226
+
+@ExperimentalResourceApi
+internal val Res.string.str_2260: StringResource
+  get() = String28.str_2260
+
+@ExperimentalResourceApi
+internal val Res.string.str_22600: StringResource
+  get() = String28.str_22600
+
+@ExperimentalResourceApi
+internal val Res.string.str_22601: StringResource
+  get() = String28.str_22601
+
+@ExperimentalResourceApi
+internal val Res.string.str_22602: StringResource
+  get() = String28.str_22602
+
+@ExperimentalResourceApi
+internal val Res.string.str_22603: StringResource
+  get() = String28.str_22603
+
+@ExperimentalResourceApi
+internal val Res.string.str_22604: StringResource
+  get() = String28.str_22604
+
+@ExperimentalResourceApi
+internal val Res.string.str_22605: StringResource
+  get() = String28.str_22605
+
+@ExperimentalResourceApi
+internal val Res.string.str_22606: StringResource
+  get() = String28.str_22606
+
+@ExperimentalResourceApi
+internal val Res.string.str_22607: StringResource
+  get() = String28.str_22607
+
+@ExperimentalResourceApi
+internal val Res.string.str_22608: StringResource
+  get() = String28.str_22608
+
+@ExperimentalResourceApi
+internal val Res.string.str_22609: StringResource
+  get() = String28.str_22609
+
+@ExperimentalResourceApi
+internal val Res.string.str_2261: StringResource
+  get() = String28.str_2261
+
+@ExperimentalResourceApi
+internal val Res.string.str_22610: StringResource
+  get() = String28.str_22610
+
+@ExperimentalResourceApi
+internal val Res.string.str_22611: StringResource
+  get() = String28.str_22611
+
+@ExperimentalResourceApi
+internal val Res.string.str_22612: StringResource
+  get() = String28.str_22612
+
+@ExperimentalResourceApi
+internal val Res.string.str_22613: StringResource
+  get() = String28.str_22613
+
+@ExperimentalResourceApi
+internal val Res.string.str_22614: StringResource
+  get() = String28.str_22614
+
+@ExperimentalResourceApi
+internal val Res.string.str_22615: StringResource
+  get() = String28.str_22615
+
+@ExperimentalResourceApi
+internal val Res.string.str_22616: StringResource
+  get() = String28.str_22616
+
+@ExperimentalResourceApi
+internal val Res.string.str_22617: StringResource
+  get() = String28.str_22617
+
+@ExperimentalResourceApi
+internal val Res.string.str_22618: StringResource
+  get() = String28.str_22618
+
+@ExperimentalResourceApi
+internal val Res.string.str_22619: StringResource
+  get() = String28.str_22619
+
+@ExperimentalResourceApi
+internal val Res.string.str_2262: StringResource
+  get() = String28.str_2262
+
+@ExperimentalResourceApi
+internal val Res.string.str_22620: StringResource
+  get() = String28.str_22620
+
+@ExperimentalResourceApi
+internal val Res.string.str_22621: StringResource
+  get() = String28.str_22621
+
+@ExperimentalResourceApi
+internal val Res.string.str_22622: StringResource
+  get() = String28.str_22622
+
+@ExperimentalResourceApi
+internal val Res.string.str_22623: StringResource
+  get() = String28.str_22623
+
+@ExperimentalResourceApi
+internal val Res.string.str_22624: StringResource
+  get() = String28.str_22624
+
+@ExperimentalResourceApi
+internal val Res.string.str_22625: StringResource
+  get() = String28.str_22625
+
+@ExperimentalResourceApi
+internal val Res.string.str_22626: StringResource
+  get() = String28.str_22626
+
+@ExperimentalResourceApi
+internal val Res.string.str_22627: StringResource
+  get() = String28.str_22627
+
+@ExperimentalResourceApi
+internal val Res.string.str_22628: StringResource
+  get() = String28.str_22628
+
+@ExperimentalResourceApi
+internal val Res.string.str_22629: StringResource
+  get() = String28.str_22629
+
+@ExperimentalResourceApi
+internal val Res.string.str_2263: StringResource
+  get() = String28.str_2263
+
+@ExperimentalResourceApi
+internal val Res.string.str_22630: StringResource
+  get() = String28.str_22630
+
+@ExperimentalResourceApi
+internal val Res.string.str_22631: StringResource
+  get() = String28.str_22631
+
+@ExperimentalResourceApi
+internal val Res.string.str_22632: StringResource
+  get() = String28.str_22632
+
+@ExperimentalResourceApi
+internal val Res.string.str_22633: StringResource
+  get() = String28.str_22633
+
+@ExperimentalResourceApi
+internal val Res.string.str_22634: StringResource
+  get() = String28.str_22634
+
+@ExperimentalResourceApi
+internal val Res.string.str_22635: StringResource
+  get() = String28.str_22635
+
+@ExperimentalResourceApi
+internal val Res.string.str_22636: StringResource
+  get() = String28.str_22636
+
+@ExperimentalResourceApi
+internal val Res.string.str_22637: StringResource
+  get() = String28.str_22637
+
+@ExperimentalResourceApi
+internal val Res.string.str_22638: StringResource
+  get() = String28.str_22638
+
+@ExperimentalResourceApi
+internal val Res.string.str_22639: StringResource
+  get() = String28.str_22639
+
+@ExperimentalResourceApi
+internal val Res.string.str_2264: StringResource
+  get() = String28.str_2264
+
+@ExperimentalResourceApi
+internal val Res.string.str_22640: StringResource
+  get() = String28.str_22640
+
+@ExperimentalResourceApi
+internal val Res.string.str_22641: StringResource
+  get() = String28.str_22641
+
+@ExperimentalResourceApi
+internal val Res.string.str_22642: StringResource
+  get() = String28.str_22642
+
+@ExperimentalResourceApi
+internal val Res.string.str_22643: StringResource
+  get() = String28.str_22643
+
+@ExperimentalResourceApi
+internal val Res.string.str_22644: StringResource
+  get() = String28.str_22644
+
+@ExperimentalResourceApi
+internal val Res.string.str_22645: StringResource
+  get() = String28.str_22645
+
+@ExperimentalResourceApi
+internal val Res.string.str_22646: StringResource
+  get() = String28.str_22646
+
+@ExperimentalResourceApi
+internal val Res.string.str_22647: StringResource
+  get() = String28.str_22647
+
+@ExperimentalResourceApi
+internal val Res.string.str_22648: StringResource
+  get() = String28.str_22648
+
+@ExperimentalResourceApi
+internal val Res.string.str_22649: StringResource
+  get() = String28.str_22649
+
+@ExperimentalResourceApi
+internal val Res.string.str_2265: StringResource
+  get() = String28.str_2265
+
+@ExperimentalResourceApi
+internal val Res.string.str_22650: StringResource
+  get() = String28.str_22650
+
+@ExperimentalResourceApi
+internal val Res.string.str_22651: StringResource
+  get() = String28.str_22651
+
+@ExperimentalResourceApi
+internal val Res.string.str_22652: StringResource
+  get() = String28.str_22652
+
+@ExperimentalResourceApi
+internal val Res.string.str_22653: StringResource
+  get() = String28.str_22653
+
+@ExperimentalResourceApi
+internal val Res.string.str_22654: StringResource
+  get() = String28.str_22654
+
+@ExperimentalResourceApi
+internal val Res.string.str_22655: StringResource
+  get() = String28.str_22655
+
+@ExperimentalResourceApi
+internal val Res.string.str_22656: StringResource
+  get() = String28.str_22656
+
+@ExperimentalResourceApi
+internal val Res.string.str_22657: StringResource
+  get() = String28.str_22657
+
+@ExperimentalResourceApi
+internal val Res.string.str_22658: StringResource
+  get() = String28.str_22658
+
+@ExperimentalResourceApi
+internal val Res.string.str_22659: StringResource
+  get() = String28.str_22659
+
+@ExperimentalResourceApi
+internal val Res.string.str_2266: StringResource
+  get() = String28.str_2266
+
+@ExperimentalResourceApi
+internal val Res.string.str_22660: StringResource
+  get() = String28.str_22660
+
+@ExperimentalResourceApi
+internal val Res.string.str_22661: StringResource
+  get() = String28.str_22661
+
+@ExperimentalResourceApi
+internal val Res.string.str_22662: StringResource
+  get() = String28.str_22662
+
+@ExperimentalResourceApi
+internal val Res.string.str_22663: StringResource
+  get() = String28.str_22663
+
+@ExperimentalResourceApi
+internal val Res.string.str_22664: StringResource
+  get() = String28.str_22664
+
+@ExperimentalResourceApi
+internal val Res.string.str_22665: StringResource
+  get() = String28.str_22665
+
+@ExperimentalResourceApi
+internal val Res.string.str_22666: StringResource
+  get() = String28.str_22666
+
+@ExperimentalResourceApi
+internal val Res.string.str_22667: StringResource
+  get() = String28.str_22667
+
+@ExperimentalResourceApi
+internal val Res.string.str_22668: StringResource
+  get() = String28.str_22668
+
+@ExperimentalResourceApi
+internal val Res.string.str_22669: StringResource
+  get() = String28.str_22669
+
+@ExperimentalResourceApi
+internal val Res.string.str_2267: StringResource
+  get() = String28.str_2267
+
+@ExperimentalResourceApi
+internal val Res.string.str_22670: StringResource
+  get() = String28.str_22670
+
+@ExperimentalResourceApi
+internal val Res.string.str_22671: StringResource
+  get() = String28.str_22671
+
+@ExperimentalResourceApi
+internal val Res.string.str_22672: StringResource
+  get() = String28.str_22672
+
+@ExperimentalResourceApi
+internal val Res.string.str_22673: StringResource
+  get() = String28.str_22673
+
+@ExperimentalResourceApi
+internal val Res.string.str_22674: StringResource
+  get() = String28.str_22674
+
+@ExperimentalResourceApi
+internal val Res.string.str_22675: StringResource
+  get() = String28.str_22675
+
+@ExperimentalResourceApi
+internal val Res.string.str_22676: StringResource
+  get() = String28.str_22676
+
+@ExperimentalResourceApi
+internal val Res.string.str_22677: StringResource
+  get() = String28.str_22677
+
+@ExperimentalResourceApi
+internal val Res.string.str_22678: StringResource
+  get() = String28.str_22678
+
+@ExperimentalResourceApi
+internal val Res.string.str_22679: StringResource
+  get() = String28.str_22679
+
+@ExperimentalResourceApi
+internal val Res.string.str_2268: StringResource
+  get() = String28.str_2268
+
+@ExperimentalResourceApi
+internal val Res.string.str_22680: StringResource
+  get() = String28.str_22680
+
+@ExperimentalResourceApi
+internal val Res.string.str_22681: StringResource
+  get() = String28.str_22681
+
+@ExperimentalResourceApi
+internal val Res.string.str_22682: StringResource
+  get() = String28.str_22682
+
+@ExperimentalResourceApi
+internal val Res.string.str_22683: StringResource
+  get() = String28.str_22683
+
+@ExperimentalResourceApi
+internal val Res.string.str_22684: StringResource
+  get() = String28.str_22684
+
+@ExperimentalResourceApi
+internal val Res.string.str_22685: StringResource
+  get() = String28.str_22685
+
+@ExperimentalResourceApi
+internal val Res.string.str_22686: StringResource
+  get() = String28.str_22686
+
+@ExperimentalResourceApi
+internal val Res.string.str_22687: StringResource
+  get() = String28.str_22687
+
+@ExperimentalResourceApi
+internal val Res.string.str_22688: StringResource
+  get() = String28.str_22688
+
+@ExperimentalResourceApi
+internal val Res.string.str_22689: StringResource
+  get() = String28.str_22689
+
+@ExperimentalResourceApi
+internal val Res.string.str_2269: StringResource
+  get() = String28.str_2269
+
+@ExperimentalResourceApi
+internal val Res.string.str_22690: StringResource
+  get() = String28.str_22690
+
+@ExperimentalResourceApi
+internal val Res.string.str_22691: StringResource
+  get() = String28.str_22691
+
+@ExperimentalResourceApi
+internal val Res.string.str_22692: StringResource
+  get() = String28.str_22692
+
+@ExperimentalResourceApi
+internal val Res.string.str_22693: StringResource
+  get() = String28.str_22693
+
+@ExperimentalResourceApi
+internal val Res.string.str_22694: StringResource
+  get() = String28.str_22694
+
+@ExperimentalResourceApi
+internal val Res.string.str_22695: StringResource
+  get() = String28.str_22695
+
+@ExperimentalResourceApi
+internal val Res.string.str_22696: StringResource
+  get() = String28.str_22696
+
+@ExperimentalResourceApi
+internal val Res.string.str_22697: StringResource
+  get() = String28.str_22697
+
+@ExperimentalResourceApi
+internal val Res.string.str_22698: StringResource
+  get() = String28.str_22698
+
+@ExperimentalResourceApi
+internal val Res.string.str_22699: StringResource
+  get() = String28.str_22699
+
+@ExperimentalResourceApi
+internal val Res.string.str_227: StringResource
+  get() = String28.str_227
+
+@ExperimentalResourceApi
+internal val Res.string.str_2270: StringResource
+  get() = String28.str_2270
+
+@ExperimentalResourceApi
+internal val Res.string.str_22700: StringResource
+  get() = String28.str_22700
+
+@ExperimentalResourceApi
+internal val Res.string.str_22701: StringResource
+  get() = String28.str_22701
+
+@ExperimentalResourceApi
+internal val Res.string.str_22702: StringResource
+  get() = String28.str_22702
+
+@ExperimentalResourceApi
+internal val Res.string.str_22703: StringResource
+  get() = String28.str_22703
+
+@ExperimentalResourceApi
+internal val Res.string.str_22704: StringResource
+  get() = String28.str_22704
+
+@ExperimentalResourceApi
+internal val Res.string.str_22705: StringResource
+  get() = String28.str_22705
+
+@ExperimentalResourceApi
+internal val Res.string.str_22706: StringResource
+  get() = String28.str_22706
+
+@ExperimentalResourceApi
+internal val Res.string.str_22707: StringResource
+  get() = String28.str_22707
+
+@ExperimentalResourceApi
+internal val Res.string.str_22708: StringResource
+  get() = String28.str_22708
+
+@ExperimentalResourceApi
+internal val Res.string.str_22709: StringResource
+  get() = String28.str_22709
+
+@ExperimentalResourceApi
+internal val Res.string.str_2271: StringResource
+  get() = String28.str_2271
+
+@ExperimentalResourceApi
+internal val Res.string.str_22710: StringResource
+  get() = String28.str_22710
+
+@ExperimentalResourceApi
+internal val Res.string.str_22711: StringResource
+  get() = String28.str_22711
+
+@ExperimentalResourceApi
+internal val Res.string.str_22712: StringResource
+  get() = String28.str_22712
+
+@ExperimentalResourceApi
+internal val Res.string.str_22713: StringResource
+  get() = String28.str_22713
+
+@ExperimentalResourceApi
+internal val Res.string.str_22714: StringResource
+  get() = String28.str_22714
+
+@ExperimentalResourceApi
+internal val Res.string.str_22715: StringResource
+  get() = String28.str_22715
+
+@ExperimentalResourceApi
+internal val Res.string.str_22716: StringResource
+  get() = String28.str_22716
+
+@ExperimentalResourceApi
+internal val Res.string.str_22717: StringResource
+  get() = String28.str_22717
+
+@ExperimentalResourceApi
+internal val Res.string.str_22718: StringResource
+  get() = String28.str_22718
+
+@ExperimentalResourceApi
+internal val Res.string.str_22719: StringResource
+  get() = String28.str_22719
+
+@ExperimentalResourceApi
+internal val Res.string.str_2272: StringResource
+  get() = String28.str_2272
+
+@ExperimentalResourceApi
+internal val Res.string.str_22720: StringResource
+  get() = String28.str_22720
+
+@ExperimentalResourceApi
+internal val Res.string.str_22721: StringResource
+  get() = String28.str_22721
+
+@ExperimentalResourceApi
+internal val Res.string.str_22722: StringResource
+  get() = String28.str_22722
+
+@ExperimentalResourceApi
+internal val Res.string.str_22723: StringResource
+  get() = String28.str_22723
+
+@ExperimentalResourceApi
+internal val Res.string.str_22724: StringResource
+  get() = String28.str_22724
+
+@ExperimentalResourceApi
+internal val Res.string.str_22725: StringResource
+  get() = String28.str_22725
+
+@ExperimentalResourceApi
+internal val Res.string.str_22726: StringResource
+  get() = String28.str_22726
+
+@ExperimentalResourceApi
+internal val Res.string.str_22727: StringResource
+  get() = String28.str_22727
+
+@ExperimentalResourceApi
+internal val Res.string.str_22728: StringResource
+  get() = String28.str_22728
+
+@ExperimentalResourceApi
+internal val Res.string.str_22729: StringResource
+  get() = String28.str_22729
+
+@ExperimentalResourceApi
+internal val Res.string.str_2273: StringResource
+  get() = String28.str_2273
+
+@ExperimentalResourceApi
+internal val Res.string.str_22730: StringResource
+  get() = String28.str_22730
+
+@ExperimentalResourceApi
+internal val Res.string.str_22731: StringResource
+  get() = String28.str_22731
+
+@ExperimentalResourceApi
+internal val Res.string.str_22732: StringResource
+  get() = String28.str_22732
+
+@ExperimentalResourceApi
+internal val Res.string.str_22733: StringResource
+  get() = String28.str_22733
+
+@ExperimentalResourceApi
+internal val Res.string.str_22734: StringResource
+  get() = String28.str_22734
+
+@ExperimentalResourceApi
+internal val Res.string.str_22735: StringResource
+  get() = String28.str_22735
+
+@ExperimentalResourceApi
+internal val Res.string.str_22736: StringResource
+  get() = String28.str_22736
+
+@ExperimentalResourceApi
+internal val Res.string.str_22737: StringResource
+  get() = String28.str_22737
+
+@ExperimentalResourceApi
+internal val Res.string.str_22738: StringResource
+  get() = String28.str_22738
+
+@ExperimentalResourceApi
+internal val Res.string.str_22739: StringResource
+  get() = String28.str_22739
+
+@ExperimentalResourceApi
+internal val Res.string.str_2274: StringResource
+  get() = String28.str_2274
+
+@ExperimentalResourceApi
+internal val Res.string.str_22740: StringResource
+  get() = String28.str_22740
+
+@ExperimentalResourceApi
+internal val Res.string.str_22741: StringResource
+  get() = String28.str_22741
+
+@ExperimentalResourceApi
+internal val Res.string.str_22742: StringResource
+  get() = String28.str_22742
+
+@ExperimentalResourceApi
+internal val Res.string.str_22743: StringResource
+  get() = String28.str_22743
+
+@ExperimentalResourceApi
+internal val Res.string.str_22744: StringResource
+  get() = String28.str_22744
+
+@ExperimentalResourceApi
+internal val Res.string.str_22745: StringResource
+  get() = String28.str_22745
+
+@ExperimentalResourceApi
+internal val Res.string.str_22746: StringResource
+  get() = String28.str_22746
+
+@ExperimentalResourceApi
+internal val Res.string.str_22747: StringResource
+  get() = String28.str_22747
+
+@ExperimentalResourceApi
+internal val Res.string.str_22748: StringResource
+  get() = String28.str_22748
+
+@ExperimentalResourceApi
+internal val Res.string.str_22749: StringResource
+  get() = String28.str_22749
+
+@ExperimentalResourceApi
+internal val Res.string.str_2275: StringResource
+  get() = String28.str_2275
+
+@ExperimentalResourceApi
+internal val Res.string.str_22750: StringResource
+  get() = String28.str_22750
+
+@ExperimentalResourceApi
+internal val Res.string.str_22751: StringResource
+  get() = String28.str_22751
+
+@ExperimentalResourceApi
+internal val Res.string.str_22752: StringResource
+  get() = String28.str_22752
+
+@ExperimentalResourceApi
+internal val Res.string.str_22753: StringResource
+  get() = String28.str_22753
+
+@ExperimentalResourceApi
+internal val Res.string.str_22754: StringResource
+  get() = String28.str_22754
+
+@ExperimentalResourceApi
+internal val Res.string.str_22755: StringResource
+  get() = String28.str_22755
+
+@ExperimentalResourceApi
+internal val Res.string.str_22756: StringResource
+  get() = String28.str_22756
+
+@ExperimentalResourceApi
+internal val Res.string.str_22757: StringResource
+  get() = String28.str_22757
+
+@ExperimentalResourceApi
+internal val Res.string.str_22758: StringResource
+  get() = String28.str_22758
+
+@ExperimentalResourceApi
+internal val Res.string.str_22759: StringResource
+  get() = String28.str_22759
+
+@ExperimentalResourceApi
+internal val Res.string.str_2276: StringResource
+  get() = String28.str_2276
+
+@ExperimentalResourceApi
+internal val Res.string.str_22760: StringResource
+  get() = String28.str_22760
+
+@ExperimentalResourceApi
+internal val Res.string.str_22761: StringResource
+  get() = String28.str_22761
+
+@ExperimentalResourceApi
+internal val Res.string.str_22762: StringResource
+  get() = String28.str_22762
+
+@ExperimentalResourceApi
+internal val Res.string.str_22763: StringResource
+  get() = String28.str_22763
+
+@ExperimentalResourceApi
+internal val Res.string.str_22764: StringResource
+  get() = String28.str_22764
+
+@ExperimentalResourceApi
+internal val Res.string.str_22765: StringResource
+  get() = String28.str_22765
+
+@ExperimentalResourceApi
+internal val Res.string.str_22766: StringResource
+  get() = String28.str_22766
+
+@ExperimentalResourceApi
+internal val Res.string.str_22767: StringResource
+  get() = String28.str_22767
+
+@ExperimentalResourceApi
+internal val Res.string.str_22768: StringResource
+  get() = String28.str_22768
+
+@ExperimentalResourceApi
+internal val Res.string.str_22769: StringResource
+  get() = String28.str_22769
+
+@ExperimentalResourceApi
+internal val Res.string.str_2277: StringResource
+  get() = String28.str_2277
+
+@ExperimentalResourceApi
+internal val Res.string.str_22770: StringResource
+  get() = String28.str_22770
+
+@ExperimentalResourceApi
+internal val Res.string.str_22771: StringResource
+  get() = String28.str_22771
+
+@ExperimentalResourceApi
+internal val Res.string.str_22772: StringResource
+  get() = String28.str_22772
+
+@ExperimentalResourceApi
+internal val Res.string.str_22773: StringResource
+  get() = String28.str_22773
+
+@ExperimentalResourceApi
+internal val Res.string.str_22774: StringResource
+  get() = String28.str_22774
+
+@ExperimentalResourceApi
+internal val Res.string.str_22775: StringResource
+  get() = String28.str_22775
+
+@ExperimentalResourceApi
+internal val Res.string.str_22776: StringResource
+  get() = String28.str_22776
+
+@ExperimentalResourceApi
+internal val Res.string.str_22777: StringResource
+  get() = String28.str_22777
+
+@ExperimentalResourceApi
+internal val Res.string.str_22778: StringResource
+  get() = String28.str_22778
+
+@ExperimentalResourceApi
+internal val Res.string.str_22779: StringResource
+  get() = String28.str_22779
+
+@ExperimentalResourceApi
+internal val Res.string.str_2278: StringResource
+  get() = String28.str_2278
+
+@ExperimentalResourceApi
+internal val Res.string.str_22780: StringResource
+  get() = String28.str_22780
+
+@ExperimentalResourceApi
+internal val Res.string.str_22781: StringResource
+  get() = String28.str_22781
+
+@ExperimentalResourceApi
+internal val Res.string.str_22782: StringResource
+  get() = String28.str_22782
+
+@ExperimentalResourceApi
+internal val Res.string.str_22783: StringResource
+  get() = String28.str_22783
+
+@ExperimentalResourceApi
+internal val Res.string.str_22784: StringResource
+  get() = String28.str_22784
+
+@ExperimentalResourceApi
+internal val Res.string.str_22785: StringResource
+  get() = String28.str_22785
+
+@ExperimentalResourceApi
+internal val Res.string.str_22786: StringResource
+  get() = String28.str_22786
+
+@ExperimentalResourceApi
+internal val Res.string.str_22787: StringResource
+  get() = String28.str_22787
+
+@ExperimentalResourceApi
+internal val Res.string.str_22788: StringResource
+  get() = String28.str_22788
+
+@ExperimentalResourceApi
+internal val Res.string.str_22789: StringResource
+  get() = String28.str_22789
+
+@ExperimentalResourceApi
+internal val Res.string.str_2279: StringResource
+  get() = String28.str_2279
+
+@ExperimentalResourceApi
+internal val Res.string.str_22790: StringResource
+  get() = String28.str_22790
+
+@ExperimentalResourceApi
+internal val Res.string.str_22791: StringResource
+  get() = String28.str_22791
+
+@ExperimentalResourceApi
+internal val Res.string.str_22792: StringResource
+  get() = String28.str_22792
+
+@ExperimentalResourceApi
+internal val Res.string.str_22793: StringResource
+  get() = String28.str_22793
+
+@ExperimentalResourceApi
+internal val Res.string.str_22794: StringResource
+  get() = String28.str_22794
+
+@ExperimentalResourceApi
+internal val Res.string.str_22795: StringResource
+  get() = String28.str_22795
+
+@ExperimentalResourceApi
+internal val Res.string.str_22796: StringResource
+  get() = String28.str_22796
+
+@ExperimentalResourceApi
+internal val Res.string.str_22797: StringResource
+  get() = String28.str_22797
+
+@ExperimentalResourceApi
+internal val Res.string.str_22798: StringResource
+  get() = String28.str_22798
+
+@ExperimentalResourceApi
+internal val Res.string.str_22799: StringResource
+  get() = String28.str_22799
+
+@ExperimentalResourceApi
+internal val Res.string.str_228: StringResource
+  get() = String28.str_228
+
+@ExperimentalResourceApi
+internal val Res.string.str_2280: StringResource
+  get() = String28.str_2280
+
+@ExperimentalResourceApi
+internal val Res.string.str_22800: StringResource
+  get() = String28.str_22800
+
+@ExperimentalResourceApi
+internal val Res.string.str_22801: StringResource
+  get() = String28.str_22801
+
+@ExperimentalResourceApi
+internal val Res.string.str_22802: StringResource
+  get() = String28.str_22802
+
+@ExperimentalResourceApi
+internal val Res.string.str_22803: StringResource
+  get() = String28.str_22803
+
+@ExperimentalResourceApi
+internal val Res.string.str_22804: StringResource
+  get() = String28.str_22804
+
+@ExperimentalResourceApi
+internal val Res.string.str_22805: StringResource
+  get() = String28.str_22805
+
+@ExperimentalResourceApi
+internal val Res.string.str_22806: StringResource
+  get() = String28.str_22806
+
+@ExperimentalResourceApi
+internal val Res.string.str_22807: StringResource
+  get() = String28.str_22807
+
+@ExperimentalResourceApi
+internal val Res.string.str_22808: StringResource
+  get() = String28.str_22808
+
+@ExperimentalResourceApi
+internal val Res.string.str_22809: StringResource
+  get() = String28.str_22809
+
+@ExperimentalResourceApi
+internal val Res.string.str_2281: StringResource
+  get() = String28.str_2281
+
+@ExperimentalResourceApi
+internal val Res.string.str_22810: StringResource
+  get() = String28.str_22810
+
+@ExperimentalResourceApi
+internal val Res.string.str_22811: StringResource
+  get() = String28.str_22811
+
+@ExperimentalResourceApi
+internal val Res.string.str_22812: StringResource
+  get() = String28.str_22812
+
+@ExperimentalResourceApi
+internal val Res.string.str_22813: StringResource
+  get() = String28.str_22813
+
+@ExperimentalResourceApi
+internal val Res.string.str_22814: StringResource
+  get() = String28.str_22814
+
+@ExperimentalResourceApi
+internal val Res.string.str_22815: StringResource
+  get() = String28.str_22815
+
+@ExperimentalResourceApi
+internal val Res.string.str_22816: StringResource
+  get() = String28.str_22816
+
+@ExperimentalResourceApi
+internal val Res.string.str_22817: StringResource
+  get() = String28.str_22817
+
+@ExperimentalResourceApi
+internal val Res.string.str_22818: StringResource
+  get() = String28.str_22818
+
+@ExperimentalResourceApi
+internal val Res.string.str_22819: StringResource
+  get() = String28.str_22819
+
+@ExperimentalResourceApi
+internal val Res.string.str_2282: StringResource
+  get() = String28.str_2282
+
+@ExperimentalResourceApi
+internal val Res.string.str_22820: StringResource
+  get() = String28.str_22820
+
+@ExperimentalResourceApi
+internal val Res.string.str_22821: StringResource
+  get() = String28.str_22821
+
+@ExperimentalResourceApi
+internal val Res.string.str_22822: StringResource
+  get() = String28.str_22822
+
+@ExperimentalResourceApi
+internal val Res.string.str_22823: StringResource
+  get() = String28.str_22823
+
+@ExperimentalResourceApi
+internal val Res.string.str_22824: StringResource
+  get() = String28.str_22824
+
+@ExperimentalResourceApi
+internal val Res.string.str_22825: StringResource
+  get() = String28.str_22825
+
+@ExperimentalResourceApi
+internal val Res.string.str_22826: StringResource
+  get() = String28.str_22826
+
+@ExperimentalResourceApi
+internal val Res.string.str_22827: StringResource
+  get() = String28.str_22827
+
+@ExperimentalResourceApi
+internal val Res.string.str_22828: StringResource
+  get() = String28.str_22828
+
+@ExperimentalResourceApi
+internal val Res.string.str_22829: StringResource
+  get() = String28.str_22829
+
+@ExperimentalResourceApi
+internal val Res.string.str_2283: StringResource
+  get() = String28.str_2283
+
+@ExperimentalResourceApi
+internal val Res.string.str_22830: StringResource
+  get() = String28.str_22830
+
+@ExperimentalResourceApi
+internal val Res.string.str_22831: StringResource
+  get() = String28.str_22831
+
+@ExperimentalResourceApi
+internal val Res.string.str_22832: StringResource
+  get() = String28.str_22832
+
+@ExperimentalResourceApi
+internal val Res.string.str_22833: StringResource
+  get() = String28.str_22833
+
+@ExperimentalResourceApi
+internal val Res.string.str_22834: StringResource
+  get() = String28.str_22834
+
+@ExperimentalResourceApi
+internal val Res.string.str_22835: StringResource
+  get() = String28.str_22835
+
+@ExperimentalResourceApi
+internal val Res.string.str_22836: StringResource
+  get() = String28.str_22836
+
+@ExperimentalResourceApi
+internal val Res.string.str_22837: StringResource
+  get() = String28.str_22837
+
+@ExperimentalResourceApi
+internal val Res.string.str_22838: StringResource
+  get() = String28.str_22838
+
+@ExperimentalResourceApi
+internal val Res.string.str_22839: StringResource
+  get() = String28.str_22839
+
+@ExperimentalResourceApi
+internal val Res.string.str_2284: StringResource
+  get() = String28.str_2284
+
+@ExperimentalResourceApi
+internal val Res.string.str_22840: StringResource
+  get() = String28.str_22840
+
+@ExperimentalResourceApi
+internal val Res.string.str_22841: StringResource
+  get() = String28.str_22841
+
+@ExperimentalResourceApi
+internal val Res.string.str_22842: StringResource
+  get() = String28.str_22842
+
+@ExperimentalResourceApi
+internal val Res.string.str_22843: StringResource
+  get() = String28.str_22843
+
+@ExperimentalResourceApi
+internal val Res.string.str_22844: StringResource
+  get() = String28.str_22844
+
+@ExperimentalResourceApi
+internal val Res.string.str_22845: StringResource
+  get() = String28.str_22845
+
+@ExperimentalResourceApi
+internal val Res.string.str_22846: StringResource
+  get() = String28.str_22846
+
+@ExperimentalResourceApi
+internal val Res.string.str_22847: StringResource
+  get() = String28.str_22847
+
+@ExperimentalResourceApi
+internal val Res.string.str_22848: StringResource
+  get() = String28.str_22848
+
+@ExperimentalResourceApi
+internal val Res.string.str_22849: StringResource
+  get() = String28.str_22849
+
+@ExperimentalResourceApi
+internal val Res.string.str_2285: StringResource
+  get() = String28.str_2285
+
+@ExperimentalResourceApi
+internal val Res.string.str_22850: StringResource
+  get() = String28.str_22850
+
+@ExperimentalResourceApi
+internal val Res.string.str_22851: StringResource
+  get() = String28.str_22851
+
+@ExperimentalResourceApi
+internal val Res.string.str_22852: StringResource
+  get() = String28.str_22852
+
+@ExperimentalResourceApi
+internal val Res.string.str_22853: StringResource
+  get() = String28.str_22853
+
+@ExperimentalResourceApi
+internal val Res.string.str_22854: StringResource
+  get() = String28.str_22854
+
+@ExperimentalResourceApi
+internal val Res.string.str_22855: StringResource
+  get() = String28.str_22855
+
+@ExperimentalResourceApi
+internal val Res.string.str_22856: StringResource
+  get() = String28.str_22856
+
+@ExperimentalResourceApi
+internal val Res.string.str_22857: StringResource
+  get() = String28.str_22857
+
+@ExperimentalResourceApi
+internal val Res.string.str_22858: StringResource
+  get() = String28.str_22858
+
+@ExperimentalResourceApi
+internal val Res.string.str_22859: StringResource
+  get() = String28.str_22859
+
+@ExperimentalResourceApi
+internal val Res.string.str_2286: StringResource
+  get() = String28.str_2286
+
+@ExperimentalResourceApi
+internal val Res.string.str_22860: StringResource
+  get() = String28.str_22860
+
+@ExperimentalResourceApi
+internal val Res.string.str_22861: StringResource
+  get() = String28.str_22861
+
+@ExperimentalResourceApi
+internal val Res.string.str_22862: StringResource
+  get() = String28.str_22862
+
+@ExperimentalResourceApi
+internal val Res.string.str_22863: StringResource
+  get() = String28.str_22863
+
+@ExperimentalResourceApi
+internal val Res.string.str_22864: StringResource
+  get() = String28.str_22864
+
+@ExperimentalResourceApi
+internal val Res.string.str_22865: StringResource
+  get() = String28.str_22865
+
+@ExperimentalResourceApi
+internal val Res.string.str_22866: StringResource
+  get() = String28.str_22866
+
+@ExperimentalResourceApi
+internal val Res.string.str_22867: StringResource
+  get() = String28.str_22867
+
+@ExperimentalResourceApi
+internal val Res.string.str_22868: StringResource
+  get() = String28.str_22868
+
+@ExperimentalResourceApi
+internal val Res.string.str_22869: StringResource
+  get() = String28.str_22869
+
+@ExperimentalResourceApi
+internal val Res.string.str_2287: StringResource
+  get() = String28.str_2287
+
+@ExperimentalResourceApi
+internal val Res.string.str_22870: StringResource
+  get() = String28.str_22870
+
+@ExperimentalResourceApi
+internal val Res.string.str_22871: StringResource
+  get() = String28.str_22871
+
+@ExperimentalResourceApi
+internal val Res.string.str_22872: StringResource
+  get() = String28.str_22872
+
+@ExperimentalResourceApi
+internal val Res.string.str_22873: StringResource
+  get() = String28.str_22873
+
+@ExperimentalResourceApi
+internal val Res.string.str_22874: StringResource
+  get() = String28.str_22874
+
+@ExperimentalResourceApi
+internal val Res.string.str_22875: StringResource
+  get() = String28.str_22875
+
+@ExperimentalResourceApi
+internal val Res.string.str_22876: StringResource
+  get() = String28.str_22876
+
+@ExperimentalResourceApi
+internal val Res.string.str_22877: StringResource
+  get() = String28.str_22877
+
+@ExperimentalResourceApi
+internal val Res.string.str_22878: StringResource
+  get() = String28.str_22878
+
+@ExperimentalResourceApi
+internal val Res.string.str_22879: StringResource
+  get() = String28.str_22879
+
+@ExperimentalResourceApi
+internal val Res.string.str_2288: StringResource
+  get() = String28.str_2288
+
+@ExperimentalResourceApi
+internal val Res.string.str_22880: StringResource
+  get() = String28.str_22880
+
+@ExperimentalResourceApi
+internal val Res.string.str_22881: StringResource
+  get() = String28.str_22881
+
+@ExperimentalResourceApi
+internal val Res.string.str_22882: StringResource
+  get() = String28.str_22882
+
+@ExperimentalResourceApi
+internal val Res.string.str_22883: StringResource
+  get() = String28.str_22883
+
+@ExperimentalResourceApi
+internal val Res.string.str_22884: StringResource
+  get() = String28.str_22884
+
+@ExperimentalResourceApi
+internal val Res.string.str_22885: StringResource
+  get() = String28.str_22885
+
+@ExperimentalResourceApi
+internal val Res.string.str_22886: StringResource
+  get() = String28.str_22886
+
+@ExperimentalResourceApi
+internal val Res.string.str_22887: StringResource
+  get() = String28.str_22887
+
+@ExperimentalResourceApi
+internal val Res.string.str_22888: StringResource
+  get() = String28.str_22888
+
+@ExperimentalResourceApi
+internal val Res.string.str_22889: StringResource
+  get() = String28.str_22889
+
+@ExperimentalResourceApi
+internal val Res.string.str_2289: StringResource
+  get() = String28.str_2289
+
+@ExperimentalResourceApi
+internal val Res.string.str_22890: StringResource
+  get() = String28.str_22890
+
+@ExperimentalResourceApi
+internal val Res.string.str_22891: StringResource
+  get() = String28.str_22891
+
+@ExperimentalResourceApi
+internal val Res.string.str_22892: StringResource
+  get() = String28.str_22892
+
+@ExperimentalResourceApi
+internal val Res.string.str_22893: StringResource
+  get() = String28.str_22893
+
+@ExperimentalResourceApi
+internal val Res.string.str_22894: StringResource
+  get() = String28.str_22894
+
+@ExperimentalResourceApi
+internal val Res.string.str_22895: StringResource
+  get() = String28.str_22895
+
+@ExperimentalResourceApi
+internal val Res.string.str_22896: StringResource
+  get() = String28.str_22896
+
+@ExperimentalResourceApi
+internal val Res.string.str_22897: StringResource
+  get() = String28.str_22897
+
+@ExperimentalResourceApi
+internal val Res.string.str_22898: StringResource
+  get() = String28.str_22898
+
+@ExperimentalResourceApi
+internal val Res.string.str_22899: StringResource
+  get() = String28.str_22899
+
+@ExperimentalResourceApi
+internal val Res.string.str_229: StringResource
+  get() = String28.str_229
+
+@ExperimentalResourceApi
+internal val Res.string.str_2290: StringResource
+  get() = String28.str_2290
+
+@ExperimentalResourceApi
+internal val Res.string.str_22900: StringResource
+  get() = String28.str_22900
+
+@ExperimentalResourceApi
+internal val Res.string.str_22901: StringResource
+  get() = String28.str_22901
+
+@ExperimentalResourceApi
+internal val Res.string.str_22902: StringResource
+  get() = String28.str_22902
+
+@ExperimentalResourceApi
+internal val Res.string.str_22903: StringResource
+  get() = String28.str_22903
+
+@ExperimentalResourceApi
+internal val Res.string.str_22904: StringResource
+  get() = String28.str_22904
+
+@ExperimentalResourceApi
+internal val Res.string.str_22905: StringResource
+  get() = String28.str_22905
+
+@ExperimentalResourceApi
+internal val Res.string.str_22906: StringResource
+  get() = String28.str_22906
+
+@ExperimentalResourceApi
+internal val Res.string.str_22907: StringResource
+  get() = String28.str_22907
+
+@ExperimentalResourceApi
+internal val Res.string.str_22908: StringResource
+  get() = String28.str_22908
+
+@ExperimentalResourceApi
+internal val Res.string.str_22909: StringResource
+  get() = String28.str_22909
+
+@ExperimentalResourceApi
+internal val Res.string.str_2291: StringResource
+  get() = String28.str_2291
+
+@ExperimentalResourceApi
+internal val Res.string.str_22910: StringResource
+  get() = String28.str_22910
+
+@ExperimentalResourceApi
+internal val Res.string.str_22911: StringResource
+  get() = String28.str_22911
+
+@ExperimentalResourceApi
+internal val Res.string.str_22912: StringResource
+  get() = String28.str_22912
+
+@ExperimentalResourceApi
+internal val Res.string.str_22913: StringResource
+  get() = String28.str_22913
+
+@ExperimentalResourceApi
+internal val Res.string.str_22914: StringResource
+  get() = String28.str_22914
+
+@ExperimentalResourceApi
+internal val Res.string.str_22915: StringResource
+  get() = String28.str_22915
+
+@ExperimentalResourceApi
+internal val Res.string.str_22916: StringResource
+  get() = String28.str_22916
+
+@ExperimentalResourceApi
+internal val Res.string.str_22917: StringResource
+  get() = String28.str_22917
+
+@ExperimentalResourceApi
+internal val Res.string.str_22918: StringResource
+  get() = String28.str_22918
+
+@ExperimentalResourceApi
+internal val Res.string.str_22919: StringResource
+  get() = String28.str_22919
+
+@ExperimentalResourceApi
+internal val Res.string.str_2292: StringResource
+  get() = String28.str_2292
+
+@ExperimentalResourceApi
+internal val Res.string.str_22920: StringResource
+  get() = String28.str_22920
+
+@ExperimentalResourceApi
+internal val Res.string.str_22921: StringResource
+  get() = String28.str_22921
+
+@ExperimentalResourceApi
+internal val Res.string.str_22922: StringResource
+  get() = String28.str_22922
+
+@ExperimentalResourceApi
+internal val Res.string.str_22923: StringResource
+  get() = String28.str_22923
+
+@ExperimentalResourceApi
+internal val Res.string.str_22924: StringResource
+  get() = String28.str_22924
+
+@ExperimentalResourceApi
+internal val Res.string.str_22925: StringResource
+  get() = String28.str_22925
+
+@ExperimentalResourceApi
+internal val Res.string.str_22926: StringResource
+  get() = String28.str_22926
+
+@ExperimentalResourceApi
+internal val Res.string.str_22927: StringResource
+  get() = String28.str_22927
+
+@ExperimentalResourceApi
+internal val Res.string.str_22928: StringResource
+  get() = String28.str_22928
+
+@ExperimentalResourceApi
+internal val Res.string.str_22929: StringResource
+  get() = String28.str_22929
+
+@ExperimentalResourceApi
+internal val Res.string.str_2293: StringResource
+  get() = String28.str_2293
+
+@ExperimentalResourceApi
+internal val Res.string.str_22930: StringResource
+  get() = String28.str_22930
+
+@ExperimentalResourceApi
+internal val Res.string.str_22931: StringResource
+  get() = String28.str_22931
+
+@ExperimentalResourceApi
+internal val Res.string.str_22932: StringResource
+  get() = String28.str_22932
+
+@ExperimentalResourceApi
+internal val Res.string.str_22933: StringResource
+  get() = String28.str_22933
+
+@ExperimentalResourceApi
+internal val Res.string.str_22934: StringResource
+  get() = String28.str_22934
+
+@ExperimentalResourceApi
+internal val Res.string.str_22935: StringResource
+  get() = String28.str_22935
+
+@ExperimentalResourceApi
+internal val Res.string.str_22936: StringResource
+  get() = String28.str_22936
+
+@ExperimentalResourceApi
+internal val Res.string.str_22937: StringResource
+  get() = String28.str_22937
+
+@ExperimentalResourceApi
+internal val Res.string.str_22938: StringResource
+  get() = String28.str_22938
+
+@ExperimentalResourceApi
+internal val Res.string.str_22939: StringResource
+  get() = String28.str_22939
+
+@ExperimentalResourceApi
+internal val Res.string.str_2294: StringResource
+  get() = String28.str_2294
+
+@ExperimentalResourceApi
+internal val Res.string.str_22940: StringResource
+  get() = String28.str_22940
+
+@ExperimentalResourceApi
+internal val Res.string.str_22941: StringResource
+  get() = String28.str_22941
+
+@ExperimentalResourceApi
+internal val Res.string.str_22942: StringResource
+  get() = String28.str_22942
+
+@ExperimentalResourceApi
+internal val Res.string.str_22943: StringResource
+  get() = String28.str_22943
+
+@ExperimentalResourceApi
+internal val Res.string.str_22944: StringResource
+  get() = String28.str_22944
+
+@ExperimentalResourceApi
+internal val Res.string.str_22945: StringResource
+  get() = String28.str_22945
+
+@ExperimentalResourceApi
+internal val Res.string.str_22946: StringResource
+  get() = String28.str_22946
+
+@ExperimentalResourceApi
+internal val Res.string.str_22947: StringResource
+  get() = String28.str_22947
+
+@ExperimentalResourceApi
+internal val Res.string.str_22948: StringResource
+  get() = String28.str_22948
+
+@ExperimentalResourceApi
+internal val Res.string.str_22949: StringResource
+  get() = String28.str_22949
+
+@ExperimentalResourceApi
+internal val Res.string.str_2295: StringResource
+  get() = String28.str_2295
+
+@ExperimentalResourceApi
+internal val Res.string.str_22950: StringResource
+  get() = String28.str_22950
+
+@ExperimentalResourceApi
+internal val Res.string.str_22951: StringResource
+  get() = String28.str_22951
+
+@ExperimentalResourceApi
+internal val Res.string.str_22952: StringResource
+  get() = String28.str_22952
+
+@ExperimentalResourceApi
+internal val Res.string.str_22953: StringResource
+  get() = String28.str_22953
+
+@ExperimentalResourceApi
+internal val Res.string.str_22954: StringResource
+  get() = String28.str_22954
+
+@ExperimentalResourceApi
+internal val Res.string.str_22955: StringResource
+  get() = String28.str_22955
+
+@ExperimentalResourceApi
+internal val Res.string.str_22956: StringResource
+  get() = String28.str_22956
+
+@ExperimentalResourceApi
+internal val Res.string.str_22957: StringResource
+  get() = String28.str_22957
+
+@ExperimentalResourceApi
+internal val Res.string.str_22958: StringResource
+  get() = String28.str_22958
+
+@ExperimentalResourceApi
+internal val Res.string.str_22959: StringResource
+  get() = String28.str_22959
+
+@ExperimentalResourceApi
+internal val Res.string.str_2296: StringResource
+  get() = String28.str_2296
+
+@ExperimentalResourceApi
+internal val Res.string.str_22960: StringResource
+  get() = String28.str_22960
+
+@ExperimentalResourceApi
+internal val Res.string.str_22961: StringResource
+  get() = String28.str_22961
+
+@ExperimentalResourceApi
+internal val Res.string.str_22962: StringResource
+  get() = String28.str_22962
+
+@ExperimentalResourceApi
+internal val Res.string.str_22963: StringResource
+  get() = String28.str_22963
+
+@ExperimentalResourceApi
+internal val Res.string.str_22964: StringResource
+  get() = String28.str_22964
+
+@ExperimentalResourceApi
+internal val Res.string.str_22965: StringResource
+  get() = String28.str_22965
+
+@ExperimentalResourceApi
+internal val Res.string.str_22966: StringResource
+  get() = String28.str_22966
+
+@ExperimentalResourceApi
+internal val Res.string.str_22967: StringResource
+  get() = String28.str_22967
+
+@ExperimentalResourceApi
+internal val Res.string.str_22968: StringResource
+  get() = String28.str_22968
+
+@ExperimentalResourceApi
+internal val Res.string.str_22969: StringResource
+  get() = String28.str_22969
+
+@ExperimentalResourceApi
+internal val Res.string.str_2297: StringResource
+  get() = String28.str_2297
+
+@ExperimentalResourceApi
+internal val Res.string.str_22970: StringResource
+  get() = String28.str_22970
+
+@ExperimentalResourceApi
+internal val Res.string.str_22971: StringResource
+  get() = String28.str_22971
+
+@ExperimentalResourceApi
+internal val Res.string.str_22972: StringResource
+  get() = String28.str_22972
+
+@ExperimentalResourceApi
+internal val Res.string.str_22973: StringResource
+  get() = String28.str_22973
+
+@ExperimentalResourceApi
+internal val Res.string.str_22974: StringResource
+  get() = String28.str_22974
+
+@ExperimentalResourceApi
+internal val Res.string.str_22975: StringResource
+  get() = String28.str_22975
+
+@ExperimentalResourceApi
+internal val Res.string.str_22976: StringResource
+  get() = String28.str_22976
+
+@ExperimentalResourceApi
+internal val Res.string.str_22977: StringResource
+  get() = String28.str_22977
+
+@ExperimentalResourceApi
+internal val Res.string.str_22978: StringResource
+  get() = String28.str_22978
+
+@ExperimentalResourceApi
+internal val Res.string.str_22979: StringResource
+  get() = String28.str_22979
+
+@ExperimentalResourceApi
+internal val Res.string.str_2298: StringResource
+  get() = String28.str_2298
+
+@ExperimentalResourceApi
+internal val Res.string.str_22980: StringResource
+  get() = String28.str_22980
+
+@ExperimentalResourceApi
+internal val Res.string.str_22981: StringResource
+  get() = String28.str_22981
+
+@ExperimentalResourceApi
+internal val Res.string.str_22982: StringResource
+  get() = String28.str_22982
+
+@ExperimentalResourceApi
+internal val Res.string.str_22983: StringResource
+  get() = String28.str_22983
+
+@ExperimentalResourceApi
+internal val Res.string.str_22984: StringResource
+  get() = String28.str_22984
+
+@ExperimentalResourceApi
+internal val Res.string.str_22985: StringResource
+  get() = String28.str_22985
+
+@ExperimentalResourceApi
+internal val Res.string.str_22986: StringResource
+  get() = String28.str_22986
+
+@ExperimentalResourceApi
+internal val Res.string.str_22987: StringResource
+  get() = String28.str_22987
+
+@ExperimentalResourceApi
+internal val Res.string.str_22988: StringResource
+  get() = String28.str_22988
+
+@ExperimentalResourceApi
+internal val Res.string.str_22989: StringResource
+  get() = String28.str_22989
+
+@ExperimentalResourceApi
+internal val Res.string.str_2299: StringResource
+  get() = String28.str_2299
+
+@ExperimentalResourceApi
+internal val Res.string.str_22990: StringResource
+  get() = String28.str_22990
+
+@ExperimentalResourceApi
+internal val Res.string.str_22991: StringResource
+  get() = String28.str_22991
+
+@ExperimentalResourceApi
+internal val Res.string.str_22992: StringResource
+  get() = String28.str_22992
+
+@ExperimentalResourceApi
+internal val Res.string.str_22993: StringResource
+  get() = String28.str_22993
+
+@ExperimentalResourceApi
+internal val Res.string.str_22994: StringResource
+  get() = String28.str_22994
+
+@ExperimentalResourceApi
+internal val Res.string.str_22995: StringResource
+  get() = String28.str_22995
+
+@ExperimentalResourceApi
+internal val Res.string.str_22996: StringResource
+  get() = String28.str_22996
+
+@ExperimentalResourceApi
+internal val Res.string.str_22997: StringResource
+  get() = String28.str_22997
+
+@ExperimentalResourceApi
+internal val Res.string.str_22998: StringResource
+  get() = String28.str_22998
+
+@ExperimentalResourceApi
+internal val Res.string.str_22999: StringResource
+  get() = String28.str_22999
+
+@ExperimentalResourceApi
+internal val Res.string.str_23: StringResource
+  get() = String28.str_23
+
+@ExperimentalResourceApi
+internal val Res.string.str_230: StringResource
+  get() = String28.str_230
+
+@ExperimentalResourceApi
+internal val Res.string.str_2300: StringResource
+  get() = String28.str_2300
+
+@ExperimentalResourceApi
+internal val Res.string.str_23000: StringResource
+  get() = String28.str_23000
+
+@ExperimentalResourceApi
+internal val Res.string.str_23001: StringResource
+  get() = String28.str_23001
+
+@ExperimentalResourceApi
+internal val Res.string.str_23002: StringResource
+  get() = String28.str_23002
+
+@ExperimentalResourceApi
+internal val Res.string.str_23003: StringResource
+  get() = String28.str_23003
+
+@ExperimentalResourceApi
+internal val Res.string.str_23004: StringResource
+  get() = String28.str_23004
+
+@ExperimentalResourceApi
+internal val Res.string.str_23005: StringResource
+  get() = String28.str_23005
+
+@ExperimentalResourceApi
+internal val Res.string.str_23006: StringResource
+  get() = String28.str_23006
+
+@ExperimentalResourceApi
+internal val Res.string.str_23007: StringResource
+  get() = String28.str_23007
+
+@ExperimentalResourceApi
+internal val Res.string.str_23008: StringResource
+  get() = String28.str_23008
+
+@ExperimentalResourceApi
+internal val Res.string.str_23009: StringResource
+  get() = String28.str_23009
+
+@ExperimentalResourceApi
+internal val Res.string.str_2301: StringResource
+  get() = String28.str_2301
+
+@ExperimentalResourceApi
+internal val Res.string.str_23010: StringResource
+  get() = String28.str_23010
+
+@ExperimentalResourceApi
+internal val Res.string.str_23011: StringResource
+  get() = String28.str_23011
+
+@ExperimentalResourceApi
+internal val Res.string.str_23012: StringResource
+  get() = String28.str_23012
+
+@ExperimentalResourceApi
+internal val Res.string.str_23013: StringResource
+  get() = String28.str_23013
+
+@ExperimentalResourceApi
+internal val Res.string.str_23014: StringResource
+  get() = String28.str_23014
+
+@ExperimentalResourceApi
+internal val Res.string.str_23015: StringResource
+  get() = String28.str_23015
+
+@ExperimentalResourceApi
+internal val Res.string.str_23016: StringResource
+  get() = String28.str_23016
+
+@ExperimentalResourceApi
+internal val Res.string.str_23017: StringResource
+  get() = String28.str_23017
+
+@ExperimentalResourceApi
+internal val Res.string.str_23018: StringResource
+  get() = String28.str_23018
+
+@ExperimentalResourceApi
+internal val Res.string.str_23019: StringResource
+  get() = String28.str_23019
+
+@ExperimentalResourceApi
+internal val Res.string.str_2302: StringResource
+  get() = String28.str_2302
+
+@ExperimentalResourceApi
+internal val Res.string.str_23020: StringResource
+  get() = String28.str_23020
+
+@ExperimentalResourceApi
+internal val Res.string.str_23021: StringResource
+  get() = String28.str_23021
+
+@ExperimentalResourceApi
+internal val Res.string.str_23022: StringResource
+  get() = String28.str_23022
+
+@ExperimentalResourceApi
+internal val Res.string.str_23023: StringResource
+  get() = String28.str_23023
+
+@ExperimentalResourceApi
+internal val Res.string.str_23024: StringResource
+  get() = String28.str_23024
+
+@ExperimentalResourceApi
+internal val Res.string.str_23025: StringResource
+  get() = String28.str_23025
+
+@ExperimentalResourceApi
+internal val Res.string.str_23026: StringResource
+  get() = String28.str_23026
+
+@ExperimentalResourceApi
+internal val Res.string.str_23027: StringResource
+  get() = String28.str_23027
+
+@ExperimentalResourceApi
+internal val Res.string.str_23028: StringResource
+  get() = String28.str_23028
+
+@ExperimentalResourceApi
+internal val Res.string.str_23029: StringResource
+  get() = String28.str_23029
+
+@ExperimentalResourceApi
+internal val Res.string.str_2303: StringResource
+  get() = String28.str_2303
+
+@ExperimentalResourceApi
+internal val Res.string.str_23030: StringResource
+  get() = String28.str_23030
+
+@ExperimentalResourceApi
+internal val Res.string.str_23031: StringResource
+  get() = String28.str_23031
+
+@ExperimentalResourceApi
+internal val Res.string.str_23032: StringResource
+  get() = String28.str_23032
+
+@ExperimentalResourceApi
+internal val Res.string.str_23033: StringResource
+  get() = String28.str_23033
+
+@ExperimentalResourceApi
+internal val Res.string.str_23034: StringResource
+  get() = String28.str_23034
+
+@ExperimentalResourceApi
+internal val Res.string.str_23035: StringResource
+  get() = String28.str_23035
+
+@ExperimentalResourceApi
+internal val Res.string.str_23036: StringResource
+  get() = String28.str_23036
+
+@ExperimentalResourceApi
+internal val Res.string.str_23037: StringResource
+  get() = String28.str_23037
+
+@ExperimentalResourceApi
+internal val Res.string.str_23038: StringResource
+  get() = String28.str_23038
+
+@ExperimentalResourceApi
+internal val Res.string.str_23039: StringResource
+  get() = String28.str_23039
+
+@ExperimentalResourceApi
+internal val Res.string.str_2304: StringResource
+  get() = String28.str_2304
+
+@ExperimentalResourceApi
+internal val Res.string.str_23040: StringResource
+  get() = String28.str_23040
+
+@ExperimentalResourceApi
+internal val Res.string.str_23041: StringResource
+  get() = String28.str_23041
+
+@ExperimentalResourceApi
+internal val Res.string.str_23042: StringResource
+  get() = String28.str_23042
+
+@ExperimentalResourceApi
+internal val Res.string.str_23043: StringResource
+  get() = String28.str_23043
+
+@ExperimentalResourceApi
+internal val Res.string.str_23044: StringResource
+  get() = String28.str_23044
+
+@ExperimentalResourceApi
+internal val Res.string.str_23045: StringResource
+  get() = String28.str_23045
+
+@ExperimentalResourceApi
+internal val Res.string.str_23046: StringResource
+  get() = String28.str_23046

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String29.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String29.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String29 {
+  public val str_23047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23047", "str_23047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23048", "str_23048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23049", "str_23049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2305", "str_2305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23050", "str_23050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23051", "str_23051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23052", "str_23052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23053", "str_23053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23054", "str_23054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23055", "str_23055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23056", "str_23056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23057", "str_23057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23058", "str_23058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23059", "str_23059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2306", "str_2306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23060", "str_23060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23061", "str_23061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23062", "str_23062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23063", "str_23063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23064", "str_23064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23065", "str_23065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23066", "str_23066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23067", "str_23067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23068", "str_23068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23069", "str_23069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2307", "str_2307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23070", "str_23070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23071", "str_23071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23072", "str_23072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23073", "str_23073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23074", "str_23074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23075", "str_23075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23076", "str_23076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23077", "str_23077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23078", "str_23078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23079", "str_23079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2308", "str_2308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23080", "str_23080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23081", "str_23081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23082", "str_23082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23083", "str_23083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23084", "str_23084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23085", "str_23085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23086", "str_23086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23087", "str_23087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23088", "str_23088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23089", "str_23089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2309", "str_2309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23090", "str_23090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23091", "str_23091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23092", "str_23092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23093", "str_23093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23094", "str_23094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23095", "str_23095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23096", "str_23096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23097", "str_23097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23098", "str_23098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23099", "str_23099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_231", "str_231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2310", "str_2310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23100", "str_23100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23101", "str_23101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23102", "str_23102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23103", "str_23103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23104", "str_23104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23105", "str_23105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23106", "str_23106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23107", "str_23107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23108", "str_23108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23109", "str_23109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2311", "str_2311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23110", "str_23110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23111", "str_23111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23112", "str_23112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23113", "str_23113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23114", "str_23114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23115", "str_23115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23116", "str_23116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23117", "str_23117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23118", "str_23118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23119", "str_23119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2312", "str_2312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23120", "str_23120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23121", "str_23121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23122", "str_23122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23123", "str_23123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23124", "str_23124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23125", "str_23125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23126", "str_23126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23127", "str_23127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23128", "str_23128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23129", "str_23129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2313", "str_2313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23130", "str_23130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23131", "str_23131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23132", "str_23132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23133", "str_23133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23134", "str_23134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23135", "str_23135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23136", "str_23136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23137", "str_23137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23138", "str_23138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23139", "str_23139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2314", "str_2314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23140", "str_23140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23141", "str_23141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23142", "str_23142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23143", "str_23143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23144", "str_23144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23145", "str_23145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23146", "str_23146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23147", "str_23147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23148", "str_23148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23149", "str_23149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2315", "str_2315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23150", "str_23150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23151", "str_23151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23152", "str_23152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23153", "str_23153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23154", "str_23154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23155", "str_23155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23156", "str_23156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23157", "str_23157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23158", "str_23158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23159", "str_23159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2316", "str_2316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23160", "str_23160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23161", "str_23161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23162", "str_23162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23163", "str_23163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23164", "str_23164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23165", "str_23165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23166", "str_23166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23167", "str_23167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23168", "str_23168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23169", "str_23169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2317", "str_2317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23170", "str_23170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23171", "str_23171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23172", "str_23172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23173", "str_23173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23174", "str_23174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23175", "str_23175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23176", "str_23176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23177", "str_23177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23178", "str_23178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23179", "str_23179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2318", "str_2318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23180", "str_23180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23181", "str_23181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23182", "str_23182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23183", "str_23183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23184", "str_23184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23185", "str_23185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23186", "str_23186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23187", "str_23187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23188", "str_23188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23189", "str_23189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2319", "str_2319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23190", "str_23190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23191", "str_23191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23192", "str_23192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23193", "str_23193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23194", "str_23194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23195", "str_23195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23196", "str_23196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23197", "str_23197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23198", "str_23198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23199", "str_23199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_232", "str_232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2320", "str_2320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23200", "str_23200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23201", "str_23201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23202", "str_23202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23203", "str_23203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23204", "str_23204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23205", "str_23205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23206", "str_23206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23207", "str_23207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23208", "str_23208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23209", "str_23209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2321", "str_2321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23210", "str_23210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23211", "str_23211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23212", "str_23212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23213", "str_23213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23214", "str_23214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23215", "str_23215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23216", "str_23216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23217", "str_23217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23218", "str_23218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23219", "str_23219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2322", "str_2322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23220", "str_23220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23221", "str_23221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23222", "str_23222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23223", "str_23223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23224", "str_23224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23225", "str_23225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23226", "str_23226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23227", "str_23227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23228", "str_23228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23229", "str_23229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2323", "str_2323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23230", "str_23230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23231", "str_23231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23232", "str_23232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23233", "str_23233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23234", "str_23234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23235", "str_23235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23236", "str_23236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23237", "str_23237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23238", "str_23238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23239", "str_23239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2324", "str_2324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23240", "str_23240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23241", "str_23241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23242", "str_23242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23243", "str_23243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23244", "str_23244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23245", "str_23245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23246", "str_23246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23247", "str_23247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23248", "str_23248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23249", "str_23249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2325", "str_2325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23250", "str_23250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23251", "str_23251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23252", "str_23252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23253", "str_23253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23254", "str_23254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23255", "str_23255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23256", "str_23256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23257", "str_23257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23258", "str_23258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23259", "str_23259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2326", "str_2326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23260", "str_23260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23261", "str_23261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23262", "str_23262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23263", "str_23263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23264", "str_23264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23265", "str_23265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23266", "str_23266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23267", "str_23267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23268", "str_23268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23269", "str_23269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2327", "str_2327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23270", "str_23270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23271", "str_23271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23272", "str_23272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23273", "str_23273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23274", "str_23274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23275", "str_23275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23276", "str_23276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23277", "str_23277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23278", "str_23278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23279", "str_23279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2328", "str_2328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23280", "str_23280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23281", "str_23281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23282", "str_23282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23283", "str_23283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23284", "str_23284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23285", "str_23285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23286", "str_23286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23287", "str_23287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23288", "str_23288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23289", "str_23289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2329", "str_2329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23290", "str_23290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23291", "str_23291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23292", "str_23292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23293", "str_23293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23294", "str_23294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23295", "str_23295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23296", "str_23296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23297", "str_23297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23298", "str_23298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23299", "str_23299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_233", "str_233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2330", "str_2330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23300", "str_23300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23301", "str_23301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23302", "str_23302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23303", "str_23303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23304", "str_23304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23305", "str_23305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23306", "str_23306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23307", "str_23307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23308", "str_23308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23309", "str_23309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2331", "str_2331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23310", "str_23310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23311", "str_23311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23312", "str_23312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23313", "str_23313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23314", "str_23314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23315", "str_23315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23316", "str_23316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23317", "str_23317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23318", "str_23318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23319", "str_23319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2332", "str_2332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23320", "str_23320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23321", "str_23321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23322", "str_23322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23323", "str_23323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23324", "str_23324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23325", "str_23325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23326", "str_23326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23327", "str_23327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23328", "str_23328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23329", "str_23329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2333", "str_2333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23330", "str_23330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23331", "str_23331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23332", "str_23332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23333", "str_23333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23334", "str_23334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23335", "str_23335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23336", "str_23336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23337", "str_23337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23338", "str_23338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23339", "str_23339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2334", "str_2334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23340", "str_23340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23341", "str_23341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23342", "str_23342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23343", "str_23343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23344", "str_23344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23345", "str_23345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23346", "str_23346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23347", "str_23347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23348", "str_23348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23349", "str_23349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2335", "str_2335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23350", "str_23350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23351", "str_23351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23352", "str_23352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23353", "str_23353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23354", "str_23354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23355", "str_23355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23356", "str_23356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23357", "str_23357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23358", "str_23358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23359", "str_23359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2336", "str_2336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23360", "str_23360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23361", "str_23361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23362", "str_23362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23363", "str_23363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23364", "str_23364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23365", "str_23365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23366", "str_23366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23367", "str_23367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23368", "str_23368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23369", "str_23369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2337", "str_2337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23370", "str_23370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23371", "str_23371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23372", "str_23372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23373", "str_23373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23374", "str_23374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23375", "str_23375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23376", "str_23376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23377", "str_23377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23378", "str_23378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23379", "str_23379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2338", "str_2338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23380", "str_23380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23381", "str_23381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23382", "str_23382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23383", "str_23383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23384", "str_23384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23385", "str_23385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23386", "str_23386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23387", "str_23387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23388", "str_23388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23389", "str_23389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2339", "str_2339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23390", "str_23390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23391", "str_23391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23392", "str_23392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23393", "str_23393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23394", "str_23394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23395", "str_23395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23396", "str_23396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23397", "str_23397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23398", "str_23398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23399", "str_23399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_234", "str_234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2340", "str_2340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23400", "str_23400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23401", "str_23401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23402", "str_23402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23403", "str_23403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23404", "str_23404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23405", "str_23405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23406", "str_23406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23407", "str_23407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23408", "str_23408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23409", "str_23409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2341", "str_2341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23410", "str_23410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23411", "str_23411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23412", "str_23412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23413", "str_23413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23414", "str_23414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23415", "str_23415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23416", "str_23416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23417", "str_23417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23418", "str_23418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23419", "str_23419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2342", "str_2342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23420", "str_23420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23421", "str_23421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23422", "str_23422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23423", "str_23423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23424", "str_23424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23425", "str_23425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23426", "str_23426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23427", "str_23427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23428", "str_23428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23429", "str_23429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2343", "str_2343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23430", "str_23430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23431", "str_23431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23432", "str_23432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23433", "str_23433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23434", "str_23434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23435", "str_23435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23436", "str_23436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23437", "str_23437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23438", "str_23438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23439", "str_23439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2344", "str_2344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23440", "str_23440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23441", "str_23441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23442", "str_23442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23443", "str_23443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23444", "str_23444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23445", "str_23445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23446", "str_23446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23447", "str_23447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23448", "str_23448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23449", "str_23449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2345", "str_2345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23450", "str_23450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23451", "str_23451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23452", "str_23452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23453", "str_23453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23454", "str_23454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23455", "str_23455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23456", "str_23456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23457", "str_23457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23458", "str_23458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23459", "str_23459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2346", "str_2346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23460", "str_23460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23461", "str_23461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23462", "str_23462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23463", "str_23463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23464", "str_23464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23465", "str_23465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23466", "str_23466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23467", "str_23467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23468", "str_23468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23469", "str_23469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2347", "str_2347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23470", "str_23470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23471", "str_23471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23472", "str_23472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23473", "str_23473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23474", "str_23474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23475", "str_23475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23476", "str_23476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23477", "str_23477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23478", "str_23478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23479", "str_23479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2348", "str_2348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23480", "str_23480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23481", "str_23481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23482", "str_23482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23483", "str_23483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23484", "str_23484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23485", "str_23485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23486", "str_23486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23487", "str_23487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23488", "str_23488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23489", "str_23489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2349", "str_2349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23490", "str_23490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23491", "str_23491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23492", "str_23492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23493", "str_23493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23494", "str_23494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23495", "str_23495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23496", "str_23496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23497", "str_23497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_23047: StringResource
+  get() = String29.str_23047
+
+@ExperimentalResourceApi
+internal val Res.string.str_23048: StringResource
+  get() = String29.str_23048
+
+@ExperimentalResourceApi
+internal val Res.string.str_23049: StringResource
+  get() = String29.str_23049
+
+@ExperimentalResourceApi
+internal val Res.string.str_2305: StringResource
+  get() = String29.str_2305
+
+@ExperimentalResourceApi
+internal val Res.string.str_23050: StringResource
+  get() = String29.str_23050
+
+@ExperimentalResourceApi
+internal val Res.string.str_23051: StringResource
+  get() = String29.str_23051
+
+@ExperimentalResourceApi
+internal val Res.string.str_23052: StringResource
+  get() = String29.str_23052
+
+@ExperimentalResourceApi
+internal val Res.string.str_23053: StringResource
+  get() = String29.str_23053
+
+@ExperimentalResourceApi
+internal val Res.string.str_23054: StringResource
+  get() = String29.str_23054
+
+@ExperimentalResourceApi
+internal val Res.string.str_23055: StringResource
+  get() = String29.str_23055
+
+@ExperimentalResourceApi
+internal val Res.string.str_23056: StringResource
+  get() = String29.str_23056
+
+@ExperimentalResourceApi
+internal val Res.string.str_23057: StringResource
+  get() = String29.str_23057
+
+@ExperimentalResourceApi
+internal val Res.string.str_23058: StringResource
+  get() = String29.str_23058
+
+@ExperimentalResourceApi
+internal val Res.string.str_23059: StringResource
+  get() = String29.str_23059
+
+@ExperimentalResourceApi
+internal val Res.string.str_2306: StringResource
+  get() = String29.str_2306
+
+@ExperimentalResourceApi
+internal val Res.string.str_23060: StringResource
+  get() = String29.str_23060
+
+@ExperimentalResourceApi
+internal val Res.string.str_23061: StringResource
+  get() = String29.str_23061
+
+@ExperimentalResourceApi
+internal val Res.string.str_23062: StringResource
+  get() = String29.str_23062
+
+@ExperimentalResourceApi
+internal val Res.string.str_23063: StringResource
+  get() = String29.str_23063
+
+@ExperimentalResourceApi
+internal val Res.string.str_23064: StringResource
+  get() = String29.str_23064
+
+@ExperimentalResourceApi
+internal val Res.string.str_23065: StringResource
+  get() = String29.str_23065
+
+@ExperimentalResourceApi
+internal val Res.string.str_23066: StringResource
+  get() = String29.str_23066
+
+@ExperimentalResourceApi
+internal val Res.string.str_23067: StringResource
+  get() = String29.str_23067
+
+@ExperimentalResourceApi
+internal val Res.string.str_23068: StringResource
+  get() = String29.str_23068
+
+@ExperimentalResourceApi
+internal val Res.string.str_23069: StringResource
+  get() = String29.str_23069
+
+@ExperimentalResourceApi
+internal val Res.string.str_2307: StringResource
+  get() = String29.str_2307
+
+@ExperimentalResourceApi
+internal val Res.string.str_23070: StringResource
+  get() = String29.str_23070
+
+@ExperimentalResourceApi
+internal val Res.string.str_23071: StringResource
+  get() = String29.str_23071
+
+@ExperimentalResourceApi
+internal val Res.string.str_23072: StringResource
+  get() = String29.str_23072
+
+@ExperimentalResourceApi
+internal val Res.string.str_23073: StringResource
+  get() = String29.str_23073
+
+@ExperimentalResourceApi
+internal val Res.string.str_23074: StringResource
+  get() = String29.str_23074
+
+@ExperimentalResourceApi
+internal val Res.string.str_23075: StringResource
+  get() = String29.str_23075
+
+@ExperimentalResourceApi
+internal val Res.string.str_23076: StringResource
+  get() = String29.str_23076
+
+@ExperimentalResourceApi
+internal val Res.string.str_23077: StringResource
+  get() = String29.str_23077
+
+@ExperimentalResourceApi
+internal val Res.string.str_23078: StringResource
+  get() = String29.str_23078
+
+@ExperimentalResourceApi
+internal val Res.string.str_23079: StringResource
+  get() = String29.str_23079
+
+@ExperimentalResourceApi
+internal val Res.string.str_2308: StringResource
+  get() = String29.str_2308
+
+@ExperimentalResourceApi
+internal val Res.string.str_23080: StringResource
+  get() = String29.str_23080
+
+@ExperimentalResourceApi
+internal val Res.string.str_23081: StringResource
+  get() = String29.str_23081
+
+@ExperimentalResourceApi
+internal val Res.string.str_23082: StringResource
+  get() = String29.str_23082
+
+@ExperimentalResourceApi
+internal val Res.string.str_23083: StringResource
+  get() = String29.str_23083
+
+@ExperimentalResourceApi
+internal val Res.string.str_23084: StringResource
+  get() = String29.str_23084
+
+@ExperimentalResourceApi
+internal val Res.string.str_23085: StringResource
+  get() = String29.str_23085
+
+@ExperimentalResourceApi
+internal val Res.string.str_23086: StringResource
+  get() = String29.str_23086
+
+@ExperimentalResourceApi
+internal val Res.string.str_23087: StringResource
+  get() = String29.str_23087
+
+@ExperimentalResourceApi
+internal val Res.string.str_23088: StringResource
+  get() = String29.str_23088
+
+@ExperimentalResourceApi
+internal val Res.string.str_23089: StringResource
+  get() = String29.str_23089
+
+@ExperimentalResourceApi
+internal val Res.string.str_2309: StringResource
+  get() = String29.str_2309
+
+@ExperimentalResourceApi
+internal val Res.string.str_23090: StringResource
+  get() = String29.str_23090
+
+@ExperimentalResourceApi
+internal val Res.string.str_23091: StringResource
+  get() = String29.str_23091
+
+@ExperimentalResourceApi
+internal val Res.string.str_23092: StringResource
+  get() = String29.str_23092
+
+@ExperimentalResourceApi
+internal val Res.string.str_23093: StringResource
+  get() = String29.str_23093
+
+@ExperimentalResourceApi
+internal val Res.string.str_23094: StringResource
+  get() = String29.str_23094
+
+@ExperimentalResourceApi
+internal val Res.string.str_23095: StringResource
+  get() = String29.str_23095
+
+@ExperimentalResourceApi
+internal val Res.string.str_23096: StringResource
+  get() = String29.str_23096
+
+@ExperimentalResourceApi
+internal val Res.string.str_23097: StringResource
+  get() = String29.str_23097
+
+@ExperimentalResourceApi
+internal val Res.string.str_23098: StringResource
+  get() = String29.str_23098
+
+@ExperimentalResourceApi
+internal val Res.string.str_23099: StringResource
+  get() = String29.str_23099
+
+@ExperimentalResourceApi
+internal val Res.string.str_231: StringResource
+  get() = String29.str_231
+
+@ExperimentalResourceApi
+internal val Res.string.str_2310: StringResource
+  get() = String29.str_2310
+
+@ExperimentalResourceApi
+internal val Res.string.str_23100: StringResource
+  get() = String29.str_23100
+
+@ExperimentalResourceApi
+internal val Res.string.str_23101: StringResource
+  get() = String29.str_23101
+
+@ExperimentalResourceApi
+internal val Res.string.str_23102: StringResource
+  get() = String29.str_23102
+
+@ExperimentalResourceApi
+internal val Res.string.str_23103: StringResource
+  get() = String29.str_23103
+
+@ExperimentalResourceApi
+internal val Res.string.str_23104: StringResource
+  get() = String29.str_23104
+
+@ExperimentalResourceApi
+internal val Res.string.str_23105: StringResource
+  get() = String29.str_23105
+
+@ExperimentalResourceApi
+internal val Res.string.str_23106: StringResource
+  get() = String29.str_23106
+
+@ExperimentalResourceApi
+internal val Res.string.str_23107: StringResource
+  get() = String29.str_23107
+
+@ExperimentalResourceApi
+internal val Res.string.str_23108: StringResource
+  get() = String29.str_23108
+
+@ExperimentalResourceApi
+internal val Res.string.str_23109: StringResource
+  get() = String29.str_23109
+
+@ExperimentalResourceApi
+internal val Res.string.str_2311: StringResource
+  get() = String29.str_2311
+
+@ExperimentalResourceApi
+internal val Res.string.str_23110: StringResource
+  get() = String29.str_23110
+
+@ExperimentalResourceApi
+internal val Res.string.str_23111: StringResource
+  get() = String29.str_23111
+
+@ExperimentalResourceApi
+internal val Res.string.str_23112: StringResource
+  get() = String29.str_23112
+
+@ExperimentalResourceApi
+internal val Res.string.str_23113: StringResource
+  get() = String29.str_23113
+
+@ExperimentalResourceApi
+internal val Res.string.str_23114: StringResource
+  get() = String29.str_23114
+
+@ExperimentalResourceApi
+internal val Res.string.str_23115: StringResource
+  get() = String29.str_23115
+
+@ExperimentalResourceApi
+internal val Res.string.str_23116: StringResource
+  get() = String29.str_23116
+
+@ExperimentalResourceApi
+internal val Res.string.str_23117: StringResource
+  get() = String29.str_23117
+
+@ExperimentalResourceApi
+internal val Res.string.str_23118: StringResource
+  get() = String29.str_23118
+
+@ExperimentalResourceApi
+internal val Res.string.str_23119: StringResource
+  get() = String29.str_23119
+
+@ExperimentalResourceApi
+internal val Res.string.str_2312: StringResource
+  get() = String29.str_2312
+
+@ExperimentalResourceApi
+internal val Res.string.str_23120: StringResource
+  get() = String29.str_23120
+
+@ExperimentalResourceApi
+internal val Res.string.str_23121: StringResource
+  get() = String29.str_23121
+
+@ExperimentalResourceApi
+internal val Res.string.str_23122: StringResource
+  get() = String29.str_23122
+
+@ExperimentalResourceApi
+internal val Res.string.str_23123: StringResource
+  get() = String29.str_23123
+
+@ExperimentalResourceApi
+internal val Res.string.str_23124: StringResource
+  get() = String29.str_23124
+
+@ExperimentalResourceApi
+internal val Res.string.str_23125: StringResource
+  get() = String29.str_23125
+
+@ExperimentalResourceApi
+internal val Res.string.str_23126: StringResource
+  get() = String29.str_23126
+
+@ExperimentalResourceApi
+internal val Res.string.str_23127: StringResource
+  get() = String29.str_23127
+
+@ExperimentalResourceApi
+internal val Res.string.str_23128: StringResource
+  get() = String29.str_23128
+
+@ExperimentalResourceApi
+internal val Res.string.str_23129: StringResource
+  get() = String29.str_23129
+
+@ExperimentalResourceApi
+internal val Res.string.str_2313: StringResource
+  get() = String29.str_2313
+
+@ExperimentalResourceApi
+internal val Res.string.str_23130: StringResource
+  get() = String29.str_23130
+
+@ExperimentalResourceApi
+internal val Res.string.str_23131: StringResource
+  get() = String29.str_23131
+
+@ExperimentalResourceApi
+internal val Res.string.str_23132: StringResource
+  get() = String29.str_23132
+
+@ExperimentalResourceApi
+internal val Res.string.str_23133: StringResource
+  get() = String29.str_23133
+
+@ExperimentalResourceApi
+internal val Res.string.str_23134: StringResource
+  get() = String29.str_23134
+
+@ExperimentalResourceApi
+internal val Res.string.str_23135: StringResource
+  get() = String29.str_23135
+
+@ExperimentalResourceApi
+internal val Res.string.str_23136: StringResource
+  get() = String29.str_23136
+
+@ExperimentalResourceApi
+internal val Res.string.str_23137: StringResource
+  get() = String29.str_23137
+
+@ExperimentalResourceApi
+internal val Res.string.str_23138: StringResource
+  get() = String29.str_23138
+
+@ExperimentalResourceApi
+internal val Res.string.str_23139: StringResource
+  get() = String29.str_23139
+
+@ExperimentalResourceApi
+internal val Res.string.str_2314: StringResource
+  get() = String29.str_2314
+
+@ExperimentalResourceApi
+internal val Res.string.str_23140: StringResource
+  get() = String29.str_23140
+
+@ExperimentalResourceApi
+internal val Res.string.str_23141: StringResource
+  get() = String29.str_23141
+
+@ExperimentalResourceApi
+internal val Res.string.str_23142: StringResource
+  get() = String29.str_23142
+
+@ExperimentalResourceApi
+internal val Res.string.str_23143: StringResource
+  get() = String29.str_23143
+
+@ExperimentalResourceApi
+internal val Res.string.str_23144: StringResource
+  get() = String29.str_23144
+
+@ExperimentalResourceApi
+internal val Res.string.str_23145: StringResource
+  get() = String29.str_23145
+
+@ExperimentalResourceApi
+internal val Res.string.str_23146: StringResource
+  get() = String29.str_23146
+
+@ExperimentalResourceApi
+internal val Res.string.str_23147: StringResource
+  get() = String29.str_23147
+
+@ExperimentalResourceApi
+internal val Res.string.str_23148: StringResource
+  get() = String29.str_23148
+
+@ExperimentalResourceApi
+internal val Res.string.str_23149: StringResource
+  get() = String29.str_23149
+
+@ExperimentalResourceApi
+internal val Res.string.str_2315: StringResource
+  get() = String29.str_2315
+
+@ExperimentalResourceApi
+internal val Res.string.str_23150: StringResource
+  get() = String29.str_23150
+
+@ExperimentalResourceApi
+internal val Res.string.str_23151: StringResource
+  get() = String29.str_23151
+
+@ExperimentalResourceApi
+internal val Res.string.str_23152: StringResource
+  get() = String29.str_23152
+
+@ExperimentalResourceApi
+internal val Res.string.str_23153: StringResource
+  get() = String29.str_23153
+
+@ExperimentalResourceApi
+internal val Res.string.str_23154: StringResource
+  get() = String29.str_23154
+
+@ExperimentalResourceApi
+internal val Res.string.str_23155: StringResource
+  get() = String29.str_23155
+
+@ExperimentalResourceApi
+internal val Res.string.str_23156: StringResource
+  get() = String29.str_23156
+
+@ExperimentalResourceApi
+internal val Res.string.str_23157: StringResource
+  get() = String29.str_23157
+
+@ExperimentalResourceApi
+internal val Res.string.str_23158: StringResource
+  get() = String29.str_23158
+
+@ExperimentalResourceApi
+internal val Res.string.str_23159: StringResource
+  get() = String29.str_23159
+
+@ExperimentalResourceApi
+internal val Res.string.str_2316: StringResource
+  get() = String29.str_2316
+
+@ExperimentalResourceApi
+internal val Res.string.str_23160: StringResource
+  get() = String29.str_23160
+
+@ExperimentalResourceApi
+internal val Res.string.str_23161: StringResource
+  get() = String29.str_23161
+
+@ExperimentalResourceApi
+internal val Res.string.str_23162: StringResource
+  get() = String29.str_23162
+
+@ExperimentalResourceApi
+internal val Res.string.str_23163: StringResource
+  get() = String29.str_23163
+
+@ExperimentalResourceApi
+internal val Res.string.str_23164: StringResource
+  get() = String29.str_23164
+
+@ExperimentalResourceApi
+internal val Res.string.str_23165: StringResource
+  get() = String29.str_23165
+
+@ExperimentalResourceApi
+internal val Res.string.str_23166: StringResource
+  get() = String29.str_23166
+
+@ExperimentalResourceApi
+internal val Res.string.str_23167: StringResource
+  get() = String29.str_23167
+
+@ExperimentalResourceApi
+internal val Res.string.str_23168: StringResource
+  get() = String29.str_23168
+
+@ExperimentalResourceApi
+internal val Res.string.str_23169: StringResource
+  get() = String29.str_23169
+
+@ExperimentalResourceApi
+internal val Res.string.str_2317: StringResource
+  get() = String29.str_2317
+
+@ExperimentalResourceApi
+internal val Res.string.str_23170: StringResource
+  get() = String29.str_23170
+
+@ExperimentalResourceApi
+internal val Res.string.str_23171: StringResource
+  get() = String29.str_23171
+
+@ExperimentalResourceApi
+internal val Res.string.str_23172: StringResource
+  get() = String29.str_23172
+
+@ExperimentalResourceApi
+internal val Res.string.str_23173: StringResource
+  get() = String29.str_23173
+
+@ExperimentalResourceApi
+internal val Res.string.str_23174: StringResource
+  get() = String29.str_23174
+
+@ExperimentalResourceApi
+internal val Res.string.str_23175: StringResource
+  get() = String29.str_23175
+
+@ExperimentalResourceApi
+internal val Res.string.str_23176: StringResource
+  get() = String29.str_23176
+
+@ExperimentalResourceApi
+internal val Res.string.str_23177: StringResource
+  get() = String29.str_23177
+
+@ExperimentalResourceApi
+internal val Res.string.str_23178: StringResource
+  get() = String29.str_23178
+
+@ExperimentalResourceApi
+internal val Res.string.str_23179: StringResource
+  get() = String29.str_23179
+
+@ExperimentalResourceApi
+internal val Res.string.str_2318: StringResource
+  get() = String29.str_2318
+
+@ExperimentalResourceApi
+internal val Res.string.str_23180: StringResource
+  get() = String29.str_23180
+
+@ExperimentalResourceApi
+internal val Res.string.str_23181: StringResource
+  get() = String29.str_23181
+
+@ExperimentalResourceApi
+internal val Res.string.str_23182: StringResource
+  get() = String29.str_23182
+
+@ExperimentalResourceApi
+internal val Res.string.str_23183: StringResource
+  get() = String29.str_23183
+
+@ExperimentalResourceApi
+internal val Res.string.str_23184: StringResource
+  get() = String29.str_23184
+
+@ExperimentalResourceApi
+internal val Res.string.str_23185: StringResource
+  get() = String29.str_23185
+
+@ExperimentalResourceApi
+internal val Res.string.str_23186: StringResource
+  get() = String29.str_23186
+
+@ExperimentalResourceApi
+internal val Res.string.str_23187: StringResource
+  get() = String29.str_23187
+
+@ExperimentalResourceApi
+internal val Res.string.str_23188: StringResource
+  get() = String29.str_23188
+
+@ExperimentalResourceApi
+internal val Res.string.str_23189: StringResource
+  get() = String29.str_23189
+
+@ExperimentalResourceApi
+internal val Res.string.str_2319: StringResource
+  get() = String29.str_2319
+
+@ExperimentalResourceApi
+internal val Res.string.str_23190: StringResource
+  get() = String29.str_23190
+
+@ExperimentalResourceApi
+internal val Res.string.str_23191: StringResource
+  get() = String29.str_23191
+
+@ExperimentalResourceApi
+internal val Res.string.str_23192: StringResource
+  get() = String29.str_23192
+
+@ExperimentalResourceApi
+internal val Res.string.str_23193: StringResource
+  get() = String29.str_23193
+
+@ExperimentalResourceApi
+internal val Res.string.str_23194: StringResource
+  get() = String29.str_23194
+
+@ExperimentalResourceApi
+internal val Res.string.str_23195: StringResource
+  get() = String29.str_23195
+
+@ExperimentalResourceApi
+internal val Res.string.str_23196: StringResource
+  get() = String29.str_23196
+
+@ExperimentalResourceApi
+internal val Res.string.str_23197: StringResource
+  get() = String29.str_23197
+
+@ExperimentalResourceApi
+internal val Res.string.str_23198: StringResource
+  get() = String29.str_23198
+
+@ExperimentalResourceApi
+internal val Res.string.str_23199: StringResource
+  get() = String29.str_23199
+
+@ExperimentalResourceApi
+internal val Res.string.str_232: StringResource
+  get() = String29.str_232
+
+@ExperimentalResourceApi
+internal val Res.string.str_2320: StringResource
+  get() = String29.str_2320
+
+@ExperimentalResourceApi
+internal val Res.string.str_23200: StringResource
+  get() = String29.str_23200
+
+@ExperimentalResourceApi
+internal val Res.string.str_23201: StringResource
+  get() = String29.str_23201
+
+@ExperimentalResourceApi
+internal val Res.string.str_23202: StringResource
+  get() = String29.str_23202
+
+@ExperimentalResourceApi
+internal val Res.string.str_23203: StringResource
+  get() = String29.str_23203
+
+@ExperimentalResourceApi
+internal val Res.string.str_23204: StringResource
+  get() = String29.str_23204
+
+@ExperimentalResourceApi
+internal val Res.string.str_23205: StringResource
+  get() = String29.str_23205
+
+@ExperimentalResourceApi
+internal val Res.string.str_23206: StringResource
+  get() = String29.str_23206
+
+@ExperimentalResourceApi
+internal val Res.string.str_23207: StringResource
+  get() = String29.str_23207
+
+@ExperimentalResourceApi
+internal val Res.string.str_23208: StringResource
+  get() = String29.str_23208
+
+@ExperimentalResourceApi
+internal val Res.string.str_23209: StringResource
+  get() = String29.str_23209
+
+@ExperimentalResourceApi
+internal val Res.string.str_2321: StringResource
+  get() = String29.str_2321
+
+@ExperimentalResourceApi
+internal val Res.string.str_23210: StringResource
+  get() = String29.str_23210
+
+@ExperimentalResourceApi
+internal val Res.string.str_23211: StringResource
+  get() = String29.str_23211
+
+@ExperimentalResourceApi
+internal val Res.string.str_23212: StringResource
+  get() = String29.str_23212
+
+@ExperimentalResourceApi
+internal val Res.string.str_23213: StringResource
+  get() = String29.str_23213
+
+@ExperimentalResourceApi
+internal val Res.string.str_23214: StringResource
+  get() = String29.str_23214
+
+@ExperimentalResourceApi
+internal val Res.string.str_23215: StringResource
+  get() = String29.str_23215
+
+@ExperimentalResourceApi
+internal val Res.string.str_23216: StringResource
+  get() = String29.str_23216
+
+@ExperimentalResourceApi
+internal val Res.string.str_23217: StringResource
+  get() = String29.str_23217
+
+@ExperimentalResourceApi
+internal val Res.string.str_23218: StringResource
+  get() = String29.str_23218
+
+@ExperimentalResourceApi
+internal val Res.string.str_23219: StringResource
+  get() = String29.str_23219
+
+@ExperimentalResourceApi
+internal val Res.string.str_2322: StringResource
+  get() = String29.str_2322
+
+@ExperimentalResourceApi
+internal val Res.string.str_23220: StringResource
+  get() = String29.str_23220
+
+@ExperimentalResourceApi
+internal val Res.string.str_23221: StringResource
+  get() = String29.str_23221
+
+@ExperimentalResourceApi
+internal val Res.string.str_23222: StringResource
+  get() = String29.str_23222
+
+@ExperimentalResourceApi
+internal val Res.string.str_23223: StringResource
+  get() = String29.str_23223
+
+@ExperimentalResourceApi
+internal val Res.string.str_23224: StringResource
+  get() = String29.str_23224
+
+@ExperimentalResourceApi
+internal val Res.string.str_23225: StringResource
+  get() = String29.str_23225
+
+@ExperimentalResourceApi
+internal val Res.string.str_23226: StringResource
+  get() = String29.str_23226
+
+@ExperimentalResourceApi
+internal val Res.string.str_23227: StringResource
+  get() = String29.str_23227
+
+@ExperimentalResourceApi
+internal val Res.string.str_23228: StringResource
+  get() = String29.str_23228
+
+@ExperimentalResourceApi
+internal val Res.string.str_23229: StringResource
+  get() = String29.str_23229
+
+@ExperimentalResourceApi
+internal val Res.string.str_2323: StringResource
+  get() = String29.str_2323
+
+@ExperimentalResourceApi
+internal val Res.string.str_23230: StringResource
+  get() = String29.str_23230
+
+@ExperimentalResourceApi
+internal val Res.string.str_23231: StringResource
+  get() = String29.str_23231
+
+@ExperimentalResourceApi
+internal val Res.string.str_23232: StringResource
+  get() = String29.str_23232
+
+@ExperimentalResourceApi
+internal val Res.string.str_23233: StringResource
+  get() = String29.str_23233
+
+@ExperimentalResourceApi
+internal val Res.string.str_23234: StringResource
+  get() = String29.str_23234
+
+@ExperimentalResourceApi
+internal val Res.string.str_23235: StringResource
+  get() = String29.str_23235
+
+@ExperimentalResourceApi
+internal val Res.string.str_23236: StringResource
+  get() = String29.str_23236
+
+@ExperimentalResourceApi
+internal val Res.string.str_23237: StringResource
+  get() = String29.str_23237
+
+@ExperimentalResourceApi
+internal val Res.string.str_23238: StringResource
+  get() = String29.str_23238
+
+@ExperimentalResourceApi
+internal val Res.string.str_23239: StringResource
+  get() = String29.str_23239
+
+@ExperimentalResourceApi
+internal val Res.string.str_2324: StringResource
+  get() = String29.str_2324
+
+@ExperimentalResourceApi
+internal val Res.string.str_23240: StringResource
+  get() = String29.str_23240
+
+@ExperimentalResourceApi
+internal val Res.string.str_23241: StringResource
+  get() = String29.str_23241
+
+@ExperimentalResourceApi
+internal val Res.string.str_23242: StringResource
+  get() = String29.str_23242
+
+@ExperimentalResourceApi
+internal val Res.string.str_23243: StringResource
+  get() = String29.str_23243
+
+@ExperimentalResourceApi
+internal val Res.string.str_23244: StringResource
+  get() = String29.str_23244
+
+@ExperimentalResourceApi
+internal val Res.string.str_23245: StringResource
+  get() = String29.str_23245
+
+@ExperimentalResourceApi
+internal val Res.string.str_23246: StringResource
+  get() = String29.str_23246
+
+@ExperimentalResourceApi
+internal val Res.string.str_23247: StringResource
+  get() = String29.str_23247
+
+@ExperimentalResourceApi
+internal val Res.string.str_23248: StringResource
+  get() = String29.str_23248
+
+@ExperimentalResourceApi
+internal val Res.string.str_23249: StringResource
+  get() = String29.str_23249
+
+@ExperimentalResourceApi
+internal val Res.string.str_2325: StringResource
+  get() = String29.str_2325
+
+@ExperimentalResourceApi
+internal val Res.string.str_23250: StringResource
+  get() = String29.str_23250
+
+@ExperimentalResourceApi
+internal val Res.string.str_23251: StringResource
+  get() = String29.str_23251
+
+@ExperimentalResourceApi
+internal val Res.string.str_23252: StringResource
+  get() = String29.str_23252
+
+@ExperimentalResourceApi
+internal val Res.string.str_23253: StringResource
+  get() = String29.str_23253
+
+@ExperimentalResourceApi
+internal val Res.string.str_23254: StringResource
+  get() = String29.str_23254
+
+@ExperimentalResourceApi
+internal val Res.string.str_23255: StringResource
+  get() = String29.str_23255
+
+@ExperimentalResourceApi
+internal val Res.string.str_23256: StringResource
+  get() = String29.str_23256
+
+@ExperimentalResourceApi
+internal val Res.string.str_23257: StringResource
+  get() = String29.str_23257
+
+@ExperimentalResourceApi
+internal val Res.string.str_23258: StringResource
+  get() = String29.str_23258
+
+@ExperimentalResourceApi
+internal val Res.string.str_23259: StringResource
+  get() = String29.str_23259
+
+@ExperimentalResourceApi
+internal val Res.string.str_2326: StringResource
+  get() = String29.str_2326
+
+@ExperimentalResourceApi
+internal val Res.string.str_23260: StringResource
+  get() = String29.str_23260
+
+@ExperimentalResourceApi
+internal val Res.string.str_23261: StringResource
+  get() = String29.str_23261
+
+@ExperimentalResourceApi
+internal val Res.string.str_23262: StringResource
+  get() = String29.str_23262
+
+@ExperimentalResourceApi
+internal val Res.string.str_23263: StringResource
+  get() = String29.str_23263
+
+@ExperimentalResourceApi
+internal val Res.string.str_23264: StringResource
+  get() = String29.str_23264
+
+@ExperimentalResourceApi
+internal val Res.string.str_23265: StringResource
+  get() = String29.str_23265
+
+@ExperimentalResourceApi
+internal val Res.string.str_23266: StringResource
+  get() = String29.str_23266
+
+@ExperimentalResourceApi
+internal val Res.string.str_23267: StringResource
+  get() = String29.str_23267
+
+@ExperimentalResourceApi
+internal val Res.string.str_23268: StringResource
+  get() = String29.str_23268
+
+@ExperimentalResourceApi
+internal val Res.string.str_23269: StringResource
+  get() = String29.str_23269
+
+@ExperimentalResourceApi
+internal val Res.string.str_2327: StringResource
+  get() = String29.str_2327
+
+@ExperimentalResourceApi
+internal val Res.string.str_23270: StringResource
+  get() = String29.str_23270
+
+@ExperimentalResourceApi
+internal val Res.string.str_23271: StringResource
+  get() = String29.str_23271
+
+@ExperimentalResourceApi
+internal val Res.string.str_23272: StringResource
+  get() = String29.str_23272
+
+@ExperimentalResourceApi
+internal val Res.string.str_23273: StringResource
+  get() = String29.str_23273
+
+@ExperimentalResourceApi
+internal val Res.string.str_23274: StringResource
+  get() = String29.str_23274
+
+@ExperimentalResourceApi
+internal val Res.string.str_23275: StringResource
+  get() = String29.str_23275
+
+@ExperimentalResourceApi
+internal val Res.string.str_23276: StringResource
+  get() = String29.str_23276
+
+@ExperimentalResourceApi
+internal val Res.string.str_23277: StringResource
+  get() = String29.str_23277
+
+@ExperimentalResourceApi
+internal val Res.string.str_23278: StringResource
+  get() = String29.str_23278
+
+@ExperimentalResourceApi
+internal val Res.string.str_23279: StringResource
+  get() = String29.str_23279
+
+@ExperimentalResourceApi
+internal val Res.string.str_2328: StringResource
+  get() = String29.str_2328
+
+@ExperimentalResourceApi
+internal val Res.string.str_23280: StringResource
+  get() = String29.str_23280
+
+@ExperimentalResourceApi
+internal val Res.string.str_23281: StringResource
+  get() = String29.str_23281
+
+@ExperimentalResourceApi
+internal val Res.string.str_23282: StringResource
+  get() = String29.str_23282
+
+@ExperimentalResourceApi
+internal val Res.string.str_23283: StringResource
+  get() = String29.str_23283
+
+@ExperimentalResourceApi
+internal val Res.string.str_23284: StringResource
+  get() = String29.str_23284
+
+@ExperimentalResourceApi
+internal val Res.string.str_23285: StringResource
+  get() = String29.str_23285
+
+@ExperimentalResourceApi
+internal val Res.string.str_23286: StringResource
+  get() = String29.str_23286
+
+@ExperimentalResourceApi
+internal val Res.string.str_23287: StringResource
+  get() = String29.str_23287
+
+@ExperimentalResourceApi
+internal val Res.string.str_23288: StringResource
+  get() = String29.str_23288
+
+@ExperimentalResourceApi
+internal val Res.string.str_23289: StringResource
+  get() = String29.str_23289
+
+@ExperimentalResourceApi
+internal val Res.string.str_2329: StringResource
+  get() = String29.str_2329
+
+@ExperimentalResourceApi
+internal val Res.string.str_23290: StringResource
+  get() = String29.str_23290
+
+@ExperimentalResourceApi
+internal val Res.string.str_23291: StringResource
+  get() = String29.str_23291
+
+@ExperimentalResourceApi
+internal val Res.string.str_23292: StringResource
+  get() = String29.str_23292
+
+@ExperimentalResourceApi
+internal val Res.string.str_23293: StringResource
+  get() = String29.str_23293
+
+@ExperimentalResourceApi
+internal val Res.string.str_23294: StringResource
+  get() = String29.str_23294
+
+@ExperimentalResourceApi
+internal val Res.string.str_23295: StringResource
+  get() = String29.str_23295
+
+@ExperimentalResourceApi
+internal val Res.string.str_23296: StringResource
+  get() = String29.str_23296
+
+@ExperimentalResourceApi
+internal val Res.string.str_23297: StringResource
+  get() = String29.str_23297
+
+@ExperimentalResourceApi
+internal val Res.string.str_23298: StringResource
+  get() = String29.str_23298
+
+@ExperimentalResourceApi
+internal val Res.string.str_23299: StringResource
+  get() = String29.str_23299
+
+@ExperimentalResourceApi
+internal val Res.string.str_233: StringResource
+  get() = String29.str_233
+
+@ExperimentalResourceApi
+internal val Res.string.str_2330: StringResource
+  get() = String29.str_2330
+
+@ExperimentalResourceApi
+internal val Res.string.str_23300: StringResource
+  get() = String29.str_23300
+
+@ExperimentalResourceApi
+internal val Res.string.str_23301: StringResource
+  get() = String29.str_23301
+
+@ExperimentalResourceApi
+internal val Res.string.str_23302: StringResource
+  get() = String29.str_23302
+
+@ExperimentalResourceApi
+internal val Res.string.str_23303: StringResource
+  get() = String29.str_23303
+
+@ExperimentalResourceApi
+internal val Res.string.str_23304: StringResource
+  get() = String29.str_23304
+
+@ExperimentalResourceApi
+internal val Res.string.str_23305: StringResource
+  get() = String29.str_23305
+
+@ExperimentalResourceApi
+internal val Res.string.str_23306: StringResource
+  get() = String29.str_23306
+
+@ExperimentalResourceApi
+internal val Res.string.str_23307: StringResource
+  get() = String29.str_23307
+
+@ExperimentalResourceApi
+internal val Res.string.str_23308: StringResource
+  get() = String29.str_23308
+
+@ExperimentalResourceApi
+internal val Res.string.str_23309: StringResource
+  get() = String29.str_23309
+
+@ExperimentalResourceApi
+internal val Res.string.str_2331: StringResource
+  get() = String29.str_2331
+
+@ExperimentalResourceApi
+internal val Res.string.str_23310: StringResource
+  get() = String29.str_23310
+
+@ExperimentalResourceApi
+internal val Res.string.str_23311: StringResource
+  get() = String29.str_23311
+
+@ExperimentalResourceApi
+internal val Res.string.str_23312: StringResource
+  get() = String29.str_23312
+
+@ExperimentalResourceApi
+internal val Res.string.str_23313: StringResource
+  get() = String29.str_23313
+
+@ExperimentalResourceApi
+internal val Res.string.str_23314: StringResource
+  get() = String29.str_23314
+
+@ExperimentalResourceApi
+internal val Res.string.str_23315: StringResource
+  get() = String29.str_23315
+
+@ExperimentalResourceApi
+internal val Res.string.str_23316: StringResource
+  get() = String29.str_23316
+
+@ExperimentalResourceApi
+internal val Res.string.str_23317: StringResource
+  get() = String29.str_23317
+
+@ExperimentalResourceApi
+internal val Res.string.str_23318: StringResource
+  get() = String29.str_23318
+
+@ExperimentalResourceApi
+internal val Res.string.str_23319: StringResource
+  get() = String29.str_23319
+
+@ExperimentalResourceApi
+internal val Res.string.str_2332: StringResource
+  get() = String29.str_2332
+
+@ExperimentalResourceApi
+internal val Res.string.str_23320: StringResource
+  get() = String29.str_23320
+
+@ExperimentalResourceApi
+internal val Res.string.str_23321: StringResource
+  get() = String29.str_23321
+
+@ExperimentalResourceApi
+internal val Res.string.str_23322: StringResource
+  get() = String29.str_23322
+
+@ExperimentalResourceApi
+internal val Res.string.str_23323: StringResource
+  get() = String29.str_23323
+
+@ExperimentalResourceApi
+internal val Res.string.str_23324: StringResource
+  get() = String29.str_23324
+
+@ExperimentalResourceApi
+internal val Res.string.str_23325: StringResource
+  get() = String29.str_23325
+
+@ExperimentalResourceApi
+internal val Res.string.str_23326: StringResource
+  get() = String29.str_23326
+
+@ExperimentalResourceApi
+internal val Res.string.str_23327: StringResource
+  get() = String29.str_23327
+
+@ExperimentalResourceApi
+internal val Res.string.str_23328: StringResource
+  get() = String29.str_23328
+
+@ExperimentalResourceApi
+internal val Res.string.str_23329: StringResource
+  get() = String29.str_23329
+
+@ExperimentalResourceApi
+internal val Res.string.str_2333: StringResource
+  get() = String29.str_2333
+
+@ExperimentalResourceApi
+internal val Res.string.str_23330: StringResource
+  get() = String29.str_23330
+
+@ExperimentalResourceApi
+internal val Res.string.str_23331: StringResource
+  get() = String29.str_23331
+
+@ExperimentalResourceApi
+internal val Res.string.str_23332: StringResource
+  get() = String29.str_23332
+
+@ExperimentalResourceApi
+internal val Res.string.str_23333: StringResource
+  get() = String29.str_23333
+
+@ExperimentalResourceApi
+internal val Res.string.str_23334: StringResource
+  get() = String29.str_23334
+
+@ExperimentalResourceApi
+internal val Res.string.str_23335: StringResource
+  get() = String29.str_23335
+
+@ExperimentalResourceApi
+internal val Res.string.str_23336: StringResource
+  get() = String29.str_23336
+
+@ExperimentalResourceApi
+internal val Res.string.str_23337: StringResource
+  get() = String29.str_23337
+
+@ExperimentalResourceApi
+internal val Res.string.str_23338: StringResource
+  get() = String29.str_23338
+
+@ExperimentalResourceApi
+internal val Res.string.str_23339: StringResource
+  get() = String29.str_23339
+
+@ExperimentalResourceApi
+internal val Res.string.str_2334: StringResource
+  get() = String29.str_2334
+
+@ExperimentalResourceApi
+internal val Res.string.str_23340: StringResource
+  get() = String29.str_23340
+
+@ExperimentalResourceApi
+internal val Res.string.str_23341: StringResource
+  get() = String29.str_23341
+
+@ExperimentalResourceApi
+internal val Res.string.str_23342: StringResource
+  get() = String29.str_23342
+
+@ExperimentalResourceApi
+internal val Res.string.str_23343: StringResource
+  get() = String29.str_23343
+
+@ExperimentalResourceApi
+internal val Res.string.str_23344: StringResource
+  get() = String29.str_23344
+
+@ExperimentalResourceApi
+internal val Res.string.str_23345: StringResource
+  get() = String29.str_23345
+
+@ExperimentalResourceApi
+internal val Res.string.str_23346: StringResource
+  get() = String29.str_23346
+
+@ExperimentalResourceApi
+internal val Res.string.str_23347: StringResource
+  get() = String29.str_23347
+
+@ExperimentalResourceApi
+internal val Res.string.str_23348: StringResource
+  get() = String29.str_23348
+
+@ExperimentalResourceApi
+internal val Res.string.str_23349: StringResource
+  get() = String29.str_23349
+
+@ExperimentalResourceApi
+internal val Res.string.str_2335: StringResource
+  get() = String29.str_2335
+
+@ExperimentalResourceApi
+internal val Res.string.str_23350: StringResource
+  get() = String29.str_23350
+
+@ExperimentalResourceApi
+internal val Res.string.str_23351: StringResource
+  get() = String29.str_23351
+
+@ExperimentalResourceApi
+internal val Res.string.str_23352: StringResource
+  get() = String29.str_23352
+
+@ExperimentalResourceApi
+internal val Res.string.str_23353: StringResource
+  get() = String29.str_23353
+
+@ExperimentalResourceApi
+internal val Res.string.str_23354: StringResource
+  get() = String29.str_23354
+
+@ExperimentalResourceApi
+internal val Res.string.str_23355: StringResource
+  get() = String29.str_23355
+
+@ExperimentalResourceApi
+internal val Res.string.str_23356: StringResource
+  get() = String29.str_23356
+
+@ExperimentalResourceApi
+internal val Res.string.str_23357: StringResource
+  get() = String29.str_23357
+
+@ExperimentalResourceApi
+internal val Res.string.str_23358: StringResource
+  get() = String29.str_23358
+
+@ExperimentalResourceApi
+internal val Res.string.str_23359: StringResource
+  get() = String29.str_23359
+
+@ExperimentalResourceApi
+internal val Res.string.str_2336: StringResource
+  get() = String29.str_2336
+
+@ExperimentalResourceApi
+internal val Res.string.str_23360: StringResource
+  get() = String29.str_23360
+
+@ExperimentalResourceApi
+internal val Res.string.str_23361: StringResource
+  get() = String29.str_23361
+
+@ExperimentalResourceApi
+internal val Res.string.str_23362: StringResource
+  get() = String29.str_23362
+
+@ExperimentalResourceApi
+internal val Res.string.str_23363: StringResource
+  get() = String29.str_23363
+
+@ExperimentalResourceApi
+internal val Res.string.str_23364: StringResource
+  get() = String29.str_23364
+
+@ExperimentalResourceApi
+internal val Res.string.str_23365: StringResource
+  get() = String29.str_23365
+
+@ExperimentalResourceApi
+internal val Res.string.str_23366: StringResource
+  get() = String29.str_23366
+
+@ExperimentalResourceApi
+internal val Res.string.str_23367: StringResource
+  get() = String29.str_23367
+
+@ExperimentalResourceApi
+internal val Res.string.str_23368: StringResource
+  get() = String29.str_23368
+
+@ExperimentalResourceApi
+internal val Res.string.str_23369: StringResource
+  get() = String29.str_23369
+
+@ExperimentalResourceApi
+internal val Res.string.str_2337: StringResource
+  get() = String29.str_2337
+
+@ExperimentalResourceApi
+internal val Res.string.str_23370: StringResource
+  get() = String29.str_23370
+
+@ExperimentalResourceApi
+internal val Res.string.str_23371: StringResource
+  get() = String29.str_23371
+
+@ExperimentalResourceApi
+internal val Res.string.str_23372: StringResource
+  get() = String29.str_23372
+
+@ExperimentalResourceApi
+internal val Res.string.str_23373: StringResource
+  get() = String29.str_23373
+
+@ExperimentalResourceApi
+internal val Res.string.str_23374: StringResource
+  get() = String29.str_23374
+
+@ExperimentalResourceApi
+internal val Res.string.str_23375: StringResource
+  get() = String29.str_23375
+
+@ExperimentalResourceApi
+internal val Res.string.str_23376: StringResource
+  get() = String29.str_23376
+
+@ExperimentalResourceApi
+internal val Res.string.str_23377: StringResource
+  get() = String29.str_23377
+
+@ExperimentalResourceApi
+internal val Res.string.str_23378: StringResource
+  get() = String29.str_23378
+
+@ExperimentalResourceApi
+internal val Res.string.str_23379: StringResource
+  get() = String29.str_23379
+
+@ExperimentalResourceApi
+internal val Res.string.str_2338: StringResource
+  get() = String29.str_2338
+
+@ExperimentalResourceApi
+internal val Res.string.str_23380: StringResource
+  get() = String29.str_23380
+
+@ExperimentalResourceApi
+internal val Res.string.str_23381: StringResource
+  get() = String29.str_23381
+
+@ExperimentalResourceApi
+internal val Res.string.str_23382: StringResource
+  get() = String29.str_23382
+
+@ExperimentalResourceApi
+internal val Res.string.str_23383: StringResource
+  get() = String29.str_23383
+
+@ExperimentalResourceApi
+internal val Res.string.str_23384: StringResource
+  get() = String29.str_23384
+
+@ExperimentalResourceApi
+internal val Res.string.str_23385: StringResource
+  get() = String29.str_23385
+
+@ExperimentalResourceApi
+internal val Res.string.str_23386: StringResource
+  get() = String29.str_23386
+
+@ExperimentalResourceApi
+internal val Res.string.str_23387: StringResource
+  get() = String29.str_23387
+
+@ExperimentalResourceApi
+internal val Res.string.str_23388: StringResource
+  get() = String29.str_23388
+
+@ExperimentalResourceApi
+internal val Res.string.str_23389: StringResource
+  get() = String29.str_23389
+
+@ExperimentalResourceApi
+internal val Res.string.str_2339: StringResource
+  get() = String29.str_2339
+
+@ExperimentalResourceApi
+internal val Res.string.str_23390: StringResource
+  get() = String29.str_23390
+
+@ExperimentalResourceApi
+internal val Res.string.str_23391: StringResource
+  get() = String29.str_23391
+
+@ExperimentalResourceApi
+internal val Res.string.str_23392: StringResource
+  get() = String29.str_23392
+
+@ExperimentalResourceApi
+internal val Res.string.str_23393: StringResource
+  get() = String29.str_23393
+
+@ExperimentalResourceApi
+internal val Res.string.str_23394: StringResource
+  get() = String29.str_23394
+
+@ExperimentalResourceApi
+internal val Res.string.str_23395: StringResource
+  get() = String29.str_23395
+
+@ExperimentalResourceApi
+internal val Res.string.str_23396: StringResource
+  get() = String29.str_23396
+
+@ExperimentalResourceApi
+internal val Res.string.str_23397: StringResource
+  get() = String29.str_23397
+
+@ExperimentalResourceApi
+internal val Res.string.str_23398: StringResource
+  get() = String29.str_23398
+
+@ExperimentalResourceApi
+internal val Res.string.str_23399: StringResource
+  get() = String29.str_23399
+
+@ExperimentalResourceApi
+internal val Res.string.str_234: StringResource
+  get() = String29.str_234
+
+@ExperimentalResourceApi
+internal val Res.string.str_2340: StringResource
+  get() = String29.str_2340
+
+@ExperimentalResourceApi
+internal val Res.string.str_23400: StringResource
+  get() = String29.str_23400
+
+@ExperimentalResourceApi
+internal val Res.string.str_23401: StringResource
+  get() = String29.str_23401
+
+@ExperimentalResourceApi
+internal val Res.string.str_23402: StringResource
+  get() = String29.str_23402
+
+@ExperimentalResourceApi
+internal val Res.string.str_23403: StringResource
+  get() = String29.str_23403
+
+@ExperimentalResourceApi
+internal val Res.string.str_23404: StringResource
+  get() = String29.str_23404
+
+@ExperimentalResourceApi
+internal val Res.string.str_23405: StringResource
+  get() = String29.str_23405
+
+@ExperimentalResourceApi
+internal val Res.string.str_23406: StringResource
+  get() = String29.str_23406
+
+@ExperimentalResourceApi
+internal val Res.string.str_23407: StringResource
+  get() = String29.str_23407
+
+@ExperimentalResourceApi
+internal val Res.string.str_23408: StringResource
+  get() = String29.str_23408
+
+@ExperimentalResourceApi
+internal val Res.string.str_23409: StringResource
+  get() = String29.str_23409
+
+@ExperimentalResourceApi
+internal val Res.string.str_2341: StringResource
+  get() = String29.str_2341
+
+@ExperimentalResourceApi
+internal val Res.string.str_23410: StringResource
+  get() = String29.str_23410
+
+@ExperimentalResourceApi
+internal val Res.string.str_23411: StringResource
+  get() = String29.str_23411
+
+@ExperimentalResourceApi
+internal val Res.string.str_23412: StringResource
+  get() = String29.str_23412
+
+@ExperimentalResourceApi
+internal val Res.string.str_23413: StringResource
+  get() = String29.str_23413
+
+@ExperimentalResourceApi
+internal val Res.string.str_23414: StringResource
+  get() = String29.str_23414
+
+@ExperimentalResourceApi
+internal val Res.string.str_23415: StringResource
+  get() = String29.str_23415
+
+@ExperimentalResourceApi
+internal val Res.string.str_23416: StringResource
+  get() = String29.str_23416
+
+@ExperimentalResourceApi
+internal val Res.string.str_23417: StringResource
+  get() = String29.str_23417
+
+@ExperimentalResourceApi
+internal val Res.string.str_23418: StringResource
+  get() = String29.str_23418
+
+@ExperimentalResourceApi
+internal val Res.string.str_23419: StringResource
+  get() = String29.str_23419
+
+@ExperimentalResourceApi
+internal val Res.string.str_2342: StringResource
+  get() = String29.str_2342
+
+@ExperimentalResourceApi
+internal val Res.string.str_23420: StringResource
+  get() = String29.str_23420
+
+@ExperimentalResourceApi
+internal val Res.string.str_23421: StringResource
+  get() = String29.str_23421
+
+@ExperimentalResourceApi
+internal val Res.string.str_23422: StringResource
+  get() = String29.str_23422
+
+@ExperimentalResourceApi
+internal val Res.string.str_23423: StringResource
+  get() = String29.str_23423
+
+@ExperimentalResourceApi
+internal val Res.string.str_23424: StringResource
+  get() = String29.str_23424
+
+@ExperimentalResourceApi
+internal val Res.string.str_23425: StringResource
+  get() = String29.str_23425
+
+@ExperimentalResourceApi
+internal val Res.string.str_23426: StringResource
+  get() = String29.str_23426
+
+@ExperimentalResourceApi
+internal val Res.string.str_23427: StringResource
+  get() = String29.str_23427
+
+@ExperimentalResourceApi
+internal val Res.string.str_23428: StringResource
+  get() = String29.str_23428
+
+@ExperimentalResourceApi
+internal val Res.string.str_23429: StringResource
+  get() = String29.str_23429
+
+@ExperimentalResourceApi
+internal val Res.string.str_2343: StringResource
+  get() = String29.str_2343
+
+@ExperimentalResourceApi
+internal val Res.string.str_23430: StringResource
+  get() = String29.str_23430
+
+@ExperimentalResourceApi
+internal val Res.string.str_23431: StringResource
+  get() = String29.str_23431
+
+@ExperimentalResourceApi
+internal val Res.string.str_23432: StringResource
+  get() = String29.str_23432
+
+@ExperimentalResourceApi
+internal val Res.string.str_23433: StringResource
+  get() = String29.str_23433
+
+@ExperimentalResourceApi
+internal val Res.string.str_23434: StringResource
+  get() = String29.str_23434
+
+@ExperimentalResourceApi
+internal val Res.string.str_23435: StringResource
+  get() = String29.str_23435
+
+@ExperimentalResourceApi
+internal val Res.string.str_23436: StringResource
+  get() = String29.str_23436
+
+@ExperimentalResourceApi
+internal val Res.string.str_23437: StringResource
+  get() = String29.str_23437
+
+@ExperimentalResourceApi
+internal val Res.string.str_23438: StringResource
+  get() = String29.str_23438
+
+@ExperimentalResourceApi
+internal val Res.string.str_23439: StringResource
+  get() = String29.str_23439
+
+@ExperimentalResourceApi
+internal val Res.string.str_2344: StringResource
+  get() = String29.str_2344
+
+@ExperimentalResourceApi
+internal val Res.string.str_23440: StringResource
+  get() = String29.str_23440
+
+@ExperimentalResourceApi
+internal val Res.string.str_23441: StringResource
+  get() = String29.str_23441
+
+@ExperimentalResourceApi
+internal val Res.string.str_23442: StringResource
+  get() = String29.str_23442
+
+@ExperimentalResourceApi
+internal val Res.string.str_23443: StringResource
+  get() = String29.str_23443
+
+@ExperimentalResourceApi
+internal val Res.string.str_23444: StringResource
+  get() = String29.str_23444
+
+@ExperimentalResourceApi
+internal val Res.string.str_23445: StringResource
+  get() = String29.str_23445
+
+@ExperimentalResourceApi
+internal val Res.string.str_23446: StringResource
+  get() = String29.str_23446
+
+@ExperimentalResourceApi
+internal val Res.string.str_23447: StringResource
+  get() = String29.str_23447
+
+@ExperimentalResourceApi
+internal val Res.string.str_23448: StringResource
+  get() = String29.str_23448
+
+@ExperimentalResourceApi
+internal val Res.string.str_23449: StringResource
+  get() = String29.str_23449
+
+@ExperimentalResourceApi
+internal val Res.string.str_2345: StringResource
+  get() = String29.str_2345
+
+@ExperimentalResourceApi
+internal val Res.string.str_23450: StringResource
+  get() = String29.str_23450
+
+@ExperimentalResourceApi
+internal val Res.string.str_23451: StringResource
+  get() = String29.str_23451
+
+@ExperimentalResourceApi
+internal val Res.string.str_23452: StringResource
+  get() = String29.str_23452
+
+@ExperimentalResourceApi
+internal val Res.string.str_23453: StringResource
+  get() = String29.str_23453
+
+@ExperimentalResourceApi
+internal val Res.string.str_23454: StringResource
+  get() = String29.str_23454
+
+@ExperimentalResourceApi
+internal val Res.string.str_23455: StringResource
+  get() = String29.str_23455
+
+@ExperimentalResourceApi
+internal val Res.string.str_23456: StringResource
+  get() = String29.str_23456
+
+@ExperimentalResourceApi
+internal val Res.string.str_23457: StringResource
+  get() = String29.str_23457
+
+@ExperimentalResourceApi
+internal val Res.string.str_23458: StringResource
+  get() = String29.str_23458
+
+@ExperimentalResourceApi
+internal val Res.string.str_23459: StringResource
+  get() = String29.str_23459
+
+@ExperimentalResourceApi
+internal val Res.string.str_2346: StringResource
+  get() = String29.str_2346
+
+@ExperimentalResourceApi
+internal val Res.string.str_23460: StringResource
+  get() = String29.str_23460
+
+@ExperimentalResourceApi
+internal val Res.string.str_23461: StringResource
+  get() = String29.str_23461
+
+@ExperimentalResourceApi
+internal val Res.string.str_23462: StringResource
+  get() = String29.str_23462
+
+@ExperimentalResourceApi
+internal val Res.string.str_23463: StringResource
+  get() = String29.str_23463
+
+@ExperimentalResourceApi
+internal val Res.string.str_23464: StringResource
+  get() = String29.str_23464
+
+@ExperimentalResourceApi
+internal val Res.string.str_23465: StringResource
+  get() = String29.str_23465
+
+@ExperimentalResourceApi
+internal val Res.string.str_23466: StringResource
+  get() = String29.str_23466
+
+@ExperimentalResourceApi
+internal val Res.string.str_23467: StringResource
+  get() = String29.str_23467
+
+@ExperimentalResourceApi
+internal val Res.string.str_23468: StringResource
+  get() = String29.str_23468
+
+@ExperimentalResourceApi
+internal val Res.string.str_23469: StringResource
+  get() = String29.str_23469
+
+@ExperimentalResourceApi
+internal val Res.string.str_2347: StringResource
+  get() = String29.str_2347
+
+@ExperimentalResourceApi
+internal val Res.string.str_23470: StringResource
+  get() = String29.str_23470
+
+@ExperimentalResourceApi
+internal val Res.string.str_23471: StringResource
+  get() = String29.str_23471
+
+@ExperimentalResourceApi
+internal val Res.string.str_23472: StringResource
+  get() = String29.str_23472
+
+@ExperimentalResourceApi
+internal val Res.string.str_23473: StringResource
+  get() = String29.str_23473
+
+@ExperimentalResourceApi
+internal val Res.string.str_23474: StringResource
+  get() = String29.str_23474
+
+@ExperimentalResourceApi
+internal val Res.string.str_23475: StringResource
+  get() = String29.str_23475
+
+@ExperimentalResourceApi
+internal val Res.string.str_23476: StringResource
+  get() = String29.str_23476
+
+@ExperimentalResourceApi
+internal val Res.string.str_23477: StringResource
+  get() = String29.str_23477
+
+@ExperimentalResourceApi
+internal val Res.string.str_23478: StringResource
+  get() = String29.str_23478
+
+@ExperimentalResourceApi
+internal val Res.string.str_23479: StringResource
+  get() = String29.str_23479
+
+@ExperimentalResourceApi
+internal val Res.string.str_2348: StringResource
+  get() = String29.str_2348
+
+@ExperimentalResourceApi
+internal val Res.string.str_23480: StringResource
+  get() = String29.str_23480
+
+@ExperimentalResourceApi
+internal val Res.string.str_23481: StringResource
+  get() = String29.str_23481
+
+@ExperimentalResourceApi
+internal val Res.string.str_23482: StringResource
+  get() = String29.str_23482
+
+@ExperimentalResourceApi
+internal val Res.string.str_23483: StringResource
+  get() = String29.str_23483
+
+@ExperimentalResourceApi
+internal val Res.string.str_23484: StringResource
+  get() = String29.str_23484
+
+@ExperimentalResourceApi
+internal val Res.string.str_23485: StringResource
+  get() = String29.str_23485
+
+@ExperimentalResourceApi
+internal val Res.string.str_23486: StringResource
+  get() = String29.str_23486
+
+@ExperimentalResourceApi
+internal val Res.string.str_23487: StringResource
+  get() = String29.str_23487
+
+@ExperimentalResourceApi
+internal val Res.string.str_23488: StringResource
+  get() = String29.str_23488
+
+@ExperimentalResourceApi
+internal val Res.string.str_23489: StringResource
+  get() = String29.str_23489
+
+@ExperimentalResourceApi
+internal val Res.string.str_2349: StringResource
+  get() = String29.str_2349
+
+@ExperimentalResourceApi
+internal val Res.string.str_23490: StringResource
+  get() = String29.str_23490
+
+@ExperimentalResourceApi
+internal val Res.string.str_23491: StringResource
+  get() = String29.str_23491
+
+@ExperimentalResourceApi
+internal val Res.string.str_23492: StringResource
+  get() = String29.str_23492
+
+@ExperimentalResourceApi
+internal val Res.string.str_23493: StringResource
+  get() = String29.str_23493
+
+@ExperimentalResourceApi
+internal val Res.string.str_23494: StringResource
+  get() = String29.str_23494
+
+@ExperimentalResourceApi
+internal val Res.string.str_23495: StringResource
+  get() = String29.str_23495
+
+@ExperimentalResourceApi
+internal val Res.string.str_23496: StringResource
+  get() = String29.str_23496
+
+@ExperimentalResourceApi
+internal val Res.string.str_23497: StringResource
+  get() = String29.str_23497

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String3.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String3.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String3 {
+  public val str_11347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11347", "str_11347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11348", "str_11348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11349", "str_11349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1135", "str_1135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11350", "str_11350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11351", "str_11351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11352", "str_11352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11353", "str_11353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11354", "str_11354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11355", "str_11355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11356", "str_11356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11357", "str_11357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11358", "str_11358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11359", "str_11359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1136", "str_1136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11360", "str_11360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11361", "str_11361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11362", "str_11362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11363", "str_11363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11364", "str_11364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11365", "str_11365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11366", "str_11366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11367", "str_11367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11368", "str_11368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11369", "str_11369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1137", "str_1137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11370", "str_11370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11371", "str_11371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11372", "str_11372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11373", "str_11373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11374", "str_11374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11375", "str_11375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11376", "str_11376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11377", "str_11377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11378", "str_11378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11379", "str_11379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1138", "str_1138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11380", "str_11380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11381", "str_11381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11382", "str_11382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11383", "str_11383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11384", "str_11384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11385", "str_11385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11386", "str_11386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11387", "str_11387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11388", "str_11388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11389", "str_11389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1139", "str_1139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11390", "str_11390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11391", "str_11391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11392", "str_11392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11393", "str_11393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11394", "str_11394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11395", "str_11395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11396", "str_11396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11397", "str_11397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11398", "str_11398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11399", "str_11399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_114", "str_114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1140", "str_1140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11400", "str_11400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11401", "str_11401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11402", "str_11402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11403", "str_11403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11404", "str_11404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11405", "str_11405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11406", "str_11406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11407", "str_11407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11408", "str_11408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11409", "str_11409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1141", "str_1141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11410", "str_11410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11411", "str_11411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11412", "str_11412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11413", "str_11413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11414", "str_11414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11415", "str_11415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11416", "str_11416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11417", "str_11417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11418", "str_11418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11419", "str_11419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1142", "str_1142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11420", "str_11420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11421", "str_11421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11422", "str_11422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11423", "str_11423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11424", "str_11424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11425", "str_11425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11426", "str_11426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11427", "str_11427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11428", "str_11428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11429", "str_11429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1143", "str_1143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11430", "str_11430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11431", "str_11431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11432", "str_11432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11433", "str_11433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11434", "str_11434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11435", "str_11435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11436", "str_11436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11437", "str_11437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11438", "str_11438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11439", "str_11439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1144", "str_1144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11440", "str_11440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11441", "str_11441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11442", "str_11442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11443", "str_11443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11444", "str_11444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11445", "str_11445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11446", "str_11446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11447", "str_11447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11448", "str_11448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11449", "str_11449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1145", "str_1145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11450", "str_11450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11451", "str_11451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11452", "str_11452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11453", "str_11453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11454", "str_11454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11455", "str_11455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11456", "str_11456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11457", "str_11457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11458", "str_11458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11459", "str_11459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1146", "str_1146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11460", "str_11460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11461", "str_11461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11462", "str_11462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11463", "str_11463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11464", "str_11464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11465", "str_11465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11466", "str_11466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11467", "str_11467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11468", "str_11468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11469", "str_11469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1147", "str_1147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11470", "str_11470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11471", "str_11471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11472", "str_11472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11473", "str_11473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11474", "str_11474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11475", "str_11475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11476", "str_11476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11477", "str_11477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11478", "str_11478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11479", "str_11479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1148", "str_1148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11480", "str_11480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11481", "str_11481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11482", "str_11482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11483", "str_11483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11484", "str_11484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11485", "str_11485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11486", "str_11486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11487", "str_11487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11488", "str_11488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11489", "str_11489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1149", "str_1149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11490", "str_11490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11491", "str_11491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11492", "str_11492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11493", "str_11493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11494", "str_11494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11495", "str_11495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11496", "str_11496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11497", "str_11497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11498", "str_11498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11499", "str_11499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_115", "str_115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1150", "str_1150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11500", "str_11500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11501", "str_11501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11502", "str_11502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11503", "str_11503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11504", "str_11504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11505", "str_11505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11506", "str_11506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11507", "str_11507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11508", "str_11508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11509", "str_11509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1151", "str_1151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11510", "str_11510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11511", "str_11511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11512", "str_11512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11513", "str_11513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11514", "str_11514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11515", "str_11515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11516", "str_11516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11517", "str_11517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11518", "str_11518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11519", "str_11519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1152", "str_1152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11520", "str_11520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11521", "str_11521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11522", "str_11522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11523", "str_11523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11524", "str_11524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11525", "str_11525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11526", "str_11526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11527", "str_11527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11528", "str_11528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11529", "str_11529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1153", "str_1153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11530", "str_11530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11531", "str_11531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11532", "str_11532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11533", "str_11533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11534", "str_11534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11535", "str_11535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11536", "str_11536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11537", "str_11537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11538", "str_11538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11539", "str_11539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1154", "str_1154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11540", "str_11540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11541", "str_11541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11542", "str_11542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11543", "str_11543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11544", "str_11544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11545", "str_11545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11546", "str_11546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11547", "str_11547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11548", "str_11548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11549", "str_11549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1155", "str_1155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11550", "str_11550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11551", "str_11551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11552", "str_11552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11553", "str_11553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11554", "str_11554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11555", "str_11555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11556", "str_11556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11557", "str_11557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11558", "str_11558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11559", "str_11559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1156", "str_1156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11560", "str_11560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11561", "str_11561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11562", "str_11562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11563", "str_11563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11564", "str_11564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11565", "str_11565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11566", "str_11566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11567", "str_11567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11568", "str_11568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11569", "str_11569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1157", "str_1157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11570", "str_11570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11571", "str_11571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11572", "str_11572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11573", "str_11573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11574", "str_11574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11575", "str_11575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11576", "str_11576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11577", "str_11577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11578", "str_11578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11579", "str_11579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1158", "str_1158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11580", "str_11580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11581", "str_11581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11582", "str_11582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11583", "str_11583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11584", "str_11584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11585", "str_11585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11586", "str_11586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11587", "str_11587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11588", "str_11588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11589", "str_11589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1159", "str_1159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11590", "str_11590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11591", "str_11591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11592", "str_11592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11593", "str_11593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11594", "str_11594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11595", "str_11595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11596", "str_11596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11597", "str_11597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11598", "str_11598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11599", "str_11599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_116", "str_116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1160", "str_1160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11600", "str_11600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11601", "str_11601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11602", "str_11602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11603", "str_11603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11604", "str_11604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11605", "str_11605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11606", "str_11606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11607", "str_11607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11608", "str_11608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11609", "str_11609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1161", "str_1161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11610", "str_11610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11611", "str_11611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11612", "str_11612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11613", "str_11613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11614", "str_11614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11615", "str_11615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11616", "str_11616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11617", "str_11617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11618", "str_11618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11619", "str_11619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1162", "str_1162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11620", "str_11620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11621", "str_11621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11622", "str_11622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11623", "str_11623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11624", "str_11624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11625", "str_11625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11626", "str_11626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11627", "str_11627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11628", "str_11628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11629", "str_11629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1163", "str_1163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11630", "str_11630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11631", "str_11631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11632", "str_11632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11633", "str_11633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11634", "str_11634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11635", "str_11635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11636", "str_11636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11637", "str_11637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11638", "str_11638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11639", "str_11639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1164", "str_1164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11640", "str_11640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11641", "str_11641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11642", "str_11642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11643", "str_11643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11644", "str_11644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11645", "str_11645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11646", "str_11646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11647", "str_11647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11648", "str_11648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11649", "str_11649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1165", "str_1165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11650", "str_11650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11651", "str_11651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11652", "str_11652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11653", "str_11653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11654", "str_11654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11655", "str_11655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11656", "str_11656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11657", "str_11657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11658", "str_11658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11659", "str_11659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1166", "str_1166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11660", "str_11660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11661", "str_11661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11662", "str_11662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11663", "str_11663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11664", "str_11664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11665", "str_11665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11666", "str_11666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11667", "str_11667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11668", "str_11668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11669", "str_11669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1167", "str_1167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11670", "str_11670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11671", "str_11671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11672", "str_11672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11673", "str_11673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11674", "str_11674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11675", "str_11675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11676", "str_11676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11677", "str_11677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11678", "str_11678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11679", "str_11679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1168", "str_1168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11680", "str_11680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11681", "str_11681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11682", "str_11682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11683", "str_11683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11684", "str_11684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11685", "str_11685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11686", "str_11686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11687", "str_11687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11688", "str_11688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11689", "str_11689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1169", "str_1169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11690", "str_11690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11691", "str_11691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11692", "str_11692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11693", "str_11693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11694", "str_11694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11695", "str_11695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11696", "str_11696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11697", "str_11697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11698", "str_11698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11699", "str_11699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_117", "str_117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1170", "str_1170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11700", "str_11700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11701", "str_11701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11702", "str_11702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11703", "str_11703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11704", "str_11704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11705", "str_11705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11706", "str_11706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11707", "str_11707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11708", "str_11708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11709", "str_11709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1171", "str_1171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11710", "str_11710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11711", "str_11711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11712", "str_11712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11713", "str_11713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11714", "str_11714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11715", "str_11715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11716", "str_11716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11717", "str_11717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11718", "str_11718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11719", "str_11719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1172", "str_1172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11720", "str_11720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11721", "str_11721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11722", "str_11722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11723", "str_11723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11724", "str_11724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11725", "str_11725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11726", "str_11726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11727", "str_11727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11728", "str_11728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11729", "str_11729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1173", "str_1173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11730", "str_11730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11731", "str_11731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11732", "str_11732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11733", "str_11733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11734", "str_11734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11735", "str_11735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11736", "str_11736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11737", "str_11737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11738", "str_11738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11739", "str_11739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1174", "str_1174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11740", "str_11740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11741", "str_11741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11742", "str_11742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11743", "str_11743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11744", "str_11744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11745", "str_11745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11746", "str_11746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11747", "str_11747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11748", "str_11748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11749", "str_11749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1175", "str_1175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11750", "str_11750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11751", "str_11751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11752", "str_11752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11753", "str_11753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11754", "str_11754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11755", "str_11755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11756", "str_11756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11757", "str_11757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11758", "str_11758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11759", "str_11759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1176", "str_1176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11760", "str_11760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11761", "str_11761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11762", "str_11762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11763", "str_11763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11764", "str_11764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11765", "str_11765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11766", "str_11766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11767", "str_11767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11768", "str_11768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11769", "str_11769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1177", "str_1177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11770", "str_11770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11771", "str_11771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11772", "str_11772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11773", "str_11773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11774", "str_11774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11775", "str_11775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11776", "str_11776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11777", "str_11777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11778", "str_11778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11779", "str_11779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1178", "str_1178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11780", "str_11780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11781", "str_11781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11782", "str_11782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11783", "str_11783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11784", "str_11784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11785", "str_11785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11786", "str_11786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11787", "str_11787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11788", "str_11788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11789", "str_11789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1179", "str_1179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11790", "str_11790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11791", "str_11791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11792", "str_11792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11793", "str_11793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11794", "str_11794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11795", "str_11795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11796", "str_11796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11797", "str_11797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_11347: StringResource
+  get() = String3.str_11347
+
+@ExperimentalResourceApi
+internal val Res.string.str_11348: StringResource
+  get() = String3.str_11348
+
+@ExperimentalResourceApi
+internal val Res.string.str_11349: StringResource
+  get() = String3.str_11349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1135: StringResource
+  get() = String3.str_1135
+
+@ExperimentalResourceApi
+internal val Res.string.str_11350: StringResource
+  get() = String3.str_11350
+
+@ExperimentalResourceApi
+internal val Res.string.str_11351: StringResource
+  get() = String3.str_11351
+
+@ExperimentalResourceApi
+internal val Res.string.str_11352: StringResource
+  get() = String3.str_11352
+
+@ExperimentalResourceApi
+internal val Res.string.str_11353: StringResource
+  get() = String3.str_11353
+
+@ExperimentalResourceApi
+internal val Res.string.str_11354: StringResource
+  get() = String3.str_11354
+
+@ExperimentalResourceApi
+internal val Res.string.str_11355: StringResource
+  get() = String3.str_11355
+
+@ExperimentalResourceApi
+internal val Res.string.str_11356: StringResource
+  get() = String3.str_11356
+
+@ExperimentalResourceApi
+internal val Res.string.str_11357: StringResource
+  get() = String3.str_11357
+
+@ExperimentalResourceApi
+internal val Res.string.str_11358: StringResource
+  get() = String3.str_11358
+
+@ExperimentalResourceApi
+internal val Res.string.str_11359: StringResource
+  get() = String3.str_11359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1136: StringResource
+  get() = String3.str_1136
+
+@ExperimentalResourceApi
+internal val Res.string.str_11360: StringResource
+  get() = String3.str_11360
+
+@ExperimentalResourceApi
+internal val Res.string.str_11361: StringResource
+  get() = String3.str_11361
+
+@ExperimentalResourceApi
+internal val Res.string.str_11362: StringResource
+  get() = String3.str_11362
+
+@ExperimentalResourceApi
+internal val Res.string.str_11363: StringResource
+  get() = String3.str_11363
+
+@ExperimentalResourceApi
+internal val Res.string.str_11364: StringResource
+  get() = String3.str_11364
+
+@ExperimentalResourceApi
+internal val Res.string.str_11365: StringResource
+  get() = String3.str_11365
+
+@ExperimentalResourceApi
+internal val Res.string.str_11366: StringResource
+  get() = String3.str_11366
+
+@ExperimentalResourceApi
+internal val Res.string.str_11367: StringResource
+  get() = String3.str_11367
+
+@ExperimentalResourceApi
+internal val Res.string.str_11368: StringResource
+  get() = String3.str_11368
+
+@ExperimentalResourceApi
+internal val Res.string.str_11369: StringResource
+  get() = String3.str_11369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1137: StringResource
+  get() = String3.str_1137
+
+@ExperimentalResourceApi
+internal val Res.string.str_11370: StringResource
+  get() = String3.str_11370
+
+@ExperimentalResourceApi
+internal val Res.string.str_11371: StringResource
+  get() = String3.str_11371
+
+@ExperimentalResourceApi
+internal val Res.string.str_11372: StringResource
+  get() = String3.str_11372
+
+@ExperimentalResourceApi
+internal val Res.string.str_11373: StringResource
+  get() = String3.str_11373
+
+@ExperimentalResourceApi
+internal val Res.string.str_11374: StringResource
+  get() = String3.str_11374
+
+@ExperimentalResourceApi
+internal val Res.string.str_11375: StringResource
+  get() = String3.str_11375
+
+@ExperimentalResourceApi
+internal val Res.string.str_11376: StringResource
+  get() = String3.str_11376
+
+@ExperimentalResourceApi
+internal val Res.string.str_11377: StringResource
+  get() = String3.str_11377
+
+@ExperimentalResourceApi
+internal val Res.string.str_11378: StringResource
+  get() = String3.str_11378
+
+@ExperimentalResourceApi
+internal val Res.string.str_11379: StringResource
+  get() = String3.str_11379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1138: StringResource
+  get() = String3.str_1138
+
+@ExperimentalResourceApi
+internal val Res.string.str_11380: StringResource
+  get() = String3.str_11380
+
+@ExperimentalResourceApi
+internal val Res.string.str_11381: StringResource
+  get() = String3.str_11381
+
+@ExperimentalResourceApi
+internal val Res.string.str_11382: StringResource
+  get() = String3.str_11382
+
+@ExperimentalResourceApi
+internal val Res.string.str_11383: StringResource
+  get() = String3.str_11383
+
+@ExperimentalResourceApi
+internal val Res.string.str_11384: StringResource
+  get() = String3.str_11384
+
+@ExperimentalResourceApi
+internal val Res.string.str_11385: StringResource
+  get() = String3.str_11385
+
+@ExperimentalResourceApi
+internal val Res.string.str_11386: StringResource
+  get() = String3.str_11386
+
+@ExperimentalResourceApi
+internal val Res.string.str_11387: StringResource
+  get() = String3.str_11387
+
+@ExperimentalResourceApi
+internal val Res.string.str_11388: StringResource
+  get() = String3.str_11388
+
+@ExperimentalResourceApi
+internal val Res.string.str_11389: StringResource
+  get() = String3.str_11389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1139: StringResource
+  get() = String3.str_1139
+
+@ExperimentalResourceApi
+internal val Res.string.str_11390: StringResource
+  get() = String3.str_11390
+
+@ExperimentalResourceApi
+internal val Res.string.str_11391: StringResource
+  get() = String3.str_11391
+
+@ExperimentalResourceApi
+internal val Res.string.str_11392: StringResource
+  get() = String3.str_11392
+
+@ExperimentalResourceApi
+internal val Res.string.str_11393: StringResource
+  get() = String3.str_11393
+
+@ExperimentalResourceApi
+internal val Res.string.str_11394: StringResource
+  get() = String3.str_11394
+
+@ExperimentalResourceApi
+internal val Res.string.str_11395: StringResource
+  get() = String3.str_11395
+
+@ExperimentalResourceApi
+internal val Res.string.str_11396: StringResource
+  get() = String3.str_11396
+
+@ExperimentalResourceApi
+internal val Res.string.str_11397: StringResource
+  get() = String3.str_11397
+
+@ExperimentalResourceApi
+internal val Res.string.str_11398: StringResource
+  get() = String3.str_11398
+
+@ExperimentalResourceApi
+internal val Res.string.str_11399: StringResource
+  get() = String3.str_11399
+
+@ExperimentalResourceApi
+internal val Res.string.str_114: StringResource
+  get() = String3.str_114
+
+@ExperimentalResourceApi
+internal val Res.string.str_1140: StringResource
+  get() = String3.str_1140
+
+@ExperimentalResourceApi
+internal val Res.string.str_11400: StringResource
+  get() = String3.str_11400
+
+@ExperimentalResourceApi
+internal val Res.string.str_11401: StringResource
+  get() = String3.str_11401
+
+@ExperimentalResourceApi
+internal val Res.string.str_11402: StringResource
+  get() = String3.str_11402
+
+@ExperimentalResourceApi
+internal val Res.string.str_11403: StringResource
+  get() = String3.str_11403
+
+@ExperimentalResourceApi
+internal val Res.string.str_11404: StringResource
+  get() = String3.str_11404
+
+@ExperimentalResourceApi
+internal val Res.string.str_11405: StringResource
+  get() = String3.str_11405
+
+@ExperimentalResourceApi
+internal val Res.string.str_11406: StringResource
+  get() = String3.str_11406
+
+@ExperimentalResourceApi
+internal val Res.string.str_11407: StringResource
+  get() = String3.str_11407
+
+@ExperimentalResourceApi
+internal val Res.string.str_11408: StringResource
+  get() = String3.str_11408
+
+@ExperimentalResourceApi
+internal val Res.string.str_11409: StringResource
+  get() = String3.str_11409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1141: StringResource
+  get() = String3.str_1141
+
+@ExperimentalResourceApi
+internal val Res.string.str_11410: StringResource
+  get() = String3.str_11410
+
+@ExperimentalResourceApi
+internal val Res.string.str_11411: StringResource
+  get() = String3.str_11411
+
+@ExperimentalResourceApi
+internal val Res.string.str_11412: StringResource
+  get() = String3.str_11412
+
+@ExperimentalResourceApi
+internal val Res.string.str_11413: StringResource
+  get() = String3.str_11413
+
+@ExperimentalResourceApi
+internal val Res.string.str_11414: StringResource
+  get() = String3.str_11414
+
+@ExperimentalResourceApi
+internal val Res.string.str_11415: StringResource
+  get() = String3.str_11415
+
+@ExperimentalResourceApi
+internal val Res.string.str_11416: StringResource
+  get() = String3.str_11416
+
+@ExperimentalResourceApi
+internal val Res.string.str_11417: StringResource
+  get() = String3.str_11417
+
+@ExperimentalResourceApi
+internal val Res.string.str_11418: StringResource
+  get() = String3.str_11418
+
+@ExperimentalResourceApi
+internal val Res.string.str_11419: StringResource
+  get() = String3.str_11419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1142: StringResource
+  get() = String3.str_1142
+
+@ExperimentalResourceApi
+internal val Res.string.str_11420: StringResource
+  get() = String3.str_11420
+
+@ExperimentalResourceApi
+internal val Res.string.str_11421: StringResource
+  get() = String3.str_11421
+
+@ExperimentalResourceApi
+internal val Res.string.str_11422: StringResource
+  get() = String3.str_11422
+
+@ExperimentalResourceApi
+internal val Res.string.str_11423: StringResource
+  get() = String3.str_11423
+
+@ExperimentalResourceApi
+internal val Res.string.str_11424: StringResource
+  get() = String3.str_11424
+
+@ExperimentalResourceApi
+internal val Res.string.str_11425: StringResource
+  get() = String3.str_11425
+
+@ExperimentalResourceApi
+internal val Res.string.str_11426: StringResource
+  get() = String3.str_11426
+
+@ExperimentalResourceApi
+internal val Res.string.str_11427: StringResource
+  get() = String3.str_11427
+
+@ExperimentalResourceApi
+internal val Res.string.str_11428: StringResource
+  get() = String3.str_11428
+
+@ExperimentalResourceApi
+internal val Res.string.str_11429: StringResource
+  get() = String3.str_11429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1143: StringResource
+  get() = String3.str_1143
+
+@ExperimentalResourceApi
+internal val Res.string.str_11430: StringResource
+  get() = String3.str_11430
+
+@ExperimentalResourceApi
+internal val Res.string.str_11431: StringResource
+  get() = String3.str_11431
+
+@ExperimentalResourceApi
+internal val Res.string.str_11432: StringResource
+  get() = String3.str_11432
+
+@ExperimentalResourceApi
+internal val Res.string.str_11433: StringResource
+  get() = String3.str_11433
+
+@ExperimentalResourceApi
+internal val Res.string.str_11434: StringResource
+  get() = String3.str_11434
+
+@ExperimentalResourceApi
+internal val Res.string.str_11435: StringResource
+  get() = String3.str_11435
+
+@ExperimentalResourceApi
+internal val Res.string.str_11436: StringResource
+  get() = String3.str_11436
+
+@ExperimentalResourceApi
+internal val Res.string.str_11437: StringResource
+  get() = String3.str_11437
+
+@ExperimentalResourceApi
+internal val Res.string.str_11438: StringResource
+  get() = String3.str_11438
+
+@ExperimentalResourceApi
+internal val Res.string.str_11439: StringResource
+  get() = String3.str_11439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1144: StringResource
+  get() = String3.str_1144
+
+@ExperimentalResourceApi
+internal val Res.string.str_11440: StringResource
+  get() = String3.str_11440
+
+@ExperimentalResourceApi
+internal val Res.string.str_11441: StringResource
+  get() = String3.str_11441
+
+@ExperimentalResourceApi
+internal val Res.string.str_11442: StringResource
+  get() = String3.str_11442
+
+@ExperimentalResourceApi
+internal val Res.string.str_11443: StringResource
+  get() = String3.str_11443
+
+@ExperimentalResourceApi
+internal val Res.string.str_11444: StringResource
+  get() = String3.str_11444
+
+@ExperimentalResourceApi
+internal val Res.string.str_11445: StringResource
+  get() = String3.str_11445
+
+@ExperimentalResourceApi
+internal val Res.string.str_11446: StringResource
+  get() = String3.str_11446
+
+@ExperimentalResourceApi
+internal val Res.string.str_11447: StringResource
+  get() = String3.str_11447
+
+@ExperimentalResourceApi
+internal val Res.string.str_11448: StringResource
+  get() = String3.str_11448
+
+@ExperimentalResourceApi
+internal val Res.string.str_11449: StringResource
+  get() = String3.str_11449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1145: StringResource
+  get() = String3.str_1145
+
+@ExperimentalResourceApi
+internal val Res.string.str_11450: StringResource
+  get() = String3.str_11450
+
+@ExperimentalResourceApi
+internal val Res.string.str_11451: StringResource
+  get() = String3.str_11451
+
+@ExperimentalResourceApi
+internal val Res.string.str_11452: StringResource
+  get() = String3.str_11452
+
+@ExperimentalResourceApi
+internal val Res.string.str_11453: StringResource
+  get() = String3.str_11453
+
+@ExperimentalResourceApi
+internal val Res.string.str_11454: StringResource
+  get() = String3.str_11454
+
+@ExperimentalResourceApi
+internal val Res.string.str_11455: StringResource
+  get() = String3.str_11455
+
+@ExperimentalResourceApi
+internal val Res.string.str_11456: StringResource
+  get() = String3.str_11456
+
+@ExperimentalResourceApi
+internal val Res.string.str_11457: StringResource
+  get() = String3.str_11457
+
+@ExperimentalResourceApi
+internal val Res.string.str_11458: StringResource
+  get() = String3.str_11458
+
+@ExperimentalResourceApi
+internal val Res.string.str_11459: StringResource
+  get() = String3.str_11459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1146: StringResource
+  get() = String3.str_1146
+
+@ExperimentalResourceApi
+internal val Res.string.str_11460: StringResource
+  get() = String3.str_11460
+
+@ExperimentalResourceApi
+internal val Res.string.str_11461: StringResource
+  get() = String3.str_11461
+
+@ExperimentalResourceApi
+internal val Res.string.str_11462: StringResource
+  get() = String3.str_11462
+
+@ExperimentalResourceApi
+internal val Res.string.str_11463: StringResource
+  get() = String3.str_11463
+
+@ExperimentalResourceApi
+internal val Res.string.str_11464: StringResource
+  get() = String3.str_11464
+
+@ExperimentalResourceApi
+internal val Res.string.str_11465: StringResource
+  get() = String3.str_11465
+
+@ExperimentalResourceApi
+internal val Res.string.str_11466: StringResource
+  get() = String3.str_11466
+
+@ExperimentalResourceApi
+internal val Res.string.str_11467: StringResource
+  get() = String3.str_11467
+
+@ExperimentalResourceApi
+internal val Res.string.str_11468: StringResource
+  get() = String3.str_11468
+
+@ExperimentalResourceApi
+internal val Res.string.str_11469: StringResource
+  get() = String3.str_11469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1147: StringResource
+  get() = String3.str_1147
+
+@ExperimentalResourceApi
+internal val Res.string.str_11470: StringResource
+  get() = String3.str_11470
+
+@ExperimentalResourceApi
+internal val Res.string.str_11471: StringResource
+  get() = String3.str_11471
+
+@ExperimentalResourceApi
+internal val Res.string.str_11472: StringResource
+  get() = String3.str_11472
+
+@ExperimentalResourceApi
+internal val Res.string.str_11473: StringResource
+  get() = String3.str_11473
+
+@ExperimentalResourceApi
+internal val Res.string.str_11474: StringResource
+  get() = String3.str_11474
+
+@ExperimentalResourceApi
+internal val Res.string.str_11475: StringResource
+  get() = String3.str_11475
+
+@ExperimentalResourceApi
+internal val Res.string.str_11476: StringResource
+  get() = String3.str_11476
+
+@ExperimentalResourceApi
+internal val Res.string.str_11477: StringResource
+  get() = String3.str_11477
+
+@ExperimentalResourceApi
+internal val Res.string.str_11478: StringResource
+  get() = String3.str_11478
+
+@ExperimentalResourceApi
+internal val Res.string.str_11479: StringResource
+  get() = String3.str_11479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1148: StringResource
+  get() = String3.str_1148
+
+@ExperimentalResourceApi
+internal val Res.string.str_11480: StringResource
+  get() = String3.str_11480
+
+@ExperimentalResourceApi
+internal val Res.string.str_11481: StringResource
+  get() = String3.str_11481
+
+@ExperimentalResourceApi
+internal val Res.string.str_11482: StringResource
+  get() = String3.str_11482
+
+@ExperimentalResourceApi
+internal val Res.string.str_11483: StringResource
+  get() = String3.str_11483
+
+@ExperimentalResourceApi
+internal val Res.string.str_11484: StringResource
+  get() = String3.str_11484
+
+@ExperimentalResourceApi
+internal val Res.string.str_11485: StringResource
+  get() = String3.str_11485
+
+@ExperimentalResourceApi
+internal val Res.string.str_11486: StringResource
+  get() = String3.str_11486
+
+@ExperimentalResourceApi
+internal val Res.string.str_11487: StringResource
+  get() = String3.str_11487
+
+@ExperimentalResourceApi
+internal val Res.string.str_11488: StringResource
+  get() = String3.str_11488
+
+@ExperimentalResourceApi
+internal val Res.string.str_11489: StringResource
+  get() = String3.str_11489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1149: StringResource
+  get() = String3.str_1149
+
+@ExperimentalResourceApi
+internal val Res.string.str_11490: StringResource
+  get() = String3.str_11490
+
+@ExperimentalResourceApi
+internal val Res.string.str_11491: StringResource
+  get() = String3.str_11491
+
+@ExperimentalResourceApi
+internal val Res.string.str_11492: StringResource
+  get() = String3.str_11492
+
+@ExperimentalResourceApi
+internal val Res.string.str_11493: StringResource
+  get() = String3.str_11493
+
+@ExperimentalResourceApi
+internal val Res.string.str_11494: StringResource
+  get() = String3.str_11494
+
+@ExperimentalResourceApi
+internal val Res.string.str_11495: StringResource
+  get() = String3.str_11495
+
+@ExperimentalResourceApi
+internal val Res.string.str_11496: StringResource
+  get() = String3.str_11496
+
+@ExperimentalResourceApi
+internal val Res.string.str_11497: StringResource
+  get() = String3.str_11497
+
+@ExperimentalResourceApi
+internal val Res.string.str_11498: StringResource
+  get() = String3.str_11498
+
+@ExperimentalResourceApi
+internal val Res.string.str_11499: StringResource
+  get() = String3.str_11499
+
+@ExperimentalResourceApi
+internal val Res.string.str_115: StringResource
+  get() = String3.str_115
+
+@ExperimentalResourceApi
+internal val Res.string.str_1150: StringResource
+  get() = String3.str_1150
+
+@ExperimentalResourceApi
+internal val Res.string.str_11500: StringResource
+  get() = String3.str_11500
+
+@ExperimentalResourceApi
+internal val Res.string.str_11501: StringResource
+  get() = String3.str_11501
+
+@ExperimentalResourceApi
+internal val Res.string.str_11502: StringResource
+  get() = String3.str_11502
+
+@ExperimentalResourceApi
+internal val Res.string.str_11503: StringResource
+  get() = String3.str_11503
+
+@ExperimentalResourceApi
+internal val Res.string.str_11504: StringResource
+  get() = String3.str_11504
+
+@ExperimentalResourceApi
+internal val Res.string.str_11505: StringResource
+  get() = String3.str_11505
+
+@ExperimentalResourceApi
+internal val Res.string.str_11506: StringResource
+  get() = String3.str_11506
+
+@ExperimentalResourceApi
+internal val Res.string.str_11507: StringResource
+  get() = String3.str_11507
+
+@ExperimentalResourceApi
+internal val Res.string.str_11508: StringResource
+  get() = String3.str_11508
+
+@ExperimentalResourceApi
+internal val Res.string.str_11509: StringResource
+  get() = String3.str_11509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1151: StringResource
+  get() = String3.str_1151
+
+@ExperimentalResourceApi
+internal val Res.string.str_11510: StringResource
+  get() = String3.str_11510
+
+@ExperimentalResourceApi
+internal val Res.string.str_11511: StringResource
+  get() = String3.str_11511
+
+@ExperimentalResourceApi
+internal val Res.string.str_11512: StringResource
+  get() = String3.str_11512
+
+@ExperimentalResourceApi
+internal val Res.string.str_11513: StringResource
+  get() = String3.str_11513
+
+@ExperimentalResourceApi
+internal val Res.string.str_11514: StringResource
+  get() = String3.str_11514
+
+@ExperimentalResourceApi
+internal val Res.string.str_11515: StringResource
+  get() = String3.str_11515
+
+@ExperimentalResourceApi
+internal val Res.string.str_11516: StringResource
+  get() = String3.str_11516
+
+@ExperimentalResourceApi
+internal val Res.string.str_11517: StringResource
+  get() = String3.str_11517
+
+@ExperimentalResourceApi
+internal val Res.string.str_11518: StringResource
+  get() = String3.str_11518
+
+@ExperimentalResourceApi
+internal val Res.string.str_11519: StringResource
+  get() = String3.str_11519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1152: StringResource
+  get() = String3.str_1152
+
+@ExperimentalResourceApi
+internal val Res.string.str_11520: StringResource
+  get() = String3.str_11520
+
+@ExperimentalResourceApi
+internal val Res.string.str_11521: StringResource
+  get() = String3.str_11521
+
+@ExperimentalResourceApi
+internal val Res.string.str_11522: StringResource
+  get() = String3.str_11522
+
+@ExperimentalResourceApi
+internal val Res.string.str_11523: StringResource
+  get() = String3.str_11523
+
+@ExperimentalResourceApi
+internal val Res.string.str_11524: StringResource
+  get() = String3.str_11524
+
+@ExperimentalResourceApi
+internal val Res.string.str_11525: StringResource
+  get() = String3.str_11525
+
+@ExperimentalResourceApi
+internal val Res.string.str_11526: StringResource
+  get() = String3.str_11526
+
+@ExperimentalResourceApi
+internal val Res.string.str_11527: StringResource
+  get() = String3.str_11527
+
+@ExperimentalResourceApi
+internal val Res.string.str_11528: StringResource
+  get() = String3.str_11528
+
+@ExperimentalResourceApi
+internal val Res.string.str_11529: StringResource
+  get() = String3.str_11529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1153: StringResource
+  get() = String3.str_1153
+
+@ExperimentalResourceApi
+internal val Res.string.str_11530: StringResource
+  get() = String3.str_11530
+
+@ExperimentalResourceApi
+internal val Res.string.str_11531: StringResource
+  get() = String3.str_11531
+
+@ExperimentalResourceApi
+internal val Res.string.str_11532: StringResource
+  get() = String3.str_11532
+
+@ExperimentalResourceApi
+internal val Res.string.str_11533: StringResource
+  get() = String3.str_11533
+
+@ExperimentalResourceApi
+internal val Res.string.str_11534: StringResource
+  get() = String3.str_11534
+
+@ExperimentalResourceApi
+internal val Res.string.str_11535: StringResource
+  get() = String3.str_11535
+
+@ExperimentalResourceApi
+internal val Res.string.str_11536: StringResource
+  get() = String3.str_11536
+
+@ExperimentalResourceApi
+internal val Res.string.str_11537: StringResource
+  get() = String3.str_11537
+
+@ExperimentalResourceApi
+internal val Res.string.str_11538: StringResource
+  get() = String3.str_11538
+
+@ExperimentalResourceApi
+internal val Res.string.str_11539: StringResource
+  get() = String3.str_11539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1154: StringResource
+  get() = String3.str_1154
+
+@ExperimentalResourceApi
+internal val Res.string.str_11540: StringResource
+  get() = String3.str_11540
+
+@ExperimentalResourceApi
+internal val Res.string.str_11541: StringResource
+  get() = String3.str_11541
+
+@ExperimentalResourceApi
+internal val Res.string.str_11542: StringResource
+  get() = String3.str_11542
+
+@ExperimentalResourceApi
+internal val Res.string.str_11543: StringResource
+  get() = String3.str_11543
+
+@ExperimentalResourceApi
+internal val Res.string.str_11544: StringResource
+  get() = String3.str_11544
+
+@ExperimentalResourceApi
+internal val Res.string.str_11545: StringResource
+  get() = String3.str_11545
+
+@ExperimentalResourceApi
+internal val Res.string.str_11546: StringResource
+  get() = String3.str_11546
+
+@ExperimentalResourceApi
+internal val Res.string.str_11547: StringResource
+  get() = String3.str_11547
+
+@ExperimentalResourceApi
+internal val Res.string.str_11548: StringResource
+  get() = String3.str_11548
+
+@ExperimentalResourceApi
+internal val Res.string.str_11549: StringResource
+  get() = String3.str_11549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1155: StringResource
+  get() = String3.str_1155
+
+@ExperimentalResourceApi
+internal val Res.string.str_11550: StringResource
+  get() = String3.str_11550
+
+@ExperimentalResourceApi
+internal val Res.string.str_11551: StringResource
+  get() = String3.str_11551
+
+@ExperimentalResourceApi
+internal val Res.string.str_11552: StringResource
+  get() = String3.str_11552
+
+@ExperimentalResourceApi
+internal val Res.string.str_11553: StringResource
+  get() = String3.str_11553
+
+@ExperimentalResourceApi
+internal val Res.string.str_11554: StringResource
+  get() = String3.str_11554
+
+@ExperimentalResourceApi
+internal val Res.string.str_11555: StringResource
+  get() = String3.str_11555
+
+@ExperimentalResourceApi
+internal val Res.string.str_11556: StringResource
+  get() = String3.str_11556
+
+@ExperimentalResourceApi
+internal val Res.string.str_11557: StringResource
+  get() = String3.str_11557
+
+@ExperimentalResourceApi
+internal val Res.string.str_11558: StringResource
+  get() = String3.str_11558
+
+@ExperimentalResourceApi
+internal val Res.string.str_11559: StringResource
+  get() = String3.str_11559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1156: StringResource
+  get() = String3.str_1156
+
+@ExperimentalResourceApi
+internal val Res.string.str_11560: StringResource
+  get() = String3.str_11560
+
+@ExperimentalResourceApi
+internal val Res.string.str_11561: StringResource
+  get() = String3.str_11561
+
+@ExperimentalResourceApi
+internal val Res.string.str_11562: StringResource
+  get() = String3.str_11562
+
+@ExperimentalResourceApi
+internal val Res.string.str_11563: StringResource
+  get() = String3.str_11563
+
+@ExperimentalResourceApi
+internal val Res.string.str_11564: StringResource
+  get() = String3.str_11564
+
+@ExperimentalResourceApi
+internal val Res.string.str_11565: StringResource
+  get() = String3.str_11565
+
+@ExperimentalResourceApi
+internal val Res.string.str_11566: StringResource
+  get() = String3.str_11566
+
+@ExperimentalResourceApi
+internal val Res.string.str_11567: StringResource
+  get() = String3.str_11567
+
+@ExperimentalResourceApi
+internal val Res.string.str_11568: StringResource
+  get() = String3.str_11568
+
+@ExperimentalResourceApi
+internal val Res.string.str_11569: StringResource
+  get() = String3.str_11569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1157: StringResource
+  get() = String3.str_1157
+
+@ExperimentalResourceApi
+internal val Res.string.str_11570: StringResource
+  get() = String3.str_11570
+
+@ExperimentalResourceApi
+internal val Res.string.str_11571: StringResource
+  get() = String3.str_11571
+
+@ExperimentalResourceApi
+internal val Res.string.str_11572: StringResource
+  get() = String3.str_11572
+
+@ExperimentalResourceApi
+internal val Res.string.str_11573: StringResource
+  get() = String3.str_11573
+
+@ExperimentalResourceApi
+internal val Res.string.str_11574: StringResource
+  get() = String3.str_11574
+
+@ExperimentalResourceApi
+internal val Res.string.str_11575: StringResource
+  get() = String3.str_11575
+
+@ExperimentalResourceApi
+internal val Res.string.str_11576: StringResource
+  get() = String3.str_11576
+
+@ExperimentalResourceApi
+internal val Res.string.str_11577: StringResource
+  get() = String3.str_11577
+
+@ExperimentalResourceApi
+internal val Res.string.str_11578: StringResource
+  get() = String3.str_11578
+
+@ExperimentalResourceApi
+internal val Res.string.str_11579: StringResource
+  get() = String3.str_11579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1158: StringResource
+  get() = String3.str_1158
+
+@ExperimentalResourceApi
+internal val Res.string.str_11580: StringResource
+  get() = String3.str_11580
+
+@ExperimentalResourceApi
+internal val Res.string.str_11581: StringResource
+  get() = String3.str_11581
+
+@ExperimentalResourceApi
+internal val Res.string.str_11582: StringResource
+  get() = String3.str_11582
+
+@ExperimentalResourceApi
+internal val Res.string.str_11583: StringResource
+  get() = String3.str_11583
+
+@ExperimentalResourceApi
+internal val Res.string.str_11584: StringResource
+  get() = String3.str_11584
+
+@ExperimentalResourceApi
+internal val Res.string.str_11585: StringResource
+  get() = String3.str_11585
+
+@ExperimentalResourceApi
+internal val Res.string.str_11586: StringResource
+  get() = String3.str_11586
+
+@ExperimentalResourceApi
+internal val Res.string.str_11587: StringResource
+  get() = String3.str_11587
+
+@ExperimentalResourceApi
+internal val Res.string.str_11588: StringResource
+  get() = String3.str_11588
+
+@ExperimentalResourceApi
+internal val Res.string.str_11589: StringResource
+  get() = String3.str_11589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1159: StringResource
+  get() = String3.str_1159
+
+@ExperimentalResourceApi
+internal val Res.string.str_11590: StringResource
+  get() = String3.str_11590
+
+@ExperimentalResourceApi
+internal val Res.string.str_11591: StringResource
+  get() = String3.str_11591
+
+@ExperimentalResourceApi
+internal val Res.string.str_11592: StringResource
+  get() = String3.str_11592
+
+@ExperimentalResourceApi
+internal val Res.string.str_11593: StringResource
+  get() = String3.str_11593
+
+@ExperimentalResourceApi
+internal val Res.string.str_11594: StringResource
+  get() = String3.str_11594
+
+@ExperimentalResourceApi
+internal val Res.string.str_11595: StringResource
+  get() = String3.str_11595
+
+@ExperimentalResourceApi
+internal val Res.string.str_11596: StringResource
+  get() = String3.str_11596
+
+@ExperimentalResourceApi
+internal val Res.string.str_11597: StringResource
+  get() = String3.str_11597
+
+@ExperimentalResourceApi
+internal val Res.string.str_11598: StringResource
+  get() = String3.str_11598
+
+@ExperimentalResourceApi
+internal val Res.string.str_11599: StringResource
+  get() = String3.str_11599
+
+@ExperimentalResourceApi
+internal val Res.string.str_116: StringResource
+  get() = String3.str_116
+
+@ExperimentalResourceApi
+internal val Res.string.str_1160: StringResource
+  get() = String3.str_1160
+
+@ExperimentalResourceApi
+internal val Res.string.str_11600: StringResource
+  get() = String3.str_11600
+
+@ExperimentalResourceApi
+internal val Res.string.str_11601: StringResource
+  get() = String3.str_11601
+
+@ExperimentalResourceApi
+internal val Res.string.str_11602: StringResource
+  get() = String3.str_11602
+
+@ExperimentalResourceApi
+internal val Res.string.str_11603: StringResource
+  get() = String3.str_11603
+
+@ExperimentalResourceApi
+internal val Res.string.str_11604: StringResource
+  get() = String3.str_11604
+
+@ExperimentalResourceApi
+internal val Res.string.str_11605: StringResource
+  get() = String3.str_11605
+
+@ExperimentalResourceApi
+internal val Res.string.str_11606: StringResource
+  get() = String3.str_11606
+
+@ExperimentalResourceApi
+internal val Res.string.str_11607: StringResource
+  get() = String3.str_11607
+
+@ExperimentalResourceApi
+internal val Res.string.str_11608: StringResource
+  get() = String3.str_11608
+
+@ExperimentalResourceApi
+internal val Res.string.str_11609: StringResource
+  get() = String3.str_11609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1161: StringResource
+  get() = String3.str_1161
+
+@ExperimentalResourceApi
+internal val Res.string.str_11610: StringResource
+  get() = String3.str_11610
+
+@ExperimentalResourceApi
+internal val Res.string.str_11611: StringResource
+  get() = String3.str_11611
+
+@ExperimentalResourceApi
+internal val Res.string.str_11612: StringResource
+  get() = String3.str_11612
+
+@ExperimentalResourceApi
+internal val Res.string.str_11613: StringResource
+  get() = String3.str_11613
+
+@ExperimentalResourceApi
+internal val Res.string.str_11614: StringResource
+  get() = String3.str_11614
+
+@ExperimentalResourceApi
+internal val Res.string.str_11615: StringResource
+  get() = String3.str_11615
+
+@ExperimentalResourceApi
+internal val Res.string.str_11616: StringResource
+  get() = String3.str_11616
+
+@ExperimentalResourceApi
+internal val Res.string.str_11617: StringResource
+  get() = String3.str_11617
+
+@ExperimentalResourceApi
+internal val Res.string.str_11618: StringResource
+  get() = String3.str_11618
+
+@ExperimentalResourceApi
+internal val Res.string.str_11619: StringResource
+  get() = String3.str_11619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1162: StringResource
+  get() = String3.str_1162
+
+@ExperimentalResourceApi
+internal val Res.string.str_11620: StringResource
+  get() = String3.str_11620
+
+@ExperimentalResourceApi
+internal val Res.string.str_11621: StringResource
+  get() = String3.str_11621
+
+@ExperimentalResourceApi
+internal val Res.string.str_11622: StringResource
+  get() = String3.str_11622
+
+@ExperimentalResourceApi
+internal val Res.string.str_11623: StringResource
+  get() = String3.str_11623
+
+@ExperimentalResourceApi
+internal val Res.string.str_11624: StringResource
+  get() = String3.str_11624
+
+@ExperimentalResourceApi
+internal val Res.string.str_11625: StringResource
+  get() = String3.str_11625
+
+@ExperimentalResourceApi
+internal val Res.string.str_11626: StringResource
+  get() = String3.str_11626
+
+@ExperimentalResourceApi
+internal val Res.string.str_11627: StringResource
+  get() = String3.str_11627
+
+@ExperimentalResourceApi
+internal val Res.string.str_11628: StringResource
+  get() = String3.str_11628
+
+@ExperimentalResourceApi
+internal val Res.string.str_11629: StringResource
+  get() = String3.str_11629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1163: StringResource
+  get() = String3.str_1163
+
+@ExperimentalResourceApi
+internal val Res.string.str_11630: StringResource
+  get() = String3.str_11630
+
+@ExperimentalResourceApi
+internal val Res.string.str_11631: StringResource
+  get() = String3.str_11631
+
+@ExperimentalResourceApi
+internal val Res.string.str_11632: StringResource
+  get() = String3.str_11632
+
+@ExperimentalResourceApi
+internal val Res.string.str_11633: StringResource
+  get() = String3.str_11633
+
+@ExperimentalResourceApi
+internal val Res.string.str_11634: StringResource
+  get() = String3.str_11634
+
+@ExperimentalResourceApi
+internal val Res.string.str_11635: StringResource
+  get() = String3.str_11635
+
+@ExperimentalResourceApi
+internal val Res.string.str_11636: StringResource
+  get() = String3.str_11636
+
+@ExperimentalResourceApi
+internal val Res.string.str_11637: StringResource
+  get() = String3.str_11637
+
+@ExperimentalResourceApi
+internal val Res.string.str_11638: StringResource
+  get() = String3.str_11638
+
+@ExperimentalResourceApi
+internal val Res.string.str_11639: StringResource
+  get() = String3.str_11639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1164: StringResource
+  get() = String3.str_1164
+
+@ExperimentalResourceApi
+internal val Res.string.str_11640: StringResource
+  get() = String3.str_11640
+
+@ExperimentalResourceApi
+internal val Res.string.str_11641: StringResource
+  get() = String3.str_11641
+
+@ExperimentalResourceApi
+internal val Res.string.str_11642: StringResource
+  get() = String3.str_11642
+
+@ExperimentalResourceApi
+internal val Res.string.str_11643: StringResource
+  get() = String3.str_11643
+
+@ExperimentalResourceApi
+internal val Res.string.str_11644: StringResource
+  get() = String3.str_11644
+
+@ExperimentalResourceApi
+internal val Res.string.str_11645: StringResource
+  get() = String3.str_11645
+
+@ExperimentalResourceApi
+internal val Res.string.str_11646: StringResource
+  get() = String3.str_11646
+
+@ExperimentalResourceApi
+internal val Res.string.str_11647: StringResource
+  get() = String3.str_11647
+
+@ExperimentalResourceApi
+internal val Res.string.str_11648: StringResource
+  get() = String3.str_11648
+
+@ExperimentalResourceApi
+internal val Res.string.str_11649: StringResource
+  get() = String3.str_11649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1165: StringResource
+  get() = String3.str_1165
+
+@ExperimentalResourceApi
+internal val Res.string.str_11650: StringResource
+  get() = String3.str_11650
+
+@ExperimentalResourceApi
+internal val Res.string.str_11651: StringResource
+  get() = String3.str_11651
+
+@ExperimentalResourceApi
+internal val Res.string.str_11652: StringResource
+  get() = String3.str_11652
+
+@ExperimentalResourceApi
+internal val Res.string.str_11653: StringResource
+  get() = String3.str_11653
+
+@ExperimentalResourceApi
+internal val Res.string.str_11654: StringResource
+  get() = String3.str_11654
+
+@ExperimentalResourceApi
+internal val Res.string.str_11655: StringResource
+  get() = String3.str_11655
+
+@ExperimentalResourceApi
+internal val Res.string.str_11656: StringResource
+  get() = String3.str_11656
+
+@ExperimentalResourceApi
+internal val Res.string.str_11657: StringResource
+  get() = String3.str_11657
+
+@ExperimentalResourceApi
+internal val Res.string.str_11658: StringResource
+  get() = String3.str_11658
+
+@ExperimentalResourceApi
+internal val Res.string.str_11659: StringResource
+  get() = String3.str_11659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1166: StringResource
+  get() = String3.str_1166
+
+@ExperimentalResourceApi
+internal val Res.string.str_11660: StringResource
+  get() = String3.str_11660
+
+@ExperimentalResourceApi
+internal val Res.string.str_11661: StringResource
+  get() = String3.str_11661
+
+@ExperimentalResourceApi
+internal val Res.string.str_11662: StringResource
+  get() = String3.str_11662
+
+@ExperimentalResourceApi
+internal val Res.string.str_11663: StringResource
+  get() = String3.str_11663
+
+@ExperimentalResourceApi
+internal val Res.string.str_11664: StringResource
+  get() = String3.str_11664
+
+@ExperimentalResourceApi
+internal val Res.string.str_11665: StringResource
+  get() = String3.str_11665
+
+@ExperimentalResourceApi
+internal val Res.string.str_11666: StringResource
+  get() = String3.str_11666
+
+@ExperimentalResourceApi
+internal val Res.string.str_11667: StringResource
+  get() = String3.str_11667
+
+@ExperimentalResourceApi
+internal val Res.string.str_11668: StringResource
+  get() = String3.str_11668
+
+@ExperimentalResourceApi
+internal val Res.string.str_11669: StringResource
+  get() = String3.str_11669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1167: StringResource
+  get() = String3.str_1167
+
+@ExperimentalResourceApi
+internal val Res.string.str_11670: StringResource
+  get() = String3.str_11670
+
+@ExperimentalResourceApi
+internal val Res.string.str_11671: StringResource
+  get() = String3.str_11671
+
+@ExperimentalResourceApi
+internal val Res.string.str_11672: StringResource
+  get() = String3.str_11672
+
+@ExperimentalResourceApi
+internal val Res.string.str_11673: StringResource
+  get() = String3.str_11673
+
+@ExperimentalResourceApi
+internal val Res.string.str_11674: StringResource
+  get() = String3.str_11674
+
+@ExperimentalResourceApi
+internal val Res.string.str_11675: StringResource
+  get() = String3.str_11675
+
+@ExperimentalResourceApi
+internal val Res.string.str_11676: StringResource
+  get() = String3.str_11676
+
+@ExperimentalResourceApi
+internal val Res.string.str_11677: StringResource
+  get() = String3.str_11677
+
+@ExperimentalResourceApi
+internal val Res.string.str_11678: StringResource
+  get() = String3.str_11678
+
+@ExperimentalResourceApi
+internal val Res.string.str_11679: StringResource
+  get() = String3.str_11679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1168: StringResource
+  get() = String3.str_1168
+
+@ExperimentalResourceApi
+internal val Res.string.str_11680: StringResource
+  get() = String3.str_11680
+
+@ExperimentalResourceApi
+internal val Res.string.str_11681: StringResource
+  get() = String3.str_11681
+
+@ExperimentalResourceApi
+internal val Res.string.str_11682: StringResource
+  get() = String3.str_11682
+
+@ExperimentalResourceApi
+internal val Res.string.str_11683: StringResource
+  get() = String3.str_11683
+
+@ExperimentalResourceApi
+internal val Res.string.str_11684: StringResource
+  get() = String3.str_11684
+
+@ExperimentalResourceApi
+internal val Res.string.str_11685: StringResource
+  get() = String3.str_11685
+
+@ExperimentalResourceApi
+internal val Res.string.str_11686: StringResource
+  get() = String3.str_11686
+
+@ExperimentalResourceApi
+internal val Res.string.str_11687: StringResource
+  get() = String3.str_11687
+
+@ExperimentalResourceApi
+internal val Res.string.str_11688: StringResource
+  get() = String3.str_11688
+
+@ExperimentalResourceApi
+internal val Res.string.str_11689: StringResource
+  get() = String3.str_11689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1169: StringResource
+  get() = String3.str_1169
+
+@ExperimentalResourceApi
+internal val Res.string.str_11690: StringResource
+  get() = String3.str_11690
+
+@ExperimentalResourceApi
+internal val Res.string.str_11691: StringResource
+  get() = String3.str_11691
+
+@ExperimentalResourceApi
+internal val Res.string.str_11692: StringResource
+  get() = String3.str_11692
+
+@ExperimentalResourceApi
+internal val Res.string.str_11693: StringResource
+  get() = String3.str_11693
+
+@ExperimentalResourceApi
+internal val Res.string.str_11694: StringResource
+  get() = String3.str_11694
+
+@ExperimentalResourceApi
+internal val Res.string.str_11695: StringResource
+  get() = String3.str_11695
+
+@ExperimentalResourceApi
+internal val Res.string.str_11696: StringResource
+  get() = String3.str_11696
+
+@ExperimentalResourceApi
+internal val Res.string.str_11697: StringResource
+  get() = String3.str_11697
+
+@ExperimentalResourceApi
+internal val Res.string.str_11698: StringResource
+  get() = String3.str_11698
+
+@ExperimentalResourceApi
+internal val Res.string.str_11699: StringResource
+  get() = String3.str_11699
+
+@ExperimentalResourceApi
+internal val Res.string.str_117: StringResource
+  get() = String3.str_117
+
+@ExperimentalResourceApi
+internal val Res.string.str_1170: StringResource
+  get() = String3.str_1170
+
+@ExperimentalResourceApi
+internal val Res.string.str_11700: StringResource
+  get() = String3.str_11700
+
+@ExperimentalResourceApi
+internal val Res.string.str_11701: StringResource
+  get() = String3.str_11701
+
+@ExperimentalResourceApi
+internal val Res.string.str_11702: StringResource
+  get() = String3.str_11702
+
+@ExperimentalResourceApi
+internal val Res.string.str_11703: StringResource
+  get() = String3.str_11703
+
+@ExperimentalResourceApi
+internal val Res.string.str_11704: StringResource
+  get() = String3.str_11704
+
+@ExperimentalResourceApi
+internal val Res.string.str_11705: StringResource
+  get() = String3.str_11705
+
+@ExperimentalResourceApi
+internal val Res.string.str_11706: StringResource
+  get() = String3.str_11706
+
+@ExperimentalResourceApi
+internal val Res.string.str_11707: StringResource
+  get() = String3.str_11707
+
+@ExperimentalResourceApi
+internal val Res.string.str_11708: StringResource
+  get() = String3.str_11708
+
+@ExperimentalResourceApi
+internal val Res.string.str_11709: StringResource
+  get() = String3.str_11709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1171: StringResource
+  get() = String3.str_1171
+
+@ExperimentalResourceApi
+internal val Res.string.str_11710: StringResource
+  get() = String3.str_11710
+
+@ExperimentalResourceApi
+internal val Res.string.str_11711: StringResource
+  get() = String3.str_11711
+
+@ExperimentalResourceApi
+internal val Res.string.str_11712: StringResource
+  get() = String3.str_11712
+
+@ExperimentalResourceApi
+internal val Res.string.str_11713: StringResource
+  get() = String3.str_11713
+
+@ExperimentalResourceApi
+internal val Res.string.str_11714: StringResource
+  get() = String3.str_11714
+
+@ExperimentalResourceApi
+internal val Res.string.str_11715: StringResource
+  get() = String3.str_11715
+
+@ExperimentalResourceApi
+internal val Res.string.str_11716: StringResource
+  get() = String3.str_11716
+
+@ExperimentalResourceApi
+internal val Res.string.str_11717: StringResource
+  get() = String3.str_11717
+
+@ExperimentalResourceApi
+internal val Res.string.str_11718: StringResource
+  get() = String3.str_11718
+
+@ExperimentalResourceApi
+internal val Res.string.str_11719: StringResource
+  get() = String3.str_11719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1172: StringResource
+  get() = String3.str_1172
+
+@ExperimentalResourceApi
+internal val Res.string.str_11720: StringResource
+  get() = String3.str_11720
+
+@ExperimentalResourceApi
+internal val Res.string.str_11721: StringResource
+  get() = String3.str_11721
+
+@ExperimentalResourceApi
+internal val Res.string.str_11722: StringResource
+  get() = String3.str_11722
+
+@ExperimentalResourceApi
+internal val Res.string.str_11723: StringResource
+  get() = String3.str_11723
+
+@ExperimentalResourceApi
+internal val Res.string.str_11724: StringResource
+  get() = String3.str_11724
+
+@ExperimentalResourceApi
+internal val Res.string.str_11725: StringResource
+  get() = String3.str_11725
+
+@ExperimentalResourceApi
+internal val Res.string.str_11726: StringResource
+  get() = String3.str_11726
+
+@ExperimentalResourceApi
+internal val Res.string.str_11727: StringResource
+  get() = String3.str_11727
+
+@ExperimentalResourceApi
+internal val Res.string.str_11728: StringResource
+  get() = String3.str_11728
+
+@ExperimentalResourceApi
+internal val Res.string.str_11729: StringResource
+  get() = String3.str_11729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1173: StringResource
+  get() = String3.str_1173
+
+@ExperimentalResourceApi
+internal val Res.string.str_11730: StringResource
+  get() = String3.str_11730
+
+@ExperimentalResourceApi
+internal val Res.string.str_11731: StringResource
+  get() = String3.str_11731
+
+@ExperimentalResourceApi
+internal val Res.string.str_11732: StringResource
+  get() = String3.str_11732
+
+@ExperimentalResourceApi
+internal val Res.string.str_11733: StringResource
+  get() = String3.str_11733
+
+@ExperimentalResourceApi
+internal val Res.string.str_11734: StringResource
+  get() = String3.str_11734
+
+@ExperimentalResourceApi
+internal val Res.string.str_11735: StringResource
+  get() = String3.str_11735
+
+@ExperimentalResourceApi
+internal val Res.string.str_11736: StringResource
+  get() = String3.str_11736
+
+@ExperimentalResourceApi
+internal val Res.string.str_11737: StringResource
+  get() = String3.str_11737
+
+@ExperimentalResourceApi
+internal val Res.string.str_11738: StringResource
+  get() = String3.str_11738
+
+@ExperimentalResourceApi
+internal val Res.string.str_11739: StringResource
+  get() = String3.str_11739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1174: StringResource
+  get() = String3.str_1174
+
+@ExperimentalResourceApi
+internal val Res.string.str_11740: StringResource
+  get() = String3.str_11740
+
+@ExperimentalResourceApi
+internal val Res.string.str_11741: StringResource
+  get() = String3.str_11741
+
+@ExperimentalResourceApi
+internal val Res.string.str_11742: StringResource
+  get() = String3.str_11742
+
+@ExperimentalResourceApi
+internal val Res.string.str_11743: StringResource
+  get() = String3.str_11743
+
+@ExperimentalResourceApi
+internal val Res.string.str_11744: StringResource
+  get() = String3.str_11744
+
+@ExperimentalResourceApi
+internal val Res.string.str_11745: StringResource
+  get() = String3.str_11745
+
+@ExperimentalResourceApi
+internal val Res.string.str_11746: StringResource
+  get() = String3.str_11746
+
+@ExperimentalResourceApi
+internal val Res.string.str_11747: StringResource
+  get() = String3.str_11747
+
+@ExperimentalResourceApi
+internal val Res.string.str_11748: StringResource
+  get() = String3.str_11748
+
+@ExperimentalResourceApi
+internal val Res.string.str_11749: StringResource
+  get() = String3.str_11749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1175: StringResource
+  get() = String3.str_1175
+
+@ExperimentalResourceApi
+internal val Res.string.str_11750: StringResource
+  get() = String3.str_11750
+
+@ExperimentalResourceApi
+internal val Res.string.str_11751: StringResource
+  get() = String3.str_11751
+
+@ExperimentalResourceApi
+internal val Res.string.str_11752: StringResource
+  get() = String3.str_11752
+
+@ExperimentalResourceApi
+internal val Res.string.str_11753: StringResource
+  get() = String3.str_11753
+
+@ExperimentalResourceApi
+internal val Res.string.str_11754: StringResource
+  get() = String3.str_11754
+
+@ExperimentalResourceApi
+internal val Res.string.str_11755: StringResource
+  get() = String3.str_11755
+
+@ExperimentalResourceApi
+internal val Res.string.str_11756: StringResource
+  get() = String3.str_11756
+
+@ExperimentalResourceApi
+internal val Res.string.str_11757: StringResource
+  get() = String3.str_11757
+
+@ExperimentalResourceApi
+internal val Res.string.str_11758: StringResource
+  get() = String3.str_11758
+
+@ExperimentalResourceApi
+internal val Res.string.str_11759: StringResource
+  get() = String3.str_11759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1176: StringResource
+  get() = String3.str_1176
+
+@ExperimentalResourceApi
+internal val Res.string.str_11760: StringResource
+  get() = String3.str_11760
+
+@ExperimentalResourceApi
+internal val Res.string.str_11761: StringResource
+  get() = String3.str_11761
+
+@ExperimentalResourceApi
+internal val Res.string.str_11762: StringResource
+  get() = String3.str_11762
+
+@ExperimentalResourceApi
+internal val Res.string.str_11763: StringResource
+  get() = String3.str_11763
+
+@ExperimentalResourceApi
+internal val Res.string.str_11764: StringResource
+  get() = String3.str_11764
+
+@ExperimentalResourceApi
+internal val Res.string.str_11765: StringResource
+  get() = String3.str_11765
+
+@ExperimentalResourceApi
+internal val Res.string.str_11766: StringResource
+  get() = String3.str_11766
+
+@ExperimentalResourceApi
+internal val Res.string.str_11767: StringResource
+  get() = String3.str_11767
+
+@ExperimentalResourceApi
+internal val Res.string.str_11768: StringResource
+  get() = String3.str_11768
+
+@ExperimentalResourceApi
+internal val Res.string.str_11769: StringResource
+  get() = String3.str_11769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1177: StringResource
+  get() = String3.str_1177
+
+@ExperimentalResourceApi
+internal val Res.string.str_11770: StringResource
+  get() = String3.str_11770
+
+@ExperimentalResourceApi
+internal val Res.string.str_11771: StringResource
+  get() = String3.str_11771
+
+@ExperimentalResourceApi
+internal val Res.string.str_11772: StringResource
+  get() = String3.str_11772
+
+@ExperimentalResourceApi
+internal val Res.string.str_11773: StringResource
+  get() = String3.str_11773
+
+@ExperimentalResourceApi
+internal val Res.string.str_11774: StringResource
+  get() = String3.str_11774
+
+@ExperimentalResourceApi
+internal val Res.string.str_11775: StringResource
+  get() = String3.str_11775
+
+@ExperimentalResourceApi
+internal val Res.string.str_11776: StringResource
+  get() = String3.str_11776
+
+@ExperimentalResourceApi
+internal val Res.string.str_11777: StringResource
+  get() = String3.str_11777
+
+@ExperimentalResourceApi
+internal val Res.string.str_11778: StringResource
+  get() = String3.str_11778
+
+@ExperimentalResourceApi
+internal val Res.string.str_11779: StringResource
+  get() = String3.str_11779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1178: StringResource
+  get() = String3.str_1178
+
+@ExperimentalResourceApi
+internal val Res.string.str_11780: StringResource
+  get() = String3.str_11780
+
+@ExperimentalResourceApi
+internal val Res.string.str_11781: StringResource
+  get() = String3.str_11781
+
+@ExperimentalResourceApi
+internal val Res.string.str_11782: StringResource
+  get() = String3.str_11782
+
+@ExperimentalResourceApi
+internal val Res.string.str_11783: StringResource
+  get() = String3.str_11783
+
+@ExperimentalResourceApi
+internal val Res.string.str_11784: StringResource
+  get() = String3.str_11784
+
+@ExperimentalResourceApi
+internal val Res.string.str_11785: StringResource
+  get() = String3.str_11785
+
+@ExperimentalResourceApi
+internal val Res.string.str_11786: StringResource
+  get() = String3.str_11786
+
+@ExperimentalResourceApi
+internal val Res.string.str_11787: StringResource
+  get() = String3.str_11787
+
+@ExperimentalResourceApi
+internal val Res.string.str_11788: StringResource
+  get() = String3.str_11788
+
+@ExperimentalResourceApi
+internal val Res.string.str_11789: StringResource
+  get() = String3.str_11789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1179: StringResource
+  get() = String3.str_1179
+
+@ExperimentalResourceApi
+internal val Res.string.str_11790: StringResource
+  get() = String3.str_11790
+
+@ExperimentalResourceApi
+internal val Res.string.str_11791: StringResource
+  get() = String3.str_11791
+
+@ExperimentalResourceApi
+internal val Res.string.str_11792: StringResource
+  get() = String3.str_11792
+
+@ExperimentalResourceApi
+internal val Res.string.str_11793: StringResource
+  get() = String3.str_11793
+
+@ExperimentalResourceApi
+internal val Res.string.str_11794: StringResource
+  get() = String3.str_11794
+
+@ExperimentalResourceApi
+internal val Res.string.str_11795: StringResource
+  get() = String3.str_11795
+
+@ExperimentalResourceApi
+internal val Res.string.str_11796: StringResource
+  get() = String3.str_11796
+
+@ExperimentalResourceApi
+internal val Res.string.str_11797: StringResource
+  get() = String3.str_11797

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String30.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String30.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String30 {
+  public val str_23498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23498", "str_23498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23499", "str_23499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_235", "str_235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2350", "str_2350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23500", "str_23500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23501", "str_23501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23502", "str_23502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23503", "str_23503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23504", "str_23504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23505", "str_23505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23506", "str_23506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23507", "str_23507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23508", "str_23508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23509", "str_23509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2351", "str_2351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23510", "str_23510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23511", "str_23511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23512", "str_23512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23513", "str_23513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23514", "str_23514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23515", "str_23515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23516", "str_23516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23517", "str_23517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23518", "str_23518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23519", "str_23519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2352", "str_2352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23520", "str_23520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23521", "str_23521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23522", "str_23522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23523", "str_23523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23524", "str_23524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23525", "str_23525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23526", "str_23526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23527", "str_23527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23528", "str_23528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23529", "str_23529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2353", "str_2353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23530", "str_23530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23531", "str_23531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23532", "str_23532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23533", "str_23533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23534", "str_23534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23535", "str_23535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23536", "str_23536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23537", "str_23537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23538", "str_23538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23539", "str_23539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2354", "str_2354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23540", "str_23540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23541", "str_23541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23542", "str_23542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23543", "str_23543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23544", "str_23544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23545", "str_23545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23546", "str_23546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23547", "str_23547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23548", "str_23548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23549", "str_23549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2355", "str_2355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23550", "str_23550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23551", "str_23551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23552", "str_23552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23553", "str_23553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23554", "str_23554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23555", "str_23555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23556", "str_23556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23557", "str_23557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23558", "str_23558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23559", "str_23559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2356", "str_2356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23560", "str_23560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23561", "str_23561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23562", "str_23562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23563", "str_23563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23564", "str_23564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23565", "str_23565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23566", "str_23566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23567", "str_23567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23568", "str_23568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23569", "str_23569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2357", "str_2357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23570", "str_23570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23571", "str_23571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23572", "str_23572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23573", "str_23573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23574", "str_23574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23575", "str_23575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23576", "str_23576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23577", "str_23577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23578", "str_23578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23579", "str_23579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2358", "str_2358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23580", "str_23580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23581", "str_23581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23582", "str_23582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23583", "str_23583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23584", "str_23584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23585", "str_23585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23586", "str_23586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23587", "str_23587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23588", "str_23588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23589", "str_23589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2359", "str_2359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23590", "str_23590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23591", "str_23591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23592", "str_23592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23593", "str_23593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23594", "str_23594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23595", "str_23595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23596", "str_23596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23597", "str_23597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23598", "str_23598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23599", "str_23599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_236", "str_236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2360", "str_2360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23600", "str_23600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23601", "str_23601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23602", "str_23602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23603", "str_23603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23604", "str_23604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23605", "str_23605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23606", "str_23606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23607", "str_23607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23608", "str_23608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23609", "str_23609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2361", "str_2361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23610", "str_23610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23611", "str_23611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23612", "str_23612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23613", "str_23613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23614", "str_23614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23615", "str_23615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23616", "str_23616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23617", "str_23617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23618", "str_23618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23619", "str_23619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2362", "str_2362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23620", "str_23620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23621", "str_23621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23622", "str_23622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23623", "str_23623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23624", "str_23624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23625", "str_23625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23626", "str_23626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23627", "str_23627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23628", "str_23628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23629", "str_23629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2363", "str_2363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23630", "str_23630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23631", "str_23631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23632", "str_23632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23633", "str_23633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23634", "str_23634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23635", "str_23635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23636", "str_23636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23637", "str_23637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23638", "str_23638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23639", "str_23639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2364", "str_2364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23640", "str_23640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23641", "str_23641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23642", "str_23642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23643", "str_23643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23644", "str_23644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23645", "str_23645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23646", "str_23646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23647", "str_23647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23648", "str_23648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23649", "str_23649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2365", "str_2365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23650", "str_23650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23651", "str_23651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23652", "str_23652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23653", "str_23653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23654", "str_23654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23655", "str_23655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23656", "str_23656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23657", "str_23657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23658", "str_23658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23659", "str_23659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2366", "str_2366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23660", "str_23660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23661", "str_23661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23662", "str_23662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23663", "str_23663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23664", "str_23664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23665", "str_23665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23666", "str_23666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23667", "str_23667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23668", "str_23668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23669", "str_23669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2367", "str_2367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23670", "str_23670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23671", "str_23671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23672", "str_23672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23673", "str_23673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23674", "str_23674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23675", "str_23675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23676", "str_23676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23677", "str_23677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23678", "str_23678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23679", "str_23679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2368", "str_2368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23680", "str_23680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23681", "str_23681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23682", "str_23682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23683", "str_23683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23684", "str_23684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23685", "str_23685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23686", "str_23686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23687", "str_23687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23688", "str_23688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23689", "str_23689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2369", "str_2369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23690", "str_23690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23691", "str_23691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23692", "str_23692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23693", "str_23693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23694", "str_23694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23695", "str_23695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23696", "str_23696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23697", "str_23697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23698", "str_23698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23699", "str_23699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_237", "str_237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2370", "str_2370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23700", "str_23700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23701", "str_23701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23702", "str_23702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23703", "str_23703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23704", "str_23704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23705", "str_23705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23706", "str_23706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23707", "str_23707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23708", "str_23708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23709", "str_23709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2371", "str_2371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23710", "str_23710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23711", "str_23711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23712", "str_23712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23713", "str_23713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23714", "str_23714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23715", "str_23715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23716", "str_23716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23717", "str_23717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23718", "str_23718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23719", "str_23719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2372", "str_2372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23720", "str_23720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23721", "str_23721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23722", "str_23722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23723", "str_23723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23724", "str_23724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23725", "str_23725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23726", "str_23726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23727", "str_23727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23728", "str_23728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23729", "str_23729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2373", "str_2373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23730", "str_23730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23731", "str_23731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23732", "str_23732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23733", "str_23733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23734", "str_23734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23735", "str_23735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23736", "str_23736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23737", "str_23737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23738", "str_23738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23739", "str_23739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2374", "str_2374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23740", "str_23740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23741", "str_23741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23742", "str_23742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23743", "str_23743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23744", "str_23744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23745", "str_23745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23746", "str_23746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23747", "str_23747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23748", "str_23748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23749", "str_23749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2375", "str_2375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23750", "str_23750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23751", "str_23751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23752", "str_23752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23753", "str_23753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23754", "str_23754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23755", "str_23755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23756", "str_23756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23757", "str_23757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23758", "str_23758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23759", "str_23759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2376", "str_2376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23760", "str_23760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23761", "str_23761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23762", "str_23762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23763", "str_23763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23764", "str_23764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23765", "str_23765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23766", "str_23766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23767", "str_23767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23768", "str_23768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23769", "str_23769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2377", "str_2377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23770", "str_23770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23771", "str_23771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23772", "str_23772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23773", "str_23773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23774", "str_23774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23775", "str_23775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23776", "str_23776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23777", "str_23777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23778", "str_23778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23779", "str_23779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2378", "str_2378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23780", "str_23780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23781", "str_23781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23782", "str_23782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23783", "str_23783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23784", "str_23784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23785", "str_23785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23786", "str_23786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23787", "str_23787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23788", "str_23788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23789", "str_23789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2379", "str_2379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23790", "str_23790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23791", "str_23791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23792", "str_23792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23793", "str_23793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23794", "str_23794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23795", "str_23795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23796", "str_23796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23797", "str_23797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23798", "str_23798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23799", "str_23799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_238", "str_238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2380", "str_2380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23800", "str_23800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23801", "str_23801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23802", "str_23802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23803", "str_23803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23804", "str_23804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23805", "str_23805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23806", "str_23806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23807", "str_23807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23808", "str_23808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23809", "str_23809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2381", "str_2381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23810", "str_23810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23811", "str_23811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23812", "str_23812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23813", "str_23813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23814", "str_23814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23815", "str_23815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23816", "str_23816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23817", "str_23817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23818", "str_23818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23819", "str_23819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2382", "str_2382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23820", "str_23820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23821", "str_23821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23822", "str_23822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23823", "str_23823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23824", "str_23824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23825", "str_23825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23826", "str_23826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23827", "str_23827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23828", "str_23828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23829", "str_23829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2383", "str_2383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23830", "str_23830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23831", "str_23831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23832", "str_23832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23833", "str_23833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23834", "str_23834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23835", "str_23835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23836", "str_23836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23837", "str_23837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23838", "str_23838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23839", "str_23839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2384", "str_2384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23840", "str_23840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23841", "str_23841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23842", "str_23842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23843", "str_23843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23844", "str_23844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23845", "str_23845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23846", "str_23846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23847", "str_23847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23848", "str_23848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23849", "str_23849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2385", "str_2385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23850", "str_23850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23851", "str_23851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23852", "str_23852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23853", "str_23853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23854", "str_23854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23855", "str_23855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23856", "str_23856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23857", "str_23857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23858", "str_23858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23859", "str_23859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2386", "str_2386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23860", "str_23860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23861", "str_23861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23862", "str_23862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23863", "str_23863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23864", "str_23864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23865", "str_23865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23866", "str_23866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23867", "str_23867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23868", "str_23868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23869", "str_23869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2387", "str_2387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23870", "str_23870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23871", "str_23871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23872", "str_23872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23873", "str_23873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23874", "str_23874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23875", "str_23875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23876", "str_23876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23877", "str_23877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23878", "str_23878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23879", "str_23879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2388", "str_2388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23880", "str_23880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23881", "str_23881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23882", "str_23882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23883", "str_23883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23884", "str_23884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23885", "str_23885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23886", "str_23886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23887", "str_23887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23888", "str_23888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23889", "str_23889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2389", "str_2389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23890", "str_23890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23891", "str_23891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23892", "str_23892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23893", "str_23893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23894", "str_23894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23895", "str_23895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23896", "str_23896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23897", "str_23897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23898", "str_23898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23899", "str_23899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_239", "str_239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2390", "str_2390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23900", "str_23900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23901", "str_23901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23902", "str_23902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23903", "str_23903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23904", "str_23904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23905", "str_23905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23906", "str_23906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23907", "str_23907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23908", "str_23908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23909", "str_23909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2391", "str_2391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23910", "str_23910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23911", "str_23911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23912", "str_23912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23913", "str_23913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23914", "str_23914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23915", "str_23915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23916", "str_23916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23917", "str_23917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23918", "str_23918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23919", "str_23919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2392", "str_2392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23920", "str_23920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23921", "str_23921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23922", "str_23922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23923", "str_23923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23924", "str_23924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23925", "str_23925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23926", "str_23926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23927", "str_23927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23928", "str_23928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23929", "str_23929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2393", "str_2393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23930", "str_23930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23931", "str_23931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23932", "str_23932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23933", "str_23933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23934", "str_23934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23935", "str_23935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23936", "str_23936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23937", "str_23937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23938", "str_23938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23939", "str_23939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2394", "str_2394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23940", "str_23940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23941", "str_23941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23942", "str_23942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23943", "str_23943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23944", "str_23944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23945", "str_23945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23946", "str_23946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23947", "str_23947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_23498: StringResource
+  get() = String30.str_23498
+
+@ExperimentalResourceApi
+internal val Res.string.str_23499: StringResource
+  get() = String30.str_23499
+
+@ExperimentalResourceApi
+internal val Res.string.str_235: StringResource
+  get() = String30.str_235
+
+@ExperimentalResourceApi
+internal val Res.string.str_2350: StringResource
+  get() = String30.str_2350
+
+@ExperimentalResourceApi
+internal val Res.string.str_23500: StringResource
+  get() = String30.str_23500
+
+@ExperimentalResourceApi
+internal val Res.string.str_23501: StringResource
+  get() = String30.str_23501
+
+@ExperimentalResourceApi
+internal val Res.string.str_23502: StringResource
+  get() = String30.str_23502
+
+@ExperimentalResourceApi
+internal val Res.string.str_23503: StringResource
+  get() = String30.str_23503
+
+@ExperimentalResourceApi
+internal val Res.string.str_23504: StringResource
+  get() = String30.str_23504
+
+@ExperimentalResourceApi
+internal val Res.string.str_23505: StringResource
+  get() = String30.str_23505
+
+@ExperimentalResourceApi
+internal val Res.string.str_23506: StringResource
+  get() = String30.str_23506
+
+@ExperimentalResourceApi
+internal val Res.string.str_23507: StringResource
+  get() = String30.str_23507
+
+@ExperimentalResourceApi
+internal val Res.string.str_23508: StringResource
+  get() = String30.str_23508
+
+@ExperimentalResourceApi
+internal val Res.string.str_23509: StringResource
+  get() = String30.str_23509
+
+@ExperimentalResourceApi
+internal val Res.string.str_2351: StringResource
+  get() = String30.str_2351
+
+@ExperimentalResourceApi
+internal val Res.string.str_23510: StringResource
+  get() = String30.str_23510
+
+@ExperimentalResourceApi
+internal val Res.string.str_23511: StringResource
+  get() = String30.str_23511
+
+@ExperimentalResourceApi
+internal val Res.string.str_23512: StringResource
+  get() = String30.str_23512
+
+@ExperimentalResourceApi
+internal val Res.string.str_23513: StringResource
+  get() = String30.str_23513
+
+@ExperimentalResourceApi
+internal val Res.string.str_23514: StringResource
+  get() = String30.str_23514
+
+@ExperimentalResourceApi
+internal val Res.string.str_23515: StringResource
+  get() = String30.str_23515
+
+@ExperimentalResourceApi
+internal val Res.string.str_23516: StringResource
+  get() = String30.str_23516
+
+@ExperimentalResourceApi
+internal val Res.string.str_23517: StringResource
+  get() = String30.str_23517
+
+@ExperimentalResourceApi
+internal val Res.string.str_23518: StringResource
+  get() = String30.str_23518
+
+@ExperimentalResourceApi
+internal val Res.string.str_23519: StringResource
+  get() = String30.str_23519
+
+@ExperimentalResourceApi
+internal val Res.string.str_2352: StringResource
+  get() = String30.str_2352
+
+@ExperimentalResourceApi
+internal val Res.string.str_23520: StringResource
+  get() = String30.str_23520
+
+@ExperimentalResourceApi
+internal val Res.string.str_23521: StringResource
+  get() = String30.str_23521
+
+@ExperimentalResourceApi
+internal val Res.string.str_23522: StringResource
+  get() = String30.str_23522
+
+@ExperimentalResourceApi
+internal val Res.string.str_23523: StringResource
+  get() = String30.str_23523
+
+@ExperimentalResourceApi
+internal val Res.string.str_23524: StringResource
+  get() = String30.str_23524
+
+@ExperimentalResourceApi
+internal val Res.string.str_23525: StringResource
+  get() = String30.str_23525
+
+@ExperimentalResourceApi
+internal val Res.string.str_23526: StringResource
+  get() = String30.str_23526
+
+@ExperimentalResourceApi
+internal val Res.string.str_23527: StringResource
+  get() = String30.str_23527
+
+@ExperimentalResourceApi
+internal val Res.string.str_23528: StringResource
+  get() = String30.str_23528
+
+@ExperimentalResourceApi
+internal val Res.string.str_23529: StringResource
+  get() = String30.str_23529
+
+@ExperimentalResourceApi
+internal val Res.string.str_2353: StringResource
+  get() = String30.str_2353
+
+@ExperimentalResourceApi
+internal val Res.string.str_23530: StringResource
+  get() = String30.str_23530
+
+@ExperimentalResourceApi
+internal val Res.string.str_23531: StringResource
+  get() = String30.str_23531
+
+@ExperimentalResourceApi
+internal val Res.string.str_23532: StringResource
+  get() = String30.str_23532
+
+@ExperimentalResourceApi
+internal val Res.string.str_23533: StringResource
+  get() = String30.str_23533
+
+@ExperimentalResourceApi
+internal val Res.string.str_23534: StringResource
+  get() = String30.str_23534
+
+@ExperimentalResourceApi
+internal val Res.string.str_23535: StringResource
+  get() = String30.str_23535
+
+@ExperimentalResourceApi
+internal val Res.string.str_23536: StringResource
+  get() = String30.str_23536
+
+@ExperimentalResourceApi
+internal val Res.string.str_23537: StringResource
+  get() = String30.str_23537
+
+@ExperimentalResourceApi
+internal val Res.string.str_23538: StringResource
+  get() = String30.str_23538
+
+@ExperimentalResourceApi
+internal val Res.string.str_23539: StringResource
+  get() = String30.str_23539
+
+@ExperimentalResourceApi
+internal val Res.string.str_2354: StringResource
+  get() = String30.str_2354
+
+@ExperimentalResourceApi
+internal val Res.string.str_23540: StringResource
+  get() = String30.str_23540
+
+@ExperimentalResourceApi
+internal val Res.string.str_23541: StringResource
+  get() = String30.str_23541
+
+@ExperimentalResourceApi
+internal val Res.string.str_23542: StringResource
+  get() = String30.str_23542
+
+@ExperimentalResourceApi
+internal val Res.string.str_23543: StringResource
+  get() = String30.str_23543
+
+@ExperimentalResourceApi
+internal val Res.string.str_23544: StringResource
+  get() = String30.str_23544
+
+@ExperimentalResourceApi
+internal val Res.string.str_23545: StringResource
+  get() = String30.str_23545
+
+@ExperimentalResourceApi
+internal val Res.string.str_23546: StringResource
+  get() = String30.str_23546
+
+@ExperimentalResourceApi
+internal val Res.string.str_23547: StringResource
+  get() = String30.str_23547
+
+@ExperimentalResourceApi
+internal val Res.string.str_23548: StringResource
+  get() = String30.str_23548
+
+@ExperimentalResourceApi
+internal val Res.string.str_23549: StringResource
+  get() = String30.str_23549
+
+@ExperimentalResourceApi
+internal val Res.string.str_2355: StringResource
+  get() = String30.str_2355
+
+@ExperimentalResourceApi
+internal val Res.string.str_23550: StringResource
+  get() = String30.str_23550
+
+@ExperimentalResourceApi
+internal val Res.string.str_23551: StringResource
+  get() = String30.str_23551
+
+@ExperimentalResourceApi
+internal val Res.string.str_23552: StringResource
+  get() = String30.str_23552
+
+@ExperimentalResourceApi
+internal val Res.string.str_23553: StringResource
+  get() = String30.str_23553
+
+@ExperimentalResourceApi
+internal val Res.string.str_23554: StringResource
+  get() = String30.str_23554
+
+@ExperimentalResourceApi
+internal val Res.string.str_23555: StringResource
+  get() = String30.str_23555
+
+@ExperimentalResourceApi
+internal val Res.string.str_23556: StringResource
+  get() = String30.str_23556
+
+@ExperimentalResourceApi
+internal val Res.string.str_23557: StringResource
+  get() = String30.str_23557
+
+@ExperimentalResourceApi
+internal val Res.string.str_23558: StringResource
+  get() = String30.str_23558
+
+@ExperimentalResourceApi
+internal val Res.string.str_23559: StringResource
+  get() = String30.str_23559
+
+@ExperimentalResourceApi
+internal val Res.string.str_2356: StringResource
+  get() = String30.str_2356
+
+@ExperimentalResourceApi
+internal val Res.string.str_23560: StringResource
+  get() = String30.str_23560
+
+@ExperimentalResourceApi
+internal val Res.string.str_23561: StringResource
+  get() = String30.str_23561
+
+@ExperimentalResourceApi
+internal val Res.string.str_23562: StringResource
+  get() = String30.str_23562
+
+@ExperimentalResourceApi
+internal val Res.string.str_23563: StringResource
+  get() = String30.str_23563
+
+@ExperimentalResourceApi
+internal val Res.string.str_23564: StringResource
+  get() = String30.str_23564
+
+@ExperimentalResourceApi
+internal val Res.string.str_23565: StringResource
+  get() = String30.str_23565
+
+@ExperimentalResourceApi
+internal val Res.string.str_23566: StringResource
+  get() = String30.str_23566
+
+@ExperimentalResourceApi
+internal val Res.string.str_23567: StringResource
+  get() = String30.str_23567
+
+@ExperimentalResourceApi
+internal val Res.string.str_23568: StringResource
+  get() = String30.str_23568
+
+@ExperimentalResourceApi
+internal val Res.string.str_23569: StringResource
+  get() = String30.str_23569
+
+@ExperimentalResourceApi
+internal val Res.string.str_2357: StringResource
+  get() = String30.str_2357
+
+@ExperimentalResourceApi
+internal val Res.string.str_23570: StringResource
+  get() = String30.str_23570
+
+@ExperimentalResourceApi
+internal val Res.string.str_23571: StringResource
+  get() = String30.str_23571
+
+@ExperimentalResourceApi
+internal val Res.string.str_23572: StringResource
+  get() = String30.str_23572
+
+@ExperimentalResourceApi
+internal val Res.string.str_23573: StringResource
+  get() = String30.str_23573
+
+@ExperimentalResourceApi
+internal val Res.string.str_23574: StringResource
+  get() = String30.str_23574
+
+@ExperimentalResourceApi
+internal val Res.string.str_23575: StringResource
+  get() = String30.str_23575
+
+@ExperimentalResourceApi
+internal val Res.string.str_23576: StringResource
+  get() = String30.str_23576
+
+@ExperimentalResourceApi
+internal val Res.string.str_23577: StringResource
+  get() = String30.str_23577
+
+@ExperimentalResourceApi
+internal val Res.string.str_23578: StringResource
+  get() = String30.str_23578
+
+@ExperimentalResourceApi
+internal val Res.string.str_23579: StringResource
+  get() = String30.str_23579
+
+@ExperimentalResourceApi
+internal val Res.string.str_2358: StringResource
+  get() = String30.str_2358
+
+@ExperimentalResourceApi
+internal val Res.string.str_23580: StringResource
+  get() = String30.str_23580
+
+@ExperimentalResourceApi
+internal val Res.string.str_23581: StringResource
+  get() = String30.str_23581
+
+@ExperimentalResourceApi
+internal val Res.string.str_23582: StringResource
+  get() = String30.str_23582
+
+@ExperimentalResourceApi
+internal val Res.string.str_23583: StringResource
+  get() = String30.str_23583
+
+@ExperimentalResourceApi
+internal val Res.string.str_23584: StringResource
+  get() = String30.str_23584
+
+@ExperimentalResourceApi
+internal val Res.string.str_23585: StringResource
+  get() = String30.str_23585
+
+@ExperimentalResourceApi
+internal val Res.string.str_23586: StringResource
+  get() = String30.str_23586
+
+@ExperimentalResourceApi
+internal val Res.string.str_23587: StringResource
+  get() = String30.str_23587
+
+@ExperimentalResourceApi
+internal val Res.string.str_23588: StringResource
+  get() = String30.str_23588
+
+@ExperimentalResourceApi
+internal val Res.string.str_23589: StringResource
+  get() = String30.str_23589
+
+@ExperimentalResourceApi
+internal val Res.string.str_2359: StringResource
+  get() = String30.str_2359
+
+@ExperimentalResourceApi
+internal val Res.string.str_23590: StringResource
+  get() = String30.str_23590
+
+@ExperimentalResourceApi
+internal val Res.string.str_23591: StringResource
+  get() = String30.str_23591
+
+@ExperimentalResourceApi
+internal val Res.string.str_23592: StringResource
+  get() = String30.str_23592
+
+@ExperimentalResourceApi
+internal val Res.string.str_23593: StringResource
+  get() = String30.str_23593
+
+@ExperimentalResourceApi
+internal val Res.string.str_23594: StringResource
+  get() = String30.str_23594
+
+@ExperimentalResourceApi
+internal val Res.string.str_23595: StringResource
+  get() = String30.str_23595
+
+@ExperimentalResourceApi
+internal val Res.string.str_23596: StringResource
+  get() = String30.str_23596
+
+@ExperimentalResourceApi
+internal val Res.string.str_23597: StringResource
+  get() = String30.str_23597
+
+@ExperimentalResourceApi
+internal val Res.string.str_23598: StringResource
+  get() = String30.str_23598
+
+@ExperimentalResourceApi
+internal val Res.string.str_23599: StringResource
+  get() = String30.str_23599
+
+@ExperimentalResourceApi
+internal val Res.string.str_236: StringResource
+  get() = String30.str_236
+
+@ExperimentalResourceApi
+internal val Res.string.str_2360: StringResource
+  get() = String30.str_2360
+
+@ExperimentalResourceApi
+internal val Res.string.str_23600: StringResource
+  get() = String30.str_23600
+
+@ExperimentalResourceApi
+internal val Res.string.str_23601: StringResource
+  get() = String30.str_23601
+
+@ExperimentalResourceApi
+internal val Res.string.str_23602: StringResource
+  get() = String30.str_23602
+
+@ExperimentalResourceApi
+internal val Res.string.str_23603: StringResource
+  get() = String30.str_23603
+
+@ExperimentalResourceApi
+internal val Res.string.str_23604: StringResource
+  get() = String30.str_23604
+
+@ExperimentalResourceApi
+internal val Res.string.str_23605: StringResource
+  get() = String30.str_23605
+
+@ExperimentalResourceApi
+internal val Res.string.str_23606: StringResource
+  get() = String30.str_23606
+
+@ExperimentalResourceApi
+internal val Res.string.str_23607: StringResource
+  get() = String30.str_23607
+
+@ExperimentalResourceApi
+internal val Res.string.str_23608: StringResource
+  get() = String30.str_23608
+
+@ExperimentalResourceApi
+internal val Res.string.str_23609: StringResource
+  get() = String30.str_23609
+
+@ExperimentalResourceApi
+internal val Res.string.str_2361: StringResource
+  get() = String30.str_2361
+
+@ExperimentalResourceApi
+internal val Res.string.str_23610: StringResource
+  get() = String30.str_23610
+
+@ExperimentalResourceApi
+internal val Res.string.str_23611: StringResource
+  get() = String30.str_23611
+
+@ExperimentalResourceApi
+internal val Res.string.str_23612: StringResource
+  get() = String30.str_23612
+
+@ExperimentalResourceApi
+internal val Res.string.str_23613: StringResource
+  get() = String30.str_23613
+
+@ExperimentalResourceApi
+internal val Res.string.str_23614: StringResource
+  get() = String30.str_23614
+
+@ExperimentalResourceApi
+internal val Res.string.str_23615: StringResource
+  get() = String30.str_23615
+
+@ExperimentalResourceApi
+internal val Res.string.str_23616: StringResource
+  get() = String30.str_23616
+
+@ExperimentalResourceApi
+internal val Res.string.str_23617: StringResource
+  get() = String30.str_23617
+
+@ExperimentalResourceApi
+internal val Res.string.str_23618: StringResource
+  get() = String30.str_23618
+
+@ExperimentalResourceApi
+internal val Res.string.str_23619: StringResource
+  get() = String30.str_23619
+
+@ExperimentalResourceApi
+internal val Res.string.str_2362: StringResource
+  get() = String30.str_2362
+
+@ExperimentalResourceApi
+internal val Res.string.str_23620: StringResource
+  get() = String30.str_23620
+
+@ExperimentalResourceApi
+internal val Res.string.str_23621: StringResource
+  get() = String30.str_23621
+
+@ExperimentalResourceApi
+internal val Res.string.str_23622: StringResource
+  get() = String30.str_23622
+
+@ExperimentalResourceApi
+internal val Res.string.str_23623: StringResource
+  get() = String30.str_23623
+
+@ExperimentalResourceApi
+internal val Res.string.str_23624: StringResource
+  get() = String30.str_23624
+
+@ExperimentalResourceApi
+internal val Res.string.str_23625: StringResource
+  get() = String30.str_23625
+
+@ExperimentalResourceApi
+internal val Res.string.str_23626: StringResource
+  get() = String30.str_23626
+
+@ExperimentalResourceApi
+internal val Res.string.str_23627: StringResource
+  get() = String30.str_23627
+
+@ExperimentalResourceApi
+internal val Res.string.str_23628: StringResource
+  get() = String30.str_23628
+
+@ExperimentalResourceApi
+internal val Res.string.str_23629: StringResource
+  get() = String30.str_23629
+
+@ExperimentalResourceApi
+internal val Res.string.str_2363: StringResource
+  get() = String30.str_2363
+
+@ExperimentalResourceApi
+internal val Res.string.str_23630: StringResource
+  get() = String30.str_23630
+
+@ExperimentalResourceApi
+internal val Res.string.str_23631: StringResource
+  get() = String30.str_23631
+
+@ExperimentalResourceApi
+internal val Res.string.str_23632: StringResource
+  get() = String30.str_23632
+
+@ExperimentalResourceApi
+internal val Res.string.str_23633: StringResource
+  get() = String30.str_23633
+
+@ExperimentalResourceApi
+internal val Res.string.str_23634: StringResource
+  get() = String30.str_23634
+
+@ExperimentalResourceApi
+internal val Res.string.str_23635: StringResource
+  get() = String30.str_23635
+
+@ExperimentalResourceApi
+internal val Res.string.str_23636: StringResource
+  get() = String30.str_23636
+
+@ExperimentalResourceApi
+internal val Res.string.str_23637: StringResource
+  get() = String30.str_23637
+
+@ExperimentalResourceApi
+internal val Res.string.str_23638: StringResource
+  get() = String30.str_23638
+
+@ExperimentalResourceApi
+internal val Res.string.str_23639: StringResource
+  get() = String30.str_23639
+
+@ExperimentalResourceApi
+internal val Res.string.str_2364: StringResource
+  get() = String30.str_2364
+
+@ExperimentalResourceApi
+internal val Res.string.str_23640: StringResource
+  get() = String30.str_23640
+
+@ExperimentalResourceApi
+internal val Res.string.str_23641: StringResource
+  get() = String30.str_23641
+
+@ExperimentalResourceApi
+internal val Res.string.str_23642: StringResource
+  get() = String30.str_23642
+
+@ExperimentalResourceApi
+internal val Res.string.str_23643: StringResource
+  get() = String30.str_23643
+
+@ExperimentalResourceApi
+internal val Res.string.str_23644: StringResource
+  get() = String30.str_23644
+
+@ExperimentalResourceApi
+internal val Res.string.str_23645: StringResource
+  get() = String30.str_23645
+
+@ExperimentalResourceApi
+internal val Res.string.str_23646: StringResource
+  get() = String30.str_23646
+
+@ExperimentalResourceApi
+internal val Res.string.str_23647: StringResource
+  get() = String30.str_23647
+
+@ExperimentalResourceApi
+internal val Res.string.str_23648: StringResource
+  get() = String30.str_23648
+
+@ExperimentalResourceApi
+internal val Res.string.str_23649: StringResource
+  get() = String30.str_23649
+
+@ExperimentalResourceApi
+internal val Res.string.str_2365: StringResource
+  get() = String30.str_2365
+
+@ExperimentalResourceApi
+internal val Res.string.str_23650: StringResource
+  get() = String30.str_23650
+
+@ExperimentalResourceApi
+internal val Res.string.str_23651: StringResource
+  get() = String30.str_23651
+
+@ExperimentalResourceApi
+internal val Res.string.str_23652: StringResource
+  get() = String30.str_23652
+
+@ExperimentalResourceApi
+internal val Res.string.str_23653: StringResource
+  get() = String30.str_23653
+
+@ExperimentalResourceApi
+internal val Res.string.str_23654: StringResource
+  get() = String30.str_23654
+
+@ExperimentalResourceApi
+internal val Res.string.str_23655: StringResource
+  get() = String30.str_23655
+
+@ExperimentalResourceApi
+internal val Res.string.str_23656: StringResource
+  get() = String30.str_23656
+
+@ExperimentalResourceApi
+internal val Res.string.str_23657: StringResource
+  get() = String30.str_23657
+
+@ExperimentalResourceApi
+internal val Res.string.str_23658: StringResource
+  get() = String30.str_23658
+
+@ExperimentalResourceApi
+internal val Res.string.str_23659: StringResource
+  get() = String30.str_23659
+
+@ExperimentalResourceApi
+internal val Res.string.str_2366: StringResource
+  get() = String30.str_2366
+
+@ExperimentalResourceApi
+internal val Res.string.str_23660: StringResource
+  get() = String30.str_23660
+
+@ExperimentalResourceApi
+internal val Res.string.str_23661: StringResource
+  get() = String30.str_23661
+
+@ExperimentalResourceApi
+internal val Res.string.str_23662: StringResource
+  get() = String30.str_23662
+
+@ExperimentalResourceApi
+internal val Res.string.str_23663: StringResource
+  get() = String30.str_23663
+
+@ExperimentalResourceApi
+internal val Res.string.str_23664: StringResource
+  get() = String30.str_23664
+
+@ExperimentalResourceApi
+internal val Res.string.str_23665: StringResource
+  get() = String30.str_23665
+
+@ExperimentalResourceApi
+internal val Res.string.str_23666: StringResource
+  get() = String30.str_23666
+
+@ExperimentalResourceApi
+internal val Res.string.str_23667: StringResource
+  get() = String30.str_23667
+
+@ExperimentalResourceApi
+internal val Res.string.str_23668: StringResource
+  get() = String30.str_23668
+
+@ExperimentalResourceApi
+internal val Res.string.str_23669: StringResource
+  get() = String30.str_23669
+
+@ExperimentalResourceApi
+internal val Res.string.str_2367: StringResource
+  get() = String30.str_2367
+
+@ExperimentalResourceApi
+internal val Res.string.str_23670: StringResource
+  get() = String30.str_23670
+
+@ExperimentalResourceApi
+internal val Res.string.str_23671: StringResource
+  get() = String30.str_23671
+
+@ExperimentalResourceApi
+internal val Res.string.str_23672: StringResource
+  get() = String30.str_23672
+
+@ExperimentalResourceApi
+internal val Res.string.str_23673: StringResource
+  get() = String30.str_23673
+
+@ExperimentalResourceApi
+internal val Res.string.str_23674: StringResource
+  get() = String30.str_23674
+
+@ExperimentalResourceApi
+internal val Res.string.str_23675: StringResource
+  get() = String30.str_23675
+
+@ExperimentalResourceApi
+internal val Res.string.str_23676: StringResource
+  get() = String30.str_23676
+
+@ExperimentalResourceApi
+internal val Res.string.str_23677: StringResource
+  get() = String30.str_23677
+
+@ExperimentalResourceApi
+internal val Res.string.str_23678: StringResource
+  get() = String30.str_23678
+
+@ExperimentalResourceApi
+internal val Res.string.str_23679: StringResource
+  get() = String30.str_23679
+
+@ExperimentalResourceApi
+internal val Res.string.str_2368: StringResource
+  get() = String30.str_2368
+
+@ExperimentalResourceApi
+internal val Res.string.str_23680: StringResource
+  get() = String30.str_23680
+
+@ExperimentalResourceApi
+internal val Res.string.str_23681: StringResource
+  get() = String30.str_23681
+
+@ExperimentalResourceApi
+internal val Res.string.str_23682: StringResource
+  get() = String30.str_23682
+
+@ExperimentalResourceApi
+internal val Res.string.str_23683: StringResource
+  get() = String30.str_23683
+
+@ExperimentalResourceApi
+internal val Res.string.str_23684: StringResource
+  get() = String30.str_23684
+
+@ExperimentalResourceApi
+internal val Res.string.str_23685: StringResource
+  get() = String30.str_23685
+
+@ExperimentalResourceApi
+internal val Res.string.str_23686: StringResource
+  get() = String30.str_23686
+
+@ExperimentalResourceApi
+internal val Res.string.str_23687: StringResource
+  get() = String30.str_23687
+
+@ExperimentalResourceApi
+internal val Res.string.str_23688: StringResource
+  get() = String30.str_23688
+
+@ExperimentalResourceApi
+internal val Res.string.str_23689: StringResource
+  get() = String30.str_23689
+
+@ExperimentalResourceApi
+internal val Res.string.str_2369: StringResource
+  get() = String30.str_2369
+
+@ExperimentalResourceApi
+internal val Res.string.str_23690: StringResource
+  get() = String30.str_23690
+
+@ExperimentalResourceApi
+internal val Res.string.str_23691: StringResource
+  get() = String30.str_23691
+
+@ExperimentalResourceApi
+internal val Res.string.str_23692: StringResource
+  get() = String30.str_23692
+
+@ExperimentalResourceApi
+internal val Res.string.str_23693: StringResource
+  get() = String30.str_23693
+
+@ExperimentalResourceApi
+internal val Res.string.str_23694: StringResource
+  get() = String30.str_23694
+
+@ExperimentalResourceApi
+internal val Res.string.str_23695: StringResource
+  get() = String30.str_23695
+
+@ExperimentalResourceApi
+internal val Res.string.str_23696: StringResource
+  get() = String30.str_23696
+
+@ExperimentalResourceApi
+internal val Res.string.str_23697: StringResource
+  get() = String30.str_23697
+
+@ExperimentalResourceApi
+internal val Res.string.str_23698: StringResource
+  get() = String30.str_23698
+
+@ExperimentalResourceApi
+internal val Res.string.str_23699: StringResource
+  get() = String30.str_23699
+
+@ExperimentalResourceApi
+internal val Res.string.str_237: StringResource
+  get() = String30.str_237
+
+@ExperimentalResourceApi
+internal val Res.string.str_2370: StringResource
+  get() = String30.str_2370
+
+@ExperimentalResourceApi
+internal val Res.string.str_23700: StringResource
+  get() = String30.str_23700
+
+@ExperimentalResourceApi
+internal val Res.string.str_23701: StringResource
+  get() = String30.str_23701
+
+@ExperimentalResourceApi
+internal val Res.string.str_23702: StringResource
+  get() = String30.str_23702
+
+@ExperimentalResourceApi
+internal val Res.string.str_23703: StringResource
+  get() = String30.str_23703
+
+@ExperimentalResourceApi
+internal val Res.string.str_23704: StringResource
+  get() = String30.str_23704
+
+@ExperimentalResourceApi
+internal val Res.string.str_23705: StringResource
+  get() = String30.str_23705
+
+@ExperimentalResourceApi
+internal val Res.string.str_23706: StringResource
+  get() = String30.str_23706
+
+@ExperimentalResourceApi
+internal val Res.string.str_23707: StringResource
+  get() = String30.str_23707
+
+@ExperimentalResourceApi
+internal val Res.string.str_23708: StringResource
+  get() = String30.str_23708
+
+@ExperimentalResourceApi
+internal val Res.string.str_23709: StringResource
+  get() = String30.str_23709
+
+@ExperimentalResourceApi
+internal val Res.string.str_2371: StringResource
+  get() = String30.str_2371
+
+@ExperimentalResourceApi
+internal val Res.string.str_23710: StringResource
+  get() = String30.str_23710
+
+@ExperimentalResourceApi
+internal val Res.string.str_23711: StringResource
+  get() = String30.str_23711
+
+@ExperimentalResourceApi
+internal val Res.string.str_23712: StringResource
+  get() = String30.str_23712
+
+@ExperimentalResourceApi
+internal val Res.string.str_23713: StringResource
+  get() = String30.str_23713
+
+@ExperimentalResourceApi
+internal val Res.string.str_23714: StringResource
+  get() = String30.str_23714
+
+@ExperimentalResourceApi
+internal val Res.string.str_23715: StringResource
+  get() = String30.str_23715
+
+@ExperimentalResourceApi
+internal val Res.string.str_23716: StringResource
+  get() = String30.str_23716
+
+@ExperimentalResourceApi
+internal val Res.string.str_23717: StringResource
+  get() = String30.str_23717
+
+@ExperimentalResourceApi
+internal val Res.string.str_23718: StringResource
+  get() = String30.str_23718
+
+@ExperimentalResourceApi
+internal val Res.string.str_23719: StringResource
+  get() = String30.str_23719
+
+@ExperimentalResourceApi
+internal val Res.string.str_2372: StringResource
+  get() = String30.str_2372
+
+@ExperimentalResourceApi
+internal val Res.string.str_23720: StringResource
+  get() = String30.str_23720
+
+@ExperimentalResourceApi
+internal val Res.string.str_23721: StringResource
+  get() = String30.str_23721
+
+@ExperimentalResourceApi
+internal val Res.string.str_23722: StringResource
+  get() = String30.str_23722
+
+@ExperimentalResourceApi
+internal val Res.string.str_23723: StringResource
+  get() = String30.str_23723
+
+@ExperimentalResourceApi
+internal val Res.string.str_23724: StringResource
+  get() = String30.str_23724
+
+@ExperimentalResourceApi
+internal val Res.string.str_23725: StringResource
+  get() = String30.str_23725
+
+@ExperimentalResourceApi
+internal val Res.string.str_23726: StringResource
+  get() = String30.str_23726
+
+@ExperimentalResourceApi
+internal val Res.string.str_23727: StringResource
+  get() = String30.str_23727
+
+@ExperimentalResourceApi
+internal val Res.string.str_23728: StringResource
+  get() = String30.str_23728
+
+@ExperimentalResourceApi
+internal val Res.string.str_23729: StringResource
+  get() = String30.str_23729
+
+@ExperimentalResourceApi
+internal val Res.string.str_2373: StringResource
+  get() = String30.str_2373
+
+@ExperimentalResourceApi
+internal val Res.string.str_23730: StringResource
+  get() = String30.str_23730
+
+@ExperimentalResourceApi
+internal val Res.string.str_23731: StringResource
+  get() = String30.str_23731
+
+@ExperimentalResourceApi
+internal val Res.string.str_23732: StringResource
+  get() = String30.str_23732
+
+@ExperimentalResourceApi
+internal val Res.string.str_23733: StringResource
+  get() = String30.str_23733
+
+@ExperimentalResourceApi
+internal val Res.string.str_23734: StringResource
+  get() = String30.str_23734
+
+@ExperimentalResourceApi
+internal val Res.string.str_23735: StringResource
+  get() = String30.str_23735
+
+@ExperimentalResourceApi
+internal val Res.string.str_23736: StringResource
+  get() = String30.str_23736
+
+@ExperimentalResourceApi
+internal val Res.string.str_23737: StringResource
+  get() = String30.str_23737
+
+@ExperimentalResourceApi
+internal val Res.string.str_23738: StringResource
+  get() = String30.str_23738
+
+@ExperimentalResourceApi
+internal val Res.string.str_23739: StringResource
+  get() = String30.str_23739
+
+@ExperimentalResourceApi
+internal val Res.string.str_2374: StringResource
+  get() = String30.str_2374
+
+@ExperimentalResourceApi
+internal val Res.string.str_23740: StringResource
+  get() = String30.str_23740
+
+@ExperimentalResourceApi
+internal val Res.string.str_23741: StringResource
+  get() = String30.str_23741
+
+@ExperimentalResourceApi
+internal val Res.string.str_23742: StringResource
+  get() = String30.str_23742
+
+@ExperimentalResourceApi
+internal val Res.string.str_23743: StringResource
+  get() = String30.str_23743
+
+@ExperimentalResourceApi
+internal val Res.string.str_23744: StringResource
+  get() = String30.str_23744
+
+@ExperimentalResourceApi
+internal val Res.string.str_23745: StringResource
+  get() = String30.str_23745
+
+@ExperimentalResourceApi
+internal val Res.string.str_23746: StringResource
+  get() = String30.str_23746
+
+@ExperimentalResourceApi
+internal val Res.string.str_23747: StringResource
+  get() = String30.str_23747
+
+@ExperimentalResourceApi
+internal val Res.string.str_23748: StringResource
+  get() = String30.str_23748
+
+@ExperimentalResourceApi
+internal val Res.string.str_23749: StringResource
+  get() = String30.str_23749
+
+@ExperimentalResourceApi
+internal val Res.string.str_2375: StringResource
+  get() = String30.str_2375
+
+@ExperimentalResourceApi
+internal val Res.string.str_23750: StringResource
+  get() = String30.str_23750
+
+@ExperimentalResourceApi
+internal val Res.string.str_23751: StringResource
+  get() = String30.str_23751
+
+@ExperimentalResourceApi
+internal val Res.string.str_23752: StringResource
+  get() = String30.str_23752
+
+@ExperimentalResourceApi
+internal val Res.string.str_23753: StringResource
+  get() = String30.str_23753
+
+@ExperimentalResourceApi
+internal val Res.string.str_23754: StringResource
+  get() = String30.str_23754
+
+@ExperimentalResourceApi
+internal val Res.string.str_23755: StringResource
+  get() = String30.str_23755
+
+@ExperimentalResourceApi
+internal val Res.string.str_23756: StringResource
+  get() = String30.str_23756
+
+@ExperimentalResourceApi
+internal val Res.string.str_23757: StringResource
+  get() = String30.str_23757
+
+@ExperimentalResourceApi
+internal val Res.string.str_23758: StringResource
+  get() = String30.str_23758
+
+@ExperimentalResourceApi
+internal val Res.string.str_23759: StringResource
+  get() = String30.str_23759
+
+@ExperimentalResourceApi
+internal val Res.string.str_2376: StringResource
+  get() = String30.str_2376
+
+@ExperimentalResourceApi
+internal val Res.string.str_23760: StringResource
+  get() = String30.str_23760
+
+@ExperimentalResourceApi
+internal val Res.string.str_23761: StringResource
+  get() = String30.str_23761
+
+@ExperimentalResourceApi
+internal val Res.string.str_23762: StringResource
+  get() = String30.str_23762
+
+@ExperimentalResourceApi
+internal val Res.string.str_23763: StringResource
+  get() = String30.str_23763
+
+@ExperimentalResourceApi
+internal val Res.string.str_23764: StringResource
+  get() = String30.str_23764
+
+@ExperimentalResourceApi
+internal val Res.string.str_23765: StringResource
+  get() = String30.str_23765
+
+@ExperimentalResourceApi
+internal val Res.string.str_23766: StringResource
+  get() = String30.str_23766
+
+@ExperimentalResourceApi
+internal val Res.string.str_23767: StringResource
+  get() = String30.str_23767
+
+@ExperimentalResourceApi
+internal val Res.string.str_23768: StringResource
+  get() = String30.str_23768
+
+@ExperimentalResourceApi
+internal val Res.string.str_23769: StringResource
+  get() = String30.str_23769
+
+@ExperimentalResourceApi
+internal val Res.string.str_2377: StringResource
+  get() = String30.str_2377
+
+@ExperimentalResourceApi
+internal val Res.string.str_23770: StringResource
+  get() = String30.str_23770
+
+@ExperimentalResourceApi
+internal val Res.string.str_23771: StringResource
+  get() = String30.str_23771
+
+@ExperimentalResourceApi
+internal val Res.string.str_23772: StringResource
+  get() = String30.str_23772
+
+@ExperimentalResourceApi
+internal val Res.string.str_23773: StringResource
+  get() = String30.str_23773
+
+@ExperimentalResourceApi
+internal val Res.string.str_23774: StringResource
+  get() = String30.str_23774
+
+@ExperimentalResourceApi
+internal val Res.string.str_23775: StringResource
+  get() = String30.str_23775
+
+@ExperimentalResourceApi
+internal val Res.string.str_23776: StringResource
+  get() = String30.str_23776
+
+@ExperimentalResourceApi
+internal val Res.string.str_23777: StringResource
+  get() = String30.str_23777
+
+@ExperimentalResourceApi
+internal val Res.string.str_23778: StringResource
+  get() = String30.str_23778
+
+@ExperimentalResourceApi
+internal val Res.string.str_23779: StringResource
+  get() = String30.str_23779
+
+@ExperimentalResourceApi
+internal val Res.string.str_2378: StringResource
+  get() = String30.str_2378
+
+@ExperimentalResourceApi
+internal val Res.string.str_23780: StringResource
+  get() = String30.str_23780
+
+@ExperimentalResourceApi
+internal val Res.string.str_23781: StringResource
+  get() = String30.str_23781
+
+@ExperimentalResourceApi
+internal val Res.string.str_23782: StringResource
+  get() = String30.str_23782
+
+@ExperimentalResourceApi
+internal val Res.string.str_23783: StringResource
+  get() = String30.str_23783
+
+@ExperimentalResourceApi
+internal val Res.string.str_23784: StringResource
+  get() = String30.str_23784
+
+@ExperimentalResourceApi
+internal val Res.string.str_23785: StringResource
+  get() = String30.str_23785
+
+@ExperimentalResourceApi
+internal val Res.string.str_23786: StringResource
+  get() = String30.str_23786
+
+@ExperimentalResourceApi
+internal val Res.string.str_23787: StringResource
+  get() = String30.str_23787
+
+@ExperimentalResourceApi
+internal val Res.string.str_23788: StringResource
+  get() = String30.str_23788
+
+@ExperimentalResourceApi
+internal val Res.string.str_23789: StringResource
+  get() = String30.str_23789
+
+@ExperimentalResourceApi
+internal val Res.string.str_2379: StringResource
+  get() = String30.str_2379
+
+@ExperimentalResourceApi
+internal val Res.string.str_23790: StringResource
+  get() = String30.str_23790
+
+@ExperimentalResourceApi
+internal val Res.string.str_23791: StringResource
+  get() = String30.str_23791
+
+@ExperimentalResourceApi
+internal val Res.string.str_23792: StringResource
+  get() = String30.str_23792
+
+@ExperimentalResourceApi
+internal val Res.string.str_23793: StringResource
+  get() = String30.str_23793
+
+@ExperimentalResourceApi
+internal val Res.string.str_23794: StringResource
+  get() = String30.str_23794
+
+@ExperimentalResourceApi
+internal val Res.string.str_23795: StringResource
+  get() = String30.str_23795
+
+@ExperimentalResourceApi
+internal val Res.string.str_23796: StringResource
+  get() = String30.str_23796
+
+@ExperimentalResourceApi
+internal val Res.string.str_23797: StringResource
+  get() = String30.str_23797
+
+@ExperimentalResourceApi
+internal val Res.string.str_23798: StringResource
+  get() = String30.str_23798
+
+@ExperimentalResourceApi
+internal val Res.string.str_23799: StringResource
+  get() = String30.str_23799
+
+@ExperimentalResourceApi
+internal val Res.string.str_238: StringResource
+  get() = String30.str_238
+
+@ExperimentalResourceApi
+internal val Res.string.str_2380: StringResource
+  get() = String30.str_2380
+
+@ExperimentalResourceApi
+internal val Res.string.str_23800: StringResource
+  get() = String30.str_23800
+
+@ExperimentalResourceApi
+internal val Res.string.str_23801: StringResource
+  get() = String30.str_23801
+
+@ExperimentalResourceApi
+internal val Res.string.str_23802: StringResource
+  get() = String30.str_23802
+
+@ExperimentalResourceApi
+internal val Res.string.str_23803: StringResource
+  get() = String30.str_23803
+
+@ExperimentalResourceApi
+internal val Res.string.str_23804: StringResource
+  get() = String30.str_23804
+
+@ExperimentalResourceApi
+internal val Res.string.str_23805: StringResource
+  get() = String30.str_23805
+
+@ExperimentalResourceApi
+internal val Res.string.str_23806: StringResource
+  get() = String30.str_23806
+
+@ExperimentalResourceApi
+internal val Res.string.str_23807: StringResource
+  get() = String30.str_23807
+
+@ExperimentalResourceApi
+internal val Res.string.str_23808: StringResource
+  get() = String30.str_23808
+
+@ExperimentalResourceApi
+internal val Res.string.str_23809: StringResource
+  get() = String30.str_23809
+
+@ExperimentalResourceApi
+internal val Res.string.str_2381: StringResource
+  get() = String30.str_2381
+
+@ExperimentalResourceApi
+internal val Res.string.str_23810: StringResource
+  get() = String30.str_23810
+
+@ExperimentalResourceApi
+internal val Res.string.str_23811: StringResource
+  get() = String30.str_23811
+
+@ExperimentalResourceApi
+internal val Res.string.str_23812: StringResource
+  get() = String30.str_23812
+
+@ExperimentalResourceApi
+internal val Res.string.str_23813: StringResource
+  get() = String30.str_23813
+
+@ExperimentalResourceApi
+internal val Res.string.str_23814: StringResource
+  get() = String30.str_23814
+
+@ExperimentalResourceApi
+internal val Res.string.str_23815: StringResource
+  get() = String30.str_23815
+
+@ExperimentalResourceApi
+internal val Res.string.str_23816: StringResource
+  get() = String30.str_23816
+
+@ExperimentalResourceApi
+internal val Res.string.str_23817: StringResource
+  get() = String30.str_23817
+
+@ExperimentalResourceApi
+internal val Res.string.str_23818: StringResource
+  get() = String30.str_23818
+
+@ExperimentalResourceApi
+internal val Res.string.str_23819: StringResource
+  get() = String30.str_23819
+
+@ExperimentalResourceApi
+internal val Res.string.str_2382: StringResource
+  get() = String30.str_2382
+
+@ExperimentalResourceApi
+internal val Res.string.str_23820: StringResource
+  get() = String30.str_23820
+
+@ExperimentalResourceApi
+internal val Res.string.str_23821: StringResource
+  get() = String30.str_23821
+
+@ExperimentalResourceApi
+internal val Res.string.str_23822: StringResource
+  get() = String30.str_23822
+
+@ExperimentalResourceApi
+internal val Res.string.str_23823: StringResource
+  get() = String30.str_23823
+
+@ExperimentalResourceApi
+internal val Res.string.str_23824: StringResource
+  get() = String30.str_23824
+
+@ExperimentalResourceApi
+internal val Res.string.str_23825: StringResource
+  get() = String30.str_23825
+
+@ExperimentalResourceApi
+internal val Res.string.str_23826: StringResource
+  get() = String30.str_23826
+
+@ExperimentalResourceApi
+internal val Res.string.str_23827: StringResource
+  get() = String30.str_23827
+
+@ExperimentalResourceApi
+internal val Res.string.str_23828: StringResource
+  get() = String30.str_23828
+
+@ExperimentalResourceApi
+internal val Res.string.str_23829: StringResource
+  get() = String30.str_23829
+
+@ExperimentalResourceApi
+internal val Res.string.str_2383: StringResource
+  get() = String30.str_2383
+
+@ExperimentalResourceApi
+internal val Res.string.str_23830: StringResource
+  get() = String30.str_23830
+
+@ExperimentalResourceApi
+internal val Res.string.str_23831: StringResource
+  get() = String30.str_23831
+
+@ExperimentalResourceApi
+internal val Res.string.str_23832: StringResource
+  get() = String30.str_23832
+
+@ExperimentalResourceApi
+internal val Res.string.str_23833: StringResource
+  get() = String30.str_23833
+
+@ExperimentalResourceApi
+internal val Res.string.str_23834: StringResource
+  get() = String30.str_23834
+
+@ExperimentalResourceApi
+internal val Res.string.str_23835: StringResource
+  get() = String30.str_23835
+
+@ExperimentalResourceApi
+internal val Res.string.str_23836: StringResource
+  get() = String30.str_23836
+
+@ExperimentalResourceApi
+internal val Res.string.str_23837: StringResource
+  get() = String30.str_23837
+
+@ExperimentalResourceApi
+internal val Res.string.str_23838: StringResource
+  get() = String30.str_23838
+
+@ExperimentalResourceApi
+internal val Res.string.str_23839: StringResource
+  get() = String30.str_23839
+
+@ExperimentalResourceApi
+internal val Res.string.str_2384: StringResource
+  get() = String30.str_2384
+
+@ExperimentalResourceApi
+internal val Res.string.str_23840: StringResource
+  get() = String30.str_23840
+
+@ExperimentalResourceApi
+internal val Res.string.str_23841: StringResource
+  get() = String30.str_23841
+
+@ExperimentalResourceApi
+internal val Res.string.str_23842: StringResource
+  get() = String30.str_23842
+
+@ExperimentalResourceApi
+internal val Res.string.str_23843: StringResource
+  get() = String30.str_23843
+
+@ExperimentalResourceApi
+internal val Res.string.str_23844: StringResource
+  get() = String30.str_23844
+
+@ExperimentalResourceApi
+internal val Res.string.str_23845: StringResource
+  get() = String30.str_23845
+
+@ExperimentalResourceApi
+internal val Res.string.str_23846: StringResource
+  get() = String30.str_23846
+
+@ExperimentalResourceApi
+internal val Res.string.str_23847: StringResource
+  get() = String30.str_23847
+
+@ExperimentalResourceApi
+internal val Res.string.str_23848: StringResource
+  get() = String30.str_23848
+
+@ExperimentalResourceApi
+internal val Res.string.str_23849: StringResource
+  get() = String30.str_23849
+
+@ExperimentalResourceApi
+internal val Res.string.str_2385: StringResource
+  get() = String30.str_2385
+
+@ExperimentalResourceApi
+internal val Res.string.str_23850: StringResource
+  get() = String30.str_23850
+
+@ExperimentalResourceApi
+internal val Res.string.str_23851: StringResource
+  get() = String30.str_23851
+
+@ExperimentalResourceApi
+internal val Res.string.str_23852: StringResource
+  get() = String30.str_23852
+
+@ExperimentalResourceApi
+internal val Res.string.str_23853: StringResource
+  get() = String30.str_23853
+
+@ExperimentalResourceApi
+internal val Res.string.str_23854: StringResource
+  get() = String30.str_23854
+
+@ExperimentalResourceApi
+internal val Res.string.str_23855: StringResource
+  get() = String30.str_23855
+
+@ExperimentalResourceApi
+internal val Res.string.str_23856: StringResource
+  get() = String30.str_23856
+
+@ExperimentalResourceApi
+internal val Res.string.str_23857: StringResource
+  get() = String30.str_23857
+
+@ExperimentalResourceApi
+internal val Res.string.str_23858: StringResource
+  get() = String30.str_23858
+
+@ExperimentalResourceApi
+internal val Res.string.str_23859: StringResource
+  get() = String30.str_23859
+
+@ExperimentalResourceApi
+internal val Res.string.str_2386: StringResource
+  get() = String30.str_2386
+
+@ExperimentalResourceApi
+internal val Res.string.str_23860: StringResource
+  get() = String30.str_23860
+
+@ExperimentalResourceApi
+internal val Res.string.str_23861: StringResource
+  get() = String30.str_23861
+
+@ExperimentalResourceApi
+internal val Res.string.str_23862: StringResource
+  get() = String30.str_23862
+
+@ExperimentalResourceApi
+internal val Res.string.str_23863: StringResource
+  get() = String30.str_23863
+
+@ExperimentalResourceApi
+internal val Res.string.str_23864: StringResource
+  get() = String30.str_23864
+
+@ExperimentalResourceApi
+internal val Res.string.str_23865: StringResource
+  get() = String30.str_23865
+
+@ExperimentalResourceApi
+internal val Res.string.str_23866: StringResource
+  get() = String30.str_23866
+
+@ExperimentalResourceApi
+internal val Res.string.str_23867: StringResource
+  get() = String30.str_23867
+
+@ExperimentalResourceApi
+internal val Res.string.str_23868: StringResource
+  get() = String30.str_23868
+
+@ExperimentalResourceApi
+internal val Res.string.str_23869: StringResource
+  get() = String30.str_23869
+
+@ExperimentalResourceApi
+internal val Res.string.str_2387: StringResource
+  get() = String30.str_2387
+
+@ExperimentalResourceApi
+internal val Res.string.str_23870: StringResource
+  get() = String30.str_23870
+
+@ExperimentalResourceApi
+internal val Res.string.str_23871: StringResource
+  get() = String30.str_23871
+
+@ExperimentalResourceApi
+internal val Res.string.str_23872: StringResource
+  get() = String30.str_23872
+
+@ExperimentalResourceApi
+internal val Res.string.str_23873: StringResource
+  get() = String30.str_23873
+
+@ExperimentalResourceApi
+internal val Res.string.str_23874: StringResource
+  get() = String30.str_23874
+
+@ExperimentalResourceApi
+internal val Res.string.str_23875: StringResource
+  get() = String30.str_23875
+
+@ExperimentalResourceApi
+internal val Res.string.str_23876: StringResource
+  get() = String30.str_23876
+
+@ExperimentalResourceApi
+internal val Res.string.str_23877: StringResource
+  get() = String30.str_23877
+
+@ExperimentalResourceApi
+internal val Res.string.str_23878: StringResource
+  get() = String30.str_23878
+
+@ExperimentalResourceApi
+internal val Res.string.str_23879: StringResource
+  get() = String30.str_23879
+
+@ExperimentalResourceApi
+internal val Res.string.str_2388: StringResource
+  get() = String30.str_2388
+
+@ExperimentalResourceApi
+internal val Res.string.str_23880: StringResource
+  get() = String30.str_23880
+
+@ExperimentalResourceApi
+internal val Res.string.str_23881: StringResource
+  get() = String30.str_23881
+
+@ExperimentalResourceApi
+internal val Res.string.str_23882: StringResource
+  get() = String30.str_23882
+
+@ExperimentalResourceApi
+internal val Res.string.str_23883: StringResource
+  get() = String30.str_23883
+
+@ExperimentalResourceApi
+internal val Res.string.str_23884: StringResource
+  get() = String30.str_23884
+
+@ExperimentalResourceApi
+internal val Res.string.str_23885: StringResource
+  get() = String30.str_23885
+
+@ExperimentalResourceApi
+internal val Res.string.str_23886: StringResource
+  get() = String30.str_23886
+
+@ExperimentalResourceApi
+internal val Res.string.str_23887: StringResource
+  get() = String30.str_23887
+
+@ExperimentalResourceApi
+internal val Res.string.str_23888: StringResource
+  get() = String30.str_23888
+
+@ExperimentalResourceApi
+internal val Res.string.str_23889: StringResource
+  get() = String30.str_23889
+
+@ExperimentalResourceApi
+internal val Res.string.str_2389: StringResource
+  get() = String30.str_2389
+
+@ExperimentalResourceApi
+internal val Res.string.str_23890: StringResource
+  get() = String30.str_23890
+
+@ExperimentalResourceApi
+internal val Res.string.str_23891: StringResource
+  get() = String30.str_23891
+
+@ExperimentalResourceApi
+internal val Res.string.str_23892: StringResource
+  get() = String30.str_23892
+
+@ExperimentalResourceApi
+internal val Res.string.str_23893: StringResource
+  get() = String30.str_23893
+
+@ExperimentalResourceApi
+internal val Res.string.str_23894: StringResource
+  get() = String30.str_23894
+
+@ExperimentalResourceApi
+internal val Res.string.str_23895: StringResource
+  get() = String30.str_23895
+
+@ExperimentalResourceApi
+internal val Res.string.str_23896: StringResource
+  get() = String30.str_23896
+
+@ExperimentalResourceApi
+internal val Res.string.str_23897: StringResource
+  get() = String30.str_23897
+
+@ExperimentalResourceApi
+internal val Res.string.str_23898: StringResource
+  get() = String30.str_23898
+
+@ExperimentalResourceApi
+internal val Res.string.str_23899: StringResource
+  get() = String30.str_23899
+
+@ExperimentalResourceApi
+internal val Res.string.str_239: StringResource
+  get() = String30.str_239
+
+@ExperimentalResourceApi
+internal val Res.string.str_2390: StringResource
+  get() = String30.str_2390
+
+@ExperimentalResourceApi
+internal val Res.string.str_23900: StringResource
+  get() = String30.str_23900
+
+@ExperimentalResourceApi
+internal val Res.string.str_23901: StringResource
+  get() = String30.str_23901
+
+@ExperimentalResourceApi
+internal val Res.string.str_23902: StringResource
+  get() = String30.str_23902
+
+@ExperimentalResourceApi
+internal val Res.string.str_23903: StringResource
+  get() = String30.str_23903
+
+@ExperimentalResourceApi
+internal val Res.string.str_23904: StringResource
+  get() = String30.str_23904
+
+@ExperimentalResourceApi
+internal val Res.string.str_23905: StringResource
+  get() = String30.str_23905
+
+@ExperimentalResourceApi
+internal val Res.string.str_23906: StringResource
+  get() = String30.str_23906
+
+@ExperimentalResourceApi
+internal val Res.string.str_23907: StringResource
+  get() = String30.str_23907
+
+@ExperimentalResourceApi
+internal val Res.string.str_23908: StringResource
+  get() = String30.str_23908
+
+@ExperimentalResourceApi
+internal val Res.string.str_23909: StringResource
+  get() = String30.str_23909
+
+@ExperimentalResourceApi
+internal val Res.string.str_2391: StringResource
+  get() = String30.str_2391
+
+@ExperimentalResourceApi
+internal val Res.string.str_23910: StringResource
+  get() = String30.str_23910
+
+@ExperimentalResourceApi
+internal val Res.string.str_23911: StringResource
+  get() = String30.str_23911
+
+@ExperimentalResourceApi
+internal val Res.string.str_23912: StringResource
+  get() = String30.str_23912
+
+@ExperimentalResourceApi
+internal val Res.string.str_23913: StringResource
+  get() = String30.str_23913
+
+@ExperimentalResourceApi
+internal val Res.string.str_23914: StringResource
+  get() = String30.str_23914
+
+@ExperimentalResourceApi
+internal val Res.string.str_23915: StringResource
+  get() = String30.str_23915
+
+@ExperimentalResourceApi
+internal val Res.string.str_23916: StringResource
+  get() = String30.str_23916
+
+@ExperimentalResourceApi
+internal val Res.string.str_23917: StringResource
+  get() = String30.str_23917
+
+@ExperimentalResourceApi
+internal val Res.string.str_23918: StringResource
+  get() = String30.str_23918
+
+@ExperimentalResourceApi
+internal val Res.string.str_23919: StringResource
+  get() = String30.str_23919
+
+@ExperimentalResourceApi
+internal val Res.string.str_2392: StringResource
+  get() = String30.str_2392
+
+@ExperimentalResourceApi
+internal val Res.string.str_23920: StringResource
+  get() = String30.str_23920
+
+@ExperimentalResourceApi
+internal val Res.string.str_23921: StringResource
+  get() = String30.str_23921
+
+@ExperimentalResourceApi
+internal val Res.string.str_23922: StringResource
+  get() = String30.str_23922
+
+@ExperimentalResourceApi
+internal val Res.string.str_23923: StringResource
+  get() = String30.str_23923
+
+@ExperimentalResourceApi
+internal val Res.string.str_23924: StringResource
+  get() = String30.str_23924
+
+@ExperimentalResourceApi
+internal val Res.string.str_23925: StringResource
+  get() = String30.str_23925
+
+@ExperimentalResourceApi
+internal val Res.string.str_23926: StringResource
+  get() = String30.str_23926
+
+@ExperimentalResourceApi
+internal val Res.string.str_23927: StringResource
+  get() = String30.str_23927
+
+@ExperimentalResourceApi
+internal val Res.string.str_23928: StringResource
+  get() = String30.str_23928
+
+@ExperimentalResourceApi
+internal val Res.string.str_23929: StringResource
+  get() = String30.str_23929
+
+@ExperimentalResourceApi
+internal val Res.string.str_2393: StringResource
+  get() = String30.str_2393
+
+@ExperimentalResourceApi
+internal val Res.string.str_23930: StringResource
+  get() = String30.str_23930
+
+@ExperimentalResourceApi
+internal val Res.string.str_23931: StringResource
+  get() = String30.str_23931
+
+@ExperimentalResourceApi
+internal val Res.string.str_23932: StringResource
+  get() = String30.str_23932
+
+@ExperimentalResourceApi
+internal val Res.string.str_23933: StringResource
+  get() = String30.str_23933
+
+@ExperimentalResourceApi
+internal val Res.string.str_23934: StringResource
+  get() = String30.str_23934
+
+@ExperimentalResourceApi
+internal val Res.string.str_23935: StringResource
+  get() = String30.str_23935
+
+@ExperimentalResourceApi
+internal val Res.string.str_23936: StringResource
+  get() = String30.str_23936
+
+@ExperimentalResourceApi
+internal val Res.string.str_23937: StringResource
+  get() = String30.str_23937
+
+@ExperimentalResourceApi
+internal val Res.string.str_23938: StringResource
+  get() = String30.str_23938
+
+@ExperimentalResourceApi
+internal val Res.string.str_23939: StringResource
+  get() = String30.str_23939
+
+@ExperimentalResourceApi
+internal val Res.string.str_2394: StringResource
+  get() = String30.str_2394
+
+@ExperimentalResourceApi
+internal val Res.string.str_23940: StringResource
+  get() = String30.str_23940
+
+@ExperimentalResourceApi
+internal val Res.string.str_23941: StringResource
+  get() = String30.str_23941
+
+@ExperimentalResourceApi
+internal val Res.string.str_23942: StringResource
+  get() = String30.str_23942
+
+@ExperimentalResourceApi
+internal val Res.string.str_23943: StringResource
+  get() = String30.str_23943
+
+@ExperimentalResourceApi
+internal val Res.string.str_23944: StringResource
+  get() = String30.str_23944
+
+@ExperimentalResourceApi
+internal val Res.string.str_23945: StringResource
+  get() = String30.str_23945
+
+@ExperimentalResourceApi
+internal val Res.string.str_23946: StringResource
+  get() = String30.str_23946
+
+@ExperimentalResourceApi
+internal val Res.string.str_23947: StringResource
+  get() = String30.str_23947

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String31.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String31.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String31 {
+  public val str_23948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23948", "str_23948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23949", "str_23949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2395", "str_2395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23950", "str_23950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23951", "str_23951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23952", "str_23952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23953", "str_23953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23954", "str_23954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23955", "str_23955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23956", "str_23956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23957", "str_23957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23958", "str_23958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23959", "str_23959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2396", "str_2396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23960", "str_23960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23961", "str_23961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23962", "str_23962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23963", "str_23963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23964", "str_23964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23965", "str_23965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23966", "str_23966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23967", "str_23967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23968", "str_23968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23969", "str_23969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2397", "str_2397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23970", "str_23970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23971", "str_23971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23972", "str_23972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23973", "str_23973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23974", "str_23974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23975", "str_23975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23976", "str_23976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23977", "str_23977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23978", "str_23978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23979", "str_23979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2398", "str_2398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23980", "str_23980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23981", "str_23981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23982", "str_23982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23983", "str_23983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23984", "str_23984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23985", "str_23985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23986", "str_23986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23987", "str_23987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23988", "str_23988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23989", "str_23989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2399", "str_2399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23990", "str_23990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23991", "str_23991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23992", "str_23992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23993", "str_23993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23994", "str_23994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23995", "str_23995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23996", "str_23996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23997", "str_23997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23998", "str_23998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_23999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_23999", "str_23999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24", "str_24",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_240", "str_240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2400", "str_2400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24000", "str_24000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24001", "str_24001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24002", "str_24002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24003", "str_24003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24004", "str_24004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24005", "str_24005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24006", "str_24006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24007", "str_24007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24008", "str_24008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24009", "str_24009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2401", "str_2401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24010", "str_24010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24011", "str_24011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24012", "str_24012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24013", "str_24013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24014", "str_24014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24015", "str_24015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24016", "str_24016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24017", "str_24017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24018", "str_24018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24019", "str_24019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2402", "str_2402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24020", "str_24020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24021", "str_24021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24022", "str_24022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24023", "str_24023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24024", "str_24024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24025", "str_24025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24026", "str_24026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24027", "str_24027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24028", "str_24028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24029", "str_24029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2403", "str_2403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24030", "str_24030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24031", "str_24031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24032", "str_24032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24033", "str_24033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24034", "str_24034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24035", "str_24035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24036", "str_24036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24037", "str_24037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24038", "str_24038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24039", "str_24039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2404", "str_2404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24040", "str_24040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24041", "str_24041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24042", "str_24042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24043", "str_24043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24044", "str_24044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24045", "str_24045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24046", "str_24046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24047", "str_24047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24048", "str_24048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24049", "str_24049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2405", "str_2405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24050", "str_24050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24051", "str_24051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24052", "str_24052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24053", "str_24053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24054", "str_24054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24055", "str_24055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24056", "str_24056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24057", "str_24057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24058", "str_24058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24059", "str_24059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2406", "str_2406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24060", "str_24060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24061", "str_24061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24062", "str_24062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24063", "str_24063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24064", "str_24064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24065", "str_24065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24066", "str_24066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24067", "str_24067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24068", "str_24068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24069", "str_24069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2407", "str_2407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24070", "str_24070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24071", "str_24071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24072", "str_24072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24073", "str_24073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24074", "str_24074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24075", "str_24075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24076", "str_24076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24077", "str_24077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24078", "str_24078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24079", "str_24079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2408", "str_2408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24080", "str_24080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24081", "str_24081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24082", "str_24082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24083", "str_24083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24084", "str_24084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24085", "str_24085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24086", "str_24086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24087", "str_24087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24088", "str_24088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24089", "str_24089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2409", "str_2409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24090", "str_24090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24091", "str_24091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24092", "str_24092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24093", "str_24093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24094", "str_24094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24095", "str_24095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24096", "str_24096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24097", "str_24097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24098", "str_24098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24099", "str_24099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_241", "str_241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2410", "str_2410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24100", "str_24100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24101", "str_24101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24102", "str_24102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24103", "str_24103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24104", "str_24104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24105", "str_24105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24106", "str_24106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24107", "str_24107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24108", "str_24108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24109", "str_24109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2411", "str_2411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24110", "str_24110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24111", "str_24111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24112", "str_24112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24113", "str_24113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24114", "str_24114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24115", "str_24115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24116", "str_24116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24117", "str_24117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24118", "str_24118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24119", "str_24119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2412", "str_2412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24120", "str_24120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24121", "str_24121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24122", "str_24122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24123", "str_24123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24124", "str_24124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24125", "str_24125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24126", "str_24126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24127", "str_24127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24128", "str_24128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24129", "str_24129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2413", "str_2413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24130", "str_24130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24131", "str_24131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24132", "str_24132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24133", "str_24133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24134", "str_24134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24135", "str_24135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24136", "str_24136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24137", "str_24137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24138", "str_24138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24139", "str_24139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2414", "str_2414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24140", "str_24140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24141", "str_24141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24142", "str_24142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24143", "str_24143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24144", "str_24144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24145", "str_24145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24146", "str_24146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24147", "str_24147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24148", "str_24148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24149", "str_24149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2415", "str_2415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24150", "str_24150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24151", "str_24151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24152", "str_24152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24153", "str_24153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24154", "str_24154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24155", "str_24155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24156", "str_24156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24157", "str_24157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24158", "str_24158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24159", "str_24159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2416", "str_2416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24160", "str_24160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24161", "str_24161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24162", "str_24162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24163", "str_24163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24164", "str_24164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24165", "str_24165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24166", "str_24166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24167", "str_24167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24168", "str_24168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24169", "str_24169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2417", "str_2417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24170", "str_24170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24171", "str_24171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24172", "str_24172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24173", "str_24173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24174", "str_24174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24175", "str_24175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24176", "str_24176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24177", "str_24177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24178", "str_24178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24179", "str_24179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2418", "str_2418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24180", "str_24180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24181", "str_24181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24182", "str_24182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24183", "str_24183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24184", "str_24184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24185", "str_24185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24186", "str_24186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24187", "str_24187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24188", "str_24188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24189", "str_24189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2419", "str_2419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24190", "str_24190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24191", "str_24191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24192", "str_24192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24193", "str_24193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24194", "str_24194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24195", "str_24195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24196", "str_24196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24197", "str_24197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24198", "str_24198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24199", "str_24199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_242", "str_242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2420", "str_2420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24200", "str_24200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24201", "str_24201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24202", "str_24202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24203", "str_24203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24204", "str_24204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24205", "str_24205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24206", "str_24206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24207", "str_24207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24208", "str_24208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24209", "str_24209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2421", "str_2421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24210", "str_24210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24211", "str_24211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24212", "str_24212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24213", "str_24213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24214", "str_24214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24215", "str_24215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24216", "str_24216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24217", "str_24217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24218", "str_24218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24219", "str_24219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2422", "str_2422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24220", "str_24220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24221", "str_24221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24222", "str_24222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24223", "str_24223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24224", "str_24224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24225", "str_24225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24226", "str_24226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24227", "str_24227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24228", "str_24228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24229", "str_24229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2423", "str_2423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24230", "str_24230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24231", "str_24231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24232", "str_24232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24233", "str_24233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24234", "str_24234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24235", "str_24235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24236", "str_24236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24237", "str_24237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24238", "str_24238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24239", "str_24239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2424", "str_2424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24240", "str_24240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24241", "str_24241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24242", "str_24242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24243", "str_24243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24244", "str_24244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24245", "str_24245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24246", "str_24246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24247", "str_24247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24248", "str_24248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24249", "str_24249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2425", "str_2425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24250", "str_24250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24251", "str_24251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24252", "str_24252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24253", "str_24253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24254", "str_24254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24255", "str_24255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24256", "str_24256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24257", "str_24257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24258", "str_24258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24259", "str_24259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2426", "str_2426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24260", "str_24260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24261", "str_24261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24262", "str_24262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24263", "str_24263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24264", "str_24264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24265", "str_24265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24266", "str_24266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24267", "str_24267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24268", "str_24268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24269", "str_24269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2427", "str_2427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24270", "str_24270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24271", "str_24271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24272", "str_24272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24273", "str_24273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24274", "str_24274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24275", "str_24275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24276", "str_24276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24277", "str_24277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24278", "str_24278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24279", "str_24279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2428", "str_2428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24280", "str_24280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24281", "str_24281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24282", "str_24282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24283", "str_24283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24284", "str_24284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24285", "str_24285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24286", "str_24286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24287", "str_24287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24288", "str_24288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24289", "str_24289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2429", "str_2429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24290", "str_24290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24291", "str_24291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24292", "str_24292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24293", "str_24293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24294", "str_24294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24295", "str_24295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24296", "str_24296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24297", "str_24297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24298", "str_24298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24299", "str_24299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_243", "str_243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2430", "str_2430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24300", "str_24300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24301", "str_24301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24302", "str_24302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24303", "str_24303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24304", "str_24304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24305", "str_24305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24306", "str_24306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24307", "str_24307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24308", "str_24308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24309", "str_24309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2431", "str_2431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24310", "str_24310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24311", "str_24311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24312", "str_24312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24313", "str_24313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24314", "str_24314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24315", "str_24315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24316", "str_24316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24317", "str_24317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24318", "str_24318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24319", "str_24319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2432", "str_2432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24320", "str_24320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24321", "str_24321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24322", "str_24322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24323", "str_24323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24324", "str_24324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24325", "str_24325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24326", "str_24326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24327", "str_24327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24328", "str_24328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24329", "str_24329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2433", "str_2433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24330", "str_24330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24331", "str_24331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24332", "str_24332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24333", "str_24333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24334", "str_24334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24335", "str_24335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24336", "str_24336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24337", "str_24337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24338", "str_24338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24339", "str_24339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2434", "str_2434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24340", "str_24340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24341", "str_24341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24342", "str_24342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24343", "str_24343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24344", "str_24344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24345", "str_24345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24346", "str_24346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24347", "str_24347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24348", "str_24348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24349", "str_24349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2435", "str_2435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24350", "str_24350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24351", "str_24351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24352", "str_24352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24353", "str_24353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24354", "str_24354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24355", "str_24355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24356", "str_24356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24357", "str_24357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24358", "str_24358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24359", "str_24359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2436", "str_2436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24360", "str_24360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24361", "str_24361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24362", "str_24362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24363", "str_24363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24364", "str_24364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24365", "str_24365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24366", "str_24366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24367", "str_24367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24368", "str_24368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24369", "str_24369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2437", "str_2437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24370", "str_24370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24371", "str_24371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24372", "str_24372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24373", "str_24373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24374", "str_24374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24375", "str_24375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24376", "str_24376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24377", "str_24377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24378", "str_24378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24379", "str_24379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2438", "str_2438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24380", "str_24380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24381", "str_24381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24382", "str_24382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24383", "str_24383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24384", "str_24384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24385", "str_24385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24386", "str_24386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24387", "str_24387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24388", "str_24388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24389", "str_24389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2439", "str_2439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24390", "str_24390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24391", "str_24391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24392", "str_24392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24393", "str_24393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24394", "str_24394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24395", "str_24395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24396", "str_24396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24397", "str_24397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_23948: StringResource
+  get() = String31.str_23948
+
+@ExperimentalResourceApi
+internal val Res.string.str_23949: StringResource
+  get() = String31.str_23949
+
+@ExperimentalResourceApi
+internal val Res.string.str_2395: StringResource
+  get() = String31.str_2395
+
+@ExperimentalResourceApi
+internal val Res.string.str_23950: StringResource
+  get() = String31.str_23950
+
+@ExperimentalResourceApi
+internal val Res.string.str_23951: StringResource
+  get() = String31.str_23951
+
+@ExperimentalResourceApi
+internal val Res.string.str_23952: StringResource
+  get() = String31.str_23952
+
+@ExperimentalResourceApi
+internal val Res.string.str_23953: StringResource
+  get() = String31.str_23953
+
+@ExperimentalResourceApi
+internal val Res.string.str_23954: StringResource
+  get() = String31.str_23954
+
+@ExperimentalResourceApi
+internal val Res.string.str_23955: StringResource
+  get() = String31.str_23955
+
+@ExperimentalResourceApi
+internal val Res.string.str_23956: StringResource
+  get() = String31.str_23956
+
+@ExperimentalResourceApi
+internal val Res.string.str_23957: StringResource
+  get() = String31.str_23957
+
+@ExperimentalResourceApi
+internal val Res.string.str_23958: StringResource
+  get() = String31.str_23958
+
+@ExperimentalResourceApi
+internal val Res.string.str_23959: StringResource
+  get() = String31.str_23959
+
+@ExperimentalResourceApi
+internal val Res.string.str_2396: StringResource
+  get() = String31.str_2396
+
+@ExperimentalResourceApi
+internal val Res.string.str_23960: StringResource
+  get() = String31.str_23960
+
+@ExperimentalResourceApi
+internal val Res.string.str_23961: StringResource
+  get() = String31.str_23961
+
+@ExperimentalResourceApi
+internal val Res.string.str_23962: StringResource
+  get() = String31.str_23962
+
+@ExperimentalResourceApi
+internal val Res.string.str_23963: StringResource
+  get() = String31.str_23963
+
+@ExperimentalResourceApi
+internal val Res.string.str_23964: StringResource
+  get() = String31.str_23964
+
+@ExperimentalResourceApi
+internal val Res.string.str_23965: StringResource
+  get() = String31.str_23965
+
+@ExperimentalResourceApi
+internal val Res.string.str_23966: StringResource
+  get() = String31.str_23966
+
+@ExperimentalResourceApi
+internal val Res.string.str_23967: StringResource
+  get() = String31.str_23967
+
+@ExperimentalResourceApi
+internal val Res.string.str_23968: StringResource
+  get() = String31.str_23968
+
+@ExperimentalResourceApi
+internal val Res.string.str_23969: StringResource
+  get() = String31.str_23969
+
+@ExperimentalResourceApi
+internal val Res.string.str_2397: StringResource
+  get() = String31.str_2397
+
+@ExperimentalResourceApi
+internal val Res.string.str_23970: StringResource
+  get() = String31.str_23970
+
+@ExperimentalResourceApi
+internal val Res.string.str_23971: StringResource
+  get() = String31.str_23971
+
+@ExperimentalResourceApi
+internal val Res.string.str_23972: StringResource
+  get() = String31.str_23972
+
+@ExperimentalResourceApi
+internal val Res.string.str_23973: StringResource
+  get() = String31.str_23973
+
+@ExperimentalResourceApi
+internal val Res.string.str_23974: StringResource
+  get() = String31.str_23974
+
+@ExperimentalResourceApi
+internal val Res.string.str_23975: StringResource
+  get() = String31.str_23975
+
+@ExperimentalResourceApi
+internal val Res.string.str_23976: StringResource
+  get() = String31.str_23976
+
+@ExperimentalResourceApi
+internal val Res.string.str_23977: StringResource
+  get() = String31.str_23977
+
+@ExperimentalResourceApi
+internal val Res.string.str_23978: StringResource
+  get() = String31.str_23978
+
+@ExperimentalResourceApi
+internal val Res.string.str_23979: StringResource
+  get() = String31.str_23979
+
+@ExperimentalResourceApi
+internal val Res.string.str_2398: StringResource
+  get() = String31.str_2398
+
+@ExperimentalResourceApi
+internal val Res.string.str_23980: StringResource
+  get() = String31.str_23980
+
+@ExperimentalResourceApi
+internal val Res.string.str_23981: StringResource
+  get() = String31.str_23981
+
+@ExperimentalResourceApi
+internal val Res.string.str_23982: StringResource
+  get() = String31.str_23982
+
+@ExperimentalResourceApi
+internal val Res.string.str_23983: StringResource
+  get() = String31.str_23983
+
+@ExperimentalResourceApi
+internal val Res.string.str_23984: StringResource
+  get() = String31.str_23984
+
+@ExperimentalResourceApi
+internal val Res.string.str_23985: StringResource
+  get() = String31.str_23985
+
+@ExperimentalResourceApi
+internal val Res.string.str_23986: StringResource
+  get() = String31.str_23986
+
+@ExperimentalResourceApi
+internal val Res.string.str_23987: StringResource
+  get() = String31.str_23987
+
+@ExperimentalResourceApi
+internal val Res.string.str_23988: StringResource
+  get() = String31.str_23988
+
+@ExperimentalResourceApi
+internal val Res.string.str_23989: StringResource
+  get() = String31.str_23989
+
+@ExperimentalResourceApi
+internal val Res.string.str_2399: StringResource
+  get() = String31.str_2399
+
+@ExperimentalResourceApi
+internal val Res.string.str_23990: StringResource
+  get() = String31.str_23990
+
+@ExperimentalResourceApi
+internal val Res.string.str_23991: StringResource
+  get() = String31.str_23991
+
+@ExperimentalResourceApi
+internal val Res.string.str_23992: StringResource
+  get() = String31.str_23992
+
+@ExperimentalResourceApi
+internal val Res.string.str_23993: StringResource
+  get() = String31.str_23993
+
+@ExperimentalResourceApi
+internal val Res.string.str_23994: StringResource
+  get() = String31.str_23994
+
+@ExperimentalResourceApi
+internal val Res.string.str_23995: StringResource
+  get() = String31.str_23995
+
+@ExperimentalResourceApi
+internal val Res.string.str_23996: StringResource
+  get() = String31.str_23996
+
+@ExperimentalResourceApi
+internal val Res.string.str_23997: StringResource
+  get() = String31.str_23997
+
+@ExperimentalResourceApi
+internal val Res.string.str_23998: StringResource
+  get() = String31.str_23998
+
+@ExperimentalResourceApi
+internal val Res.string.str_23999: StringResource
+  get() = String31.str_23999
+
+@ExperimentalResourceApi
+internal val Res.string.str_24: StringResource
+  get() = String31.str_24
+
+@ExperimentalResourceApi
+internal val Res.string.str_240: StringResource
+  get() = String31.str_240
+
+@ExperimentalResourceApi
+internal val Res.string.str_2400: StringResource
+  get() = String31.str_2400
+
+@ExperimentalResourceApi
+internal val Res.string.str_24000: StringResource
+  get() = String31.str_24000
+
+@ExperimentalResourceApi
+internal val Res.string.str_24001: StringResource
+  get() = String31.str_24001
+
+@ExperimentalResourceApi
+internal val Res.string.str_24002: StringResource
+  get() = String31.str_24002
+
+@ExperimentalResourceApi
+internal val Res.string.str_24003: StringResource
+  get() = String31.str_24003
+
+@ExperimentalResourceApi
+internal val Res.string.str_24004: StringResource
+  get() = String31.str_24004
+
+@ExperimentalResourceApi
+internal val Res.string.str_24005: StringResource
+  get() = String31.str_24005
+
+@ExperimentalResourceApi
+internal val Res.string.str_24006: StringResource
+  get() = String31.str_24006
+
+@ExperimentalResourceApi
+internal val Res.string.str_24007: StringResource
+  get() = String31.str_24007
+
+@ExperimentalResourceApi
+internal val Res.string.str_24008: StringResource
+  get() = String31.str_24008
+
+@ExperimentalResourceApi
+internal val Res.string.str_24009: StringResource
+  get() = String31.str_24009
+
+@ExperimentalResourceApi
+internal val Res.string.str_2401: StringResource
+  get() = String31.str_2401
+
+@ExperimentalResourceApi
+internal val Res.string.str_24010: StringResource
+  get() = String31.str_24010
+
+@ExperimentalResourceApi
+internal val Res.string.str_24011: StringResource
+  get() = String31.str_24011
+
+@ExperimentalResourceApi
+internal val Res.string.str_24012: StringResource
+  get() = String31.str_24012
+
+@ExperimentalResourceApi
+internal val Res.string.str_24013: StringResource
+  get() = String31.str_24013
+
+@ExperimentalResourceApi
+internal val Res.string.str_24014: StringResource
+  get() = String31.str_24014
+
+@ExperimentalResourceApi
+internal val Res.string.str_24015: StringResource
+  get() = String31.str_24015
+
+@ExperimentalResourceApi
+internal val Res.string.str_24016: StringResource
+  get() = String31.str_24016
+
+@ExperimentalResourceApi
+internal val Res.string.str_24017: StringResource
+  get() = String31.str_24017
+
+@ExperimentalResourceApi
+internal val Res.string.str_24018: StringResource
+  get() = String31.str_24018
+
+@ExperimentalResourceApi
+internal val Res.string.str_24019: StringResource
+  get() = String31.str_24019
+
+@ExperimentalResourceApi
+internal val Res.string.str_2402: StringResource
+  get() = String31.str_2402
+
+@ExperimentalResourceApi
+internal val Res.string.str_24020: StringResource
+  get() = String31.str_24020
+
+@ExperimentalResourceApi
+internal val Res.string.str_24021: StringResource
+  get() = String31.str_24021
+
+@ExperimentalResourceApi
+internal val Res.string.str_24022: StringResource
+  get() = String31.str_24022
+
+@ExperimentalResourceApi
+internal val Res.string.str_24023: StringResource
+  get() = String31.str_24023
+
+@ExperimentalResourceApi
+internal val Res.string.str_24024: StringResource
+  get() = String31.str_24024
+
+@ExperimentalResourceApi
+internal val Res.string.str_24025: StringResource
+  get() = String31.str_24025
+
+@ExperimentalResourceApi
+internal val Res.string.str_24026: StringResource
+  get() = String31.str_24026
+
+@ExperimentalResourceApi
+internal val Res.string.str_24027: StringResource
+  get() = String31.str_24027
+
+@ExperimentalResourceApi
+internal val Res.string.str_24028: StringResource
+  get() = String31.str_24028
+
+@ExperimentalResourceApi
+internal val Res.string.str_24029: StringResource
+  get() = String31.str_24029
+
+@ExperimentalResourceApi
+internal val Res.string.str_2403: StringResource
+  get() = String31.str_2403
+
+@ExperimentalResourceApi
+internal val Res.string.str_24030: StringResource
+  get() = String31.str_24030
+
+@ExperimentalResourceApi
+internal val Res.string.str_24031: StringResource
+  get() = String31.str_24031
+
+@ExperimentalResourceApi
+internal val Res.string.str_24032: StringResource
+  get() = String31.str_24032
+
+@ExperimentalResourceApi
+internal val Res.string.str_24033: StringResource
+  get() = String31.str_24033
+
+@ExperimentalResourceApi
+internal val Res.string.str_24034: StringResource
+  get() = String31.str_24034
+
+@ExperimentalResourceApi
+internal val Res.string.str_24035: StringResource
+  get() = String31.str_24035
+
+@ExperimentalResourceApi
+internal val Res.string.str_24036: StringResource
+  get() = String31.str_24036
+
+@ExperimentalResourceApi
+internal val Res.string.str_24037: StringResource
+  get() = String31.str_24037
+
+@ExperimentalResourceApi
+internal val Res.string.str_24038: StringResource
+  get() = String31.str_24038
+
+@ExperimentalResourceApi
+internal val Res.string.str_24039: StringResource
+  get() = String31.str_24039
+
+@ExperimentalResourceApi
+internal val Res.string.str_2404: StringResource
+  get() = String31.str_2404
+
+@ExperimentalResourceApi
+internal val Res.string.str_24040: StringResource
+  get() = String31.str_24040
+
+@ExperimentalResourceApi
+internal val Res.string.str_24041: StringResource
+  get() = String31.str_24041
+
+@ExperimentalResourceApi
+internal val Res.string.str_24042: StringResource
+  get() = String31.str_24042
+
+@ExperimentalResourceApi
+internal val Res.string.str_24043: StringResource
+  get() = String31.str_24043
+
+@ExperimentalResourceApi
+internal val Res.string.str_24044: StringResource
+  get() = String31.str_24044
+
+@ExperimentalResourceApi
+internal val Res.string.str_24045: StringResource
+  get() = String31.str_24045
+
+@ExperimentalResourceApi
+internal val Res.string.str_24046: StringResource
+  get() = String31.str_24046
+
+@ExperimentalResourceApi
+internal val Res.string.str_24047: StringResource
+  get() = String31.str_24047
+
+@ExperimentalResourceApi
+internal val Res.string.str_24048: StringResource
+  get() = String31.str_24048
+
+@ExperimentalResourceApi
+internal val Res.string.str_24049: StringResource
+  get() = String31.str_24049
+
+@ExperimentalResourceApi
+internal val Res.string.str_2405: StringResource
+  get() = String31.str_2405
+
+@ExperimentalResourceApi
+internal val Res.string.str_24050: StringResource
+  get() = String31.str_24050
+
+@ExperimentalResourceApi
+internal val Res.string.str_24051: StringResource
+  get() = String31.str_24051
+
+@ExperimentalResourceApi
+internal val Res.string.str_24052: StringResource
+  get() = String31.str_24052
+
+@ExperimentalResourceApi
+internal val Res.string.str_24053: StringResource
+  get() = String31.str_24053
+
+@ExperimentalResourceApi
+internal val Res.string.str_24054: StringResource
+  get() = String31.str_24054
+
+@ExperimentalResourceApi
+internal val Res.string.str_24055: StringResource
+  get() = String31.str_24055
+
+@ExperimentalResourceApi
+internal val Res.string.str_24056: StringResource
+  get() = String31.str_24056
+
+@ExperimentalResourceApi
+internal val Res.string.str_24057: StringResource
+  get() = String31.str_24057
+
+@ExperimentalResourceApi
+internal val Res.string.str_24058: StringResource
+  get() = String31.str_24058
+
+@ExperimentalResourceApi
+internal val Res.string.str_24059: StringResource
+  get() = String31.str_24059
+
+@ExperimentalResourceApi
+internal val Res.string.str_2406: StringResource
+  get() = String31.str_2406
+
+@ExperimentalResourceApi
+internal val Res.string.str_24060: StringResource
+  get() = String31.str_24060
+
+@ExperimentalResourceApi
+internal val Res.string.str_24061: StringResource
+  get() = String31.str_24061
+
+@ExperimentalResourceApi
+internal val Res.string.str_24062: StringResource
+  get() = String31.str_24062
+
+@ExperimentalResourceApi
+internal val Res.string.str_24063: StringResource
+  get() = String31.str_24063
+
+@ExperimentalResourceApi
+internal val Res.string.str_24064: StringResource
+  get() = String31.str_24064
+
+@ExperimentalResourceApi
+internal val Res.string.str_24065: StringResource
+  get() = String31.str_24065
+
+@ExperimentalResourceApi
+internal val Res.string.str_24066: StringResource
+  get() = String31.str_24066
+
+@ExperimentalResourceApi
+internal val Res.string.str_24067: StringResource
+  get() = String31.str_24067
+
+@ExperimentalResourceApi
+internal val Res.string.str_24068: StringResource
+  get() = String31.str_24068
+
+@ExperimentalResourceApi
+internal val Res.string.str_24069: StringResource
+  get() = String31.str_24069
+
+@ExperimentalResourceApi
+internal val Res.string.str_2407: StringResource
+  get() = String31.str_2407
+
+@ExperimentalResourceApi
+internal val Res.string.str_24070: StringResource
+  get() = String31.str_24070
+
+@ExperimentalResourceApi
+internal val Res.string.str_24071: StringResource
+  get() = String31.str_24071
+
+@ExperimentalResourceApi
+internal val Res.string.str_24072: StringResource
+  get() = String31.str_24072
+
+@ExperimentalResourceApi
+internal val Res.string.str_24073: StringResource
+  get() = String31.str_24073
+
+@ExperimentalResourceApi
+internal val Res.string.str_24074: StringResource
+  get() = String31.str_24074
+
+@ExperimentalResourceApi
+internal val Res.string.str_24075: StringResource
+  get() = String31.str_24075
+
+@ExperimentalResourceApi
+internal val Res.string.str_24076: StringResource
+  get() = String31.str_24076
+
+@ExperimentalResourceApi
+internal val Res.string.str_24077: StringResource
+  get() = String31.str_24077
+
+@ExperimentalResourceApi
+internal val Res.string.str_24078: StringResource
+  get() = String31.str_24078
+
+@ExperimentalResourceApi
+internal val Res.string.str_24079: StringResource
+  get() = String31.str_24079
+
+@ExperimentalResourceApi
+internal val Res.string.str_2408: StringResource
+  get() = String31.str_2408
+
+@ExperimentalResourceApi
+internal val Res.string.str_24080: StringResource
+  get() = String31.str_24080
+
+@ExperimentalResourceApi
+internal val Res.string.str_24081: StringResource
+  get() = String31.str_24081
+
+@ExperimentalResourceApi
+internal val Res.string.str_24082: StringResource
+  get() = String31.str_24082
+
+@ExperimentalResourceApi
+internal val Res.string.str_24083: StringResource
+  get() = String31.str_24083
+
+@ExperimentalResourceApi
+internal val Res.string.str_24084: StringResource
+  get() = String31.str_24084
+
+@ExperimentalResourceApi
+internal val Res.string.str_24085: StringResource
+  get() = String31.str_24085
+
+@ExperimentalResourceApi
+internal val Res.string.str_24086: StringResource
+  get() = String31.str_24086
+
+@ExperimentalResourceApi
+internal val Res.string.str_24087: StringResource
+  get() = String31.str_24087
+
+@ExperimentalResourceApi
+internal val Res.string.str_24088: StringResource
+  get() = String31.str_24088
+
+@ExperimentalResourceApi
+internal val Res.string.str_24089: StringResource
+  get() = String31.str_24089
+
+@ExperimentalResourceApi
+internal val Res.string.str_2409: StringResource
+  get() = String31.str_2409
+
+@ExperimentalResourceApi
+internal val Res.string.str_24090: StringResource
+  get() = String31.str_24090
+
+@ExperimentalResourceApi
+internal val Res.string.str_24091: StringResource
+  get() = String31.str_24091
+
+@ExperimentalResourceApi
+internal val Res.string.str_24092: StringResource
+  get() = String31.str_24092
+
+@ExperimentalResourceApi
+internal val Res.string.str_24093: StringResource
+  get() = String31.str_24093
+
+@ExperimentalResourceApi
+internal val Res.string.str_24094: StringResource
+  get() = String31.str_24094
+
+@ExperimentalResourceApi
+internal val Res.string.str_24095: StringResource
+  get() = String31.str_24095
+
+@ExperimentalResourceApi
+internal val Res.string.str_24096: StringResource
+  get() = String31.str_24096
+
+@ExperimentalResourceApi
+internal val Res.string.str_24097: StringResource
+  get() = String31.str_24097
+
+@ExperimentalResourceApi
+internal val Res.string.str_24098: StringResource
+  get() = String31.str_24098
+
+@ExperimentalResourceApi
+internal val Res.string.str_24099: StringResource
+  get() = String31.str_24099
+
+@ExperimentalResourceApi
+internal val Res.string.str_241: StringResource
+  get() = String31.str_241
+
+@ExperimentalResourceApi
+internal val Res.string.str_2410: StringResource
+  get() = String31.str_2410
+
+@ExperimentalResourceApi
+internal val Res.string.str_24100: StringResource
+  get() = String31.str_24100
+
+@ExperimentalResourceApi
+internal val Res.string.str_24101: StringResource
+  get() = String31.str_24101
+
+@ExperimentalResourceApi
+internal val Res.string.str_24102: StringResource
+  get() = String31.str_24102
+
+@ExperimentalResourceApi
+internal val Res.string.str_24103: StringResource
+  get() = String31.str_24103
+
+@ExperimentalResourceApi
+internal val Res.string.str_24104: StringResource
+  get() = String31.str_24104
+
+@ExperimentalResourceApi
+internal val Res.string.str_24105: StringResource
+  get() = String31.str_24105
+
+@ExperimentalResourceApi
+internal val Res.string.str_24106: StringResource
+  get() = String31.str_24106
+
+@ExperimentalResourceApi
+internal val Res.string.str_24107: StringResource
+  get() = String31.str_24107
+
+@ExperimentalResourceApi
+internal val Res.string.str_24108: StringResource
+  get() = String31.str_24108
+
+@ExperimentalResourceApi
+internal val Res.string.str_24109: StringResource
+  get() = String31.str_24109
+
+@ExperimentalResourceApi
+internal val Res.string.str_2411: StringResource
+  get() = String31.str_2411
+
+@ExperimentalResourceApi
+internal val Res.string.str_24110: StringResource
+  get() = String31.str_24110
+
+@ExperimentalResourceApi
+internal val Res.string.str_24111: StringResource
+  get() = String31.str_24111
+
+@ExperimentalResourceApi
+internal val Res.string.str_24112: StringResource
+  get() = String31.str_24112
+
+@ExperimentalResourceApi
+internal val Res.string.str_24113: StringResource
+  get() = String31.str_24113
+
+@ExperimentalResourceApi
+internal val Res.string.str_24114: StringResource
+  get() = String31.str_24114
+
+@ExperimentalResourceApi
+internal val Res.string.str_24115: StringResource
+  get() = String31.str_24115
+
+@ExperimentalResourceApi
+internal val Res.string.str_24116: StringResource
+  get() = String31.str_24116
+
+@ExperimentalResourceApi
+internal val Res.string.str_24117: StringResource
+  get() = String31.str_24117
+
+@ExperimentalResourceApi
+internal val Res.string.str_24118: StringResource
+  get() = String31.str_24118
+
+@ExperimentalResourceApi
+internal val Res.string.str_24119: StringResource
+  get() = String31.str_24119
+
+@ExperimentalResourceApi
+internal val Res.string.str_2412: StringResource
+  get() = String31.str_2412
+
+@ExperimentalResourceApi
+internal val Res.string.str_24120: StringResource
+  get() = String31.str_24120
+
+@ExperimentalResourceApi
+internal val Res.string.str_24121: StringResource
+  get() = String31.str_24121
+
+@ExperimentalResourceApi
+internal val Res.string.str_24122: StringResource
+  get() = String31.str_24122
+
+@ExperimentalResourceApi
+internal val Res.string.str_24123: StringResource
+  get() = String31.str_24123
+
+@ExperimentalResourceApi
+internal val Res.string.str_24124: StringResource
+  get() = String31.str_24124
+
+@ExperimentalResourceApi
+internal val Res.string.str_24125: StringResource
+  get() = String31.str_24125
+
+@ExperimentalResourceApi
+internal val Res.string.str_24126: StringResource
+  get() = String31.str_24126
+
+@ExperimentalResourceApi
+internal val Res.string.str_24127: StringResource
+  get() = String31.str_24127
+
+@ExperimentalResourceApi
+internal val Res.string.str_24128: StringResource
+  get() = String31.str_24128
+
+@ExperimentalResourceApi
+internal val Res.string.str_24129: StringResource
+  get() = String31.str_24129
+
+@ExperimentalResourceApi
+internal val Res.string.str_2413: StringResource
+  get() = String31.str_2413
+
+@ExperimentalResourceApi
+internal val Res.string.str_24130: StringResource
+  get() = String31.str_24130
+
+@ExperimentalResourceApi
+internal val Res.string.str_24131: StringResource
+  get() = String31.str_24131
+
+@ExperimentalResourceApi
+internal val Res.string.str_24132: StringResource
+  get() = String31.str_24132
+
+@ExperimentalResourceApi
+internal val Res.string.str_24133: StringResource
+  get() = String31.str_24133
+
+@ExperimentalResourceApi
+internal val Res.string.str_24134: StringResource
+  get() = String31.str_24134
+
+@ExperimentalResourceApi
+internal val Res.string.str_24135: StringResource
+  get() = String31.str_24135
+
+@ExperimentalResourceApi
+internal val Res.string.str_24136: StringResource
+  get() = String31.str_24136
+
+@ExperimentalResourceApi
+internal val Res.string.str_24137: StringResource
+  get() = String31.str_24137
+
+@ExperimentalResourceApi
+internal val Res.string.str_24138: StringResource
+  get() = String31.str_24138
+
+@ExperimentalResourceApi
+internal val Res.string.str_24139: StringResource
+  get() = String31.str_24139
+
+@ExperimentalResourceApi
+internal val Res.string.str_2414: StringResource
+  get() = String31.str_2414
+
+@ExperimentalResourceApi
+internal val Res.string.str_24140: StringResource
+  get() = String31.str_24140
+
+@ExperimentalResourceApi
+internal val Res.string.str_24141: StringResource
+  get() = String31.str_24141
+
+@ExperimentalResourceApi
+internal val Res.string.str_24142: StringResource
+  get() = String31.str_24142
+
+@ExperimentalResourceApi
+internal val Res.string.str_24143: StringResource
+  get() = String31.str_24143
+
+@ExperimentalResourceApi
+internal val Res.string.str_24144: StringResource
+  get() = String31.str_24144
+
+@ExperimentalResourceApi
+internal val Res.string.str_24145: StringResource
+  get() = String31.str_24145
+
+@ExperimentalResourceApi
+internal val Res.string.str_24146: StringResource
+  get() = String31.str_24146
+
+@ExperimentalResourceApi
+internal val Res.string.str_24147: StringResource
+  get() = String31.str_24147
+
+@ExperimentalResourceApi
+internal val Res.string.str_24148: StringResource
+  get() = String31.str_24148
+
+@ExperimentalResourceApi
+internal val Res.string.str_24149: StringResource
+  get() = String31.str_24149
+
+@ExperimentalResourceApi
+internal val Res.string.str_2415: StringResource
+  get() = String31.str_2415
+
+@ExperimentalResourceApi
+internal val Res.string.str_24150: StringResource
+  get() = String31.str_24150
+
+@ExperimentalResourceApi
+internal val Res.string.str_24151: StringResource
+  get() = String31.str_24151
+
+@ExperimentalResourceApi
+internal val Res.string.str_24152: StringResource
+  get() = String31.str_24152
+
+@ExperimentalResourceApi
+internal val Res.string.str_24153: StringResource
+  get() = String31.str_24153
+
+@ExperimentalResourceApi
+internal val Res.string.str_24154: StringResource
+  get() = String31.str_24154
+
+@ExperimentalResourceApi
+internal val Res.string.str_24155: StringResource
+  get() = String31.str_24155
+
+@ExperimentalResourceApi
+internal val Res.string.str_24156: StringResource
+  get() = String31.str_24156
+
+@ExperimentalResourceApi
+internal val Res.string.str_24157: StringResource
+  get() = String31.str_24157
+
+@ExperimentalResourceApi
+internal val Res.string.str_24158: StringResource
+  get() = String31.str_24158
+
+@ExperimentalResourceApi
+internal val Res.string.str_24159: StringResource
+  get() = String31.str_24159
+
+@ExperimentalResourceApi
+internal val Res.string.str_2416: StringResource
+  get() = String31.str_2416
+
+@ExperimentalResourceApi
+internal val Res.string.str_24160: StringResource
+  get() = String31.str_24160
+
+@ExperimentalResourceApi
+internal val Res.string.str_24161: StringResource
+  get() = String31.str_24161
+
+@ExperimentalResourceApi
+internal val Res.string.str_24162: StringResource
+  get() = String31.str_24162
+
+@ExperimentalResourceApi
+internal val Res.string.str_24163: StringResource
+  get() = String31.str_24163
+
+@ExperimentalResourceApi
+internal val Res.string.str_24164: StringResource
+  get() = String31.str_24164
+
+@ExperimentalResourceApi
+internal val Res.string.str_24165: StringResource
+  get() = String31.str_24165
+
+@ExperimentalResourceApi
+internal val Res.string.str_24166: StringResource
+  get() = String31.str_24166
+
+@ExperimentalResourceApi
+internal val Res.string.str_24167: StringResource
+  get() = String31.str_24167
+
+@ExperimentalResourceApi
+internal val Res.string.str_24168: StringResource
+  get() = String31.str_24168
+
+@ExperimentalResourceApi
+internal val Res.string.str_24169: StringResource
+  get() = String31.str_24169
+
+@ExperimentalResourceApi
+internal val Res.string.str_2417: StringResource
+  get() = String31.str_2417
+
+@ExperimentalResourceApi
+internal val Res.string.str_24170: StringResource
+  get() = String31.str_24170
+
+@ExperimentalResourceApi
+internal val Res.string.str_24171: StringResource
+  get() = String31.str_24171
+
+@ExperimentalResourceApi
+internal val Res.string.str_24172: StringResource
+  get() = String31.str_24172
+
+@ExperimentalResourceApi
+internal val Res.string.str_24173: StringResource
+  get() = String31.str_24173
+
+@ExperimentalResourceApi
+internal val Res.string.str_24174: StringResource
+  get() = String31.str_24174
+
+@ExperimentalResourceApi
+internal val Res.string.str_24175: StringResource
+  get() = String31.str_24175
+
+@ExperimentalResourceApi
+internal val Res.string.str_24176: StringResource
+  get() = String31.str_24176
+
+@ExperimentalResourceApi
+internal val Res.string.str_24177: StringResource
+  get() = String31.str_24177
+
+@ExperimentalResourceApi
+internal val Res.string.str_24178: StringResource
+  get() = String31.str_24178
+
+@ExperimentalResourceApi
+internal val Res.string.str_24179: StringResource
+  get() = String31.str_24179
+
+@ExperimentalResourceApi
+internal val Res.string.str_2418: StringResource
+  get() = String31.str_2418
+
+@ExperimentalResourceApi
+internal val Res.string.str_24180: StringResource
+  get() = String31.str_24180
+
+@ExperimentalResourceApi
+internal val Res.string.str_24181: StringResource
+  get() = String31.str_24181
+
+@ExperimentalResourceApi
+internal val Res.string.str_24182: StringResource
+  get() = String31.str_24182
+
+@ExperimentalResourceApi
+internal val Res.string.str_24183: StringResource
+  get() = String31.str_24183
+
+@ExperimentalResourceApi
+internal val Res.string.str_24184: StringResource
+  get() = String31.str_24184
+
+@ExperimentalResourceApi
+internal val Res.string.str_24185: StringResource
+  get() = String31.str_24185
+
+@ExperimentalResourceApi
+internal val Res.string.str_24186: StringResource
+  get() = String31.str_24186
+
+@ExperimentalResourceApi
+internal val Res.string.str_24187: StringResource
+  get() = String31.str_24187
+
+@ExperimentalResourceApi
+internal val Res.string.str_24188: StringResource
+  get() = String31.str_24188
+
+@ExperimentalResourceApi
+internal val Res.string.str_24189: StringResource
+  get() = String31.str_24189
+
+@ExperimentalResourceApi
+internal val Res.string.str_2419: StringResource
+  get() = String31.str_2419
+
+@ExperimentalResourceApi
+internal val Res.string.str_24190: StringResource
+  get() = String31.str_24190
+
+@ExperimentalResourceApi
+internal val Res.string.str_24191: StringResource
+  get() = String31.str_24191
+
+@ExperimentalResourceApi
+internal val Res.string.str_24192: StringResource
+  get() = String31.str_24192
+
+@ExperimentalResourceApi
+internal val Res.string.str_24193: StringResource
+  get() = String31.str_24193
+
+@ExperimentalResourceApi
+internal val Res.string.str_24194: StringResource
+  get() = String31.str_24194
+
+@ExperimentalResourceApi
+internal val Res.string.str_24195: StringResource
+  get() = String31.str_24195
+
+@ExperimentalResourceApi
+internal val Res.string.str_24196: StringResource
+  get() = String31.str_24196
+
+@ExperimentalResourceApi
+internal val Res.string.str_24197: StringResource
+  get() = String31.str_24197
+
+@ExperimentalResourceApi
+internal val Res.string.str_24198: StringResource
+  get() = String31.str_24198
+
+@ExperimentalResourceApi
+internal val Res.string.str_24199: StringResource
+  get() = String31.str_24199
+
+@ExperimentalResourceApi
+internal val Res.string.str_242: StringResource
+  get() = String31.str_242
+
+@ExperimentalResourceApi
+internal val Res.string.str_2420: StringResource
+  get() = String31.str_2420
+
+@ExperimentalResourceApi
+internal val Res.string.str_24200: StringResource
+  get() = String31.str_24200
+
+@ExperimentalResourceApi
+internal val Res.string.str_24201: StringResource
+  get() = String31.str_24201
+
+@ExperimentalResourceApi
+internal val Res.string.str_24202: StringResource
+  get() = String31.str_24202
+
+@ExperimentalResourceApi
+internal val Res.string.str_24203: StringResource
+  get() = String31.str_24203
+
+@ExperimentalResourceApi
+internal val Res.string.str_24204: StringResource
+  get() = String31.str_24204
+
+@ExperimentalResourceApi
+internal val Res.string.str_24205: StringResource
+  get() = String31.str_24205
+
+@ExperimentalResourceApi
+internal val Res.string.str_24206: StringResource
+  get() = String31.str_24206
+
+@ExperimentalResourceApi
+internal val Res.string.str_24207: StringResource
+  get() = String31.str_24207
+
+@ExperimentalResourceApi
+internal val Res.string.str_24208: StringResource
+  get() = String31.str_24208
+
+@ExperimentalResourceApi
+internal val Res.string.str_24209: StringResource
+  get() = String31.str_24209
+
+@ExperimentalResourceApi
+internal val Res.string.str_2421: StringResource
+  get() = String31.str_2421
+
+@ExperimentalResourceApi
+internal val Res.string.str_24210: StringResource
+  get() = String31.str_24210
+
+@ExperimentalResourceApi
+internal val Res.string.str_24211: StringResource
+  get() = String31.str_24211
+
+@ExperimentalResourceApi
+internal val Res.string.str_24212: StringResource
+  get() = String31.str_24212
+
+@ExperimentalResourceApi
+internal val Res.string.str_24213: StringResource
+  get() = String31.str_24213
+
+@ExperimentalResourceApi
+internal val Res.string.str_24214: StringResource
+  get() = String31.str_24214
+
+@ExperimentalResourceApi
+internal val Res.string.str_24215: StringResource
+  get() = String31.str_24215
+
+@ExperimentalResourceApi
+internal val Res.string.str_24216: StringResource
+  get() = String31.str_24216
+
+@ExperimentalResourceApi
+internal val Res.string.str_24217: StringResource
+  get() = String31.str_24217
+
+@ExperimentalResourceApi
+internal val Res.string.str_24218: StringResource
+  get() = String31.str_24218
+
+@ExperimentalResourceApi
+internal val Res.string.str_24219: StringResource
+  get() = String31.str_24219
+
+@ExperimentalResourceApi
+internal val Res.string.str_2422: StringResource
+  get() = String31.str_2422
+
+@ExperimentalResourceApi
+internal val Res.string.str_24220: StringResource
+  get() = String31.str_24220
+
+@ExperimentalResourceApi
+internal val Res.string.str_24221: StringResource
+  get() = String31.str_24221
+
+@ExperimentalResourceApi
+internal val Res.string.str_24222: StringResource
+  get() = String31.str_24222
+
+@ExperimentalResourceApi
+internal val Res.string.str_24223: StringResource
+  get() = String31.str_24223
+
+@ExperimentalResourceApi
+internal val Res.string.str_24224: StringResource
+  get() = String31.str_24224
+
+@ExperimentalResourceApi
+internal val Res.string.str_24225: StringResource
+  get() = String31.str_24225
+
+@ExperimentalResourceApi
+internal val Res.string.str_24226: StringResource
+  get() = String31.str_24226
+
+@ExperimentalResourceApi
+internal val Res.string.str_24227: StringResource
+  get() = String31.str_24227
+
+@ExperimentalResourceApi
+internal val Res.string.str_24228: StringResource
+  get() = String31.str_24228
+
+@ExperimentalResourceApi
+internal val Res.string.str_24229: StringResource
+  get() = String31.str_24229
+
+@ExperimentalResourceApi
+internal val Res.string.str_2423: StringResource
+  get() = String31.str_2423
+
+@ExperimentalResourceApi
+internal val Res.string.str_24230: StringResource
+  get() = String31.str_24230
+
+@ExperimentalResourceApi
+internal val Res.string.str_24231: StringResource
+  get() = String31.str_24231
+
+@ExperimentalResourceApi
+internal val Res.string.str_24232: StringResource
+  get() = String31.str_24232
+
+@ExperimentalResourceApi
+internal val Res.string.str_24233: StringResource
+  get() = String31.str_24233
+
+@ExperimentalResourceApi
+internal val Res.string.str_24234: StringResource
+  get() = String31.str_24234
+
+@ExperimentalResourceApi
+internal val Res.string.str_24235: StringResource
+  get() = String31.str_24235
+
+@ExperimentalResourceApi
+internal val Res.string.str_24236: StringResource
+  get() = String31.str_24236
+
+@ExperimentalResourceApi
+internal val Res.string.str_24237: StringResource
+  get() = String31.str_24237
+
+@ExperimentalResourceApi
+internal val Res.string.str_24238: StringResource
+  get() = String31.str_24238
+
+@ExperimentalResourceApi
+internal val Res.string.str_24239: StringResource
+  get() = String31.str_24239
+
+@ExperimentalResourceApi
+internal val Res.string.str_2424: StringResource
+  get() = String31.str_2424
+
+@ExperimentalResourceApi
+internal val Res.string.str_24240: StringResource
+  get() = String31.str_24240
+
+@ExperimentalResourceApi
+internal val Res.string.str_24241: StringResource
+  get() = String31.str_24241
+
+@ExperimentalResourceApi
+internal val Res.string.str_24242: StringResource
+  get() = String31.str_24242
+
+@ExperimentalResourceApi
+internal val Res.string.str_24243: StringResource
+  get() = String31.str_24243
+
+@ExperimentalResourceApi
+internal val Res.string.str_24244: StringResource
+  get() = String31.str_24244
+
+@ExperimentalResourceApi
+internal val Res.string.str_24245: StringResource
+  get() = String31.str_24245
+
+@ExperimentalResourceApi
+internal val Res.string.str_24246: StringResource
+  get() = String31.str_24246
+
+@ExperimentalResourceApi
+internal val Res.string.str_24247: StringResource
+  get() = String31.str_24247
+
+@ExperimentalResourceApi
+internal val Res.string.str_24248: StringResource
+  get() = String31.str_24248
+
+@ExperimentalResourceApi
+internal val Res.string.str_24249: StringResource
+  get() = String31.str_24249
+
+@ExperimentalResourceApi
+internal val Res.string.str_2425: StringResource
+  get() = String31.str_2425
+
+@ExperimentalResourceApi
+internal val Res.string.str_24250: StringResource
+  get() = String31.str_24250
+
+@ExperimentalResourceApi
+internal val Res.string.str_24251: StringResource
+  get() = String31.str_24251
+
+@ExperimentalResourceApi
+internal val Res.string.str_24252: StringResource
+  get() = String31.str_24252
+
+@ExperimentalResourceApi
+internal val Res.string.str_24253: StringResource
+  get() = String31.str_24253
+
+@ExperimentalResourceApi
+internal val Res.string.str_24254: StringResource
+  get() = String31.str_24254
+
+@ExperimentalResourceApi
+internal val Res.string.str_24255: StringResource
+  get() = String31.str_24255
+
+@ExperimentalResourceApi
+internal val Res.string.str_24256: StringResource
+  get() = String31.str_24256
+
+@ExperimentalResourceApi
+internal val Res.string.str_24257: StringResource
+  get() = String31.str_24257
+
+@ExperimentalResourceApi
+internal val Res.string.str_24258: StringResource
+  get() = String31.str_24258
+
+@ExperimentalResourceApi
+internal val Res.string.str_24259: StringResource
+  get() = String31.str_24259
+
+@ExperimentalResourceApi
+internal val Res.string.str_2426: StringResource
+  get() = String31.str_2426
+
+@ExperimentalResourceApi
+internal val Res.string.str_24260: StringResource
+  get() = String31.str_24260
+
+@ExperimentalResourceApi
+internal val Res.string.str_24261: StringResource
+  get() = String31.str_24261
+
+@ExperimentalResourceApi
+internal val Res.string.str_24262: StringResource
+  get() = String31.str_24262
+
+@ExperimentalResourceApi
+internal val Res.string.str_24263: StringResource
+  get() = String31.str_24263
+
+@ExperimentalResourceApi
+internal val Res.string.str_24264: StringResource
+  get() = String31.str_24264
+
+@ExperimentalResourceApi
+internal val Res.string.str_24265: StringResource
+  get() = String31.str_24265
+
+@ExperimentalResourceApi
+internal val Res.string.str_24266: StringResource
+  get() = String31.str_24266
+
+@ExperimentalResourceApi
+internal val Res.string.str_24267: StringResource
+  get() = String31.str_24267
+
+@ExperimentalResourceApi
+internal val Res.string.str_24268: StringResource
+  get() = String31.str_24268
+
+@ExperimentalResourceApi
+internal val Res.string.str_24269: StringResource
+  get() = String31.str_24269
+
+@ExperimentalResourceApi
+internal val Res.string.str_2427: StringResource
+  get() = String31.str_2427
+
+@ExperimentalResourceApi
+internal val Res.string.str_24270: StringResource
+  get() = String31.str_24270
+
+@ExperimentalResourceApi
+internal val Res.string.str_24271: StringResource
+  get() = String31.str_24271
+
+@ExperimentalResourceApi
+internal val Res.string.str_24272: StringResource
+  get() = String31.str_24272
+
+@ExperimentalResourceApi
+internal val Res.string.str_24273: StringResource
+  get() = String31.str_24273
+
+@ExperimentalResourceApi
+internal val Res.string.str_24274: StringResource
+  get() = String31.str_24274
+
+@ExperimentalResourceApi
+internal val Res.string.str_24275: StringResource
+  get() = String31.str_24275
+
+@ExperimentalResourceApi
+internal val Res.string.str_24276: StringResource
+  get() = String31.str_24276
+
+@ExperimentalResourceApi
+internal val Res.string.str_24277: StringResource
+  get() = String31.str_24277
+
+@ExperimentalResourceApi
+internal val Res.string.str_24278: StringResource
+  get() = String31.str_24278
+
+@ExperimentalResourceApi
+internal val Res.string.str_24279: StringResource
+  get() = String31.str_24279
+
+@ExperimentalResourceApi
+internal val Res.string.str_2428: StringResource
+  get() = String31.str_2428
+
+@ExperimentalResourceApi
+internal val Res.string.str_24280: StringResource
+  get() = String31.str_24280
+
+@ExperimentalResourceApi
+internal val Res.string.str_24281: StringResource
+  get() = String31.str_24281
+
+@ExperimentalResourceApi
+internal val Res.string.str_24282: StringResource
+  get() = String31.str_24282
+
+@ExperimentalResourceApi
+internal val Res.string.str_24283: StringResource
+  get() = String31.str_24283
+
+@ExperimentalResourceApi
+internal val Res.string.str_24284: StringResource
+  get() = String31.str_24284
+
+@ExperimentalResourceApi
+internal val Res.string.str_24285: StringResource
+  get() = String31.str_24285
+
+@ExperimentalResourceApi
+internal val Res.string.str_24286: StringResource
+  get() = String31.str_24286
+
+@ExperimentalResourceApi
+internal val Res.string.str_24287: StringResource
+  get() = String31.str_24287
+
+@ExperimentalResourceApi
+internal val Res.string.str_24288: StringResource
+  get() = String31.str_24288
+
+@ExperimentalResourceApi
+internal val Res.string.str_24289: StringResource
+  get() = String31.str_24289
+
+@ExperimentalResourceApi
+internal val Res.string.str_2429: StringResource
+  get() = String31.str_2429
+
+@ExperimentalResourceApi
+internal val Res.string.str_24290: StringResource
+  get() = String31.str_24290
+
+@ExperimentalResourceApi
+internal val Res.string.str_24291: StringResource
+  get() = String31.str_24291
+
+@ExperimentalResourceApi
+internal val Res.string.str_24292: StringResource
+  get() = String31.str_24292
+
+@ExperimentalResourceApi
+internal val Res.string.str_24293: StringResource
+  get() = String31.str_24293
+
+@ExperimentalResourceApi
+internal val Res.string.str_24294: StringResource
+  get() = String31.str_24294
+
+@ExperimentalResourceApi
+internal val Res.string.str_24295: StringResource
+  get() = String31.str_24295
+
+@ExperimentalResourceApi
+internal val Res.string.str_24296: StringResource
+  get() = String31.str_24296
+
+@ExperimentalResourceApi
+internal val Res.string.str_24297: StringResource
+  get() = String31.str_24297
+
+@ExperimentalResourceApi
+internal val Res.string.str_24298: StringResource
+  get() = String31.str_24298
+
+@ExperimentalResourceApi
+internal val Res.string.str_24299: StringResource
+  get() = String31.str_24299
+
+@ExperimentalResourceApi
+internal val Res.string.str_243: StringResource
+  get() = String31.str_243
+
+@ExperimentalResourceApi
+internal val Res.string.str_2430: StringResource
+  get() = String31.str_2430
+
+@ExperimentalResourceApi
+internal val Res.string.str_24300: StringResource
+  get() = String31.str_24300
+
+@ExperimentalResourceApi
+internal val Res.string.str_24301: StringResource
+  get() = String31.str_24301
+
+@ExperimentalResourceApi
+internal val Res.string.str_24302: StringResource
+  get() = String31.str_24302
+
+@ExperimentalResourceApi
+internal val Res.string.str_24303: StringResource
+  get() = String31.str_24303
+
+@ExperimentalResourceApi
+internal val Res.string.str_24304: StringResource
+  get() = String31.str_24304
+
+@ExperimentalResourceApi
+internal val Res.string.str_24305: StringResource
+  get() = String31.str_24305
+
+@ExperimentalResourceApi
+internal val Res.string.str_24306: StringResource
+  get() = String31.str_24306
+
+@ExperimentalResourceApi
+internal val Res.string.str_24307: StringResource
+  get() = String31.str_24307
+
+@ExperimentalResourceApi
+internal val Res.string.str_24308: StringResource
+  get() = String31.str_24308
+
+@ExperimentalResourceApi
+internal val Res.string.str_24309: StringResource
+  get() = String31.str_24309
+
+@ExperimentalResourceApi
+internal val Res.string.str_2431: StringResource
+  get() = String31.str_2431
+
+@ExperimentalResourceApi
+internal val Res.string.str_24310: StringResource
+  get() = String31.str_24310
+
+@ExperimentalResourceApi
+internal val Res.string.str_24311: StringResource
+  get() = String31.str_24311
+
+@ExperimentalResourceApi
+internal val Res.string.str_24312: StringResource
+  get() = String31.str_24312
+
+@ExperimentalResourceApi
+internal val Res.string.str_24313: StringResource
+  get() = String31.str_24313
+
+@ExperimentalResourceApi
+internal val Res.string.str_24314: StringResource
+  get() = String31.str_24314
+
+@ExperimentalResourceApi
+internal val Res.string.str_24315: StringResource
+  get() = String31.str_24315
+
+@ExperimentalResourceApi
+internal val Res.string.str_24316: StringResource
+  get() = String31.str_24316
+
+@ExperimentalResourceApi
+internal val Res.string.str_24317: StringResource
+  get() = String31.str_24317
+
+@ExperimentalResourceApi
+internal val Res.string.str_24318: StringResource
+  get() = String31.str_24318
+
+@ExperimentalResourceApi
+internal val Res.string.str_24319: StringResource
+  get() = String31.str_24319
+
+@ExperimentalResourceApi
+internal val Res.string.str_2432: StringResource
+  get() = String31.str_2432
+
+@ExperimentalResourceApi
+internal val Res.string.str_24320: StringResource
+  get() = String31.str_24320
+
+@ExperimentalResourceApi
+internal val Res.string.str_24321: StringResource
+  get() = String31.str_24321
+
+@ExperimentalResourceApi
+internal val Res.string.str_24322: StringResource
+  get() = String31.str_24322
+
+@ExperimentalResourceApi
+internal val Res.string.str_24323: StringResource
+  get() = String31.str_24323
+
+@ExperimentalResourceApi
+internal val Res.string.str_24324: StringResource
+  get() = String31.str_24324
+
+@ExperimentalResourceApi
+internal val Res.string.str_24325: StringResource
+  get() = String31.str_24325
+
+@ExperimentalResourceApi
+internal val Res.string.str_24326: StringResource
+  get() = String31.str_24326
+
+@ExperimentalResourceApi
+internal val Res.string.str_24327: StringResource
+  get() = String31.str_24327
+
+@ExperimentalResourceApi
+internal val Res.string.str_24328: StringResource
+  get() = String31.str_24328
+
+@ExperimentalResourceApi
+internal val Res.string.str_24329: StringResource
+  get() = String31.str_24329
+
+@ExperimentalResourceApi
+internal val Res.string.str_2433: StringResource
+  get() = String31.str_2433
+
+@ExperimentalResourceApi
+internal val Res.string.str_24330: StringResource
+  get() = String31.str_24330
+
+@ExperimentalResourceApi
+internal val Res.string.str_24331: StringResource
+  get() = String31.str_24331
+
+@ExperimentalResourceApi
+internal val Res.string.str_24332: StringResource
+  get() = String31.str_24332
+
+@ExperimentalResourceApi
+internal val Res.string.str_24333: StringResource
+  get() = String31.str_24333
+
+@ExperimentalResourceApi
+internal val Res.string.str_24334: StringResource
+  get() = String31.str_24334
+
+@ExperimentalResourceApi
+internal val Res.string.str_24335: StringResource
+  get() = String31.str_24335
+
+@ExperimentalResourceApi
+internal val Res.string.str_24336: StringResource
+  get() = String31.str_24336
+
+@ExperimentalResourceApi
+internal val Res.string.str_24337: StringResource
+  get() = String31.str_24337
+
+@ExperimentalResourceApi
+internal val Res.string.str_24338: StringResource
+  get() = String31.str_24338
+
+@ExperimentalResourceApi
+internal val Res.string.str_24339: StringResource
+  get() = String31.str_24339
+
+@ExperimentalResourceApi
+internal val Res.string.str_2434: StringResource
+  get() = String31.str_2434
+
+@ExperimentalResourceApi
+internal val Res.string.str_24340: StringResource
+  get() = String31.str_24340
+
+@ExperimentalResourceApi
+internal val Res.string.str_24341: StringResource
+  get() = String31.str_24341
+
+@ExperimentalResourceApi
+internal val Res.string.str_24342: StringResource
+  get() = String31.str_24342
+
+@ExperimentalResourceApi
+internal val Res.string.str_24343: StringResource
+  get() = String31.str_24343
+
+@ExperimentalResourceApi
+internal val Res.string.str_24344: StringResource
+  get() = String31.str_24344
+
+@ExperimentalResourceApi
+internal val Res.string.str_24345: StringResource
+  get() = String31.str_24345
+
+@ExperimentalResourceApi
+internal val Res.string.str_24346: StringResource
+  get() = String31.str_24346
+
+@ExperimentalResourceApi
+internal val Res.string.str_24347: StringResource
+  get() = String31.str_24347
+
+@ExperimentalResourceApi
+internal val Res.string.str_24348: StringResource
+  get() = String31.str_24348
+
+@ExperimentalResourceApi
+internal val Res.string.str_24349: StringResource
+  get() = String31.str_24349
+
+@ExperimentalResourceApi
+internal val Res.string.str_2435: StringResource
+  get() = String31.str_2435
+
+@ExperimentalResourceApi
+internal val Res.string.str_24350: StringResource
+  get() = String31.str_24350
+
+@ExperimentalResourceApi
+internal val Res.string.str_24351: StringResource
+  get() = String31.str_24351
+
+@ExperimentalResourceApi
+internal val Res.string.str_24352: StringResource
+  get() = String31.str_24352
+
+@ExperimentalResourceApi
+internal val Res.string.str_24353: StringResource
+  get() = String31.str_24353
+
+@ExperimentalResourceApi
+internal val Res.string.str_24354: StringResource
+  get() = String31.str_24354
+
+@ExperimentalResourceApi
+internal val Res.string.str_24355: StringResource
+  get() = String31.str_24355
+
+@ExperimentalResourceApi
+internal val Res.string.str_24356: StringResource
+  get() = String31.str_24356
+
+@ExperimentalResourceApi
+internal val Res.string.str_24357: StringResource
+  get() = String31.str_24357
+
+@ExperimentalResourceApi
+internal val Res.string.str_24358: StringResource
+  get() = String31.str_24358
+
+@ExperimentalResourceApi
+internal val Res.string.str_24359: StringResource
+  get() = String31.str_24359
+
+@ExperimentalResourceApi
+internal val Res.string.str_2436: StringResource
+  get() = String31.str_2436
+
+@ExperimentalResourceApi
+internal val Res.string.str_24360: StringResource
+  get() = String31.str_24360
+
+@ExperimentalResourceApi
+internal val Res.string.str_24361: StringResource
+  get() = String31.str_24361
+
+@ExperimentalResourceApi
+internal val Res.string.str_24362: StringResource
+  get() = String31.str_24362
+
+@ExperimentalResourceApi
+internal val Res.string.str_24363: StringResource
+  get() = String31.str_24363
+
+@ExperimentalResourceApi
+internal val Res.string.str_24364: StringResource
+  get() = String31.str_24364
+
+@ExperimentalResourceApi
+internal val Res.string.str_24365: StringResource
+  get() = String31.str_24365
+
+@ExperimentalResourceApi
+internal val Res.string.str_24366: StringResource
+  get() = String31.str_24366
+
+@ExperimentalResourceApi
+internal val Res.string.str_24367: StringResource
+  get() = String31.str_24367
+
+@ExperimentalResourceApi
+internal val Res.string.str_24368: StringResource
+  get() = String31.str_24368
+
+@ExperimentalResourceApi
+internal val Res.string.str_24369: StringResource
+  get() = String31.str_24369
+
+@ExperimentalResourceApi
+internal val Res.string.str_2437: StringResource
+  get() = String31.str_2437
+
+@ExperimentalResourceApi
+internal val Res.string.str_24370: StringResource
+  get() = String31.str_24370
+
+@ExperimentalResourceApi
+internal val Res.string.str_24371: StringResource
+  get() = String31.str_24371
+
+@ExperimentalResourceApi
+internal val Res.string.str_24372: StringResource
+  get() = String31.str_24372
+
+@ExperimentalResourceApi
+internal val Res.string.str_24373: StringResource
+  get() = String31.str_24373
+
+@ExperimentalResourceApi
+internal val Res.string.str_24374: StringResource
+  get() = String31.str_24374
+
+@ExperimentalResourceApi
+internal val Res.string.str_24375: StringResource
+  get() = String31.str_24375
+
+@ExperimentalResourceApi
+internal val Res.string.str_24376: StringResource
+  get() = String31.str_24376
+
+@ExperimentalResourceApi
+internal val Res.string.str_24377: StringResource
+  get() = String31.str_24377
+
+@ExperimentalResourceApi
+internal val Res.string.str_24378: StringResource
+  get() = String31.str_24378
+
+@ExperimentalResourceApi
+internal val Res.string.str_24379: StringResource
+  get() = String31.str_24379
+
+@ExperimentalResourceApi
+internal val Res.string.str_2438: StringResource
+  get() = String31.str_2438
+
+@ExperimentalResourceApi
+internal val Res.string.str_24380: StringResource
+  get() = String31.str_24380
+
+@ExperimentalResourceApi
+internal val Res.string.str_24381: StringResource
+  get() = String31.str_24381
+
+@ExperimentalResourceApi
+internal val Res.string.str_24382: StringResource
+  get() = String31.str_24382
+
+@ExperimentalResourceApi
+internal val Res.string.str_24383: StringResource
+  get() = String31.str_24383
+
+@ExperimentalResourceApi
+internal val Res.string.str_24384: StringResource
+  get() = String31.str_24384
+
+@ExperimentalResourceApi
+internal val Res.string.str_24385: StringResource
+  get() = String31.str_24385
+
+@ExperimentalResourceApi
+internal val Res.string.str_24386: StringResource
+  get() = String31.str_24386
+
+@ExperimentalResourceApi
+internal val Res.string.str_24387: StringResource
+  get() = String31.str_24387
+
+@ExperimentalResourceApi
+internal val Res.string.str_24388: StringResource
+  get() = String31.str_24388
+
+@ExperimentalResourceApi
+internal val Res.string.str_24389: StringResource
+  get() = String31.str_24389
+
+@ExperimentalResourceApi
+internal val Res.string.str_2439: StringResource
+  get() = String31.str_2439
+
+@ExperimentalResourceApi
+internal val Res.string.str_24390: StringResource
+  get() = String31.str_24390
+
+@ExperimentalResourceApi
+internal val Res.string.str_24391: StringResource
+  get() = String31.str_24391
+
+@ExperimentalResourceApi
+internal val Res.string.str_24392: StringResource
+  get() = String31.str_24392
+
+@ExperimentalResourceApi
+internal val Res.string.str_24393: StringResource
+  get() = String31.str_24393
+
+@ExperimentalResourceApi
+internal val Res.string.str_24394: StringResource
+  get() = String31.str_24394
+
+@ExperimentalResourceApi
+internal val Res.string.str_24395: StringResource
+  get() = String31.str_24395
+
+@ExperimentalResourceApi
+internal val Res.string.str_24396: StringResource
+  get() = String31.str_24396
+
+@ExperimentalResourceApi
+internal val Res.string.str_24397: StringResource
+  get() = String31.str_24397

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String32.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String32.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String32 {
+  public val str_24398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24398", "str_24398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24399", "str_24399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_244", "str_244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2440", "str_2440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24400", "str_24400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24401", "str_24401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24402", "str_24402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24403", "str_24403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24404", "str_24404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24405", "str_24405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24406", "str_24406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24407", "str_24407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24408", "str_24408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24409", "str_24409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2441", "str_2441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24410", "str_24410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24411", "str_24411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24412", "str_24412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24413", "str_24413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24414", "str_24414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24415", "str_24415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24416", "str_24416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24417", "str_24417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24418", "str_24418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24419", "str_24419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2442", "str_2442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24420", "str_24420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24421", "str_24421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24422", "str_24422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24423", "str_24423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24424", "str_24424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24425", "str_24425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24426", "str_24426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24427", "str_24427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24428", "str_24428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24429", "str_24429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2443", "str_2443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24430", "str_24430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24431", "str_24431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24432", "str_24432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24433", "str_24433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24434", "str_24434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24435", "str_24435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24436", "str_24436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24437", "str_24437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24438", "str_24438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24439", "str_24439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2444", "str_2444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24440", "str_24440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24441", "str_24441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24442", "str_24442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24443", "str_24443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24444", "str_24444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24445", "str_24445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24446", "str_24446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24447", "str_24447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24448", "str_24448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24449", "str_24449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2445", "str_2445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24450", "str_24450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24451", "str_24451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24452", "str_24452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24453", "str_24453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24454", "str_24454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24455", "str_24455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24456", "str_24456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24457", "str_24457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24458", "str_24458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24459", "str_24459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2446", "str_2446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24460", "str_24460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24461", "str_24461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24462", "str_24462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24463", "str_24463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24464", "str_24464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24465", "str_24465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24466", "str_24466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24467", "str_24467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24468", "str_24468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24469", "str_24469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2447", "str_2447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24470", "str_24470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24471", "str_24471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24472", "str_24472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24473", "str_24473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24474", "str_24474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24475", "str_24475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24476", "str_24476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24477", "str_24477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24478", "str_24478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24479", "str_24479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2448", "str_2448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24480", "str_24480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24481", "str_24481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24482", "str_24482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24483", "str_24483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24484", "str_24484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24485", "str_24485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24486", "str_24486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24487", "str_24487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24488", "str_24488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24489", "str_24489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2449", "str_2449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24490", "str_24490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24491", "str_24491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24492", "str_24492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24493", "str_24493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24494", "str_24494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24495", "str_24495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24496", "str_24496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24497", "str_24497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24498", "str_24498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24499", "str_24499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_245", "str_245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2450", "str_2450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24500", "str_24500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24501", "str_24501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24502", "str_24502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24503", "str_24503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24504", "str_24504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24505", "str_24505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24506", "str_24506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24507", "str_24507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24508", "str_24508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24509", "str_24509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2451", "str_2451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24510", "str_24510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24511", "str_24511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24512", "str_24512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24513", "str_24513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24514", "str_24514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24515", "str_24515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24516", "str_24516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24517", "str_24517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24518", "str_24518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24519", "str_24519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2452", "str_2452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24520", "str_24520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24521", "str_24521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24522", "str_24522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24523", "str_24523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24524", "str_24524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24525", "str_24525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24526", "str_24526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24527", "str_24527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24528", "str_24528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24529", "str_24529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2453", "str_2453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24530", "str_24530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24531", "str_24531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24532", "str_24532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24533", "str_24533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24534", "str_24534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24535", "str_24535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24536", "str_24536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24537", "str_24537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24538", "str_24538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24539", "str_24539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2454", "str_2454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24540", "str_24540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24541", "str_24541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24542", "str_24542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24543", "str_24543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24544", "str_24544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24545", "str_24545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24546", "str_24546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24547", "str_24547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24548", "str_24548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24549", "str_24549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2455", "str_2455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24550", "str_24550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24551", "str_24551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24552", "str_24552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24553", "str_24553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24554", "str_24554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24555", "str_24555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24556", "str_24556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24557", "str_24557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24558", "str_24558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24559", "str_24559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2456", "str_2456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24560", "str_24560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24561", "str_24561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24562", "str_24562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24563", "str_24563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24564", "str_24564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24565", "str_24565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24566", "str_24566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24567", "str_24567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24568", "str_24568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24569", "str_24569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2457", "str_2457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24570", "str_24570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24571", "str_24571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24572", "str_24572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24573", "str_24573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24574", "str_24574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24575", "str_24575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24576", "str_24576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24577", "str_24577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24578", "str_24578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24579", "str_24579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2458", "str_2458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24580", "str_24580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24581", "str_24581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24582", "str_24582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24583", "str_24583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24584", "str_24584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24585", "str_24585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24586", "str_24586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24587", "str_24587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24588", "str_24588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24589", "str_24589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2459", "str_2459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24590", "str_24590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24591", "str_24591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24592", "str_24592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24593", "str_24593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24594", "str_24594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24595", "str_24595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24596", "str_24596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24597", "str_24597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24598", "str_24598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24599", "str_24599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_246", "str_246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2460", "str_2460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24600", "str_24600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24601", "str_24601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24602", "str_24602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24603", "str_24603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24604", "str_24604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24605", "str_24605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24606", "str_24606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24607", "str_24607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24608", "str_24608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24609", "str_24609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2461", "str_2461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24610", "str_24610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24611", "str_24611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24612", "str_24612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24613", "str_24613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24614", "str_24614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24615", "str_24615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24616", "str_24616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24617", "str_24617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24618", "str_24618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24619", "str_24619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2462", "str_2462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24620", "str_24620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24621", "str_24621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24622", "str_24622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24623", "str_24623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24624", "str_24624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24625", "str_24625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24626", "str_24626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24627", "str_24627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24628", "str_24628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24629", "str_24629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2463", "str_2463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24630", "str_24630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24631", "str_24631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24632", "str_24632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24633", "str_24633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24634", "str_24634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24635", "str_24635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24636", "str_24636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24637", "str_24637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24638", "str_24638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24639", "str_24639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2464", "str_2464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24640", "str_24640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24641", "str_24641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24642", "str_24642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24643", "str_24643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24644", "str_24644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24645", "str_24645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24646", "str_24646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24647", "str_24647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24648", "str_24648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24649", "str_24649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2465", "str_2465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24650", "str_24650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24651", "str_24651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24652", "str_24652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24653", "str_24653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24654", "str_24654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24655", "str_24655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24656", "str_24656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24657", "str_24657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24658", "str_24658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24659", "str_24659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2466", "str_2466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24660", "str_24660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24661", "str_24661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24662", "str_24662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24663", "str_24663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24664", "str_24664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24665", "str_24665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24666", "str_24666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24667", "str_24667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24668", "str_24668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24669", "str_24669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2467", "str_2467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24670", "str_24670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24671", "str_24671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24672", "str_24672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24673", "str_24673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24674", "str_24674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24675", "str_24675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24676", "str_24676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24677", "str_24677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24678", "str_24678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24679", "str_24679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2468", "str_2468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24680", "str_24680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24681", "str_24681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24682", "str_24682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24683", "str_24683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24684", "str_24684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24685", "str_24685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24686", "str_24686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24687", "str_24687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24688", "str_24688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24689", "str_24689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2469", "str_2469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24690", "str_24690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24691", "str_24691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24692", "str_24692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24693", "str_24693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24694", "str_24694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24695", "str_24695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24696", "str_24696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24697", "str_24697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24698", "str_24698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24699", "str_24699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_247", "str_247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2470", "str_2470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24700", "str_24700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24701", "str_24701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24702", "str_24702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24703", "str_24703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24704", "str_24704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24705", "str_24705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24706", "str_24706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24707", "str_24707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24708", "str_24708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24709", "str_24709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2471", "str_2471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24710", "str_24710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24711", "str_24711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24712", "str_24712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24713", "str_24713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24714", "str_24714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24715", "str_24715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24716", "str_24716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24717", "str_24717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24718", "str_24718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24719", "str_24719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2472", "str_2472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24720", "str_24720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24721", "str_24721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24722", "str_24722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24723", "str_24723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24724", "str_24724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24725", "str_24725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24726", "str_24726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24727", "str_24727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24728", "str_24728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24729", "str_24729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2473", "str_2473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24730", "str_24730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24731", "str_24731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24732", "str_24732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24733", "str_24733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24734", "str_24734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24735", "str_24735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24736", "str_24736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24737", "str_24737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24738", "str_24738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24739", "str_24739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2474", "str_2474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24740", "str_24740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24741", "str_24741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24742", "str_24742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24743", "str_24743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24744", "str_24744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24745", "str_24745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24746", "str_24746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24747", "str_24747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24748", "str_24748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24749", "str_24749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2475", "str_2475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24750", "str_24750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24751", "str_24751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24752", "str_24752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24753", "str_24753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24754", "str_24754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24755", "str_24755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24756", "str_24756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24757", "str_24757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24758", "str_24758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24759", "str_24759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2476", "str_2476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24760", "str_24760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24761", "str_24761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24762", "str_24762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24763", "str_24763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24764", "str_24764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24765", "str_24765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24766", "str_24766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24767", "str_24767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24768", "str_24768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24769", "str_24769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2477", "str_2477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24770", "str_24770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24771", "str_24771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24772", "str_24772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24773", "str_24773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24774", "str_24774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24775", "str_24775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24776", "str_24776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24777", "str_24777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24778", "str_24778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24779", "str_24779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2478", "str_2478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24780", "str_24780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24781", "str_24781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24782", "str_24782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24783", "str_24783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24784", "str_24784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24785", "str_24785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24786", "str_24786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24787", "str_24787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24788", "str_24788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24789", "str_24789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2479", "str_2479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24790", "str_24790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24791", "str_24791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24792", "str_24792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24793", "str_24793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24794", "str_24794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24795", "str_24795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24796", "str_24796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24797", "str_24797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24798", "str_24798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24799", "str_24799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_248", "str_248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2480", "str_2480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24800", "str_24800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24801", "str_24801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24802", "str_24802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24803", "str_24803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24804", "str_24804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24805", "str_24805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24806", "str_24806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24807", "str_24807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24808", "str_24808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24809", "str_24809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2481", "str_2481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24810", "str_24810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24811", "str_24811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24812", "str_24812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24813", "str_24813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24814", "str_24814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24815", "str_24815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24816", "str_24816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24817", "str_24817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24818", "str_24818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24819", "str_24819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2482", "str_2482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24820", "str_24820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24821", "str_24821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24822", "str_24822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24823", "str_24823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24824", "str_24824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24825", "str_24825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24826", "str_24826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24827", "str_24827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24828", "str_24828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24829", "str_24829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2483", "str_2483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24830", "str_24830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24831", "str_24831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24832", "str_24832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24833", "str_24833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24834", "str_24834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24835", "str_24835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24836", "str_24836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24837", "str_24837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24838", "str_24838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24839", "str_24839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2484", "str_2484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24840", "str_24840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24841", "str_24841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24842", "str_24842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24843", "str_24843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24844", "str_24844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24845", "str_24845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24846", "str_24846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24847", "str_24847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_24398: StringResource
+  get() = String32.str_24398
+
+@ExperimentalResourceApi
+internal val Res.string.str_24399: StringResource
+  get() = String32.str_24399
+
+@ExperimentalResourceApi
+internal val Res.string.str_244: StringResource
+  get() = String32.str_244
+
+@ExperimentalResourceApi
+internal val Res.string.str_2440: StringResource
+  get() = String32.str_2440
+
+@ExperimentalResourceApi
+internal val Res.string.str_24400: StringResource
+  get() = String32.str_24400
+
+@ExperimentalResourceApi
+internal val Res.string.str_24401: StringResource
+  get() = String32.str_24401
+
+@ExperimentalResourceApi
+internal val Res.string.str_24402: StringResource
+  get() = String32.str_24402
+
+@ExperimentalResourceApi
+internal val Res.string.str_24403: StringResource
+  get() = String32.str_24403
+
+@ExperimentalResourceApi
+internal val Res.string.str_24404: StringResource
+  get() = String32.str_24404
+
+@ExperimentalResourceApi
+internal val Res.string.str_24405: StringResource
+  get() = String32.str_24405
+
+@ExperimentalResourceApi
+internal val Res.string.str_24406: StringResource
+  get() = String32.str_24406
+
+@ExperimentalResourceApi
+internal val Res.string.str_24407: StringResource
+  get() = String32.str_24407
+
+@ExperimentalResourceApi
+internal val Res.string.str_24408: StringResource
+  get() = String32.str_24408
+
+@ExperimentalResourceApi
+internal val Res.string.str_24409: StringResource
+  get() = String32.str_24409
+
+@ExperimentalResourceApi
+internal val Res.string.str_2441: StringResource
+  get() = String32.str_2441
+
+@ExperimentalResourceApi
+internal val Res.string.str_24410: StringResource
+  get() = String32.str_24410
+
+@ExperimentalResourceApi
+internal val Res.string.str_24411: StringResource
+  get() = String32.str_24411
+
+@ExperimentalResourceApi
+internal val Res.string.str_24412: StringResource
+  get() = String32.str_24412
+
+@ExperimentalResourceApi
+internal val Res.string.str_24413: StringResource
+  get() = String32.str_24413
+
+@ExperimentalResourceApi
+internal val Res.string.str_24414: StringResource
+  get() = String32.str_24414
+
+@ExperimentalResourceApi
+internal val Res.string.str_24415: StringResource
+  get() = String32.str_24415
+
+@ExperimentalResourceApi
+internal val Res.string.str_24416: StringResource
+  get() = String32.str_24416
+
+@ExperimentalResourceApi
+internal val Res.string.str_24417: StringResource
+  get() = String32.str_24417
+
+@ExperimentalResourceApi
+internal val Res.string.str_24418: StringResource
+  get() = String32.str_24418
+
+@ExperimentalResourceApi
+internal val Res.string.str_24419: StringResource
+  get() = String32.str_24419
+
+@ExperimentalResourceApi
+internal val Res.string.str_2442: StringResource
+  get() = String32.str_2442
+
+@ExperimentalResourceApi
+internal val Res.string.str_24420: StringResource
+  get() = String32.str_24420
+
+@ExperimentalResourceApi
+internal val Res.string.str_24421: StringResource
+  get() = String32.str_24421
+
+@ExperimentalResourceApi
+internal val Res.string.str_24422: StringResource
+  get() = String32.str_24422
+
+@ExperimentalResourceApi
+internal val Res.string.str_24423: StringResource
+  get() = String32.str_24423
+
+@ExperimentalResourceApi
+internal val Res.string.str_24424: StringResource
+  get() = String32.str_24424
+
+@ExperimentalResourceApi
+internal val Res.string.str_24425: StringResource
+  get() = String32.str_24425
+
+@ExperimentalResourceApi
+internal val Res.string.str_24426: StringResource
+  get() = String32.str_24426
+
+@ExperimentalResourceApi
+internal val Res.string.str_24427: StringResource
+  get() = String32.str_24427
+
+@ExperimentalResourceApi
+internal val Res.string.str_24428: StringResource
+  get() = String32.str_24428
+
+@ExperimentalResourceApi
+internal val Res.string.str_24429: StringResource
+  get() = String32.str_24429
+
+@ExperimentalResourceApi
+internal val Res.string.str_2443: StringResource
+  get() = String32.str_2443
+
+@ExperimentalResourceApi
+internal val Res.string.str_24430: StringResource
+  get() = String32.str_24430
+
+@ExperimentalResourceApi
+internal val Res.string.str_24431: StringResource
+  get() = String32.str_24431
+
+@ExperimentalResourceApi
+internal val Res.string.str_24432: StringResource
+  get() = String32.str_24432
+
+@ExperimentalResourceApi
+internal val Res.string.str_24433: StringResource
+  get() = String32.str_24433
+
+@ExperimentalResourceApi
+internal val Res.string.str_24434: StringResource
+  get() = String32.str_24434
+
+@ExperimentalResourceApi
+internal val Res.string.str_24435: StringResource
+  get() = String32.str_24435
+
+@ExperimentalResourceApi
+internal val Res.string.str_24436: StringResource
+  get() = String32.str_24436
+
+@ExperimentalResourceApi
+internal val Res.string.str_24437: StringResource
+  get() = String32.str_24437
+
+@ExperimentalResourceApi
+internal val Res.string.str_24438: StringResource
+  get() = String32.str_24438
+
+@ExperimentalResourceApi
+internal val Res.string.str_24439: StringResource
+  get() = String32.str_24439
+
+@ExperimentalResourceApi
+internal val Res.string.str_2444: StringResource
+  get() = String32.str_2444
+
+@ExperimentalResourceApi
+internal val Res.string.str_24440: StringResource
+  get() = String32.str_24440
+
+@ExperimentalResourceApi
+internal val Res.string.str_24441: StringResource
+  get() = String32.str_24441
+
+@ExperimentalResourceApi
+internal val Res.string.str_24442: StringResource
+  get() = String32.str_24442
+
+@ExperimentalResourceApi
+internal val Res.string.str_24443: StringResource
+  get() = String32.str_24443
+
+@ExperimentalResourceApi
+internal val Res.string.str_24444: StringResource
+  get() = String32.str_24444
+
+@ExperimentalResourceApi
+internal val Res.string.str_24445: StringResource
+  get() = String32.str_24445
+
+@ExperimentalResourceApi
+internal val Res.string.str_24446: StringResource
+  get() = String32.str_24446
+
+@ExperimentalResourceApi
+internal val Res.string.str_24447: StringResource
+  get() = String32.str_24447
+
+@ExperimentalResourceApi
+internal val Res.string.str_24448: StringResource
+  get() = String32.str_24448
+
+@ExperimentalResourceApi
+internal val Res.string.str_24449: StringResource
+  get() = String32.str_24449
+
+@ExperimentalResourceApi
+internal val Res.string.str_2445: StringResource
+  get() = String32.str_2445
+
+@ExperimentalResourceApi
+internal val Res.string.str_24450: StringResource
+  get() = String32.str_24450
+
+@ExperimentalResourceApi
+internal val Res.string.str_24451: StringResource
+  get() = String32.str_24451
+
+@ExperimentalResourceApi
+internal val Res.string.str_24452: StringResource
+  get() = String32.str_24452
+
+@ExperimentalResourceApi
+internal val Res.string.str_24453: StringResource
+  get() = String32.str_24453
+
+@ExperimentalResourceApi
+internal val Res.string.str_24454: StringResource
+  get() = String32.str_24454
+
+@ExperimentalResourceApi
+internal val Res.string.str_24455: StringResource
+  get() = String32.str_24455
+
+@ExperimentalResourceApi
+internal val Res.string.str_24456: StringResource
+  get() = String32.str_24456
+
+@ExperimentalResourceApi
+internal val Res.string.str_24457: StringResource
+  get() = String32.str_24457
+
+@ExperimentalResourceApi
+internal val Res.string.str_24458: StringResource
+  get() = String32.str_24458
+
+@ExperimentalResourceApi
+internal val Res.string.str_24459: StringResource
+  get() = String32.str_24459
+
+@ExperimentalResourceApi
+internal val Res.string.str_2446: StringResource
+  get() = String32.str_2446
+
+@ExperimentalResourceApi
+internal val Res.string.str_24460: StringResource
+  get() = String32.str_24460
+
+@ExperimentalResourceApi
+internal val Res.string.str_24461: StringResource
+  get() = String32.str_24461
+
+@ExperimentalResourceApi
+internal val Res.string.str_24462: StringResource
+  get() = String32.str_24462
+
+@ExperimentalResourceApi
+internal val Res.string.str_24463: StringResource
+  get() = String32.str_24463
+
+@ExperimentalResourceApi
+internal val Res.string.str_24464: StringResource
+  get() = String32.str_24464
+
+@ExperimentalResourceApi
+internal val Res.string.str_24465: StringResource
+  get() = String32.str_24465
+
+@ExperimentalResourceApi
+internal val Res.string.str_24466: StringResource
+  get() = String32.str_24466
+
+@ExperimentalResourceApi
+internal val Res.string.str_24467: StringResource
+  get() = String32.str_24467
+
+@ExperimentalResourceApi
+internal val Res.string.str_24468: StringResource
+  get() = String32.str_24468
+
+@ExperimentalResourceApi
+internal val Res.string.str_24469: StringResource
+  get() = String32.str_24469
+
+@ExperimentalResourceApi
+internal val Res.string.str_2447: StringResource
+  get() = String32.str_2447
+
+@ExperimentalResourceApi
+internal val Res.string.str_24470: StringResource
+  get() = String32.str_24470
+
+@ExperimentalResourceApi
+internal val Res.string.str_24471: StringResource
+  get() = String32.str_24471
+
+@ExperimentalResourceApi
+internal val Res.string.str_24472: StringResource
+  get() = String32.str_24472
+
+@ExperimentalResourceApi
+internal val Res.string.str_24473: StringResource
+  get() = String32.str_24473
+
+@ExperimentalResourceApi
+internal val Res.string.str_24474: StringResource
+  get() = String32.str_24474
+
+@ExperimentalResourceApi
+internal val Res.string.str_24475: StringResource
+  get() = String32.str_24475
+
+@ExperimentalResourceApi
+internal val Res.string.str_24476: StringResource
+  get() = String32.str_24476
+
+@ExperimentalResourceApi
+internal val Res.string.str_24477: StringResource
+  get() = String32.str_24477
+
+@ExperimentalResourceApi
+internal val Res.string.str_24478: StringResource
+  get() = String32.str_24478
+
+@ExperimentalResourceApi
+internal val Res.string.str_24479: StringResource
+  get() = String32.str_24479
+
+@ExperimentalResourceApi
+internal val Res.string.str_2448: StringResource
+  get() = String32.str_2448
+
+@ExperimentalResourceApi
+internal val Res.string.str_24480: StringResource
+  get() = String32.str_24480
+
+@ExperimentalResourceApi
+internal val Res.string.str_24481: StringResource
+  get() = String32.str_24481
+
+@ExperimentalResourceApi
+internal val Res.string.str_24482: StringResource
+  get() = String32.str_24482
+
+@ExperimentalResourceApi
+internal val Res.string.str_24483: StringResource
+  get() = String32.str_24483
+
+@ExperimentalResourceApi
+internal val Res.string.str_24484: StringResource
+  get() = String32.str_24484
+
+@ExperimentalResourceApi
+internal val Res.string.str_24485: StringResource
+  get() = String32.str_24485
+
+@ExperimentalResourceApi
+internal val Res.string.str_24486: StringResource
+  get() = String32.str_24486
+
+@ExperimentalResourceApi
+internal val Res.string.str_24487: StringResource
+  get() = String32.str_24487
+
+@ExperimentalResourceApi
+internal val Res.string.str_24488: StringResource
+  get() = String32.str_24488
+
+@ExperimentalResourceApi
+internal val Res.string.str_24489: StringResource
+  get() = String32.str_24489
+
+@ExperimentalResourceApi
+internal val Res.string.str_2449: StringResource
+  get() = String32.str_2449
+
+@ExperimentalResourceApi
+internal val Res.string.str_24490: StringResource
+  get() = String32.str_24490
+
+@ExperimentalResourceApi
+internal val Res.string.str_24491: StringResource
+  get() = String32.str_24491
+
+@ExperimentalResourceApi
+internal val Res.string.str_24492: StringResource
+  get() = String32.str_24492
+
+@ExperimentalResourceApi
+internal val Res.string.str_24493: StringResource
+  get() = String32.str_24493
+
+@ExperimentalResourceApi
+internal val Res.string.str_24494: StringResource
+  get() = String32.str_24494
+
+@ExperimentalResourceApi
+internal val Res.string.str_24495: StringResource
+  get() = String32.str_24495
+
+@ExperimentalResourceApi
+internal val Res.string.str_24496: StringResource
+  get() = String32.str_24496
+
+@ExperimentalResourceApi
+internal val Res.string.str_24497: StringResource
+  get() = String32.str_24497
+
+@ExperimentalResourceApi
+internal val Res.string.str_24498: StringResource
+  get() = String32.str_24498
+
+@ExperimentalResourceApi
+internal val Res.string.str_24499: StringResource
+  get() = String32.str_24499
+
+@ExperimentalResourceApi
+internal val Res.string.str_245: StringResource
+  get() = String32.str_245
+
+@ExperimentalResourceApi
+internal val Res.string.str_2450: StringResource
+  get() = String32.str_2450
+
+@ExperimentalResourceApi
+internal val Res.string.str_24500: StringResource
+  get() = String32.str_24500
+
+@ExperimentalResourceApi
+internal val Res.string.str_24501: StringResource
+  get() = String32.str_24501
+
+@ExperimentalResourceApi
+internal val Res.string.str_24502: StringResource
+  get() = String32.str_24502
+
+@ExperimentalResourceApi
+internal val Res.string.str_24503: StringResource
+  get() = String32.str_24503
+
+@ExperimentalResourceApi
+internal val Res.string.str_24504: StringResource
+  get() = String32.str_24504
+
+@ExperimentalResourceApi
+internal val Res.string.str_24505: StringResource
+  get() = String32.str_24505
+
+@ExperimentalResourceApi
+internal val Res.string.str_24506: StringResource
+  get() = String32.str_24506
+
+@ExperimentalResourceApi
+internal val Res.string.str_24507: StringResource
+  get() = String32.str_24507
+
+@ExperimentalResourceApi
+internal val Res.string.str_24508: StringResource
+  get() = String32.str_24508
+
+@ExperimentalResourceApi
+internal val Res.string.str_24509: StringResource
+  get() = String32.str_24509
+
+@ExperimentalResourceApi
+internal val Res.string.str_2451: StringResource
+  get() = String32.str_2451
+
+@ExperimentalResourceApi
+internal val Res.string.str_24510: StringResource
+  get() = String32.str_24510
+
+@ExperimentalResourceApi
+internal val Res.string.str_24511: StringResource
+  get() = String32.str_24511
+
+@ExperimentalResourceApi
+internal val Res.string.str_24512: StringResource
+  get() = String32.str_24512
+
+@ExperimentalResourceApi
+internal val Res.string.str_24513: StringResource
+  get() = String32.str_24513
+
+@ExperimentalResourceApi
+internal val Res.string.str_24514: StringResource
+  get() = String32.str_24514
+
+@ExperimentalResourceApi
+internal val Res.string.str_24515: StringResource
+  get() = String32.str_24515
+
+@ExperimentalResourceApi
+internal val Res.string.str_24516: StringResource
+  get() = String32.str_24516
+
+@ExperimentalResourceApi
+internal val Res.string.str_24517: StringResource
+  get() = String32.str_24517
+
+@ExperimentalResourceApi
+internal val Res.string.str_24518: StringResource
+  get() = String32.str_24518
+
+@ExperimentalResourceApi
+internal val Res.string.str_24519: StringResource
+  get() = String32.str_24519
+
+@ExperimentalResourceApi
+internal val Res.string.str_2452: StringResource
+  get() = String32.str_2452
+
+@ExperimentalResourceApi
+internal val Res.string.str_24520: StringResource
+  get() = String32.str_24520
+
+@ExperimentalResourceApi
+internal val Res.string.str_24521: StringResource
+  get() = String32.str_24521
+
+@ExperimentalResourceApi
+internal val Res.string.str_24522: StringResource
+  get() = String32.str_24522
+
+@ExperimentalResourceApi
+internal val Res.string.str_24523: StringResource
+  get() = String32.str_24523
+
+@ExperimentalResourceApi
+internal val Res.string.str_24524: StringResource
+  get() = String32.str_24524
+
+@ExperimentalResourceApi
+internal val Res.string.str_24525: StringResource
+  get() = String32.str_24525
+
+@ExperimentalResourceApi
+internal val Res.string.str_24526: StringResource
+  get() = String32.str_24526
+
+@ExperimentalResourceApi
+internal val Res.string.str_24527: StringResource
+  get() = String32.str_24527
+
+@ExperimentalResourceApi
+internal val Res.string.str_24528: StringResource
+  get() = String32.str_24528
+
+@ExperimentalResourceApi
+internal val Res.string.str_24529: StringResource
+  get() = String32.str_24529
+
+@ExperimentalResourceApi
+internal val Res.string.str_2453: StringResource
+  get() = String32.str_2453
+
+@ExperimentalResourceApi
+internal val Res.string.str_24530: StringResource
+  get() = String32.str_24530
+
+@ExperimentalResourceApi
+internal val Res.string.str_24531: StringResource
+  get() = String32.str_24531
+
+@ExperimentalResourceApi
+internal val Res.string.str_24532: StringResource
+  get() = String32.str_24532
+
+@ExperimentalResourceApi
+internal val Res.string.str_24533: StringResource
+  get() = String32.str_24533
+
+@ExperimentalResourceApi
+internal val Res.string.str_24534: StringResource
+  get() = String32.str_24534
+
+@ExperimentalResourceApi
+internal val Res.string.str_24535: StringResource
+  get() = String32.str_24535
+
+@ExperimentalResourceApi
+internal val Res.string.str_24536: StringResource
+  get() = String32.str_24536
+
+@ExperimentalResourceApi
+internal val Res.string.str_24537: StringResource
+  get() = String32.str_24537
+
+@ExperimentalResourceApi
+internal val Res.string.str_24538: StringResource
+  get() = String32.str_24538
+
+@ExperimentalResourceApi
+internal val Res.string.str_24539: StringResource
+  get() = String32.str_24539
+
+@ExperimentalResourceApi
+internal val Res.string.str_2454: StringResource
+  get() = String32.str_2454
+
+@ExperimentalResourceApi
+internal val Res.string.str_24540: StringResource
+  get() = String32.str_24540
+
+@ExperimentalResourceApi
+internal val Res.string.str_24541: StringResource
+  get() = String32.str_24541
+
+@ExperimentalResourceApi
+internal val Res.string.str_24542: StringResource
+  get() = String32.str_24542
+
+@ExperimentalResourceApi
+internal val Res.string.str_24543: StringResource
+  get() = String32.str_24543
+
+@ExperimentalResourceApi
+internal val Res.string.str_24544: StringResource
+  get() = String32.str_24544
+
+@ExperimentalResourceApi
+internal val Res.string.str_24545: StringResource
+  get() = String32.str_24545
+
+@ExperimentalResourceApi
+internal val Res.string.str_24546: StringResource
+  get() = String32.str_24546
+
+@ExperimentalResourceApi
+internal val Res.string.str_24547: StringResource
+  get() = String32.str_24547
+
+@ExperimentalResourceApi
+internal val Res.string.str_24548: StringResource
+  get() = String32.str_24548
+
+@ExperimentalResourceApi
+internal val Res.string.str_24549: StringResource
+  get() = String32.str_24549
+
+@ExperimentalResourceApi
+internal val Res.string.str_2455: StringResource
+  get() = String32.str_2455
+
+@ExperimentalResourceApi
+internal val Res.string.str_24550: StringResource
+  get() = String32.str_24550
+
+@ExperimentalResourceApi
+internal val Res.string.str_24551: StringResource
+  get() = String32.str_24551
+
+@ExperimentalResourceApi
+internal val Res.string.str_24552: StringResource
+  get() = String32.str_24552
+
+@ExperimentalResourceApi
+internal val Res.string.str_24553: StringResource
+  get() = String32.str_24553
+
+@ExperimentalResourceApi
+internal val Res.string.str_24554: StringResource
+  get() = String32.str_24554
+
+@ExperimentalResourceApi
+internal val Res.string.str_24555: StringResource
+  get() = String32.str_24555
+
+@ExperimentalResourceApi
+internal val Res.string.str_24556: StringResource
+  get() = String32.str_24556
+
+@ExperimentalResourceApi
+internal val Res.string.str_24557: StringResource
+  get() = String32.str_24557
+
+@ExperimentalResourceApi
+internal val Res.string.str_24558: StringResource
+  get() = String32.str_24558
+
+@ExperimentalResourceApi
+internal val Res.string.str_24559: StringResource
+  get() = String32.str_24559
+
+@ExperimentalResourceApi
+internal val Res.string.str_2456: StringResource
+  get() = String32.str_2456
+
+@ExperimentalResourceApi
+internal val Res.string.str_24560: StringResource
+  get() = String32.str_24560
+
+@ExperimentalResourceApi
+internal val Res.string.str_24561: StringResource
+  get() = String32.str_24561
+
+@ExperimentalResourceApi
+internal val Res.string.str_24562: StringResource
+  get() = String32.str_24562
+
+@ExperimentalResourceApi
+internal val Res.string.str_24563: StringResource
+  get() = String32.str_24563
+
+@ExperimentalResourceApi
+internal val Res.string.str_24564: StringResource
+  get() = String32.str_24564
+
+@ExperimentalResourceApi
+internal val Res.string.str_24565: StringResource
+  get() = String32.str_24565
+
+@ExperimentalResourceApi
+internal val Res.string.str_24566: StringResource
+  get() = String32.str_24566
+
+@ExperimentalResourceApi
+internal val Res.string.str_24567: StringResource
+  get() = String32.str_24567
+
+@ExperimentalResourceApi
+internal val Res.string.str_24568: StringResource
+  get() = String32.str_24568
+
+@ExperimentalResourceApi
+internal val Res.string.str_24569: StringResource
+  get() = String32.str_24569
+
+@ExperimentalResourceApi
+internal val Res.string.str_2457: StringResource
+  get() = String32.str_2457
+
+@ExperimentalResourceApi
+internal val Res.string.str_24570: StringResource
+  get() = String32.str_24570
+
+@ExperimentalResourceApi
+internal val Res.string.str_24571: StringResource
+  get() = String32.str_24571
+
+@ExperimentalResourceApi
+internal val Res.string.str_24572: StringResource
+  get() = String32.str_24572
+
+@ExperimentalResourceApi
+internal val Res.string.str_24573: StringResource
+  get() = String32.str_24573
+
+@ExperimentalResourceApi
+internal val Res.string.str_24574: StringResource
+  get() = String32.str_24574
+
+@ExperimentalResourceApi
+internal val Res.string.str_24575: StringResource
+  get() = String32.str_24575
+
+@ExperimentalResourceApi
+internal val Res.string.str_24576: StringResource
+  get() = String32.str_24576
+
+@ExperimentalResourceApi
+internal val Res.string.str_24577: StringResource
+  get() = String32.str_24577
+
+@ExperimentalResourceApi
+internal val Res.string.str_24578: StringResource
+  get() = String32.str_24578
+
+@ExperimentalResourceApi
+internal val Res.string.str_24579: StringResource
+  get() = String32.str_24579
+
+@ExperimentalResourceApi
+internal val Res.string.str_2458: StringResource
+  get() = String32.str_2458
+
+@ExperimentalResourceApi
+internal val Res.string.str_24580: StringResource
+  get() = String32.str_24580
+
+@ExperimentalResourceApi
+internal val Res.string.str_24581: StringResource
+  get() = String32.str_24581
+
+@ExperimentalResourceApi
+internal val Res.string.str_24582: StringResource
+  get() = String32.str_24582
+
+@ExperimentalResourceApi
+internal val Res.string.str_24583: StringResource
+  get() = String32.str_24583
+
+@ExperimentalResourceApi
+internal val Res.string.str_24584: StringResource
+  get() = String32.str_24584
+
+@ExperimentalResourceApi
+internal val Res.string.str_24585: StringResource
+  get() = String32.str_24585
+
+@ExperimentalResourceApi
+internal val Res.string.str_24586: StringResource
+  get() = String32.str_24586
+
+@ExperimentalResourceApi
+internal val Res.string.str_24587: StringResource
+  get() = String32.str_24587
+
+@ExperimentalResourceApi
+internal val Res.string.str_24588: StringResource
+  get() = String32.str_24588
+
+@ExperimentalResourceApi
+internal val Res.string.str_24589: StringResource
+  get() = String32.str_24589
+
+@ExperimentalResourceApi
+internal val Res.string.str_2459: StringResource
+  get() = String32.str_2459
+
+@ExperimentalResourceApi
+internal val Res.string.str_24590: StringResource
+  get() = String32.str_24590
+
+@ExperimentalResourceApi
+internal val Res.string.str_24591: StringResource
+  get() = String32.str_24591
+
+@ExperimentalResourceApi
+internal val Res.string.str_24592: StringResource
+  get() = String32.str_24592
+
+@ExperimentalResourceApi
+internal val Res.string.str_24593: StringResource
+  get() = String32.str_24593
+
+@ExperimentalResourceApi
+internal val Res.string.str_24594: StringResource
+  get() = String32.str_24594
+
+@ExperimentalResourceApi
+internal val Res.string.str_24595: StringResource
+  get() = String32.str_24595
+
+@ExperimentalResourceApi
+internal val Res.string.str_24596: StringResource
+  get() = String32.str_24596
+
+@ExperimentalResourceApi
+internal val Res.string.str_24597: StringResource
+  get() = String32.str_24597
+
+@ExperimentalResourceApi
+internal val Res.string.str_24598: StringResource
+  get() = String32.str_24598
+
+@ExperimentalResourceApi
+internal val Res.string.str_24599: StringResource
+  get() = String32.str_24599
+
+@ExperimentalResourceApi
+internal val Res.string.str_246: StringResource
+  get() = String32.str_246
+
+@ExperimentalResourceApi
+internal val Res.string.str_2460: StringResource
+  get() = String32.str_2460
+
+@ExperimentalResourceApi
+internal val Res.string.str_24600: StringResource
+  get() = String32.str_24600
+
+@ExperimentalResourceApi
+internal val Res.string.str_24601: StringResource
+  get() = String32.str_24601
+
+@ExperimentalResourceApi
+internal val Res.string.str_24602: StringResource
+  get() = String32.str_24602
+
+@ExperimentalResourceApi
+internal val Res.string.str_24603: StringResource
+  get() = String32.str_24603
+
+@ExperimentalResourceApi
+internal val Res.string.str_24604: StringResource
+  get() = String32.str_24604
+
+@ExperimentalResourceApi
+internal val Res.string.str_24605: StringResource
+  get() = String32.str_24605
+
+@ExperimentalResourceApi
+internal val Res.string.str_24606: StringResource
+  get() = String32.str_24606
+
+@ExperimentalResourceApi
+internal val Res.string.str_24607: StringResource
+  get() = String32.str_24607
+
+@ExperimentalResourceApi
+internal val Res.string.str_24608: StringResource
+  get() = String32.str_24608
+
+@ExperimentalResourceApi
+internal val Res.string.str_24609: StringResource
+  get() = String32.str_24609
+
+@ExperimentalResourceApi
+internal val Res.string.str_2461: StringResource
+  get() = String32.str_2461
+
+@ExperimentalResourceApi
+internal val Res.string.str_24610: StringResource
+  get() = String32.str_24610
+
+@ExperimentalResourceApi
+internal val Res.string.str_24611: StringResource
+  get() = String32.str_24611
+
+@ExperimentalResourceApi
+internal val Res.string.str_24612: StringResource
+  get() = String32.str_24612
+
+@ExperimentalResourceApi
+internal val Res.string.str_24613: StringResource
+  get() = String32.str_24613
+
+@ExperimentalResourceApi
+internal val Res.string.str_24614: StringResource
+  get() = String32.str_24614
+
+@ExperimentalResourceApi
+internal val Res.string.str_24615: StringResource
+  get() = String32.str_24615
+
+@ExperimentalResourceApi
+internal val Res.string.str_24616: StringResource
+  get() = String32.str_24616
+
+@ExperimentalResourceApi
+internal val Res.string.str_24617: StringResource
+  get() = String32.str_24617
+
+@ExperimentalResourceApi
+internal val Res.string.str_24618: StringResource
+  get() = String32.str_24618
+
+@ExperimentalResourceApi
+internal val Res.string.str_24619: StringResource
+  get() = String32.str_24619
+
+@ExperimentalResourceApi
+internal val Res.string.str_2462: StringResource
+  get() = String32.str_2462
+
+@ExperimentalResourceApi
+internal val Res.string.str_24620: StringResource
+  get() = String32.str_24620
+
+@ExperimentalResourceApi
+internal val Res.string.str_24621: StringResource
+  get() = String32.str_24621
+
+@ExperimentalResourceApi
+internal val Res.string.str_24622: StringResource
+  get() = String32.str_24622
+
+@ExperimentalResourceApi
+internal val Res.string.str_24623: StringResource
+  get() = String32.str_24623
+
+@ExperimentalResourceApi
+internal val Res.string.str_24624: StringResource
+  get() = String32.str_24624
+
+@ExperimentalResourceApi
+internal val Res.string.str_24625: StringResource
+  get() = String32.str_24625
+
+@ExperimentalResourceApi
+internal val Res.string.str_24626: StringResource
+  get() = String32.str_24626
+
+@ExperimentalResourceApi
+internal val Res.string.str_24627: StringResource
+  get() = String32.str_24627
+
+@ExperimentalResourceApi
+internal val Res.string.str_24628: StringResource
+  get() = String32.str_24628
+
+@ExperimentalResourceApi
+internal val Res.string.str_24629: StringResource
+  get() = String32.str_24629
+
+@ExperimentalResourceApi
+internal val Res.string.str_2463: StringResource
+  get() = String32.str_2463
+
+@ExperimentalResourceApi
+internal val Res.string.str_24630: StringResource
+  get() = String32.str_24630
+
+@ExperimentalResourceApi
+internal val Res.string.str_24631: StringResource
+  get() = String32.str_24631
+
+@ExperimentalResourceApi
+internal val Res.string.str_24632: StringResource
+  get() = String32.str_24632
+
+@ExperimentalResourceApi
+internal val Res.string.str_24633: StringResource
+  get() = String32.str_24633
+
+@ExperimentalResourceApi
+internal val Res.string.str_24634: StringResource
+  get() = String32.str_24634
+
+@ExperimentalResourceApi
+internal val Res.string.str_24635: StringResource
+  get() = String32.str_24635
+
+@ExperimentalResourceApi
+internal val Res.string.str_24636: StringResource
+  get() = String32.str_24636
+
+@ExperimentalResourceApi
+internal val Res.string.str_24637: StringResource
+  get() = String32.str_24637
+
+@ExperimentalResourceApi
+internal val Res.string.str_24638: StringResource
+  get() = String32.str_24638
+
+@ExperimentalResourceApi
+internal val Res.string.str_24639: StringResource
+  get() = String32.str_24639
+
+@ExperimentalResourceApi
+internal val Res.string.str_2464: StringResource
+  get() = String32.str_2464
+
+@ExperimentalResourceApi
+internal val Res.string.str_24640: StringResource
+  get() = String32.str_24640
+
+@ExperimentalResourceApi
+internal val Res.string.str_24641: StringResource
+  get() = String32.str_24641
+
+@ExperimentalResourceApi
+internal val Res.string.str_24642: StringResource
+  get() = String32.str_24642
+
+@ExperimentalResourceApi
+internal val Res.string.str_24643: StringResource
+  get() = String32.str_24643
+
+@ExperimentalResourceApi
+internal val Res.string.str_24644: StringResource
+  get() = String32.str_24644
+
+@ExperimentalResourceApi
+internal val Res.string.str_24645: StringResource
+  get() = String32.str_24645
+
+@ExperimentalResourceApi
+internal val Res.string.str_24646: StringResource
+  get() = String32.str_24646
+
+@ExperimentalResourceApi
+internal val Res.string.str_24647: StringResource
+  get() = String32.str_24647
+
+@ExperimentalResourceApi
+internal val Res.string.str_24648: StringResource
+  get() = String32.str_24648
+
+@ExperimentalResourceApi
+internal val Res.string.str_24649: StringResource
+  get() = String32.str_24649
+
+@ExperimentalResourceApi
+internal val Res.string.str_2465: StringResource
+  get() = String32.str_2465
+
+@ExperimentalResourceApi
+internal val Res.string.str_24650: StringResource
+  get() = String32.str_24650
+
+@ExperimentalResourceApi
+internal val Res.string.str_24651: StringResource
+  get() = String32.str_24651
+
+@ExperimentalResourceApi
+internal val Res.string.str_24652: StringResource
+  get() = String32.str_24652
+
+@ExperimentalResourceApi
+internal val Res.string.str_24653: StringResource
+  get() = String32.str_24653
+
+@ExperimentalResourceApi
+internal val Res.string.str_24654: StringResource
+  get() = String32.str_24654
+
+@ExperimentalResourceApi
+internal val Res.string.str_24655: StringResource
+  get() = String32.str_24655
+
+@ExperimentalResourceApi
+internal val Res.string.str_24656: StringResource
+  get() = String32.str_24656
+
+@ExperimentalResourceApi
+internal val Res.string.str_24657: StringResource
+  get() = String32.str_24657
+
+@ExperimentalResourceApi
+internal val Res.string.str_24658: StringResource
+  get() = String32.str_24658
+
+@ExperimentalResourceApi
+internal val Res.string.str_24659: StringResource
+  get() = String32.str_24659
+
+@ExperimentalResourceApi
+internal val Res.string.str_2466: StringResource
+  get() = String32.str_2466
+
+@ExperimentalResourceApi
+internal val Res.string.str_24660: StringResource
+  get() = String32.str_24660
+
+@ExperimentalResourceApi
+internal val Res.string.str_24661: StringResource
+  get() = String32.str_24661
+
+@ExperimentalResourceApi
+internal val Res.string.str_24662: StringResource
+  get() = String32.str_24662
+
+@ExperimentalResourceApi
+internal val Res.string.str_24663: StringResource
+  get() = String32.str_24663
+
+@ExperimentalResourceApi
+internal val Res.string.str_24664: StringResource
+  get() = String32.str_24664
+
+@ExperimentalResourceApi
+internal val Res.string.str_24665: StringResource
+  get() = String32.str_24665
+
+@ExperimentalResourceApi
+internal val Res.string.str_24666: StringResource
+  get() = String32.str_24666
+
+@ExperimentalResourceApi
+internal val Res.string.str_24667: StringResource
+  get() = String32.str_24667
+
+@ExperimentalResourceApi
+internal val Res.string.str_24668: StringResource
+  get() = String32.str_24668
+
+@ExperimentalResourceApi
+internal val Res.string.str_24669: StringResource
+  get() = String32.str_24669
+
+@ExperimentalResourceApi
+internal val Res.string.str_2467: StringResource
+  get() = String32.str_2467
+
+@ExperimentalResourceApi
+internal val Res.string.str_24670: StringResource
+  get() = String32.str_24670
+
+@ExperimentalResourceApi
+internal val Res.string.str_24671: StringResource
+  get() = String32.str_24671
+
+@ExperimentalResourceApi
+internal val Res.string.str_24672: StringResource
+  get() = String32.str_24672
+
+@ExperimentalResourceApi
+internal val Res.string.str_24673: StringResource
+  get() = String32.str_24673
+
+@ExperimentalResourceApi
+internal val Res.string.str_24674: StringResource
+  get() = String32.str_24674
+
+@ExperimentalResourceApi
+internal val Res.string.str_24675: StringResource
+  get() = String32.str_24675
+
+@ExperimentalResourceApi
+internal val Res.string.str_24676: StringResource
+  get() = String32.str_24676
+
+@ExperimentalResourceApi
+internal val Res.string.str_24677: StringResource
+  get() = String32.str_24677
+
+@ExperimentalResourceApi
+internal val Res.string.str_24678: StringResource
+  get() = String32.str_24678
+
+@ExperimentalResourceApi
+internal val Res.string.str_24679: StringResource
+  get() = String32.str_24679
+
+@ExperimentalResourceApi
+internal val Res.string.str_2468: StringResource
+  get() = String32.str_2468
+
+@ExperimentalResourceApi
+internal val Res.string.str_24680: StringResource
+  get() = String32.str_24680
+
+@ExperimentalResourceApi
+internal val Res.string.str_24681: StringResource
+  get() = String32.str_24681
+
+@ExperimentalResourceApi
+internal val Res.string.str_24682: StringResource
+  get() = String32.str_24682
+
+@ExperimentalResourceApi
+internal val Res.string.str_24683: StringResource
+  get() = String32.str_24683
+
+@ExperimentalResourceApi
+internal val Res.string.str_24684: StringResource
+  get() = String32.str_24684
+
+@ExperimentalResourceApi
+internal val Res.string.str_24685: StringResource
+  get() = String32.str_24685
+
+@ExperimentalResourceApi
+internal val Res.string.str_24686: StringResource
+  get() = String32.str_24686
+
+@ExperimentalResourceApi
+internal val Res.string.str_24687: StringResource
+  get() = String32.str_24687
+
+@ExperimentalResourceApi
+internal val Res.string.str_24688: StringResource
+  get() = String32.str_24688
+
+@ExperimentalResourceApi
+internal val Res.string.str_24689: StringResource
+  get() = String32.str_24689
+
+@ExperimentalResourceApi
+internal val Res.string.str_2469: StringResource
+  get() = String32.str_2469
+
+@ExperimentalResourceApi
+internal val Res.string.str_24690: StringResource
+  get() = String32.str_24690
+
+@ExperimentalResourceApi
+internal val Res.string.str_24691: StringResource
+  get() = String32.str_24691
+
+@ExperimentalResourceApi
+internal val Res.string.str_24692: StringResource
+  get() = String32.str_24692
+
+@ExperimentalResourceApi
+internal val Res.string.str_24693: StringResource
+  get() = String32.str_24693
+
+@ExperimentalResourceApi
+internal val Res.string.str_24694: StringResource
+  get() = String32.str_24694
+
+@ExperimentalResourceApi
+internal val Res.string.str_24695: StringResource
+  get() = String32.str_24695
+
+@ExperimentalResourceApi
+internal val Res.string.str_24696: StringResource
+  get() = String32.str_24696
+
+@ExperimentalResourceApi
+internal val Res.string.str_24697: StringResource
+  get() = String32.str_24697
+
+@ExperimentalResourceApi
+internal val Res.string.str_24698: StringResource
+  get() = String32.str_24698
+
+@ExperimentalResourceApi
+internal val Res.string.str_24699: StringResource
+  get() = String32.str_24699
+
+@ExperimentalResourceApi
+internal val Res.string.str_247: StringResource
+  get() = String32.str_247
+
+@ExperimentalResourceApi
+internal val Res.string.str_2470: StringResource
+  get() = String32.str_2470
+
+@ExperimentalResourceApi
+internal val Res.string.str_24700: StringResource
+  get() = String32.str_24700
+
+@ExperimentalResourceApi
+internal val Res.string.str_24701: StringResource
+  get() = String32.str_24701
+
+@ExperimentalResourceApi
+internal val Res.string.str_24702: StringResource
+  get() = String32.str_24702
+
+@ExperimentalResourceApi
+internal val Res.string.str_24703: StringResource
+  get() = String32.str_24703
+
+@ExperimentalResourceApi
+internal val Res.string.str_24704: StringResource
+  get() = String32.str_24704
+
+@ExperimentalResourceApi
+internal val Res.string.str_24705: StringResource
+  get() = String32.str_24705
+
+@ExperimentalResourceApi
+internal val Res.string.str_24706: StringResource
+  get() = String32.str_24706
+
+@ExperimentalResourceApi
+internal val Res.string.str_24707: StringResource
+  get() = String32.str_24707
+
+@ExperimentalResourceApi
+internal val Res.string.str_24708: StringResource
+  get() = String32.str_24708
+
+@ExperimentalResourceApi
+internal val Res.string.str_24709: StringResource
+  get() = String32.str_24709
+
+@ExperimentalResourceApi
+internal val Res.string.str_2471: StringResource
+  get() = String32.str_2471
+
+@ExperimentalResourceApi
+internal val Res.string.str_24710: StringResource
+  get() = String32.str_24710
+
+@ExperimentalResourceApi
+internal val Res.string.str_24711: StringResource
+  get() = String32.str_24711
+
+@ExperimentalResourceApi
+internal val Res.string.str_24712: StringResource
+  get() = String32.str_24712
+
+@ExperimentalResourceApi
+internal val Res.string.str_24713: StringResource
+  get() = String32.str_24713
+
+@ExperimentalResourceApi
+internal val Res.string.str_24714: StringResource
+  get() = String32.str_24714
+
+@ExperimentalResourceApi
+internal val Res.string.str_24715: StringResource
+  get() = String32.str_24715
+
+@ExperimentalResourceApi
+internal val Res.string.str_24716: StringResource
+  get() = String32.str_24716
+
+@ExperimentalResourceApi
+internal val Res.string.str_24717: StringResource
+  get() = String32.str_24717
+
+@ExperimentalResourceApi
+internal val Res.string.str_24718: StringResource
+  get() = String32.str_24718
+
+@ExperimentalResourceApi
+internal val Res.string.str_24719: StringResource
+  get() = String32.str_24719
+
+@ExperimentalResourceApi
+internal val Res.string.str_2472: StringResource
+  get() = String32.str_2472
+
+@ExperimentalResourceApi
+internal val Res.string.str_24720: StringResource
+  get() = String32.str_24720
+
+@ExperimentalResourceApi
+internal val Res.string.str_24721: StringResource
+  get() = String32.str_24721
+
+@ExperimentalResourceApi
+internal val Res.string.str_24722: StringResource
+  get() = String32.str_24722
+
+@ExperimentalResourceApi
+internal val Res.string.str_24723: StringResource
+  get() = String32.str_24723
+
+@ExperimentalResourceApi
+internal val Res.string.str_24724: StringResource
+  get() = String32.str_24724
+
+@ExperimentalResourceApi
+internal val Res.string.str_24725: StringResource
+  get() = String32.str_24725
+
+@ExperimentalResourceApi
+internal val Res.string.str_24726: StringResource
+  get() = String32.str_24726
+
+@ExperimentalResourceApi
+internal val Res.string.str_24727: StringResource
+  get() = String32.str_24727
+
+@ExperimentalResourceApi
+internal val Res.string.str_24728: StringResource
+  get() = String32.str_24728
+
+@ExperimentalResourceApi
+internal val Res.string.str_24729: StringResource
+  get() = String32.str_24729
+
+@ExperimentalResourceApi
+internal val Res.string.str_2473: StringResource
+  get() = String32.str_2473
+
+@ExperimentalResourceApi
+internal val Res.string.str_24730: StringResource
+  get() = String32.str_24730
+
+@ExperimentalResourceApi
+internal val Res.string.str_24731: StringResource
+  get() = String32.str_24731
+
+@ExperimentalResourceApi
+internal val Res.string.str_24732: StringResource
+  get() = String32.str_24732
+
+@ExperimentalResourceApi
+internal val Res.string.str_24733: StringResource
+  get() = String32.str_24733
+
+@ExperimentalResourceApi
+internal val Res.string.str_24734: StringResource
+  get() = String32.str_24734
+
+@ExperimentalResourceApi
+internal val Res.string.str_24735: StringResource
+  get() = String32.str_24735
+
+@ExperimentalResourceApi
+internal val Res.string.str_24736: StringResource
+  get() = String32.str_24736
+
+@ExperimentalResourceApi
+internal val Res.string.str_24737: StringResource
+  get() = String32.str_24737
+
+@ExperimentalResourceApi
+internal val Res.string.str_24738: StringResource
+  get() = String32.str_24738
+
+@ExperimentalResourceApi
+internal val Res.string.str_24739: StringResource
+  get() = String32.str_24739
+
+@ExperimentalResourceApi
+internal val Res.string.str_2474: StringResource
+  get() = String32.str_2474
+
+@ExperimentalResourceApi
+internal val Res.string.str_24740: StringResource
+  get() = String32.str_24740
+
+@ExperimentalResourceApi
+internal val Res.string.str_24741: StringResource
+  get() = String32.str_24741
+
+@ExperimentalResourceApi
+internal val Res.string.str_24742: StringResource
+  get() = String32.str_24742
+
+@ExperimentalResourceApi
+internal val Res.string.str_24743: StringResource
+  get() = String32.str_24743
+
+@ExperimentalResourceApi
+internal val Res.string.str_24744: StringResource
+  get() = String32.str_24744
+
+@ExperimentalResourceApi
+internal val Res.string.str_24745: StringResource
+  get() = String32.str_24745
+
+@ExperimentalResourceApi
+internal val Res.string.str_24746: StringResource
+  get() = String32.str_24746
+
+@ExperimentalResourceApi
+internal val Res.string.str_24747: StringResource
+  get() = String32.str_24747
+
+@ExperimentalResourceApi
+internal val Res.string.str_24748: StringResource
+  get() = String32.str_24748
+
+@ExperimentalResourceApi
+internal val Res.string.str_24749: StringResource
+  get() = String32.str_24749
+
+@ExperimentalResourceApi
+internal val Res.string.str_2475: StringResource
+  get() = String32.str_2475
+
+@ExperimentalResourceApi
+internal val Res.string.str_24750: StringResource
+  get() = String32.str_24750
+
+@ExperimentalResourceApi
+internal val Res.string.str_24751: StringResource
+  get() = String32.str_24751
+
+@ExperimentalResourceApi
+internal val Res.string.str_24752: StringResource
+  get() = String32.str_24752
+
+@ExperimentalResourceApi
+internal val Res.string.str_24753: StringResource
+  get() = String32.str_24753
+
+@ExperimentalResourceApi
+internal val Res.string.str_24754: StringResource
+  get() = String32.str_24754
+
+@ExperimentalResourceApi
+internal val Res.string.str_24755: StringResource
+  get() = String32.str_24755
+
+@ExperimentalResourceApi
+internal val Res.string.str_24756: StringResource
+  get() = String32.str_24756
+
+@ExperimentalResourceApi
+internal val Res.string.str_24757: StringResource
+  get() = String32.str_24757
+
+@ExperimentalResourceApi
+internal val Res.string.str_24758: StringResource
+  get() = String32.str_24758
+
+@ExperimentalResourceApi
+internal val Res.string.str_24759: StringResource
+  get() = String32.str_24759
+
+@ExperimentalResourceApi
+internal val Res.string.str_2476: StringResource
+  get() = String32.str_2476
+
+@ExperimentalResourceApi
+internal val Res.string.str_24760: StringResource
+  get() = String32.str_24760
+
+@ExperimentalResourceApi
+internal val Res.string.str_24761: StringResource
+  get() = String32.str_24761
+
+@ExperimentalResourceApi
+internal val Res.string.str_24762: StringResource
+  get() = String32.str_24762
+
+@ExperimentalResourceApi
+internal val Res.string.str_24763: StringResource
+  get() = String32.str_24763
+
+@ExperimentalResourceApi
+internal val Res.string.str_24764: StringResource
+  get() = String32.str_24764
+
+@ExperimentalResourceApi
+internal val Res.string.str_24765: StringResource
+  get() = String32.str_24765
+
+@ExperimentalResourceApi
+internal val Res.string.str_24766: StringResource
+  get() = String32.str_24766
+
+@ExperimentalResourceApi
+internal val Res.string.str_24767: StringResource
+  get() = String32.str_24767
+
+@ExperimentalResourceApi
+internal val Res.string.str_24768: StringResource
+  get() = String32.str_24768
+
+@ExperimentalResourceApi
+internal val Res.string.str_24769: StringResource
+  get() = String32.str_24769
+
+@ExperimentalResourceApi
+internal val Res.string.str_2477: StringResource
+  get() = String32.str_2477
+
+@ExperimentalResourceApi
+internal val Res.string.str_24770: StringResource
+  get() = String32.str_24770
+
+@ExperimentalResourceApi
+internal val Res.string.str_24771: StringResource
+  get() = String32.str_24771
+
+@ExperimentalResourceApi
+internal val Res.string.str_24772: StringResource
+  get() = String32.str_24772
+
+@ExperimentalResourceApi
+internal val Res.string.str_24773: StringResource
+  get() = String32.str_24773
+
+@ExperimentalResourceApi
+internal val Res.string.str_24774: StringResource
+  get() = String32.str_24774
+
+@ExperimentalResourceApi
+internal val Res.string.str_24775: StringResource
+  get() = String32.str_24775
+
+@ExperimentalResourceApi
+internal val Res.string.str_24776: StringResource
+  get() = String32.str_24776
+
+@ExperimentalResourceApi
+internal val Res.string.str_24777: StringResource
+  get() = String32.str_24777
+
+@ExperimentalResourceApi
+internal val Res.string.str_24778: StringResource
+  get() = String32.str_24778
+
+@ExperimentalResourceApi
+internal val Res.string.str_24779: StringResource
+  get() = String32.str_24779
+
+@ExperimentalResourceApi
+internal val Res.string.str_2478: StringResource
+  get() = String32.str_2478
+
+@ExperimentalResourceApi
+internal val Res.string.str_24780: StringResource
+  get() = String32.str_24780
+
+@ExperimentalResourceApi
+internal val Res.string.str_24781: StringResource
+  get() = String32.str_24781
+
+@ExperimentalResourceApi
+internal val Res.string.str_24782: StringResource
+  get() = String32.str_24782
+
+@ExperimentalResourceApi
+internal val Res.string.str_24783: StringResource
+  get() = String32.str_24783
+
+@ExperimentalResourceApi
+internal val Res.string.str_24784: StringResource
+  get() = String32.str_24784
+
+@ExperimentalResourceApi
+internal val Res.string.str_24785: StringResource
+  get() = String32.str_24785
+
+@ExperimentalResourceApi
+internal val Res.string.str_24786: StringResource
+  get() = String32.str_24786
+
+@ExperimentalResourceApi
+internal val Res.string.str_24787: StringResource
+  get() = String32.str_24787
+
+@ExperimentalResourceApi
+internal val Res.string.str_24788: StringResource
+  get() = String32.str_24788
+
+@ExperimentalResourceApi
+internal val Res.string.str_24789: StringResource
+  get() = String32.str_24789
+
+@ExperimentalResourceApi
+internal val Res.string.str_2479: StringResource
+  get() = String32.str_2479
+
+@ExperimentalResourceApi
+internal val Res.string.str_24790: StringResource
+  get() = String32.str_24790
+
+@ExperimentalResourceApi
+internal val Res.string.str_24791: StringResource
+  get() = String32.str_24791
+
+@ExperimentalResourceApi
+internal val Res.string.str_24792: StringResource
+  get() = String32.str_24792
+
+@ExperimentalResourceApi
+internal val Res.string.str_24793: StringResource
+  get() = String32.str_24793
+
+@ExperimentalResourceApi
+internal val Res.string.str_24794: StringResource
+  get() = String32.str_24794
+
+@ExperimentalResourceApi
+internal val Res.string.str_24795: StringResource
+  get() = String32.str_24795
+
+@ExperimentalResourceApi
+internal val Res.string.str_24796: StringResource
+  get() = String32.str_24796
+
+@ExperimentalResourceApi
+internal val Res.string.str_24797: StringResource
+  get() = String32.str_24797
+
+@ExperimentalResourceApi
+internal val Res.string.str_24798: StringResource
+  get() = String32.str_24798
+
+@ExperimentalResourceApi
+internal val Res.string.str_24799: StringResource
+  get() = String32.str_24799
+
+@ExperimentalResourceApi
+internal val Res.string.str_248: StringResource
+  get() = String32.str_248
+
+@ExperimentalResourceApi
+internal val Res.string.str_2480: StringResource
+  get() = String32.str_2480
+
+@ExperimentalResourceApi
+internal val Res.string.str_24800: StringResource
+  get() = String32.str_24800
+
+@ExperimentalResourceApi
+internal val Res.string.str_24801: StringResource
+  get() = String32.str_24801
+
+@ExperimentalResourceApi
+internal val Res.string.str_24802: StringResource
+  get() = String32.str_24802
+
+@ExperimentalResourceApi
+internal val Res.string.str_24803: StringResource
+  get() = String32.str_24803
+
+@ExperimentalResourceApi
+internal val Res.string.str_24804: StringResource
+  get() = String32.str_24804
+
+@ExperimentalResourceApi
+internal val Res.string.str_24805: StringResource
+  get() = String32.str_24805
+
+@ExperimentalResourceApi
+internal val Res.string.str_24806: StringResource
+  get() = String32.str_24806
+
+@ExperimentalResourceApi
+internal val Res.string.str_24807: StringResource
+  get() = String32.str_24807
+
+@ExperimentalResourceApi
+internal val Res.string.str_24808: StringResource
+  get() = String32.str_24808
+
+@ExperimentalResourceApi
+internal val Res.string.str_24809: StringResource
+  get() = String32.str_24809
+
+@ExperimentalResourceApi
+internal val Res.string.str_2481: StringResource
+  get() = String32.str_2481
+
+@ExperimentalResourceApi
+internal val Res.string.str_24810: StringResource
+  get() = String32.str_24810
+
+@ExperimentalResourceApi
+internal val Res.string.str_24811: StringResource
+  get() = String32.str_24811
+
+@ExperimentalResourceApi
+internal val Res.string.str_24812: StringResource
+  get() = String32.str_24812
+
+@ExperimentalResourceApi
+internal val Res.string.str_24813: StringResource
+  get() = String32.str_24813
+
+@ExperimentalResourceApi
+internal val Res.string.str_24814: StringResource
+  get() = String32.str_24814
+
+@ExperimentalResourceApi
+internal val Res.string.str_24815: StringResource
+  get() = String32.str_24815
+
+@ExperimentalResourceApi
+internal val Res.string.str_24816: StringResource
+  get() = String32.str_24816
+
+@ExperimentalResourceApi
+internal val Res.string.str_24817: StringResource
+  get() = String32.str_24817
+
+@ExperimentalResourceApi
+internal val Res.string.str_24818: StringResource
+  get() = String32.str_24818
+
+@ExperimentalResourceApi
+internal val Res.string.str_24819: StringResource
+  get() = String32.str_24819
+
+@ExperimentalResourceApi
+internal val Res.string.str_2482: StringResource
+  get() = String32.str_2482
+
+@ExperimentalResourceApi
+internal val Res.string.str_24820: StringResource
+  get() = String32.str_24820
+
+@ExperimentalResourceApi
+internal val Res.string.str_24821: StringResource
+  get() = String32.str_24821
+
+@ExperimentalResourceApi
+internal val Res.string.str_24822: StringResource
+  get() = String32.str_24822
+
+@ExperimentalResourceApi
+internal val Res.string.str_24823: StringResource
+  get() = String32.str_24823
+
+@ExperimentalResourceApi
+internal val Res.string.str_24824: StringResource
+  get() = String32.str_24824
+
+@ExperimentalResourceApi
+internal val Res.string.str_24825: StringResource
+  get() = String32.str_24825
+
+@ExperimentalResourceApi
+internal val Res.string.str_24826: StringResource
+  get() = String32.str_24826
+
+@ExperimentalResourceApi
+internal val Res.string.str_24827: StringResource
+  get() = String32.str_24827
+
+@ExperimentalResourceApi
+internal val Res.string.str_24828: StringResource
+  get() = String32.str_24828
+
+@ExperimentalResourceApi
+internal val Res.string.str_24829: StringResource
+  get() = String32.str_24829
+
+@ExperimentalResourceApi
+internal val Res.string.str_2483: StringResource
+  get() = String32.str_2483
+
+@ExperimentalResourceApi
+internal val Res.string.str_24830: StringResource
+  get() = String32.str_24830
+
+@ExperimentalResourceApi
+internal val Res.string.str_24831: StringResource
+  get() = String32.str_24831
+
+@ExperimentalResourceApi
+internal val Res.string.str_24832: StringResource
+  get() = String32.str_24832
+
+@ExperimentalResourceApi
+internal val Res.string.str_24833: StringResource
+  get() = String32.str_24833
+
+@ExperimentalResourceApi
+internal val Res.string.str_24834: StringResource
+  get() = String32.str_24834
+
+@ExperimentalResourceApi
+internal val Res.string.str_24835: StringResource
+  get() = String32.str_24835
+
+@ExperimentalResourceApi
+internal val Res.string.str_24836: StringResource
+  get() = String32.str_24836
+
+@ExperimentalResourceApi
+internal val Res.string.str_24837: StringResource
+  get() = String32.str_24837
+
+@ExperimentalResourceApi
+internal val Res.string.str_24838: StringResource
+  get() = String32.str_24838
+
+@ExperimentalResourceApi
+internal val Res.string.str_24839: StringResource
+  get() = String32.str_24839
+
+@ExperimentalResourceApi
+internal val Res.string.str_2484: StringResource
+  get() = String32.str_2484
+
+@ExperimentalResourceApi
+internal val Res.string.str_24840: StringResource
+  get() = String32.str_24840
+
+@ExperimentalResourceApi
+internal val Res.string.str_24841: StringResource
+  get() = String32.str_24841
+
+@ExperimentalResourceApi
+internal val Res.string.str_24842: StringResource
+  get() = String32.str_24842
+
+@ExperimentalResourceApi
+internal val Res.string.str_24843: StringResource
+  get() = String32.str_24843
+
+@ExperimentalResourceApi
+internal val Res.string.str_24844: StringResource
+  get() = String32.str_24844
+
+@ExperimentalResourceApi
+internal val Res.string.str_24845: StringResource
+  get() = String32.str_24845
+
+@ExperimentalResourceApi
+internal val Res.string.str_24846: StringResource
+  get() = String32.str_24846
+
+@ExperimentalResourceApi
+internal val Res.string.str_24847: StringResource
+  get() = String32.str_24847

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String33.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String33.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String33 {
+  public val str_24848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24848", "str_24848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24849", "str_24849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2485", "str_2485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24850", "str_24850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24851", "str_24851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24852", "str_24852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24853", "str_24853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24854", "str_24854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24855", "str_24855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24856", "str_24856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24857", "str_24857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24858", "str_24858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24859", "str_24859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2486", "str_2486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24860", "str_24860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24861", "str_24861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24862", "str_24862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24863", "str_24863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24864", "str_24864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24865", "str_24865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24866", "str_24866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24867", "str_24867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24868", "str_24868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24869", "str_24869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2487", "str_2487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24870", "str_24870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24871", "str_24871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24872", "str_24872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24873", "str_24873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24874", "str_24874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24875", "str_24875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24876", "str_24876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24877", "str_24877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24878", "str_24878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24879", "str_24879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2488", "str_2488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24880", "str_24880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24881", "str_24881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24882", "str_24882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24883", "str_24883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24884", "str_24884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24885", "str_24885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24886", "str_24886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24887", "str_24887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24888", "str_24888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24889", "str_24889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2489", "str_2489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24890", "str_24890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24891", "str_24891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24892", "str_24892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24893", "str_24893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24894", "str_24894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24895", "str_24895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24896", "str_24896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24897", "str_24897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24898", "str_24898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24899", "str_24899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_249", "str_249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2490", "str_2490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24900", "str_24900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24901", "str_24901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24902", "str_24902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24903", "str_24903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24904", "str_24904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24905", "str_24905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24906", "str_24906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24907", "str_24907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24908", "str_24908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24909", "str_24909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2491", "str_2491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24910", "str_24910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24911", "str_24911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24912", "str_24912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24913", "str_24913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24914", "str_24914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24915", "str_24915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24916", "str_24916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24917", "str_24917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24918", "str_24918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24919", "str_24919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2492", "str_2492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24920", "str_24920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24921", "str_24921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24922", "str_24922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24923", "str_24923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24924", "str_24924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24925", "str_24925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24926", "str_24926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24927", "str_24927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24928", "str_24928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24929", "str_24929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2493", "str_2493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24930", "str_24930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24931", "str_24931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24932", "str_24932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24933", "str_24933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24934", "str_24934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24935", "str_24935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24936", "str_24936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24937", "str_24937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24938", "str_24938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24939", "str_24939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2494", "str_2494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24940", "str_24940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24941", "str_24941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24942", "str_24942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24943", "str_24943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24944", "str_24944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24945", "str_24945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24946", "str_24946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24947", "str_24947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24948", "str_24948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24949", "str_24949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2495", "str_2495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24950", "str_24950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24951", "str_24951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24952", "str_24952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24953", "str_24953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24954", "str_24954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24955", "str_24955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24956", "str_24956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24957", "str_24957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24958", "str_24958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24959", "str_24959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2496", "str_2496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24960", "str_24960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24961", "str_24961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24962", "str_24962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24963", "str_24963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24964", "str_24964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24965", "str_24965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24966", "str_24966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24967", "str_24967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24968", "str_24968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24969", "str_24969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2497", "str_2497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24970", "str_24970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24971", "str_24971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24972", "str_24972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24973", "str_24973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24974", "str_24974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24975", "str_24975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24976", "str_24976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24977", "str_24977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24978", "str_24978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24979", "str_24979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2498", "str_2498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24980", "str_24980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24981", "str_24981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24982", "str_24982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24983", "str_24983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24984", "str_24984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24985", "str_24985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24986", "str_24986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24987", "str_24987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24988", "str_24988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24989", "str_24989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2499", "str_2499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24990", "str_24990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24991", "str_24991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24992", "str_24992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24993", "str_24993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24994", "str_24994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24995", "str_24995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24996", "str_24996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24997", "str_24997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24998", "str_24998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_24999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_24999", "str_24999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_25: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_25", "str_25",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_250", "str_250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2500", "str_2500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2501", "str_2501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2502", "str_2502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2503", "str_2503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2504", "str_2504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2505", "str_2505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2506", "str_2506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2507", "str_2507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2508", "str_2508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2509", "str_2509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_251", "str_251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2510", "str_2510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2511", "str_2511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2512", "str_2512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2513", "str_2513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2514", "str_2514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2515", "str_2515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2516", "str_2516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2517", "str_2517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2518", "str_2518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2519", "str_2519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_252", "str_252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2520", "str_2520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2521", "str_2521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2522", "str_2522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2523", "str_2523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2524", "str_2524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2525", "str_2525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2526", "str_2526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2527", "str_2527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2528", "str_2528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2529", "str_2529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_253", "str_253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2530", "str_2530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2531", "str_2531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2532", "str_2532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2533", "str_2533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2534", "str_2534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2535", "str_2535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2536", "str_2536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2537", "str_2537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2538", "str_2538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2539", "str_2539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_254", "str_254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2540", "str_2540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2541", "str_2541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2542", "str_2542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2543", "str_2543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2544", "str_2544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2545", "str_2545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2546", "str_2546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2547", "str_2547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2548", "str_2548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2549", "str_2549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_255", "str_255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2550", "str_2550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2551", "str_2551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2552", "str_2552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2553", "str_2553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2554", "str_2554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2555", "str_2555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2556", "str_2556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2557", "str_2557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2558", "str_2558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2559", "str_2559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_256", "str_256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2560", "str_2560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2561", "str_2561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2562", "str_2562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2563", "str_2563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2564", "str_2564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2565", "str_2565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2566", "str_2566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2567", "str_2567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2568", "str_2568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2569", "str_2569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_257", "str_257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2570", "str_2570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2571", "str_2571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2572", "str_2572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2573", "str_2573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2574", "str_2574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2575", "str_2575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2576", "str_2576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2577", "str_2577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2578", "str_2578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2579", "str_2579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_258", "str_258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2580", "str_2580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2581", "str_2581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2582", "str_2582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2583", "str_2583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2584", "str_2584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2585", "str_2585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2586", "str_2586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2587", "str_2587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2588", "str_2588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2589", "str_2589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_259", "str_259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2590", "str_2590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2591", "str_2591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2592", "str_2592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2593", "str_2593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2594", "str_2594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2595", "str_2595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2596", "str_2596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2597", "str_2597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2598", "str_2598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2599", "str_2599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_26: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_26", "str_26",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_260", "str_260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2600", "str_2600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2601", "str_2601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2602", "str_2602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2603", "str_2603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2604", "str_2604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2605", "str_2605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2606", "str_2606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2607", "str_2607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2608", "str_2608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2609", "str_2609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_261", "str_261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2610", "str_2610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2611", "str_2611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2612", "str_2612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2613", "str_2613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2614", "str_2614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2615", "str_2615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2616", "str_2616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2617", "str_2617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2618", "str_2618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2619", "str_2619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_262", "str_262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2620", "str_2620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2621", "str_2621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2622", "str_2622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2623", "str_2623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2624", "str_2624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2625", "str_2625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2626", "str_2626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2627", "str_2627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2628", "str_2628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2629", "str_2629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_263", "str_263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2630", "str_2630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2631", "str_2631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2632", "str_2632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2633", "str_2633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2634", "str_2634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2635", "str_2635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2636", "str_2636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2637", "str_2637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2638", "str_2638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2639", "str_2639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_264", "str_264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2640", "str_2640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2641", "str_2641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2642", "str_2642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2643", "str_2643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2644", "str_2644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2645", "str_2645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2646", "str_2646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2647", "str_2647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2648", "str_2648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2649", "str_2649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_265", "str_265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2650", "str_2650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2651", "str_2651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2652", "str_2652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2653", "str_2653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2654", "str_2654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2655", "str_2655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2656", "str_2656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2657", "str_2657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2658", "str_2658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2659", "str_2659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_266", "str_266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2660", "str_2660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2661", "str_2661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2662", "str_2662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2663", "str_2663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2664", "str_2664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2665", "str_2665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2666", "str_2666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2667", "str_2667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2668", "str_2668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2669", "str_2669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_267", "str_267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2670", "str_2670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2671", "str_2671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2672", "str_2672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2673", "str_2673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2674", "str_2674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2675", "str_2675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2676", "str_2676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2677", "str_2677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2678", "str_2678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2679", "str_2679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_268", "str_268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2680", "str_2680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2681", "str_2681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2682", "str_2682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2683", "str_2683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2684", "str_2684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2685", "str_2685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2686", "str_2686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2687", "str_2687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2688", "str_2688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2689", "str_2689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_269", "str_269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2690", "str_2690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2691", "str_2691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2692", "str_2692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2693", "str_2693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2694", "str_2694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2695", "str_2695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2696", "str_2696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2697", "str_2697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2698", "str_2698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2699", "str_2699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_27: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_27", "str_27",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_270", "str_270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2700", "str_2700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2701", "str_2701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2702", "str_2702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2703", "str_2703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2704", "str_2704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2705", "str_2705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2706", "str_2706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2707", "str_2707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2708", "str_2708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2709", "str_2709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_271", "str_271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2710", "str_2710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2711", "str_2711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2712", "str_2712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2713", "str_2713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2714", "str_2714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2715", "str_2715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2716", "str_2716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2717", "str_2717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2718", "str_2718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2719", "str_2719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_272", "str_272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2720", "str_2720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2721", "str_2721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2722", "str_2722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2723", "str_2723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2724", "str_2724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2725", "str_2725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2726", "str_2726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2727", "str_2727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2728", "str_2728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2729", "str_2729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_273", "str_273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2730", "str_2730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2731", "str_2731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2732", "str_2732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2733", "str_2733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2734", "str_2734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2735", "str_2735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2736", "str_2736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2737", "str_2737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2738", "str_2738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2739", "str_2739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_274", "str_274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2740", "str_2740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2741", "str_2741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2742", "str_2742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2743", "str_2743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2744", "str_2744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2745", "str_2745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2746", "str_2746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2747", "str_2747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2748", "str_2748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2749", "str_2749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_275", "str_275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2750", "str_2750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2751", "str_2751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2752", "str_2752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2753", "str_2753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2754", "str_2754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2755", "str_2755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2756", "str_2756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2757", "str_2757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2758", "str_2758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2759", "str_2759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_276", "str_276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2760", "str_2760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2761", "str_2761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2762", "str_2762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2763", "str_2763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2764", "str_2764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2765", "str_2765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2766", "str_2766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2767", "str_2767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2768", "str_2768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2769", "str_2769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_277", "str_277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2770", "str_2770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2771", "str_2771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2772", "str_2772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2773", "str_2773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2774", "str_2774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2775", "str_2775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2776", "str_2776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2777", "str_2777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2778", "str_2778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2779", "str_2779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_278", "str_278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2780", "str_2780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2781", "str_2781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2782", "str_2782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2783", "str_2783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2784", "str_2784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2785", "str_2785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2786", "str_2786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2787", "str_2787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2788", "str_2788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2789", "str_2789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_279", "str_279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2790", "str_2790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2791", "str_2791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2792", "str_2792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2793", "str_2793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2794", "str_2794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2795", "str_2795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2796", "str_2796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2797", "str_2797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2798", "str_2798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_24848: StringResource
+  get() = String33.str_24848
+
+@ExperimentalResourceApi
+internal val Res.string.str_24849: StringResource
+  get() = String33.str_24849
+
+@ExperimentalResourceApi
+internal val Res.string.str_2485: StringResource
+  get() = String33.str_2485
+
+@ExperimentalResourceApi
+internal val Res.string.str_24850: StringResource
+  get() = String33.str_24850
+
+@ExperimentalResourceApi
+internal val Res.string.str_24851: StringResource
+  get() = String33.str_24851
+
+@ExperimentalResourceApi
+internal val Res.string.str_24852: StringResource
+  get() = String33.str_24852
+
+@ExperimentalResourceApi
+internal val Res.string.str_24853: StringResource
+  get() = String33.str_24853
+
+@ExperimentalResourceApi
+internal val Res.string.str_24854: StringResource
+  get() = String33.str_24854
+
+@ExperimentalResourceApi
+internal val Res.string.str_24855: StringResource
+  get() = String33.str_24855
+
+@ExperimentalResourceApi
+internal val Res.string.str_24856: StringResource
+  get() = String33.str_24856
+
+@ExperimentalResourceApi
+internal val Res.string.str_24857: StringResource
+  get() = String33.str_24857
+
+@ExperimentalResourceApi
+internal val Res.string.str_24858: StringResource
+  get() = String33.str_24858
+
+@ExperimentalResourceApi
+internal val Res.string.str_24859: StringResource
+  get() = String33.str_24859
+
+@ExperimentalResourceApi
+internal val Res.string.str_2486: StringResource
+  get() = String33.str_2486
+
+@ExperimentalResourceApi
+internal val Res.string.str_24860: StringResource
+  get() = String33.str_24860
+
+@ExperimentalResourceApi
+internal val Res.string.str_24861: StringResource
+  get() = String33.str_24861
+
+@ExperimentalResourceApi
+internal val Res.string.str_24862: StringResource
+  get() = String33.str_24862
+
+@ExperimentalResourceApi
+internal val Res.string.str_24863: StringResource
+  get() = String33.str_24863
+
+@ExperimentalResourceApi
+internal val Res.string.str_24864: StringResource
+  get() = String33.str_24864
+
+@ExperimentalResourceApi
+internal val Res.string.str_24865: StringResource
+  get() = String33.str_24865
+
+@ExperimentalResourceApi
+internal val Res.string.str_24866: StringResource
+  get() = String33.str_24866
+
+@ExperimentalResourceApi
+internal val Res.string.str_24867: StringResource
+  get() = String33.str_24867
+
+@ExperimentalResourceApi
+internal val Res.string.str_24868: StringResource
+  get() = String33.str_24868
+
+@ExperimentalResourceApi
+internal val Res.string.str_24869: StringResource
+  get() = String33.str_24869
+
+@ExperimentalResourceApi
+internal val Res.string.str_2487: StringResource
+  get() = String33.str_2487
+
+@ExperimentalResourceApi
+internal val Res.string.str_24870: StringResource
+  get() = String33.str_24870
+
+@ExperimentalResourceApi
+internal val Res.string.str_24871: StringResource
+  get() = String33.str_24871
+
+@ExperimentalResourceApi
+internal val Res.string.str_24872: StringResource
+  get() = String33.str_24872
+
+@ExperimentalResourceApi
+internal val Res.string.str_24873: StringResource
+  get() = String33.str_24873
+
+@ExperimentalResourceApi
+internal val Res.string.str_24874: StringResource
+  get() = String33.str_24874
+
+@ExperimentalResourceApi
+internal val Res.string.str_24875: StringResource
+  get() = String33.str_24875
+
+@ExperimentalResourceApi
+internal val Res.string.str_24876: StringResource
+  get() = String33.str_24876
+
+@ExperimentalResourceApi
+internal val Res.string.str_24877: StringResource
+  get() = String33.str_24877
+
+@ExperimentalResourceApi
+internal val Res.string.str_24878: StringResource
+  get() = String33.str_24878
+
+@ExperimentalResourceApi
+internal val Res.string.str_24879: StringResource
+  get() = String33.str_24879
+
+@ExperimentalResourceApi
+internal val Res.string.str_2488: StringResource
+  get() = String33.str_2488
+
+@ExperimentalResourceApi
+internal val Res.string.str_24880: StringResource
+  get() = String33.str_24880
+
+@ExperimentalResourceApi
+internal val Res.string.str_24881: StringResource
+  get() = String33.str_24881
+
+@ExperimentalResourceApi
+internal val Res.string.str_24882: StringResource
+  get() = String33.str_24882
+
+@ExperimentalResourceApi
+internal val Res.string.str_24883: StringResource
+  get() = String33.str_24883
+
+@ExperimentalResourceApi
+internal val Res.string.str_24884: StringResource
+  get() = String33.str_24884
+
+@ExperimentalResourceApi
+internal val Res.string.str_24885: StringResource
+  get() = String33.str_24885
+
+@ExperimentalResourceApi
+internal val Res.string.str_24886: StringResource
+  get() = String33.str_24886
+
+@ExperimentalResourceApi
+internal val Res.string.str_24887: StringResource
+  get() = String33.str_24887
+
+@ExperimentalResourceApi
+internal val Res.string.str_24888: StringResource
+  get() = String33.str_24888
+
+@ExperimentalResourceApi
+internal val Res.string.str_24889: StringResource
+  get() = String33.str_24889
+
+@ExperimentalResourceApi
+internal val Res.string.str_2489: StringResource
+  get() = String33.str_2489
+
+@ExperimentalResourceApi
+internal val Res.string.str_24890: StringResource
+  get() = String33.str_24890
+
+@ExperimentalResourceApi
+internal val Res.string.str_24891: StringResource
+  get() = String33.str_24891
+
+@ExperimentalResourceApi
+internal val Res.string.str_24892: StringResource
+  get() = String33.str_24892
+
+@ExperimentalResourceApi
+internal val Res.string.str_24893: StringResource
+  get() = String33.str_24893
+
+@ExperimentalResourceApi
+internal val Res.string.str_24894: StringResource
+  get() = String33.str_24894
+
+@ExperimentalResourceApi
+internal val Res.string.str_24895: StringResource
+  get() = String33.str_24895
+
+@ExperimentalResourceApi
+internal val Res.string.str_24896: StringResource
+  get() = String33.str_24896
+
+@ExperimentalResourceApi
+internal val Res.string.str_24897: StringResource
+  get() = String33.str_24897
+
+@ExperimentalResourceApi
+internal val Res.string.str_24898: StringResource
+  get() = String33.str_24898
+
+@ExperimentalResourceApi
+internal val Res.string.str_24899: StringResource
+  get() = String33.str_24899
+
+@ExperimentalResourceApi
+internal val Res.string.str_249: StringResource
+  get() = String33.str_249
+
+@ExperimentalResourceApi
+internal val Res.string.str_2490: StringResource
+  get() = String33.str_2490
+
+@ExperimentalResourceApi
+internal val Res.string.str_24900: StringResource
+  get() = String33.str_24900
+
+@ExperimentalResourceApi
+internal val Res.string.str_24901: StringResource
+  get() = String33.str_24901
+
+@ExperimentalResourceApi
+internal val Res.string.str_24902: StringResource
+  get() = String33.str_24902
+
+@ExperimentalResourceApi
+internal val Res.string.str_24903: StringResource
+  get() = String33.str_24903
+
+@ExperimentalResourceApi
+internal val Res.string.str_24904: StringResource
+  get() = String33.str_24904
+
+@ExperimentalResourceApi
+internal val Res.string.str_24905: StringResource
+  get() = String33.str_24905
+
+@ExperimentalResourceApi
+internal val Res.string.str_24906: StringResource
+  get() = String33.str_24906
+
+@ExperimentalResourceApi
+internal val Res.string.str_24907: StringResource
+  get() = String33.str_24907
+
+@ExperimentalResourceApi
+internal val Res.string.str_24908: StringResource
+  get() = String33.str_24908
+
+@ExperimentalResourceApi
+internal val Res.string.str_24909: StringResource
+  get() = String33.str_24909
+
+@ExperimentalResourceApi
+internal val Res.string.str_2491: StringResource
+  get() = String33.str_2491
+
+@ExperimentalResourceApi
+internal val Res.string.str_24910: StringResource
+  get() = String33.str_24910
+
+@ExperimentalResourceApi
+internal val Res.string.str_24911: StringResource
+  get() = String33.str_24911
+
+@ExperimentalResourceApi
+internal val Res.string.str_24912: StringResource
+  get() = String33.str_24912
+
+@ExperimentalResourceApi
+internal val Res.string.str_24913: StringResource
+  get() = String33.str_24913
+
+@ExperimentalResourceApi
+internal val Res.string.str_24914: StringResource
+  get() = String33.str_24914
+
+@ExperimentalResourceApi
+internal val Res.string.str_24915: StringResource
+  get() = String33.str_24915
+
+@ExperimentalResourceApi
+internal val Res.string.str_24916: StringResource
+  get() = String33.str_24916
+
+@ExperimentalResourceApi
+internal val Res.string.str_24917: StringResource
+  get() = String33.str_24917
+
+@ExperimentalResourceApi
+internal val Res.string.str_24918: StringResource
+  get() = String33.str_24918
+
+@ExperimentalResourceApi
+internal val Res.string.str_24919: StringResource
+  get() = String33.str_24919
+
+@ExperimentalResourceApi
+internal val Res.string.str_2492: StringResource
+  get() = String33.str_2492
+
+@ExperimentalResourceApi
+internal val Res.string.str_24920: StringResource
+  get() = String33.str_24920
+
+@ExperimentalResourceApi
+internal val Res.string.str_24921: StringResource
+  get() = String33.str_24921
+
+@ExperimentalResourceApi
+internal val Res.string.str_24922: StringResource
+  get() = String33.str_24922
+
+@ExperimentalResourceApi
+internal val Res.string.str_24923: StringResource
+  get() = String33.str_24923
+
+@ExperimentalResourceApi
+internal val Res.string.str_24924: StringResource
+  get() = String33.str_24924
+
+@ExperimentalResourceApi
+internal val Res.string.str_24925: StringResource
+  get() = String33.str_24925
+
+@ExperimentalResourceApi
+internal val Res.string.str_24926: StringResource
+  get() = String33.str_24926
+
+@ExperimentalResourceApi
+internal val Res.string.str_24927: StringResource
+  get() = String33.str_24927
+
+@ExperimentalResourceApi
+internal val Res.string.str_24928: StringResource
+  get() = String33.str_24928
+
+@ExperimentalResourceApi
+internal val Res.string.str_24929: StringResource
+  get() = String33.str_24929
+
+@ExperimentalResourceApi
+internal val Res.string.str_2493: StringResource
+  get() = String33.str_2493
+
+@ExperimentalResourceApi
+internal val Res.string.str_24930: StringResource
+  get() = String33.str_24930
+
+@ExperimentalResourceApi
+internal val Res.string.str_24931: StringResource
+  get() = String33.str_24931
+
+@ExperimentalResourceApi
+internal val Res.string.str_24932: StringResource
+  get() = String33.str_24932
+
+@ExperimentalResourceApi
+internal val Res.string.str_24933: StringResource
+  get() = String33.str_24933
+
+@ExperimentalResourceApi
+internal val Res.string.str_24934: StringResource
+  get() = String33.str_24934
+
+@ExperimentalResourceApi
+internal val Res.string.str_24935: StringResource
+  get() = String33.str_24935
+
+@ExperimentalResourceApi
+internal val Res.string.str_24936: StringResource
+  get() = String33.str_24936
+
+@ExperimentalResourceApi
+internal val Res.string.str_24937: StringResource
+  get() = String33.str_24937
+
+@ExperimentalResourceApi
+internal val Res.string.str_24938: StringResource
+  get() = String33.str_24938
+
+@ExperimentalResourceApi
+internal val Res.string.str_24939: StringResource
+  get() = String33.str_24939
+
+@ExperimentalResourceApi
+internal val Res.string.str_2494: StringResource
+  get() = String33.str_2494
+
+@ExperimentalResourceApi
+internal val Res.string.str_24940: StringResource
+  get() = String33.str_24940
+
+@ExperimentalResourceApi
+internal val Res.string.str_24941: StringResource
+  get() = String33.str_24941
+
+@ExperimentalResourceApi
+internal val Res.string.str_24942: StringResource
+  get() = String33.str_24942
+
+@ExperimentalResourceApi
+internal val Res.string.str_24943: StringResource
+  get() = String33.str_24943
+
+@ExperimentalResourceApi
+internal val Res.string.str_24944: StringResource
+  get() = String33.str_24944
+
+@ExperimentalResourceApi
+internal val Res.string.str_24945: StringResource
+  get() = String33.str_24945
+
+@ExperimentalResourceApi
+internal val Res.string.str_24946: StringResource
+  get() = String33.str_24946
+
+@ExperimentalResourceApi
+internal val Res.string.str_24947: StringResource
+  get() = String33.str_24947
+
+@ExperimentalResourceApi
+internal val Res.string.str_24948: StringResource
+  get() = String33.str_24948
+
+@ExperimentalResourceApi
+internal val Res.string.str_24949: StringResource
+  get() = String33.str_24949
+
+@ExperimentalResourceApi
+internal val Res.string.str_2495: StringResource
+  get() = String33.str_2495
+
+@ExperimentalResourceApi
+internal val Res.string.str_24950: StringResource
+  get() = String33.str_24950
+
+@ExperimentalResourceApi
+internal val Res.string.str_24951: StringResource
+  get() = String33.str_24951
+
+@ExperimentalResourceApi
+internal val Res.string.str_24952: StringResource
+  get() = String33.str_24952
+
+@ExperimentalResourceApi
+internal val Res.string.str_24953: StringResource
+  get() = String33.str_24953
+
+@ExperimentalResourceApi
+internal val Res.string.str_24954: StringResource
+  get() = String33.str_24954
+
+@ExperimentalResourceApi
+internal val Res.string.str_24955: StringResource
+  get() = String33.str_24955
+
+@ExperimentalResourceApi
+internal val Res.string.str_24956: StringResource
+  get() = String33.str_24956
+
+@ExperimentalResourceApi
+internal val Res.string.str_24957: StringResource
+  get() = String33.str_24957
+
+@ExperimentalResourceApi
+internal val Res.string.str_24958: StringResource
+  get() = String33.str_24958
+
+@ExperimentalResourceApi
+internal val Res.string.str_24959: StringResource
+  get() = String33.str_24959
+
+@ExperimentalResourceApi
+internal val Res.string.str_2496: StringResource
+  get() = String33.str_2496
+
+@ExperimentalResourceApi
+internal val Res.string.str_24960: StringResource
+  get() = String33.str_24960
+
+@ExperimentalResourceApi
+internal val Res.string.str_24961: StringResource
+  get() = String33.str_24961
+
+@ExperimentalResourceApi
+internal val Res.string.str_24962: StringResource
+  get() = String33.str_24962
+
+@ExperimentalResourceApi
+internal val Res.string.str_24963: StringResource
+  get() = String33.str_24963
+
+@ExperimentalResourceApi
+internal val Res.string.str_24964: StringResource
+  get() = String33.str_24964
+
+@ExperimentalResourceApi
+internal val Res.string.str_24965: StringResource
+  get() = String33.str_24965
+
+@ExperimentalResourceApi
+internal val Res.string.str_24966: StringResource
+  get() = String33.str_24966
+
+@ExperimentalResourceApi
+internal val Res.string.str_24967: StringResource
+  get() = String33.str_24967
+
+@ExperimentalResourceApi
+internal val Res.string.str_24968: StringResource
+  get() = String33.str_24968
+
+@ExperimentalResourceApi
+internal val Res.string.str_24969: StringResource
+  get() = String33.str_24969
+
+@ExperimentalResourceApi
+internal val Res.string.str_2497: StringResource
+  get() = String33.str_2497
+
+@ExperimentalResourceApi
+internal val Res.string.str_24970: StringResource
+  get() = String33.str_24970
+
+@ExperimentalResourceApi
+internal val Res.string.str_24971: StringResource
+  get() = String33.str_24971
+
+@ExperimentalResourceApi
+internal val Res.string.str_24972: StringResource
+  get() = String33.str_24972
+
+@ExperimentalResourceApi
+internal val Res.string.str_24973: StringResource
+  get() = String33.str_24973
+
+@ExperimentalResourceApi
+internal val Res.string.str_24974: StringResource
+  get() = String33.str_24974
+
+@ExperimentalResourceApi
+internal val Res.string.str_24975: StringResource
+  get() = String33.str_24975
+
+@ExperimentalResourceApi
+internal val Res.string.str_24976: StringResource
+  get() = String33.str_24976
+
+@ExperimentalResourceApi
+internal val Res.string.str_24977: StringResource
+  get() = String33.str_24977
+
+@ExperimentalResourceApi
+internal val Res.string.str_24978: StringResource
+  get() = String33.str_24978
+
+@ExperimentalResourceApi
+internal val Res.string.str_24979: StringResource
+  get() = String33.str_24979
+
+@ExperimentalResourceApi
+internal val Res.string.str_2498: StringResource
+  get() = String33.str_2498
+
+@ExperimentalResourceApi
+internal val Res.string.str_24980: StringResource
+  get() = String33.str_24980
+
+@ExperimentalResourceApi
+internal val Res.string.str_24981: StringResource
+  get() = String33.str_24981
+
+@ExperimentalResourceApi
+internal val Res.string.str_24982: StringResource
+  get() = String33.str_24982
+
+@ExperimentalResourceApi
+internal val Res.string.str_24983: StringResource
+  get() = String33.str_24983
+
+@ExperimentalResourceApi
+internal val Res.string.str_24984: StringResource
+  get() = String33.str_24984
+
+@ExperimentalResourceApi
+internal val Res.string.str_24985: StringResource
+  get() = String33.str_24985
+
+@ExperimentalResourceApi
+internal val Res.string.str_24986: StringResource
+  get() = String33.str_24986
+
+@ExperimentalResourceApi
+internal val Res.string.str_24987: StringResource
+  get() = String33.str_24987
+
+@ExperimentalResourceApi
+internal val Res.string.str_24988: StringResource
+  get() = String33.str_24988
+
+@ExperimentalResourceApi
+internal val Res.string.str_24989: StringResource
+  get() = String33.str_24989
+
+@ExperimentalResourceApi
+internal val Res.string.str_2499: StringResource
+  get() = String33.str_2499
+
+@ExperimentalResourceApi
+internal val Res.string.str_24990: StringResource
+  get() = String33.str_24990
+
+@ExperimentalResourceApi
+internal val Res.string.str_24991: StringResource
+  get() = String33.str_24991
+
+@ExperimentalResourceApi
+internal val Res.string.str_24992: StringResource
+  get() = String33.str_24992
+
+@ExperimentalResourceApi
+internal val Res.string.str_24993: StringResource
+  get() = String33.str_24993
+
+@ExperimentalResourceApi
+internal val Res.string.str_24994: StringResource
+  get() = String33.str_24994
+
+@ExperimentalResourceApi
+internal val Res.string.str_24995: StringResource
+  get() = String33.str_24995
+
+@ExperimentalResourceApi
+internal val Res.string.str_24996: StringResource
+  get() = String33.str_24996
+
+@ExperimentalResourceApi
+internal val Res.string.str_24997: StringResource
+  get() = String33.str_24997
+
+@ExperimentalResourceApi
+internal val Res.string.str_24998: StringResource
+  get() = String33.str_24998
+
+@ExperimentalResourceApi
+internal val Res.string.str_24999: StringResource
+  get() = String33.str_24999
+
+@ExperimentalResourceApi
+internal val Res.string.str_25: StringResource
+  get() = String33.str_25
+
+@ExperimentalResourceApi
+internal val Res.string.str_250: StringResource
+  get() = String33.str_250
+
+@ExperimentalResourceApi
+internal val Res.string.str_2500: StringResource
+  get() = String33.str_2500
+
+@ExperimentalResourceApi
+internal val Res.string.str_2501: StringResource
+  get() = String33.str_2501
+
+@ExperimentalResourceApi
+internal val Res.string.str_2502: StringResource
+  get() = String33.str_2502
+
+@ExperimentalResourceApi
+internal val Res.string.str_2503: StringResource
+  get() = String33.str_2503
+
+@ExperimentalResourceApi
+internal val Res.string.str_2504: StringResource
+  get() = String33.str_2504
+
+@ExperimentalResourceApi
+internal val Res.string.str_2505: StringResource
+  get() = String33.str_2505
+
+@ExperimentalResourceApi
+internal val Res.string.str_2506: StringResource
+  get() = String33.str_2506
+
+@ExperimentalResourceApi
+internal val Res.string.str_2507: StringResource
+  get() = String33.str_2507
+
+@ExperimentalResourceApi
+internal val Res.string.str_2508: StringResource
+  get() = String33.str_2508
+
+@ExperimentalResourceApi
+internal val Res.string.str_2509: StringResource
+  get() = String33.str_2509
+
+@ExperimentalResourceApi
+internal val Res.string.str_251: StringResource
+  get() = String33.str_251
+
+@ExperimentalResourceApi
+internal val Res.string.str_2510: StringResource
+  get() = String33.str_2510
+
+@ExperimentalResourceApi
+internal val Res.string.str_2511: StringResource
+  get() = String33.str_2511
+
+@ExperimentalResourceApi
+internal val Res.string.str_2512: StringResource
+  get() = String33.str_2512
+
+@ExperimentalResourceApi
+internal val Res.string.str_2513: StringResource
+  get() = String33.str_2513
+
+@ExperimentalResourceApi
+internal val Res.string.str_2514: StringResource
+  get() = String33.str_2514
+
+@ExperimentalResourceApi
+internal val Res.string.str_2515: StringResource
+  get() = String33.str_2515
+
+@ExperimentalResourceApi
+internal val Res.string.str_2516: StringResource
+  get() = String33.str_2516
+
+@ExperimentalResourceApi
+internal val Res.string.str_2517: StringResource
+  get() = String33.str_2517
+
+@ExperimentalResourceApi
+internal val Res.string.str_2518: StringResource
+  get() = String33.str_2518
+
+@ExperimentalResourceApi
+internal val Res.string.str_2519: StringResource
+  get() = String33.str_2519
+
+@ExperimentalResourceApi
+internal val Res.string.str_252: StringResource
+  get() = String33.str_252
+
+@ExperimentalResourceApi
+internal val Res.string.str_2520: StringResource
+  get() = String33.str_2520
+
+@ExperimentalResourceApi
+internal val Res.string.str_2521: StringResource
+  get() = String33.str_2521
+
+@ExperimentalResourceApi
+internal val Res.string.str_2522: StringResource
+  get() = String33.str_2522
+
+@ExperimentalResourceApi
+internal val Res.string.str_2523: StringResource
+  get() = String33.str_2523
+
+@ExperimentalResourceApi
+internal val Res.string.str_2524: StringResource
+  get() = String33.str_2524
+
+@ExperimentalResourceApi
+internal val Res.string.str_2525: StringResource
+  get() = String33.str_2525
+
+@ExperimentalResourceApi
+internal val Res.string.str_2526: StringResource
+  get() = String33.str_2526
+
+@ExperimentalResourceApi
+internal val Res.string.str_2527: StringResource
+  get() = String33.str_2527
+
+@ExperimentalResourceApi
+internal val Res.string.str_2528: StringResource
+  get() = String33.str_2528
+
+@ExperimentalResourceApi
+internal val Res.string.str_2529: StringResource
+  get() = String33.str_2529
+
+@ExperimentalResourceApi
+internal val Res.string.str_253: StringResource
+  get() = String33.str_253
+
+@ExperimentalResourceApi
+internal val Res.string.str_2530: StringResource
+  get() = String33.str_2530
+
+@ExperimentalResourceApi
+internal val Res.string.str_2531: StringResource
+  get() = String33.str_2531
+
+@ExperimentalResourceApi
+internal val Res.string.str_2532: StringResource
+  get() = String33.str_2532
+
+@ExperimentalResourceApi
+internal val Res.string.str_2533: StringResource
+  get() = String33.str_2533
+
+@ExperimentalResourceApi
+internal val Res.string.str_2534: StringResource
+  get() = String33.str_2534
+
+@ExperimentalResourceApi
+internal val Res.string.str_2535: StringResource
+  get() = String33.str_2535
+
+@ExperimentalResourceApi
+internal val Res.string.str_2536: StringResource
+  get() = String33.str_2536
+
+@ExperimentalResourceApi
+internal val Res.string.str_2537: StringResource
+  get() = String33.str_2537
+
+@ExperimentalResourceApi
+internal val Res.string.str_2538: StringResource
+  get() = String33.str_2538
+
+@ExperimentalResourceApi
+internal val Res.string.str_2539: StringResource
+  get() = String33.str_2539
+
+@ExperimentalResourceApi
+internal val Res.string.str_254: StringResource
+  get() = String33.str_254
+
+@ExperimentalResourceApi
+internal val Res.string.str_2540: StringResource
+  get() = String33.str_2540
+
+@ExperimentalResourceApi
+internal val Res.string.str_2541: StringResource
+  get() = String33.str_2541
+
+@ExperimentalResourceApi
+internal val Res.string.str_2542: StringResource
+  get() = String33.str_2542
+
+@ExperimentalResourceApi
+internal val Res.string.str_2543: StringResource
+  get() = String33.str_2543
+
+@ExperimentalResourceApi
+internal val Res.string.str_2544: StringResource
+  get() = String33.str_2544
+
+@ExperimentalResourceApi
+internal val Res.string.str_2545: StringResource
+  get() = String33.str_2545
+
+@ExperimentalResourceApi
+internal val Res.string.str_2546: StringResource
+  get() = String33.str_2546
+
+@ExperimentalResourceApi
+internal val Res.string.str_2547: StringResource
+  get() = String33.str_2547
+
+@ExperimentalResourceApi
+internal val Res.string.str_2548: StringResource
+  get() = String33.str_2548
+
+@ExperimentalResourceApi
+internal val Res.string.str_2549: StringResource
+  get() = String33.str_2549
+
+@ExperimentalResourceApi
+internal val Res.string.str_255: StringResource
+  get() = String33.str_255
+
+@ExperimentalResourceApi
+internal val Res.string.str_2550: StringResource
+  get() = String33.str_2550
+
+@ExperimentalResourceApi
+internal val Res.string.str_2551: StringResource
+  get() = String33.str_2551
+
+@ExperimentalResourceApi
+internal val Res.string.str_2552: StringResource
+  get() = String33.str_2552
+
+@ExperimentalResourceApi
+internal val Res.string.str_2553: StringResource
+  get() = String33.str_2553
+
+@ExperimentalResourceApi
+internal val Res.string.str_2554: StringResource
+  get() = String33.str_2554
+
+@ExperimentalResourceApi
+internal val Res.string.str_2555: StringResource
+  get() = String33.str_2555
+
+@ExperimentalResourceApi
+internal val Res.string.str_2556: StringResource
+  get() = String33.str_2556
+
+@ExperimentalResourceApi
+internal val Res.string.str_2557: StringResource
+  get() = String33.str_2557
+
+@ExperimentalResourceApi
+internal val Res.string.str_2558: StringResource
+  get() = String33.str_2558
+
+@ExperimentalResourceApi
+internal val Res.string.str_2559: StringResource
+  get() = String33.str_2559
+
+@ExperimentalResourceApi
+internal val Res.string.str_256: StringResource
+  get() = String33.str_256
+
+@ExperimentalResourceApi
+internal val Res.string.str_2560: StringResource
+  get() = String33.str_2560
+
+@ExperimentalResourceApi
+internal val Res.string.str_2561: StringResource
+  get() = String33.str_2561
+
+@ExperimentalResourceApi
+internal val Res.string.str_2562: StringResource
+  get() = String33.str_2562
+
+@ExperimentalResourceApi
+internal val Res.string.str_2563: StringResource
+  get() = String33.str_2563
+
+@ExperimentalResourceApi
+internal val Res.string.str_2564: StringResource
+  get() = String33.str_2564
+
+@ExperimentalResourceApi
+internal val Res.string.str_2565: StringResource
+  get() = String33.str_2565
+
+@ExperimentalResourceApi
+internal val Res.string.str_2566: StringResource
+  get() = String33.str_2566
+
+@ExperimentalResourceApi
+internal val Res.string.str_2567: StringResource
+  get() = String33.str_2567
+
+@ExperimentalResourceApi
+internal val Res.string.str_2568: StringResource
+  get() = String33.str_2568
+
+@ExperimentalResourceApi
+internal val Res.string.str_2569: StringResource
+  get() = String33.str_2569
+
+@ExperimentalResourceApi
+internal val Res.string.str_257: StringResource
+  get() = String33.str_257
+
+@ExperimentalResourceApi
+internal val Res.string.str_2570: StringResource
+  get() = String33.str_2570
+
+@ExperimentalResourceApi
+internal val Res.string.str_2571: StringResource
+  get() = String33.str_2571
+
+@ExperimentalResourceApi
+internal val Res.string.str_2572: StringResource
+  get() = String33.str_2572
+
+@ExperimentalResourceApi
+internal val Res.string.str_2573: StringResource
+  get() = String33.str_2573
+
+@ExperimentalResourceApi
+internal val Res.string.str_2574: StringResource
+  get() = String33.str_2574
+
+@ExperimentalResourceApi
+internal val Res.string.str_2575: StringResource
+  get() = String33.str_2575
+
+@ExperimentalResourceApi
+internal val Res.string.str_2576: StringResource
+  get() = String33.str_2576
+
+@ExperimentalResourceApi
+internal val Res.string.str_2577: StringResource
+  get() = String33.str_2577
+
+@ExperimentalResourceApi
+internal val Res.string.str_2578: StringResource
+  get() = String33.str_2578
+
+@ExperimentalResourceApi
+internal val Res.string.str_2579: StringResource
+  get() = String33.str_2579
+
+@ExperimentalResourceApi
+internal val Res.string.str_258: StringResource
+  get() = String33.str_258
+
+@ExperimentalResourceApi
+internal val Res.string.str_2580: StringResource
+  get() = String33.str_2580
+
+@ExperimentalResourceApi
+internal val Res.string.str_2581: StringResource
+  get() = String33.str_2581
+
+@ExperimentalResourceApi
+internal val Res.string.str_2582: StringResource
+  get() = String33.str_2582
+
+@ExperimentalResourceApi
+internal val Res.string.str_2583: StringResource
+  get() = String33.str_2583
+
+@ExperimentalResourceApi
+internal val Res.string.str_2584: StringResource
+  get() = String33.str_2584
+
+@ExperimentalResourceApi
+internal val Res.string.str_2585: StringResource
+  get() = String33.str_2585
+
+@ExperimentalResourceApi
+internal val Res.string.str_2586: StringResource
+  get() = String33.str_2586
+
+@ExperimentalResourceApi
+internal val Res.string.str_2587: StringResource
+  get() = String33.str_2587
+
+@ExperimentalResourceApi
+internal val Res.string.str_2588: StringResource
+  get() = String33.str_2588
+
+@ExperimentalResourceApi
+internal val Res.string.str_2589: StringResource
+  get() = String33.str_2589
+
+@ExperimentalResourceApi
+internal val Res.string.str_259: StringResource
+  get() = String33.str_259
+
+@ExperimentalResourceApi
+internal val Res.string.str_2590: StringResource
+  get() = String33.str_2590
+
+@ExperimentalResourceApi
+internal val Res.string.str_2591: StringResource
+  get() = String33.str_2591
+
+@ExperimentalResourceApi
+internal val Res.string.str_2592: StringResource
+  get() = String33.str_2592
+
+@ExperimentalResourceApi
+internal val Res.string.str_2593: StringResource
+  get() = String33.str_2593
+
+@ExperimentalResourceApi
+internal val Res.string.str_2594: StringResource
+  get() = String33.str_2594
+
+@ExperimentalResourceApi
+internal val Res.string.str_2595: StringResource
+  get() = String33.str_2595
+
+@ExperimentalResourceApi
+internal val Res.string.str_2596: StringResource
+  get() = String33.str_2596
+
+@ExperimentalResourceApi
+internal val Res.string.str_2597: StringResource
+  get() = String33.str_2597
+
+@ExperimentalResourceApi
+internal val Res.string.str_2598: StringResource
+  get() = String33.str_2598
+
+@ExperimentalResourceApi
+internal val Res.string.str_2599: StringResource
+  get() = String33.str_2599
+
+@ExperimentalResourceApi
+internal val Res.string.str_26: StringResource
+  get() = String33.str_26
+
+@ExperimentalResourceApi
+internal val Res.string.str_260: StringResource
+  get() = String33.str_260
+
+@ExperimentalResourceApi
+internal val Res.string.str_2600: StringResource
+  get() = String33.str_2600
+
+@ExperimentalResourceApi
+internal val Res.string.str_2601: StringResource
+  get() = String33.str_2601
+
+@ExperimentalResourceApi
+internal val Res.string.str_2602: StringResource
+  get() = String33.str_2602
+
+@ExperimentalResourceApi
+internal val Res.string.str_2603: StringResource
+  get() = String33.str_2603
+
+@ExperimentalResourceApi
+internal val Res.string.str_2604: StringResource
+  get() = String33.str_2604
+
+@ExperimentalResourceApi
+internal val Res.string.str_2605: StringResource
+  get() = String33.str_2605
+
+@ExperimentalResourceApi
+internal val Res.string.str_2606: StringResource
+  get() = String33.str_2606
+
+@ExperimentalResourceApi
+internal val Res.string.str_2607: StringResource
+  get() = String33.str_2607
+
+@ExperimentalResourceApi
+internal val Res.string.str_2608: StringResource
+  get() = String33.str_2608
+
+@ExperimentalResourceApi
+internal val Res.string.str_2609: StringResource
+  get() = String33.str_2609
+
+@ExperimentalResourceApi
+internal val Res.string.str_261: StringResource
+  get() = String33.str_261
+
+@ExperimentalResourceApi
+internal val Res.string.str_2610: StringResource
+  get() = String33.str_2610
+
+@ExperimentalResourceApi
+internal val Res.string.str_2611: StringResource
+  get() = String33.str_2611
+
+@ExperimentalResourceApi
+internal val Res.string.str_2612: StringResource
+  get() = String33.str_2612
+
+@ExperimentalResourceApi
+internal val Res.string.str_2613: StringResource
+  get() = String33.str_2613
+
+@ExperimentalResourceApi
+internal val Res.string.str_2614: StringResource
+  get() = String33.str_2614
+
+@ExperimentalResourceApi
+internal val Res.string.str_2615: StringResource
+  get() = String33.str_2615
+
+@ExperimentalResourceApi
+internal val Res.string.str_2616: StringResource
+  get() = String33.str_2616
+
+@ExperimentalResourceApi
+internal val Res.string.str_2617: StringResource
+  get() = String33.str_2617
+
+@ExperimentalResourceApi
+internal val Res.string.str_2618: StringResource
+  get() = String33.str_2618
+
+@ExperimentalResourceApi
+internal val Res.string.str_2619: StringResource
+  get() = String33.str_2619
+
+@ExperimentalResourceApi
+internal val Res.string.str_262: StringResource
+  get() = String33.str_262
+
+@ExperimentalResourceApi
+internal val Res.string.str_2620: StringResource
+  get() = String33.str_2620
+
+@ExperimentalResourceApi
+internal val Res.string.str_2621: StringResource
+  get() = String33.str_2621
+
+@ExperimentalResourceApi
+internal val Res.string.str_2622: StringResource
+  get() = String33.str_2622
+
+@ExperimentalResourceApi
+internal val Res.string.str_2623: StringResource
+  get() = String33.str_2623
+
+@ExperimentalResourceApi
+internal val Res.string.str_2624: StringResource
+  get() = String33.str_2624
+
+@ExperimentalResourceApi
+internal val Res.string.str_2625: StringResource
+  get() = String33.str_2625
+
+@ExperimentalResourceApi
+internal val Res.string.str_2626: StringResource
+  get() = String33.str_2626
+
+@ExperimentalResourceApi
+internal val Res.string.str_2627: StringResource
+  get() = String33.str_2627
+
+@ExperimentalResourceApi
+internal val Res.string.str_2628: StringResource
+  get() = String33.str_2628
+
+@ExperimentalResourceApi
+internal val Res.string.str_2629: StringResource
+  get() = String33.str_2629
+
+@ExperimentalResourceApi
+internal val Res.string.str_263: StringResource
+  get() = String33.str_263
+
+@ExperimentalResourceApi
+internal val Res.string.str_2630: StringResource
+  get() = String33.str_2630
+
+@ExperimentalResourceApi
+internal val Res.string.str_2631: StringResource
+  get() = String33.str_2631
+
+@ExperimentalResourceApi
+internal val Res.string.str_2632: StringResource
+  get() = String33.str_2632
+
+@ExperimentalResourceApi
+internal val Res.string.str_2633: StringResource
+  get() = String33.str_2633
+
+@ExperimentalResourceApi
+internal val Res.string.str_2634: StringResource
+  get() = String33.str_2634
+
+@ExperimentalResourceApi
+internal val Res.string.str_2635: StringResource
+  get() = String33.str_2635
+
+@ExperimentalResourceApi
+internal val Res.string.str_2636: StringResource
+  get() = String33.str_2636
+
+@ExperimentalResourceApi
+internal val Res.string.str_2637: StringResource
+  get() = String33.str_2637
+
+@ExperimentalResourceApi
+internal val Res.string.str_2638: StringResource
+  get() = String33.str_2638
+
+@ExperimentalResourceApi
+internal val Res.string.str_2639: StringResource
+  get() = String33.str_2639
+
+@ExperimentalResourceApi
+internal val Res.string.str_264: StringResource
+  get() = String33.str_264
+
+@ExperimentalResourceApi
+internal val Res.string.str_2640: StringResource
+  get() = String33.str_2640
+
+@ExperimentalResourceApi
+internal val Res.string.str_2641: StringResource
+  get() = String33.str_2641
+
+@ExperimentalResourceApi
+internal val Res.string.str_2642: StringResource
+  get() = String33.str_2642
+
+@ExperimentalResourceApi
+internal val Res.string.str_2643: StringResource
+  get() = String33.str_2643
+
+@ExperimentalResourceApi
+internal val Res.string.str_2644: StringResource
+  get() = String33.str_2644
+
+@ExperimentalResourceApi
+internal val Res.string.str_2645: StringResource
+  get() = String33.str_2645
+
+@ExperimentalResourceApi
+internal val Res.string.str_2646: StringResource
+  get() = String33.str_2646
+
+@ExperimentalResourceApi
+internal val Res.string.str_2647: StringResource
+  get() = String33.str_2647
+
+@ExperimentalResourceApi
+internal val Res.string.str_2648: StringResource
+  get() = String33.str_2648
+
+@ExperimentalResourceApi
+internal val Res.string.str_2649: StringResource
+  get() = String33.str_2649
+
+@ExperimentalResourceApi
+internal val Res.string.str_265: StringResource
+  get() = String33.str_265
+
+@ExperimentalResourceApi
+internal val Res.string.str_2650: StringResource
+  get() = String33.str_2650
+
+@ExperimentalResourceApi
+internal val Res.string.str_2651: StringResource
+  get() = String33.str_2651
+
+@ExperimentalResourceApi
+internal val Res.string.str_2652: StringResource
+  get() = String33.str_2652
+
+@ExperimentalResourceApi
+internal val Res.string.str_2653: StringResource
+  get() = String33.str_2653
+
+@ExperimentalResourceApi
+internal val Res.string.str_2654: StringResource
+  get() = String33.str_2654
+
+@ExperimentalResourceApi
+internal val Res.string.str_2655: StringResource
+  get() = String33.str_2655
+
+@ExperimentalResourceApi
+internal val Res.string.str_2656: StringResource
+  get() = String33.str_2656
+
+@ExperimentalResourceApi
+internal val Res.string.str_2657: StringResource
+  get() = String33.str_2657
+
+@ExperimentalResourceApi
+internal val Res.string.str_2658: StringResource
+  get() = String33.str_2658
+
+@ExperimentalResourceApi
+internal val Res.string.str_2659: StringResource
+  get() = String33.str_2659
+
+@ExperimentalResourceApi
+internal val Res.string.str_266: StringResource
+  get() = String33.str_266
+
+@ExperimentalResourceApi
+internal val Res.string.str_2660: StringResource
+  get() = String33.str_2660
+
+@ExperimentalResourceApi
+internal val Res.string.str_2661: StringResource
+  get() = String33.str_2661
+
+@ExperimentalResourceApi
+internal val Res.string.str_2662: StringResource
+  get() = String33.str_2662
+
+@ExperimentalResourceApi
+internal val Res.string.str_2663: StringResource
+  get() = String33.str_2663
+
+@ExperimentalResourceApi
+internal val Res.string.str_2664: StringResource
+  get() = String33.str_2664
+
+@ExperimentalResourceApi
+internal val Res.string.str_2665: StringResource
+  get() = String33.str_2665
+
+@ExperimentalResourceApi
+internal val Res.string.str_2666: StringResource
+  get() = String33.str_2666
+
+@ExperimentalResourceApi
+internal val Res.string.str_2667: StringResource
+  get() = String33.str_2667
+
+@ExperimentalResourceApi
+internal val Res.string.str_2668: StringResource
+  get() = String33.str_2668
+
+@ExperimentalResourceApi
+internal val Res.string.str_2669: StringResource
+  get() = String33.str_2669
+
+@ExperimentalResourceApi
+internal val Res.string.str_267: StringResource
+  get() = String33.str_267
+
+@ExperimentalResourceApi
+internal val Res.string.str_2670: StringResource
+  get() = String33.str_2670
+
+@ExperimentalResourceApi
+internal val Res.string.str_2671: StringResource
+  get() = String33.str_2671
+
+@ExperimentalResourceApi
+internal val Res.string.str_2672: StringResource
+  get() = String33.str_2672
+
+@ExperimentalResourceApi
+internal val Res.string.str_2673: StringResource
+  get() = String33.str_2673
+
+@ExperimentalResourceApi
+internal val Res.string.str_2674: StringResource
+  get() = String33.str_2674
+
+@ExperimentalResourceApi
+internal val Res.string.str_2675: StringResource
+  get() = String33.str_2675
+
+@ExperimentalResourceApi
+internal val Res.string.str_2676: StringResource
+  get() = String33.str_2676
+
+@ExperimentalResourceApi
+internal val Res.string.str_2677: StringResource
+  get() = String33.str_2677
+
+@ExperimentalResourceApi
+internal val Res.string.str_2678: StringResource
+  get() = String33.str_2678
+
+@ExperimentalResourceApi
+internal val Res.string.str_2679: StringResource
+  get() = String33.str_2679
+
+@ExperimentalResourceApi
+internal val Res.string.str_268: StringResource
+  get() = String33.str_268
+
+@ExperimentalResourceApi
+internal val Res.string.str_2680: StringResource
+  get() = String33.str_2680
+
+@ExperimentalResourceApi
+internal val Res.string.str_2681: StringResource
+  get() = String33.str_2681
+
+@ExperimentalResourceApi
+internal val Res.string.str_2682: StringResource
+  get() = String33.str_2682
+
+@ExperimentalResourceApi
+internal val Res.string.str_2683: StringResource
+  get() = String33.str_2683
+
+@ExperimentalResourceApi
+internal val Res.string.str_2684: StringResource
+  get() = String33.str_2684
+
+@ExperimentalResourceApi
+internal val Res.string.str_2685: StringResource
+  get() = String33.str_2685
+
+@ExperimentalResourceApi
+internal val Res.string.str_2686: StringResource
+  get() = String33.str_2686
+
+@ExperimentalResourceApi
+internal val Res.string.str_2687: StringResource
+  get() = String33.str_2687
+
+@ExperimentalResourceApi
+internal val Res.string.str_2688: StringResource
+  get() = String33.str_2688
+
+@ExperimentalResourceApi
+internal val Res.string.str_2689: StringResource
+  get() = String33.str_2689
+
+@ExperimentalResourceApi
+internal val Res.string.str_269: StringResource
+  get() = String33.str_269
+
+@ExperimentalResourceApi
+internal val Res.string.str_2690: StringResource
+  get() = String33.str_2690
+
+@ExperimentalResourceApi
+internal val Res.string.str_2691: StringResource
+  get() = String33.str_2691
+
+@ExperimentalResourceApi
+internal val Res.string.str_2692: StringResource
+  get() = String33.str_2692
+
+@ExperimentalResourceApi
+internal val Res.string.str_2693: StringResource
+  get() = String33.str_2693
+
+@ExperimentalResourceApi
+internal val Res.string.str_2694: StringResource
+  get() = String33.str_2694
+
+@ExperimentalResourceApi
+internal val Res.string.str_2695: StringResource
+  get() = String33.str_2695
+
+@ExperimentalResourceApi
+internal val Res.string.str_2696: StringResource
+  get() = String33.str_2696
+
+@ExperimentalResourceApi
+internal val Res.string.str_2697: StringResource
+  get() = String33.str_2697
+
+@ExperimentalResourceApi
+internal val Res.string.str_2698: StringResource
+  get() = String33.str_2698
+
+@ExperimentalResourceApi
+internal val Res.string.str_2699: StringResource
+  get() = String33.str_2699
+
+@ExperimentalResourceApi
+internal val Res.string.str_27: StringResource
+  get() = String33.str_27
+
+@ExperimentalResourceApi
+internal val Res.string.str_270: StringResource
+  get() = String33.str_270
+
+@ExperimentalResourceApi
+internal val Res.string.str_2700: StringResource
+  get() = String33.str_2700
+
+@ExperimentalResourceApi
+internal val Res.string.str_2701: StringResource
+  get() = String33.str_2701
+
+@ExperimentalResourceApi
+internal val Res.string.str_2702: StringResource
+  get() = String33.str_2702
+
+@ExperimentalResourceApi
+internal val Res.string.str_2703: StringResource
+  get() = String33.str_2703
+
+@ExperimentalResourceApi
+internal val Res.string.str_2704: StringResource
+  get() = String33.str_2704
+
+@ExperimentalResourceApi
+internal val Res.string.str_2705: StringResource
+  get() = String33.str_2705
+
+@ExperimentalResourceApi
+internal val Res.string.str_2706: StringResource
+  get() = String33.str_2706
+
+@ExperimentalResourceApi
+internal val Res.string.str_2707: StringResource
+  get() = String33.str_2707
+
+@ExperimentalResourceApi
+internal val Res.string.str_2708: StringResource
+  get() = String33.str_2708
+
+@ExperimentalResourceApi
+internal val Res.string.str_2709: StringResource
+  get() = String33.str_2709
+
+@ExperimentalResourceApi
+internal val Res.string.str_271: StringResource
+  get() = String33.str_271
+
+@ExperimentalResourceApi
+internal val Res.string.str_2710: StringResource
+  get() = String33.str_2710
+
+@ExperimentalResourceApi
+internal val Res.string.str_2711: StringResource
+  get() = String33.str_2711
+
+@ExperimentalResourceApi
+internal val Res.string.str_2712: StringResource
+  get() = String33.str_2712
+
+@ExperimentalResourceApi
+internal val Res.string.str_2713: StringResource
+  get() = String33.str_2713
+
+@ExperimentalResourceApi
+internal val Res.string.str_2714: StringResource
+  get() = String33.str_2714
+
+@ExperimentalResourceApi
+internal val Res.string.str_2715: StringResource
+  get() = String33.str_2715
+
+@ExperimentalResourceApi
+internal val Res.string.str_2716: StringResource
+  get() = String33.str_2716
+
+@ExperimentalResourceApi
+internal val Res.string.str_2717: StringResource
+  get() = String33.str_2717
+
+@ExperimentalResourceApi
+internal val Res.string.str_2718: StringResource
+  get() = String33.str_2718
+
+@ExperimentalResourceApi
+internal val Res.string.str_2719: StringResource
+  get() = String33.str_2719
+
+@ExperimentalResourceApi
+internal val Res.string.str_272: StringResource
+  get() = String33.str_272
+
+@ExperimentalResourceApi
+internal val Res.string.str_2720: StringResource
+  get() = String33.str_2720
+
+@ExperimentalResourceApi
+internal val Res.string.str_2721: StringResource
+  get() = String33.str_2721
+
+@ExperimentalResourceApi
+internal val Res.string.str_2722: StringResource
+  get() = String33.str_2722
+
+@ExperimentalResourceApi
+internal val Res.string.str_2723: StringResource
+  get() = String33.str_2723
+
+@ExperimentalResourceApi
+internal val Res.string.str_2724: StringResource
+  get() = String33.str_2724
+
+@ExperimentalResourceApi
+internal val Res.string.str_2725: StringResource
+  get() = String33.str_2725
+
+@ExperimentalResourceApi
+internal val Res.string.str_2726: StringResource
+  get() = String33.str_2726
+
+@ExperimentalResourceApi
+internal val Res.string.str_2727: StringResource
+  get() = String33.str_2727
+
+@ExperimentalResourceApi
+internal val Res.string.str_2728: StringResource
+  get() = String33.str_2728
+
+@ExperimentalResourceApi
+internal val Res.string.str_2729: StringResource
+  get() = String33.str_2729
+
+@ExperimentalResourceApi
+internal val Res.string.str_273: StringResource
+  get() = String33.str_273
+
+@ExperimentalResourceApi
+internal val Res.string.str_2730: StringResource
+  get() = String33.str_2730
+
+@ExperimentalResourceApi
+internal val Res.string.str_2731: StringResource
+  get() = String33.str_2731
+
+@ExperimentalResourceApi
+internal val Res.string.str_2732: StringResource
+  get() = String33.str_2732
+
+@ExperimentalResourceApi
+internal val Res.string.str_2733: StringResource
+  get() = String33.str_2733
+
+@ExperimentalResourceApi
+internal val Res.string.str_2734: StringResource
+  get() = String33.str_2734
+
+@ExperimentalResourceApi
+internal val Res.string.str_2735: StringResource
+  get() = String33.str_2735
+
+@ExperimentalResourceApi
+internal val Res.string.str_2736: StringResource
+  get() = String33.str_2736
+
+@ExperimentalResourceApi
+internal val Res.string.str_2737: StringResource
+  get() = String33.str_2737
+
+@ExperimentalResourceApi
+internal val Res.string.str_2738: StringResource
+  get() = String33.str_2738
+
+@ExperimentalResourceApi
+internal val Res.string.str_2739: StringResource
+  get() = String33.str_2739
+
+@ExperimentalResourceApi
+internal val Res.string.str_274: StringResource
+  get() = String33.str_274
+
+@ExperimentalResourceApi
+internal val Res.string.str_2740: StringResource
+  get() = String33.str_2740
+
+@ExperimentalResourceApi
+internal val Res.string.str_2741: StringResource
+  get() = String33.str_2741
+
+@ExperimentalResourceApi
+internal val Res.string.str_2742: StringResource
+  get() = String33.str_2742
+
+@ExperimentalResourceApi
+internal val Res.string.str_2743: StringResource
+  get() = String33.str_2743
+
+@ExperimentalResourceApi
+internal val Res.string.str_2744: StringResource
+  get() = String33.str_2744
+
+@ExperimentalResourceApi
+internal val Res.string.str_2745: StringResource
+  get() = String33.str_2745
+
+@ExperimentalResourceApi
+internal val Res.string.str_2746: StringResource
+  get() = String33.str_2746
+
+@ExperimentalResourceApi
+internal val Res.string.str_2747: StringResource
+  get() = String33.str_2747
+
+@ExperimentalResourceApi
+internal val Res.string.str_2748: StringResource
+  get() = String33.str_2748
+
+@ExperimentalResourceApi
+internal val Res.string.str_2749: StringResource
+  get() = String33.str_2749
+
+@ExperimentalResourceApi
+internal val Res.string.str_275: StringResource
+  get() = String33.str_275
+
+@ExperimentalResourceApi
+internal val Res.string.str_2750: StringResource
+  get() = String33.str_2750
+
+@ExperimentalResourceApi
+internal val Res.string.str_2751: StringResource
+  get() = String33.str_2751
+
+@ExperimentalResourceApi
+internal val Res.string.str_2752: StringResource
+  get() = String33.str_2752
+
+@ExperimentalResourceApi
+internal val Res.string.str_2753: StringResource
+  get() = String33.str_2753
+
+@ExperimentalResourceApi
+internal val Res.string.str_2754: StringResource
+  get() = String33.str_2754
+
+@ExperimentalResourceApi
+internal val Res.string.str_2755: StringResource
+  get() = String33.str_2755
+
+@ExperimentalResourceApi
+internal val Res.string.str_2756: StringResource
+  get() = String33.str_2756
+
+@ExperimentalResourceApi
+internal val Res.string.str_2757: StringResource
+  get() = String33.str_2757
+
+@ExperimentalResourceApi
+internal val Res.string.str_2758: StringResource
+  get() = String33.str_2758
+
+@ExperimentalResourceApi
+internal val Res.string.str_2759: StringResource
+  get() = String33.str_2759
+
+@ExperimentalResourceApi
+internal val Res.string.str_276: StringResource
+  get() = String33.str_276
+
+@ExperimentalResourceApi
+internal val Res.string.str_2760: StringResource
+  get() = String33.str_2760
+
+@ExperimentalResourceApi
+internal val Res.string.str_2761: StringResource
+  get() = String33.str_2761
+
+@ExperimentalResourceApi
+internal val Res.string.str_2762: StringResource
+  get() = String33.str_2762
+
+@ExperimentalResourceApi
+internal val Res.string.str_2763: StringResource
+  get() = String33.str_2763
+
+@ExperimentalResourceApi
+internal val Res.string.str_2764: StringResource
+  get() = String33.str_2764
+
+@ExperimentalResourceApi
+internal val Res.string.str_2765: StringResource
+  get() = String33.str_2765
+
+@ExperimentalResourceApi
+internal val Res.string.str_2766: StringResource
+  get() = String33.str_2766
+
+@ExperimentalResourceApi
+internal val Res.string.str_2767: StringResource
+  get() = String33.str_2767
+
+@ExperimentalResourceApi
+internal val Res.string.str_2768: StringResource
+  get() = String33.str_2768
+
+@ExperimentalResourceApi
+internal val Res.string.str_2769: StringResource
+  get() = String33.str_2769
+
+@ExperimentalResourceApi
+internal val Res.string.str_277: StringResource
+  get() = String33.str_277
+
+@ExperimentalResourceApi
+internal val Res.string.str_2770: StringResource
+  get() = String33.str_2770
+
+@ExperimentalResourceApi
+internal val Res.string.str_2771: StringResource
+  get() = String33.str_2771
+
+@ExperimentalResourceApi
+internal val Res.string.str_2772: StringResource
+  get() = String33.str_2772
+
+@ExperimentalResourceApi
+internal val Res.string.str_2773: StringResource
+  get() = String33.str_2773
+
+@ExperimentalResourceApi
+internal val Res.string.str_2774: StringResource
+  get() = String33.str_2774
+
+@ExperimentalResourceApi
+internal val Res.string.str_2775: StringResource
+  get() = String33.str_2775
+
+@ExperimentalResourceApi
+internal val Res.string.str_2776: StringResource
+  get() = String33.str_2776
+
+@ExperimentalResourceApi
+internal val Res.string.str_2777: StringResource
+  get() = String33.str_2777
+
+@ExperimentalResourceApi
+internal val Res.string.str_2778: StringResource
+  get() = String33.str_2778
+
+@ExperimentalResourceApi
+internal val Res.string.str_2779: StringResource
+  get() = String33.str_2779
+
+@ExperimentalResourceApi
+internal val Res.string.str_278: StringResource
+  get() = String33.str_278
+
+@ExperimentalResourceApi
+internal val Res.string.str_2780: StringResource
+  get() = String33.str_2780
+
+@ExperimentalResourceApi
+internal val Res.string.str_2781: StringResource
+  get() = String33.str_2781
+
+@ExperimentalResourceApi
+internal val Res.string.str_2782: StringResource
+  get() = String33.str_2782
+
+@ExperimentalResourceApi
+internal val Res.string.str_2783: StringResource
+  get() = String33.str_2783
+
+@ExperimentalResourceApi
+internal val Res.string.str_2784: StringResource
+  get() = String33.str_2784
+
+@ExperimentalResourceApi
+internal val Res.string.str_2785: StringResource
+  get() = String33.str_2785
+
+@ExperimentalResourceApi
+internal val Res.string.str_2786: StringResource
+  get() = String33.str_2786
+
+@ExperimentalResourceApi
+internal val Res.string.str_2787: StringResource
+  get() = String33.str_2787
+
+@ExperimentalResourceApi
+internal val Res.string.str_2788: StringResource
+  get() = String33.str_2788
+
+@ExperimentalResourceApi
+internal val Res.string.str_2789: StringResource
+  get() = String33.str_2789
+
+@ExperimentalResourceApi
+internal val Res.string.str_279: StringResource
+  get() = String33.str_279
+
+@ExperimentalResourceApi
+internal val Res.string.str_2790: StringResource
+  get() = String33.str_2790
+
+@ExperimentalResourceApi
+internal val Res.string.str_2791: StringResource
+  get() = String33.str_2791
+
+@ExperimentalResourceApi
+internal val Res.string.str_2792: StringResource
+  get() = String33.str_2792
+
+@ExperimentalResourceApi
+internal val Res.string.str_2793: StringResource
+  get() = String33.str_2793
+
+@ExperimentalResourceApi
+internal val Res.string.str_2794: StringResource
+  get() = String33.str_2794
+
+@ExperimentalResourceApi
+internal val Res.string.str_2795: StringResource
+  get() = String33.str_2795
+
+@ExperimentalResourceApi
+internal val Res.string.str_2796: StringResource
+  get() = String33.str_2796
+
+@ExperimentalResourceApi
+internal val Res.string.str_2797: StringResource
+  get() = String33.str_2797
+
+@ExperimentalResourceApi
+internal val Res.string.str_2798: StringResource
+  get() = String33.str_2798

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String34.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String34.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String34 {
+  public val str_2799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2799", "str_2799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_28: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_28", "str_28",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_280", "str_280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2800", "str_2800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2801", "str_2801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2802", "str_2802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2803", "str_2803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2804", "str_2804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2805", "str_2805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2806", "str_2806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2807", "str_2807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2808", "str_2808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2809", "str_2809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_281", "str_281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2810", "str_2810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2811", "str_2811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2812", "str_2812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2813", "str_2813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2814", "str_2814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2815", "str_2815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2816", "str_2816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2817", "str_2817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2818", "str_2818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2819", "str_2819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_282", "str_282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2820", "str_2820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2821", "str_2821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2822", "str_2822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2823", "str_2823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2824", "str_2824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2825", "str_2825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2826", "str_2826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2827", "str_2827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2828", "str_2828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2829", "str_2829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_283", "str_283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2830", "str_2830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2831", "str_2831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2832", "str_2832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2833", "str_2833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2834", "str_2834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2835", "str_2835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2836", "str_2836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2837", "str_2837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2838", "str_2838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2839", "str_2839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_284", "str_284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2840", "str_2840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2841", "str_2841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2842", "str_2842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2843", "str_2843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2844", "str_2844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2845", "str_2845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2846", "str_2846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2847", "str_2847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2848", "str_2848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2849", "str_2849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_285", "str_285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2850", "str_2850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2851", "str_2851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2852", "str_2852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2853", "str_2853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2854", "str_2854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2855", "str_2855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2856", "str_2856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2857", "str_2857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2858", "str_2858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2859", "str_2859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_286", "str_286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2860", "str_2860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2861", "str_2861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2862", "str_2862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2863", "str_2863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2864", "str_2864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2865", "str_2865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2866", "str_2866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2867", "str_2867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2868", "str_2868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2869", "str_2869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_287", "str_287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2870", "str_2870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2871", "str_2871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2872", "str_2872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2873", "str_2873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2874", "str_2874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2875", "str_2875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2876", "str_2876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2877", "str_2877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2878", "str_2878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2879", "str_2879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_288", "str_288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2880", "str_2880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2881", "str_2881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2882", "str_2882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2883", "str_2883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2884", "str_2884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2885", "str_2885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2886", "str_2886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2887", "str_2887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2888", "str_2888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2889", "str_2889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_289", "str_289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2890", "str_2890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2891", "str_2891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2892", "str_2892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2893", "str_2893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2894", "str_2894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2895", "str_2895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2896", "str_2896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2897", "str_2897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2898", "str_2898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2899", "str_2899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_29: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_29", "str_29",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_290", "str_290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2900", "str_2900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2901", "str_2901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2902", "str_2902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2903", "str_2903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2904", "str_2904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2905", "str_2905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2906", "str_2906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2907", "str_2907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2908", "str_2908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2909", "str_2909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_291", "str_291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2910", "str_2910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2911", "str_2911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2912", "str_2912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2913", "str_2913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2914", "str_2914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2915", "str_2915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2916", "str_2916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2917", "str_2917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2918", "str_2918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2919", "str_2919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_292", "str_292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2920", "str_2920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2921", "str_2921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2922", "str_2922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2923", "str_2923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2924", "str_2924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2925", "str_2925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2926", "str_2926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2927", "str_2927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2928", "str_2928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2929", "str_2929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_293", "str_293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2930", "str_2930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2931", "str_2931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2932", "str_2932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2933", "str_2933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2934", "str_2934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2935", "str_2935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2936", "str_2936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2937", "str_2937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2938", "str_2938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2939", "str_2939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_294", "str_294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2940", "str_2940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2941", "str_2941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2942", "str_2942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2943", "str_2943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2944", "str_2944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2945", "str_2945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2946", "str_2946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2947", "str_2947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2948", "str_2948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2949", "str_2949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_295", "str_295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2950", "str_2950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2951", "str_2951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2952", "str_2952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2953", "str_2953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2954", "str_2954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2955", "str_2955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2956", "str_2956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2957", "str_2957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2958", "str_2958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2959", "str_2959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_296", "str_296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2960", "str_2960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2961", "str_2961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2962", "str_2962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2963", "str_2963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2964", "str_2964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2965", "str_2965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2966", "str_2966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2967", "str_2967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2968", "str_2968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2969", "str_2969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_297", "str_297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2970", "str_2970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2971", "str_2971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2972", "str_2972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2973", "str_2973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2974", "str_2974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2975", "str_2975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2976", "str_2976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2977", "str_2977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2978", "str_2978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2979", "str_2979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_298", "str_298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2980", "str_2980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2981", "str_2981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2982", "str_2982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2983", "str_2983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2984", "str_2984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2985", "str_2985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2986", "str_2986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2987", "str_2987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2988", "str_2988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2989", "str_2989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_299", "str_299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2990", "str_2990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2991", "str_2991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2992", "str_2992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2993", "str_2993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2994", "str_2994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2995", "str_2995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2996", "str_2996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2997", "str_2997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2998", "str_2998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_2999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_2999", "str_2999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3", "str_3",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_30: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_30", "str_30",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_300", "str_300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3000", "str_3000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3001", "str_3001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3002", "str_3002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3003", "str_3003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3004", "str_3004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3005", "str_3005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3006", "str_3006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3007", "str_3007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3008", "str_3008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3009", "str_3009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_301", "str_301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3010", "str_3010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3011", "str_3011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3012", "str_3012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3013", "str_3013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3014", "str_3014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3015", "str_3015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3016", "str_3016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3017", "str_3017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3018", "str_3018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3019", "str_3019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_302", "str_302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3020", "str_3020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3021", "str_3021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3022", "str_3022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3023", "str_3023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3024", "str_3024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3025", "str_3025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3026", "str_3026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3027", "str_3027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3028", "str_3028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3029", "str_3029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_303", "str_303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3030", "str_3030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3031", "str_3031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3032", "str_3032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3033", "str_3033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3034", "str_3034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3035", "str_3035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3036", "str_3036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3037", "str_3037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3038", "str_3038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3039", "str_3039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_304", "str_304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3040", "str_3040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3041", "str_3041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3042", "str_3042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3043", "str_3043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3044", "str_3044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3045", "str_3045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3046", "str_3046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3047", "str_3047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3048", "str_3048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3049", "str_3049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_305", "str_305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3050", "str_3050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3051", "str_3051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3052", "str_3052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3053", "str_3053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3054", "str_3054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3055", "str_3055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3056", "str_3056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3057", "str_3057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3058", "str_3058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3059", "str_3059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_306", "str_306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3060", "str_3060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3061", "str_3061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3062", "str_3062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3063", "str_3063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3064", "str_3064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3065", "str_3065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3066", "str_3066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3067", "str_3067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3068", "str_3068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3069", "str_3069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_307", "str_307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3070", "str_3070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3071", "str_3071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3072", "str_3072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3073", "str_3073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3074", "str_3074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3075", "str_3075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3076", "str_3076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3077", "str_3077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3078", "str_3078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3079", "str_3079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_308", "str_308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3080", "str_3080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3081", "str_3081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3082", "str_3082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3083", "str_3083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3084", "str_3084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3085", "str_3085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3086", "str_3086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3087", "str_3087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3088", "str_3088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3089", "str_3089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_309", "str_309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3090", "str_3090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3091", "str_3091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3092", "str_3092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3093", "str_3093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3094", "str_3094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3095", "str_3095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3096", "str_3096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3097", "str_3097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3098", "str_3098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3099", "str_3099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_31: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_31", "str_31",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_310", "str_310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3100", "str_3100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3101", "str_3101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3102", "str_3102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3103", "str_3103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3104", "str_3104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3105", "str_3105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3106", "str_3106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3107", "str_3107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3108", "str_3108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3109", "str_3109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_311", "str_311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3110", "str_3110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3111", "str_3111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3112", "str_3112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3113", "str_3113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3114", "str_3114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3115", "str_3115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3116", "str_3116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3117", "str_3117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3118", "str_3118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3119", "str_3119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_312", "str_312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3120", "str_3120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3121", "str_3121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3122", "str_3122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3123", "str_3123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3124", "str_3124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3125", "str_3125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3126", "str_3126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3127", "str_3127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3128", "str_3128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3129", "str_3129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_313", "str_313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3130", "str_3130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3131", "str_3131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3132", "str_3132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3133", "str_3133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3134", "str_3134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3135", "str_3135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3136", "str_3136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3137", "str_3137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3138", "str_3138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3139", "str_3139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_314", "str_314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3140", "str_3140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3141", "str_3141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3142", "str_3142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3143", "str_3143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3144", "str_3144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3145", "str_3145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3146", "str_3146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3147", "str_3147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3148", "str_3148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3149", "str_3149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_315", "str_315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3150", "str_3150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3151", "str_3151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3152", "str_3152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3153", "str_3153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3154", "str_3154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3155", "str_3155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3156", "str_3156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3157", "str_3157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3158", "str_3158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3159", "str_3159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_316", "str_316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3160", "str_3160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3161", "str_3161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3162", "str_3162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3163", "str_3163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3164", "str_3164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3165", "str_3165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3166", "str_3166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3167", "str_3167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3168", "str_3168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3169", "str_3169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_317", "str_317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3170", "str_3170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3171", "str_3171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3172", "str_3172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3173", "str_3173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3174", "str_3174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3175", "str_3175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3176", "str_3176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3177", "str_3177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3178", "str_3178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3179", "str_3179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_318", "str_318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3180", "str_3180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3181", "str_3181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3182", "str_3182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3183", "str_3183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3184", "str_3184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3185", "str_3185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3186", "str_3186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3187", "str_3187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3188", "str_3188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3189", "str_3189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_319", "str_319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3190", "str_3190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3191", "str_3191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3192", "str_3192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3193", "str_3193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3194", "str_3194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3195", "str_3195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3196", "str_3196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3197", "str_3197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3198", "str_3198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3199", "str_3199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_32: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_32", "str_32",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_320", "str_320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3200", "str_3200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3201", "str_3201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3202", "str_3202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3203", "str_3203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3204", "str_3204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3205", "str_3205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3206", "str_3206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3207", "str_3207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3208", "str_3208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3209", "str_3209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_321", "str_321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3210", "str_3210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3211", "str_3211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3212", "str_3212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3213", "str_3213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3214", "str_3214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3215", "str_3215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3216", "str_3216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3217", "str_3217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3218", "str_3218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3219", "str_3219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_322", "str_322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3220", "str_3220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3221", "str_3221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3222", "str_3222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3223", "str_3223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3224", "str_3224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3225", "str_3225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3226", "str_3226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3227", "str_3227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3228", "str_3228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3229", "str_3229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_323", "str_323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3230", "str_3230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3231", "str_3231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3232", "str_3232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3233", "str_3233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3234", "str_3234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3235", "str_3235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3236", "str_3236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3237", "str_3237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3238", "str_3238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3239", "str_3239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_324", "str_324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3240", "str_3240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3241", "str_3241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3242", "str_3242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3243", "str_3243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3244", "str_3244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3245", "str_3245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3246", "str_3246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3247", "str_3247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_2799: StringResource
+  get() = String34.str_2799
+
+@ExperimentalResourceApi
+internal val Res.string.str_28: StringResource
+  get() = String34.str_28
+
+@ExperimentalResourceApi
+internal val Res.string.str_280: StringResource
+  get() = String34.str_280
+
+@ExperimentalResourceApi
+internal val Res.string.str_2800: StringResource
+  get() = String34.str_2800
+
+@ExperimentalResourceApi
+internal val Res.string.str_2801: StringResource
+  get() = String34.str_2801
+
+@ExperimentalResourceApi
+internal val Res.string.str_2802: StringResource
+  get() = String34.str_2802
+
+@ExperimentalResourceApi
+internal val Res.string.str_2803: StringResource
+  get() = String34.str_2803
+
+@ExperimentalResourceApi
+internal val Res.string.str_2804: StringResource
+  get() = String34.str_2804
+
+@ExperimentalResourceApi
+internal val Res.string.str_2805: StringResource
+  get() = String34.str_2805
+
+@ExperimentalResourceApi
+internal val Res.string.str_2806: StringResource
+  get() = String34.str_2806
+
+@ExperimentalResourceApi
+internal val Res.string.str_2807: StringResource
+  get() = String34.str_2807
+
+@ExperimentalResourceApi
+internal val Res.string.str_2808: StringResource
+  get() = String34.str_2808
+
+@ExperimentalResourceApi
+internal val Res.string.str_2809: StringResource
+  get() = String34.str_2809
+
+@ExperimentalResourceApi
+internal val Res.string.str_281: StringResource
+  get() = String34.str_281
+
+@ExperimentalResourceApi
+internal val Res.string.str_2810: StringResource
+  get() = String34.str_2810
+
+@ExperimentalResourceApi
+internal val Res.string.str_2811: StringResource
+  get() = String34.str_2811
+
+@ExperimentalResourceApi
+internal val Res.string.str_2812: StringResource
+  get() = String34.str_2812
+
+@ExperimentalResourceApi
+internal val Res.string.str_2813: StringResource
+  get() = String34.str_2813
+
+@ExperimentalResourceApi
+internal val Res.string.str_2814: StringResource
+  get() = String34.str_2814
+
+@ExperimentalResourceApi
+internal val Res.string.str_2815: StringResource
+  get() = String34.str_2815
+
+@ExperimentalResourceApi
+internal val Res.string.str_2816: StringResource
+  get() = String34.str_2816
+
+@ExperimentalResourceApi
+internal val Res.string.str_2817: StringResource
+  get() = String34.str_2817
+
+@ExperimentalResourceApi
+internal val Res.string.str_2818: StringResource
+  get() = String34.str_2818
+
+@ExperimentalResourceApi
+internal val Res.string.str_2819: StringResource
+  get() = String34.str_2819
+
+@ExperimentalResourceApi
+internal val Res.string.str_282: StringResource
+  get() = String34.str_282
+
+@ExperimentalResourceApi
+internal val Res.string.str_2820: StringResource
+  get() = String34.str_2820
+
+@ExperimentalResourceApi
+internal val Res.string.str_2821: StringResource
+  get() = String34.str_2821
+
+@ExperimentalResourceApi
+internal val Res.string.str_2822: StringResource
+  get() = String34.str_2822
+
+@ExperimentalResourceApi
+internal val Res.string.str_2823: StringResource
+  get() = String34.str_2823
+
+@ExperimentalResourceApi
+internal val Res.string.str_2824: StringResource
+  get() = String34.str_2824
+
+@ExperimentalResourceApi
+internal val Res.string.str_2825: StringResource
+  get() = String34.str_2825
+
+@ExperimentalResourceApi
+internal val Res.string.str_2826: StringResource
+  get() = String34.str_2826
+
+@ExperimentalResourceApi
+internal val Res.string.str_2827: StringResource
+  get() = String34.str_2827
+
+@ExperimentalResourceApi
+internal val Res.string.str_2828: StringResource
+  get() = String34.str_2828
+
+@ExperimentalResourceApi
+internal val Res.string.str_2829: StringResource
+  get() = String34.str_2829
+
+@ExperimentalResourceApi
+internal val Res.string.str_283: StringResource
+  get() = String34.str_283
+
+@ExperimentalResourceApi
+internal val Res.string.str_2830: StringResource
+  get() = String34.str_2830
+
+@ExperimentalResourceApi
+internal val Res.string.str_2831: StringResource
+  get() = String34.str_2831
+
+@ExperimentalResourceApi
+internal val Res.string.str_2832: StringResource
+  get() = String34.str_2832
+
+@ExperimentalResourceApi
+internal val Res.string.str_2833: StringResource
+  get() = String34.str_2833
+
+@ExperimentalResourceApi
+internal val Res.string.str_2834: StringResource
+  get() = String34.str_2834
+
+@ExperimentalResourceApi
+internal val Res.string.str_2835: StringResource
+  get() = String34.str_2835
+
+@ExperimentalResourceApi
+internal val Res.string.str_2836: StringResource
+  get() = String34.str_2836
+
+@ExperimentalResourceApi
+internal val Res.string.str_2837: StringResource
+  get() = String34.str_2837
+
+@ExperimentalResourceApi
+internal val Res.string.str_2838: StringResource
+  get() = String34.str_2838
+
+@ExperimentalResourceApi
+internal val Res.string.str_2839: StringResource
+  get() = String34.str_2839
+
+@ExperimentalResourceApi
+internal val Res.string.str_284: StringResource
+  get() = String34.str_284
+
+@ExperimentalResourceApi
+internal val Res.string.str_2840: StringResource
+  get() = String34.str_2840
+
+@ExperimentalResourceApi
+internal val Res.string.str_2841: StringResource
+  get() = String34.str_2841
+
+@ExperimentalResourceApi
+internal val Res.string.str_2842: StringResource
+  get() = String34.str_2842
+
+@ExperimentalResourceApi
+internal val Res.string.str_2843: StringResource
+  get() = String34.str_2843
+
+@ExperimentalResourceApi
+internal val Res.string.str_2844: StringResource
+  get() = String34.str_2844
+
+@ExperimentalResourceApi
+internal val Res.string.str_2845: StringResource
+  get() = String34.str_2845
+
+@ExperimentalResourceApi
+internal val Res.string.str_2846: StringResource
+  get() = String34.str_2846
+
+@ExperimentalResourceApi
+internal val Res.string.str_2847: StringResource
+  get() = String34.str_2847
+
+@ExperimentalResourceApi
+internal val Res.string.str_2848: StringResource
+  get() = String34.str_2848
+
+@ExperimentalResourceApi
+internal val Res.string.str_2849: StringResource
+  get() = String34.str_2849
+
+@ExperimentalResourceApi
+internal val Res.string.str_285: StringResource
+  get() = String34.str_285
+
+@ExperimentalResourceApi
+internal val Res.string.str_2850: StringResource
+  get() = String34.str_2850
+
+@ExperimentalResourceApi
+internal val Res.string.str_2851: StringResource
+  get() = String34.str_2851
+
+@ExperimentalResourceApi
+internal val Res.string.str_2852: StringResource
+  get() = String34.str_2852
+
+@ExperimentalResourceApi
+internal val Res.string.str_2853: StringResource
+  get() = String34.str_2853
+
+@ExperimentalResourceApi
+internal val Res.string.str_2854: StringResource
+  get() = String34.str_2854
+
+@ExperimentalResourceApi
+internal val Res.string.str_2855: StringResource
+  get() = String34.str_2855
+
+@ExperimentalResourceApi
+internal val Res.string.str_2856: StringResource
+  get() = String34.str_2856
+
+@ExperimentalResourceApi
+internal val Res.string.str_2857: StringResource
+  get() = String34.str_2857
+
+@ExperimentalResourceApi
+internal val Res.string.str_2858: StringResource
+  get() = String34.str_2858
+
+@ExperimentalResourceApi
+internal val Res.string.str_2859: StringResource
+  get() = String34.str_2859
+
+@ExperimentalResourceApi
+internal val Res.string.str_286: StringResource
+  get() = String34.str_286
+
+@ExperimentalResourceApi
+internal val Res.string.str_2860: StringResource
+  get() = String34.str_2860
+
+@ExperimentalResourceApi
+internal val Res.string.str_2861: StringResource
+  get() = String34.str_2861
+
+@ExperimentalResourceApi
+internal val Res.string.str_2862: StringResource
+  get() = String34.str_2862
+
+@ExperimentalResourceApi
+internal val Res.string.str_2863: StringResource
+  get() = String34.str_2863
+
+@ExperimentalResourceApi
+internal val Res.string.str_2864: StringResource
+  get() = String34.str_2864
+
+@ExperimentalResourceApi
+internal val Res.string.str_2865: StringResource
+  get() = String34.str_2865
+
+@ExperimentalResourceApi
+internal val Res.string.str_2866: StringResource
+  get() = String34.str_2866
+
+@ExperimentalResourceApi
+internal val Res.string.str_2867: StringResource
+  get() = String34.str_2867
+
+@ExperimentalResourceApi
+internal val Res.string.str_2868: StringResource
+  get() = String34.str_2868
+
+@ExperimentalResourceApi
+internal val Res.string.str_2869: StringResource
+  get() = String34.str_2869
+
+@ExperimentalResourceApi
+internal val Res.string.str_287: StringResource
+  get() = String34.str_287
+
+@ExperimentalResourceApi
+internal val Res.string.str_2870: StringResource
+  get() = String34.str_2870
+
+@ExperimentalResourceApi
+internal val Res.string.str_2871: StringResource
+  get() = String34.str_2871
+
+@ExperimentalResourceApi
+internal val Res.string.str_2872: StringResource
+  get() = String34.str_2872
+
+@ExperimentalResourceApi
+internal val Res.string.str_2873: StringResource
+  get() = String34.str_2873
+
+@ExperimentalResourceApi
+internal val Res.string.str_2874: StringResource
+  get() = String34.str_2874
+
+@ExperimentalResourceApi
+internal val Res.string.str_2875: StringResource
+  get() = String34.str_2875
+
+@ExperimentalResourceApi
+internal val Res.string.str_2876: StringResource
+  get() = String34.str_2876
+
+@ExperimentalResourceApi
+internal val Res.string.str_2877: StringResource
+  get() = String34.str_2877
+
+@ExperimentalResourceApi
+internal val Res.string.str_2878: StringResource
+  get() = String34.str_2878
+
+@ExperimentalResourceApi
+internal val Res.string.str_2879: StringResource
+  get() = String34.str_2879
+
+@ExperimentalResourceApi
+internal val Res.string.str_288: StringResource
+  get() = String34.str_288
+
+@ExperimentalResourceApi
+internal val Res.string.str_2880: StringResource
+  get() = String34.str_2880
+
+@ExperimentalResourceApi
+internal val Res.string.str_2881: StringResource
+  get() = String34.str_2881
+
+@ExperimentalResourceApi
+internal val Res.string.str_2882: StringResource
+  get() = String34.str_2882
+
+@ExperimentalResourceApi
+internal val Res.string.str_2883: StringResource
+  get() = String34.str_2883
+
+@ExperimentalResourceApi
+internal val Res.string.str_2884: StringResource
+  get() = String34.str_2884
+
+@ExperimentalResourceApi
+internal val Res.string.str_2885: StringResource
+  get() = String34.str_2885
+
+@ExperimentalResourceApi
+internal val Res.string.str_2886: StringResource
+  get() = String34.str_2886
+
+@ExperimentalResourceApi
+internal val Res.string.str_2887: StringResource
+  get() = String34.str_2887
+
+@ExperimentalResourceApi
+internal val Res.string.str_2888: StringResource
+  get() = String34.str_2888
+
+@ExperimentalResourceApi
+internal val Res.string.str_2889: StringResource
+  get() = String34.str_2889
+
+@ExperimentalResourceApi
+internal val Res.string.str_289: StringResource
+  get() = String34.str_289
+
+@ExperimentalResourceApi
+internal val Res.string.str_2890: StringResource
+  get() = String34.str_2890
+
+@ExperimentalResourceApi
+internal val Res.string.str_2891: StringResource
+  get() = String34.str_2891
+
+@ExperimentalResourceApi
+internal val Res.string.str_2892: StringResource
+  get() = String34.str_2892
+
+@ExperimentalResourceApi
+internal val Res.string.str_2893: StringResource
+  get() = String34.str_2893
+
+@ExperimentalResourceApi
+internal val Res.string.str_2894: StringResource
+  get() = String34.str_2894
+
+@ExperimentalResourceApi
+internal val Res.string.str_2895: StringResource
+  get() = String34.str_2895
+
+@ExperimentalResourceApi
+internal val Res.string.str_2896: StringResource
+  get() = String34.str_2896
+
+@ExperimentalResourceApi
+internal val Res.string.str_2897: StringResource
+  get() = String34.str_2897
+
+@ExperimentalResourceApi
+internal val Res.string.str_2898: StringResource
+  get() = String34.str_2898
+
+@ExperimentalResourceApi
+internal val Res.string.str_2899: StringResource
+  get() = String34.str_2899
+
+@ExperimentalResourceApi
+internal val Res.string.str_29: StringResource
+  get() = String34.str_29
+
+@ExperimentalResourceApi
+internal val Res.string.str_290: StringResource
+  get() = String34.str_290
+
+@ExperimentalResourceApi
+internal val Res.string.str_2900: StringResource
+  get() = String34.str_2900
+
+@ExperimentalResourceApi
+internal val Res.string.str_2901: StringResource
+  get() = String34.str_2901
+
+@ExperimentalResourceApi
+internal val Res.string.str_2902: StringResource
+  get() = String34.str_2902
+
+@ExperimentalResourceApi
+internal val Res.string.str_2903: StringResource
+  get() = String34.str_2903
+
+@ExperimentalResourceApi
+internal val Res.string.str_2904: StringResource
+  get() = String34.str_2904
+
+@ExperimentalResourceApi
+internal val Res.string.str_2905: StringResource
+  get() = String34.str_2905
+
+@ExperimentalResourceApi
+internal val Res.string.str_2906: StringResource
+  get() = String34.str_2906
+
+@ExperimentalResourceApi
+internal val Res.string.str_2907: StringResource
+  get() = String34.str_2907
+
+@ExperimentalResourceApi
+internal val Res.string.str_2908: StringResource
+  get() = String34.str_2908
+
+@ExperimentalResourceApi
+internal val Res.string.str_2909: StringResource
+  get() = String34.str_2909
+
+@ExperimentalResourceApi
+internal val Res.string.str_291: StringResource
+  get() = String34.str_291
+
+@ExperimentalResourceApi
+internal val Res.string.str_2910: StringResource
+  get() = String34.str_2910
+
+@ExperimentalResourceApi
+internal val Res.string.str_2911: StringResource
+  get() = String34.str_2911
+
+@ExperimentalResourceApi
+internal val Res.string.str_2912: StringResource
+  get() = String34.str_2912
+
+@ExperimentalResourceApi
+internal val Res.string.str_2913: StringResource
+  get() = String34.str_2913
+
+@ExperimentalResourceApi
+internal val Res.string.str_2914: StringResource
+  get() = String34.str_2914
+
+@ExperimentalResourceApi
+internal val Res.string.str_2915: StringResource
+  get() = String34.str_2915
+
+@ExperimentalResourceApi
+internal val Res.string.str_2916: StringResource
+  get() = String34.str_2916
+
+@ExperimentalResourceApi
+internal val Res.string.str_2917: StringResource
+  get() = String34.str_2917
+
+@ExperimentalResourceApi
+internal val Res.string.str_2918: StringResource
+  get() = String34.str_2918
+
+@ExperimentalResourceApi
+internal val Res.string.str_2919: StringResource
+  get() = String34.str_2919
+
+@ExperimentalResourceApi
+internal val Res.string.str_292: StringResource
+  get() = String34.str_292
+
+@ExperimentalResourceApi
+internal val Res.string.str_2920: StringResource
+  get() = String34.str_2920
+
+@ExperimentalResourceApi
+internal val Res.string.str_2921: StringResource
+  get() = String34.str_2921
+
+@ExperimentalResourceApi
+internal val Res.string.str_2922: StringResource
+  get() = String34.str_2922
+
+@ExperimentalResourceApi
+internal val Res.string.str_2923: StringResource
+  get() = String34.str_2923
+
+@ExperimentalResourceApi
+internal val Res.string.str_2924: StringResource
+  get() = String34.str_2924
+
+@ExperimentalResourceApi
+internal val Res.string.str_2925: StringResource
+  get() = String34.str_2925
+
+@ExperimentalResourceApi
+internal val Res.string.str_2926: StringResource
+  get() = String34.str_2926
+
+@ExperimentalResourceApi
+internal val Res.string.str_2927: StringResource
+  get() = String34.str_2927
+
+@ExperimentalResourceApi
+internal val Res.string.str_2928: StringResource
+  get() = String34.str_2928
+
+@ExperimentalResourceApi
+internal val Res.string.str_2929: StringResource
+  get() = String34.str_2929
+
+@ExperimentalResourceApi
+internal val Res.string.str_293: StringResource
+  get() = String34.str_293
+
+@ExperimentalResourceApi
+internal val Res.string.str_2930: StringResource
+  get() = String34.str_2930
+
+@ExperimentalResourceApi
+internal val Res.string.str_2931: StringResource
+  get() = String34.str_2931
+
+@ExperimentalResourceApi
+internal val Res.string.str_2932: StringResource
+  get() = String34.str_2932
+
+@ExperimentalResourceApi
+internal val Res.string.str_2933: StringResource
+  get() = String34.str_2933
+
+@ExperimentalResourceApi
+internal val Res.string.str_2934: StringResource
+  get() = String34.str_2934
+
+@ExperimentalResourceApi
+internal val Res.string.str_2935: StringResource
+  get() = String34.str_2935
+
+@ExperimentalResourceApi
+internal val Res.string.str_2936: StringResource
+  get() = String34.str_2936
+
+@ExperimentalResourceApi
+internal val Res.string.str_2937: StringResource
+  get() = String34.str_2937
+
+@ExperimentalResourceApi
+internal val Res.string.str_2938: StringResource
+  get() = String34.str_2938
+
+@ExperimentalResourceApi
+internal val Res.string.str_2939: StringResource
+  get() = String34.str_2939
+
+@ExperimentalResourceApi
+internal val Res.string.str_294: StringResource
+  get() = String34.str_294
+
+@ExperimentalResourceApi
+internal val Res.string.str_2940: StringResource
+  get() = String34.str_2940
+
+@ExperimentalResourceApi
+internal val Res.string.str_2941: StringResource
+  get() = String34.str_2941
+
+@ExperimentalResourceApi
+internal val Res.string.str_2942: StringResource
+  get() = String34.str_2942
+
+@ExperimentalResourceApi
+internal val Res.string.str_2943: StringResource
+  get() = String34.str_2943
+
+@ExperimentalResourceApi
+internal val Res.string.str_2944: StringResource
+  get() = String34.str_2944
+
+@ExperimentalResourceApi
+internal val Res.string.str_2945: StringResource
+  get() = String34.str_2945
+
+@ExperimentalResourceApi
+internal val Res.string.str_2946: StringResource
+  get() = String34.str_2946
+
+@ExperimentalResourceApi
+internal val Res.string.str_2947: StringResource
+  get() = String34.str_2947
+
+@ExperimentalResourceApi
+internal val Res.string.str_2948: StringResource
+  get() = String34.str_2948
+
+@ExperimentalResourceApi
+internal val Res.string.str_2949: StringResource
+  get() = String34.str_2949
+
+@ExperimentalResourceApi
+internal val Res.string.str_295: StringResource
+  get() = String34.str_295
+
+@ExperimentalResourceApi
+internal val Res.string.str_2950: StringResource
+  get() = String34.str_2950
+
+@ExperimentalResourceApi
+internal val Res.string.str_2951: StringResource
+  get() = String34.str_2951
+
+@ExperimentalResourceApi
+internal val Res.string.str_2952: StringResource
+  get() = String34.str_2952
+
+@ExperimentalResourceApi
+internal val Res.string.str_2953: StringResource
+  get() = String34.str_2953
+
+@ExperimentalResourceApi
+internal val Res.string.str_2954: StringResource
+  get() = String34.str_2954
+
+@ExperimentalResourceApi
+internal val Res.string.str_2955: StringResource
+  get() = String34.str_2955
+
+@ExperimentalResourceApi
+internal val Res.string.str_2956: StringResource
+  get() = String34.str_2956
+
+@ExperimentalResourceApi
+internal val Res.string.str_2957: StringResource
+  get() = String34.str_2957
+
+@ExperimentalResourceApi
+internal val Res.string.str_2958: StringResource
+  get() = String34.str_2958
+
+@ExperimentalResourceApi
+internal val Res.string.str_2959: StringResource
+  get() = String34.str_2959
+
+@ExperimentalResourceApi
+internal val Res.string.str_296: StringResource
+  get() = String34.str_296
+
+@ExperimentalResourceApi
+internal val Res.string.str_2960: StringResource
+  get() = String34.str_2960
+
+@ExperimentalResourceApi
+internal val Res.string.str_2961: StringResource
+  get() = String34.str_2961
+
+@ExperimentalResourceApi
+internal val Res.string.str_2962: StringResource
+  get() = String34.str_2962
+
+@ExperimentalResourceApi
+internal val Res.string.str_2963: StringResource
+  get() = String34.str_2963
+
+@ExperimentalResourceApi
+internal val Res.string.str_2964: StringResource
+  get() = String34.str_2964
+
+@ExperimentalResourceApi
+internal val Res.string.str_2965: StringResource
+  get() = String34.str_2965
+
+@ExperimentalResourceApi
+internal val Res.string.str_2966: StringResource
+  get() = String34.str_2966
+
+@ExperimentalResourceApi
+internal val Res.string.str_2967: StringResource
+  get() = String34.str_2967
+
+@ExperimentalResourceApi
+internal val Res.string.str_2968: StringResource
+  get() = String34.str_2968
+
+@ExperimentalResourceApi
+internal val Res.string.str_2969: StringResource
+  get() = String34.str_2969
+
+@ExperimentalResourceApi
+internal val Res.string.str_297: StringResource
+  get() = String34.str_297
+
+@ExperimentalResourceApi
+internal val Res.string.str_2970: StringResource
+  get() = String34.str_2970
+
+@ExperimentalResourceApi
+internal val Res.string.str_2971: StringResource
+  get() = String34.str_2971
+
+@ExperimentalResourceApi
+internal val Res.string.str_2972: StringResource
+  get() = String34.str_2972
+
+@ExperimentalResourceApi
+internal val Res.string.str_2973: StringResource
+  get() = String34.str_2973
+
+@ExperimentalResourceApi
+internal val Res.string.str_2974: StringResource
+  get() = String34.str_2974
+
+@ExperimentalResourceApi
+internal val Res.string.str_2975: StringResource
+  get() = String34.str_2975
+
+@ExperimentalResourceApi
+internal val Res.string.str_2976: StringResource
+  get() = String34.str_2976
+
+@ExperimentalResourceApi
+internal val Res.string.str_2977: StringResource
+  get() = String34.str_2977
+
+@ExperimentalResourceApi
+internal val Res.string.str_2978: StringResource
+  get() = String34.str_2978
+
+@ExperimentalResourceApi
+internal val Res.string.str_2979: StringResource
+  get() = String34.str_2979
+
+@ExperimentalResourceApi
+internal val Res.string.str_298: StringResource
+  get() = String34.str_298
+
+@ExperimentalResourceApi
+internal val Res.string.str_2980: StringResource
+  get() = String34.str_2980
+
+@ExperimentalResourceApi
+internal val Res.string.str_2981: StringResource
+  get() = String34.str_2981
+
+@ExperimentalResourceApi
+internal val Res.string.str_2982: StringResource
+  get() = String34.str_2982
+
+@ExperimentalResourceApi
+internal val Res.string.str_2983: StringResource
+  get() = String34.str_2983
+
+@ExperimentalResourceApi
+internal val Res.string.str_2984: StringResource
+  get() = String34.str_2984
+
+@ExperimentalResourceApi
+internal val Res.string.str_2985: StringResource
+  get() = String34.str_2985
+
+@ExperimentalResourceApi
+internal val Res.string.str_2986: StringResource
+  get() = String34.str_2986
+
+@ExperimentalResourceApi
+internal val Res.string.str_2987: StringResource
+  get() = String34.str_2987
+
+@ExperimentalResourceApi
+internal val Res.string.str_2988: StringResource
+  get() = String34.str_2988
+
+@ExperimentalResourceApi
+internal val Res.string.str_2989: StringResource
+  get() = String34.str_2989
+
+@ExperimentalResourceApi
+internal val Res.string.str_299: StringResource
+  get() = String34.str_299
+
+@ExperimentalResourceApi
+internal val Res.string.str_2990: StringResource
+  get() = String34.str_2990
+
+@ExperimentalResourceApi
+internal val Res.string.str_2991: StringResource
+  get() = String34.str_2991
+
+@ExperimentalResourceApi
+internal val Res.string.str_2992: StringResource
+  get() = String34.str_2992
+
+@ExperimentalResourceApi
+internal val Res.string.str_2993: StringResource
+  get() = String34.str_2993
+
+@ExperimentalResourceApi
+internal val Res.string.str_2994: StringResource
+  get() = String34.str_2994
+
+@ExperimentalResourceApi
+internal val Res.string.str_2995: StringResource
+  get() = String34.str_2995
+
+@ExperimentalResourceApi
+internal val Res.string.str_2996: StringResource
+  get() = String34.str_2996
+
+@ExperimentalResourceApi
+internal val Res.string.str_2997: StringResource
+  get() = String34.str_2997
+
+@ExperimentalResourceApi
+internal val Res.string.str_2998: StringResource
+  get() = String34.str_2998
+
+@ExperimentalResourceApi
+internal val Res.string.str_2999: StringResource
+  get() = String34.str_2999
+
+@ExperimentalResourceApi
+internal val Res.string.str_3: StringResource
+  get() = String34.str_3
+
+@ExperimentalResourceApi
+internal val Res.string.str_30: StringResource
+  get() = String34.str_30
+
+@ExperimentalResourceApi
+internal val Res.string.str_300: StringResource
+  get() = String34.str_300
+
+@ExperimentalResourceApi
+internal val Res.string.str_3000: StringResource
+  get() = String34.str_3000
+
+@ExperimentalResourceApi
+internal val Res.string.str_3001: StringResource
+  get() = String34.str_3001
+
+@ExperimentalResourceApi
+internal val Res.string.str_3002: StringResource
+  get() = String34.str_3002
+
+@ExperimentalResourceApi
+internal val Res.string.str_3003: StringResource
+  get() = String34.str_3003
+
+@ExperimentalResourceApi
+internal val Res.string.str_3004: StringResource
+  get() = String34.str_3004
+
+@ExperimentalResourceApi
+internal val Res.string.str_3005: StringResource
+  get() = String34.str_3005
+
+@ExperimentalResourceApi
+internal val Res.string.str_3006: StringResource
+  get() = String34.str_3006
+
+@ExperimentalResourceApi
+internal val Res.string.str_3007: StringResource
+  get() = String34.str_3007
+
+@ExperimentalResourceApi
+internal val Res.string.str_3008: StringResource
+  get() = String34.str_3008
+
+@ExperimentalResourceApi
+internal val Res.string.str_3009: StringResource
+  get() = String34.str_3009
+
+@ExperimentalResourceApi
+internal val Res.string.str_301: StringResource
+  get() = String34.str_301
+
+@ExperimentalResourceApi
+internal val Res.string.str_3010: StringResource
+  get() = String34.str_3010
+
+@ExperimentalResourceApi
+internal val Res.string.str_3011: StringResource
+  get() = String34.str_3011
+
+@ExperimentalResourceApi
+internal val Res.string.str_3012: StringResource
+  get() = String34.str_3012
+
+@ExperimentalResourceApi
+internal val Res.string.str_3013: StringResource
+  get() = String34.str_3013
+
+@ExperimentalResourceApi
+internal val Res.string.str_3014: StringResource
+  get() = String34.str_3014
+
+@ExperimentalResourceApi
+internal val Res.string.str_3015: StringResource
+  get() = String34.str_3015
+
+@ExperimentalResourceApi
+internal val Res.string.str_3016: StringResource
+  get() = String34.str_3016
+
+@ExperimentalResourceApi
+internal val Res.string.str_3017: StringResource
+  get() = String34.str_3017
+
+@ExperimentalResourceApi
+internal val Res.string.str_3018: StringResource
+  get() = String34.str_3018
+
+@ExperimentalResourceApi
+internal val Res.string.str_3019: StringResource
+  get() = String34.str_3019
+
+@ExperimentalResourceApi
+internal val Res.string.str_302: StringResource
+  get() = String34.str_302
+
+@ExperimentalResourceApi
+internal val Res.string.str_3020: StringResource
+  get() = String34.str_3020
+
+@ExperimentalResourceApi
+internal val Res.string.str_3021: StringResource
+  get() = String34.str_3021
+
+@ExperimentalResourceApi
+internal val Res.string.str_3022: StringResource
+  get() = String34.str_3022
+
+@ExperimentalResourceApi
+internal val Res.string.str_3023: StringResource
+  get() = String34.str_3023
+
+@ExperimentalResourceApi
+internal val Res.string.str_3024: StringResource
+  get() = String34.str_3024
+
+@ExperimentalResourceApi
+internal val Res.string.str_3025: StringResource
+  get() = String34.str_3025
+
+@ExperimentalResourceApi
+internal val Res.string.str_3026: StringResource
+  get() = String34.str_3026
+
+@ExperimentalResourceApi
+internal val Res.string.str_3027: StringResource
+  get() = String34.str_3027
+
+@ExperimentalResourceApi
+internal val Res.string.str_3028: StringResource
+  get() = String34.str_3028
+
+@ExperimentalResourceApi
+internal val Res.string.str_3029: StringResource
+  get() = String34.str_3029
+
+@ExperimentalResourceApi
+internal val Res.string.str_303: StringResource
+  get() = String34.str_303
+
+@ExperimentalResourceApi
+internal val Res.string.str_3030: StringResource
+  get() = String34.str_3030
+
+@ExperimentalResourceApi
+internal val Res.string.str_3031: StringResource
+  get() = String34.str_3031
+
+@ExperimentalResourceApi
+internal val Res.string.str_3032: StringResource
+  get() = String34.str_3032
+
+@ExperimentalResourceApi
+internal val Res.string.str_3033: StringResource
+  get() = String34.str_3033
+
+@ExperimentalResourceApi
+internal val Res.string.str_3034: StringResource
+  get() = String34.str_3034
+
+@ExperimentalResourceApi
+internal val Res.string.str_3035: StringResource
+  get() = String34.str_3035
+
+@ExperimentalResourceApi
+internal val Res.string.str_3036: StringResource
+  get() = String34.str_3036
+
+@ExperimentalResourceApi
+internal val Res.string.str_3037: StringResource
+  get() = String34.str_3037
+
+@ExperimentalResourceApi
+internal val Res.string.str_3038: StringResource
+  get() = String34.str_3038
+
+@ExperimentalResourceApi
+internal val Res.string.str_3039: StringResource
+  get() = String34.str_3039
+
+@ExperimentalResourceApi
+internal val Res.string.str_304: StringResource
+  get() = String34.str_304
+
+@ExperimentalResourceApi
+internal val Res.string.str_3040: StringResource
+  get() = String34.str_3040
+
+@ExperimentalResourceApi
+internal val Res.string.str_3041: StringResource
+  get() = String34.str_3041
+
+@ExperimentalResourceApi
+internal val Res.string.str_3042: StringResource
+  get() = String34.str_3042
+
+@ExperimentalResourceApi
+internal val Res.string.str_3043: StringResource
+  get() = String34.str_3043
+
+@ExperimentalResourceApi
+internal val Res.string.str_3044: StringResource
+  get() = String34.str_3044
+
+@ExperimentalResourceApi
+internal val Res.string.str_3045: StringResource
+  get() = String34.str_3045
+
+@ExperimentalResourceApi
+internal val Res.string.str_3046: StringResource
+  get() = String34.str_3046
+
+@ExperimentalResourceApi
+internal val Res.string.str_3047: StringResource
+  get() = String34.str_3047
+
+@ExperimentalResourceApi
+internal val Res.string.str_3048: StringResource
+  get() = String34.str_3048
+
+@ExperimentalResourceApi
+internal val Res.string.str_3049: StringResource
+  get() = String34.str_3049
+
+@ExperimentalResourceApi
+internal val Res.string.str_305: StringResource
+  get() = String34.str_305
+
+@ExperimentalResourceApi
+internal val Res.string.str_3050: StringResource
+  get() = String34.str_3050
+
+@ExperimentalResourceApi
+internal val Res.string.str_3051: StringResource
+  get() = String34.str_3051
+
+@ExperimentalResourceApi
+internal val Res.string.str_3052: StringResource
+  get() = String34.str_3052
+
+@ExperimentalResourceApi
+internal val Res.string.str_3053: StringResource
+  get() = String34.str_3053
+
+@ExperimentalResourceApi
+internal val Res.string.str_3054: StringResource
+  get() = String34.str_3054
+
+@ExperimentalResourceApi
+internal val Res.string.str_3055: StringResource
+  get() = String34.str_3055
+
+@ExperimentalResourceApi
+internal val Res.string.str_3056: StringResource
+  get() = String34.str_3056
+
+@ExperimentalResourceApi
+internal val Res.string.str_3057: StringResource
+  get() = String34.str_3057
+
+@ExperimentalResourceApi
+internal val Res.string.str_3058: StringResource
+  get() = String34.str_3058
+
+@ExperimentalResourceApi
+internal val Res.string.str_3059: StringResource
+  get() = String34.str_3059
+
+@ExperimentalResourceApi
+internal val Res.string.str_306: StringResource
+  get() = String34.str_306
+
+@ExperimentalResourceApi
+internal val Res.string.str_3060: StringResource
+  get() = String34.str_3060
+
+@ExperimentalResourceApi
+internal val Res.string.str_3061: StringResource
+  get() = String34.str_3061
+
+@ExperimentalResourceApi
+internal val Res.string.str_3062: StringResource
+  get() = String34.str_3062
+
+@ExperimentalResourceApi
+internal val Res.string.str_3063: StringResource
+  get() = String34.str_3063
+
+@ExperimentalResourceApi
+internal val Res.string.str_3064: StringResource
+  get() = String34.str_3064
+
+@ExperimentalResourceApi
+internal val Res.string.str_3065: StringResource
+  get() = String34.str_3065
+
+@ExperimentalResourceApi
+internal val Res.string.str_3066: StringResource
+  get() = String34.str_3066
+
+@ExperimentalResourceApi
+internal val Res.string.str_3067: StringResource
+  get() = String34.str_3067
+
+@ExperimentalResourceApi
+internal val Res.string.str_3068: StringResource
+  get() = String34.str_3068
+
+@ExperimentalResourceApi
+internal val Res.string.str_3069: StringResource
+  get() = String34.str_3069
+
+@ExperimentalResourceApi
+internal val Res.string.str_307: StringResource
+  get() = String34.str_307
+
+@ExperimentalResourceApi
+internal val Res.string.str_3070: StringResource
+  get() = String34.str_3070
+
+@ExperimentalResourceApi
+internal val Res.string.str_3071: StringResource
+  get() = String34.str_3071
+
+@ExperimentalResourceApi
+internal val Res.string.str_3072: StringResource
+  get() = String34.str_3072
+
+@ExperimentalResourceApi
+internal val Res.string.str_3073: StringResource
+  get() = String34.str_3073
+
+@ExperimentalResourceApi
+internal val Res.string.str_3074: StringResource
+  get() = String34.str_3074
+
+@ExperimentalResourceApi
+internal val Res.string.str_3075: StringResource
+  get() = String34.str_3075
+
+@ExperimentalResourceApi
+internal val Res.string.str_3076: StringResource
+  get() = String34.str_3076
+
+@ExperimentalResourceApi
+internal val Res.string.str_3077: StringResource
+  get() = String34.str_3077
+
+@ExperimentalResourceApi
+internal val Res.string.str_3078: StringResource
+  get() = String34.str_3078
+
+@ExperimentalResourceApi
+internal val Res.string.str_3079: StringResource
+  get() = String34.str_3079
+
+@ExperimentalResourceApi
+internal val Res.string.str_308: StringResource
+  get() = String34.str_308
+
+@ExperimentalResourceApi
+internal val Res.string.str_3080: StringResource
+  get() = String34.str_3080
+
+@ExperimentalResourceApi
+internal val Res.string.str_3081: StringResource
+  get() = String34.str_3081
+
+@ExperimentalResourceApi
+internal val Res.string.str_3082: StringResource
+  get() = String34.str_3082
+
+@ExperimentalResourceApi
+internal val Res.string.str_3083: StringResource
+  get() = String34.str_3083
+
+@ExperimentalResourceApi
+internal val Res.string.str_3084: StringResource
+  get() = String34.str_3084
+
+@ExperimentalResourceApi
+internal val Res.string.str_3085: StringResource
+  get() = String34.str_3085
+
+@ExperimentalResourceApi
+internal val Res.string.str_3086: StringResource
+  get() = String34.str_3086
+
+@ExperimentalResourceApi
+internal val Res.string.str_3087: StringResource
+  get() = String34.str_3087
+
+@ExperimentalResourceApi
+internal val Res.string.str_3088: StringResource
+  get() = String34.str_3088
+
+@ExperimentalResourceApi
+internal val Res.string.str_3089: StringResource
+  get() = String34.str_3089
+
+@ExperimentalResourceApi
+internal val Res.string.str_309: StringResource
+  get() = String34.str_309
+
+@ExperimentalResourceApi
+internal val Res.string.str_3090: StringResource
+  get() = String34.str_3090
+
+@ExperimentalResourceApi
+internal val Res.string.str_3091: StringResource
+  get() = String34.str_3091
+
+@ExperimentalResourceApi
+internal val Res.string.str_3092: StringResource
+  get() = String34.str_3092
+
+@ExperimentalResourceApi
+internal val Res.string.str_3093: StringResource
+  get() = String34.str_3093
+
+@ExperimentalResourceApi
+internal val Res.string.str_3094: StringResource
+  get() = String34.str_3094
+
+@ExperimentalResourceApi
+internal val Res.string.str_3095: StringResource
+  get() = String34.str_3095
+
+@ExperimentalResourceApi
+internal val Res.string.str_3096: StringResource
+  get() = String34.str_3096
+
+@ExperimentalResourceApi
+internal val Res.string.str_3097: StringResource
+  get() = String34.str_3097
+
+@ExperimentalResourceApi
+internal val Res.string.str_3098: StringResource
+  get() = String34.str_3098
+
+@ExperimentalResourceApi
+internal val Res.string.str_3099: StringResource
+  get() = String34.str_3099
+
+@ExperimentalResourceApi
+internal val Res.string.str_31: StringResource
+  get() = String34.str_31
+
+@ExperimentalResourceApi
+internal val Res.string.str_310: StringResource
+  get() = String34.str_310
+
+@ExperimentalResourceApi
+internal val Res.string.str_3100: StringResource
+  get() = String34.str_3100
+
+@ExperimentalResourceApi
+internal val Res.string.str_3101: StringResource
+  get() = String34.str_3101
+
+@ExperimentalResourceApi
+internal val Res.string.str_3102: StringResource
+  get() = String34.str_3102
+
+@ExperimentalResourceApi
+internal val Res.string.str_3103: StringResource
+  get() = String34.str_3103
+
+@ExperimentalResourceApi
+internal val Res.string.str_3104: StringResource
+  get() = String34.str_3104
+
+@ExperimentalResourceApi
+internal val Res.string.str_3105: StringResource
+  get() = String34.str_3105
+
+@ExperimentalResourceApi
+internal val Res.string.str_3106: StringResource
+  get() = String34.str_3106
+
+@ExperimentalResourceApi
+internal val Res.string.str_3107: StringResource
+  get() = String34.str_3107
+
+@ExperimentalResourceApi
+internal val Res.string.str_3108: StringResource
+  get() = String34.str_3108
+
+@ExperimentalResourceApi
+internal val Res.string.str_3109: StringResource
+  get() = String34.str_3109
+
+@ExperimentalResourceApi
+internal val Res.string.str_311: StringResource
+  get() = String34.str_311
+
+@ExperimentalResourceApi
+internal val Res.string.str_3110: StringResource
+  get() = String34.str_3110
+
+@ExperimentalResourceApi
+internal val Res.string.str_3111: StringResource
+  get() = String34.str_3111
+
+@ExperimentalResourceApi
+internal val Res.string.str_3112: StringResource
+  get() = String34.str_3112
+
+@ExperimentalResourceApi
+internal val Res.string.str_3113: StringResource
+  get() = String34.str_3113
+
+@ExperimentalResourceApi
+internal val Res.string.str_3114: StringResource
+  get() = String34.str_3114
+
+@ExperimentalResourceApi
+internal val Res.string.str_3115: StringResource
+  get() = String34.str_3115
+
+@ExperimentalResourceApi
+internal val Res.string.str_3116: StringResource
+  get() = String34.str_3116
+
+@ExperimentalResourceApi
+internal val Res.string.str_3117: StringResource
+  get() = String34.str_3117
+
+@ExperimentalResourceApi
+internal val Res.string.str_3118: StringResource
+  get() = String34.str_3118
+
+@ExperimentalResourceApi
+internal val Res.string.str_3119: StringResource
+  get() = String34.str_3119
+
+@ExperimentalResourceApi
+internal val Res.string.str_312: StringResource
+  get() = String34.str_312
+
+@ExperimentalResourceApi
+internal val Res.string.str_3120: StringResource
+  get() = String34.str_3120
+
+@ExperimentalResourceApi
+internal val Res.string.str_3121: StringResource
+  get() = String34.str_3121
+
+@ExperimentalResourceApi
+internal val Res.string.str_3122: StringResource
+  get() = String34.str_3122
+
+@ExperimentalResourceApi
+internal val Res.string.str_3123: StringResource
+  get() = String34.str_3123
+
+@ExperimentalResourceApi
+internal val Res.string.str_3124: StringResource
+  get() = String34.str_3124
+
+@ExperimentalResourceApi
+internal val Res.string.str_3125: StringResource
+  get() = String34.str_3125
+
+@ExperimentalResourceApi
+internal val Res.string.str_3126: StringResource
+  get() = String34.str_3126
+
+@ExperimentalResourceApi
+internal val Res.string.str_3127: StringResource
+  get() = String34.str_3127
+
+@ExperimentalResourceApi
+internal val Res.string.str_3128: StringResource
+  get() = String34.str_3128
+
+@ExperimentalResourceApi
+internal val Res.string.str_3129: StringResource
+  get() = String34.str_3129
+
+@ExperimentalResourceApi
+internal val Res.string.str_313: StringResource
+  get() = String34.str_313
+
+@ExperimentalResourceApi
+internal val Res.string.str_3130: StringResource
+  get() = String34.str_3130
+
+@ExperimentalResourceApi
+internal val Res.string.str_3131: StringResource
+  get() = String34.str_3131
+
+@ExperimentalResourceApi
+internal val Res.string.str_3132: StringResource
+  get() = String34.str_3132
+
+@ExperimentalResourceApi
+internal val Res.string.str_3133: StringResource
+  get() = String34.str_3133
+
+@ExperimentalResourceApi
+internal val Res.string.str_3134: StringResource
+  get() = String34.str_3134
+
+@ExperimentalResourceApi
+internal val Res.string.str_3135: StringResource
+  get() = String34.str_3135
+
+@ExperimentalResourceApi
+internal val Res.string.str_3136: StringResource
+  get() = String34.str_3136
+
+@ExperimentalResourceApi
+internal val Res.string.str_3137: StringResource
+  get() = String34.str_3137
+
+@ExperimentalResourceApi
+internal val Res.string.str_3138: StringResource
+  get() = String34.str_3138
+
+@ExperimentalResourceApi
+internal val Res.string.str_3139: StringResource
+  get() = String34.str_3139
+
+@ExperimentalResourceApi
+internal val Res.string.str_314: StringResource
+  get() = String34.str_314
+
+@ExperimentalResourceApi
+internal val Res.string.str_3140: StringResource
+  get() = String34.str_3140
+
+@ExperimentalResourceApi
+internal val Res.string.str_3141: StringResource
+  get() = String34.str_3141
+
+@ExperimentalResourceApi
+internal val Res.string.str_3142: StringResource
+  get() = String34.str_3142
+
+@ExperimentalResourceApi
+internal val Res.string.str_3143: StringResource
+  get() = String34.str_3143
+
+@ExperimentalResourceApi
+internal val Res.string.str_3144: StringResource
+  get() = String34.str_3144
+
+@ExperimentalResourceApi
+internal val Res.string.str_3145: StringResource
+  get() = String34.str_3145
+
+@ExperimentalResourceApi
+internal val Res.string.str_3146: StringResource
+  get() = String34.str_3146
+
+@ExperimentalResourceApi
+internal val Res.string.str_3147: StringResource
+  get() = String34.str_3147
+
+@ExperimentalResourceApi
+internal val Res.string.str_3148: StringResource
+  get() = String34.str_3148
+
+@ExperimentalResourceApi
+internal val Res.string.str_3149: StringResource
+  get() = String34.str_3149
+
+@ExperimentalResourceApi
+internal val Res.string.str_315: StringResource
+  get() = String34.str_315
+
+@ExperimentalResourceApi
+internal val Res.string.str_3150: StringResource
+  get() = String34.str_3150
+
+@ExperimentalResourceApi
+internal val Res.string.str_3151: StringResource
+  get() = String34.str_3151
+
+@ExperimentalResourceApi
+internal val Res.string.str_3152: StringResource
+  get() = String34.str_3152
+
+@ExperimentalResourceApi
+internal val Res.string.str_3153: StringResource
+  get() = String34.str_3153
+
+@ExperimentalResourceApi
+internal val Res.string.str_3154: StringResource
+  get() = String34.str_3154
+
+@ExperimentalResourceApi
+internal val Res.string.str_3155: StringResource
+  get() = String34.str_3155
+
+@ExperimentalResourceApi
+internal val Res.string.str_3156: StringResource
+  get() = String34.str_3156
+
+@ExperimentalResourceApi
+internal val Res.string.str_3157: StringResource
+  get() = String34.str_3157
+
+@ExperimentalResourceApi
+internal val Res.string.str_3158: StringResource
+  get() = String34.str_3158
+
+@ExperimentalResourceApi
+internal val Res.string.str_3159: StringResource
+  get() = String34.str_3159
+
+@ExperimentalResourceApi
+internal val Res.string.str_316: StringResource
+  get() = String34.str_316
+
+@ExperimentalResourceApi
+internal val Res.string.str_3160: StringResource
+  get() = String34.str_3160
+
+@ExperimentalResourceApi
+internal val Res.string.str_3161: StringResource
+  get() = String34.str_3161
+
+@ExperimentalResourceApi
+internal val Res.string.str_3162: StringResource
+  get() = String34.str_3162
+
+@ExperimentalResourceApi
+internal val Res.string.str_3163: StringResource
+  get() = String34.str_3163
+
+@ExperimentalResourceApi
+internal val Res.string.str_3164: StringResource
+  get() = String34.str_3164
+
+@ExperimentalResourceApi
+internal val Res.string.str_3165: StringResource
+  get() = String34.str_3165
+
+@ExperimentalResourceApi
+internal val Res.string.str_3166: StringResource
+  get() = String34.str_3166
+
+@ExperimentalResourceApi
+internal val Res.string.str_3167: StringResource
+  get() = String34.str_3167
+
+@ExperimentalResourceApi
+internal val Res.string.str_3168: StringResource
+  get() = String34.str_3168
+
+@ExperimentalResourceApi
+internal val Res.string.str_3169: StringResource
+  get() = String34.str_3169
+
+@ExperimentalResourceApi
+internal val Res.string.str_317: StringResource
+  get() = String34.str_317
+
+@ExperimentalResourceApi
+internal val Res.string.str_3170: StringResource
+  get() = String34.str_3170
+
+@ExperimentalResourceApi
+internal val Res.string.str_3171: StringResource
+  get() = String34.str_3171
+
+@ExperimentalResourceApi
+internal val Res.string.str_3172: StringResource
+  get() = String34.str_3172
+
+@ExperimentalResourceApi
+internal val Res.string.str_3173: StringResource
+  get() = String34.str_3173
+
+@ExperimentalResourceApi
+internal val Res.string.str_3174: StringResource
+  get() = String34.str_3174
+
+@ExperimentalResourceApi
+internal val Res.string.str_3175: StringResource
+  get() = String34.str_3175
+
+@ExperimentalResourceApi
+internal val Res.string.str_3176: StringResource
+  get() = String34.str_3176
+
+@ExperimentalResourceApi
+internal val Res.string.str_3177: StringResource
+  get() = String34.str_3177
+
+@ExperimentalResourceApi
+internal val Res.string.str_3178: StringResource
+  get() = String34.str_3178
+
+@ExperimentalResourceApi
+internal val Res.string.str_3179: StringResource
+  get() = String34.str_3179
+
+@ExperimentalResourceApi
+internal val Res.string.str_318: StringResource
+  get() = String34.str_318
+
+@ExperimentalResourceApi
+internal val Res.string.str_3180: StringResource
+  get() = String34.str_3180
+
+@ExperimentalResourceApi
+internal val Res.string.str_3181: StringResource
+  get() = String34.str_3181
+
+@ExperimentalResourceApi
+internal val Res.string.str_3182: StringResource
+  get() = String34.str_3182
+
+@ExperimentalResourceApi
+internal val Res.string.str_3183: StringResource
+  get() = String34.str_3183
+
+@ExperimentalResourceApi
+internal val Res.string.str_3184: StringResource
+  get() = String34.str_3184
+
+@ExperimentalResourceApi
+internal val Res.string.str_3185: StringResource
+  get() = String34.str_3185
+
+@ExperimentalResourceApi
+internal val Res.string.str_3186: StringResource
+  get() = String34.str_3186
+
+@ExperimentalResourceApi
+internal val Res.string.str_3187: StringResource
+  get() = String34.str_3187
+
+@ExperimentalResourceApi
+internal val Res.string.str_3188: StringResource
+  get() = String34.str_3188
+
+@ExperimentalResourceApi
+internal val Res.string.str_3189: StringResource
+  get() = String34.str_3189
+
+@ExperimentalResourceApi
+internal val Res.string.str_319: StringResource
+  get() = String34.str_319
+
+@ExperimentalResourceApi
+internal val Res.string.str_3190: StringResource
+  get() = String34.str_3190
+
+@ExperimentalResourceApi
+internal val Res.string.str_3191: StringResource
+  get() = String34.str_3191
+
+@ExperimentalResourceApi
+internal val Res.string.str_3192: StringResource
+  get() = String34.str_3192
+
+@ExperimentalResourceApi
+internal val Res.string.str_3193: StringResource
+  get() = String34.str_3193
+
+@ExperimentalResourceApi
+internal val Res.string.str_3194: StringResource
+  get() = String34.str_3194
+
+@ExperimentalResourceApi
+internal val Res.string.str_3195: StringResource
+  get() = String34.str_3195
+
+@ExperimentalResourceApi
+internal val Res.string.str_3196: StringResource
+  get() = String34.str_3196
+
+@ExperimentalResourceApi
+internal val Res.string.str_3197: StringResource
+  get() = String34.str_3197
+
+@ExperimentalResourceApi
+internal val Res.string.str_3198: StringResource
+  get() = String34.str_3198
+
+@ExperimentalResourceApi
+internal val Res.string.str_3199: StringResource
+  get() = String34.str_3199
+
+@ExperimentalResourceApi
+internal val Res.string.str_32: StringResource
+  get() = String34.str_32
+
+@ExperimentalResourceApi
+internal val Res.string.str_320: StringResource
+  get() = String34.str_320
+
+@ExperimentalResourceApi
+internal val Res.string.str_3200: StringResource
+  get() = String34.str_3200
+
+@ExperimentalResourceApi
+internal val Res.string.str_3201: StringResource
+  get() = String34.str_3201
+
+@ExperimentalResourceApi
+internal val Res.string.str_3202: StringResource
+  get() = String34.str_3202
+
+@ExperimentalResourceApi
+internal val Res.string.str_3203: StringResource
+  get() = String34.str_3203
+
+@ExperimentalResourceApi
+internal val Res.string.str_3204: StringResource
+  get() = String34.str_3204
+
+@ExperimentalResourceApi
+internal val Res.string.str_3205: StringResource
+  get() = String34.str_3205
+
+@ExperimentalResourceApi
+internal val Res.string.str_3206: StringResource
+  get() = String34.str_3206
+
+@ExperimentalResourceApi
+internal val Res.string.str_3207: StringResource
+  get() = String34.str_3207
+
+@ExperimentalResourceApi
+internal val Res.string.str_3208: StringResource
+  get() = String34.str_3208
+
+@ExperimentalResourceApi
+internal val Res.string.str_3209: StringResource
+  get() = String34.str_3209
+
+@ExperimentalResourceApi
+internal val Res.string.str_321: StringResource
+  get() = String34.str_321
+
+@ExperimentalResourceApi
+internal val Res.string.str_3210: StringResource
+  get() = String34.str_3210
+
+@ExperimentalResourceApi
+internal val Res.string.str_3211: StringResource
+  get() = String34.str_3211
+
+@ExperimentalResourceApi
+internal val Res.string.str_3212: StringResource
+  get() = String34.str_3212
+
+@ExperimentalResourceApi
+internal val Res.string.str_3213: StringResource
+  get() = String34.str_3213
+
+@ExperimentalResourceApi
+internal val Res.string.str_3214: StringResource
+  get() = String34.str_3214
+
+@ExperimentalResourceApi
+internal val Res.string.str_3215: StringResource
+  get() = String34.str_3215
+
+@ExperimentalResourceApi
+internal val Res.string.str_3216: StringResource
+  get() = String34.str_3216
+
+@ExperimentalResourceApi
+internal val Res.string.str_3217: StringResource
+  get() = String34.str_3217
+
+@ExperimentalResourceApi
+internal val Res.string.str_3218: StringResource
+  get() = String34.str_3218
+
+@ExperimentalResourceApi
+internal val Res.string.str_3219: StringResource
+  get() = String34.str_3219
+
+@ExperimentalResourceApi
+internal val Res.string.str_322: StringResource
+  get() = String34.str_322
+
+@ExperimentalResourceApi
+internal val Res.string.str_3220: StringResource
+  get() = String34.str_3220
+
+@ExperimentalResourceApi
+internal val Res.string.str_3221: StringResource
+  get() = String34.str_3221
+
+@ExperimentalResourceApi
+internal val Res.string.str_3222: StringResource
+  get() = String34.str_3222
+
+@ExperimentalResourceApi
+internal val Res.string.str_3223: StringResource
+  get() = String34.str_3223
+
+@ExperimentalResourceApi
+internal val Res.string.str_3224: StringResource
+  get() = String34.str_3224
+
+@ExperimentalResourceApi
+internal val Res.string.str_3225: StringResource
+  get() = String34.str_3225
+
+@ExperimentalResourceApi
+internal val Res.string.str_3226: StringResource
+  get() = String34.str_3226
+
+@ExperimentalResourceApi
+internal val Res.string.str_3227: StringResource
+  get() = String34.str_3227
+
+@ExperimentalResourceApi
+internal val Res.string.str_3228: StringResource
+  get() = String34.str_3228
+
+@ExperimentalResourceApi
+internal val Res.string.str_3229: StringResource
+  get() = String34.str_3229
+
+@ExperimentalResourceApi
+internal val Res.string.str_323: StringResource
+  get() = String34.str_323
+
+@ExperimentalResourceApi
+internal val Res.string.str_3230: StringResource
+  get() = String34.str_3230
+
+@ExperimentalResourceApi
+internal val Res.string.str_3231: StringResource
+  get() = String34.str_3231
+
+@ExperimentalResourceApi
+internal val Res.string.str_3232: StringResource
+  get() = String34.str_3232
+
+@ExperimentalResourceApi
+internal val Res.string.str_3233: StringResource
+  get() = String34.str_3233
+
+@ExperimentalResourceApi
+internal val Res.string.str_3234: StringResource
+  get() = String34.str_3234
+
+@ExperimentalResourceApi
+internal val Res.string.str_3235: StringResource
+  get() = String34.str_3235
+
+@ExperimentalResourceApi
+internal val Res.string.str_3236: StringResource
+  get() = String34.str_3236
+
+@ExperimentalResourceApi
+internal val Res.string.str_3237: StringResource
+  get() = String34.str_3237
+
+@ExperimentalResourceApi
+internal val Res.string.str_3238: StringResource
+  get() = String34.str_3238
+
+@ExperimentalResourceApi
+internal val Res.string.str_3239: StringResource
+  get() = String34.str_3239
+
+@ExperimentalResourceApi
+internal val Res.string.str_324: StringResource
+  get() = String34.str_324
+
+@ExperimentalResourceApi
+internal val Res.string.str_3240: StringResource
+  get() = String34.str_3240
+
+@ExperimentalResourceApi
+internal val Res.string.str_3241: StringResource
+  get() = String34.str_3241
+
+@ExperimentalResourceApi
+internal val Res.string.str_3242: StringResource
+  get() = String34.str_3242
+
+@ExperimentalResourceApi
+internal val Res.string.str_3243: StringResource
+  get() = String34.str_3243
+
+@ExperimentalResourceApi
+internal val Res.string.str_3244: StringResource
+  get() = String34.str_3244
+
+@ExperimentalResourceApi
+internal val Res.string.str_3245: StringResource
+  get() = String34.str_3245
+
+@ExperimentalResourceApi
+internal val Res.string.str_3246: StringResource
+  get() = String34.str_3246
+
+@ExperimentalResourceApi
+internal val Res.string.str_3247: StringResource
+  get() = String34.str_3247

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String35.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String35.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String35 {
+  public val str_3248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3248", "str_3248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3249", "str_3249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_325", "str_325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3250", "str_3250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3251", "str_3251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3252", "str_3252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3253", "str_3253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3254", "str_3254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3255", "str_3255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3256", "str_3256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3257", "str_3257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3258", "str_3258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3259", "str_3259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_326", "str_326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3260", "str_3260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3261", "str_3261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3262", "str_3262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3263", "str_3263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3264", "str_3264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3265", "str_3265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3266", "str_3266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3267", "str_3267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3268", "str_3268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3269", "str_3269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_327", "str_327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3270", "str_3270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3271", "str_3271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3272", "str_3272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3273", "str_3273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3274", "str_3274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3275", "str_3275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3276", "str_3276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3277", "str_3277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3278", "str_3278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3279", "str_3279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_328", "str_328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3280", "str_3280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3281", "str_3281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3282", "str_3282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3283", "str_3283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3284", "str_3284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3285", "str_3285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3286", "str_3286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3287", "str_3287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3288", "str_3288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3289", "str_3289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_329", "str_329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3290", "str_3290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3291", "str_3291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3292", "str_3292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3293", "str_3293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3294", "str_3294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3295", "str_3295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3296", "str_3296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3297", "str_3297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3298", "str_3298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3299", "str_3299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_33: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_33", "str_33",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_330", "str_330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3300", "str_3300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3301", "str_3301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3302", "str_3302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3303", "str_3303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3304", "str_3304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3305", "str_3305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3306", "str_3306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3307", "str_3307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3308", "str_3308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3309", "str_3309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_331", "str_331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3310", "str_3310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3311", "str_3311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3312", "str_3312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3313", "str_3313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3314", "str_3314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3315", "str_3315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3316", "str_3316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3317", "str_3317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3318", "str_3318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3319", "str_3319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_332", "str_332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3320", "str_3320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3321", "str_3321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3322", "str_3322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3323", "str_3323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3324", "str_3324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3325", "str_3325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3326", "str_3326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3327", "str_3327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3328", "str_3328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3329", "str_3329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_333", "str_333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3330", "str_3330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3331", "str_3331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3332", "str_3332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3333", "str_3333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3334", "str_3334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3335", "str_3335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3336", "str_3336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3337", "str_3337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3338", "str_3338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3339", "str_3339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_334", "str_334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3340", "str_3340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3341", "str_3341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3342", "str_3342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3343", "str_3343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3344", "str_3344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3345", "str_3345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3346", "str_3346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3347", "str_3347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3348", "str_3348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3349", "str_3349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_335", "str_335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3350", "str_3350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3351", "str_3351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3352", "str_3352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3353", "str_3353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3354", "str_3354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3355", "str_3355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3356", "str_3356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3357", "str_3357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3358", "str_3358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3359", "str_3359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_336", "str_336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3360", "str_3360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3361", "str_3361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3362", "str_3362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3363", "str_3363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3364", "str_3364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3365", "str_3365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3366", "str_3366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3367", "str_3367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3368", "str_3368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3369", "str_3369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_337", "str_337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3370", "str_3370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3371", "str_3371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3372", "str_3372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3373", "str_3373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3374", "str_3374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3375", "str_3375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3376", "str_3376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3377", "str_3377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3378", "str_3378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3379", "str_3379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_338", "str_338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3380", "str_3380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3381", "str_3381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3382", "str_3382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3383", "str_3383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3384", "str_3384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3385", "str_3385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3386", "str_3386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3387", "str_3387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3388", "str_3388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3389", "str_3389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_339", "str_339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3390", "str_3390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3391", "str_3391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3392", "str_3392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3393", "str_3393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3394", "str_3394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3395", "str_3395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3396", "str_3396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3397", "str_3397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3398", "str_3398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3399", "str_3399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_34: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_34", "str_34",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_340", "str_340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3400", "str_3400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3401", "str_3401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3402", "str_3402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3403", "str_3403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3404", "str_3404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3405", "str_3405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3406", "str_3406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3407", "str_3407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3408", "str_3408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3409", "str_3409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_341", "str_341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3410", "str_3410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3411", "str_3411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3412", "str_3412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3413", "str_3413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3414", "str_3414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3415", "str_3415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3416", "str_3416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3417", "str_3417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3418", "str_3418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3419", "str_3419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_342", "str_342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3420", "str_3420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3421", "str_3421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3422", "str_3422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3423", "str_3423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3424", "str_3424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3425", "str_3425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3426", "str_3426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3427", "str_3427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3428", "str_3428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3429", "str_3429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_343", "str_343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3430", "str_3430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3431", "str_3431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3432", "str_3432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3433", "str_3433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3434", "str_3434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3435", "str_3435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3436", "str_3436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3437", "str_3437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3438", "str_3438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3439", "str_3439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_344", "str_344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3440", "str_3440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3441", "str_3441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3442", "str_3442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3443", "str_3443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3444", "str_3444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3445", "str_3445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3446", "str_3446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3447", "str_3447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3448", "str_3448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3449", "str_3449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_345", "str_345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3450", "str_3450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3451", "str_3451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3452", "str_3452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3453", "str_3453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3454", "str_3454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3455", "str_3455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3456", "str_3456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3457", "str_3457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3458", "str_3458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3459", "str_3459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_346", "str_346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3460", "str_3460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3461", "str_3461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3462", "str_3462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3463", "str_3463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3464", "str_3464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3465", "str_3465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3466", "str_3466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3467", "str_3467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3468", "str_3468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3469", "str_3469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_347", "str_347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3470", "str_3470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3471", "str_3471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3472", "str_3472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3473", "str_3473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3474", "str_3474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3475", "str_3475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3476", "str_3476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3477", "str_3477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3478", "str_3478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3479", "str_3479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_348", "str_348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3480", "str_3480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3481", "str_3481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3482", "str_3482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3483", "str_3483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3484", "str_3484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3485", "str_3485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3486", "str_3486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3487", "str_3487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3488", "str_3488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3489", "str_3489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_349", "str_349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3490", "str_3490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3491", "str_3491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3492", "str_3492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3493", "str_3493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3494", "str_3494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3495", "str_3495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3496", "str_3496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3497", "str_3497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3498", "str_3498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3499", "str_3499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_35: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_35", "str_35",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_350", "str_350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3500", "str_3500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3501", "str_3501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3502", "str_3502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3503", "str_3503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3504", "str_3504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3505", "str_3505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3506", "str_3506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3507", "str_3507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3508", "str_3508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3509", "str_3509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_351", "str_351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3510", "str_3510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3511", "str_3511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3512", "str_3512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3513", "str_3513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3514", "str_3514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3515", "str_3515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3516", "str_3516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3517", "str_3517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3518", "str_3518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3519", "str_3519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_352", "str_352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3520", "str_3520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3521", "str_3521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3522", "str_3522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3523", "str_3523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3524", "str_3524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3525", "str_3525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3526", "str_3526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3527", "str_3527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3528", "str_3528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3529", "str_3529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_353", "str_353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3530", "str_3530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3531", "str_3531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3532", "str_3532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3533", "str_3533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3534", "str_3534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3535", "str_3535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3536", "str_3536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3537", "str_3537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3538", "str_3538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3539", "str_3539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_354", "str_354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3540", "str_3540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3541", "str_3541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3542", "str_3542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3543", "str_3543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3544", "str_3544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3545", "str_3545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3546", "str_3546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3547", "str_3547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3548", "str_3548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3549", "str_3549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_355", "str_355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3550", "str_3550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3551", "str_3551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3552", "str_3552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3553", "str_3553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3554", "str_3554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3555", "str_3555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3556", "str_3556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3557", "str_3557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3558", "str_3558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3559", "str_3559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_356", "str_356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3560", "str_3560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3561", "str_3561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3562", "str_3562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3563", "str_3563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3564", "str_3564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3565", "str_3565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3566", "str_3566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3567", "str_3567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3568", "str_3568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3569", "str_3569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_357", "str_357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3570", "str_3570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3571", "str_3571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3572", "str_3572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3573", "str_3573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3574", "str_3574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3575", "str_3575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3576", "str_3576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3577", "str_3577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3578", "str_3578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3579", "str_3579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_358", "str_358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3580", "str_3580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3581", "str_3581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3582", "str_3582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3583", "str_3583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3584", "str_3584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3585", "str_3585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3586", "str_3586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3587", "str_3587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3588", "str_3588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3589", "str_3589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_359", "str_359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3590", "str_3590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3591", "str_3591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3592", "str_3592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3593", "str_3593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3594", "str_3594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3595", "str_3595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3596", "str_3596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3597", "str_3597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3598", "str_3598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3599", "str_3599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_36: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_36", "str_36",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_360", "str_360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3600", "str_3600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3601", "str_3601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3602", "str_3602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3603", "str_3603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3604", "str_3604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3605", "str_3605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3606", "str_3606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3607", "str_3607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3608", "str_3608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3609", "str_3609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_361", "str_361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3610", "str_3610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3611", "str_3611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3612", "str_3612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3613", "str_3613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3614", "str_3614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3615", "str_3615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3616", "str_3616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3617", "str_3617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3618", "str_3618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3619", "str_3619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_362", "str_362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3620", "str_3620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3621", "str_3621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3622", "str_3622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3623", "str_3623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3624", "str_3624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3625", "str_3625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3626", "str_3626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3627", "str_3627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3628", "str_3628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3629", "str_3629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_363", "str_363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3630", "str_3630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3631", "str_3631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3632", "str_3632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3633", "str_3633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3634", "str_3634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3635", "str_3635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3636", "str_3636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3637", "str_3637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3638", "str_3638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3639", "str_3639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_364", "str_364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3640", "str_3640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3641", "str_3641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3642", "str_3642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3643", "str_3643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3644", "str_3644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3645", "str_3645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3646", "str_3646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3647", "str_3647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3648", "str_3648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3649", "str_3649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_365", "str_365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3650", "str_3650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3651", "str_3651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3652", "str_3652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3653", "str_3653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3654", "str_3654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3655", "str_3655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3656", "str_3656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3657", "str_3657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3658", "str_3658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3659", "str_3659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_366", "str_366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3660", "str_3660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3661", "str_3661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3662", "str_3662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3663", "str_3663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3664", "str_3664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3665", "str_3665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3666", "str_3666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3667", "str_3667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3668", "str_3668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3669", "str_3669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_367", "str_367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3670", "str_3670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3671", "str_3671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3672", "str_3672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3673", "str_3673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3674", "str_3674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3675", "str_3675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3676", "str_3676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3677", "str_3677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3678", "str_3678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3679", "str_3679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_368", "str_368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3680", "str_3680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3681", "str_3681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3682", "str_3682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3683", "str_3683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3684", "str_3684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3685", "str_3685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3686", "str_3686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3687", "str_3687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3688", "str_3688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3689", "str_3689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_369", "str_369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3690", "str_3690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3691", "str_3691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3692", "str_3692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3693", "str_3693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3694", "str_3694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3695", "str_3695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3696", "str_3696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3697", "str_3697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3698", "str_3698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_3248: StringResource
+  get() = String35.str_3248
+
+@ExperimentalResourceApi
+internal val Res.string.str_3249: StringResource
+  get() = String35.str_3249
+
+@ExperimentalResourceApi
+internal val Res.string.str_325: StringResource
+  get() = String35.str_325
+
+@ExperimentalResourceApi
+internal val Res.string.str_3250: StringResource
+  get() = String35.str_3250
+
+@ExperimentalResourceApi
+internal val Res.string.str_3251: StringResource
+  get() = String35.str_3251
+
+@ExperimentalResourceApi
+internal val Res.string.str_3252: StringResource
+  get() = String35.str_3252
+
+@ExperimentalResourceApi
+internal val Res.string.str_3253: StringResource
+  get() = String35.str_3253
+
+@ExperimentalResourceApi
+internal val Res.string.str_3254: StringResource
+  get() = String35.str_3254
+
+@ExperimentalResourceApi
+internal val Res.string.str_3255: StringResource
+  get() = String35.str_3255
+
+@ExperimentalResourceApi
+internal val Res.string.str_3256: StringResource
+  get() = String35.str_3256
+
+@ExperimentalResourceApi
+internal val Res.string.str_3257: StringResource
+  get() = String35.str_3257
+
+@ExperimentalResourceApi
+internal val Res.string.str_3258: StringResource
+  get() = String35.str_3258
+
+@ExperimentalResourceApi
+internal val Res.string.str_3259: StringResource
+  get() = String35.str_3259
+
+@ExperimentalResourceApi
+internal val Res.string.str_326: StringResource
+  get() = String35.str_326
+
+@ExperimentalResourceApi
+internal val Res.string.str_3260: StringResource
+  get() = String35.str_3260
+
+@ExperimentalResourceApi
+internal val Res.string.str_3261: StringResource
+  get() = String35.str_3261
+
+@ExperimentalResourceApi
+internal val Res.string.str_3262: StringResource
+  get() = String35.str_3262
+
+@ExperimentalResourceApi
+internal val Res.string.str_3263: StringResource
+  get() = String35.str_3263
+
+@ExperimentalResourceApi
+internal val Res.string.str_3264: StringResource
+  get() = String35.str_3264
+
+@ExperimentalResourceApi
+internal val Res.string.str_3265: StringResource
+  get() = String35.str_3265
+
+@ExperimentalResourceApi
+internal val Res.string.str_3266: StringResource
+  get() = String35.str_3266
+
+@ExperimentalResourceApi
+internal val Res.string.str_3267: StringResource
+  get() = String35.str_3267
+
+@ExperimentalResourceApi
+internal val Res.string.str_3268: StringResource
+  get() = String35.str_3268
+
+@ExperimentalResourceApi
+internal val Res.string.str_3269: StringResource
+  get() = String35.str_3269
+
+@ExperimentalResourceApi
+internal val Res.string.str_327: StringResource
+  get() = String35.str_327
+
+@ExperimentalResourceApi
+internal val Res.string.str_3270: StringResource
+  get() = String35.str_3270
+
+@ExperimentalResourceApi
+internal val Res.string.str_3271: StringResource
+  get() = String35.str_3271
+
+@ExperimentalResourceApi
+internal val Res.string.str_3272: StringResource
+  get() = String35.str_3272
+
+@ExperimentalResourceApi
+internal val Res.string.str_3273: StringResource
+  get() = String35.str_3273
+
+@ExperimentalResourceApi
+internal val Res.string.str_3274: StringResource
+  get() = String35.str_3274
+
+@ExperimentalResourceApi
+internal val Res.string.str_3275: StringResource
+  get() = String35.str_3275
+
+@ExperimentalResourceApi
+internal val Res.string.str_3276: StringResource
+  get() = String35.str_3276
+
+@ExperimentalResourceApi
+internal val Res.string.str_3277: StringResource
+  get() = String35.str_3277
+
+@ExperimentalResourceApi
+internal val Res.string.str_3278: StringResource
+  get() = String35.str_3278
+
+@ExperimentalResourceApi
+internal val Res.string.str_3279: StringResource
+  get() = String35.str_3279
+
+@ExperimentalResourceApi
+internal val Res.string.str_328: StringResource
+  get() = String35.str_328
+
+@ExperimentalResourceApi
+internal val Res.string.str_3280: StringResource
+  get() = String35.str_3280
+
+@ExperimentalResourceApi
+internal val Res.string.str_3281: StringResource
+  get() = String35.str_3281
+
+@ExperimentalResourceApi
+internal val Res.string.str_3282: StringResource
+  get() = String35.str_3282
+
+@ExperimentalResourceApi
+internal val Res.string.str_3283: StringResource
+  get() = String35.str_3283
+
+@ExperimentalResourceApi
+internal val Res.string.str_3284: StringResource
+  get() = String35.str_3284
+
+@ExperimentalResourceApi
+internal val Res.string.str_3285: StringResource
+  get() = String35.str_3285
+
+@ExperimentalResourceApi
+internal val Res.string.str_3286: StringResource
+  get() = String35.str_3286
+
+@ExperimentalResourceApi
+internal val Res.string.str_3287: StringResource
+  get() = String35.str_3287
+
+@ExperimentalResourceApi
+internal val Res.string.str_3288: StringResource
+  get() = String35.str_3288
+
+@ExperimentalResourceApi
+internal val Res.string.str_3289: StringResource
+  get() = String35.str_3289
+
+@ExperimentalResourceApi
+internal val Res.string.str_329: StringResource
+  get() = String35.str_329
+
+@ExperimentalResourceApi
+internal val Res.string.str_3290: StringResource
+  get() = String35.str_3290
+
+@ExperimentalResourceApi
+internal val Res.string.str_3291: StringResource
+  get() = String35.str_3291
+
+@ExperimentalResourceApi
+internal val Res.string.str_3292: StringResource
+  get() = String35.str_3292
+
+@ExperimentalResourceApi
+internal val Res.string.str_3293: StringResource
+  get() = String35.str_3293
+
+@ExperimentalResourceApi
+internal val Res.string.str_3294: StringResource
+  get() = String35.str_3294
+
+@ExperimentalResourceApi
+internal val Res.string.str_3295: StringResource
+  get() = String35.str_3295
+
+@ExperimentalResourceApi
+internal val Res.string.str_3296: StringResource
+  get() = String35.str_3296
+
+@ExperimentalResourceApi
+internal val Res.string.str_3297: StringResource
+  get() = String35.str_3297
+
+@ExperimentalResourceApi
+internal val Res.string.str_3298: StringResource
+  get() = String35.str_3298
+
+@ExperimentalResourceApi
+internal val Res.string.str_3299: StringResource
+  get() = String35.str_3299
+
+@ExperimentalResourceApi
+internal val Res.string.str_33: StringResource
+  get() = String35.str_33
+
+@ExperimentalResourceApi
+internal val Res.string.str_330: StringResource
+  get() = String35.str_330
+
+@ExperimentalResourceApi
+internal val Res.string.str_3300: StringResource
+  get() = String35.str_3300
+
+@ExperimentalResourceApi
+internal val Res.string.str_3301: StringResource
+  get() = String35.str_3301
+
+@ExperimentalResourceApi
+internal val Res.string.str_3302: StringResource
+  get() = String35.str_3302
+
+@ExperimentalResourceApi
+internal val Res.string.str_3303: StringResource
+  get() = String35.str_3303
+
+@ExperimentalResourceApi
+internal val Res.string.str_3304: StringResource
+  get() = String35.str_3304
+
+@ExperimentalResourceApi
+internal val Res.string.str_3305: StringResource
+  get() = String35.str_3305
+
+@ExperimentalResourceApi
+internal val Res.string.str_3306: StringResource
+  get() = String35.str_3306
+
+@ExperimentalResourceApi
+internal val Res.string.str_3307: StringResource
+  get() = String35.str_3307
+
+@ExperimentalResourceApi
+internal val Res.string.str_3308: StringResource
+  get() = String35.str_3308
+
+@ExperimentalResourceApi
+internal val Res.string.str_3309: StringResource
+  get() = String35.str_3309
+
+@ExperimentalResourceApi
+internal val Res.string.str_331: StringResource
+  get() = String35.str_331
+
+@ExperimentalResourceApi
+internal val Res.string.str_3310: StringResource
+  get() = String35.str_3310
+
+@ExperimentalResourceApi
+internal val Res.string.str_3311: StringResource
+  get() = String35.str_3311
+
+@ExperimentalResourceApi
+internal val Res.string.str_3312: StringResource
+  get() = String35.str_3312
+
+@ExperimentalResourceApi
+internal val Res.string.str_3313: StringResource
+  get() = String35.str_3313
+
+@ExperimentalResourceApi
+internal val Res.string.str_3314: StringResource
+  get() = String35.str_3314
+
+@ExperimentalResourceApi
+internal val Res.string.str_3315: StringResource
+  get() = String35.str_3315
+
+@ExperimentalResourceApi
+internal val Res.string.str_3316: StringResource
+  get() = String35.str_3316
+
+@ExperimentalResourceApi
+internal val Res.string.str_3317: StringResource
+  get() = String35.str_3317
+
+@ExperimentalResourceApi
+internal val Res.string.str_3318: StringResource
+  get() = String35.str_3318
+
+@ExperimentalResourceApi
+internal val Res.string.str_3319: StringResource
+  get() = String35.str_3319
+
+@ExperimentalResourceApi
+internal val Res.string.str_332: StringResource
+  get() = String35.str_332
+
+@ExperimentalResourceApi
+internal val Res.string.str_3320: StringResource
+  get() = String35.str_3320
+
+@ExperimentalResourceApi
+internal val Res.string.str_3321: StringResource
+  get() = String35.str_3321
+
+@ExperimentalResourceApi
+internal val Res.string.str_3322: StringResource
+  get() = String35.str_3322
+
+@ExperimentalResourceApi
+internal val Res.string.str_3323: StringResource
+  get() = String35.str_3323
+
+@ExperimentalResourceApi
+internal val Res.string.str_3324: StringResource
+  get() = String35.str_3324
+
+@ExperimentalResourceApi
+internal val Res.string.str_3325: StringResource
+  get() = String35.str_3325
+
+@ExperimentalResourceApi
+internal val Res.string.str_3326: StringResource
+  get() = String35.str_3326
+
+@ExperimentalResourceApi
+internal val Res.string.str_3327: StringResource
+  get() = String35.str_3327
+
+@ExperimentalResourceApi
+internal val Res.string.str_3328: StringResource
+  get() = String35.str_3328
+
+@ExperimentalResourceApi
+internal val Res.string.str_3329: StringResource
+  get() = String35.str_3329
+
+@ExperimentalResourceApi
+internal val Res.string.str_333: StringResource
+  get() = String35.str_333
+
+@ExperimentalResourceApi
+internal val Res.string.str_3330: StringResource
+  get() = String35.str_3330
+
+@ExperimentalResourceApi
+internal val Res.string.str_3331: StringResource
+  get() = String35.str_3331
+
+@ExperimentalResourceApi
+internal val Res.string.str_3332: StringResource
+  get() = String35.str_3332
+
+@ExperimentalResourceApi
+internal val Res.string.str_3333: StringResource
+  get() = String35.str_3333
+
+@ExperimentalResourceApi
+internal val Res.string.str_3334: StringResource
+  get() = String35.str_3334
+
+@ExperimentalResourceApi
+internal val Res.string.str_3335: StringResource
+  get() = String35.str_3335
+
+@ExperimentalResourceApi
+internal val Res.string.str_3336: StringResource
+  get() = String35.str_3336
+
+@ExperimentalResourceApi
+internal val Res.string.str_3337: StringResource
+  get() = String35.str_3337
+
+@ExperimentalResourceApi
+internal val Res.string.str_3338: StringResource
+  get() = String35.str_3338
+
+@ExperimentalResourceApi
+internal val Res.string.str_3339: StringResource
+  get() = String35.str_3339
+
+@ExperimentalResourceApi
+internal val Res.string.str_334: StringResource
+  get() = String35.str_334
+
+@ExperimentalResourceApi
+internal val Res.string.str_3340: StringResource
+  get() = String35.str_3340
+
+@ExperimentalResourceApi
+internal val Res.string.str_3341: StringResource
+  get() = String35.str_3341
+
+@ExperimentalResourceApi
+internal val Res.string.str_3342: StringResource
+  get() = String35.str_3342
+
+@ExperimentalResourceApi
+internal val Res.string.str_3343: StringResource
+  get() = String35.str_3343
+
+@ExperimentalResourceApi
+internal val Res.string.str_3344: StringResource
+  get() = String35.str_3344
+
+@ExperimentalResourceApi
+internal val Res.string.str_3345: StringResource
+  get() = String35.str_3345
+
+@ExperimentalResourceApi
+internal val Res.string.str_3346: StringResource
+  get() = String35.str_3346
+
+@ExperimentalResourceApi
+internal val Res.string.str_3347: StringResource
+  get() = String35.str_3347
+
+@ExperimentalResourceApi
+internal val Res.string.str_3348: StringResource
+  get() = String35.str_3348
+
+@ExperimentalResourceApi
+internal val Res.string.str_3349: StringResource
+  get() = String35.str_3349
+
+@ExperimentalResourceApi
+internal val Res.string.str_335: StringResource
+  get() = String35.str_335
+
+@ExperimentalResourceApi
+internal val Res.string.str_3350: StringResource
+  get() = String35.str_3350
+
+@ExperimentalResourceApi
+internal val Res.string.str_3351: StringResource
+  get() = String35.str_3351
+
+@ExperimentalResourceApi
+internal val Res.string.str_3352: StringResource
+  get() = String35.str_3352
+
+@ExperimentalResourceApi
+internal val Res.string.str_3353: StringResource
+  get() = String35.str_3353
+
+@ExperimentalResourceApi
+internal val Res.string.str_3354: StringResource
+  get() = String35.str_3354
+
+@ExperimentalResourceApi
+internal val Res.string.str_3355: StringResource
+  get() = String35.str_3355
+
+@ExperimentalResourceApi
+internal val Res.string.str_3356: StringResource
+  get() = String35.str_3356
+
+@ExperimentalResourceApi
+internal val Res.string.str_3357: StringResource
+  get() = String35.str_3357
+
+@ExperimentalResourceApi
+internal val Res.string.str_3358: StringResource
+  get() = String35.str_3358
+
+@ExperimentalResourceApi
+internal val Res.string.str_3359: StringResource
+  get() = String35.str_3359
+
+@ExperimentalResourceApi
+internal val Res.string.str_336: StringResource
+  get() = String35.str_336
+
+@ExperimentalResourceApi
+internal val Res.string.str_3360: StringResource
+  get() = String35.str_3360
+
+@ExperimentalResourceApi
+internal val Res.string.str_3361: StringResource
+  get() = String35.str_3361
+
+@ExperimentalResourceApi
+internal val Res.string.str_3362: StringResource
+  get() = String35.str_3362
+
+@ExperimentalResourceApi
+internal val Res.string.str_3363: StringResource
+  get() = String35.str_3363
+
+@ExperimentalResourceApi
+internal val Res.string.str_3364: StringResource
+  get() = String35.str_3364
+
+@ExperimentalResourceApi
+internal val Res.string.str_3365: StringResource
+  get() = String35.str_3365
+
+@ExperimentalResourceApi
+internal val Res.string.str_3366: StringResource
+  get() = String35.str_3366
+
+@ExperimentalResourceApi
+internal val Res.string.str_3367: StringResource
+  get() = String35.str_3367
+
+@ExperimentalResourceApi
+internal val Res.string.str_3368: StringResource
+  get() = String35.str_3368
+
+@ExperimentalResourceApi
+internal val Res.string.str_3369: StringResource
+  get() = String35.str_3369
+
+@ExperimentalResourceApi
+internal val Res.string.str_337: StringResource
+  get() = String35.str_337
+
+@ExperimentalResourceApi
+internal val Res.string.str_3370: StringResource
+  get() = String35.str_3370
+
+@ExperimentalResourceApi
+internal val Res.string.str_3371: StringResource
+  get() = String35.str_3371
+
+@ExperimentalResourceApi
+internal val Res.string.str_3372: StringResource
+  get() = String35.str_3372
+
+@ExperimentalResourceApi
+internal val Res.string.str_3373: StringResource
+  get() = String35.str_3373
+
+@ExperimentalResourceApi
+internal val Res.string.str_3374: StringResource
+  get() = String35.str_3374
+
+@ExperimentalResourceApi
+internal val Res.string.str_3375: StringResource
+  get() = String35.str_3375
+
+@ExperimentalResourceApi
+internal val Res.string.str_3376: StringResource
+  get() = String35.str_3376
+
+@ExperimentalResourceApi
+internal val Res.string.str_3377: StringResource
+  get() = String35.str_3377
+
+@ExperimentalResourceApi
+internal val Res.string.str_3378: StringResource
+  get() = String35.str_3378
+
+@ExperimentalResourceApi
+internal val Res.string.str_3379: StringResource
+  get() = String35.str_3379
+
+@ExperimentalResourceApi
+internal val Res.string.str_338: StringResource
+  get() = String35.str_338
+
+@ExperimentalResourceApi
+internal val Res.string.str_3380: StringResource
+  get() = String35.str_3380
+
+@ExperimentalResourceApi
+internal val Res.string.str_3381: StringResource
+  get() = String35.str_3381
+
+@ExperimentalResourceApi
+internal val Res.string.str_3382: StringResource
+  get() = String35.str_3382
+
+@ExperimentalResourceApi
+internal val Res.string.str_3383: StringResource
+  get() = String35.str_3383
+
+@ExperimentalResourceApi
+internal val Res.string.str_3384: StringResource
+  get() = String35.str_3384
+
+@ExperimentalResourceApi
+internal val Res.string.str_3385: StringResource
+  get() = String35.str_3385
+
+@ExperimentalResourceApi
+internal val Res.string.str_3386: StringResource
+  get() = String35.str_3386
+
+@ExperimentalResourceApi
+internal val Res.string.str_3387: StringResource
+  get() = String35.str_3387
+
+@ExperimentalResourceApi
+internal val Res.string.str_3388: StringResource
+  get() = String35.str_3388
+
+@ExperimentalResourceApi
+internal val Res.string.str_3389: StringResource
+  get() = String35.str_3389
+
+@ExperimentalResourceApi
+internal val Res.string.str_339: StringResource
+  get() = String35.str_339
+
+@ExperimentalResourceApi
+internal val Res.string.str_3390: StringResource
+  get() = String35.str_3390
+
+@ExperimentalResourceApi
+internal val Res.string.str_3391: StringResource
+  get() = String35.str_3391
+
+@ExperimentalResourceApi
+internal val Res.string.str_3392: StringResource
+  get() = String35.str_3392
+
+@ExperimentalResourceApi
+internal val Res.string.str_3393: StringResource
+  get() = String35.str_3393
+
+@ExperimentalResourceApi
+internal val Res.string.str_3394: StringResource
+  get() = String35.str_3394
+
+@ExperimentalResourceApi
+internal val Res.string.str_3395: StringResource
+  get() = String35.str_3395
+
+@ExperimentalResourceApi
+internal val Res.string.str_3396: StringResource
+  get() = String35.str_3396
+
+@ExperimentalResourceApi
+internal val Res.string.str_3397: StringResource
+  get() = String35.str_3397
+
+@ExperimentalResourceApi
+internal val Res.string.str_3398: StringResource
+  get() = String35.str_3398
+
+@ExperimentalResourceApi
+internal val Res.string.str_3399: StringResource
+  get() = String35.str_3399
+
+@ExperimentalResourceApi
+internal val Res.string.str_34: StringResource
+  get() = String35.str_34
+
+@ExperimentalResourceApi
+internal val Res.string.str_340: StringResource
+  get() = String35.str_340
+
+@ExperimentalResourceApi
+internal val Res.string.str_3400: StringResource
+  get() = String35.str_3400
+
+@ExperimentalResourceApi
+internal val Res.string.str_3401: StringResource
+  get() = String35.str_3401
+
+@ExperimentalResourceApi
+internal val Res.string.str_3402: StringResource
+  get() = String35.str_3402
+
+@ExperimentalResourceApi
+internal val Res.string.str_3403: StringResource
+  get() = String35.str_3403
+
+@ExperimentalResourceApi
+internal val Res.string.str_3404: StringResource
+  get() = String35.str_3404
+
+@ExperimentalResourceApi
+internal val Res.string.str_3405: StringResource
+  get() = String35.str_3405
+
+@ExperimentalResourceApi
+internal val Res.string.str_3406: StringResource
+  get() = String35.str_3406
+
+@ExperimentalResourceApi
+internal val Res.string.str_3407: StringResource
+  get() = String35.str_3407
+
+@ExperimentalResourceApi
+internal val Res.string.str_3408: StringResource
+  get() = String35.str_3408
+
+@ExperimentalResourceApi
+internal val Res.string.str_3409: StringResource
+  get() = String35.str_3409
+
+@ExperimentalResourceApi
+internal val Res.string.str_341: StringResource
+  get() = String35.str_341
+
+@ExperimentalResourceApi
+internal val Res.string.str_3410: StringResource
+  get() = String35.str_3410
+
+@ExperimentalResourceApi
+internal val Res.string.str_3411: StringResource
+  get() = String35.str_3411
+
+@ExperimentalResourceApi
+internal val Res.string.str_3412: StringResource
+  get() = String35.str_3412
+
+@ExperimentalResourceApi
+internal val Res.string.str_3413: StringResource
+  get() = String35.str_3413
+
+@ExperimentalResourceApi
+internal val Res.string.str_3414: StringResource
+  get() = String35.str_3414
+
+@ExperimentalResourceApi
+internal val Res.string.str_3415: StringResource
+  get() = String35.str_3415
+
+@ExperimentalResourceApi
+internal val Res.string.str_3416: StringResource
+  get() = String35.str_3416
+
+@ExperimentalResourceApi
+internal val Res.string.str_3417: StringResource
+  get() = String35.str_3417
+
+@ExperimentalResourceApi
+internal val Res.string.str_3418: StringResource
+  get() = String35.str_3418
+
+@ExperimentalResourceApi
+internal val Res.string.str_3419: StringResource
+  get() = String35.str_3419
+
+@ExperimentalResourceApi
+internal val Res.string.str_342: StringResource
+  get() = String35.str_342
+
+@ExperimentalResourceApi
+internal val Res.string.str_3420: StringResource
+  get() = String35.str_3420
+
+@ExperimentalResourceApi
+internal val Res.string.str_3421: StringResource
+  get() = String35.str_3421
+
+@ExperimentalResourceApi
+internal val Res.string.str_3422: StringResource
+  get() = String35.str_3422
+
+@ExperimentalResourceApi
+internal val Res.string.str_3423: StringResource
+  get() = String35.str_3423
+
+@ExperimentalResourceApi
+internal val Res.string.str_3424: StringResource
+  get() = String35.str_3424
+
+@ExperimentalResourceApi
+internal val Res.string.str_3425: StringResource
+  get() = String35.str_3425
+
+@ExperimentalResourceApi
+internal val Res.string.str_3426: StringResource
+  get() = String35.str_3426
+
+@ExperimentalResourceApi
+internal val Res.string.str_3427: StringResource
+  get() = String35.str_3427
+
+@ExperimentalResourceApi
+internal val Res.string.str_3428: StringResource
+  get() = String35.str_3428
+
+@ExperimentalResourceApi
+internal val Res.string.str_3429: StringResource
+  get() = String35.str_3429
+
+@ExperimentalResourceApi
+internal val Res.string.str_343: StringResource
+  get() = String35.str_343
+
+@ExperimentalResourceApi
+internal val Res.string.str_3430: StringResource
+  get() = String35.str_3430
+
+@ExperimentalResourceApi
+internal val Res.string.str_3431: StringResource
+  get() = String35.str_3431
+
+@ExperimentalResourceApi
+internal val Res.string.str_3432: StringResource
+  get() = String35.str_3432
+
+@ExperimentalResourceApi
+internal val Res.string.str_3433: StringResource
+  get() = String35.str_3433
+
+@ExperimentalResourceApi
+internal val Res.string.str_3434: StringResource
+  get() = String35.str_3434
+
+@ExperimentalResourceApi
+internal val Res.string.str_3435: StringResource
+  get() = String35.str_3435
+
+@ExperimentalResourceApi
+internal val Res.string.str_3436: StringResource
+  get() = String35.str_3436
+
+@ExperimentalResourceApi
+internal val Res.string.str_3437: StringResource
+  get() = String35.str_3437
+
+@ExperimentalResourceApi
+internal val Res.string.str_3438: StringResource
+  get() = String35.str_3438
+
+@ExperimentalResourceApi
+internal val Res.string.str_3439: StringResource
+  get() = String35.str_3439
+
+@ExperimentalResourceApi
+internal val Res.string.str_344: StringResource
+  get() = String35.str_344
+
+@ExperimentalResourceApi
+internal val Res.string.str_3440: StringResource
+  get() = String35.str_3440
+
+@ExperimentalResourceApi
+internal val Res.string.str_3441: StringResource
+  get() = String35.str_3441
+
+@ExperimentalResourceApi
+internal val Res.string.str_3442: StringResource
+  get() = String35.str_3442
+
+@ExperimentalResourceApi
+internal val Res.string.str_3443: StringResource
+  get() = String35.str_3443
+
+@ExperimentalResourceApi
+internal val Res.string.str_3444: StringResource
+  get() = String35.str_3444
+
+@ExperimentalResourceApi
+internal val Res.string.str_3445: StringResource
+  get() = String35.str_3445
+
+@ExperimentalResourceApi
+internal val Res.string.str_3446: StringResource
+  get() = String35.str_3446
+
+@ExperimentalResourceApi
+internal val Res.string.str_3447: StringResource
+  get() = String35.str_3447
+
+@ExperimentalResourceApi
+internal val Res.string.str_3448: StringResource
+  get() = String35.str_3448
+
+@ExperimentalResourceApi
+internal val Res.string.str_3449: StringResource
+  get() = String35.str_3449
+
+@ExperimentalResourceApi
+internal val Res.string.str_345: StringResource
+  get() = String35.str_345
+
+@ExperimentalResourceApi
+internal val Res.string.str_3450: StringResource
+  get() = String35.str_3450
+
+@ExperimentalResourceApi
+internal val Res.string.str_3451: StringResource
+  get() = String35.str_3451
+
+@ExperimentalResourceApi
+internal val Res.string.str_3452: StringResource
+  get() = String35.str_3452
+
+@ExperimentalResourceApi
+internal val Res.string.str_3453: StringResource
+  get() = String35.str_3453
+
+@ExperimentalResourceApi
+internal val Res.string.str_3454: StringResource
+  get() = String35.str_3454
+
+@ExperimentalResourceApi
+internal val Res.string.str_3455: StringResource
+  get() = String35.str_3455
+
+@ExperimentalResourceApi
+internal val Res.string.str_3456: StringResource
+  get() = String35.str_3456
+
+@ExperimentalResourceApi
+internal val Res.string.str_3457: StringResource
+  get() = String35.str_3457
+
+@ExperimentalResourceApi
+internal val Res.string.str_3458: StringResource
+  get() = String35.str_3458
+
+@ExperimentalResourceApi
+internal val Res.string.str_3459: StringResource
+  get() = String35.str_3459
+
+@ExperimentalResourceApi
+internal val Res.string.str_346: StringResource
+  get() = String35.str_346
+
+@ExperimentalResourceApi
+internal val Res.string.str_3460: StringResource
+  get() = String35.str_3460
+
+@ExperimentalResourceApi
+internal val Res.string.str_3461: StringResource
+  get() = String35.str_3461
+
+@ExperimentalResourceApi
+internal val Res.string.str_3462: StringResource
+  get() = String35.str_3462
+
+@ExperimentalResourceApi
+internal val Res.string.str_3463: StringResource
+  get() = String35.str_3463
+
+@ExperimentalResourceApi
+internal val Res.string.str_3464: StringResource
+  get() = String35.str_3464
+
+@ExperimentalResourceApi
+internal val Res.string.str_3465: StringResource
+  get() = String35.str_3465
+
+@ExperimentalResourceApi
+internal val Res.string.str_3466: StringResource
+  get() = String35.str_3466
+
+@ExperimentalResourceApi
+internal val Res.string.str_3467: StringResource
+  get() = String35.str_3467
+
+@ExperimentalResourceApi
+internal val Res.string.str_3468: StringResource
+  get() = String35.str_3468
+
+@ExperimentalResourceApi
+internal val Res.string.str_3469: StringResource
+  get() = String35.str_3469
+
+@ExperimentalResourceApi
+internal val Res.string.str_347: StringResource
+  get() = String35.str_347
+
+@ExperimentalResourceApi
+internal val Res.string.str_3470: StringResource
+  get() = String35.str_3470
+
+@ExperimentalResourceApi
+internal val Res.string.str_3471: StringResource
+  get() = String35.str_3471
+
+@ExperimentalResourceApi
+internal val Res.string.str_3472: StringResource
+  get() = String35.str_3472
+
+@ExperimentalResourceApi
+internal val Res.string.str_3473: StringResource
+  get() = String35.str_3473
+
+@ExperimentalResourceApi
+internal val Res.string.str_3474: StringResource
+  get() = String35.str_3474
+
+@ExperimentalResourceApi
+internal val Res.string.str_3475: StringResource
+  get() = String35.str_3475
+
+@ExperimentalResourceApi
+internal val Res.string.str_3476: StringResource
+  get() = String35.str_3476
+
+@ExperimentalResourceApi
+internal val Res.string.str_3477: StringResource
+  get() = String35.str_3477
+
+@ExperimentalResourceApi
+internal val Res.string.str_3478: StringResource
+  get() = String35.str_3478
+
+@ExperimentalResourceApi
+internal val Res.string.str_3479: StringResource
+  get() = String35.str_3479
+
+@ExperimentalResourceApi
+internal val Res.string.str_348: StringResource
+  get() = String35.str_348
+
+@ExperimentalResourceApi
+internal val Res.string.str_3480: StringResource
+  get() = String35.str_3480
+
+@ExperimentalResourceApi
+internal val Res.string.str_3481: StringResource
+  get() = String35.str_3481
+
+@ExperimentalResourceApi
+internal val Res.string.str_3482: StringResource
+  get() = String35.str_3482
+
+@ExperimentalResourceApi
+internal val Res.string.str_3483: StringResource
+  get() = String35.str_3483
+
+@ExperimentalResourceApi
+internal val Res.string.str_3484: StringResource
+  get() = String35.str_3484
+
+@ExperimentalResourceApi
+internal val Res.string.str_3485: StringResource
+  get() = String35.str_3485
+
+@ExperimentalResourceApi
+internal val Res.string.str_3486: StringResource
+  get() = String35.str_3486
+
+@ExperimentalResourceApi
+internal val Res.string.str_3487: StringResource
+  get() = String35.str_3487
+
+@ExperimentalResourceApi
+internal val Res.string.str_3488: StringResource
+  get() = String35.str_3488
+
+@ExperimentalResourceApi
+internal val Res.string.str_3489: StringResource
+  get() = String35.str_3489
+
+@ExperimentalResourceApi
+internal val Res.string.str_349: StringResource
+  get() = String35.str_349
+
+@ExperimentalResourceApi
+internal val Res.string.str_3490: StringResource
+  get() = String35.str_3490
+
+@ExperimentalResourceApi
+internal val Res.string.str_3491: StringResource
+  get() = String35.str_3491
+
+@ExperimentalResourceApi
+internal val Res.string.str_3492: StringResource
+  get() = String35.str_3492
+
+@ExperimentalResourceApi
+internal val Res.string.str_3493: StringResource
+  get() = String35.str_3493
+
+@ExperimentalResourceApi
+internal val Res.string.str_3494: StringResource
+  get() = String35.str_3494
+
+@ExperimentalResourceApi
+internal val Res.string.str_3495: StringResource
+  get() = String35.str_3495
+
+@ExperimentalResourceApi
+internal val Res.string.str_3496: StringResource
+  get() = String35.str_3496
+
+@ExperimentalResourceApi
+internal val Res.string.str_3497: StringResource
+  get() = String35.str_3497
+
+@ExperimentalResourceApi
+internal val Res.string.str_3498: StringResource
+  get() = String35.str_3498
+
+@ExperimentalResourceApi
+internal val Res.string.str_3499: StringResource
+  get() = String35.str_3499
+
+@ExperimentalResourceApi
+internal val Res.string.str_35: StringResource
+  get() = String35.str_35
+
+@ExperimentalResourceApi
+internal val Res.string.str_350: StringResource
+  get() = String35.str_350
+
+@ExperimentalResourceApi
+internal val Res.string.str_3500: StringResource
+  get() = String35.str_3500
+
+@ExperimentalResourceApi
+internal val Res.string.str_3501: StringResource
+  get() = String35.str_3501
+
+@ExperimentalResourceApi
+internal val Res.string.str_3502: StringResource
+  get() = String35.str_3502
+
+@ExperimentalResourceApi
+internal val Res.string.str_3503: StringResource
+  get() = String35.str_3503
+
+@ExperimentalResourceApi
+internal val Res.string.str_3504: StringResource
+  get() = String35.str_3504
+
+@ExperimentalResourceApi
+internal val Res.string.str_3505: StringResource
+  get() = String35.str_3505
+
+@ExperimentalResourceApi
+internal val Res.string.str_3506: StringResource
+  get() = String35.str_3506
+
+@ExperimentalResourceApi
+internal val Res.string.str_3507: StringResource
+  get() = String35.str_3507
+
+@ExperimentalResourceApi
+internal val Res.string.str_3508: StringResource
+  get() = String35.str_3508
+
+@ExperimentalResourceApi
+internal val Res.string.str_3509: StringResource
+  get() = String35.str_3509
+
+@ExperimentalResourceApi
+internal val Res.string.str_351: StringResource
+  get() = String35.str_351
+
+@ExperimentalResourceApi
+internal val Res.string.str_3510: StringResource
+  get() = String35.str_3510
+
+@ExperimentalResourceApi
+internal val Res.string.str_3511: StringResource
+  get() = String35.str_3511
+
+@ExperimentalResourceApi
+internal val Res.string.str_3512: StringResource
+  get() = String35.str_3512
+
+@ExperimentalResourceApi
+internal val Res.string.str_3513: StringResource
+  get() = String35.str_3513
+
+@ExperimentalResourceApi
+internal val Res.string.str_3514: StringResource
+  get() = String35.str_3514
+
+@ExperimentalResourceApi
+internal val Res.string.str_3515: StringResource
+  get() = String35.str_3515
+
+@ExperimentalResourceApi
+internal val Res.string.str_3516: StringResource
+  get() = String35.str_3516
+
+@ExperimentalResourceApi
+internal val Res.string.str_3517: StringResource
+  get() = String35.str_3517
+
+@ExperimentalResourceApi
+internal val Res.string.str_3518: StringResource
+  get() = String35.str_3518
+
+@ExperimentalResourceApi
+internal val Res.string.str_3519: StringResource
+  get() = String35.str_3519
+
+@ExperimentalResourceApi
+internal val Res.string.str_352: StringResource
+  get() = String35.str_352
+
+@ExperimentalResourceApi
+internal val Res.string.str_3520: StringResource
+  get() = String35.str_3520
+
+@ExperimentalResourceApi
+internal val Res.string.str_3521: StringResource
+  get() = String35.str_3521
+
+@ExperimentalResourceApi
+internal val Res.string.str_3522: StringResource
+  get() = String35.str_3522
+
+@ExperimentalResourceApi
+internal val Res.string.str_3523: StringResource
+  get() = String35.str_3523
+
+@ExperimentalResourceApi
+internal val Res.string.str_3524: StringResource
+  get() = String35.str_3524
+
+@ExperimentalResourceApi
+internal val Res.string.str_3525: StringResource
+  get() = String35.str_3525
+
+@ExperimentalResourceApi
+internal val Res.string.str_3526: StringResource
+  get() = String35.str_3526
+
+@ExperimentalResourceApi
+internal val Res.string.str_3527: StringResource
+  get() = String35.str_3527
+
+@ExperimentalResourceApi
+internal val Res.string.str_3528: StringResource
+  get() = String35.str_3528
+
+@ExperimentalResourceApi
+internal val Res.string.str_3529: StringResource
+  get() = String35.str_3529
+
+@ExperimentalResourceApi
+internal val Res.string.str_353: StringResource
+  get() = String35.str_353
+
+@ExperimentalResourceApi
+internal val Res.string.str_3530: StringResource
+  get() = String35.str_3530
+
+@ExperimentalResourceApi
+internal val Res.string.str_3531: StringResource
+  get() = String35.str_3531
+
+@ExperimentalResourceApi
+internal val Res.string.str_3532: StringResource
+  get() = String35.str_3532
+
+@ExperimentalResourceApi
+internal val Res.string.str_3533: StringResource
+  get() = String35.str_3533
+
+@ExperimentalResourceApi
+internal val Res.string.str_3534: StringResource
+  get() = String35.str_3534
+
+@ExperimentalResourceApi
+internal val Res.string.str_3535: StringResource
+  get() = String35.str_3535
+
+@ExperimentalResourceApi
+internal val Res.string.str_3536: StringResource
+  get() = String35.str_3536
+
+@ExperimentalResourceApi
+internal val Res.string.str_3537: StringResource
+  get() = String35.str_3537
+
+@ExperimentalResourceApi
+internal val Res.string.str_3538: StringResource
+  get() = String35.str_3538
+
+@ExperimentalResourceApi
+internal val Res.string.str_3539: StringResource
+  get() = String35.str_3539
+
+@ExperimentalResourceApi
+internal val Res.string.str_354: StringResource
+  get() = String35.str_354
+
+@ExperimentalResourceApi
+internal val Res.string.str_3540: StringResource
+  get() = String35.str_3540
+
+@ExperimentalResourceApi
+internal val Res.string.str_3541: StringResource
+  get() = String35.str_3541
+
+@ExperimentalResourceApi
+internal val Res.string.str_3542: StringResource
+  get() = String35.str_3542
+
+@ExperimentalResourceApi
+internal val Res.string.str_3543: StringResource
+  get() = String35.str_3543
+
+@ExperimentalResourceApi
+internal val Res.string.str_3544: StringResource
+  get() = String35.str_3544
+
+@ExperimentalResourceApi
+internal val Res.string.str_3545: StringResource
+  get() = String35.str_3545
+
+@ExperimentalResourceApi
+internal val Res.string.str_3546: StringResource
+  get() = String35.str_3546
+
+@ExperimentalResourceApi
+internal val Res.string.str_3547: StringResource
+  get() = String35.str_3547
+
+@ExperimentalResourceApi
+internal val Res.string.str_3548: StringResource
+  get() = String35.str_3548
+
+@ExperimentalResourceApi
+internal val Res.string.str_3549: StringResource
+  get() = String35.str_3549
+
+@ExperimentalResourceApi
+internal val Res.string.str_355: StringResource
+  get() = String35.str_355
+
+@ExperimentalResourceApi
+internal val Res.string.str_3550: StringResource
+  get() = String35.str_3550
+
+@ExperimentalResourceApi
+internal val Res.string.str_3551: StringResource
+  get() = String35.str_3551
+
+@ExperimentalResourceApi
+internal val Res.string.str_3552: StringResource
+  get() = String35.str_3552
+
+@ExperimentalResourceApi
+internal val Res.string.str_3553: StringResource
+  get() = String35.str_3553
+
+@ExperimentalResourceApi
+internal val Res.string.str_3554: StringResource
+  get() = String35.str_3554
+
+@ExperimentalResourceApi
+internal val Res.string.str_3555: StringResource
+  get() = String35.str_3555
+
+@ExperimentalResourceApi
+internal val Res.string.str_3556: StringResource
+  get() = String35.str_3556
+
+@ExperimentalResourceApi
+internal val Res.string.str_3557: StringResource
+  get() = String35.str_3557
+
+@ExperimentalResourceApi
+internal val Res.string.str_3558: StringResource
+  get() = String35.str_3558
+
+@ExperimentalResourceApi
+internal val Res.string.str_3559: StringResource
+  get() = String35.str_3559
+
+@ExperimentalResourceApi
+internal val Res.string.str_356: StringResource
+  get() = String35.str_356
+
+@ExperimentalResourceApi
+internal val Res.string.str_3560: StringResource
+  get() = String35.str_3560
+
+@ExperimentalResourceApi
+internal val Res.string.str_3561: StringResource
+  get() = String35.str_3561
+
+@ExperimentalResourceApi
+internal val Res.string.str_3562: StringResource
+  get() = String35.str_3562
+
+@ExperimentalResourceApi
+internal val Res.string.str_3563: StringResource
+  get() = String35.str_3563
+
+@ExperimentalResourceApi
+internal val Res.string.str_3564: StringResource
+  get() = String35.str_3564
+
+@ExperimentalResourceApi
+internal val Res.string.str_3565: StringResource
+  get() = String35.str_3565
+
+@ExperimentalResourceApi
+internal val Res.string.str_3566: StringResource
+  get() = String35.str_3566
+
+@ExperimentalResourceApi
+internal val Res.string.str_3567: StringResource
+  get() = String35.str_3567
+
+@ExperimentalResourceApi
+internal val Res.string.str_3568: StringResource
+  get() = String35.str_3568
+
+@ExperimentalResourceApi
+internal val Res.string.str_3569: StringResource
+  get() = String35.str_3569
+
+@ExperimentalResourceApi
+internal val Res.string.str_357: StringResource
+  get() = String35.str_357
+
+@ExperimentalResourceApi
+internal val Res.string.str_3570: StringResource
+  get() = String35.str_3570
+
+@ExperimentalResourceApi
+internal val Res.string.str_3571: StringResource
+  get() = String35.str_3571
+
+@ExperimentalResourceApi
+internal val Res.string.str_3572: StringResource
+  get() = String35.str_3572
+
+@ExperimentalResourceApi
+internal val Res.string.str_3573: StringResource
+  get() = String35.str_3573
+
+@ExperimentalResourceApi
+internal val Res.string.str_3574: StringResource
+  get() = String35.str_3574
+
+@ExperimentalResourceApi
+internal val Res.string.str_3575: StringResource
+  get() = String35.str_3575
+
+@ExperimentalResourceApi
+internal val Res.string.str_3576: StringResource
+  get() = String35.str_3576
+
+@ExperimentalResourceApi
+internal val Res.string.str_3577: StringResource
+  get() = String35.str_3577
+
+@ExperimentalResourceApi
+internal val Res.string.str_3578: StringResource
+  get() = String35.str_3578
+
+@ExperimentalResourceApi
+internal val Res.string.str_3579: StringResource
+  get() = String35.str_3579
+
+@ExperimentalResourceApi
+internal val Res.string.str_358: StringResource
+  get() = String35.str_358
+
+@ExperimentalResourceApi
+internal val Res.string.str_3580: StringResource
+  get() = String35.str_3580
+
+@ExperimentalResourceApi
+internal val Res.string.str_3581: StringResource
+  get() = String35.str_3581
+
+@ExperimentalResourceApi
+internal val Res.string.str_3582: StringResource
+  get() = String35.str_3582
+
+@ExperimentalResourceApi
+internal val Res.string.str_3583: StringResource
+  get() = String35.str_3583
+
+@ExperimentalResourceApi
+internal val Res.string.str_3584: StringResource
+  get() = String35.str_3584
+
+@ExperimentalResourceApi
+internal val Res.string.str_3585: StringResource
+  get() = String35.str_3585
+
+@ExperimentalResourceApi
+internal val Res.string.str_3586: StringResource
+  get() = String35.str_3586
+
+@ExperimentalResourceApi
+internal val Res.string.str_3587: StringResource
+  get() = String35.str_3587
+
+@ExperimentalResourceApi
+internal val Res.string.str_3588: StringResource
+  get() = String35.str_3588
+
+@ExperimentalResourceApi
+internal val Res.string.str_3589: StringResource
+  get() = String35.str_3589
+
+@ExperimentalResourceApi
+internal val Res.string.str_359: StringResource
+  get() = String35.str_359
+
+@ExperimentalResourceApi
+internal val Res.string.str_3590: StringResource
+  get() = String35.str_3590
+
+@ExperimentalResourceApi
+internal val Res.string.str_3591: StringResource
+  get() = String35.str_3591
+
+@ExperimentalResourceApi
+internal val Res.string.str_3592: StringResource
+  get() = String35.str_3592
+
+@ExperimentalResourceApi
+internal val Res.string.str_3593: StringResource
+  get() = String35.str_3593
+
+@ExperimentalResourceApi
+internal val Res.string.str_3594: StringResource
+  get() = String35.str_3594
+
+@ExperimentalResourceApi
+internal val Res.string.str_3595: StringResource
+  get() = String35.str_3595
+
+@ExperimentalResourceApi
+internal val Res.string.str_3596: StringResource
+  get() = String35.str_3596
+
+@ExperimentalResourceApi
+internal val Res.string.str_3597: StringResource
+  get() = String35.str_3597
+
+@ExperimentalResourceApi
+internal val Res.string.str_3598: StringResource
+  get() = String35.str_3598
+
+@ExperimentalResourceApi
+internal val Res.string.str_3599: StringResource
+  get() = String35.str_3599
+
+@ExperimentalResourceApi
+internal val Res.string.str_36: StringResource
+  get() = String35.str_36
+
+@ExperimentalResourceApi
+internal val Res.string.str_360: StringResource
+  get() = String35.str_360
+
+@ExperimentalResourceApi
+internal val Res.string.str_3600: StringResource
+  get() = String35.str_3600
+
+@ExperimentalResourceApi
+internal val Res.string.str_3601: StringResource
+  get() = String35.str_3601
+
+@ExperimentalResourceApi
+internal val Res.string.str_3602: StringResource
+  get() = String35.str_3602
+
+@ExperimentalResourceApi
+internal val Res.string.str_3603: StringResource
+  get() = String35.str_3603
+
+@ExperimentalResourceApi
+internal val Res.string.str_3604: StringResource
+  get() = String35.str_3604
+
+@ExperimentalResourceApi
+internal val Res.string.str_3605: StringResource
+  get() = String35.str_3605
+
+@ExperimentalResourceApi
+internal val Res.string.str_3606: StringResource
+  get() = String35.str_3606
+
+@ExperimentalResourceApi
+internal val Res.string.str_3607: StringResource
+  get() = String35.str_3607
+
+@ExperimentalResourceApi
+internal val Res.string.str_3608: StringResource
+  get() = String35.str_3608
+
+@ExperimentalResourceApi
+internal val Res.string.str_3609: StringResource
+  get() = String35.str_3609
+
+@ExperimentalResourceApi
+internal val Res.string.str_361: StringResource
+  get() = String35.str_361
+
+@ExperimentalResourceApi
+internal val Res.string.str_3610: StringResource
+  get() = String35.str_3610
+
+@ExperimentalResourceApi
+internal val Res.string.str_3611: StringResource
+  get() = String35.str_3611
+
+@ExperimentalResourceApi
+internal val Res.string.str_3612: StringResource
+  get() = String35.str_3612
+
+@ExperimentalResourceApi
+internal val Res.string.str_3613: StringResource
+  get() = String35.str_3613
+
+@ExperimentalResourceApi
+internal val Res.string.str_3614: StringResource
+  get() = String35.str_3614
+
+@ExperimentalResourceApi
+internal val Res.string.str_3615: StringResource
+  get() = String35.str_3615
+
+@ExperimentalResourceApi
+internal val Res.string.str_3616: StringResource
+  get() = String35.str_3616
+
+@ExperimentalResourceApi
+internal val Res.string.str_3617: StringResource
+  get() = String35.str_3617
+
+@ExperimentalResourceApi
+internal val Res.string.str_3618: StringResource
+  get() = String35.str_3618
+
+@ExperimentalResourceApi
+internal val Res.string.str_3619: StringResource
+  get() = String35.str_3619
+
+@ExperimentalResourceApi
+internal val Res.string.str_362: StringResource
+  get() = String35.str_362
+
+@ExperimentalResourceApi
+internal val Res.string.str_3620: StringResource
+  get() = String35.str_3620
+
+@ExperimentalResourceApi
+internal val Res.string.str_3621: StringResource
+  get() = String35.str_3621
+
+@ExperimentalResourceApi
+internal val Res.string.str_3622: StringResource
+  get() = String35.str_3622
+
+@ExperimentalResourceApi
+internal val Res.string.str_3623: StringResource
+  get() = String35.str_3623
+
+@ExperimentalResourceApi
+internal val Res.string.str_3624: StringResource
+  get() = String35.str_3624
+
+@ExperimentalResourceApi
+internal val Res.string.str_3625: StringResource
+  get() = String35.str_3625
+
+@ExperimentalResourceApi
+internal val Res.string.str_3626: StringResource
+  get() = String35.str_3626
+
+@ExperimentalResourceApi
+internal val Res.string.str_3627: StringResource
+  get() = String35.str_3627
+
+@ExperimentalResourceApi
+internal val Res.string.str_3628: StringResource
+  get() = String35.str_3628
+
+@ExperimentalResourceApi
+internal val Res.string.str_3629: StringResource
+  get() = String35.str_3629
+
+@ExperimentalResourceApi
+internal val Res.string.str_363: StringResource
+  get() = String35.str_363
+
+@ExperimentalResourceApi
+internal val Res.string.str_3630: StringResource
+  get() = String35.str_3630
+
+@ExperimentalResourceApi
+internal val Res.string.str_3631: StringResource
+  get() = String35.str_3631
+
+@ExperimentalResourceApi
+internal val Res.string.str_3632: StringResource
+  get() = String35.str_3632
+
+@ExperimentalResourceApi
+internal val Res.string.str_3633: StringResource
+  get() = String35.str_3633
+
+@ExperimentalResourceApi
+internal val Res.string.str_3634: StringResource
+  get() = String35.str_3634
+
+@ExperimentalResourceApi
+internal val Res.string.str_3635: StringResource
+  get() = String35.str_3635
+
+@ExperimentalResourceApi
+internal val Res.string.str_3636: StringResource
+  get() = String35.str_3636
+
+@ExperimentalResourceApi
+internal val Res.string.str_3637: StringResource
+  get() = String35.str_3637
+
+@ExperimentalResourceApi
+internal val Res.string.str_3638: StringResource
+  get() = String35.str_3638
+
+@ExperimentalResourceApi
+internal val Res.string.str_3639: StringResource
+  get() = String35.str_3639
+
+@ExperimentalResourceApi
+internal val Res.string.str_364: StringResource
+  get() = String35.str_364
+
+@ExperimentalResourceApi
+internal val Res.string.str_3640: StringResource
+  get() = String35.str_3640
+
+@ExperimentalResourceApi
+internal val Res.string.str_3641: StringResource
+  get() = String35.str_3641
+
+@ExperimentalResourceApi
+internal val Res.string.str_3642: StringResource
+  get() = String35.str_3642
+
+@ExperimentalResourceApi
+internal val Res.string.str_3643: StringResource
+  get() = String35.str_3643
+
+@ExperimentalResourceApi
+internal val Res.string.str_3644: StringResource
+  get() = String35.str_3644
+
+@ExperimentalResourceApi
+internal val Res.string.str_3645: StringResource
+  get() = String35.str_3645
+
+@ExperimentalResourceApi
+internal val Res.string.str_3646: StringResource
+  get() = String35.str_3646
+
+@ExperimentalResourceApi
+internal val Res.string.str_3647: StringResource
+  get() = String35.str_3647
+
+@ExperimentalResourceApi
+internal val Res.string.str_3648: StringResource
+  get() = String35.str_3648
+
+@ExperimentalResourceApi
+internal val Res.string.str_3649: StringResource
+  get() = String35.str_3649
+
+@ExperimentalResourceApi
+internal val Res.string.str_365: StringResource
+  get() = String35.str_365
+
+@ExperimentalResourceApi
+internal val Res.string.str_3650: StringResource
+  get() = String35.str_3650
+
+@ExperimentalResourceApi
+internal val Res.string.str_3651: StringResource
+  get() = String35.str_3651
+
+@ExperimentalResourceApi
+internal val Res.string.str_3652: StringResource
+  get() = String35.str_3652
+
+@ExperimentalResourceApi
+internal val Res.string.str_3653: StringResource
+  get() = String35.str_3653
+
+@ExperimentalResourceApi
+internal val Res.string.str_3654: StringResource
+  get() = String35.str_3654
+
+@ExperimentalResourceApi
+internal val Res.string.str_3655: StringResource
+  get() = String35.str_3655
+
+@ExperimentalResourceApi
+internal val Res.string.str_3656: StringResource
+  get() = String35.str_3656
+
+@ExperimentalResourceApi
+internal val Res.string.str_3657: StringResource
+  get() = String35.str_3657
+
+@ExperimentalResourceApi
+internal val Res.string.str_3658: StringResource
+  get() = String35.str_3658
+
+@ExperimentalResourceApi
+internal val Res.string.str_3659: StringResource
+  get() = String35.str_3659
+
+@ExperimentalResourceApi
+internal val Res.string.str_366: StringResource
+  get() = String35.str_366
+
+@ExperimentalResourceApi
+internal val Res.string.str_3660: StringResource
+  get() = String35.str_3660
+
+@ExperimentalResourceApi
+internal val Res.string.str_3661: StringResource
+  get() = String35.str_3661
+
+@ExperimentalResourceApi
+internal val Res.string.str_3662: StringResource
+  get() = String35.str_3662
+
+@ExperimentalResourceApi
+internal val Res.string.str_3663: StringResource
+  get() = String35.str_3663
+
+@ExperimentalResourceApi
+internal val Res.string.str_3664: StringResource
+  get() = String35.str_3664
+
+@ExperimentalResourceApi
+internal val Res.string.str_3665: StringResource
+  get() = String35.str_3665
+
+@ExperimentalResourceApi
+internal val Res.string.str_3666: StringResource
+  get() = String35.str_3666
+
+@ExperimentalResourceApi
+internal val Res.string.str_3667: StringResource
+  get() = String35.str_3667
+
+@ExperimentalResourceApi
+internal val Res.string.str_3668: StringResource
+  get() = String35.str_3668
+
+@ExperimentalResourceApi
+internal val Res.string.str_3669: StringResource
+  get() = String35.str_3669
+
+@ExperimentalResourceApi
+internal val Res.string.str_367: StringResource
+  get() = String35.str_367
+
+@ExperimentalResourceApi
+internal val Res.string.str_3670: StringResource
+  get() = String35.str_3670
+
+@ExperimentalResourceApi
+internal val Res.string.str_3671: StringResource
+  get() = String35.str_3671
+
+@ExperimentalResourceApi
+internal val Res.string.str_3672: StringResource
+  get() = String35.str_3672
+
+@ExperimentalResourceApi
+internal val Res.string.str_3673: StringResource
+  get() = String35.str_3673
+
+@ExperimentalResourceApi
+internal val Res.string.str_3674: StringResource
+  get() = String35.str_3674
+
+@ExperimentalResourceApi
+internal val Res.string.str_3675: StringResource
+  get() = String35.str_3675
+
+@ExperimentalResourceApi
+internal val Res.string.str_3676: StringResource
+  get() = String35.str_3676
+
+@ExperimentalResourceApi
+internal val Res.string.str_3677: StringResource
+  get() = String35.str_3677
+
+@ExperimentalResourceApi
+internal val Res.string.str_3678: StringResource
+  get() = String35.str_3678
+
+@ExperimentalResourceApi
+internal val Res.string.str_3679: StringResource
+  get() = String35.str_3679
+
+@ExperimentalResourceApi
+internal val Res.string.str_368: StringResource
+  get() = String35.str_368
+
+@ExperimentalResourceApi
+internal val Res.string.str_3680: StringResource
+  get() = String35.str_3680
+
+@ExperimentalResourceApi
+internal val Res.string.str_3681: StringResource
+  get() = String35.str_3681
+
+@ExperimentalResourceApi
+internal val Res.string.str_3682: StringResource
+  get() = String35.str_3682
+
+@ExperimentalResourceApi
+internal val Res.string.str_3683: StringResource
+  get() = String35.str_3683
+
+@ExperimentalResourceApi
+internal val Res.string.str_3684: StringResource
+  get() = String35.str_3684
+
+@ExperimentalResourceApi
+internal val Res.string.str_3685: StringResource
+  get() = String35.str_3685
+
+@ExperimentalResourceApi
+internal val Res.string.str_3686: StringResource
+  get() = String35.str_3686
+
+@ExperimentalResourceApi
+internal val Res.string.str_3687: StringResource
+  get() = String35.str_3687
+
+@ExperimentalResourceApi
+internal val Res.string.str_3688: StringResource
+  get() = String35.str_3688
+
+@ExperimentalResourceApi
+internal val Res.string.str_3689: StringResource
+  get() = String35.str_3689
+
+@ExperimentalResourceApi
+internal val Res.string.str_369: StringResource
+  get() = String35.str_369
+
+@ExperimentalResourceApi
+internal val Res.string.str_3690: StringResource
+  get() = String35.str_3690
+
+@ExperimentalResourceApi
+internal val Res.string.str_3691: StringResource
+  get() = String35.str_3691
+
+@ExperimentalResourceApi
+internal val Res.string.str_3692: StringResource
+  get() = String35.str_3692
+
+@ExperimentalResourceApi
+internal val Res.string.str_3693: StringResource
+  get() = String35.str_3693
+
+@ExperimentalResourceApi
+internal val Res.string.str_3694: StringResource
+  get() = String35.str_3694
+
+@ExperimentalResourceApi
+internal val Res.string.str_3695: StringResource
+  get() = String35.str_3695
+
+@ExperimentalResourceApi
+internal val Res.string.str_3696: StringResource
+  get() = String35.str_3696
+
+@ExperimentalResourceApi
+internal val Res.string.str_3697: StringResource
+  get() = String35.str_3697
+
+@ExperimentalResourceApi
+internal val Res.string.str_3698: StringResource
+  get() = String35.str_3698

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String36.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String36.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String36 {
+  public val str_3699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3699", "str_3699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_37: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_37", "str_37",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_370", "str_370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3700", "str_3700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3701", "str_3701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3702", "str_3702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3703", "str_3703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3704", "str_3704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3705", "str_3705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3706", "str_3706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3707", "str_3707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3708", "str_3708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3709", "str_3709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_371", "str_371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3710", "str_3710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3711", "str_3711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3712", "str_3712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3713", "str_3713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3714", "str_3714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3715", "str_3715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3716", "str_3716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3717", "str_3717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3718", "str_3718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3719", "str_3719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_372", "str_372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3720", "str_3720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3721", "str_3721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3722", "str_3722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3723", "str_3723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3724", "str_3724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3725", "str_3725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3726", "str_3726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3727", "str_3727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3728", "str_3728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3729", "str_3729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_373", "str_373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3730", "str_3730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3731", "str_3731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3732", "str_3732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3733", "str_3733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3734", "str_3734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3735", "str_3735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3736", "str_3736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3737", "str_3737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3738", "str_3738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3739", "str_3739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_374", "str_374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3740", "str_3740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3741", "str_3741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3742", "str_3742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3743", "str_3743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3744", "str_3744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3745", "str_3745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3746", "str_3746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3747", "str_3747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3748", "str_3748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3749", "str_3749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_375", "str_375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3750", "str_3750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3751", "str_3751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3752", "str_3752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3753", "str_3753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3754", "str_3754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3755", "str_3755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3756", "str_3756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3757", "str_3757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3758", "str_3758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3759", "str_3759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_376", "str_376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3760", "str_3760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3761", "str_3761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3762", "str_3762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3763", "str_3763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3764", "str_3764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3765", "str_3765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3766", "str_3766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3767", "str_3767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3768", "str_3768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3769", "str_3769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_377", "str_377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3770", "str_3770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3771", "str_3771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3772", "str_3772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3773", "str_3773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3774", "str_3774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3775", "str_3775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3776", "str_3776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3777", "str_3777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3778", "str_3778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3779", "str_3779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_378", "str_378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3780", "str_3780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3781", "str_3781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3782", "str_3782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3783", "str_3783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3784", "str_3784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3785", "str_3785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3786", "str_3786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3787", "str_3787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3788", "str_3788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3789", "str_3789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_379", "str_379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3790", "str_3790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3791", "str_3791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3792", "str_3792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3793", "str_3793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3794", "str_3794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3795", "str_3795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3796", "str_3796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3797", "str_3797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3798", "str_3798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3799", "str_3799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_38: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_38", "str_38",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_380", "str_380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3800", "str_3800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3801", "str_3801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3802", "str_3802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3803", "str_3803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3804", "str_3804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3805", "str_3805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3806", "str_3806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3807", "str_3807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3808", "str_3808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3809", "str_3809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_381", "str_381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3810", "str_3810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3811", "str_3811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3812", "str_3812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3813", "str_3813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3814", "str_3814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3815", "str_3815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3816", "str_3816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3817", "str_3817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3818", "str_3818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3819", "str_3819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_382", "str_382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3820", "str_3820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3821", "str_3821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3822", "str_3822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3823", "str_3823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3824", "str_3824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3825", "str_3825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3826", "str_3826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3827", "str_3827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3828", "str_3828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3829", "str_3829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_383", "str_383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3830", "str_3830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3831", "str_3831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3832", "str_3832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3833", "str_3833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3834", "str_3834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3835", "str_3835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3836", "str_3836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3837", "str_3837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3838", "str_3838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3839", "str_3839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_384", "str_384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3840", "str_3840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3841", "str_3841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3842", "str_3842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3843", "str_3843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3844", "str_3844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3845", "str_3845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3846", "str_3846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3847", "str_3847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3848", "str_3848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3849", "str_3849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_385", "str_385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3850", "str_3850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3851", "str_3851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3852", "str_3852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3853", "str_3853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3854", "str_3854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3855", "str_3855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3856", "str_3856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3857", "str_3857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3858", "str_3858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3859", "str_3859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_386", "str_386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3860", "str_3860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3861", "str_3861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3862", "str_3862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3863", "str_3863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3864", "str_3864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3865", "str_3865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3866", "str_3866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3867", "str_3867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3868", "str_3868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3869", "str_3869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_387", "str_387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3870", "str_3870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3871", "str_3871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3872", "str_3872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3873", "str_3873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3874", "str_3874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3875", "str_3875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3876", "str_3876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3877", "str_3877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3878", "str_3878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3879", "str_3879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_388", "str_388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3880", "str_3880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3881", "str_3881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3882", "str_3882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3883", "str_3883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3884", "str_3884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3885", "str_3885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3886", "str_3886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3887", "str_3887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3888", "str_3888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3889", "str_3889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_389", "str_389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3890", "str_3890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3891", "str_3891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3892", "str_3892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3893", "str_3893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3894", "str_3894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3895", "str_3895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3896", "str_3896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3897", "str_3897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3898", "str_3898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3899", "str_3899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_39: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_39", "str_39",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_390", "str_390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3900", "str_3900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3901", "str_3901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3902", "str_3902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3903", "str_3903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3904", "str_3904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3905", "str_3905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3906", "str_3906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3907", "str_3907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3908", "str_3908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3909", "str_3909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_391", "str_391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3910", "str_3910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3911", "str_3911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3912", "str_3912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3913", "str_3913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3914", "str_3914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3915", "str_3915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3916", "str_3916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3917", "str_3917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3918", "str_3918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3919", "str_3919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_392", "str_392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3920", "str_3920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3921", "str_3921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3922", "str_3922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3923", "str_3923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3924", "str_3924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3925", "str_3925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3926", "str_3926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3927", "str_3927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3928", "str_3928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3929", "str_3929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_393", "str_393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3930", "str_3930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3931", "str_3931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3932", "str_3932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3933", "str_3933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3934", "str_3934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3935", "str_3935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3936", "str_3936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3937", "str_3937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3938", "str_3938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3939", "str_3939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_394", "str_394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3940", "str_3940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3941", "str_3941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3942", "str_3942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3943", "str_3943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3944", "str_3944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3945", "str_3945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3946", "str_3946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3947", "str_3947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3948", "str_3948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3949", "str_3949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_395", "str_395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3950", "str_3950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3951", "str_3951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3952", "str_3952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3953", "str_3953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3954", "str_3954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3955", "str_3955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3956", "str_3956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3957", "str_3957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3958", "str_3958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3959", "str_3959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_396", "str_396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3960", "str_3960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3961", "str_3961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3962", "str_3962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3963", "str_3963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3964", "str_3964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3965", "str_3965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3966", "str_3966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3967", "str_3967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3968", "str_3968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3969", "str_3969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_397", "str_397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3970", "str_3970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3971", "str_3971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3972", "str_3972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3973", "str_3973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3974", "str_3974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3975", "str_3975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3976", "str_3976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3977", "str_3977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3978", "str_3978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3979", "str_3979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_398", "str_398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3980", "str_3980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3981", "str_3981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3982", "str_3982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3983", "str_3983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3984", "str_3984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3985", "str_3985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3986", "str_3986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3987", "str_3987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3988", "str_3988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3989", "str_3989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_399", "str_399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3990", "str_3990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3991", "str_3991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3992", "str_3992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3993", "str_3993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3994", "str_3994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3995", "str_3995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3996", "str_3996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3997", "str_3997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3998", "str_3998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_3999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_3999", "str_3999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4", "str_4",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_40: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_40", "str_40",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_400", "str_400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4000", "str_4000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4001", "str_4001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4002", "str_4002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4003", "str_4003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4004", "str_4004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4005", "str_4005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4006", "str_4006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4007", "str_4007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4008", "str_4008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4009", "str_4009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_401", "str_401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4010", "str_4010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4011", "str_4011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4012", "str_4012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4013", "str_4013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4014", "str_4014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4015", "str_4015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4016", "str_4016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4017", "str_4017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4018", "str_4018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4019", "str_4019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_402", "str_402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4020", "str_4020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4021", "str_4021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4022", "str_4022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4023", "str_4023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4024", "str_4024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4025", "str_4025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4026", "str_4026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4027", "str_4027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4028", "str_4028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4029", "str_4029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_403", "str_403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4030", "str_4030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4031", "str_4031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4032", "str_4032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4033", "str_4033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4034", "str_4034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4035", "str_4035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4036", "str_4036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4037", "str_4037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4038", "str_4038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4039", "str_4039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_404", "str_404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4040", "str_4040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4041", "str_4041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4042", "str_4042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4043", "str_4043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4044", "str_4044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4045", "str_4045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4046", "str_4046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4047", "str_4047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4048", "str_4048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4049", "str_4049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_405", "str_405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4050", "str_4050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4051", "str_4051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4052", "str_4052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4053", "str_4053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4054", "str_4054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4055", "str_4055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4056", "str_4056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4057", "str_4057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4058", "str_4058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4059", "str_4059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_406", "str_406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4060", "str_4060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4061", "str_4061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4062", "str_4062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4063", "str_4063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4064", "str_4064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4065", "str_4065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4066", "str_4066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4067", "str_4067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4068", "str_4068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4069", "str_4069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_407", "str_407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4070", "str_4070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4071", "str_4071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4072", "str_4072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4073", "str_4073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4074", "str_4074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4075", "str_4075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4076", "str_4076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4077", "str_4077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4078", "str_4078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4079", "str_4079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_408", "str_408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4080", "str_4080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4081", "str_4081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4082", "str_4082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4083", "str_4083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4084", "str_4084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4085", "str_4085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4086", "str_4086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4087", "str_4087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4088", "str_4088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4089", "str_4089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_409", "str_409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4090", "str_4090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4091", "str_4091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4092", "str_4092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4093", "str_4093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4094", "str_4094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4095", "str_4095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4096", "str_4096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4097", "str_4097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4098", "str_4098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4099", "str_4099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_41: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_41", "str_41",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_410", "str_410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4100", "str_4100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4101", "str_4101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4102", "str_4102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4103", "str_4103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4104", "str_4104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4105", "str_4105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4106", "str_4106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4107", "str_4107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4108", "str_4108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4109", "str_4109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_411", "str_411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4110", "str_4110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4111", "str_4111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4112", "str_4112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4113", "str_4113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4114", "str_4114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4115", "str_4115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4116", "str_4116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4117", "str_4117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4118", "str_4118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4119", "str_4119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_412", "str_412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4120", "str_4120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4121", "str_4121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4122", "str_4122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4123", "str_4123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4124", "str_4124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4125", "str_4125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4126", "str_4126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4127", "str_4127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4128", "str_4128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4129", "str_4129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_413", "str_413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4130", "str_4130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4131", "str_4131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4132", "str_4132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4133", "str_4133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4134", "str_4134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4135", "str_4135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4136", "str_4136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4137", "str_4137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4138", "str_4138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4139", "str_4139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_414", "str_414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4140", "str_4140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4141", "str_4141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4142", "str_4142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4143", "str_4143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4144", "str_4144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4145", "str_4145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4146", "str_4146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4147", "str_4147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_3699: StringResource
+  get() = String36.str_3699
+
+@ExperimentalResourceApi
+internal val Res.string.str_37: StringResource
+  get() = String36.str_37
+
+@ExperimentalResourceApi
+internal val Res.string.str_370: StringResource
+  get() = String36.str_370
+
+@ExperimentalResourceApi
+internal val Res.string.str_3700: StringResource
+  get() = String36.str_3700
+
+@ExperimentalResourceApi
+internal val Res.string.str_3701: StringResource
+  get() = String36.str_3701
+
+@ExperimentalResourceApi
+internal val Res.string.str_3702: StringResource
+  get() = String36.str_3702
+
+@ExperimentalResourceApi
+internal val Res.string.str_3703: StringResource
+  get() = String36.str_3703
+
+@ExperimentalResourceApi
+internal val Res.string.str_3704: StringResource
+  get() = String36.str_3704
+
+@ExperimentalResourceApi
+internal val Res.string.str_3705: StringResource
+  get() = String36.str_3705
+
+@ExperimentalResourceApi
+internal val Res.string.str_3706: StringResource
+  get() = String36.str_3706
+
+@ExperimentalResourceApi
+internal val Res.string.str_3707: StringResource
+  get() = String36.str_3707
+
+@ExperimentalResourceApi
+internal val Res.string.str_3708: StringResource
+  get() = String36.str_3708
+
+@ExperimentalResourceApi
+internal val Res.string.str_3709: StringResource
+  get() = String36.str_3709
+
+@ExperimentalResourceApi
+internal val Res.string.str_371: StringResource
+  get() = String36.str_371
+
+@ExperimentalResourceApi
+internal val Res.string.str_3710: StringResource
+  get() = String36.str_3710
+
+@ExperimentalResourceApi
+internal val Res.string.str_3711: StringResource
+  get() = String36.str_3711
+
+@ExperimentalResourceApi
+internal val Res.string.str_3712: StringResource
+  get() = String36.str_3712
+
+@ExperimentalResourceApi
+internal val Res.string.str_3713: StringResource
+  get() = String36.str_3713
+
+@ExperimentalResourceApi
+internal val Res.string.str_3714: StringResource
+  get() = String36.str_3714
+
+@ExperimentalResourceApi
+internal val Res.string.str_3715: StringResource
+  get() = String36.str_3715
+
+@ExperimentalResourceApi
+internal val Res.string.str_3716: StringResource
+  get() = String36.str_3716
+
+@ExperimentalResourceApi
+internal val Res.string.str_3717: StringResource
+  get() = String36.str_3717
+
+@ExperimentalResourceApi
+internal val Res.string.str_3718: StringResource
+  get() = String36.str_3718
+
+@ExperimentalResourceApi
+internal val Res.string.str_3719: StringResource
+  get() = String36.str_3719
+
+@ExperimentalResourceApi
+internal val Res.string.str_372: StringResource
+  get() = String36.str_372
+
+@ExperimentalResourceApi
+internal val Res.string.str_3720: StringResource
+  get() = String36.str_3720
+
+@ExperimentalResourceApi
+internal val Res.string.str_3721: StringResource
+  get() = String36.str_3721
+
+@ExperimentalResourceApi
+internal val Res.string.str_3722: StringResource
+  get() = String36.str_3722
+
+@ExperimentalResourceApi
+internal val Res.string.str_3723: StringResource
+  get() = String36.str_3723
+
+@ExperimentalResourceApi
+internal val Res.string.str_3724: StringResource
+  get() = String36.str_3724
+
+@ExperimentalResourceApi
+internal val Res.string.str_3725: StringResource
+  get() = String36.str_3725
+
+@ExperimentalResourceApi
+internal val Res.string.str_3726: StringResource
+  get() = String36.str_3726
+
+@ExperimentalResourceApi
+internal val Res.string.str_3727: StringResource
+  get() = String36.str_3727
+
+@ExperimentalResourceApi
+internal val Res.string.str_3728: StringResource
+  get() = String36.str_3728
+
+@ExperimentalResourceApi
+internal val Res.string.str_3729: StringResource
+  get() = String36.str_3729
+
+@ExperimentalResourceApi
+internal val Res.string.str_373: StringResource
+  get() = String36.str_373
+
+@ExperimentalResourceApi
+internal val Res.string.str_3730: StringResource
+  get() = String36.str_3730
+
+@ExperimentalResourceApi
+internal val Res.string.str_3731: StringResource
+  get() = String36.str_3731
+
+@ExperimentalResourceApi
+internal val Res.string.str_3732: StringResource
+  get() = String36.str_3732
+
+@ExperimentalResourceApi
+internal val Res.string.str_3733: StringResource
+  get() = String36.str_3733
+
+@ExperimentalResourceApi
+internal val Res.string.str_3734: StringResource
+  get() = String36.str_3734
+
+@ExperimentalResourceApi
+internal val Res.string.str_3735: StringResource
+  get() = String36.str_3735
+
+@ExperimentalResourceApi
+internal val Res.string.str_3736: StringResource
+  get() = String36.str_3736
+
+@ExperimentalResourceApi
+internal val Res.string.str_3737: StringResource
+  get() = String36.str_3737
+
+@ExperimentalResourceApi
+internal val Res.string.str_3738: StringResource
+  get() = String36.str_3738
+
+@ExperimentalResourceApi
+internal val Res.string.str_3739: StringResource
+  get() = String36.str_3739
+
+@ExperimentalResourceApi
+internal val Res.string.str_374: StringResource
+  get() = String36.str_374
+
+@ExperimentalResourceApi
+internal val Res.string.str_3740: StringResource
+  get() = String36.str_3740
+
+@ExperimentalResourceApi
+internal val Res.string.str_3741: StringResource
+  get() = String36.str_3741
+
+@ExperimentalResourceApi
+internal val Res.string.str_3742: StringResource
+  get() = String36.str_3742
+
+@ExperimentalResourceApi
+internal val Res.string.str_3743: StringResource
+  get() = String36.str_3743
+
+@ExperimentalResourceApi
+internal val Res.string.str_3744: StringResource
+  get() = String36.str_3744
+
+@ExperimentalResourceApi
+internal val Res.string.str_3745: StringResource
+  get() = String36.str_3745
+
+@ExperimentalResourceApi
+internal val Res.string.str_3746: StringResource
+  get() = String36.str_3746
+
+@ExperimentalResourceApi
+internal val Res.string.str_3747: StringResource
+  get() = String36.str_3747
+
+@ExperimentalResourceApi
+internal val Res.string.str_3748: StringResource
+  get() = String36.str_3748
+
+@ExperimentalResourceApi
+internal val Res.string.str_3749: StringResource
+  get() = String36.str_3749
+
+@ExperimentalResourceApi
+internal val Res.string.str_375: StringResource
+  get() = String36.str_375
+
+@ExperimentalResourceApi
+internal val Res.string.str_3750: StringResource
+  get() = String36.str_3750
+
+@ExperimentalResourceApi
+internal val Res.string.str_3751: StringResource
+  get() = String36.str_3751
+
+@ExperimentalResourceApi
+internal val Res.string.str_3752: StringResource
+  get() = String36.str_3752
+
+@ExperimentalResourceApi
+internal val Res.string.str_3753: StringResource
+  get() = String36.str_3753
+
+@ExperimentalResourceApi
+internal val Res.string.str_3754: StringResource
+  get() = String36.str_3754
+
+@ExperimentalResourceApi
+internal val Res.string.str_3755: StringResource
+  get() = String36.str_3755
+
+@ExperimentalResourceApi
+internal val Res.string.str_3756: StringResource
+  get() = String36.str_3756
+
+@ExperimentalResourceApi
+internal val Res.string.str_3757: StringResource
+  get() = String36.str_3757
+
+@ExperimentalResourceApi
+internal val Res.string.str_3758: StringResource
+  get() = String36.str_3758
+
+@ExperimentalResourceApi
+internal val Res.string.str_3759: StringResource
+  get() = String36.str_3759
+
+@ExperimentalResourceApi
+internal val Res.string.str_376: StringResource
+  get() = String36.str_376
+
+@ExperimentalResourceApi
+internal val Res.string.str_3760: StringResource
+  get() = String36.str_3760
+
+@ExperimentalResourceApi
+internal val Res.string.str_3761: StringResource
+  get() = String36.str_3761
+
+@ExperimentalResourceApi
+internal val Res.string.str_3762: StringResource
+  get() = String36.str_3762
+
+@ExperimentalResourceApi
+internal val Res.string.str_3763: StringResource
+  get() = String36.str_3763
+
+@ExperimentalResourceApi
+internal val Res.string.str_3764: StringResource
+  get() = String36.str_3764
+
+@ExperimentalResourceApi
+internal val Res.string.str_3765: StringResource
+  get() = String36.str_3765
+
+@ExperimentalResourceApi
+internal val Res.string.str_3766: StringResource
+  get() = String36.str_3766
+
+@ExperimentalResourceApi
+internal val Res.string.str_3767: StringResource
+  get() = String36.str_3767
+
+@ExperimentalResourceApi
+internal val Res.string.str_3768: StringResource
+  get() = String36.str_3768
+
+@ExperimentalResourceApi
+internal val Res.string.str_3769: StringResource
+  get() = String36.str_3769
+
+@ExperimentalResourceApi
+internal val Res.string.str_377: StringResource
+  get() = String36.str_377
+
+@ExperimentalResourceApi
+internal val Res.string.str_3770: StringResource
+  get() = String36.str_3770
+
+@ExperimentalResourceApi
+internal val Res.string.str_3771: StringResource
+  get() = String36.str_3771
+
+@ExperimentalResourceApi
+internal val Res.string.str_3772: StringResource
+  get() = String36.str_3772
+
+@ExperimentalResourceApi
+internal val Res.string.str_3773: StringResource
+  get() = String36.str_3773
+
+@ExperimentalResourceApi
+internal val Res.string.str_3774: StringResource
+  get() = String36.str_3774
+
+@ExperimentalResourceApi
+internal val Res.string.str_3775: StringResource
+  get() = String36.str_3775
+
+@ExperimentalResourceApi
+internal val Res.string.str_3776: StringResource
+  get() = String36.str_3776
+
+@ExperimentalResourceApi
+internal val Res.string.str_3777: StringResource
+  get() = String36.str_3777
+
+@ExperimentalResourceApi
+internal val Res.string.str_3778: StringResource
+  get() = String36.str_3778
+
+@ExperimentalResourceApi
+internal val Res.string.str_3779: StringResource
+  get() = String36.str_3779
+
+@ExperimentalResourceApi
+internal val Res.string.str_378: StringResource
+  get() = String36.str_378
+
+@ExperimentalResourceApi
+internal val Res.string.str_3780: StringResource
+  get() = String36.str_3780
+
+@ExperimentalResourceApi
+internal val Res.string.str_3781: StringResource
+  get() = String36.str_3781
+
+@ExperimentalResourceApi
+internal val Res.string.str_3782: StringResource
+  get() = String36.str_3782
+
+@ExperimentalResourceApi
+internal val Res.string.str_3783: StringResource
+  get() = String36.str_3783
+
+@ExperimentalResourceApi
+internal val Res.string.str_3784: StringResource
+  get() = String36.str_3784
+
+@ExperimentalResourceApi
+internal val Res.string.str_3785: StringResource
+  get() = String36.str_3785
+
+@ExperimentalResourceApi
+internal val Res.string.str_3786: StringResource
+  get() = String36.str_3786
+
+@ExperimentalResourceApi
+internal val Res.string.str_3787: StringResource
+  get() = String36.str_3787
+
+@ExperimentalResourceApi
+internal val Res.string.str_3788: StringResource
+  get() = String36.str_3788
+
+@ExperimentalResourceApi
+internal val Res.string.str_3789: StringResource
+  get() = String36.str_3789
+
+@ExperimentalResourceApi
+internal val Res.string.str_379: StringResource
+  get() = String36.str_379
+
+@ExperimentalResourceApi
+internal val Res.string.str_3790: StringResource
+  get() = String36.str_3790
+
+@ExperimentalResourceApi
+internal val Res.string.str_3791: StringResource
+  get() = String36.str_3791
+
+@ExperimentalResourceApi
+internal val Res.string.str_3792: StringResource
+  get() = String36.str_3792
+
+@ExperimentalResourceApi
+internal val Res.string.str_3793: StringResource
+  get() = String36.str_3793
+
+@ExperimentalResourceApi
+internal val Res.string.str_3794: StringResource
+  get() = String36.str_3794
+
+@ExperimentalResourceApi
+internal val Res.string.str_3795: StringResource
+  get() = String36.str_3795
+
+@ExperimentalResourceApi
+internal val Res.string.str_3796: StringResource
+  get() = String36.str_3796
+
+@ExperimentalResourceApi
+internal val Res.string.str_3797: StringResource
+  get() = String36.str_3797
+
+@ExperimentalResourceApi
+internal val Res.string.str_3798: StringResource
+  get() = String36.str_3798
+
+@ExperimentalResourceApi
+internal val Res.string.str_3799: StringResource
+  get() = String36.str_3799
+
+@ExperimentalResourceApi
+internal val Res.string.str_38: StringResource
+  get() = String36.str_38
+
+@ExperimentalResourceApi
+internal val Res.string.str_380: StringResource
+  get() = String36.str_380
+
+@ExperimentalResourceApi
+internal val Res.string.str_3800: StringResource
+  get() = String36.str_3800
+
+@ExperimentalResourceApi
+internal val Res.string.str_3801: StringResource
+  get() = String36.str_3801
+
+@ExperimentalResourceApi
+internal val Res.string.str_3802: StringResource
+  get() = String36.str_3802
+
+@ExperimentalResourceApi
+internal val Res.string.str_3803: StringResource
+  get() = String36.str_3803
+
+@ExperimentalResourceApi
+internal val Res.string.str_3804: StringResource
+  get() = String36.str_3804
+
+@ExperimentalResourceApi
+internal val Res.string.str_3805: StringResource
+  get() = String36.str_3805
+
+@ExperimentalResourceApi
+internal val Res.string.str_3806: StringResource
+  get() = String36.str_3806
+
+@ExperimentalResourceApi
+internal val Res.string.str_3807: StringResource
+  get() = String36.str_3807
+
+@ExperimentalResourceApi
+internal val Res.string.str_3808: StringResource
+  get() = String36.str_3808
+
+@ExperimentalResourceApi
+internal val Res.string.str_3809: StringResource
+  get() = String36.str_3809
+
+@ExperimentalResourceApi
+internal val Res.string.str_381: StringResource
+  get() = String36.str_381
+
+@ExperimentalResourceApi
+internal val Res.string.str_3810: StringResource
+  get() = String36.str_3810
+
+@ExperimentalResourceApi
+internal val Res.string.str_3811: StringResource
+  get() = String36.str_3811
+
+@ExperimentalResourceApi
+internal val Res.string.str_3812: StringResource
+  get() = String36.str_3812
+
+@ExperimentalResourceApi
+internal val Res.string.str_3813: StringResource
+  get() = String36.str_3813
+
+@ExperimentalResourceApi
+internal val Res.string.str_3814: StringResource
+  get() = String36.str_3814
+
+@ExperimentalResourceApi
+internal val Res.string.str_3815: StringResource
+  get() = String36.str_3815
+
+@ExperimentalResourceApi
+internal val Res.string.str_3816: StringResource
+  get() = String36.str_3816
+
+@ExperimentalResourceApi
+internal val Res.string.str_3817: StringResource
+  get() = String36.str_3817
+
+@ExperimentalResourceApi
+internal val Res.string.str_3818: StringResource
+  get() = String36.str_3818
+
+@ExperimentalResourceApi
+internal val Res.string.str_3819: StringResource
+  get() = String36.str_3819
+
+@ExperimentalResourceApi
+internal val Res.string.str_382: StringResource
+  get() = String36.str_382
+
+@ExperimentalResourceApi
+internal val Res.string.str_3820: StringResource
+  get() = String36.str_3820
+
+@ExperimentalResourceApi
+internal val Res.string.str_3821: StringResource
+  get() = String36.str_3821
+
+@ExperimentalResourceApi
+internal val Res.string.str_3822: StringResource
+  get() = String36.str_3822
+
+@ExperimentalResourceApi
+internal val Res.string.str_3823: StringResource
+  get() = String36.str_3823
+
+@ExperimentalResourceApi
+internal val Res.string.str_3824: StringResource
+  get() = String36.str_3824
+
+@ExperimentalResourceApi
+internal val Res.string.str_3825: StringResource
+  get() = String36.str_3825
+
+@ExperimentalResourceApi
+internal val Res.string.str_3826: StringResource
+  get() = String36.str_3826
+
+@ExperimentalResourceApi
+internal val Res.string.str_3827: StringResource
+  get() = String36.str_3827
+
+@ExperimentalResourceApi
+internal val Res.string.str_3828: StringResource
+  get() = String36.str_3828
+
+@ExperimentalResourceApi
+internal val Res.string.str_3829: StringResource
+  get() = String36.str_3829
+
+@ExperimentalResourceApi
+internal val Res.string.str_383: StringResource
+  get() = String36.str_383
+
+@ExperimentalResourceApi
+internal val Res.string.str_3830: StringResource
+  get() = String36.str_3830
+
+@ExperimentalResourceApi
+internal val Res.string.str_3831: StringResource
+  get() = String36.str_3831
+
+@ExperimentalResourceApi
+internal val Res.string.str_3832: StringResource
+  get() = String36.str_3832
+
+@ExperimentalResourceApi
+internal val Res.string.str_3833: StringResource
+  get() = String36.str_3833
+
+@ExperimentalResourceApi
+internal val Res.string.str_3834: StringResource
+  get() = String36.str_3834
+
+@ExperimentalResourceApi
+internal val Res.string.str_3835: StringResource
+  get() = String36.str_3835
+
+@ExperimentalResourceApi
+internal val Res.string.str_3836: StringResource
+  get() = String36.str_3836
+
+@ExperimentalResourceApi
+internal val Res.string.str_3837: StringResource
+  get() = String36.str_3837
+
+@ExperimentalResourceApi
+internal val Res.string.str_3838: StringResource
+  get() = String36.str_3838
+
+@ExperimentalResourceApi
+internal val Res.string.str_3839: StringResource
+  get() = String36.str_3839
+
+@ExperimentalResourceApi
+internal val Res.string.str_384: StringResource
+  get() = String36.str_384
+
+@ExperimentalResourceApi
+internal val Res.string.str_3840: StringResource
+  get() = String36.str_3840
+
+@ExperimentalResourceApi
+internal val Res.string.str_3841: StringResource
+  get() = String36.str_3841
+
+@ExperimentalResourceApi
+internal val Res.string.str_3842: StringResource
+  get() = String36.str_3842
+
+@ExperimentalResourceApi
+internal val Res.string.str_3843: StringResource
+  get() = String36.str_3843
+
+@ExperimentalResourceApi
+internal val Res.string.str_3844: StringResource
+  get() = String36.str_3844
+
+@ExperimentalResourceApi
+internal val Res.string.str_3845: StringResource
+  get() = String36.str_3845
+
+@ExperimentalResourceApi
+internal val Res.string.str_3846: StringResource
+  get() = String36.str_3846
+
+@ExperimentalResourceApi
+internal val Res.string.str_3847: StringResource
+  get() = String36.str_3847
+
+@ExperimentalResourceApi
+internal val Res.string.str_3848: StringResource
+  get() = String36.str_3848
+
+@ExperimentalResourceApi
+internal val Res.string.str_3849: StringResource
+  get() = String36.str_3849
+
+@ExperimentalResourceApi
+internal val Res.string.str_385: StringResource
+  get() = String36.str_385
+
+@ExperimentalResourceApi
+internal val Res.string.str_3850: StringResource
+  get() = String36.str_3850
+
+@ExperimentalResourceApi
+internal val Res.string.str_3851: StringResource
+  get() = String36.str_3851
+
+@ExperimentalResourceApi
+internal val Res.string.str_3852: StringResource
+  get() = String36.str_3852
+
+@ExperimentalResourceApi
+internal val Res.string.str_3853: StringResource
+  get() = String36.str_3853
+
+@ExperimentalResourceApi
+internal val Res.string.str_3854: StringResource
+  get() = String36.str_3854
+
+@ExperimentalResourceApi
+internal val Res.string.str_3855: StringResource
+  get() = String36.str_3855
+
+@ExperimentalResourceApi
+internal val Res.string.str_3856: StringResource
+  get() = String36.str_3856
+
+@ExperimentalResourceApi
+internal val Res.string.str_3857: StringResource
+  get() = String36.str_3857
+
+@ExperimentalResourceApi
+internal val Res.string.str_3858: StringResource
+  get() = String36.str_3858
+
+@ExperimentalResourceApi
+internal val Res.string.str_3859: StringResource
+  get() = String36.str_3859
+
+@ExperimentalResourceApi
+internal val Res.string.str_386: StringResource
+  get() = String36.str_386
+
+@ExperimentalResourceApi
+internal val Res.string.str_3860: StringResource
+  get() = String36.str_3860
+
+@ExperimentalResourceApi
+internal val Res.string.str_3861: StringResource
+  get() = String36.str_3861
+
+@ExperimentalResourceApi
+internal val Res.string.str_3862: StringResource
+  get() = String36.str_3862
+
+@ExperimentalResourceApi
+internal val Res.string.str_3863: StringResource
+  get() = String36.str_3863
+
+@ExperimentalResourceApi
+internal val Res.string.str_3864: StringResource
+  get() = String36.str_3864
+
+@ExperimentalResourceApi
+internal val Res.string.str_3865: StringResource
+  get() = String36.str_3865
+
+@ExperimentalResourceApi
+internal val Res.string.str_3866: StringResource
+  get() = String36.str_3866
+
+@ExperimentalResourceApi
+internal val Res.string.str_3867: StringResource
+  get() = String36.str_3867
+
+@ExperimentalResourceApi
+internal val Res.string.str_3868: StringResource
+  get() = String36.str_3868
+
+@ExperimentalResourceApi
+internal val Res.string.str_3869: StringResource
+  get() = String36.str_3869
+
+@ExperimentalResourceApi
+internal val Res.string.str_387: StringResource
+  get() = String36.str_387
+
+@ExperimentalResourceApi
+internal val Res.string.str_3870: StringResource
+  get() = String36.str_3870
+
+@ExperimentalResourceApi
+internal val Res.string.str_3871: StringResource
+  get() = String36.str_3871
+
+@ExperimentalResourceApi
+internal val Res.string.str_3872: StringResource
+  get() = String36.str_3872
+
+@ExperimentalResourceApi
+internal val Res.string.str_3873: StringResource
+  get() = String36.str_3873
+
+@ExperimentalResourceApi
+internal val Res.string.str_3874: StringResource
+  get() = String36.str_3874
+
+@ExperimentalResourceApi
+internal val Res.string.str_3875: StringResource
+  get() = String36.str_3875
+
+@ExperimentalResourceApi
+internal val Res.string.str_3876: StringResource
+  get() = String36.str_3876
+
+@ExperimentalResourceApi
+internal val Res.string.str_3877: StringResource
+  get() = String36.str_3877
+
+@ExperimentalResourceApi
+internal val Res.string.str_3878: StringResource
+  get() = String36.str_3878
+
+@ExperimentalResourceApi
+internal val Res.string.str_3879: StringResource
+  get() = String36.str_3879
+
+@ExperimentalResourceApi
+internal val Res.string.str_388: StringResource
+  get() = String36.str_388
+
+@ExperimentalResourceApi
+internal val Res.string.str_3880: StringResource
+  get() = String36.str_3880
+
+@ExperimentalResourceApi
+internal val Res.string.str_3881: StringResource
+  get() = String36.str_3881
+
+@ExperimentalResourceApi
+internal val Res.string.str_3882: StringResource
+  get() = String36.str_3882
+
+@ExperimentalResourceApi
+internal val Res.string.str_3883: StringResource
+  get() = String36.str_3883
+
+@ExperimentalResourceApi
+internal val Res.string.str_3884: StringResource
+  get() = String36.str_3884
+
+@ExperimentalResourceApi
+internal val Res.string.str_3885: StringResource
+  get() = String36.str_3885
+
+@ExperimentalResourceApi
+internal val Res.string.str_3886: StringResource
+  get() = String36.str_3886
+
+@ExperimentalResourceApi
+internal val Res.string.str_3887: StringResource
+  get() = String36.str_3887
+
+@ExperimentalResourceApi
+internal val Res.string.str_3888: StringResource
+  get() = String36.str_3888
+
+@ExperimentalResourceApi
+internal val Res.string.str_3889: StringResource
+  get() = String36.str_3889
+
+@ExperimentalResourceApi
+internal val Res.string.str_389: StringResource
+  get() = String36.str_389
+
+@ExperimentalResourceApi
+internal val Res.string.str_3890: StringResource
+  get() = String36.str_3890
+
+@ExperimentalResourceApi
+internal val Res.string.str_3891: StringResource
+  get() = String36.str_3891
+
+@ExperimentalResourceApi
+internal val Res.string.str_3892: StringResource
+  get() = String36.str_3892
+
+@ExperimentalResourceApi
+internal val Res.string.str_3893: StringResource
+  get() = String36.str_3893
+
+@ExperimentalResourceApi
+internal val Res.string.str_3894: StringResource
+  get() = String36.str_3894
+
+@ExperimentalResourceApi
+internal val Res.string.str_3895: StringResource
+  get() = String36.str_3895
+
+@ExperimentalResourceApi
+internal val Res.string.str_3896: StringResource
+  get() = String36.str_3896
+
+@ExperimentalResourceApi
+internal val Res.string.str_3897: StringResource
+  get() = String36.str_3897
+
+@ExperimentalResourceApi
+internal val Res.string.str_3898: StringResource
+  get() = String36.str_3898
+
+@ExperimentalResourceApi
+internal val Res.string.str_3899: StringResource
+  get() = String36.str_3899
+
+@ExperimentalResourceApi
+internal val Res.string.str_39: StringResource
+  get() = String36.str_39
+
+@ExperimentalResourceApi
+internal val Res.string.str_390: StringResource
+  get() = String36.str_390
+
+@ExperimentalResourceApi
+internal val Res.string.str_3900: StringResource
+  get() = String36.str_3900
+
+@ExperimentalResourceApi
+internal val Res.string.str_3901: StringResource
+  get() = String36.str_3901
+
+@ExperimentalResourceApi
+internal val Res.string.str_3902: StringResource
+  get() = String36.str_3902
+
+@ExperimentalResourceApi
+internal val Res.string.str_3903: StringResource
+  get() = String36.str_3903
+
+@ExperimentalResourceApi
+internal val Res.string.str_3904: StringResource
+  get() = String36.str_3904
+
+@ExperimentalResourceApi
+internal val Res.string.str_3905: StringResource
+  get() = String36.str_3905
+
+@ExperimentalResourceApi
+internal val Res.string.str_3906: StringResource
+  get() = String36.str_3906
+
+@ExperimentalResourceApi
+internal val Res.string.str_3907: StringResource
+  get() = String36.str_3907
+
+@ExperimentalResourceApi
+internal val Res.string.str_3908: StringResource
+  get() = String36.str_3908
+
+@ExperimentalResourceApi
+internal val Res.string.str_3909: StringResource
+  get() = String36.str_3909
+
+@ExperimentalResourceApi
+internal val Res.string.str_391: StringResource
+  get() = String36.str_391
+
+@ExperimentalResourceApi
+internal val Res.string.str_3910: StringResource
+  get() = String36.str_3910
+
+@ExperimentalResourceApi
+internal val Res.string.str_3911: StringResource
+  get() = String36.str_3911
+
+@ExperimentalResourceApi
+internal val Res.string.str_3912: StringResource
+  get() = String36.str_3912
+
+@ExperimentalResourceApi
+internal val Res.string.str_3913: StringResource
+  get() = String36.str_3913
+
+@ExperimentalResourceApi
+internal val Res.string.str_3914: StringResource
+  get() = String36.str_3914
+
+@ExperimentalResourceApi
+internal val Res.string.str_3915: StringResource
+  get() = String36.str_3915
+
+@ExperimentalResourceApi
+internal val Res.string.str_3916: StringResource
+  get() = String36.str_3916
+
+@ExperimentalResourceApi
+internal val Res.string.str_3917: StringResource
+  get() = String36.str_3917
+
+@ExperimentalResourceApi
+internal val Res.string.str_3918: StringResource
+  get() = String36.str_3918
+
+@ExperimentalResourceApi
+internal val Res.string.str_3919: StringResource
+  get() = String36.str_3919
+
+@ExperimentalResourceApi
+internal val Res.string.str_392: StringResource
+  get() = String36.str_392
+
+@ExperimentalResourceApi
+internal val Res.string.str_3920: StringResource
+  get() = String36.str_3920
+
+@ExperimentalResourceApi
+internal val Res.string.str_3921: StringResource
+  get() = String36.str_3921
+
+@ExperimentalResourceApi
+internal val Res.string.str_3922: StringResource
+  get() = String36.str_3922
+
+@ExperimentalResourceApi
+internal val Res.string.str_3923: StringResource
+  get() = String36.str_3923
+
+@ExperimentalResourceApi
+internal val Res.string.str_3924: StringResource
+  get() = String36.str_3924
+
+@ExperimentalResourceApi
+internal val Res.string.str_3925: StringResource
+  get() = String36.str_3925
+
+@ExperimentalResourceApi
+internal val Res.string.str_3926: StringResource
+  get() = String36.str_3926
+
+@ExperimentalResourceApi
+internal val Res.string.str_3927: StringResource
+  get() = String36.str_3927
+
+@ExperimentalResourceApi
+internal val Res.string.str_3928: StringResource
+  get() = String36.str_3928
+
+@ExperimentalResourceApi
+internal val Res.string.str_3929: StringResource
+  get() = String36.str_3929
+
+@ExperimentalResourceApi
+internal val Res.string.str_393: StringResource
+  get() = String36.str_393
+
+@ExperimentalResourceApi
+internal val Res.string.str_3930: StringResource
+  get() = String36.str_3930
+
+@ExperimentalResourceApi
+internal val Res.string.str_3931: StringResource
+  get() = String36.str_3931
+
+@ExperimentalResourceApi
+internal val Res.string.str_3932: StringResource
+  get() = String36.str_3932
+
+@ExperimentalResourceApi
+internal val Res.string.str_3933: StringResource
+  get() = String36.str_3933
+
+@ExperimentalResourceApi
+internal val Res.string.str_3934: StringResource
+  get() = String36.str_3934
+
+@ExperimentalResourceApi
+internal val Res.string.str_3935: StringResource
+  get() = String36.str_3935
+
+@ExperimentalResourceApi
+internal val Res.string.str_3936: StringResource
+  get() = String36.str_3936
+
+@ExperimentalResourceApi
+internal val Res.string.str_3937: StringResource
+  get() = String36.str_3937
+
+@ExperimentalResourceApi
+internal val Res.string.str_3938: StringResource
+  get() = String36.str_3938
+
+@ExperimentalResourceApi
+internal val Res.string.str_3939: StringResource
+  get() = String36.str_3939
+
+@ExperimentalResourceApi
+internal val Res.string.str_394: StringResource
+  get() = String36.str_394
+
+@ExperimentalResourceApi
+internal val Res.string.str_3940: StringResource
+  get() = String36.str_3940
+
+@ExperimentalResourceApi
+internal val Res.string.str_3941: StringResource
+  get() = String36.str_3941
+
+@ExperimentalResourceApi
+internal val Res.string.str_3942: StringResource
+  get() = String36.str_3942
+
+@ExperimentalResourceApi
+internal val Res.string.str_3943: StringResource
+  get() = String36.str_3943
+
+@ExperimentalResourceApi
+internal val Res.string.str_3944: StringResource
+  get() = String36.str_3944
+
+@ExperimentalResourceApi
+internal val Res.string.str_3945: StringResource
+  get() = String36.str_3945
+
+@ExperimentalResourceApi
+internal val Res.string.str_3946: StringResource
+  get() = String36.str_3946
+
+@ExperimentalResourceApi
+internal val Res.string.str_3947: StringResource
+  get() = String36.str_3947
+
+@ExperimentalResourceApi
+internal val Res.string.str_3948: StringResource
+  get() = String36.str_3948
+
+@ExperimentalResourceApi
+internal val Res.string.str_3949: StringResource
+  get() = String36.str_3949
+
+@ExperimentalResourceApi
+internal val Res.string.str_395: StringResource
+  get() = String36.str_395
+
+@ExperimentalResourceApi
+internal val Res.string.str_3950: StringResource
+  get() = String36.str_3950
+
+@ExperimentalResourceApi
+internal val Res.string.str_3951: StringResource
+  get() = String36.str_3951
+
+@ExperimentalResourceApi
+internal val Res.string.str_3952: StringResource
+  get() = String36.str_3952
+
+@ExperimentalResourceApi
+internal val Res.string.str_3953: StringResource
+  get() = String36.str_3953
+
+@ExperimentalResourceApi
+internal val Res.string.str_3954: StringResource
+  get() = String36.str_3954
+
+@ExperimentalResourceApi
+internal val Res.string.str_3955: StringResource
+  get() = String36.str_3955
+
+@ExperimentalResourceApi
+internal val Res.string.str_3956: StringResource
+  get() = String36.str_3956
+
+@ExperimentalResourceApi
+internal val Res.string.str_3957: StringResource
+  get() = String36.str_3957
+
+@ExperimentalResourceApi
+internal val Res.string.str_3958: StringResource
+  get() = String36.str_3958
+
+@ExperimentalResourceApi
+internal val Res.string.str_3959: StringResource
+  get() = String36.str_3959
+
+@ExperimentalResourceApi
+internal val Res.string.str_396: StringResource
+  get() = String36.str_396
+
+@ExperimentalResourceApi
+internal val Res.string.str_3960: StringResource
+  get() = String36.str_3960
+
+@ExperimentalResourceApi
+internal val Res.string.str_3961: StringResource
+  get() = String36.str_3961
+
+@ExperimentalResourceApi
+internal val Res.string.str_3962: StringResource
+  get() = String36.str_3962
+
+@ExperimentalResourceApi
+internal val Res.string.str_3963: StringResource
+  get() = String36.str_3963
+
+@ExperimentalResourceApi
+internal val Res.string.str_3964: StringResource
+  get() = String36.str_3964
+
+@ExperimentalResourceApi
+internal val Res.string.str_3965: StringResource
+  get() = String36.str_3965
+
+@ExperimentalResourceApi
+internal val Res.string.str_3966: StringResource
+  get() = String36.str_3966
+
+@ExperimentalResourceApi
+internal val Res.string.str_3967: StringResource
+  get() = String36.str_3967
+
+@ExperimentalResourceApi
+internal val Res.string.str_3968: StringResource
+  get() = String36.str_3968
+
+@ExperimentalResourceApi
+internal val Res.string.str_3969: StringResource
+  get() = String36.str_3969
+
+@ExperimentalResourceApi
+internal val Res.string.str_397: StringResource
+  get() = String36.str_397
+
+@ExperimentalResourceApi
+internal val Res.string.str_3970: StringResource
+  get() = String36.str_3970
+
+@ExperimentalResourceApi
+internal val Res.string.str_3971: StringResource
+  get() = String36.str_3971
+
+@ExperimentalResourceApi
+internal val Res.string.str_3972: StringResource
+  get() = String36.str_3972
+
+@ExperimentalResourceApi
+internal val Res.string.str_3973: StringResource
+  get() = String36.str_3973
+
+@ExperimentalResourceApi
+internal val Res.string.str_3974: StringResource
+  get() = String36.str_3974
+
+@ExperimentalResourceApi
+internal val Res.string.str_3975: StringResource
+  get() = String36.str_3975
+
+@ExperimentalResourceApi
+internal val Res.string.str_3976: StringResource
+  get() = String36.str_3976
+
+@ExperimentalResourceApi
+internal val Res.string.str_3977: StringResource
+  get() = String36.str_3977
+
+@ExperimentalResourceApi
+internal val Res.string.str_3978: StringResource
+  get() = String36.str_3978
+
+@ExperimentalResourceApi
+internal val Res.string.str_3979: StringResource
+  get() = String36.str_3979
+
+@ExperimentalResourceApi
+internal val Res.string.str_398: StringResource
+  get() = String36.str_398
+
+@ExperimentalResourceApi
+internal val Res.string.str_3980: StringResource
+  get() = String36.str_3980
+
+@ExperimentalResourceApi
+internal val Res.string.str_3981: StringResource
+  get() = String36.str_3981
+
+@ExperimentalResourceApi
+internal val Res.string.str_3982: StringResource
+  get() = String36.str_3982
+
+@ExperimentalResourceApi
+internal val Res.string.str_3983: StringResource
+  get() = String36.str_3983
+
+@ExperimentalResourceApi
+internal val Res.string.str_3984: StringResource
+  get() = String36.str_3984
+
+@ExperimentalResourceApi
+internal val Res.string.str_3985: StringResource
+  get() = String36.str_3985
+
+@ExperimentalResourceApi
+internal val Res.string.str_3986: StringResource
+  get() = String36.str_3986
+
+@ExperimentalResourceApi
+internal val Res.string.str_3987: StringResource
+  get() = String36.str_3987
+
+@ExperimentalResourceApi
+internal val Res.string.str_3988: StringResource
+  get() = String36.str_3988
+
+@ExperimentalResourceApi
+internal val Res.string.str_3989: StringResource
+  get() = String36.str_3989
+
+@ExperimentalResourceApi
+internal val Res.string.str_399: StringResource
+  get() = String36.str_399
+
+@ExperimentalResourceApi
+internal val Res.string.str_3990: StringResource
+  get() = String36.str_3990
+
+@ExperimentalResourceApi
+internal val Res.string.str_3991: StringResource
+  get() = String36.str_3991
+
+@ExperimentalResourceApi
+internal val Res.string.str_3992: StringResource
+  get() = String36.str_3992
+
+@ExperimentalResourceApi
+internal val Res.string.str_3993: StringResource
+  get() = String36.str_3993
+
+@ExperimentalResourceApi
+internal val Res.string.str_3994: StringResource
+  get() = String36.str_3994
+
+@ExperimentalResourceApi
+internal val Res.string.str_3995: StringResource
+  get() = String36.str_3995
+
+@ExperimentalResourceApi
+internal val Res.string.str_3996: StringResource
+  get() = String36.str_3996
+
+@ExperimentalResourceApi
+internal val Res.string.str_3997: StringResource
+  get() = String36.str_3997
+
+@ExperimentalResourceApi
+internal val Res.string.str_3998: StringResource
+  get() = String36.str_3998
+
+@ExperimentalResourceApi
+internal val Res.string.str_3999: StringResource
+  get() = String36.str_3999
+
+@ExperimentalResourceApi
+internal val Res.string.str_4: StringResource
+  get() = String36.str_4
+
+@ExperimentalResourceApi
+internal val Res.string.str_40: StringResource
+  get() = String36.str_40
+
+@ExperimentalResourceApi
+internal val Res.string.str_400: StringResource
+  get() = String36.str_400
+
+@ExperimentalResourceApi
+internal val Res.string.str_4000: StringResource
+  get() = String36.str_4000
+
+@ExperimentalResourceApi
+internal val Res.string.str_4001: StringResource
+  get() = String36.str_4001
+
+@ExperimentalResourceApi
+internal val Res.string.str_4002: StringResource
+  get() = String36.str_4002
+
+@ExperimentalResourceApi
+internal val Res.string.str_4003: StringResource
+  get() = String36.str_4003
+
+@ExperimentalResourceApi
+internal val Res.string.str_4004: StringResource
+  get() = String36.str_4004
+
+@ExperimentalResourceApi
+internal val Res.string.str_4005: StringResource
+  get() = String36.str_4005
+
+@ExperimentalResourceApi
+internal val Res.string.str_4006: StringResource
+  get() = String36.str_4006
+
+@ExperimentalResourceApi
+internal val Res.string.str_4007: StringResource
+  get() = String36.str_4007
+
+@ExperimentalResourceApi
+internal val Res.string.str_4008: StringResource
+  get() = String36.str_4008
+
+@ExperimentalResourceApi
+internal val Res.string.str_4009: StringResource
+  get() = String36.str_4009
+
+@ExperimentalResourceApi
+internal val Res.string.str_401: StringResource
+  get() = String36.str_401
+
+@ExperimentalResourceApi
+internal val Res.string.str_4010: StringResource
+  get() = String36.str_4010
+
+@ExperimentalResourceApi
+internal val Res.string.str_4011: StringResource
+  get() = String36.str_4011
+
+@ExperimentalResourceApi
+internal val Res.string.str_4012: StringResource
+  get() = String36.str_4012
+
+@ExperimentalResourceApi
+internal val Res.string.str_4013: StringResource
+  get() = String36.str_4013
+
+@ExperimentalResourceApi
+internal val Res.string.str_4014: StringResource
+  get() = String36.str_4014
+
+@ExperimentalResourceApi
+internal val Res.string.str_4015: StringResource
+  get() = String36.str_4015
+
+@ExperimentalResourceApi
+internal val Res.string.str_4016: StringResource
+  get() = String36.str_4016
+
+@ExperimentalResourceApi
+internal val Res.string.str_4017: StringResource
+  get() = String36.str_4017
+
+@ExperimentalResourceApi
+internal val Res.string.str_4018: StringResource
+  get() = String36.str_4018
+
+@ExperimentalResourceApi
+internal val Res.string.str_4019: StringResource
+  get() = String36.str_4019
+
+@ExperimentalResourceApi
+internal val Res.string.str_402: StringResource
+  get() = String36.str_402
+
+@ExperimentalResourceApi
+internal val Res.string.str_4020: StringResource
+  get() = String36.str_4020
+
+@ExperimentalResourceApi
+internal val Res.string.str_4021: StringResource
+  get() = String36.str_4021
+
+@ExperimentalResourceApi
+internal val Res.string.str_4022: StringResource
+  get() = String36.str_4022
+
+@ExperimentalResourceApi
+internal val Res.string.str_4023: StringResource
+  get() = String36.str_4023
+
+@ExperimentalResourceApi
+internal val Res.string.str_4024: StringResource
+  get() = String36.str_4024
+
+@ExperimentalResourceApi
+internal val Res.string.str_4025: StringResource
+  get() = String36.str_4025
+
+@ExperimentalResourceApi
+internal val Res.string.str_4026: StringResource
+  get() = String36.str_4026
+
+@ExperimentalResourceApi
+internal val Res.string.str_4027: StringResource
+  get() = String36.str_4027
+
+@ExperimentalResourceApi
+internal val Res.string.str_4028: StringResource
+  get() = String36.str_4028
+
+@ExperimentalResourceApi
+internal val Res.string.str_4029: StringResource
+  get() = String36.str_4029
+
+@ExperimentalResourceApi
+internal val Res.string.str_403: StringResource
+  get() = String36.str_403
+
+@ExperimentalResourceApi
+internal val Res.string.str_4030: StringResource
+  get() = String36.str_4030
+
+@ExperimentalResourceApi
+internal val Res.string.str_4031: StringResource
+  get() = String36.str_4031
+
+@ExperimentalResourceApi
+internal val Res.string.str_4032: StringResource
+  get() = String36.str_4032
+
+@ExperimentalResourceApi
+internal val Res.string.str_4033: StringResource
+  get() = String36.str_4033
+
+@ExperimentalResourceApi
+internal val Res.string.str_4034: StringResource
+  get() = String36.str_4034
+
+@ExperimentalResourceApi
+internal val Res.string.str_4035: StringResource
+  get() = String36.str_4035
+
+@ExperimentalResourceApi
+internal val Res.string.str_4036: StringResource
+  get() = String36.str_4036
+
+@ExperimentalResourceApi
+internal val Res.string.str_4037: StringResource
+  get() = String36.str_4037
+
+@ExperimentalResourceApi
+internal val Res.string.str_4038: StringResource
+  get() = String36.str_4038
+
+@ExperimentalResourceApi
+internal val Res.string.str_4039: StringResource
+  get() = String36.str_4039
+
+@ExperimentalResourceApi
+internal val Res.string.str_404: StringResource
+  get() = String36.str_404
+
+@ExperimentalResourceApi
+internal val Res.string.str_4040: StringResource
+  get() = String36.str_4040
+
+@ExperimentalResourceApi
+internal val Res.string.str_4041: StringResource
+  get() = String36.str_4041
+
+@ExperimentalResourceApi
+internal val Res.string.str_4042: StringResource
+  get() = String36.str_4042
+
+@ExperimentalResourceApi
+internal val Res.string.str_4043: StringResource
+  get() = String36.str_4043
+
+@ExperimentalResourceApi
+internal val Res.string.str_4044: StringResource
+  get() = String36.str_4044
+
+@ExperimentalResourceApi
+internal val Res.string.str_4045: StringResource
+  get() = String36.str_4045
+
+@ExperimentalResourceApi
+internal val Res.string.str_4046: StringResource
+  get() = String36.str_4046
+
+@ExperimentalResourceApi
+internal val Res.string.str_4047: StringResource
+  get() = String36.str_4047
+
+@ExperimentalResourceApi
+internal val Res.string.str_4048: StringResource
+  get() = String36.str_4048
+
+@ExperimentalResourceApi
+internal val Res.string.str_4049: StringResource
+  get() = String36.str_4049
+
+@ExperimentalResourceApi
+internal val Res.string.str_405: StringResource
+  get() = String36.str_405
+
+@ExperimentalResourceApi
+internal val Res.string.str_4050: StringResource
+  get() = String36.str_4050
+
+@ExperimentalResourceApi
+internal val Res.string.str_4051: StringResource
+  get() = String36.str_4051
+
+@ExperimentalResourceApi
+internal val Res.string.str_4052: StringResource
+  get() = String36.str_4052
+
+@ExperimentalResourceApi
+internal val Res.string.str_4053: StringResource
+  get() = String36.str_4053
+
+@ExperimentalResourceApi
+internal val Res.string.str_4054: StringResource
+  get() = String36.str_4054
+
+@ExperimentalResourceApi
+internal val Res.string.str_4055: StringResource
+  get() = String36.str_4055
+
+@ExperimentalResourceApi
+internal val Res.string.str_4056: StringResource
+  get() = String36.str_4056
+
+@ExperimentalResourceApi
+internal val Res.string.str_4057: StringResource
+  get() = String36.str_4057
+
+@ExperimentalResourceApi
+internal val Res.string.str_4058: StringResource
+  get() = String36.str_4058
+
+@ExperimentalResourceApi
+internal val Res.string.str_4059: StringResource
+  get() = String36.str_4059
+
+@ExperimentalResourceApi
+internal val Res.string.str_406: StringResource
+  get() = String36.str_406
+
+@ExperimentalResourceApi
+internal val Res.string.str_4060: StringResource
+  get() = String36.str_4060
+
+@ExperimentalResourceApi
+internal val Res.string.str_4061: StringResource
+  get() = String36.str_4061
+
+@ExperimentalResourceApi
+internal val Res.string.str_4062: StringResource
+  get() = String36.str_4062
+
+@ExperimentalResourceApi
+internal val Res.string.str_4063: StringResource
+  get() = String36.str_4063
+
+@ExperimentalResourceApi
+internal val Res.string.str_4064: StringResource
+  get() = String36.str_4064
+
+@ExperimentalResourceApi
+internal val Res.string.str_4065: StringResource
+  get() = String36.str_4065
+
+@ExperimentalResourceApi
+internal val Res.string.str_4066: StringResource
+  get() = String36.str_4066
+
+@ExperimentalResourceApi
+internal val Res.string.str_4067: StringResource
+  get() = String36.str_4067
+
+@ExperimentalResourceApi
+internal val Res.string.str_4068: StringResource
+  get() = String36.str_4068
+
+@ExperimentalResourceApi
+internal val Res.string.str_4069: StringResource
+  get() = String36.str_4069
+
+@ExperimentalResourceApi
+internal val Res.string.str_407: StringResource
+  get() = String36.str_407
+
+@ExperimentalResourceApi
+internal val Res.string.str_4070: StringResource
+  get() = String36.str_4070
+
+@ExperimentalResourceApi
+internal val Res.string.str_4071: StringResource
+  get() = String36.str_4071
+
+@ExperimentalResourceApi
+internal val Res.string.str_4072: StringResource
+  get() = String36.str_4072
+
+@ExperimentalResourceApi
+internal val Res.string.str_4073: StringResource
+  get() = String36.str_4073
+
+@ExperimentalResourceApi
+internal val Res.string.str_4074: StringResource
+  get() = String36.str_4074
+
+@ExperimentalResourceApi
+internal val Res.string.str_4075: StringResource
+  get() = String36.str_4075
+
+@ExperimentalResourceApi
+internal val Res.string.str_4076: StringResource
+  get() = String36.str_4076
+
+@ExperimentalResourceApi
+internal val Res.string.str_4077: StringResource
+  get() = String36.str_4077
+
+@ExperimentalResourceApi
+internal val Res.string.str_4078: StringResource
+  get() = String36.str_4078
+
+@ExperimentalResourceApi
+internal val Res.string.str_4079: StringResource
+  get() = String36.str_4079
+
+@ExperimentalResourceApi
+internal val Res.string.str_408: StringResource
+  get() = String36.str_408
+
+@ExperimentalResourceApi
+internal val Res.string.str_4080: StringResource
+  get() = String36.str_4080
+
+@ExperimentalResourceApi
+internal val Res.string.str_4081: StringResource
+  get() = String36.str_4081
+
+@ExperimentalResourceApi
+internal val Res.string.str_4082: StringResource
+  get() = String36.str_4082
+
+@ExperimentalResourceApi
+internal val Res.string.str_4083: StringResource
+  get() = String36.str_4083
+
+@ExperimentalResourceApi
+internal val Res.string.str_4084: StringResource
+  get() = String36.str_4084
+
+@ExperimentalResourceApi
+internal val Res.string.str_4085: StringResource
+  get() = String36.str_4085
+
+@ExperimentalResourceApi
+internal val Res.string.str_4086: StringResource
+  get() = String36.str_4086
+
+@ExperimentalResourceApi
+internal val Res.string.str_4087: StringResource
+  get() = String36.str_4087
+
+@ExperimentalResourceApi
+internal val Res.string.str_4088: StringResource
+  get() = String36.str_4088
+
+@ExperimentalResourceApi
+internal val Res.string.str_4089: StringResource
+  get() = String36.str_4089
+
+@ExperimentalResourceApi
+internal val Res.string.str_409: StringResource
+  get() = String36.str_409
+
+@ExperimentalResourceApi
+internal val Res.string.str_4090: StringResource
+  get() = String36.str_4090
+
+@ExperimentalResourceApi
+internal val Res.string.str_4091: StringResource
+  get() = String36.str_4091
+
+@ExperimentalResourceApi
+internal val Res.string.str_4092: StringResource
+  get() = String36.str_4092
+
+@ExperimentalResourceApi
+internal val Res.string.str_4093: StringResource
+  get() = String36.str_4093
+
+@ExperimentalResourceApi
+internal val Res.string.str_4094: StringResource
+  get() = String36.str_4094
+
+@ExperimentalResourceApi
+internal val Res.string.str_4095: StringResource
+  get() = String36.str_4095
+
+@ExperimentalResourceApi
+internal val Res.string.str_4096: StringResource
+  get() = String36.str_4096
+
+@ExperimentalResourceApi
+internal val Res.string.str_4097: StringResource
+  get() = String36.str_4097
+
+@ExperimentalResourceApi
+internal val Res.string.str_4098: StringResource
+  get() = String36.str_4098
+
+@ExperimentalResourceApi
+internal val Res.string.str_4099: StringResource
+  get() = String36.str_4099
+
+@ExperimentalResourceApi
+internal val Res.string.str_41: StringResource
+  get() = String36.str_41
+
+@ExperimentalResourceApi
+internal val Res.string.str_410: StringResource
+  get() = String36.str_410
+
+@ExperimentalResourceApi
+internal val Res.string.str_4100: StringResource
+  get() = String36.str_4100
+
+@ExperimentalResourceApi
+internal val Res.string.str_4101: StringResource
+  get() = String36.str_4101
+
+@ExperimentalResourceApi
+internal val Res.string.str_4102: StringResource
+  get() = String36.str_4102
+
+@ExperimentalResourceApi
+internal val Res.string.str_4103: StringResource
+  get() = String36.str_4103
+
+@ExperimentalResourceApi
+internal val Res.string.str_4104: StringResource
+  get() = String36.str_4104
+
+@ExperimentalResourceApi
+internal val Res.string.str_4105: StringResource
+  get() = String36.str_4105
+
+@ExperimentalResourceApi
+internal val Res.string.str_4106: StringResource
+  get() = String36.str_4106
+
+@ExperimentalResourceApi
+internal val Res.string.str_4107: StringResource
+  get() = String36.str_4107
+
+@ExperimentalResourceApi
+internal val Res.string.str_4108: StringResource
+  get() = String36.str_4108
+
+@ExperimentalResourceApi
+internal val Res.string.str_4109: StringResource
+  get() = String36.str_4109
+
+@ExperimentalResourceApi
+internal val Res.string.str_411: StringResource
+  get() = String36.str_411
+
+@ExperimentalResourceApi
+internal val Res.string.str_4110: StringResource
+  get() = String36.str_4110
+
+@ExperimentalResourceApi
+internal val Res.string.str_4111: StringResource
+  get() = String36.str_4111
+
+@ExperimentalResourceApi
+internal val Res.string.str_4112: StringResource
+  get() = String36.str_4112
+
+@ExperimentalResourceApi
+internal val Res.string.str_4113: StringResource
+  get() = String36.str_4113
+
+@ExperimentalResourceApi
+internal val Res.string.str_4114: StringResource
+  get() = String36.str_4114
+
+@ExperimentalResourceApi
+internal val Res.string.str_4115: StringResource
+  get() = String36.str_4115
+
+@ExperimentalResourceApi
+internal val Res.string.str_4116: StringResource
+  get() = String36.str_4116
+
+@ExperimentalResourceApi
+internal val Res.string.str_4117: StringResource
+  get() = String36.str_4117
+
+@ExperimentalResourceApi
+internal val Res.string.str_4118: StringResource
+  get() = String36.str_4118
+
+@ExperimentalResourceApi
+internal val Res.string.str_4119: StringResource
+  get() = String36.str_4119
+
+@ExperimentalResourceApi
+internal val Res.string.str_412: StringResource
+  get() = String36.str_412
+
+@ExperimentalResourceApi
+internal val Res.string.str_4120: StringResource
+  get() = String36.str_4120
+
+@ExperimentalResourceApi
+internal val Res.string.str_4121: StringResource
+  get() = String36.str_4121
+
+@ExperimentalResourceApi
+internal val Res.string.str_4122: StringResource
+  get() = String36.str_4122
+
+@ExperimentalResourceApi
+internal val Res.string.str_4123: StringResource
+  get() = String36.str_4123
+
+@ExperimentalResourceApi
+internal val Res.string.str_4124: StringResource
+  get() = String36.str_4124
+
+@ExperimentalResourceApi
+internal val Res.string.str_4125: StringResource
+  get() = String36.str_4125
+
+@ExperimentalResourceApi
+internal val Res.string.str_4126: StringResource
+  get() = String36.str_4126
+
+@ExperimentalResourceApi
+internal val Res.string.str_4127: StringResource
+  get() = String36.str_4127
+
+@ExperimentalResourceApi
+internal val Res.string.str_4128: StringResource
+  get() = String36.str_4128
+
+@ExperimentalResourceApi
+internal val Res.string.str_4129: StringResource
+  get() = String36.str_4129
+
+@ExperimentalResourceApi
+internal val Res.string.str_413: StringResource
+  get() = String36.str_413
+
+@ExperimentalResourceApi
+internal val Res.string.str_4130: StringResource
+  get() = String36.str_4130
+
+@ExperimentalResourceApi
+internal val Res.string.str_4131: StringResource
+  get() = String36.str_4131
+
+@ExperimentalResourceApi
+internal val Res.string.str_4132: StringResource
+  get() = String36.str_4132
+
+@ExperimentalResourceApi
+internal val Res.string.str_4133: StringResource
+  get() = String36.str_4133
+
+@ExperimentalResourceApi
+internal val Res.string.str_4134: StringResource
+  get() = String36.str_4134
+
+@ExperimentalResourceApi
+internal val Res.string.str_4135: StringResource
+  get() = String36.str_4135
+
+@ExperimentalResourceApi
+internal val Res.string.str_4136: StringResource
+  get() = String36.str_4136
+
+@ExperimentalResourceApi
+internal val Res.string.str_4137: StringResource
+  get() = String36.str_4137
+
+@ExperimentalResourceApi
+internal val Res.string.str_4138: StringResource
+  get() = String36.str_4138
+
+@ExperimentalResourceApi
+internal val Res.string.str_4139: StringResource
+  get() = String36.str_4139
+
+@ExperimentalResourceApi
+internal val Res.string.str_414: StringResource
+  get() = String36.str_414
+
+@ExperimentalResourceApi
+internal val Res.string.str_4140: StringResource
+  get() = String36.str_4140
+
+@ExperimentalResourceApi
+internal val Res.string.str_4141: StringResource
+  get() = String36.str_4141
+
+@ExperimentalResourceApi
+internal val Res.string.str_4142: StringResource
+  get() = String36.str_4142
+
+@ExperimentalResourceApi
+internal val Res.string.str_4143: StringResource
+  get() = String36.str_4143
+
+@ExperimentalResourceApi
+internal val Res.string.str_4144: StringResource
+  get() = String36.str_4144
+
+@ExperimentalResourceApi
+internal val Res.string.str_4145: StringResource
+  get() = String36.str_4145
+
+@ExperimentalResourceApi
+internal val Res.string.str_4146: StringResource
+  get() = String36.str_4146
+
+@ExperimentalResourceApi
+internal val Res.string.str_4147: StringResource
+  get() = String36.str_4147

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String37.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String37.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String37 {
+  public val str_4148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4148", "str_4148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4149", "str_4149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_415", "str_415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4150", "str_4150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4151", "str_4151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4152", "str_4152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4153", "str_4153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4154", "str_4154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4155", "str_4155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4156", "str_4156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4157", "str_4157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4158", "str_4158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4159", "str_4159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_416", "str_416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4160", "str_4160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4161", "str_4161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4162", "str_4162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4163", "str_4163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4164", "str_4164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4165", "str_4165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4166", "str_4166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4167", "str_4167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4168", "str_4168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4169", "str_4169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_417", "str_417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4170", "str_4170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4171", "str_4171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4172", "str_4172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4173", "str_4173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4174", "str_4174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4175", "str_4175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4176", "str_4176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4177", "str_4177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4178", "str_4178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4179", "str_4179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_418", "str_418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4180", "str_4180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4181", "str_4181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4182", "str_4182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4183", "str_4183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4184", "str_4184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4185", "str_4185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4186", "str_4186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4187", "str_4187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4188", "str_4188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4189", "str_4189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_419", "str_419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4190", "str_4190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4191", "str_4191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4192", "str_4192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4193", "str_4193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4194", "str_4194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4195", "str_4195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4196", "str_4196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4197", "str_4197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4198", "str_4198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4199", "str_4199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_42: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_42", "str_42",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_420", "str_420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4200", "str_4200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4201", "str_4201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4202", "str_4202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4203", "str_4203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4204", "str_4204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4205", "str_4205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4206", "str_4206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4207", "str_4207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4208", "str_4208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4209", "str_4209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_421", "str_421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4210", "str_4210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4211", "str_4211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4212", "str_4212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4213", "str_4213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4214", "str_4214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4215", "str_4215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4216", "str_4216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4217", "str_4217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4218", "str_4218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4219", "str_4219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_422", "str_422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4220", "str_4220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4221", "str_4221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4222", "str_4222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4223", "str_4223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4224", "str_4224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4225", "str_4225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4226", "str_4226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4227", "str_4227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4228", "str_4228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4229", "str_4229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_423", "str_423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4230", "str_4230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4231", "str_4231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4232", "str_4232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4233", "str_4233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4234", "str_4234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4235", "str_4235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4236", "str_4236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4237", "str_4237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4238", "str_4238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4239", "str_4239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_424", "str_424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4240", "str_4240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4241", "str_4241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4242", "str_4242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4243", "str_4243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4244", "str_4244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4245", "str_4245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4246", "str_4246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4247", "str_4247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4248", "str_4248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4249", "str_4249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_425", "str_425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4250", "str_4250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4251", "str_4251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4252", "str_4252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4253", "str_4253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4254", "str_4254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4255", "str_4255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4256", "str_4256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4257", "str_4257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4258", "str_4258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4259", "str_4259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_426", "str_426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4260", "str_4260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4261", "str_4261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4262", "str_4262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4263", "str_4263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4264", "str_4264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4265", "str_4265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4266", "str_4266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4267", "str_4267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4268", "str_4268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4269", "str_4269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_427", "str_427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4270", "str_4270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4271", "str_4271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4272", "str_4272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4273", "str_4273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4274", "str_4274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4275", "str_4275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4276", "str_4276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4277", "str_4277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4278", "str_4278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4279", "str_4279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_428", "str_428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4280", "str_4280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4281", "str_4281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4282", "str_4282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4283", "str_4283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4284", "str_4284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4285", "str_4285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4286", "str_4286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4287", "str_4287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4288", "str_4288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4289", "str_4289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_429", "str_429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4290", "str_4290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4291", "str_4291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4292", "str_4292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4293", "str_4293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4294", "str_4294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4295", "str_4295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4296", "str_4296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4297", "str_4297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4298", "str_4298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4299", "str_4299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_43: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_43", "str_43",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_430", "str_430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4300", "str_4300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4301", "str_4301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4302", "str_4302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4303", "str_4303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4304", "str_4304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4305", "str_4305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4306", "str_4306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4307", "str_4307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4308", "str_4308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4309", "str_4309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_431", "str_431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4310", "str_4310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4311", "str_4311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4312", "str_4312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4313", "str_4313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4314", "str_4314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4315", "str_4315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4316", "str_4316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4317", "str_4317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4318", "str_4318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4319", "str_4319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_432", "str_432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4320", "str_4320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4321", "str_4321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4322", "str_4322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4323", "str_4323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4324", "str_4324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4325", "str_4325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4326", "str_4326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4327", "str_4327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4328", "str_4328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4329", "str_4329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_433", "str_433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4330", "str_4330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4331", "str_4331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4332", "str_4332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4333", "str_4333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4334", "str_4334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4335", "str_4335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4336", "str_4336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4337", "str_4337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4338", "str_4338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4339", "str_4339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_434", "str_434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4340", "str_4340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4341", "str_4341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4342", "str_4342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4343", "str_4343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4344", "str_4344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4345", "str_4345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4346", "str_4346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4347", "str_4347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4348", "str_4348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4349", "str_4349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_435", "str_435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4350", "str_4350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4351", "str_4351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4352", "str_4352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4353", "str_4353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4354", "str_4354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4355", "str_4355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4356", "str_4356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4357", "str_4357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4358", "str_4358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4359", "str_4359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_436", "str_436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4360", "str_4360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4361", "str_4361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4362", "str_4362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4363", "str_4363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4364", "str_4364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4365", "str_4365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4366", "str_4366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4367", "str_4367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4368", "str_4368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4369", "str_4369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_437", "str_437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4370", "str_4370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4371", "str_4371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4372", "str_4372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4373", "str_4373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4374", "str_4374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4375", "str_4375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4376", "str_4376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4377", "str_4377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4378", "str_4378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4379", "str_4379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_438", "str_438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4380", "str_4380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4381", "str_4381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4382", "str_4382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4383", "str_4383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4384", "str_4384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4385", "str_4385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4386", "str_4386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4387", "str_4387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4388", "str_4388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4389", "str_4389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_439", "str_439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4390", "str_4390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4391", "str_4391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4392", "str_4392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4393", "str_4393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4394", "str_4394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4395", "str_4395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4396", "str_4396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4397", "str_4397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4398", "str_4398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4399", "str_4399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_44: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_44", "str_44",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_440", "str_440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4400", "str_4400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4401", "str_4401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4402", "str_4402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4403", "str_4403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4404", "str_4404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4405", "str_4405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4406", "str_4406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4407", "str_4407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4408", "str_4408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4409", "str_4409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_441", "str_441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4410", "str_4410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4411", "str_4411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4412", "str_4412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4413", "str_4413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4414", "str_4414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4415", "str_4415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4416", "str_4416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4417", "str_4417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4418", "str_4418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4419", "str_4419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_442", "str_442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4420", "str_4420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4421", "str_4421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4422", "str_4422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4423", "str_4423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4424", "str_4424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4425", "str_4425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4426", "str_4426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4427", "str_4427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4428", "str_4428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4429", "str_4429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_443", "str_443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4430", "str_4430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4431", "str_4431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4432", "str_4432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4433", "str_4433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4434", "str_4434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4435", "str_4435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4436", "str_4436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4437", "str_4437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4438", "str_4438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4439", "str_4439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_444", "str_444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4440", "str_4440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4441", "str_4441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4442", "str_4442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4443", "str_4443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4444", "str_4444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4445", "str_4445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4446", "str_4446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4447", "str_4447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4448", "str_4448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4449", "str_4449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_445", "str_445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4450", "str_4450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4451", "str_4451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4452", "str_4452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4453", "str_4453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4454", "str_4454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4455", "str_4455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4456", "str_4456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4457", "str_4457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4458", "str_4458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4459", "str_4459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_446", "str_446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4460", "str_4460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4461", "str_4461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4462", "str_4462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4463", "str_4463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4464", "str_4464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4465", "str_4465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4466", "str_4466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4467", "str_4467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4468", "str_4468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4469", "str_4469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_447", "str_447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4470", "str_4470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4471", "str_4471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4472", "str_4472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4473", "str_4473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4474", "str_4474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4475", "str_4475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4476", "str_4476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4477", "str_4477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4478", "str_4478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4479", "str_4479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_448", "str_448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4480", "str_4480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4481", "str_4481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4482", "str_4482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4483", "str_4483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4484", "str_4484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4485", "str_4485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4486", "str_4486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4487", "str_4487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4488", "str_4488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4489", "str_4489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_449", "str_449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4490", "str_4490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4491", "str_4491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4492", "str_4492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4493", "str_4493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4494", "str_4494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4495", "str_4495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4496", "str_4496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4497", "str_4497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4498", "str_4498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4499", "str_4499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_45: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_45", "str_45",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_450", "str_450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4500", "str_4500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4501", "str_4501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4502", "str_4502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4503", "str_4503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4504", "str_4504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4505", "str_4505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4506", "str_4506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4507", "str_4507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4508", "str_4508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4509", "str_4509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_451", "str_451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4510", "str_4510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4511", "str_4511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4512", "str_4512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4513", "str_4513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4514", "str_4514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4515", "str_4515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4516", "str_4516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4517", "str_4517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4518", "str_4518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4519", "str_4519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_452", "str_452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4520", "str_4520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4521", "str_4521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4522", "str_4522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4523", "str_4523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4524", "str_4524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4525", "str_4525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4526", "str_4526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4527", "str_4527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4528", "str_4528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4529", "str_4529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_453", "str_453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4530", "str_4530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4531", "str_4531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4532", "str_4532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4533", "str_4533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4534", "str_4534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4535", "str_4535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4536", "str_4536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4537", "str_4537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4538", "str_4538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4539", "str_4539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_454", "str_454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4540", "str_4540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4541", "str_4541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4542", "str_4542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4543", "str_4543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4544", "str_4544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4545", "str_4545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4546", "str_4546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4547", "str_4547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4548", "str_4548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4549", "str_4549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_455", "str_455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4550", "str_4550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4551", "str_4551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4552", "str_4552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4553", "str_4553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4554", "str_4554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4555", "str_4555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4556", "str_4556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4557", "str_4557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4558", "str_4558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4559", "str_4559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_456", "str_456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4560", "str_4560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4561", "str_4561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4562", "str_4562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4563", "str_4563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4564", "str_4564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4565", "str_4565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4566", "str_4566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4567", "str_4567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4568", "str_4568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4569", "str_4569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_457", "str_457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4570", "str_4570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4571", "str_4571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4572", "str_4572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4573", "str_4573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4574", "str_4574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4575", "str_4575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4576", "str_4576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4577", "str_4577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4578", "str_4578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4579", "str_4579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_458", "str_458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4580", "str_4580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4581", "str_4581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4582", "str_4582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4583", "str_4583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4584", "str_4584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4585", "str_4585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4586", "str_4586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4587", "str_4587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4588", "str_4588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4589", "str_4589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_459", "str_459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4590", "str_4590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4591", "str_4591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4592", "str_4592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4593", "str_4593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4594", "str_4594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4595", "str_4595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4596", "str_4596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4597", "str_4597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4598", "str_4598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_4148: StringResource
+  get() = String37.str_4148
+
+@ExperimentalResourceApi
+internal val Res.string.str_4149: StringResource
+  get() = String37.str_4149
+
+@ExperimentalResourceApi
+internal val Res.string.str_415: StringResource
+  get() = String37.str_415
+
+@ExperimentalResourceApi
+internal val Res.string.str_4150: StringResource
+  get() = String37.str_4150
+
+@ExperimentalResourceApi
+internal val Res.string.str_4151: StringResource
+  get() = String37.str_4151
+
+@ExperimentalResourceApi
+internal val Res.string.str_4152: StringResource
+  get() = String37.str_4152
+
+@ExperimentalResourceApi
+internal val Res.string.str_4153: StringResource
+  get() = String37.str_4153
+
+@ExperimentalResourceApi
+internal val Res.string.str_4154: StringResource
+  get() = String37.str_4154
+
+@ExperimentalResourceApi
+internal val Res.string.str_4155: StringResource
+  get() = String37.str_4155
+
+@ExperimentalResourceApi
+internal val Res.string.str_4156: StringResource
+  get() = String37.str_4156
+
+@ExperimentalResourceApi
+internal val Res.string.str_4157: StringResource
+  get() = String37.str_4157
+
+@ExperimentalResourceApi
+internal val Res.string.str_4158: StringResource
+  get() = String37.str_4158
+
+@ExperimentalResourceApi
+internal val Res.string.str_4159: StringResource
+  get() = String37.str_4159
+
+@ExperimentalResourceApi
+internal val Res.string.str_416: StringResource
+  get() = String37.str_416
+
+@ExperimentalResourceApi
+internal val Res.string.str_4160: StringResource
+  get() = String37.str_4160
+
+@ExperimentalResourceApi
+internal val Res.string.str_4161: StringResource
+  get() = String37.str_4161
+
+@ExperimentalResourceApi
+internal val Res.string.str_4162: StringResource
+  get() = String37.str_4162
+
+@ExperimentalResourceApi
+internal val Res.string.str_4163: StringResource
+  get() = String37.str_4163
+
+@ExperimentalResourceApi
+internal val Res.string.str_4164: StringResource
+  get() = String37.str_4164
+
+@ExperimentalResourceApi
+internal val Res.string.str_4165: StringResource
+  get() = String37.str_4165
+
+@ExperimentalResourceApi
+internal val Res.string.str_4166: StringResource
+  get() = String37.str_4166
+
+@ExperimentalResourceApi
+internal val Res.string.str_4167: StringResource
+  get() = String37.str_4167
+
+@ExperimentalResourceApi
+internal val Res.string.str_4168: StringResource
+  get() = String37.str_4168
+
+@ExperimentalResourceApi
+internal val Res.string.str_4169: StringResource
+  get() = String37.str_4169
+
+@ExperimentalResourceApi
+internal val Res.string.str_417: StringResource
+  get() = String37.str_417
+
+@ExperimentalResourceApi
+internal val Res.string.str_4170: StringResource
+  get() = String37.str_4170
+
+@ExperimentalResourceApi
+internal val Res.string.str_4171: StringResource
+  get() = String37.str_4171
+
+@ExperimentalResourceApi
+internal val Res.string.str_4172: StringResource
+  get() = String37.str_4172
+
+@ExperimentalResourceApi
+internal val Res.string.str_4173: StringResource
+  get() = String37.str_4173
+
+@ExperimentalResourceApi
+internal val Res.string.str_4174: StringResource
+  get() = String37.str_4174
+
+@ExperimentalResourceApi
+internal val Res.string.str_4175: StringResource
+  get() = String37.str_4175
+
+@ExperimentalResourceApi
+internal val Res.string.str_4176: StringResource
+  get() = String37.str_4176
+
+@ExperimentalResourceApi
+internal val Res.string.str_4177: StringResource
+  get() = String37.str_4177
+
+@ExperimentalResourceApi
+internal val Res.string.str_4178: StringResource
+  get() = String37.str_4178
+
+@ExperimentalResourceApi
+internal val Res.string.str_4179: StringResource
+  get() = String37.str_4179
+
+@ExperimentalResourceApi
+internal val Res.string.str_418: StringResource
+  get() = String37.str_418
+
+@ExperimentalResourceApi
+internal val Res.string.str_4180: StringResource
+  get() = String37.str_4180
+
+@ExperimentalResourceApi
+internal val Res.string.str_4181: StringResource
+  get() = String37.str_4181
+
+@ExperimentalResourceApi
+internal val Res.string.str_4182: StringResource
+  get() = String37.str_4182
+
+@ExperimentalResourceApi
+internal val Res.string.str_4183: StringResource
+  get() = String37.str_4183
+
+@ExperimentalResourceApi
+internal val Res.string.str_4184: StringResource
+  get() = String37.str_4184
+
+@ExperimentalResourceApi
+internal val Res.string.str_4185: StringResource
+  get() = String37.str_4185
+
+@ExperimentalResourceApi
+internal val Res.string.str_4186: StringResource
+  get() = String37.str_4186
+
+@ExperimentalResourceApi
+internal val Res.string.str_4187: StringResource
+  get() = String37.str_4187
+
+@ExperimentalResourceApi
+internal val Res.string.str_4188: StringResource
+  get() = String37.str_4188
+
+@ExperimentalResourceApi
+internal val Res.string.str_4189: StringResource
+  get() = String37.str_4189
+
+@ExperimentalResourceApi
+internal val Res.string.str_419: StringResource
+  get() = String37.str_419
+
+@ExperimentalResourceApi
+internal val Res.string.str_4190: StringResource
+  get() = String37.str_4190
+
+@ExperimentalResourceApi
+internal val Res.string.str_4191: StringResource
+  get() = String37.str_4191
+
+@ExperimentalResourceApi
+internal val Res.string.str_4192: StringResource
+  get() = String37.str_4192
+
+@ExperimentalResourceApi
+internal val Res.string.str_4193: StringResource
+  get() = String37.str_4193
+
+@ExperimentalResourceApi
+internal val Res.string.str_4194: StringResource
+  get() = String37.str_4194
+
+@ExperimentalResourceApi
+internal val Res.string.str_4195: StringResource
+  get() = String37.str_4195
+
+@ExperimentalResourceApi
+internal val Res.string.str_4196: StringResource
+  get() = String37.str_4196
+
+@ExperimentalResourceApi
+internal val Res.string.str_4197: StringResource
+  get() = String37.str_4197
+
+@ExperimentalResourceApi
+internal val Res.string.str_4198: StringResource
+  get() = String37.str_4198
+
+@ExperimentalResourceApi
+internal val Res.string.str_4199: StringResource
+  get() = String37.str_4199
+
+@ExperimentalResourceApi
+internal val Res.string.str_42: StringResource
+  get() = String37.str_42
+
+@ExperimentalResourceApi
+internal val Res.string.str_420: StringResource
+  get() = String37.str_420
+
+@ExperimentalResourceApi
+internal val Res.string.str_4200: StringResource
+  get() = String37.str_4200
+
+@ExperimentalResourceApi
+internal val Res.string.str_4201: StringResource
+  get() = String37.str_4201
+
+@ExperimentalResourceApi
+internal val Res.string.str_4202: StringResource
+  get() = String37.str_4202
+
+@ExperimentalResourceApi
+internal val Res.string.str_4203: StringResource
+  get() = String37.str_4203
+
+@ExperimentalResourceApi
+internal val Res.string.str_4204: StringResource
+  get() = String37.str_4204
+
+@ExperimentalResourceApi
+internal val Res.string.str_4205: StringResource
+  get() = String37.str_4205
+
+@ExperimentalResourceApi
+internal val Res.string.str_4206: StringResource
+  get() = String37.str_4206
+
+@ExperimentalResourceApi
+internal val Res.string.str_4207: StringResource
+  get() = String37.str_4207
+
+@ExperimentalResourceApi
+internal val Res.string.str_4208: StringResource
+  get() = String37.str_4208
+
+@ExperimentalResourceApi
+internal val Res.string.str_4209: StringResource
+  get() = String37.str_4209
+
+@ExperimentalResourceApi
+internal val Res.string.str_421: StringResource
+  get() = String37.str_421
+
+@ExperimentalResourceApi
+internal val Res.string.str_4210: StringResource
+  get() = String37.str_4210
+
+@ExperimentalResourceApi
+internal val Res.string.str_4211: StringResource
+  get() = String37.str_4211
+
+@ExperimentalResourceApi
+internal val Res.string.str_4212: StringResource
+  get() = String37.str_4212
+
+@ExperimentalResourceApi
+internal val Res.string.str_4213: StringResource
+  get() = String37.str_4213
+
+@ExperimentalResourceApi
+internal val Res.string.str_4214: StringResource
+  get() = String37.str_4214
+
+@ExperimentalResourceApi
+internal val Res.string.str_4215: StringResource
+  get() = String37.str_4215
+
+@ExperimentalResourceApi
+internal val Res.string.str_4216: StringResource
+  get() = String37.str_4216
+
+@ExperimentalResourceApi
+internal val Res.string.str_4217: StringResource
+  get() = String37.str_4217
+
+@ExperimentalResourceApi
+internal val Res.string.str_4218: StringResource
+  get() = String37.str_4218
+
+@ExperimentalResourceApi
+internal val Res.string.str_4219: StringResource
+  get() = String37.str_4219
+
+@ExperimentalResourceApi
+internal val Res.string.str_422: StringResource
+  get() = String37.str_422
+
+@ExperimentalResourceApi
+internal val Res.string.str_4220: StringResource
+  get() = String37.str_4220
+
+@ExperimentalResourceApi
+internal val Res.string.str_4221: StringResource
+  get() = String37.str_4221
+
+@ExperimentalResourceApi
+internal val Res.string.str_4222: StringResource
+  get() = String37.str_4222
+
+@ExperimentalResourceApi
+internal val Res.string.str_4223: StringResource
+  get() = String37.str_4223
+
+@ExperimentalResourceApi
+internal val Res.string.str_4224: StringResource
+  get() = String37.str_4224
+
+@ExperimentalResourceApi
+internal val Res.string.str_4225: StringResource
+  get() = String37.str_4225
+
+@ExperimentalResourceApi
+internal val Res.string.str_4226: StringResource
+  get() = String37.str_4226
+
+@ExperimentalResourceApi
+internal val Res.string.str_4227: StringResource
+  get() = String37.str_4227
+
+@ExperimentalResourceApi
+internal val Res.string.str_4228: StringResource
+  get() = String37.str_4228
+
+@ExperimentalResourceApi
+internal val Res.string.str_4229: StringResource
+  get() = String37.str_4229
+
+@ExperimentalResourceApi
+internal val Res.string.str_423: StringResource
+  get() = String37.str_423
+
+@ExperimentalResourceApi
+internal val Res.string.str_4230: StringResource
+  get() = String37.str_4230
+
+@ExperimentalResourceApi
+internal val Res.string.str_4231: StringResource
+  get() = String37.str_4231
+
+@ExperimentalResourceApi
+internal val Res.string.str_4232: StringResource
+  get() = String37.str_4232
+
+@ExperimentalResourceApi
+internal val Res.string.str_4233: StringResource
+  get() = String37.str_4233
+
+@ExperimentalResourceApi
+internal val Res.string.str_4234: StringResource
+  get() = String37.str_4234
+
+@ExperimentalResourceApi
+internal val Res.string.str_4235: StringResource
+  get() = String37.str_4235
+
+@ExperimentalResourceApi
+internal val Res.string.str_4236: StringResource
+  get() = String37.str_4236
+
+@ExperimentalResourceApi
+internal val Res.string.str_4237: StringResource
+  get() = String37.str_4237
+
+@ExperimentalResourceApi
+internal val Res.string.str_4238: StringResource
+  get() = String37.str_4238
+
+@ExperimentalResourceApi
+internal val Res.string.str_4239: StringResource
+  get() = String37.str_4239
+
+@ExperimentalResourceApi
+internal val Res.string.str_424: StringResource
+  get() = String37.str_424
+
+@ExperimentalResourceApi
+internal val Res.string.str_4240: StringResource
+  get() = String37.str_4240
+
+@ExperimentalResourceApi
+internal val Res.string.str_4241: StringResource
+  get() = String37.str_4241
+
+@ExperimentalResourceApi
+internal val Res.string.str_4242: StringResource
+  get() = String37.str_4242
+
+@ExperimentalResourceApi
+internal val Res.string.str_4243: StringResource
+  get() = String37.str_4243
+
+@ExperimentalResourceApi
+internal val Res.string.str_4244: StringResource
+  get() = String37.str_4244
+
+@ExperimentalResourceApi
+internal val Res.string.str_4245: StringResource
+  get() = String37.str_4245
+
+@ExperimentalResourceApi
+internal val Res.string.str_4246: StringResource
+  get() = String37.str_4246
+
+@ExperimentalResourceApi
+internal val Res.string.str_4247: StringResource
+  get() = String37.str_4247
+
+@ExperimentalResourceApi
+internal val Res.string.str_4248: StringResource
+  get() = String37.str_4248
+
+@ExperimentalResourceApi
+internal val Res.string.str_4249: StringResource
+  get() = String37.str_4249
+
+@ExperimentalResourceApi
+internal val Res.string.str_425: StringResource
+  get() = String37.str_425
+
+@ExperimentalResourceApi
+internal val Res.string.str_4250: StringResource
+  get() = String37.str_4250
+
+@ExperimentalResourceApi
+internal val Res.string.str_4251: StringResource
+  get() = String37.str_4251
+
+@ExperimentalResourceApi
+internal val Res.string.str_4252: StringResource
+  get() = String37.str_4252
+
+@ExperimentalResourceApi
+internal val Res.string.str_4253: StringResource
+  get() = String37.str_4253
+
+@ExperimentalResourceApi
+internal val Res.string.str_4254: StringResource
+  get() = String37.str_4254
+
+@ExperimentalResourceApi
+internal val Res.string.str_4255: StringResource
+  get() = String37.str_4255
+
+@ExperimentalResourceApi
+internal val Res.string.str_4256: StringResource
+  get() = String37.str_4256
+
+@ExperimentalResourceApi
+internal val Res.string.str_4257: StringResource
+  get() = String37.str_4257
+
+@ExperimentalResourceApi
+internal val Res.string.str_4258: StringResource
+  get() = String37.str_4258
+
+@ExperimentalResourceApi
+internal val Res.string.str_4259: StringResource
+  get() = String37.str_4259
+
+@ExperimentalResourceApi
+internal val Res.string.str_426: StringResource
+  get() = String37.str_426
+
+@ExperimentalResourceApi
+internal val Res.string.str_4260: StringResource
+  get() = String37.str_4260
+
+@ExperimentalResourceApi
+internal val Res.string.str_4261: StringResource
+  get() = String37.str_4261
+
+@ExperimentalResourceApi
+internal val Res.string.str_4262: StringResource
+  get() = String37.str_4262
+
+@ExperimentalResourceApi
+internal val Res.string.str_4263: StringResource
+  get() = String37.str_4263
+
+@ExperimentalResourceApi
+internal val Res.string.str_4264: StringResource
+  get() = String37.str_4264
+
+@ExperimentalResourceApi
+internal val Res.string.str_4265: StringResource
+  get() = String37.str_4265
+
+@ExperimentalResourceApi
+internal val Res.string.str_4266: StringResource
+  get() = String37.str_4266
+
+@ExperimentalResourceApi
+internal val Res.string.str_4267: StringResource
+  get() = String37.str_4267
+
+@ExperimentalResourceApi
+internal val Res.string.str_4268: StringResource
+  get() = String37.str_4268
+
+@ExperimentalResourceApi
+internal val Res.string.str_4269: StringResource
+  get() = String37.str_4269
+
+@ExperimentalResourceApi
+internal val Res.string.str_427: StringResource
+  get() = String37.str_427
+
+@ExperimentalResourceApi
+internal val Res.string.str_4270: StringResource
+  get() = String37.str_4270
+
+@ExperimentalResourceApi
+internal val Res.string.str_4271: StringResource
+  get() = String37.str_4271
+
+@ExperimentalResourceApi
+internal val Res.string.str_4272: StringResource
+  get() = String37.str_4272
+
+@ExperimentalResourceApi
+internal val Res.string.str_4273: StringResource
+  get() = String37.str_4273
+
+@ExperimentalResourceApi
+internal val Res.string.str_4274: StringResource
+  get() = String37.str_4274
+
+@ExperimentalResourceApi
+internal val Res.string.str_4275: StringResource
+  get() = String37.str_4275
+
+@ExperimentalResourceApi
+internal val Res.string.str_4276: StringResource
+  get() = String37.str_4276
+
+@ExperimentalResourceApi
+internal val Res.string.str_4277: StringResource
+  get() = String37.str_4277
+
+@ExperimentalResourceApi
+internal val Res.string.str_4278: StringResource
+  get() = String37.str_4278
+
+@ExperimentalResourceApi
+internal val Res.string.str_4279: StringResource
+  get() = String37.str_4279
+
+@ExperimentalResourceApi
+internal val Res.string.str_428: StringResource
+  get() = String37.str_428
+
+@ExperimentalResourceApi
+internal val Res.string.str_4280: StringResource
+  get() = String37.str_4280
+
+@ExperimentalResourceApi
+internal val Res.string.str_4281: StringResource
+  get() = String37.str_4281
+
+@ExperimentalResourceApi
+internal val Res.string.str_4282: StringResource
+  get() = String37.str_4282
+
+@ExperimentalResourceApi
+internal val Res.string.str_4283: StringResource
+  get() = String37.str_4283
+
+@ExperimentalResourceApi
+internal val Res.string.str_4284: StringResource
+  get() = String37.str_4284
+
+@ExperimentalResourceApi
+internal val Res.string.str_4285: StringResource
+  get() = String37.str_4285
+
+@ExperimentalResourceApi
+internal val Res.string.str_4286: StringResource
+  get() = String37.str_4286
+
+@ExperimentalResourceApi
+internal val Res.string.str_4287: StringResource
+  get() = String37.str_4287
+
+@ExperimentalResourceApi
+internal val Res.string.str_4288: StringResource
+  get() = String37.str_4288
+
+@ExperimentalResourceApi
+internal val Res.string.str_4289: StringResource
+  get() = String37.str_4289
+
+@ExperimentalResourceApi
+internal val Res.string.str_429: StringResource
+  get() = String37.str_429
+
+@ExperimentalResourceApi
+internal val Res.string.str_4290: StringResource
+  get() = String37.str_4290
+
+@ExperimentalResourceApi
+internal val Res.string.str_4291: StringResource
+  get() = String37.str_4291
+
+@ExperimentalResourceApi
+internal val Res.string.str_4292: StringResource
+  get() = String37.str_4292
+
+@ExperimentalResourceApi
+internal val Res.string.str_4293: StringResource
+  get() = String37.str_4293
+
+@ExperimentalResourceApi
+internal val Res.string.str_4294: StringResource
+  get() = String37.str_4294
+
+@ExperimentalResourceApi
+internal val Res.string.str_4295: StringResource
+  get() = String37.str_4295
+
+@ExperimentalResourceApi
+internal val Res.string.str_4296: StringResource
+  get() = String37.str_4296
+
+@ExperimentalResourceApi
+internal val Res.string.str_4297: StringResource
+  get() = String37.str_4297
+
+@ExperimentalResourceApi
+internal val Res.string.str_4298: StringResource
+  get() = String37.str_4298
+
+@ExperimentalResourceApi
+internal val Res.string.str_4299: StringResource
+  get() = String37.str_4299
+
+@ExperimentalResourceApi
+internal val Res.string.str_43: StringResource
+  get() = String37.str_43
+
+@ExperimentalResourceApi
+internal val Res.string.str_430: StringResource
+  get() = String37.str_430
+
+@ExperimentalResourceApi
+internal val Res.string.str_4300: StringResource
+  get() = String37.str_4300
+
+@ExperimentalResourceApi
+internal val Res.string.str_4301: StringResource
+  get() = String37.str_4301
+
+@ExperimentalResourceApi
+internal val Res.string.str_4302: StringResource
+  get() = String37.str_4302
+
+@ExperimentalResourceApi
+internal val Res.string.str_4303: StringResource
+  get() = String37.str_4303
+
+@ExperimentalResourceApi
+internal val Res.string.str_4304: StringResource
+  get() = String37.str_4304
+
+@ExperimentalResourceApi
+internal val Res.string.str_4305: StringResource
+  get() = String37.str_4305
+
+@ExperimentalResourceApi
+internal val Res.string.str_4306: StringResource
+  get() = String37.str_4306
+
+@ExperimentalResourceApi
+internal val Res.string.str_4307: StringResource
+  get() = String37.str_4307
+
+@ExperimentalResourceApi
+internal val Res.string.str_4308: StringResource
+  get() = String37.str_4308
+
+@ExperimentalResourceApi
+internal val Res.string.str_4309: StringResource
+  get() = String37.str_4309
+
+@ExperimentalResourceApi
+internal val Res.string.str_431: StringResource
+  get() = String37.str_431
+
+@ExperimentalResourceApi
+internal val Res.string.str_4310: StringResource
+  get() = String37.str_4310
+
+@ExperimentalResourceApi
+internal val Res.string.str_4311: StringResource
+  get() = String37.str_4311
+
+@ExperimentalResourceApi
+internal val Res.string.str_4312: StringResource
+  get() = String37.str_4312
+
+@ExperimentalResourceApi
+internal val Res.string.str_4313: StringResource
+  get() = String37.str_4313
+
+@ExperimentalResourceApi
+internal val Res.string.str_4314: StringResource
+  get() = String37.str_4314
+
+@ExperimentalResourceApi
+internal val Res.string.str_4315: StringResource
+  get() = String37.str_4315
+
+@ExperimentalResourceApi
+internal val Res.string.str_4316: StringResource
+  get() = String37.str_4316
+
+@ExperimentalResourceApi
+internal val Res.string.str_4317: StringResource
+  get() = String37.str_4317
+
+@ExperimentalResourceApi
+internal val Res.string.str_4318: StringResource
+  get() = String37.str_4318
+
+@ExperimentalResourceApi
+internal val Res.string.str_4319: StringResource
+  get() = String37.str_4319
+
+@ExperimentalResourceApi
+internal val Res.string.str_432: StringResource
+  get() = String37.str_432
+
+@ExperimentalResourceApi
+internal val Res.string.str_4320: StringResource
+  get() = String37.str_4320
+
+@ExperimentalResourceApi
+internal val Res.string.str_4321: StringResource
+  get() = String37.str_4321
+
+@ExperimentalResourceApi
+internal val Res.string.str_4322: StringResource
+  get() = String37.str_4322
+
+@ExperimentalResourceApi
+internal val Res.string.str_4323: StringResource
+  get() = String37.str_4323
+
+@ExperimentalResourceApi
+internal val Res.string.str_4324: StringResource
+  get() = String37.str_4324
+
+@ExperimentalResourceApi
+internal val Res.string.str_4325: StringResource
+  get() = String37.str_4325
+
+@ExperimentalResourceApi
+internal val Res.string.str_4326: StringResource
+  get() = String37.str_4326
+
+@ExperimentalResourceApi
+internal val Res.string.str_4327: StringResource
+  get() = String37.str_4327
+
+@ExperimentalResourceApi
+internal val Res.string.str_4328: StringResource
+  get() = String37.str_4328
+
+@ExperimentalResourceApi
+internal val Res.string.str_4329: StringResource
+  get() = String37.str_4329
+
+@ExperimentalResourceApi
+internal val Res.string.str_433: StringResource
+  get() = String37.str_433
+
+@ExperimentalResourceApi
+internal val Res.string.str_4330: StringResource
+  get() = String37.str_4330
+
+@ExperimentalResourceApi
+internal val Res.string.str_4331: StringResource
+  get() = String37.str_4331
+
+@ExperimentalResourceApi
+internal val Res.string.str_4332: StringResource
+  get() = String37.str_4332
+
+@ExperimentalResourceApi
+internal val Res.string.str_4333: StringResource
+  get() = String37.str_4333
+
+@ExperimentalResourceApi
+internal val Res.string.str_4334: StringResource
+  get() = String37.str_4334
+
+@ExperimentalResourceApi
+internal val Res.string.str_4335: StringResource
+  get() = String37.str_4335
+
+@ExperimentalResourceApi
+internal val Res.string.str_4336: StringResource
+  get() = String37.str_4336
+
+@ExperimentalResourceApi
+internal val Res.string.str_4337: StringResource
+  get() = String37.str_4337
+
+@ExperimentalResourceApi
+internal val Res.string.str_4338: StringResource
+  get() = String37.str_4338
+
+@ExperimentalResourceApi
+internal val Res.string.str_4339: StringResource
+  get() = String37.str_4339
+
+@ExperimentalResourceApi
+internal val Res.string.str_434: StringResource
+  get() = String37.str_434
+
+@ExperimentalResourceApi
+internal val Res.string.str_4340: StringResource
+  get() = String37.str_4340
+
+@ExperimentalResourceApi
+internal val Res.string.str_4341: StringResource
+  get() = String37.str_4341
+
+@ExperimentalResourceApi
+internal val Res.string.str_4342: StringResource
+  get() = String37.str_4342
+
+@ExperimentalResourceApi
+internal val Res.string.str_4343: StringResource
+  get() = String37.str_4343
+
+@ExperimentalResourceApi
+internal val Res.string.str_4344: StringResource
+  get() = String37.str_4344
+
+@ExperimentalResourceApi
+internal val Res.string.str_4345: StringResource
+  get() = String37.str_4345
+
+@ExperimentalResourceApi
+internal val Res.string.str_4346: StringResource
+  get() = String37.str_4346
+
+@ExperimentalResourceApi
+internal val Res.string.str_4347: StringResource
+  get() = String37.str_4347
+
+@ExperimentalResourceApi
+internal val Res.string.str_4348: StringResource
+  get() = String37.str_4348
+
+@ExperimentalResourceApi
+internal val Res.string.str_4349: StringResource
+  get() = String37.str_4349
+
+@ExperimentalResourceApi
+internal val Res.string.str_435: StringResource
+  get() = String37.str_435
+
+@ExperimentalResourceApi
+internal val Res.string.str_4350: StringResource
+  get() = String37.str_4350
+
+@ExperimentalResourceApi
+internal val Res.string.str_4351: StringResource
+  get() = String37.str_4351
+
+@ExperimentalResourceApi
+internal val Res.string.str_4352: StringResource
+  get() = String37.str_4352
+
+@ExperimentalResourceApi
+internal val Res.string.str_4353: StringResource
+  get() = String37.str_4353
+
+@ExperimentalResourceApi
+internal val Res.string.str_4354: StringResource
+  get() = String37.str_4354
+
+@ExperimentalResourceApi
+internal val Res.string.str_4355: StringResource
+  get() = String37.str_4355
+
+@ExperimentalResourceApi
+internal val Res.string.str_4356: StringResource
+  get() = String37.str_4356
+
+@ExperimentalResourceApi
+internal val Res.string.str_4357: StringResource
+  get() = String37.str_4357
+
+@ExperimentalResourceApi
+internal val Res.string.str_4358: StringResource
+  get() = String37.str_4358
+
+@ExperimentalResourceApi
+internal val Res.string.str_4359: StringResource
+  get() = String37.str_4359
+
+@ExperimentalResourceApi
+internal val Res.string.str_436: StringResource
+  get() = String37.str_436
+
+@ExperimentalResourceApi
+internal val Res.string.str_4360: StringResource
+  get() = String37.str_4360
+
+@ExperimentalResourceApi
+internal val Res.string.str_4361: StringResource
+  get() = String37.str_4361
+
+@ExperimentalResourceApi
+internal val Res.string.str_4362: StringResource
+  get() = String37.str_4362
+
+@ExperimentalResourceApi
+internal val Res.string.str_4363: StringResource
+  get() = String37.str_4363
+
+@ExperimentalResourceApi
+internal val Res.string.str_4364: StringResource
+  get() = String37.str_4364
+
+@ExperimentalResourceApi
+internal val Res.string.str_4365: StringResource
+  get() = String37.str_4365
+
+@ExperimentalResourceApi
+internal val Res.string.str_4366: StringResource
+  get() = String37.str_4366
+
+@ExperimentalResourceApi
+internal val Res.string.str_4367: StringResource
+  get() = String37.str_4367
+
+@ExperimentalResourceApi
+internal val Res.string.str_4368: StringResource
+  get() = String37.str_4368
+
+@ExperimentalResourceApi
+internal val Res.string.str_4369: StringResource
+  get() = String37.str_4369
+
+@ExperimentalResourceApi
+internal val Res.string.str_437: StringResource
+  get() = String37.str_437
+
+@ExperimentalResourceApi
+internal val Res.string.str_4370: StringResource
+  get() = String37.str_4370
+
+@ExperimentalResourceApi
+internal val Res.string.str_4371: StringResource
+  get() = String37.str_4371
+
+@ExperimentalResourceApi
+internal val Res.string.str_4372: StringResource
+  get() = String37.str_4372
+
+@ExperimentalResourceApi
+internal val Res.string.str_4373: StringResource
+  get() = String37.str_4373
+
+@ExperimentalResourceApi
+internal val Res.string.str_4374: StringResource
+  get() = String37.str_4374
+
+@ExperimentalResourceApi
+internal val Res.string.str_4375: StringResource
+  get() = String37.str_4375
+
+@ExperimentalResourceApi
+internal val Res.string.str_4376: StringResource
+  get() = String37.str_4376
+
+@ExperimentalResourceApi
+internal val Res.string.str_4377: StringResource
+  get() = String37.str_4377
+
+@ExperimentalResourceApi
+internal val Res.string.str_4378: StringResource
+  get() = String37.str_4378
+
+@ExperimentalResourceApi
+internal val Res.string.str_4379: StringResource
+  get() = String37.str_4379
+
+@ExperimentalResourceApi
+internal val Res.string.str_438: StringResource
+  get() = String37.str_438
+
+@ExperimentalResourceApi
+internal val Res.string.str_4380: StringResource
+  get() = String37.str_4380
+
+@ExperimentalResourceApi
+internal val Res.string.str_4381: StringResource
+  get() = String37.str_4381
+
+@ExperimentalResourceApi
+internal val Res.string.str_4382: StringResource
+  get() = String37.str_4382
+
+@ExperimentalResourceApi
+internal val Res.string.str_4383: StringResource
+  get() = String37.str_4383
+
+@ExperimentalResourceApi
+internal val Res.string.str_4384: StringResource
+  get() = String37.str_4384
+
+@ExperimentalResourceApi
+internal val Res.string.str_4385: StringResource
+  get() = String37.str_4385
+
+@ExperimentalResourceApi
+internal val Res.string.str_4386: StringResource
+  get() = String37.str_4386
+
+@ExperimentalResourceApi
+internal val Res.string.str_4387: StringResource
+  get() = String37.str_4387
+
+@ExperimentalResourceApi
+internal val Res.string.str_4388: StringResource
+  get() = String37.str_4388
+
+@ExperimentalResourceApi
+internal val Res.string.str_4389: StringResource
+  get() = String37.str_4389
+
+@ExperimentalResourceApi
+internal val Res.string.str_439: StringResource
+  get() = String37.str_439
+
+@ExperimentalResourceApi
+internal val Res.string.str_4390: StringResource
+  get() = String37.str_4390
+
+@ExperimentalResourceApi
+internal val Res.string.str_4391: StringResource
+  get() = String37.str_4391
+
+@ExperimentalResourceApi
+internal val Res.string.str_4392: StringResource
+  get() = String37.str_4392
+
+@ExperimentalResourceApi
+internal val Res.string.str_4393: StringResource
+  get() = String37.str_4393
+
+@ExperimentalResourceApi
+internal val Res.string.str_4394: StringResource
+  get() = String37.str_4394
+
+@ExperimentalResourceApi
+internal val Res.string.str_4395: StringResource
+  get() = String37.str_4395
+
+@ExperimentalResourceApi
+internal val Res.string.str_4396: StringResource
+  get() = String37.str_4396
+
+@ExperimentalResourceApi
+internal val Res.string.str_4397: StringResource
+  get() = String37.str_4397
+
+@ExperimentalResourceApi
+internal val Res.string.str_4398: StringResource
+  get() = String37.str_4398
+
+@ExperimentalResourceApi
+internal val Res.string.str_4399: StringResource
+  get() = String37.str_4399
+
+@ExperimentalResourceApi
+internal val Res.string.str_44: StringResource
+  get() = String37.str_44
+
+@ExperimentalResourceApi
+internal val Res.string.str_440: StringResource
+  get() = String37.str_440
+
+@ExperimentalResourceApi
+internal val Res.string.str_4400: StringResource
+  get() = String37.str_4400
+
+@ExperimentalResourceApi
+internal val Res.string.str_4401: StringResource
+  get() = String37.str_4401
+
+@ExperimentalResourceApi
+internal val Res.string.str_4402: StringResource
+  get() = String37.str_4402
+
+@ExperimentalResourceApi
+internal val Res.string.str_4403: StringResource
+  get() = String37.str_4403
+
+@ExperimentalResourceApi
+internal val Res.string.str_4404: StringResource
+  get() = String37.str_4404
+
+@ExperimentalResourceApi
+internal val Res.string.str_4405: StringResource
+  get() = String37.str_4405
+
+@ExperimentalResourceApi
+internal val Res.string.str_4406: StringResource
+  get() = String37.str_4406
+
+@ExperimentalResourceApi
+internal val Res.string.str_4407: StringResource
+  get() = String37.str_4407
+
+@ExperimentalResourceApi
+internal val Res.string.str_4408: StringResource
+  get() = String37.str_4408
+
+@ExperimentalResourceApi
+internal val Res.string.str_4409: StringResource
+  get() = String37.str_4409
+
+@ExperimentalResourceApi
+internal val Res.string.str_441: StringResource
+  get() = String37.str_441
+
+@ExperimentalResourceApi
+internal val Res.string.str_4410: StringResource
+  get() = String37.str_4410
+
+@ExperimentalResourceApi
+internal val Res.string.str_4411: StringResource
+  get() = String37.str_4411
+
+@ExperimentalResourceApi
+internal val Res.string.str_4412: StringResource
+  get() = String37.str_4412
+
+@ExperimentalResourceApi
+internal val Res.string.str_4413: StringResource
+  get() = String37.str_4413
+
+@ExperimentalResourceApi
+internal val Res.string.str_4414: StringResource
+  get() = String37.str_4414
+
+@ExperimentalResourceApi
+internal val Res.string.str_4415: StringResource
+  get() = String37.str_4415
+
+@ExperimentalResourceApi
+internal val Res.string.str_4416: StringResource
+  get() = String37.str_4416
+
+@ExperimentalResourceApi
+internal val Res.string.str_4417: StringResource
+  get() = String37.str_4417
+
+@ExperimentalResourceApi
+internal val Res.string.str_4418: StringResource
+  get() = String37.str_4418
+
+@ExperimentalResourceApi
+internal val Res.string.str_4419: StringResource
+  get() = String37.str_4419
+
+@ExperimentalResourceApi
+internal val Res.string.str_442: StringResource
+  get() = String37.str_442
+
+@ExperimentalResourceApi
+internal val Res.string.str_4420: StringResource
+  get() = String37.str_4420
+
+@ExperimentalResourceApi
+internal val Res.string.str_4421: StringResource
+  get() = String37.str_4421
+
+@ExperimentalResourceApi
+internal val Res.string.str_4422: StringResource
+  get() = String37.str_4422
+
+@ExperimentalResourceApi
+internal val Res.string.str_4423: StringResource
+  get() = String37.str_4423
+
+@ExperimentalResourceApi
+internal val Res.string.str_4424: StringResource
+  get() = String37.str_4424
+
+@ExperimentalResourceApi
+internal val Res.string.str_4425: StringResource
+  get() = String37.str_4425
+
+@ExperimentalResourceApi
+internal val Res.string.str_4426: StringResource
+  get() = String37.str_4426
+
+@ExperimentalResourceApi
+internal val Res.string.str_4427: StringResource
+  get() = String37.str_4427
+
+@ExperimentalResourceApi
+internal val Res.string.str_4428: StringResource
+  get() = String37.str_4428
+
+@ExperimentalResourceApi
+internal val Res.string.str_4429: StringResource
+  get() = String37.str_4429
+
+@ExperimentalResourceApi
+internal val Res.string.str_443: StringResource
+  get() = String37.str_443
+
+@ExperimentalResourceApi
+internal val Res.string.str_4430: StringResource
+  get() = String37.str_4430
+
+@ExperimentalResourceApi
+internal val Res.string.str_4431: StringResource
+  get() = String37.str_4431
+
+@ExperimentalResourceApi
+internal val Res.string.str_4432: StringResource
+  get() = String37.str_4432
+
+@ExperimentalResourceApi
+internal val Res.string.str_4433: StringResource
+  get() = String37.str_4433
+
+@ExperimentalResourceApi
+internal val Res.string.str_4434: StringResource
+  get() = String37.str_4434
+
+@ExperimentalResourceApi
+internal val Res.string.str_4435: StringResource
+  get() = String37.str_4435
+
+@ExperimentalResourceApi
+internal val Res.string.str_4436: StringResource
+  get() = String37.str_4436
+
+@ExperimentalResourceApi
+internal val Res.string.str_4437: StringResource
+  get() = String37.str_4437
+
+@ExperimentalResourceApi
+internal val Res.string.str_4438: StringResource
+  get() = String37.str_4438
+
+@ExperimentalResourceApi
+internal val Res.string.str_4439: StringResource
+  get() = String37.str_4439
+
+@ExperimentalResourceApi
+internal val Res.string.str_444: StringResource
+  get() = String37.str_444
+
+@ExperimentalResourceApi
+internal val Res.string.str_4440: StringResource
+  get() = String37.str_4440
+
+@ExperimentalResourceApi
+internal val Res.string.str_4441: StringResource
+  get() = String37.str_4441
+
+@ExperimentalResourceApi
+internal val Res.string.str_4442: StringResource
+  get() = String37.str_4442
+
+@ExperimentalResourceApi
+internal val Res.string.str_4443: StringResource
+  get() = String37.str_4443
+
+@ExperimentalResourceApi
+internal val Res.string.str_4444: StringResource
+  get() = String37.str_4444
+
+@ExperimentalResourceApi
+internal val Res.string.str_4445: StringResource
+  get() = String37.str_4445
+
+@ExperimentalResourceApi
+internal val Res.string.str_4446: StringResource
+  get() = String37.str_4446
+
+@ExperimentalResourceApi
+internal val Res.string.str_4447: StringResource
+  get() = String37.str_4447
+
+@ExperimentalResourceApi
+internal val Res.string.str_4448: StringResource
+  get() = String37.str_4448
+
+@ExperimentalResourceApi
+internal val Res.string.str_4449: StringResource
+  get() = String37.str_4449
+
+@ExperimentalResourceApi
+internal val Res.string.str_445: StringResource
+  get() = String37.str_445
+
+@ExperimentalResourceApi
+internal val Res.string.str_4450: StringResource
+  get() = String37.str_4450
+
+@ExperimentalResourceApi
+internal val Res.string.str_4451: StringResource
+  get() = String37.str_4451
+
+@ExperimentalResourceApi
+internal val Res.string.str_4452: StringResource
+  get() = String37.str_4452
+
+@ExperimentalResourceApi
+internal val Res.string.str_4453: StringResource
+  get() = String37.str_4453
+
+@ExperimentalResourceApi
+internal val Res.string.str_4454: StringResource
+  get() = String37.str_4454
+
+@ExperimentalResourceApi
+internal val Res.string.str_4455: StringResource
+  get() = String37.str_4455
+
+@ExperimentalResourceApi
+internal val Res.string.str_4456: StringResource
+  get() = String37.str_4456
+
+@ExperimentalResourceApi
+internal val Res.string.str_4457: StringResource
+  get() = String37.str_4457
+
+@ExperimentalResourceApi
+internal val Res.string.str_4458: StringResource
+  get() = String37.str_4458
+
+@ExperimentalResourceApi
+internal val Res.string.str_4459: StringResource
+  get() = String37.str_4459
+
+@ExperimentalResourceApi
+internal val Res.string.str_446: StringResource
+  get() = String37.str_446
+
+@ExperimentalResourceApi
+internal val Res.string.str_4460: StringResource
+  get() = String37.str_4460
+
+@ExperimentalResourceApi
+internal val Res.string.str_4461: StringResource
+  get() = String37.str_4461
+
+@ExperimentalResourceApi
+internal val Res.string.str_4462: StringResource
+  get() = String37.str_4462
+
+@ExperimentalResourceApi
+internal val Res.string.str_4463: StringResource
+  get() = String37.str_4463
+
+@ExperimentalResourceApi
+internal val Res.string.str_4464: StringResource
+  get() = String37.str_4464
+
+@ExperimentalResourceApi
+internal val Res.string.str_4465: StringResource
+  get() = String37.str_4465
+
+@ExperimentalResourceApi
+internal val Res.string.str_4466: StringResource
+  get() = String37.str_4466
+
+@ExperimentalResourceApi
+internal val Res.string.str_4467: StringResource
+  get() = String37.str_4467
+
+@ExperimentalResourceApi
+internal val Res.string.str_4468: StringResource
+  get() = String37.str_4468
+
+@ExperimentalResourceApi
+internal val Res.string.str_4469: StringResource
+  get() = String37.str_4469
+
+@ExperimentalResourceApi
+internal val Res.string.str_447: StringResource
+  get() = String37.str_447
+
+@ExperimentalResourceApi
+internal val Res.string.str_4470: StringResource
+  get() = String37.str_4470
+
+@ExperimentalResourceApi
+internal val Res.string.str_4471: StringResource
+  get() = String37.str_4471
+
+@ExperimentalResourceApi
+internal val Res.string.str_4472: StringResource
+  get() = String37.str_4472
+
+@ExperimentalResourceApi
+internal val Res.string.str_4473: StringResource
+  get() = String37.str_4473
+
+@ExperimentalResourceApi
+internal val Res.string.str_4474: StringResource
+  get() = String37.str_4474
+
+@ExperimentalResourceApi
+internal val Res.string.str_4475: StringResource
+  get() = String37.str_4475
+
+@ExperimentalResourceApi
+internal val Res.string.str_4476: StringResource
+  get() = String37.str_4476
+
+@ExperimentalResourceApi
+internal val Res.string.str_4477: StringResource
+  get() = String37.str_4477
+
+@ExperimentalResourceApi
+internal val Res.string.str_4478: StringResource
+  get() = String37.str_4478
+
+@ExperimentalResourceApi
+internal val Res.string.str_4479: StringResource
+  get() = String37.str_4479
+
+@ExperimentalResourceApi
+internal val Res.string.str_448: StringResource
+  get() = String37.str_448
+
+@ExperimentalResourceApi
+internal val Res.string.str_4480: StringResource
+  get() = String37.str_4480
+
+@ExperimentalResourceApi
+internal val Res.string.str_4481: StringResource
+  get() = String37.str_4481
+
+@ExperimentalResourceApi
+internal val Res.string.str_4482: StringResource
+  get() = String37.str_4482
+
+@ExperimentalResourceApi
+internal val Res.string.str_4483: StringResource
+  get() = String37.str_4483
+
+@ExperimentalResourceApi
+internal val Res.string.str_4484: StringResource
+  get() = String37.str_4484
+
+@ExperimentalResourceApi
+internal val Res.string.str_4485: StringResource
+  get() = String37.str_4485
+
+@ExperimentalResourceApi
+internal val Res.string.str_4486: StringResource
+  get() = String37.str_4486
+
+@ExperimentalResourceApi
+internal val Res.string.str_4487: StringResource
+  get() = String37.str_4487
+
+@ExperimentalResourceApi
+internal val Res.string.str_4488: StringResource
+  get() = String37.str_4488
+
+@ExperimentalResourceApi
+internal val Res.string.str_4489: StringResource
+  get() = String37.str_4489
+
+@ExperimentalResourceApi
+internal val Res.string.str_449: StringResource
+  get() = String37.str_449
+
+@ExperimentalResourceApi
+internal val Res.string.str_4490: StringResource
+  get() = String37.str_4490
+
+@ExperimentalResourceApi
+internal val Res.string.str_4491: StringResource
+  get() = String37.str_4491
+
+@ExperimentalResourceApi
+internal val Res.string.str_4492: StringResource
+  get() = String37.str_4492
+
+@ExperimentalResourceApi
+internal val Res.string.str_4493: StringResource
+  get() = String37.str_4493
+
+@ExperimentalResourceApi
+internal val Res.string.str_4494: StringResource
+  get() = String37.str_4494
+
+@ExperimentalResourceApi
+internal val Res.string.str_4495: StringResource
+  get() = String37.str_4495
+
+@ExperimentalResourceApi
+internal val Res.string.str_4496: StringResource
+  get() = String37.str_4496
+
+@ExperimentalResourceApi
+internal val Res.string.str_4497: StringResource
+  get() = String37.str_4497
+
+@ExperimentalResourceApi
+internal val Res.string.str_4498: StringResource
+  get() = String37.str_4498
+
+@ExperimentalResourceApi
+internal val Res.string.str_4499: StringResource
+  get() = String37.str_4499
+
+@ExperimentalResourceApi
+internal val Res.string.str_45: StringResource
+  get() = String37.str_45
+
+@ExperimentalResourceApi
+internal val Res.string.str_450: StringResource
+  get() = String37.str_450
+
+@ExperimentalResourceApi
+internal val Res.string.str_4500: StringResource
+  get() = String37.str_4500
+
+@ExperimentalResourceApi
+internal val Res.string.str_4501: StringResource
+  get() = String37.str_4501
+
+@ExperimentalResourceApi
+internal val Res.string.str_4502: StringResource
+  get() = String37.str_4502
+
+@ExperimentalResourceApi
+internal val Res.string.str_4503: StringResource
+  get() = String37.str_4503
+
+@ExperimentalResourceApi
+internal val Res.string.str_4504: StringResource
+  get() = String37.str_4504
+
+@ExperimentalResourceApi
+internal val Res.string.str_4505: StringResource
+  get() = String37.str_4505
+
+@ExperimentalResourceApi
+internal val Res.string.str_4506: StringResource
+  get() = String37.str_4506
+
+@ExperimentalResourceApi
+internal val Res.string.str_4507: StringResource
+  get() = String37.str_4507
+
+@ExperimentalResourceApi
+internal val Res.string.str_4508: StringResource
+  get() = String37.str_4508
+
+@ExperimentalResourceApi
+internal val Res.string.str_4509: StringResource
+  get() = String37.str_4509
+
+@ExperimentalResourceApi
+internal val Res.string.str_451: StringResource
+  get() = String37.str_451
+
+@ExperimentalResourceApi
+internal val Res.string.str_4510: StringResource
+  get() = String37.str_4510
+
+@ExperimentalResourceApi
+internal val Res.string.str_4511: StringResource
+  get() = String37.str_4511
+
+@ExperimentalResourceApi
+internal val Res.string.str_4512: StringResource
+  get() = String37.str_4512
+
+@ExperimentalResourceApi
+internal val Res.string.str_4513: StringResource
+  get() = String37.str_4513
+
+@ExperimentalResourceApi
+internal val Res.string.str_4514: StringResource
+  get() = String37.str_4514
+
+@ExperimentalResourceApi
+internal val Res.string.str_4515: StringResource
+  get() = String37.str_4515
+
+@ExperimentalResourceApi
+internal val Res.string.str_4516: StringResource
+  get() = String37.str_4516
+
+@ExperimentalResourceApi
+internal val Res.string.str_4517: StringResource
+  get() = String37.str_4517
+
+@ExperimentalResourceApi
+internal val Res.string.str_4518: StringResource
+  get() = String37.str_4518
+
+@ExperimentalResourceApi
+internal val Res.string.str_4519: StringResource
+  get() = String37.str_4519
+
+@ExperimentalResourceApi
+internal val Res.string.str_452: StringResource
+  get() = String37.str_452
+
+@ExperimentalResourceApi
+internal val Res.string.str_4520: StringResource
+  get() = String37.str_4520
+
+@ExperimentalResourceApi
+internal val Res.string.str_4521: StringResource
+  get() = String37.str_4521
+
+@ExperimentalResourceApi
+internal val Res.string.str_4522: StringResource
+  get() = String37.str_4522
+
+@ExperimentalResourceApi
+internal val Res.string.str_4523: StringResource
+  get() = String37.str_4523
+
+@ExperimentalResourceApi
+internal val Res.string.str_4524: StringResource
+  get() = String37.str_4524
+
+@ExperimentalResourceApi
+internal val Res.string.str_4525: StringResource
+  get() = String37.str_4525
+
+@ExperimentalResourceApi
+internal val Res.string.str_4526: StringResource
+  get() = String37.str_4526
+
+@ExperimentalResourceApi
+internal val Res.string.str_4527: StringResource
+  get() = String37.str_4527
+
+@ExperimentalResourceApi
+internal val Res.string.str_4528: StringResource
+  get() = String37.str_4528
+
+@ExperimentalResourceApi
+internal val Res.string.str_4529: StringResource
+  get() = String37.str_4529
+
+@ExperimentalResourceApi
+internal val Res.string.str_453: StringResource
+  get() = String37.str_453
+
+@ExperimentalResourceApi
+internal val Res.string.str_4530: StringResource
+  get() = String37.str_4530
+
+@ExperimentalResourceApi
+internal val Res.string.str_4531: StringResource
+  get() = String37.str_4531
+
+@ExperimentalResourceApi
+internal val Res.string.str_4532: StringResource
+  get() = String37.str_4532
+
+@ExperimentalResourceApi
+internal val Res.string.str_4533: StringResource
+  get() = String37.str_4533
+
+@ExperimentalResourceApi
+internal val Res.string.str_4534: StringResource
+  get() = String37.str_4534
+
+@ExperimentalResourceApi
+internal val Res.string.str_4535: StringResource
+  get() = String37.str_4535
+
+@ExperimentalResourceApi
+internal val Res.string.str_4536: StringResource
+  get() = String37.str_4536
+
+@ExperimentalResourceApi
+internal val Res.string.str_4537: StringResource
+  get() = String37.str_4537
+
+@ExperimentalResourceApi
+internal val Res.string.str_4538: StringResource
+  get() = String37.str_4538
+
+@ExperimentalResourceApi
+internal val Res.string.str_4539: StringResource
+  get() = String37.str_4539
+
+@ExperimentalResourceApi
+internal val Res.string.str_454: StringResource
+  get() = String37.str_454
+
+@ExperimentalResourceApi
+internal val Res.string.str_4540: StringResource
+  get() = String37.str_4540
+
+@ExperimentalResourceApi
+internal val Res.string.str_4541: StringResource
+  get() = String37.str_4541
+
+@ExperimentalResourceApi
+internal val Res.string.str_4542: StringResource
+  get() = String37.str_4542
+
+@ExperimentalResourceApi
+internal val Res.string.str_4543: StringResource
+  get() = String37.str_4543
+
+@ExperimentalResourceApi
+internal val Res.string.str_4544: StringResource
+  get() = String37.str_4544
+
+@ExperimentalResourceApi
+internal val Res.string.str_4545: StringResource
+  get() = String37.str_4545
+
+@ExperimentalResourceApi
+internal val Res.string.str_4546: StringResource
+  get() = String37.str_4546
+
+@ExperimentalResourceApi
+internal val Res.string.str_4547: StringResource
+  get() = String37.str_4547
+
+@ExperimentalResourceApi
+internal val Res.string.str_4548: StringResource
+  get() = String37.str_4548
+
+@ExperimentalResourceApi
+internal val Res.string.str_4549: StringResource
+  get() = String37.str_4549
+
+@ExperimentalResourceApi
+internal val Res.string.str_455: StringResource
+  get() = String37.str_455
+
+@ExperimentalResourceApi
+internal val Res.string.str_4550: StringResource
+  get() = String37.str_4550
+
+@ExperimentalResourceApi
+internal val Res.string.str_4551: StringResource
+  get() = String37.str_4551
+
+@ExperimentalResourceApi
+internal val Res.string.str_4552: StringResource
+  get() = String37.str_4552
+
+@ExperimentalResourceApi
+internal val Res.string.str_4553: StringResource
+  get() = String37.str_4553
+
+@ExperimentalResourceApi
+internal val Res.string.str_4554: StringResource
+  get() = String37.str_4554
+
+@ExperimentalResourceApi
+internal val Res.string.str_4555: StringResource
+  get() = String37.str_4555
+
+@ExperimentalResourceApi
+internal val Res.string.str_4556: StringResource
+  get() = String37.str_4556
+
+@ExperimentalResourceApi
+internal val Res.string.str_4557: StringResource
+  get() = String37.str_4557
+
+@ExperimentalResourceApi
+internal val Res.string.str_4558: StringResource
+  get() = String37.str_4558
+
+@ExperimentalResourceApi
+internal val Res.string.str_4559: StringResource
+  get() = String37.str_4559
+
+@ExperimentalResourceApi
+internal val Res.string.str_456: StringResource
+  get() = String37.str_456
+
+@ExperimentalResourceApi
+internal val Res.string.str_4560: StringResource
+  get() = String37.str_4560
+
+@ExperimentalResourceApi
+internal val Res.string.str_4561: StringResource
+  get() = String37.str_4561
+
+@ExperimentalResourceApi
+internal val Res.string.str_4562: StringResource
+  get() = String37.str_4562
+
+@ExperimentalResourceApi
+internal val Res.string.str_4563: StringResource
+  get() = String37.str_4563
+
+@ExperimentalResourceApi
+internal val Res.string.str_4564: StringResource
+  get() = String37.str_4564
+
+@ExperimentalResourceApi
+internal val Res.string.str_4565: StringResource
+  get() = String37.str_4565
+
+@ExperimentalResourceApi
+internal val Res.string.str_4566: StringResource
+  get() = String37.str_4566
+
+@ExperimentalResourceApi
+internal val Res.string.str_4567: StringResource
+  get() = String37.str_4567
+
+@ExperimentalResourceApi
+internal val Res.string.str_4568: StringResource
+  get() = String37.str_4568
+
+@ExperimentalResourceApi
+internal val Res.string.str_4569: StringResource
+  get() = String37.str_4569
+
+@ExperimentalResourceApi
+internal val Res.string.str_457: StringResource
+  get() = String37.str_457
+
+@ExperimentalResourceApi
+internal val Res.string.str_4570: StringResource
+  get() = String37.str_4570
+
+@ExperimentalResourceApi
+internal val Res.string.str_4571: StringResource
+  get() = String37.str_4571
+
+@ExperimentalResourceApi
+internal val Res.string.str_4572: StringResource
+  get() = String37.str_4572
+
+@ExperimentalResourceApi
+internal val Res.string.str_4573: StringResource
+  get() = String37.str_4573
+
+@ExperimentalResourceApi
+internal val Res.string.str_4574: StringResource
+  get() = String37.str_4574
+
+@ExperimentalResourceApi
+internal val Res.string.str_4575: StringResource
+  get() = String37.str_4575
+
+@ExperimentalResourceApi
+internal val Res.string.str_4576: StringResource
+  get() = String37.str_4576
+
+@ExperimentalResourceApi
+internal val Res.string.str_4577: StringResource
+  get() = String37.str_4577
+
+@ExperimentalResourceApi
+internal val Res.string.str_4578: StringResource
+  get() = String37.str_4578
+
+@ExperimentalResourceApi
+internal val Res.string.str_4579: StringResource
+  get() = String37.str_4579
+
+@ExperimentalResourceApi
+internal val Res.string.str_458: StringResource
+  get() = String37.str_458
+
+@ExperimentalResourceApi
+internal val Res.string.str_4580: StringResource
+  get() = String37.str_4580
+
+@ExperimentalResourceApi
+internal val Res.string.str_4581: StringResource
+  get() = String37.str_4581
+
+@ExperimentalResourceApi
+internal val Res.string.str_4582: StringResource
+  get() = String37.str_4582
+
+@ExperimentalResourceApi
+internal val Res.string.str_4583: StringResource
+  get() = String37.str_4583
+
+@ExperimentalResourceApi
+internal val Res.string.str_4584: StringResource
+  get() = String37.str_4584
+
+@ExperimentalResourceApi
+internal val Res.string.str_4585: StringResource
+  get() = String37.str_4585
+
+@ExperimentalResourceApi
+internal val Res.string.str_4586: StringResource
+  get() = String37.str_4586
+
+@ExperimentalResourceApi
+internal val Res.string.str_4587: StringResource
+  get() = String37.str_4587
+
+@ExperimentalResourceApi
+internal val Res.string.str_4588: StringResource
+  get() = String37.str_4588
+
+@ExperimentalResourceApi
+internal val Res.string.str_4589: StringResource
+  get() = String37.str_4589
+
+@ExperimentalResourceApi
+internal val Res.string.str_459: StringResource
+  get() = String37.str_459
+
+@ExperimentalResourceApi
+internal val Res.string.str_4590: StringResource
+  get() = String37.str_4590
+
+@ExperimentalResourceApi
+internal val Res.string.str_4591: StringResource
+  get() = String37.str_4591
+
+@ExperimentalResourceApi
+internal val Res.string.str_4592: StringResource
+  get() = String37.str_4592
+
+@ExperimentalResourceApi
+internal val Res.string.str_4593: StringResource
+  get() = String37.str_4593
+
+@ExperimentalResourceApi
+internal val Res.string.str_4594: StringResource
+  get() = String37.str_4594
+
+@ExperimentalResourceApi
+internal val Res.string.str_4595: StringResource
+  get() = String37.str_4595
+
+@ExperimentalResourceApi
+internal val Res.string.str_4596: StringResource
+  get() = String37.str_4596
+
+@ExperimentalResourceApi
+internal val Res.string.str_4597: StringResource
+  get() = String37.str_4597
+
+@ExperimentalResourceApi
+internal val Res.string.str_4598: StringResource
+  get() = String37.str_4598

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String38.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String38.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String38 {
+  public val str_4599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4599", "str_4599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_46: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_46", "str_46",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_460", "str_460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4600", "str_4600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4601", "str_4601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4602", "str_4602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4603", "str_4603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4604", "str_4604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4605", "str_4605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4606", "str_4606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4607", "str_4607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4608", "str_4608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4609", "str_4609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_461", "str_461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4610", "str_4610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4611", "str_4611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4612", "str_4612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4613", "str_4613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4614", "str_4614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4615", "str_4615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4616", "str_4616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4617", "str_4617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4618", "str_4618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4619", "str_4619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_462", "str_462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4620", "str_4620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4621", "str_4621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4622", "str_4622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4623", "str_4623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4624", "str_4624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4625", "str_4625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4626", "str_4626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4627", "str_4627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4628", "str_4628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4629", "str_4629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_463", "str_463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4630", "str_4630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4631", "str_4631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4632", "str_4632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4633", "str_4633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4634", "str_4634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4635", "str_4635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4636", "str_4636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4637", "str_4637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4638", "str_4638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4639", "str_4639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_464", "str_464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4640", "str_4640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4641", "str_4641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4642", "str_4642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4643", "str_4643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4644", "str_4644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4645", "str_4645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4646", "str_4646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4647", "str_4647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4648", "str_4648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4649", "str_4649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_465", "str_465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4650", "str_4650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4651", "str_4651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4652", "str_4652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4653", "str_4653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4654", "str_4654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4655", "str_4655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4656", "str_4656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4657", "str_4657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4658", "str_4658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4659", "str_4659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_466", "str_466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4660", "str_4660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4661", "str_4661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4662", "str_4662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4663", "str_4663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4664", "str_4664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4665", "str_4665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4666", "str_4666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4667", "str_4667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4668", "str_4668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4669", "str_4669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_467", "str_467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4670", "str_4670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4671", "str_4671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4672", "str_4672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4673", "str_4673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4674", "str_4674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4675", "str_4675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4676", "str_4676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4677", "str_4677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4678", "str_4678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4679", "str_4679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_468", "str_468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4680", "str_4680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4681", "str_4681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4682", "str_4682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4683", "str_4683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4684", "str_4684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4685", "str_4685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4686", "str_4686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4687", "str_4687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4688", "str_4688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4689", "str_4689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_469", "str_469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4690", "str_4690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4691", "str_4691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4692", "str_4692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4693", "str_4693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4694", "str_4694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4695", "str_4695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4696", "str_4696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4697", "str_4697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4698", "str_4698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4699", "str_4699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_47: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_47", "str_47",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_470", "str_470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4700", "str_4700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4701", "str_4701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4702", "str_4702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4703", "str_4703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4704", "str_4704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4705", "str_4705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4706", "str_4706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4707", "str_4707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4708", "str_4708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4709", "str_4709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_471", "str_471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4710", "str_4710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4711", "str_4711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4712", "str_4712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4713", "str_4713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4714", "str_4714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4715", "str_4715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4716", "str_4716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4717", "str_4717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4718", "str_4718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4719", "str_4719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_472", "str_472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4720", "str_4720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4721", "str_4721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4722", "str_4722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4723", "str_4723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4724", "str_4724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4725", "str_4725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4726", "str_4726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4727", "str_4727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4728", "str_4728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4729", "str_4729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_473", "str_473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4730", "str_4730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4731", "str_4731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4732", "str_4732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4733", "str_4733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4734", "str_4734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4735", "str_4735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4736", "str_4736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4737", "str_4737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4738", "str_4738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4739", "str_4739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_474", "str_474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4740", "str_4740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4741", "str_4741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4742", "str_4742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4743", "str_4743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4744", "str_4744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4745", "str_4745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4746", "str_4746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4747", "str_4747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4748", "str_4748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4749", "str_4749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_475", "str_475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4750", "str_4750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4751", "str_4751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4752", "str_4752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4753", "str_4753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4754", "str_4754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4755", "str_4755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4756", "str_4756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4757", "str_4757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4758", "str_4758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4759", "str_4759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_476", "str_476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4760", "str_4760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4761", "str_4761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4762", "str_4762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4763", "str_4763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4764", "str_4764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4765", "str_4765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4766", "str_4766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4767", "str_4767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4768", "str_4768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4769", "str_4769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_477", "str_477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4770", "str_4770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4771", "str_4771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4772", "str_4772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4773", "str_4773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4774", "str_4774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4775", "str_4775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4776", "str_4776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4777", "str_4777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4778", "str_4778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4779", "str_4779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_478", "str_478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4780", "str_4780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4781", "str_4781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4782", "str_4782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4783", "str_4783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4784", "str_4784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4785", "str_4785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4786", "str_4786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4787", "str_4787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4788", "str_4788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4789", "str_4789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_479", "str_479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4790", "str_4790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4791", "str_4791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4792", "str_4792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4793", "str_4793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4794", "str_4794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4795", "str_4795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4796", "str_4796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4797", "str_4797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4798", "str_4798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4799", "str_4799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_48: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_48", "str_48",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_480", "str_480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4800", "str_4800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4801", "str_4801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4802", "str_4802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4803", "str_4803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4804", "str_4804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4805", "str_4805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4806", "str_4806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4807", "str_4807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4808", "str_4808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4809", "str_4809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_481", "str_481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4810", "str_4810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4811", "str_4811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4812", "str_4812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4813", "str_4813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4814", "str_4814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4815", "str_4815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4816", "str_4816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4817", "str_4817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4818", "str_4818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4819", "str_4819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_482", "str_482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4820", "str_4820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4821", "str_4821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4822", "str_4822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4823", "str_4823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4824", "str_4824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4825", "str_4825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4826", "str_4826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4827", "str_4827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4828", "str_4828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4829", "str_4829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_483", "str_483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4830", "str_4830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4831", "str_4831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4832", "str_4832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4833", "str_4833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4834", "str_4834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4835", "str_4835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4836", "str_4836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4837", "str_4837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4838", "str_4838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4839", "str_4839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_484", "str_484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4840", "str_4840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4841", "str_4841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4842", "str_4842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4843", "str_4843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4844", "str_4844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4845", "str_4845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4846", "str_4846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4847", "str_4847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4848", "str_4848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4849", "str_4849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_485", "str_485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4850", "str_4850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4851", "str_4851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4852", "str_4852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4853", "str_4853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4854", "str_4854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4855", "str_4855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4856", "str_4856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4857", "str_4857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4858", "str_4858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4859", "str_4859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_486", "str_486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4860", "str_4860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4861", "str_4861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4862", "str_4862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4863", "str_4863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4864", "str_4864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4865", "str_4865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4866", "str_4866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4867", "str_4867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4868", "str_4868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4869", "str_4869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_487", "str_487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4870", "str_4870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4871", "str_4871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4872", "str_4872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4873", "str_4873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4874", "str_4874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4875", "str_4875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4876", "str_4876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4877", "str_4877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4878", "str_4878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4879", "str_4879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_488", "str_488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4880", "str_4880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4881", "str_4881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4882", "str_4882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4883", "str_4883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4884", "str_4884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4885", "str_4885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4886", "str_4886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4887", "str_4887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4888", "str_4888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4889", "str_4889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_489", "str_489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4890", "str_4890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4891", "str_4891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4892", "str_4892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4893", "str_4893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4894", "str_4894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4895", "str_4895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4896", "str_4896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4897", "str_4897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4898", "str_4898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4899", "str_4899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_49: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_49", "str_49",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_490", "str_490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4900", "str_4900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4901", "str_4901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4902", "str_4902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4903", "str_4903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4904", "str_4904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4905", "str_4905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4906", "str_4906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4907", "str_4907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4908", "str_4908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4909", "str_4909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_491", "str_491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4910", "str_4910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4911", "str_4911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4912", "str_4912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4913", "str_4913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4914", "str_4914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4915", "str_4915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4916", "str_4916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4917", "str_4917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4918", "str_4918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4919", "str_4919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_492", "str_492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4920", "str_4920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4921", "str_4921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4922", "str_4922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4923", "str_4923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4924", "str_4924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4925", "str_4925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4926", "str_4926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4927", "str_4927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4928", "str_4928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4929", "str_4929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_493", "str_493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4930", "str_4930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4931", "str_4931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4932", "str_4932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4933", "str_4933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4934", "str_4934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4935", "str_4935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4936", "str_4936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4937", "str_4937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4938", "str_4938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4939", "str_4939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_494", "str_494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4940", "str_4940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4941", "str_4941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4942", "str_4942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4943", "str_4943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4944", "str_4944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4945", "str_4945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4946", "str_4946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4947", "str_4947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4948", "str_4948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4949", "str_4949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_495", "str_495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4950", "str_4950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4951", "str_4951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4952", "str_4952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4953", "str_4953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4954", "str_4954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4955", "str_4955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4956", "str_4956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4957", "str_4957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4958", "str_4958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4959", "str_4959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_496", "str_496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4960", "str_4960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4961", "str_4961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4962", "str_4962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4963", "str_4963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4964", "str_4964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4965", "str_4965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4966", "str_4966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4967", "str_4967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4968", "str_4968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4969", "str_4969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_497", "str_497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4970", "str_4970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4971", "str_4971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4972", "str_4972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4973", "str_4973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4974", "str_4974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4975", "str_4975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4976", "str_4976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4977", "str_4977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4978", "str_4978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4979", "str_4979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_498", "str_498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4980", "str_4980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4981", "str_4981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4982", "str_4982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4983", "str_4983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4984", "str_4984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4985", "str_4985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4986", "str_4986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4987", "str_4987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4988", "str_4988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4989", "str_4989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_499", "str_499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4990", "str_4990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4991", "str_4991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4992", "str_4992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4993", "str_4993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4994", "str_4994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4995", "str_4995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4996", "str_4996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4997", "str_4997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4998", "str_4998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_4999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_4999", "str_4999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5", "str_5",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_50: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_50", "str_50",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_500", "str_500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5000", "str_5000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5001", "str_5001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5002", "str_5002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5003", "str_5003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5004", "str_5004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5005", "str_5005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5006", "str_5006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5007", "str_5007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5008", "str_5008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5009", "str_5009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_501", "str_501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5010", "str_5010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5011", "str_5011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5012", "str_5012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5013", "str_5013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5014", "str_5014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5015", "str_5015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5016", "str_5016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5017", "str_5017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5018", "str_5018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5019", "str_5019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_502", "str_502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5020", "str_5020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5021", "str_5021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5022", "str_5022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5023", "str_5023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5024", "str_5024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5025", "str_5025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5026", "str_5026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5027", "str_5027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5028", "str_5028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5029", "str_5029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_503", "str_503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5030", "str_5030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5031", "str_5031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5032", "str_5032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5033", "str_5033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5034", "str_5034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5035", "str_5035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5036", "str_5036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5037", "str_5037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5038", "str_5038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5039", "str_5039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_504", "str_504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5040", "str_5040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5041", "str_5041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5042", "str_5042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5043", "str_5043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5044", "str_5044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5045", "str_5045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5046", "str_5046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5047", "str_5047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_4599: StringResource
+  get() = String38.str_4599
+
+@ExperimentalResourceApi
+internal val Res.string.str_46: StringResource
+  get() = String38.str_46
+
+@ExperimentalResourceApi
+internal val Res.string.str_460: StringResource
+  get() = String38.str_460
+
+@ExperimentalResourceApi
+internal val Res.string.str_4600: StringResource
+  get() = String38.str_4600
+
+@ExperimentalResourceApi
+internal val Res.string.str_4601: StringResource
+  get() = String38.str_4601
+
+@ExperimentalResourceApi
+internal val Res.string.str_4602: StringResource
+  get() = String38.str_4602
+
+@ExperimentalResourceApi
+internal val Res.string.str_4603: StringResource
+  get() = String38.str_4603
+
+@ExperimentalResourceApi
+internal val Res.string.str_4604: StringResource
+  get() = String38.str_4604
+
+@ExperimentalResourceApi
+internal val Res.string.str_4605: StringResource
+  get() = String38.str_4605
+
+@ExperimentalResourceApi
+internal val Res.string.str_4606: StringResource
+  get() = String38.str_4606
+
+@ExperimentalResourceApi
+internal val Res.string.str_4607: StringResource
+  get() = String38.str_4607
+
+@ExperimentalResourceApi
+internal val Res.string.str_4608: StringResource
+  get() = String38.str_4608
+
+@ExperimentalResourceApi
+internal val Res.string.str_4609: StringResource
+  get() = String38.str_4609
+
+@ExperimentalResourceApi
+internal val Res.string.str_461: StringResource
+  get() = String38.str_461
+
+@ExperimentalResourceApi
+internal val Res.string.str_4610: StringResource
+  get() = String38.str_4610
+
+@ExperimentalResourceApi
+internal val Res.string.str_4611: StringResource
+  get() = String38.str_4611
+
+@ExperimentalResourceApi
+internal val Res.string.str_4612: StringResource
+  get() = String38.str_4612
+
+@ExperimentalResourceApi
+internal val Res.string.str_4613: StringResource
+  get() = String38.str_4613
+
+@ExperimentalResourceApi
+internal val Res.string.str_4614: StringResource
+  get() = String38.str_4614
+
+@ExperimentalResourceApi
+internal val Res.string.str_4615: StringResource
+  get() = String38.str_4615
+
+@ExperimentalResourceApi
+internal val Res.string.str_4616: StringResource
+  get() = String38.str_4616
+
+@ExperimentalResourceApi
+internal val Res.string.str_4617: StringResource
+  get() = String38.str_4617
+
+@ExperimentalResourceApi
+internal val Res.string.str_4618: StringResource
+  get() = String38.str_4618
+
+@ExperimentalResourceApi
+internal val Res.string.str_4619: StringResource
+  get() = String38.str_4619
+
+@ExperimentalResourceApi
+internal val Res.string.str_462: StringResource
+  get() = String38.str_462
+
+@ExperimentalResourceApi
+internal val Res.string.str_4620: StringResource
+  get() = String38.str_4620
+
+@ExperimentalResourceApi
+internal val Res.string.str_4621: StringResource
+  get() = String38.str_4621
+
+@ExperimentalResourceApi
+internal val Res.string.str_4622: StringResource
+  get() = String38.str_4622
+
+@ExperimentalResourceApi
+internal val Res.string.str_4623: StringResource
+  get() = String38.str_4623
+
+@ExperimentalResourceApi
+internal val Res.string.str_4624: StringResource
+  get() = String38.str_4624
+
+@ExperimentalResourceApi
+internal val Res.string.str_4625: StringResource
+  get() = String38.str_4625
+
+@ExperimentalResourceApi
+internal val Res.string.str_4626: StringResource
+  get() = String38.str_4626
+
+@ExperimentalResourceApi
+internal val Res.string.str_4627: StringResource
+  get() = String38.str_4627
+
+@ExperimentalResourceApi
+internal val Res.string.str_4628: StringResource
+  get() = String38.str_4628
+
+@ExperimentalResourceApi
+internal val Res.string.str_4629: StringResource
+  get() = String38.str_4629
+
+@ExperimentalResourceApi
+internal val Res.string.str_463: StringResource
+  get() = String38.str_463
+
+@ExperimentalResourceApi
+internal val Res.string.str_4630: StringResource
+  get() = String38.str_4630
+
+@ExperimentalResourceApi
+internal val Res.string.str_4631: StringResource
+  get() = String38.str_4631
+
+@ExperimentalResourceApi
+internal val Res.string.str_4632: StringResource
+  get() = String38.str_4632
+
+@ExperimentalResourceApi
+internal val Res.string.str_4633: StringResource
+  get() = String38.str_4633
+
+@ExperimentalResourceApi
+internal val Res.string.str_4634: StringResource
+  get() = String38.str_4634
+
+@ExperimentalResourceApi
+internal val Res.string.str_4635: StringResource
+  get() = String38.str_4635
+
+@ExperimentalResourceApi
+internal val Res.string.str_4636: StringResource
+  get() = String38.str_4636
+
+@ExperimentalResourceApi
+internal val Res.string.str_4637: StringResource
+  get() = String38.str_4637
+
+@ExperimentalResourceApi
+internal val Res.string.str_4638: StringResource
+  get() = String38.str_4638
+
+@ExperimentalResourceApi
+internal val Res.string.str_4639: StringResource
+  get() = String38.str_4639
+
+@ExperimentalResourceApi
+internal val Res.string.str_464: StringResource
+  get() = String38.str_464
+
+@ExperimentalResourceApi
+internal val Res.string.str_4640: StringResource
+  get() = String38.str_4640
+
+@ExperimentalResourceApi
+internal val Res.string.str_4641: StringResource
+  get() = String38.str_4641
+
+@ExperimentalResourceApi
+internal val Res.string.str_4642: StringResource
+  get() = String38.str_4642
+
+@ExperimentalResourceApi
+internal val Res.string.str_4643: StringResource
+  get() = String38.str_4643
+
+@ExperimentalResourceApi
+internal val Res.string.str_4644: StringResource
+  get() = String38.str_4644
+
+@ExperimentalResourceApi
+internal val Res.string.str_4645: StringResource
+  get() = String38.str_4645
+
+@ExperimentalResourceApi
+internal val Res.string.str_4646: StringResource
+  get() = String38.str_4646
+
+@ExperimentalResourceApi
+internal val Res.string.str_4647: StringResource
+  get() = String38.str_4647
+
+@ExperimentalResourceApi
+internal val Res.string.str_4648: StringResource
+  get() = String38.str_4648
+
+@ExperimentalResourceApi
+internal val Res.string.str_4649: StringResource
+  get() = String38.str_4649
+
+@ExperimentalResourceApi
+internal val Res.string.str_465: StringResource
+  get() = String38.str_465
+
+@ExperimentalResourceApi
+internal val Res.string.str_4650: StringResource
+  get() = String38.str_4650
+
+@ExperimentalResourceApi
+internal val Res.string.str_4651: StringResource
+  get() = String38.str_4651
+
+@ExperimentalResourceApi
+internal val Res.string.str_4652: StringResource
+  get() = String38.str_4652
+
+@ExperimentalResourceApi
+internal val Res.string.str_4653: StringResource
+  get() = String38.str_4653
+
+@ExperimentalResourceApi
+internal val Res.string.str_4654: StringResource
+  get() = String38.str_4654
+
+@ExperimentalResourceApi
+internal val Res.string.str_4655: StringResource
+  get() = String38.str_4655
+
+@ExperimentalResourceApi
+internal val Res.string.str_4656: StringResource
+  get() = String38.str_4656
+
+@ExperimentalResourceApi
+internal val Res.string.str_4657: StringResource
+  get() = String38.str_4657
+
+@ExperimentalResourceApi
+internal val Res.string.str_4658: StringResource
+  get() = String38.str_4658
+
+@ExperimentalResourceApi
+internal val Res.string.str_4659: StringResource
+  get() = String38.str_4659
+
+@ExperimentalResourceApi
+internal val Res.string.str_466: StringResource
+  get() = String38.str_466
+
+@ExperimentalResourceApi
+internal val Res.string.str_4660: StringResource
+  get() = String38.str_4660
+
+@ExperimentalResourceApi
+internal val Res.string.str_4661: StringResource
+  get() = String38.str_4661
+
+@ExperimentalResourceApi
+internal val Res.string.str_4662: StringResource
+  get() = String38.str_4662
+
+@ExperimentalResourceApi
+internal val Res.string.str_4663: StringResource
+  get() = String38.str_4663
+
+@ExperimentalResourceApi
+internal val Res.string.str_4664: StringResource
+  get() = String38.str_4664
+
+@ExperimentalResourceApi
+internal val Res.string.str_4665: StringResource
+  get() = String38.str_4665
+
+@ExperimentalResourceApi
+internal val Res.string.str_4666: StringResource
+  get() = String38.str_4666
+
+@ExperimentalResourceApi
+internal val Res.string.str_4667: StringResource
+  get() = String38.str_4667
+
+@ExperimentalResourceApi
+internal val Res.string.str_4668: StringResource
+  get() = String38.str_4668
+
+@ExperimentalResourceApi
+internal val Res.string.str_4669: StringResource
+  get() = String38.str_4669
+
+@ExperimentalResourceApi
+internal val Res.string.str_467: StringResource
+  get() = String38.str_467
+
+@ExperimentalResourceApi
+internal val Res.string.str_4670: StringResource
+  get() = String38.str_4670
+
+@ExperimentalResourceApi
+internal val Res.string.str_4671: StringResource
+  get() = String38.str_4671
+
+@ExperimentalResourceApi
+internal val Res.string.str_4672: StringResource
+  get() = String38.str_4672
+
+@ExperimentalResourceApi
+internal val Res.string.str_4673: StringResource
+  get() = String38.str_4673
+
+@ExperimentalResourceApi
+internal val Res.string.str_4674: StringResource
+  get() = String38.str_4674
+
+@ExperimentalResourceApi
+internal val Res.string.str_4675: StringResource
+  get() = String38.str_4675
+
+@ExperimentalResourceApi
+internal val Res.string.str_4676: StringResource
+  get() = String38.str_4676
+
+@ExperimentalResourceApi
+internal val Res.string.str_4677: StringResource
+  get() = String38.str_4677
+
+@ExperimentalResourceApi
+internal val Res.string.str_4678: StringResource
+  get() = String38.str_4678
+
+@ExperimentalResourceApi
+internal val Res.string.str_4679: StringResource
+  get() = String38.str_4679
+
+@ExperimentalResourceApi
+internal val Res.string.str_468: StringResource
+  get() = String38.str_468
+
+@ExperimentalResourceApi
+internal val Res.string.str_4680: StringResource
+  get() = String38.str_4680
+
+@ExperimentalResourceApi
+internal val Res.string.str_4681: StringResource
+  get() = String38.str_4681
+
+@ExperimentalResourceApi
+internal val Res.string.str_4682: StringResource
+  get() = String38.str_4682
+
+@ExperimentalResourceApi
+internal val Res.string.str_4683: StringResource
+  get() = String38.str_4683
+
+@ExperimentalResourceApi
+internal val Res.string.str_4684: StringResource
+  get() = String38.str_4684
+
+@ExperimentalResourceApi
+internal val Res.string.str_4685: StringResource
+  get() = String38.str_4685
+
+@ExperimentalResourceApi
+internal val Res.string.str_4686: StringResource
+  get() = String38.str_4686
+
+@ExperimentalResourceApi
+internal val Res.string.str_4687: StringResource
+  get() = String38.str_4687
+
+@ExperimentalResourceApi
+internal val Res.string.str_4688: StringResource
+  get() = String38.str_4688
+
+@ExperimentalResourceApi
+internal val Res.string.str_4689: StringResource
+  get() = String38.str_4689
+
+@ExperimentalResourceApi
+internal val Res.string.str_469: StringResource
+  get() = String38.str_469
+
+@ExperimentalResourceApi
+internal val Res.string.str_4690: StringResource
+  get() = String38.str_4690
+
+@ExperimentalResourceApi
+internal val Res.string.str_4691: StringResource
+  get() = String38.str_4691
+
+@ExperimentalResourceApi
+internal val Res.string.str_4692: StringResource
+  get() = String38.str_4692
+
+@ExperimentalResourceApi
+internal val Res.string.str_4693: StringResource
+  get() = String38.str_4693
+
+@ExperimentalResourceApi
+internal val Res.string.str_4694: StringResource
+  get() = String38.str_4694
+
+@ExperimentalResourceApi
+internal val Res.string.str_4695: StringResource
+  get() = String38.str_4695
+
+@ExperimentalResourceApi
+internal val Res.string.str_4696: StringResource
+  get() = String38.str_4696
+
+@ExperimentalResourceApi
+internal val Res.string.str_4697: StringResource
+  get() = String38.str_4697
+
+@ExperimentalResourceApi
+internal val Res.string.str_4698: StringResource
+  get() = String38.str_4698
+
+@ExperimentalResourceApi
+internal val Res.string.str_4699: StringResource
+  get() = String38.str_4699
+
+@ExperimentalResourceApi
+internal val Res.string.str_47: StringResource
+  get() = String38.str_47
+
+@ExperimentalResourceApi
+internal val Res.string.str_470: StringResource
+  get() = String38.str_470
+
+@ExperimentalResourceApi
+internal val Res.string.str_4700: StringResource
+  get() = String38.str_4700
+
+@ExperimentalResourceApi
+internal val Res.string.str_4701: StringResource
+  get() = String38.str_4701
+
+@ExperimentalResourceApi
+internal val Res.string.str_4702: StringResource
+  get() = String38.str_4702
+
+@ExperimentalResourceApi
+internal val Res.string.str_4703: StringResource
+  get() = String38.str_4703
+
+@ExperimentalResourceApi
+internal val Res.string.str_4704: StringResource
+  get() = String38.str_4704
+
+@ExperimentalResourceApi
+internal val Res.string.str_4705: StringResource
+  get() = String38.str_4705
+
+@ExperimentalResourceApi
+internal val Res.string.str_4706: StringResource
+  get() = String38.str_4706
+
+@ExperimentalResourceApi
+internal val Res.string.str_4707: StringResource
+  get() = String38.str_4707
+
+@ExperimentalResourceApi
+internal val Res.string.str_4708: StringResource
+  get() = String38.str_4708
+
+@ExperimentalResourceApi
+internal val Res.string.str_4709: StringResource
+  get() = String38.str_4709
+
+@ExperimentalResourceApi
+internal val Res.string.str_471: StringResource
+  get() = String38.str_471
+
+@ExperimentalResourceApi
+internal val Res.string.str_4710: StringResource
+  get() = String38.str_4710
+
+@ExperimentalResourceApi
+internal val Res.string.str_4711: StringResource
+  get() = String38.str_4711
+
+@ExperimentalResourceApi
+internal val Res.string.str_4712: StringResource
+  get() = String38.str_4712
+
+@ExperimentalResourceApi
+internal val Res.string.str_4713: StringResource
+  get() = String38.str_4713
+
+@ExperimentalResourceApi
+internal val Res.string.str_4714: StringResource
+  get() = String38.str_4714
+
+@ExperimentalResourceApi
+internal val Res.string.str_4715: StringResource
+  get() = String38.str_4715
+
+@ExperimentalResourceApi
+internal val Res.string.str_4716: StringResource
+  get() = String38.str_4716
+
+@ExperimentalResourceApi
+internal val Res.string.str_4717: StringResource
+  get() = String38.str_4717
+
+@ExperimentalResourceApi
+internal val Res.string.str_4718: StringResource
+  get() = String38.str_4718
+
+@ExperimentalResourceApi
+internal val Res.string.str_4719: StringResource
+  get() = String38.str_4719
+
+@ExperimentalResourceApi
+internal val Res.string.str_472: StringResource
+  get() = String38.str_472
+
+@ExperimentalResourceApi
+internal val Res.string.str_4720: StringResource
+  get() = String38.str_4720
+
+@ExperimentalResourceApi
+internal val Res.string.str_4721: StringResource
+  get() = String38.str_4721
+
+@ExperimentalResourceApi
+internal val Res.string.str_4722: StringResource
+  get() = String38.str_4722
+
+@ExperimentalResourceApi
+internal val Res.string.str_4723: StringResource
+  get() = String38.str_4723
+
+@ExperimentalResourceApi
+internal val Res.string.str_4724: StringResource
+  get() = String38.str_4724
+
+@ExperimentalResourceApi
+internal val Res.string.str_4725: StringResource
+  get() = String38.str_4725
+
+@ExperimentalResourceApi
+internal val Res.string.str_4726: StringResource
+  get() = String38.str_4726
+
+@ExperimentalResourceApi
+internal val Res.string.str_4727: StringResource
+  get() = String38.str_4727
+
+@ExperimentalResourceApi
+internal val Res.string.str_4728: StringResource
+  get() = String38.str_4728
+
+@ExperimentalResourceApi
+internal val Res.string.str_4729: StringResource
+  get() = String38.str_4729
+
+@ExperimentalResourceApi
+internal val Res.string.str_473: StringResource
+  get() = String38.str_473
+
+@ExperimentalResourceApi
+internal val Res.string.str_4730: StringResource
+  get() = String38.str_4730
+
+@ExperimentalResourceApi
+internal val Res.string.str_4731: StringResource
+  get() = String38.str_4731
+
+@ExperimentalResourceApi
+internal val Res.string.str_4732: StringResource
+  get() = String38.str_4732
+
+@ExperimentalResourceApi
+internal val Res.string.str_4733: StringResource
+  get() = String38.str_4733
+
+@ExperimentalResourceApi
+internal val Res.string.str_4734: StringResource
+  get() = String38.str_4734
+
+@ExperimentalResourceApi
+internal val Res.string.str_4735: StringResource
+  get() = String38.str_4735
+
+@ExperimentalResourceApi
+internal val Res.string.str_4736: StringResource
+  get() = String38.str_4736
+
+@ExperimentalResourceApi
+internal val Res.string.str_4737: StringResource
+  get() = String38.str_4737
+
+@ExperimentalResourceApi
+internal val Res.string.str_4738: StringResource
+  get() = String38.str_4738
+
+@ExperimentalResourceApi
+internal val Res.string.str_4739: StringResource
+  get() = String38.str_4739
+
+@ExperimentalResourceApi
+internal val Res.string.str_474: StringResource
+  get() = String38.str_474
+
+@ExperimentalResourceApi
+internal val Res.string.str_4740: StringResource
+  get() = String38.str_4740
+
+@ExperimentalResourceApi
+internal val Res.string.str_4741: StringResource
+  get() = String38.str_4741
+
+@ExperimentalResourceApi
+internal val Res.string.str_4742: StringResource
+  get() = String38.str_4742
+
+@ExperimentalResourceApi
+internal val Res.string.str_4743: StringResource
+  get() = String38.str_4743
+
+@ExperimentalResourceApi
+internal val Res.string.str_4744: StringResource
+  get() = String38.str_4744
+
+@ExperimentalResourceApi
+internal val Res.string.str_4745: StringResource
+  get() = String38.str_4745
+
+@ExperimentalResourceApi
+internal val Res.string.str_4746: StringResource
+  get() = String38.str_4746
+
+@ExperimentalResourceApi
+internal val Res.string.str_4747: StringResource
+  get() = String38.str_4747
+
+@ExperimentalResourceApi
+internal val Res.string.str_4748: StringResource
+  get() = String38.str_4748
+
+@ExperimentalResourceApi
+internal val Res.string.str_4749: StringResource
+  get() = String38.str_4749
+
+@ExperimentalResourceApi
+internal val Res.string.str_475: StringResource
+  get() = String38.str_475
+
+@ExperimentalResourceApi
+internal val Res.string.str_4750: StringResource
+  get() = String38.str_4750
+
+@ExperimentalResourceApi
+internal val Res.string.str_4751: StringResource
+  get() = String38.str_4751
+
+@ExperimentalResourceApi
+internal val Res.string.str_4752: StringResource
+  get() = String38.str_4752
+
+@ExperimentalResourceApi
+internal val Res.string.str_4753: StringResource
+  get() = String38.str_4753
+
+@ExperimentalResourceApi
+internal val Res.string.str_4754: StringResource
+  get() = String38.str_4754
+
+@ExperimentalResourceApi
+internal val Res.string.str_4755: StringResource
+  get() = String38.str_4755
+
+@ExperimentalResourceApi
+internal val Res.string.str_4756: StringResource
+  get() = String38.str_4756
+
+@ExperimentalResourceApi
+internal val Res.string.str_4757: StringResource
+  get() = String38.str_4757
+
+@ExperimentalResourceApi
+internal val Res.string.str_4758: StringResource
+  get() = String38.str_4758
+
+@ExperimentalResourceApi
+internal val Res.string.str_4759: StringResource
+  get() = String38.str_4759
+
+@ExperimentalResourceApi
+internal val Res.string.str_476: StringResource
+  get() = String38.str_476
+
+@ExperimentalResourceApi
+internal val Res.string.str_4760: StringResource
+  get() = String38.str_4760
+
+@ExperimentalResourceApi
+internal val Res.string.str_4761: StringResource
+  get() = String38.str_4761
+
+@ExperimentalResourceApi
+internal val Res.string.str_4762: StringResource
+  get() = String38.str_4762
+
+@ExperimentalResourceApi
+internal val Res.string.str_4763: StringResource
+  get() = String38.str_4763
+
+@ExperimentalResourceApi
+internal val Res.string.str_4764: StringResource
+  get() = String38.str_4764
+
+@ExperimentalResourceApi
+internal val Res.string.str_4765: StringResource
+  get() = String38.str_4765
+
+@ExperimentalResourceApi
+internal val Res.string.str_4766: StringResource
+  get() = String38.str_4766
+
+@ExperimentalResourceApi
+internal val Res.string.str_4767: StringResource
+  get() = String38.str_4767
+
+@ExperimentalResourceApi
+internal val Res.string.str_4768: StringResource
+  get() = String38.str_4768
+
+@ExperimentalResourceApi
+internal val Res.string.str_4769: StringResource
+  get() = String38.str_4769
+
+@ExperimentalResourceApi
+internal val Res.string.str_477: StringResource
+  get() = String38.str_477
+
+@ExperimentalResourceApi
+internal val Res.string.str_4770: StringResource
+  get() = String38.str_4770
+
+@ExperimentalResourceApi
+internal val Res.string.str_4771: StringResource
+  get() = String38.str_4771
+
+@ExperimentalResourceApi
+internal val Res.string.str_4772: StringResource
+  get() = String38.str_4772
+
+@ExperimentalResourceApi
+internal val Res.string.str_4773: StringResource
+  get() = String38.str_4773
+
+@ExperimentalResourceApi
+internal val Res.string.str_4774: StringResource
+  get() = String38.str_4774
+
+@ExperimentalResourceApi
+internal val Res.string.str_4775: StringResource
+  get() = String38.str_4775
+
+@ExperimentalResourceApi
+internal val Res.string.str_4776: StringResource
+  get() = String38.str_4776
+
+@ExperimentalResourceApi
+internal val Res.string.str_4777: StringResource
+  get() = String38.str_4777
+
+@ExperimentalResourceApi
+internal val Res.string.str_4778: StringResource
+  get() = String38.str_4778
+
+@ExperimentalResourceApi
+internal val Res.string.str_4779: StringResource
+  get() = String38.str_4779
+
+@ExperimentalResourceApi
+internal val Res.string.str_478: StringResource
+  get() = String38.str_478
+
+@ExperimentalResourceApi
+internal val Res.string.str_4780: StringResource
+  get() = String38.str_4780
+
+@ExperimentalResourceApi
+internal val Res.string.str_4781: StringResource
+  get() = String38.str_4781
+
+@ExperimentalResourceApi
+internal val Res.string.str_4782: StringResource
+  get() = String38.str_4782
+
+@ExperimentalResourceApi
+internal val Res.string.str_4783: StringResource
+  get() = String38.str_4783
+
+@ExperimentalResourceApi
+internal val Res.string.str_4784: StringResource
+  get() = String38.str_4784
+
+@ExperimentalResourceApi
+internal val Res.string.str_4785: StringResource
+  get() = String38.str_4785
+
+@ExperimentalResourceApi
+internal val Res.string.str_4786: StringResource
+  get() = String38.str_4786
+
+@ExperimentalResourceApi
+internal val Res.string.str_4787: StringResource
+  get() = String38.str_4787
+
+@ExperimentalResourceApi
+internal val Res.string.str_4788: StringResource
+  get() = String38.str_4788
+
+@ExperimentalResourceApi
+internal val Res.string.str_4789: StringResource
+  get() = String38.str_4789
+
+@ExperimentalResourceApi
+internal val Res.string.str_479: StringResource
+  get() = String38.str_479
+
+@ExperimentalResourceApi
+internal val Res.string.str_4790: StringResource
+  get() = String38.str_4790
+
+@ExperimentalResourceApi
+internal val Res.string.str_4791: StringResource
+  get() = String38.str_4791
+
+@ExperimentalResourceApi
+internal val Res.string.str_4792: StringResource
+  get() = String38.str_4792
+
+@ExperimentalResourceApi
+internal val Res.string.str_4793: StringResource
+  get() = String38.str_4793
+
+@ExperimentalResourceApi
+internal val Res.string.str_4794: StringResource
+  get() = String38.str_4794
+
+@ExperimentalResourceApi
+internal val Res.string.str_4795: StringResource
+  get() = String38.str_4795
+
+@ExperimentalResourceApi
+internal val Res.string.str_4796: StringResource
+  get() = String38.str_4796
+
+@ExperimentalResourceApi
+internal val Res.string.str_4797: StringResource
+  get() = String38.str_4797
+
+@ExperimentalResourceApi
+internal val Res.string.str_4798: StringResource
+  get() = String38.str_4798
+
+@ExperimentalResourceApi
+internal val Res.string.str_4799: StringResource
+  get() = String38.str_4799
+
+@ExperimentalResourceApi
+internal val Res.string.str_48: StringResource
+  get() = String38.str_48
+
+@ExperimentalResourceApi
+internal val Res.string.str_480: StringResource
+  get() = String38.str_480
+
+@ExperimentalResourceApi
+internal val Res.string.str_4800: StringResource
+  get() = String38.str_4800
+
+@ExperimentalResourceApi
+internal val Res.string.str_4801: StringResource
+  get() = String38.str_4801
+
+@ExperimentalResourceApi
+internal val Res.string.str_4802: StringResource
+  get() = String38.str_4802
+
+@ExperimentalResourceApi
+internal val Res.string.str_4803: StringResource
+  get() = String38.str_4803
+
+@ExperimentalResourceApi
+internal val Res.string.str_4804: StringResource
+  get() = String38.str_4804
+
+@ExperimentalResourceApi
+internal val Res.string.str_4805: StringResource
+  get() = String38.str_4805
+
+@ExperimentalResourceApi
+internal val Res.string.str_4806: StringResource
+  get() = String38.str_4806
+
+@ExperimentalResourceApi
+internal val Res.string.str_4807: StringResource
+  get() = String38.str_4807
+
+@ExperimentalResourceApi
+internal val Res.string.str_4808: StringResource
+  get() = String38.str_4808
+
+@ExperimentalResourceApi
+internal val Res.string.str_4809: StringResource
+  get() = String38.str_4809
+
+@ExperimentalResourceApi
+internal val Res.string.str_481: StringResource
+  get() = String38.str_481
+
+@ExperimentalResourceApi
+internal val Res.string.str_4810: StringResource
+  get() = String38.str_4810
+
+@ExperimentalResourceApi
+internal val Res.string.str_4811: StringResource
+  get() = String38.str_4811
+
+@ExperimentalResourceApi
+internal val Res.string.str_4812: StringResource
+  get() = String38.str_4812
+
+@ExperimentalResourceApi
+internal val Res.string.str_4813: StringResource
+  get() = String38.str_4813
+
+@ExperimentalResourceApi
+internal val Res.string.str_4814: StringResource
+  get() = String38.str_4814
+
+@ExperimentalResourceApi
+internal val Res.string.str_4815: StringResource
+  get() = String38.str_4815
+
+@ExperimentalResourceApi
+internal val Res.string.str_4816: StringResource
+  get() = String38.str_4816
+
+@ExperimentalResourceApi
+internal val Res.string.str_4817: StringResource
+  get() = String38.str_4817
+
+@ExperimentalResourceApi
+internal val Res.string.str_4818: StringResource
+  get() = String38.str_4818
+
+@ExperimentalResourceApi
+internal val Res.string.str_4819: StringResource
+  get() = String38.str_4819
+
+@ExperimentalResourceApi
+internal val Res.string.str_482: StringResource
+  get() = String38.str_482
+
+@ExperimentalResourceApi
+internal val Res.string.str_4820: StringResource
+  get() = String38.str_4820
+
+@ExperimentalResourceApi
+internal val Res.string.str_4821: StringResource
+  get() = String38.str_4821
+
+@ExperimentalResourceApi
+internal val Res.string.str_4822: StringResource
+  get() = String38.str_4822
+
+@ExperimentalResourceApi
+internal val Res.string.str_4823: StringResource
+  get() = String38.str_4823
+
+@ExperimentalResourceApi
+internal val Res.string.str_4824: StringResource
+  get() = String38.str_4824
+
+@ExperimentalResourceApi
+internal val Res.string.str_4825: StringResource
+  get() = String38.str_4825
+
+@ExperimentalResourceApi
+internal val Res.string.str_4826: StringResource
+  get() = String38.str_4826
+
+@ExperimentalResourceApi
+internal val Res.string.str_4827: StringResource
+  get() = String38.str_4827
+
+@ExperimentalResourceApi
+internal val Res.string.str_4828: StringResource
+  get() = String38.str_4828
+
+@ExperimentalResourceApi
+internal val Res.string.str_4829: StringResource
+  get() = String38.str_4829
+
+@ExperimentalResourceApi
+internal val Res.string.str_483: StringResource
+  get() = String38.str_483
+
+@ExperimentalResourceApi
+internal val Res.string.str_4830: StringResource
+  get() = String38.str_4830
+
+@ExperimentalResourceApi
+internal val Res.string.str_4831: StringResource
+  get() = String38.str_4831
+
+@ExperimentalResourceApi
+internal val Res.string.str_4832: StringResource
+  get() = String38.str_4832
+
+@ExperimentalResourceApi
+internal val Res.string.str_4833: StringResource
+  get() = String38.str_4833
+
+@ExperimentalResourceApi
+internal val Res.string.str_4834: StringResource
+  get() = String38.str_4834
+
+@ExperimentalResourceApi
+internal val Res.string.str_4835: StringResource
+  get() = String38.str_4835
+
+@ExperimentalResourceApi
+internal val Res.string.str_4836: StringResource
+  get() = String38.str_4836
+
+@ExperimentalResourceApi
+internal val Res.string.str_4837: StringResource
+  get() = String38.str_4837
+
+@ExperimentalResourceApi
+internal val Res.string.str_4838: StringResource
+  get() = String38.str_4838
+
+@ExperimentalResourceApi
+internal val Res.string.str_4839: StringResource
+  get() = String38.str_4839
+
+@ExperimentalResourceApi
+internal val Res.string.str_484: StringResource
+  get() = String38.str_484
+
+@ExperimentalResourceApi
+internal val Res.string.str_4840: StringResource
+  get() = String38.str_4840
+
+@ExperimentalResourceApi
+internal val Res.string.str_4841: StringResource
+  get() = String38.str_4841
+
+@ExperimentalResourceApi
+internal val Res.string.str_4842: StringResource
+  get() = String38.str_4842
+
+@ExperimentalResourceApi
+internal val Res.string.str_4843: StringResource
+  get() = String38.str_4843
+
+@ExperimentalResourceApi
+internal val Res.string.str_4844: StringResource
+  get() = String38.str_4844
+
+@ExperimentalResourceApi
+internal val Res.string.str_4845: StringResource
+  get() = String38.str_4845
+
+@ExperimentalResourceApi
+internal val Res.string.str_4846: StringResource
+  get() = String38.str_4846
+
+@ExperimentalResourceApi
+internal val Res.string.str_4847: StringResource
+  get() = String38.str_4847
+
+@ExperimentalResourceApi
+internal val Res.string.str_4848: StringResource
+  get() = String38.str_4848
+
+@ExperimentalResourceApi
+internal val Res.string.str_4849: StringResource
+  get() = String38.str_4849
+
+@ExperimentalResourceApi
+internal val Res.string.str_485: StringResource
+  get() = String38.str_485
+
+@ExperimentalResourceApi
+internal val Res.string.str_4850: StringResource
+  get() = String38.str_4850
+
+@ExperimentalResourceApi
+internal val Res.string.str_4851: StringResource
+  get() = String38.str_4851
+
+@ExperimentalResourceApi
+internal val Res.string.str_4852: StringResource
+  get() = String38.str_4852
+
+@ExperimentalResourceApi
+internal val Res.string.str_4853: StringResource
+  get() = String38.str_4853
+
+@ExperimentalResourceApi
+internal val Res.string.str_4854: StringResource
+  get() = String38.str_4854
+
+@ExperimentalResourceApi
+internal val Res.string.str_4855: StringResource
+  get() = String38.str_4855
+
+@ExperimentalResourceApi
+internal val Res.string.str_4856: StringResource
+  get() = String38.str_4856
+
+@ExperimentalResourceApi
+internal val Res.string.str_4857: StringResource
+  get() = String38.str_4857
+
+@ExperimentalResourceApi
+internal val Res.string.str_4858: StringResource
+  get() = String38.str_4858
+
+@ExperimentalResourceApi
+internal val Res.string.str_4859: StringResource
+  get() = String38.str_4859
+
+@ExperimentalResourceApi
+internal val Res.string.str_486: StringResource
+  get() = String38.str_486
+
+@ExperimentalResourceApi
+internal val Res.string.str_4860: StringResource
+  get() = String38.str_4860
+
+@ExperimentalResourceApi
+internal val Res.string.str_4861: StringResource
+  get() = String38.str_4861
+
+@ExperimentalResourceApi
+internal val Res.string.str_4862: StringResource
+  get() = String38.str_4862
+
+@ExperimentalResourceApi
+internal val Res.string.str_4863: StringResource
+  get() = String38.str_4863
+
+@ExperimentalResourceApi
+internal val Res.string.str_4864: StringResource
+  get() = String38.str_4864
+
+@ExperimentalResourceApi
+internal val Res.string.str_4865: StringResource
+  get() = String38.str_4865
+
+@ExperimentalResourceApi
+internal val Res.string.str_4866: StringResource
+  get() = String38.str_4866
+
+@ExperimentalResourceApi
+internal val Res.string.str_4867: StringResource
+  get() = String38.str_4867
+
+@ExperimentalResourceApi
+internal val Res.string.str_4868: StringResource
+  get() = String38.str_4868
+
+@ExperimentalResourceApi
+internal val Res.string.str_4869: StringResource
+  get() = String38.str_4869
+
+@ExperimentalResourceApi
+internal val Res.string.str_487: StringResource
+  get() = String38.str_487
+
+@ExperimentalResourceApi
+internal val Res.string.str_4870: StringResource
+  get() = String38.str_4870
+
+@ExperimentalResourceApi
+internal val Res.string.str_4871: StringResource
+  get() = String38.str_4871
+
+@ExperimentalResourceApi
+internal val Res.string.str_4872: StringResource
+  get() = String38.str_4872
+
+@ExperimentalResourceApi
+internal val Res.string.str_4873: StringResource
+  get() = String38.str_4873
+
+@ExperimentalResourceApi
+internal val Res.string.str_4874: StringResource
+  get() = String38.str_4874
+
+@ExperimentalResourceApi
+internal val Res.string.str_4875: StringResource
+  get() = String38.str_4875
+
+@ExperimentalResourceApi
+internal val Res.string.str_4876: StringResource
+  get() = String38.str_4876
+
+@ExperimentalResourceApi
+internal val Res.string.str_4877: StringResource
+  get() = String38.str_4877
+
+@ExperimentalResourceApi
+internal val Res.string.str_4878: StringResource
+  get() = String38.str_4878
+
+@ExperimentalResourceApi
+internal val Res.string.str_4879: StringResource
+  get() = String38.str_4879
+
+@ExperimentalResourceApi
+internal val Res.string.str_488: StringResource
+  get() = String38.str_488
+
+@ExperimentalResourceApi
+internal val Res.string.str_4880: StringResource
+  get() = String38.str_4880
+
+@ExperimentalResourceApi
+internal val Res.string.str_4881: StringResource
+  get() = String38.str_4881
+
+@ExperimentalResourceApi
+internal val Res.string.str_4882: StringResource
+  get() = String38.str_4882
+
+@ExperimentalResourceApi
+internal val Res.string.str_4883: StringResource
+  get() = String38.str_4883
+
+@ExperimentalResourceApi
+internal val Res.string.str_4884: StringResource
+  get() = String38.str_4884
+
+@ExperimentalResourceApi
+internal val Res.string.str_4885: StringResource
+  get() = String38.str_4885
+
+@ExperimentalResourceApi
+internal val Res.string.str_4886: StringResource
+  get() = String38.str_4886
+
+@ExperimentalResourceApi
+internal val Res.string.str_4887: StringResource
+  get() = String38.str_4887
+
+@ExperimentalResourceApi
+internal val Res.string.str_4888: StringResource
+  get() = String38.str_4888
+
+@ExperimentalResourceApi
+internal val Res.string.str_4889: StringResource
+  get() = String38.str_4889
+
+@ExperimentalResourceApi
+internal val Res.string.str_489: StringResource
+  get() = String38.str_489
+
+@ExperimentalResourceApi
+internal val Res.string.str_4890: StringResource
+  get() = String38.str_4890
+
+@ExperimentalResourceApi
+internal val Res.string.str_4891: StringResource
+  get() = String38.str_4891
+
+@ExperimentalResourceApi
+internal val Res.string.str_4892: StringResource
+  get() = String38.str_4892
+
+@ExperimentalResourceApi
+internal val Res.string.str_4893: StringResource
+  get() = String38.str_4893
+
+@ExperimentalResourceApi
+internal val Res.string.str_4894: StringResource
+  get() = String38.str_4894
+
+@ExperimentalResourceApi
+internal val Res.string.str_4895: StringResource
+  get() = String38.str_4895
+
+@ExperimentalResourceApi
+internal val Res.string.str_4896: StringResource
+  get() = String38.str_4896
+
+@ExperimentalResourceApi
+internal val Res.string.str_4897: StringResource
+  get() = String38.str_4897
+
+@ExperimentalResourceApi
+internal val Res.string.str_4898: StringResource
+  get() = String38.str_4898
+
+@ExperimentalResourceApi
+internal val Res.string.str_4899: StringResource
+  get() = String38.str_4899
+
+@ExperimentalResourceApi
+internal val Res.string.str_49: StringResource
+  get() = String38.str_49
+
+@ExperimentalResourceApi
+internal val Res.string.str_490: StringResource
+  get() = String38.str_490
+
+@ExperimentalResourceApi
+internal val Res.string.str_4900: StringResource
+  get() = String38.str_4900
+
+@ExperimentalResourceApi
+internal val Res.string.str_4901: StringResource
+  get() = String38.str_4901
+
+@ExperimentalResourceApi
+internal val Res.string.str_4902: StringResource
+  get() = String38.str_4902
+
+@ExperimentalResourceApi
+internal val Res.string.str_4903: StringResource
+  get() = String38.str_4903
+
+@ExperimentalResourceApi
+internal val Res.string.str_4904: StringResource
+  get() = String38.str_4904
+
+@ExperimentalResourceApi
+internal val Res.string.str_4905: StringResource
+  get() = String38.str_4905
+
+@ExperimentalResourceApi
+internal val Res.string.str_4906: StringResource
+  get() = String38.str_4906
+
+@ExperimentalResourceApi
+internal val Res.string.str_4907: StringResource
+  get() = String38.str_4907
+
+@ExperimentalResourceApi
+internal val Res.string.str_4908: StringResource
+  get() = String38.str_4908
+
+@ExperimentalResourceApi
+internal val Res.string.str_4909: StringResource
+  get() = String38.str_4909
+
+@ExperimentalResourceApi
+internal val Res.string.str_491: StringResource
+  get() = String38.str_491
+
+@ExperimentalResourceApi
+internal val Res.string.str_4910: StringResource
+  get() = String38.str_4910
+
+@ExperimentalResourceApi
+internal val Res.string.str_4911: StringResource
+  get() = String38.str_4911
+
+@ExperimentalResourceApi
+internal val Res.string.str_4912: StringResource
+  get() = String38.str_4912
+
+@ExperimentalResourceApi
+internal val Res.string.str_4913: StringResource
+  get() = String38.str_4913
+
+@ExperimentalResourceApi
+internal val Res.string.str_4914: StringResource
+  get() = String38.str_4914
+
+@ExperimentalResourceApi
+internal val Res.string.str_4915: StringResource
+  get() = String38.str_4915
+
+@ExperimentalResourceApi
+internal val Res.string.str_4916: StringResource
+  get() = String38.str_4916
+
+@ExperimentalResourceApi
+internal val Res.string.str_4917: StringResource
+  get() = String38.str_4917
+
+@ExperimentalResourceApi
+internal val Res.string.str_4918: StringResource
+  get() = String38.str_4918
+
+@ExperimentalResourceApi
+internal val Res.string.str_4919: StringResource
+  get() = String38.str_4919
+
+@ExperimentalResourceApi
+internal val Res.string.str_492: StringResource
+  get() = String38.str_492
+
+@ExperimentalResourceApi
+internal val Res.string.str_4920: StringResource
+  get() = String38.str_4920
+
+@ExperimentalResourceApi
+internal val Res.string.str_4921: StringResource
+  get() = String38.str_4921
+
+@ExperimentalResourceApi
+internal val Res.string.str_4922: StringResource
+  get() = String38.str_4922
+
+@ExperimentalResourceApi
+internal val Res.string.str_4923: StringResource
+  get() = String38.str_4923
+
+@ExperimentalResourceApi
+internal val Res.string.str_4924: StringResource
+  get() = String38.str_4924
+
+@ExperimentalResourceApi
+internal val Res.string.str_4925: StringResource
+  get() = String38.str_4925
+
+@ExperimentalResourceApi
+internal val Res.string.str_4926: StringResource
+  get() = String38.str_4926
+
+@ExperimentalResourceApi
+internal val Res.string.str_4927: StringResource
+  get() = String38.str_4927
+
+@ExperimentalResourceApi
+internal val Res.string.str_4928: StringResource
+  get() = String38.str_4928
+
+@ExperimentalResourceApi
+internal val Res.string.str_4929: StringResource
+  get() = String38.str_4929
+
+@ExperimentalResourceApi
+internal val Res.string.str_493: StringResource
+  get() = String38.str_493
+
+@ExperimentalResourceApi
+internal val Res.string.str_4930: StringResource
+  get() = String38.str_4930
+
+@ExperimentalResourceApi
+internal val Res.string.str_4931: StringResource
+  get() = String38.str_4931
+
+@ExperimentalResourceApi
+internal val Res.string.str_4932: StringResource
+  get() = String38.str_4932
+
+@ExperimentalResourceApi
+internal val Res.string.str_4933: StringResource
+  get() = String38.str_4933
+
+@ExperimentalResourceApi
+internal val Res.string.str_4934: StringResource
+  get() = String38.str_4934
+
+@ExperimentalResourceApi
+internal val Res.string.str_4935: StringResource
+  get() = String38.str_4935
+
+@ExperimentalResourceApi
+internal val Res.string.str_4936: StringResource
+  get() = String38.str_4936
+
+@ExperimentalResourceApi
+internal val Res.string.str_4937: StringResource
+  get() = String38.str_4937
+
+@ExperimentalResourceApi
+internal val Res.string.str_4938: StringResource
+  get() = String38.str_4938
+
+@ExperimentalResourceApi
+internal val Res.string.str_4939: StringResource
+  get() = String38.str_4939
+
+@ExperimentalResourceApi
+internal val Res.string.str_494: StringResource
+  get() = String38.str_494
+
+@ExperimentalResourceApi
+internal val Res.string.str_4940: StringResource
+  get() = String38.str_4940
+
+@ExperimentalResourceApi
+internal val Res.string.str_4941: StringResource
+  get() = String38.str_4941
+
+@ExperimentalResourceApi
+internal val Res.string.str_4942: StringResource
+  get() = String38.str_4942
+
+@ExperimentalResourceApi
+internal val Res.string.str_4943: StringResource
+  get() = String38.str_4943
+
+@ExperimentalResourceApi
+internal val Res.string.str_4944: StringResource
+  get() = String38.str_4944
+
+@ExperimentalResourceApi
+internal val Res.string.str_4945: StringResource
+  get() = String38.str_4945
+
+@ExperimentalResourceApi
+internal val Res.string.str_4946: StringResource
+  get() = String38.str_4946
+
+@ExperimentalResourceApi
+internal val Res.string.str_4947: StringResource
+  get() = String38.str_4947
+
+@ExperimentalResourceApi
+internal val Res.string.str_4948: StringResource
+  get() = String38.str_4948
+
+@ExperimentalResourceApi
+internal val Res.string.str_4949: StringResource
+  get() = String38.str_4949
+
+@ExperimentalResourceApi
+internal val Res.string.str_495: StringResource
+  get() = String38.str_495
+
+@ExperimentalResourceApi
+internal val Res.string.str_4950: StringResource
+  get() = String38.str_4950
+
+@ExperimentalResourceApi
+internal val Res.string.str_4951: StringResource
+  get() = String38.str_4951
+
+@ExperimentalResourceApi
+internal val Res.string.str_4952: StringResource
+  get() = String38.str_4952
+
+@ExperimentalResourceApi
+internal val Res.string.str_4953: StringResource
+  get() = String38.str_4953
+
+@ExperimentalResourceApi
+internal val Res.string.str_4954: StringResource
+  get() = String38.str_4954
+
+@ExperimentalResourceApi
+internal val Res.string.str_4955: StringResource
+  get() = String38.str_4955
+
+@ExperimentalResourceApi
+internal val Res.string.str_4956: StringResource
+  get() = String38.str_4956
+
+@ExperimentalResourceApi
+internal val Res.string.str_4957: StringResource
+  get() = String38.str_4957
+
+@ExperimentalResourceApi
+internal val Res.string.str_4958: StringResource
+  get() = String38.str_4958
+
+@ExperimentalResourceApi
+internal val Res.string.str_4959: StringResource
+  get() = String38.str_4959
+
+@ExperimentalResourceApi
+internal val Res.string.str_496: StringResource
+  get() = String38.str_496
+
+@ExperimentalResourceApi
+internal val Res.string.str_4960: StringResource
+  get() = String38.str_4960
+
+@ExperimentalResourceApi
+internal val Res.string.str_4961: StringResource
+  get() = String38.str_4961
+
+@ExperimentalResourceApi
+internal val Res.string.str_4962: StringResource
+  get() = String38.str_4962
+
+@ExperimentalResourceApi
+internal val Res.string.str_4963: StringResource
+  get() = String38.str_4963
+
+@ExperimentalResourceApi
+internal val Res.string.str_4964: StringResource
+  get() = String38.str_4964
+
+@ExperimentalResourceApi
+internal val Res.string.str_4965: StringResource
+  get() = String38.str_4965
+
+@ExperimentalResourceApi
+internal val Res.string.str_4966: StringResource
+  get() = String38.str_4966
+
+@ExperimentalResourceApi
+internal val Res.string.str_4967: StringResource
+  get() = String38.str_4967
+
+@ExperimentalResourceApi
+internal val Res.string.str_4968: StringResource
+  get() = String38.str_4968
+
+@ExperimentalResourceApi
+internal val Res.string.str_4969: StringResource
+  get() = String38.str_4969
+
+@ExperimentalResourceApi
+internal val Res.string.str_497: StringResource
+  get() = String38.str_497
+
+@ExperimentalResourceApi
+internal val Res.string.str_4970: StringResource
+  get() = String38.str_4970
+
+@ExperimentalResourceApi
+internal val Res.string.str_4971: StringResource
+  get() = String38.str_4971
+
+@ExperimentalResourceApi
+internal val Res.string.str_4972: StringResource
+  get() = String38.str_4972
+
+@ExperimentalResourceApi
+internal val Res.string.str_4973: StringResource
+  get() = String38.str_4973
+
+@ExperimentalResourceApi
+internal val Res.string.str_4974: StringResource
+  get() = String38.str_4974
+
+@ExperimentalResourceApi
+internal val Res.string.str_4975: StringResource
+  get() = String38.str_4975
+
+@ExperimentalResourceApi
+internal val Res.string.str_4976: StringResource
+  get() = String38.str_4976
+
+@ExperimentalResourceApi
+internal val Res.string.str_4977: StringResource
+  get() = String38.str_4977
+
+@ExperimentalResourceApi
+internal val Res.string.str_4978: StringResource
+  get() = String38.str_4978
+
+@ExperimentalResourceApi
+internal val Res.string.str_4979: StringResource
+  get() = String38.str_4979
+
+@ExperimentalResourceApi
+internal val Res.string.str_498: StringResource
+  get() = String38.str_498
+
+@ExperimentalResourceApi
+internal val Res.string.str_4980: StringResource
+  get() = String38.str_4980
+
+@ExperimentalResourceApi
+internal val Res.string.str_4981: StringResource
+  get() = String38.str_4981
+
+@ExperimentalResourceApi
+internal val Res.string.str_4982: StringResource
+  get() = String38.str_4982
+
+@ExperimentalResourceApi
+internal val Res.string.str_4983: StringResource
+  get() = String38.str_4983
+
+@ExperimentalResourceApi
+internal val Res.string.str_4984: StringResource
+  get() = String38.str_4984
+
+@ExperimentalResourceApi
+internal val Res.string.str_4985: StringResource
+  get() = String38.str_4985
+
+@ExperimentalResourceApi
+internal val Res.string.str_4986: StringResource
+  get() = String38.str_4986
+
+@ExperimentalResourceApi
+internal val Res.string.str_4987: StringResource
+  get() = String38.str_4987
+
+@ExperimentalResourceApi
+internal val Res.string.str_4988: StringResource
+  get() = String38.str_4988
+
+@ExperimentalResourceApi
+internal val Res.string.str_4989: StringResource
+  get() = String38.str_4989
+
+@ExperimentalResourceApi
+internal val Res.string.str_499: StringResource
+  get() = String38.str_499
+
+@ExperimentalResourceApi
+internal val Res.string.str_4990: StringResource
+  get() = String38.str_4990
+
+@ExperimentalResourceApi
+internal val Res.string.str_4991: StringResource
+  get() = String38.str_4991
+
+@ExperimentalResourceApi
+internal val Res.string.str_4992: StringResource
+  get() = String38.str_4992
+
+@ExperimentalResourceApi
+internal val Res.string.str_4993: StringResource
+  get() = String38.str_4993
+
+@ExperimentalResourceApi
+internal val Res.string.str_4994: StringResource
+  get() = String38.str_4994
+
+@ExperimentalResourceApi
+internal val Res.string.str_4995: StringResource
+  get() = String38.str_4995
+
+@ExperimentalResourceApi
+internal val Res.string.str_4996: StringResource
+  get() = String38.str_4996
+
+@ExperimentalResourceApi
+internal val Res.string.str_4997: StringResource
+  get() = String38.str_4997
+
+@ExperimentalResourceApi
+internal val Res.string.str_4998: StringResource
+  get() = String38.str_4998
+
+@ExperimentalResourceApi
+internal val Res.string.str_4999: StringResource
+  get() = String38.str_4999
+
+@ExperimentalResourceApi
+internal val Res.string.str_5: StringResource
+  get() = String38.str_5
+
+@ExperimentalResourceApi
+internal val Res.string.str_50: StringResource
+  get() = String38.str_50
+
+@ExperimentalResourceApi
+internal val Res.string.str_500: StringResource
+  get() = String38.str_500
+
+@ExperimentalResourceApi
+internal val Res.string.str_5000: StringResource
+  get() = String38.str_5000
+
+@ExperimentalResourceApi
+internal val Res.string.str_5001: StringResource
+  get() = String38.str_5001
+
+@ExperimentalResourceApi
+internal val Res.string.str_5002: StringResource
+  get() = String38.str_5002
+
+@ExperimentalResourceApi
+internal val Res.string.str_5003: StringResource
+  get() = String38.str_5003
+
+@ExperimentalResourceApi
+internal val Res.string.str_5004: StringResource
+  get() = String38.str_5004
+
+@ExperimentalResourceApi
+internal val Res.string.str_5005: StringResource
+  get() = String38.str_5005
+
+@ExperimentalResourceApi
+internal val Res.string.str_5006: StringResource
+  get() = String38.str_5006
+
+@ExperimentalResourceApi
+internal val Res.string.str_5007: StringResource
+  get() = String38.str_5007
+
+@ExperimentalResourceApi
+internal val Res.string.str_5008: StringResource
+  get() = String38.str_5008
+
+@ExperimentalResourceApi
+internal val Res.string.str_5009: StringResource
+  get() = String38.str_5009
+
+@ExperimentalResourceApi
+internal val Res.string.str_501: StringResource
+  get() = String38.str_501
+
+@ExperimentalResourceApi
+internal val Res.string.str_5010: StringResource
+  get() = String38.str_5010
+
+@ExperimentalResourceApi
+internal val Res.string.str_5011: StringResource
+  get() = String38.str_5011
+
+@ExperimentalResourceApi
+internal val Res.string.str_5012: StringResource
+  get() = String38.str_5012
+
+@ExperimentalResourceApi
+internal val Res.string.str_5013: StringResource
+  get() = String38.str_5013
+
+@ExperimentalResourceApi
+internal val Res.string.str_5014: StringResource
+  get() = String38.str_5014
+
+@ExperimentalResourceApi
+internal val Res.string.str_5015: StringResource
+  get() = String38.str_5015
+
+@ExperimentalResourceApi
+internal val Res.string.str_5016: StringResource
+  get() = String38.str_5016
+
+@ExperimentalResourceApi
+internal val Res.string.str_5017: StringResource
+  get() = String38.str_5017
+
+@ExperimentalResourceApi
+internal val Res.string.str_5018: StringResource
+  get() = String38.str_5018
+
+@ExperimentalResourceApi
+internal val Res.string.str_5019: StringResource
+  get() = String38.str_5019
+
+@ExperimentalResourceApi
+internal val Res.string.str_502: StringResource
+  get() = String38.str_502
+
+@ExperimentalResourceApi
+internal val Res.string.str_5020: StringResource
+  get() = String38.str_5020
+
+@ExperimentalResourceApi
+internal val Res.string.str_5021: StringResource
+  get() = String38.str_5021
+
+@ExperimentalResourceApi
+internal val Res.string.str_5022: StringResource
+  get() = String38.str_5022
+
+@ExperimentalResourceApi
+internal val Res.string.str_5023: StringResource
+  get() = String38.str_5023
+
+@ExperimentalResourceApi
+internal val Res.string.str_5024: StringResource
+  get() = String38.str_5024
+
+@ExperimentalResourceApi
+internal val Res.string.str_5025: StringResource
+  get() = String38.str_5025
+
+@ExperimentalResourceApi
+internal val Res.string.str_5026: StringResource
+  get() = String38.str_5026
+
+@ExperimentalResourceApi
+internal val Res.string.str_5027: StringResource
+  get() = String38.str_5027
+
+@ExperimentalResourceApi
+internal val Res.string.str_5028: StringResource
+  get() = String38.str_5028
+
+@ExperimentalResourceApi
+internal val Res.string.str_5029: StringResource
+  get() = String38.str_5029
+
+@ExperimentalResourceApi
+internal val Res.string.str_503: StringResource
+  get() = String38.str_503
+
+@ExperimentalResourceApi
+internal val Res.string.str_5030: StringResource
+  get() = String38.str_5030
+
+@ExperimentalResourceApi
+internal val Res.string.str_5031: StringResource
+  get() = String38.str_5031
+
+@ExperimentalResourceApi
+internal val Res.string.str_5032: StringResource
+  get() = String38.str_5032
+
+@ExperimentalResourceApi
+internal val Res.string.str_5033: StringResource
+  get() = String38.str_5033
+
+@ExperimentalResourceApi
+internal val Res.string.str_5034: StringResource
+  get() = String38.str_5034
+
+@ExperimentalResourceApi
+internal val Res.string.str_5035: StringResource
+  get() = String38.str_5035
+
+@ExperimentalResourceApi
+internal val Res.string.str_5036: StringResource
+  get() = String38.str_5036
+
+@ExperimentalResourceApi
+internal val Res.string.str_5037: StringResource
+  get() = String38.str_5037
+
+@ExperimentalResourceApi
+internal val Res.string.str_5038: StringResource
+  get() = String38.str_5038
+
+@ExperimentalResourceApi
+internal val Res.string.str_5039: StringResource
+  get() = String38.str_5039
+
+@ExperimentalResourceApi
+internal val Res.string.str_504: StringResource
+  get() = String38.str_504
+
+@ExperimentalResourceApi
+internal val Res.string.str_5040: StringResource
+  get() = String38.str_5040
+
+@ExperimentalResourceApi
+internal val Res.string.str_5041: StringResource
+  get() = String38.str_5041
+
+@ExperimentalResourceApi
+internal val Res.string.str_5042: StringResource
+  get() = String38.str_5042
+
+@ExperimentalResourceApi
+internal val Res.string.str_5043: StringResource
+  get() = String38.str_5043
+
+@ExperimentalResourceApi
+internal val Res.string.str_5044: StringResource
+  get() = String38.str_5044
+
+@ExperimentalResourceApi
+internal val Res.string.str_5045: StringResource
+  get() = String38.str_5045
+
+@ExperimentalResourceApi
+internal val Res.string.str_5046: StringResource
+  get() = String38.str_5046
+
+@ExperimentalResourceApi
+internal val Res.string.str_5047: StringResource
+  get() = String38.str_5047

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String39.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String39.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String39 {
+  public val str_5048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5048", "str_5048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5049", "str_5049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_505", "str_505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5050", "str_5050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5051", "str_5051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5052", "str_5052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5053", "str_5053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5054", "str_5054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5055", "str_5055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5056", "str_5056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5057", "str_5057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5058", "str_5058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5059", "str_5059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_506", "str_506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5060", "str_5060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5061", "str_5061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5062", "str_5062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5063", "str_5063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5064", "str_5064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5065", "str_5065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5066", "str_5066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5067", "str_5067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5068", "str_5068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5069", "str_5069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_507", "str_507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5070", "str_5070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5071", "str_5071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5072", "str_5072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5073", "str_5073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5074", "str_5074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5075", "str_5075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5076", "str_5076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5077", "str_5077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5078", "str_5078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5079", "str_5079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_508", "str_508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5080", "str_5080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5081", "str_5081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5082", "str_5082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5083", "str_5083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5084", "str_5084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5085", "str_5085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5086", "str_5086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5087", "str_5087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5088", "str_5088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5089", "str_5089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_509", "str_509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5090", "str_5090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5091", "str_5091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5092", "str_5092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5093", "str_5093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5094", "str_5094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5095", "str_5095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5096", "str_5096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5097", "str_5097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5098", "str_5098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5099", "str_5099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_51: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_51", "str_51",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_510", "str_510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5100", "str_5100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5101", "str_5101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5102", "str_5102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5103", "str_5103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5104", "str_5104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5105", "str_5105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5106", "str_5106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5107", "str_5107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5108", "str_5108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5109", "str_5109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_511", "str_511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5110", "str_5110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5111", "str_5111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5112", "str_5112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5113", "str_5113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5114", "str_5114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5115", "str_5115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5116", "str_5116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5117", "str_5117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5118", "str_5118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5119", "str_5119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_512", "str_512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5120", "str_5120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5121", "str_5121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5122", "str_5122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5123", "str_5123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5124", "str_5124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5125", "str_5125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5126", "str_5126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5127", "str_5127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5128", "str_5128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5129", "str_5129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_513", "str_513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5130", "str_5130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5131", "str_5131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5132", "str_5132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5133", "str_5133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5134", "str_5134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5135", "str_5135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5136", "str_5136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5137", "str_5137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5138", "str_5138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5139", "str_5139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_514", "str_514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5140", "str_5140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5141", "str_5141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5142", "str_5142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5143", "str_5143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5144", "str_5144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5145", "str_5145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5146", "str_5146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5147", "str_5147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5148", "str_5148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5149", "str_5149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_515", "str_515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5150", "str_5150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5151", "str_5151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5152", "str_5152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5153", "str_5153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5154", "str_5154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5155", "str_5155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5156", "str_5156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5157", "str_5157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5158", "str_5158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5159", "str_5159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_516", "str_516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5160", "str_5160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5161", "str_5161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5162", "str_5162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5163", "str_5163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5164", "str_5164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5165", "str_5165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5166", "str_5166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5167", "str_5167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5168", "str_5168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5169", "str_5169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_517", "str_517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5170", "str_5170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5171", "str_5171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5172", "str_5172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5173", "str_5173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5174", "str_5174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5175", "str_5175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5176", "str_5176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5177", "str_5177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5178", "str_5178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5179", "str_5179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_518", "str_518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5180", "str_5180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5181", "str_5181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5182", "str_5182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5183", "str_5183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5184", "str_5184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5185", "str_5185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5186", "str_5186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5187", "str_5187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5188", "str_5188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5189", "str_5189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_519", "str_519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5190", "str_5190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5191", "str_5191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5192", "str_5192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5193", "str_5193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5194", "str_5194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5195", "str_5195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5196", "str_5196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5197", "str_5197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5198", "str_5198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5199", "str_5199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_52: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_52", "str_52",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_520", "str_520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5200", "str_5200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5201", "str_5201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5202", "str_5202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5203", "str_5203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5204", "str_5204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5205", "str_5205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5206", "str_5206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5207", "str_5207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5208", "str_5208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5209", "str_5209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_521", "str_521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5210", "str_5210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5211", "str_5211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5212", "str_5212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5213", "str_5213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5214", "str_5214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5215", "str_5215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5216", "str_5216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5217", "str_5217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5218", "str_5218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5219", "str_5219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_522", "str_522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5220", "str_5220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5221", "str_5221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5222", "str_5222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5223", "str_5223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5224", "str_5224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5225", "str_5225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5226", "str_5226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5227", "str_5227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5228", "str_5228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5229", "str_5229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_523", "str_523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5230", "str_5230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5231", "str_5231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5232", "str_5232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5233", "str_5233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5234", "str_5234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5235", "str_5235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5236", "str_5236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5237", "str_5237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5238", "str_5238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5239", "str_5239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_524", "str_524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5240", "str_5240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5241", "str_5241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5242", "str_5242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5243", "str_5243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5244", "str_5244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5245", "str_5245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5246", "str_5246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5247", "str_5247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5248", "str_5248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5249", "str_5249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_525", "str_525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5250", "str_5250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5251", "str_5251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5252", "str_5252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5253", "str_5253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5254", "str_5254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5255", "str_5255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5256", "str_5256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5257", "str_5257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5258", "str_5258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5259", "str_5259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_526", "str_526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5260", "str_5260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5261", "str_5261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5262", "str_5262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5263", "str_5263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5264", "str_5264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5265", "str_5265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5266", "str_5266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5267", "str_5267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5268", "str_5268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5269", "str_5269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_527", "str_527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5270", "str_5270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5271", "str_5271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5272", "str_5272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5273", "str_5273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5274", "str_5274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5275", "str_5275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5276", "str_5276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5277", "str_5277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5278", "str_5278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5279", "str_5279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_528", "str_528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5280", "str_5280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5281", "str_5281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5282", "str_5282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5283", "str_5283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5284", "str_5284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5285", "str_5285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5286", "str_5286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5287", "str_5287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5288", "str_5288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5289", "str_5289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_529", "str_529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5290", "str_5290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5291", "str_5291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5292", "str_5292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5293", "str_5293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5294", "str_5294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5295", "str_5295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5296", "str_5296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5297", "str_5297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5298", "str_5298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5299", "str_5299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_53: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_53", "str_53",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_530", "str_530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5300", "str_5300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5301", "str_5301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5302", "str_5302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5303", "str_5303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5304", "str_5304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5305", "str_5305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5306", "str_5306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5307", "str_5307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5308", "str_5308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5309", "str_5309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_531", "str_531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5310", "str_5310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5311", "str_5311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5312", "str_5312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5313", "str_5313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5314", "str_5314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5315", "str_5315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5316", "str_5316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5317", "str_5317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5318", "str_5318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5319", "str_5319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_532", "str_532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5320", "str_5320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5321", "str_5321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5322", "str_5322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5323", "str_5323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5324", "str_5324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5325", "str_5325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5326", "str_5326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5327", "str_5327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5328", "str_5328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5329", "str_5329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_533", "str_533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5330", "str_5330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5331", "str_5331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5332", "str_5332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5333", "str_5333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5334", "str_5334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5335", "str_5335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5336", "str_5336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5337", "str_5337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5338", "str_5338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5339", "str_5339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_534", "str_534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5340", "str_5340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5341", "str_5341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5342", "str_5342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5343", "str_5343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5344", "str_5344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5345", "str_5345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5346", "str_5346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5347", "str_5347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5348", "str_5348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5349", "str_5349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_535", "str_535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5350", "str_5350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5351", "str_5351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5352", "str_5352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5353", "str_5353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5354", "str_5354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5355", "str_5355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5356", "str_5356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5357", "str_5357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5358", "str_5358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5359", "str_5359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_536", "str_536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5360", "str_5360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5361", "str_5361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5362", "str_5362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5363", "str_5363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5364", "str_5364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5365", "str_5365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5366", "str_5366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5367", "str_5367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5368", "str_5368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5369", "str_5369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_537", "str_537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5370", "str_5370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5371", "str_5371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5372", "str_5372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5373", "str_5373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5374", "str_5374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5375", "str_5375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5376", "str_5376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5377", "str_5377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5378", "str_5378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5379", "str_5379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_538", "str_538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5380", "str_5380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5381", "str_5381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5382", "str_5382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5383", "str_5383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5384", "str_5384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5385", "str_5385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5386", "str_5386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5387", "str_5387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5388", "str_5388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5389", "str_5389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_539", "str_539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5390", "str_5390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5391", "str_5391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5392", "str_5392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5393", "str_5393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5394", "str_5394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5395", "str_5395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5396", "str_5396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5397", "str_5397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5398", "str_5398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5399", "str_5399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_54: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_54", "str_54",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_540", "str_540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5400", "str_5400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5401", "str_5401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5402", "str_5402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5403", "str_5403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5404", "str_5404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5405", "str_5405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5406", "str_5406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5407", "str_5407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5408", "str_5408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5409", "str_5409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_541", "str_541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5410", "str_5410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5411", "str_5411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5412", "str_5412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5413", "str_5413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5414", "str_5414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5415", "str_5415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5416", "str_5416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5417", "str_5417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5418", "str_5418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5419", "str_5419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_542", "str_542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5420", "str_5420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5421", "str_5421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5422", "str_5422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5423", "str_5423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5424", "str_5424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5425", "str_5425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5426", "str_5426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5427", "str_5427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5428", "str_5428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5429", "str_5429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_543", "str_543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5430", "str_5430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5431", "str_5431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5432", "str_5432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5433", "str_5433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5434", "str_5434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5435", "str_5435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5436", "str_5436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5437", "str_5437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5438", "str_5438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5439", "str_5439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_544", "str_544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5440", "str_5440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5441", "str_5441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5442", "str_5442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5443", "str_5443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5444", "str_5444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5445", "str_5445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5446", "str_5446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5447", "str_5447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5448", "str_5448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5449", "str_5449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_545", "str_545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5450", "str_5450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5451", "str_5451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5452", "str_5452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5453", "str_5453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5454", "str_5454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5455", "str_5455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5456", "str_5456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5457", "str_5457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5458", "str_5458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5459", "str_5459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_546", "str_546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5460", "str_5460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5461", "str_5461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5462", "str_5462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5463", "str_5463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5464", "str_5464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5465", "str_5465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5466", "str_5466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5467", "str_5467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5468", "str_5468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5469", "str_5469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_547", "str_547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5470", "str_5470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5471", "str_5471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5472", "str_5472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5473", "str_5473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5474", "str_5474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5475", "str_5475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5476", "str_5476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5477", "str_5477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5478", "str_5478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5479", "str_5479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_548", "str_548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5480", "str_5480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5481", "str_5481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5482", "str_5482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5483", "str_5483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5484", "str_5484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5485", "str_5485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5486", "str_5486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5487", "str_5487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5488", "str_5488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5489", "str_5489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_549", "str_549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5490", "str_5490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5491", "str_5491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5492", "str_5492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5493", "str_5493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5494", "str_5494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5495", "str_5495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5496", "str_5496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5497", "str_5497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5498", "str_5498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_5048: StringResource
+  get() = String39.str_5048
+
+@ExperimentalResourceApi
+internal val Res.string.str_5049: StringResource
+  get() = String39.str_5049
+
+@ExperimentalResourceApi
+internal val Res.string.str_505: StringResource
+  get() = String39.str_505
+
+@ExperimentalResourceApi
+internal val Res.string.str_5050: StringResource
+  get() = String39.str_5050
+
+@ExperimentalResourceApi
+internal val Res.string.str_5051: StringResource
+  get() = String39.str_5051
+
+@ExperimentalResourceApi
+internal val Res.string.str_5052: StringResource
+  get() = String39.str_5052
+
+@ExperimentalResourceApi
+internal val Res.string.str_5053: StringResource
+  get() = String39.str_5053
+
+@ExperimentalResourceApi
+internal val Res.string.str_5054: StringResource
+  get() = String39.str_5054
+
+@ExperimentalResourceApi
+internal val Res.string.str_5055: StringResource
+  get() = String39.str_5055
+
+@ExperimentalResourceApi
+internal val Res.string.str_5056: StringResource
+  get() = String39.str_5056
+
+@ExperimentalResourceApi
+internal val Res.string.str_5057: StringResource
+  get() = String39.str_5057
+
+@ExperimentalResourceApi
+internal val Res.string.str_5058: StringResource
+  get() = String39.str_5058
+
+@ExperimentalResourceApi
+internal val Res.string.str_5059: StringResource
+  get() = String39.str_5059
+
+@ExperimentalResourceApi
+internal val Res.string.str_506: StringResource
+  get() = String39.str_506
+
+@ExperimentalResourceApi
+internal val Res.string.str_5060: StringResource
+  get() = String39.str_5060
+
+@ExperimentalResourceApi
+internal val Res.string.str_5061: StringResource
+  get() = String39.str_5061
+
+@ExperimentalResourceApi
+internal val Res.string.str_5062: StringResource
+  get() = String39.str_5062
+
+@ExperimentalResourceApi
+internal val Res.string.str_5063: StringResource
+  get() = String39.str_5063
+
+@ExperimentalResourceApi
+internal val Res.string.str_5064: StringResource
+  get() = String39.str_5064
+
+@ExperimentalResourceApi
+internal val Res.string.str_5065: StringResource
+  get() = String39.str_5065
+
+@ExperimentalResourceApi
+internal val Res.string.str_5066: StringResource
+  get() = String39.str_5066
+
+@ExperimentalResourceApi
+internal val Res.string.str_5067: StringResource
+  get() = String39.str_5067
+
+@ExperimentalResourceApi
+internal val Res.string.str_5068: StringResource
+  get() = String39.str_5068
+
+@ExperimentalResourceApi
+internal val Res.string.str_5069: StringResource
+  get() = String39.str_5069
+
+@ExperimentalResourceApi
+internal val Res.string.str_507: StringResource
+  get() = String39.str_507
+
+@ExperimentalResourceApi
+internal val Res.string.str_5070: StringResource
+  get() = String39.str_5070
+
+@ExperimentalResourceApi
+internal val Res.string.str_5071: StringResource
+  get() = String39.str_5071
+
+@ExperimentalResourceApi
+internal val Res.string.str_5072: StringResource
+  get() = String39.str_5072
+
+@ExperimentalResourceApi
+internal val Res.string.str_5073: StringResource
+  get() = String39.str_5073
+
+@ExperimentalResourceApi
+internal val Res.string.str_5074: StringResource
+  get() = String39.str_5074
+
+@ExperimentalResourceApi
+internal val Res.string.str_5075: StringResource
+  get() = String39.str_5075
+
+@ExperimentalResourceApi
+internal val Res.string.str_5076: StringResource
+  get() = String39.str_5076
+
+@ExperimentalResourceApi
+internal val Res.string.str_5077: StringResource
+  get() = String39.str_5077
+
+@ExperimentalResourceApi
+internal val Res.string.str_5078: StringResource
+  get() = String39.str_5078
+
+@ExperimentalResourceApi
+internal val Res.string.str_5079: StringResource
+  get() = String39.str_5079
+
+@ExperimentalResourceApi
+internal val Res.string.str_508: StringResource
+  get() = String39.str_508
+
+@ExperimentalResourceApi
+internal val Res.string.str_5080: StringResource
+  get() = String39.str_5080
+
+@ExperimentalResourceApi
+internal val Res.string.str_5081: StringResource
+  get() = String39.str_5081
+
+@ExperimentalResourceApi
+internal val Res.string.str_5082: StringResource
+  get() = String39.str_5082
+
+@ExperimentalResourceApi
+internal val Res.string.str_5083: StringResource
+  get() = String39.str_5083
+
+@ExperimentalResourceApi
+internal val Res.string.str_5084: StringResource
+  get() = String39.str_5084
+
+@ExperimentalResourceApi
+internal val Res.string.str_5085: StringResource
+  get() = String39.str_5085
+
+@ExperimentalResourceApi
+internal val Res.string.str_5086: StringResource
+  get() = String39.str_5086
+
+@ExperimentalResourceApi
+internal val Res.string.str_5087: StringResource
+  get() = String39.str_5087
+
+@ExperimentalResourceApi
+internal val Res.string.str_5088: StringResource
+  get() = String39.str_5088
+
+@ExperimentalResourceApi
+internal val Res.string.str_5089: StringResource
+  get() = String39.str_5089
+
+@ExperimentalResourceApi
+internal val Res.string.str_509: StringResource
+  get() = String39.str_509
+
+@ExperimentalResourceApi
+internal val Res.string.str_5090: StringResource
+  get() = String39.str_5090
+
+@ExperimentalResourceApi
+internal val Res.string.str_5091: StringResource
+  get() = String39.str_5091
+
+@ExperimentalResourceApi
+internal val Res.string.str_5092: StringResource
+  get() = String39.str_5092
+
+@ExperimentalResourceApi
+internal val Res.string.str_5093: StringResource
+  get() = String39.str_5093
+
+@ExperimentalResourceApi
+internal val Res.string.str_5094: StringResource
+  get() = String39.str_5094
+
+@ExperimentalResourceApi
+internal val Res.string.str_5095: StringResource
+  get() = String39.str_5095
+
+@ExperimentalResourceApi
+internal val Res.string.str_5096: StringResource
+  get() = String39.str_5096
+
+@ExperimentalResourceApi
+internal val Res.string.str_5097: StringResource
+  get() = String39.str_5097
+
+@ExperimentalResourceApi
+internal val Res.string.str_5098: StringResource
+  get() = String39.str_5098
+
+@ExperimentalResourceApi
+internal val Res.string.str_5099: StringResource
+  get() = String39.str_5099
+
+@ExperimentalResourceApi
+internal val Res.string.str_51: StringResource
+  get() = String39.str_51
+
+@ExperimentalResourceApi
+internal val Res.string.str_510: StringResource
+  get() = String39.str_510
+
+@ExperimentalResourceApi
+internal val Res.string.str_5100: StringResource
+  get() = String39.str_5100
+
+@ExperimentalResourceApi
+internal val Res.string.str_5101: StringResource
+  get() = String39.str_5101
+
+@ExperimentalResourceApi
+internal val Res.string.str_5102: StringResource
+  get() = String39.str_5102
+
+@ExperimentalResourceApi
+internal val Res.string.str_5103: StringResource
+  get() = String39.str_5103
+
+@ExperimentalResourceApi
+internal val Res.string.str_5104: StringResource
+  get() = String39.str_5104
+
+@ExperimentalResourceApi
+internal val Res.string.str_5105: StringResource
+  get() = String39.str_5105
+
+@ExperimentalResourceApi
+internal val Res.string.str_5106: StringResource
+  get() = String39.str_5106
+
+@ExperimentalResourceApi
+internal val Res.string.str_5107: StringResource
+  get() = String39.str_5107
+
+@ExperimentalResourceApi
+internal val Res.string.str_5108: StringResource
+  get() = String39.str_5108
+
+@ExperimentalResourceApi
+internal val Res.string.str_5109: StringResource
+  get() = String39.str_5109
+
+@ExperimentalResourceApi
+internal val Res.string.str_511: StringResource
+  get() = String39.str_511
+
+@ExperimentalResourceApi
+internal val Res.string.str_5110: StringResource
+  get() = String39.str_5110
+
+@ExperimentalResourceApi
+internal val Res.string.str_5111: StringResource
+  get() = String39.str_5111
+
+@ExperimentalResourceApi
+internal val Res.string.str_5112: StringResource
+  get() = String39.str_5112
+
+@ExperimentalResourceApi
+internal val Res.string.str_5113: StringResource
+  get() = String39.str_5113
+
+@ExperimentalResourceApi
+internal val Res.string.str_5114: StringResource
+  get() = String39.str_5114
+
+@ExperimentalResourceApi
+internal val Res.string.str_5115: StringResource
+  get() = String39.str_5115
+
+@ExperimentalResourceApi
+internal val Res.string.str_5116: StringResource
+  get() = String39.str_5116
+
+@ExperimentalResourceApi
+internal val Res.string.str_5117: StringResource
+  get() = String39.str_5117
+
+@ExperimentalResourceApi
+internal val Res.string.str_5118: StringResource
+  get() = String39.str_5118
+
+@ExperimentalResourceApi
+internal val Res.string.str_5119: StringResource
+  get() = String39.str_5119
+
+@ExperimentalResourceApi
+internal val Res.string.str_512: StringResource
+  get() = String39.str_512
+
+@ExperimentalResourceApi
+internal val Res.string.str_5120: StringResource
+  get() = String39.str_5120
+
+@ExperimentalResourceApi
+internal val Res.string.str_5121: StringResource
+  get() = String39.str_5121
+
+@ExperimentalResourceApi
+internal val Res.string.str_5122: StringResource
+  get() = String39.str_5122
+
+@ExperimentalResourceApi
+internal val Res.string.str_5123: StringResource
+  get() = String39.str_5123
+
+@ExperimentalResourceApi
+internal val Res.string.str_5124: StringResource
+  get() = String39.str_5124
+
+@ExperimentalResourceApi
+internal val Res.string.str_5125: StringResource
+  get() = String39.str_5125
+
+@ExperimentalResourceApi
+internal val Res.string.str_5126: StringResource
+  get() = String39.str_5126
+
+@ExperimentalResourceApi
+internal val Res.string.str_5127: StringResource
+  get() = String39.str_5127
+
+@ExperimentalResourceApi
+internal val Res.string.str_5128: StringResource
+  get() = String39.str_5128
+
+@ExperimentalResourceApi
+internal val Res.string.str_5129: StringResource
+  get() = String39.str_5129
+
+@ExperimentalResourceApi
+internal val Res.string.str_513: StringResource
+  get() = String39.str_513
+
+@ExperimentalResourceApi
+internal val Res.string.str_5130: StringResource
+  get() = String39.str_5130
+
+@ExperimentalResourceApi
+internal val Res.string.str_5131: StringResource
+  get() = String39.str_5131
+
+@ExperimentalResourceApi
+internal val Res.string.str_5132: StringResource
+  get() = String39.str_5132
+
+@ExperimentalResourceApi
+internal val Res.string.str_5133: StringResource
+  get() = String39.str_5133
+
+@ExperimentalResourceApi
+internal val Res.string.str_5134: StringResource
+  get() = String39.str_5134
+
+@ExperimentalResourceApi
+internal val Res.string.str_5135: StringResource
+  get() = String39.str_5135
+
+@ExperimentalResourceApi
+internal val Res.string.str_5136: StringResource
+  get() = String39.str_5136
+
+@ExperimentalResourceApi
+internal val Res.string.str_5137: StringResource
+  get() = String39.str_5137
+
+@ExperimentalResourceApi
+internal val Res.string.str_5138: StringResource
+  get() = String39.str_5138
+
+@ExperimentalResourceApi
+internal val Res.string.str_5139: StringResource
+  get() = String39.str_5139
+
+@ExperimentalResourceApi
+internal val Res.string.str_514: StringResource
+  get() = String39.str_514
+
+@ExperimentalResourceApi
+internal val Res.string.str_5140: StringResource
+  get() = String39.str_5140
+
+@ExperimentalResourceApi
+internal val Res.string.str_5141: StringResource
+  get() = String39.str_5141
+
+@ExperimentalResourceApi
+internal val Res.string.str_5142: StringResource
+  get() = String39.str_5142
+
+@ExperimentalResourceApi
+internal val Res.string.str_5143: StringResource
+  get() = String39.str_5143
+
+@ExperimentalResourceApi
+internal val Res.string.str_5144: StringResource
+  get() = String39.str_5144
+
+@ExperimentalResourceApi
+internal val Res.string.str_5145: StringResource
+  get() = String39.str_5145
+
+@ExperimentalResourceApi
+internal val Res.string.str_5146: StringResource
+  get() = String39.str_5146
+
+@ExperimentalResourceApi
+internal val Res.string.str_5147: StringResource
+  get() = String39.str_5147
+
+@ExperimentalResourceApi
+internal val Res.string.str_5148: StringResource
+  get() = String39.str_5148
+
+@ExperimentalResourceApi
+internal val Res.string.str_5149: StringResource
+  get() = String39.str_5149
+
+@ExperimentalResourceApi
+internal val Res.string.str_515: StringResource
+  get() = String39.str_515
+
+@ExperimentalResourceApi
+internal val Res.string.str_5150: StringResource
+  get() = String39.str_5150
+
+@ExperimentalResourceApi
+internal val Res.string.str_5151: StringResource
+  get() = String39.str_5151
+
+@ExperimentalResourceApi
+internal val Res.string.str_5152: StringResource
+  get() = String39.str_5152
+
+@ExperimentalResourceApi
+internal val Res.string.str_5153: StringResource
+  get() = String39.str_5153
+
+@ExperimentalResourceApi
+internal val Res.string.str_5154: StringResource
+  get() = String39.str_5154
+
+@ExperimentalResourceApi
+internal val Res.string.str_5155: StringResource
+  get() = String39.str_5155
+
+@ExperimentalResourceApi
+internal val Res.string.str_5156: StringResource
+  get() = String39.str_5156
+
+@ExperimentalResourceApi
+internal val Res.string.str_5157: StringResource
+  get() = String39.str_5157
+
+@ExperimentalResourceApi
+internal val Res.string.str_5158: StringResource
+  get() = String39.str_5158
+
+@ExperimentalResourceApi
+internal val Res.string.str_5159: StringResource
+  get() = String39.str_5159
+
+@ExperimentalResourceApi
+internal val Res.string.str_516: StringResource
+  get() = String39.str_516
+
+@ExperimentalResourceApi
+internal val Res.string.str_5160: StringResource
+  get() = String39.str_5160
+
+@ExperimentalResourceApi
+internal val Res.string.str_5161: StringResource
+  get() = String39.str_5161
+
+@ExperimentalResourceApi
+internal val Res.string.str_5162: StringResource
+  get() = String39.str_5162
+
+@ExperimentalResourceApi
+internal val Res.string.str_5163: StringResource
+  get() = String39.str_5163
+
+@ExperimentalResourceApi
+internal val Res.string.str_5164: StringResource
+  get() = String39.str_5164
+
+@ExperimentalResourceApi
+internal val Res.string.str_5165: StringResource
+  get() = String39.str_5165
+
+@ExperimentalResourceApi
+internal val Res.string.str_5166: StringResource
+  get() = String39.str_5166
+
+@ExperimentalResourceApi
+internal val Res.string.str_5167: StringResource
+  get() = String39.str_5167
+
+@ExperimentalResourceApi
+internal val Res.string.str_5168: StringResource
+  get() = String39.str_5168
+
+@ExperimentalResourceApi
+internal val Res.string.str_5169: StringResource
+  get() = String39.str_5169
+
+@ExperimentalResourceApi
+internal val Res.string.str_517: StringResource
+  get() = String39.str_517
+
+@ExperimentalResourceApi
+internal val Res.string.str_5170: StringResource
+  get() = String39.str_5170
+
+@ExperimentalResourceApi
+internal val Res.string.str_5171: StringResource
+  get() = String39.str_5171
+
+@ExperimentalResourceApi
+internal val Res.string.str_5172: StringResource
+  get() = String39.str_5172
+
+@ExperimentalResourceApi
+internal val Res.string.str_5173: StringResource
+  get() = String39.str_5173
+
+@ExperimentalResourceApi
+internal val Res.string.str_5174: StringResource
+  get() = String39.str_5174
+
+@ExperimentalResourceApi
+internal val Res.string.str_5175: StringResource
+  get() = String39.str_5175
+
+@ExperimentalResourceApi
+internal val Res.string.str_5176: StringResource
+  get() = String39.str_5176
+
+@ExperimentalResourceApi
+internal val Res.string.str_5177: StringResource
+  get() = String39.str_5177
+
+@ExperimentalResourceApi
+internal val Res.string.str_5178: StringResource
+  get() = String39.str_5178
+
+@ExperimentalResourceApi
+internal val Res.string.str_5179: StringResource
+  get() = String39.str_5179
+
+@ExperimentalResourceApi
+internal val Res.string.str_518: StringResource
+  get() = String39.str_518
+
+@ExperimentalResourceApi
+internal val Res.string.str_5180: StringResource
+  get() = String39.str_5180
+
+@ExperimentalResourceApi
+internal val Res.string.str_5181: StringResource
+  get() = String39.str_5181
+
+@ExperimentalResourceApi
+internal val Res.string.str_5182: StringResource
+  get() = String39.str_5182
+
+@ExperimentalResourceApi
+internal val Res.string.str_5183: StringResource
+  get() = String39.str_5183
+
+@ExperimentalResourceApi
+internal val Res.string.str_5184: StringResource
+  get() = String39.str_5184
+
+@ExperimentalResourceApi
+internal val Res.string.str_5185: StringResource
+  get() = String39.str_5185
+
+@ExperimentalResourceApi
+internal val Res.string.str_5186: StringResource
+  get() = String39.str_5186
+
+@ExperimentalResourceApi
+internal val Res.string.str_5187: StringResource
+  get() = String39.str_5187
+
+@ExperimentalResourceApi
+internal val Res.string.str_5188: StringResource
+  get() = String39.str_5188
+
+@ExperimentalResourceApi
+internal val Res.string.str_5189: StringResource
+  get() = String39.str_5189
+
+@ExperimentalResourceApi
+internal val Res.string.str_519: StringResource
+  get() = String39.str_519
+
+@ExperimentalResourceApi
+internal val Res.string.str_5190: StringResource
+  get() = String39.str_5190
+
+@ExperimentalResourceApi
+internal val Res.string.str_5191: StringResource
+  get() = String39.str_5191
+
+@ExperimentalResourceApi
+internal val Res.string.str_5192: StringResource
+  get() = String39.str_5192
+
+@ExperimentalResourceApi
+internal val Res.string.str_5193: StringResource
+  get() = String39.str_5193
+
+@ExperimentalResourceApi
+internal val Res.string.str_5194: StringResource
+  get() = String39.str_5194
+
+@ExperimentalResourceApi
+internal val Res.string.str_5195: StringResource
+  get() = String39.str_5195
+
+@ExperimentalResourceApi
+internal val Res.string.str_5196: StringResource
+  get() = String39.str_5196
+
+@ExperimentalResourceApi
+internal val Res.string.str_5197: StringResource
+  get() = String39.str_5197
+
+@ExperimentalResourceApi
+internal val Res.string.str_5198: StringResource
+  get() = String39.str_5198
+
+@ExperimentalResourceApi
+internal val Res.string.str_5199: StringResource
+  get() = String39.str_5199
+
+@ExperimentalResourceApi
+internal val Res.string.str_52: StringResource
+  get() = String39.str_52
+
+@ExperimentalResourceApi
+internal val Res.string.str_520: StringResource
+  get() = String39.str_520
+
+@ExperimentalResourceApi
+internal val Res.string.str_5200: StringResource
+  get() = String39.str_5200
+
+@ExperimentalResourceApi
+internal val Res.string.str_5201: StringResource
+  get() = String39.str_5201
+
+@ExperimentalResourceApi
+internal val Res.string.str_5202: StringResource
+  get() = String39.str_5202
+
+@ExperimentalResourceApi
+internal val Res.string.str_5203: StringResource
+  get() = String39.str_5203
+
+@ExperimentalResourceApi
+internal val Res.string.str_5204: StringResource
+  get() = String39.str_5204
+
+@ExperimentalResourceApi
+internal val Res.string.str_5205: StringResource
+  get() = String39.str_5205
+
+@ExperimentalResourceApi
+internal val Res.string.str_5206: StringResource
+  get() = String39.str_5206
+
+@ExperimentalResourceApi
+internal val Res.string.str_5207: StringResource
+  get() = String39.str_5207
+
+@ExperimentalResourceApi
+internal val Res.string.str_5208: StringResource
+  get() = String39.str_5208
+
+@ExperimentalResourceApi
+internal val Res.string.str_5209: StringResource
+  get() = String39.str_5209
+
+@ExperimentalResourceApi
+internal val Res.string.str_521: StringResource
+  get() = String39.str_521
+
+@ExperimentalResourceApi
+internal val Res.string.str_5210: StringResource
+  get() = String39.str_5210
+
+@ExperimentalResourceApi
+internal val Res.string.str_5211: StringResource
+  get() = String39.str_5211
+
+@ExperimentalResourceApi
+internal val Res.string.str_5212: StringResource
+  get() = String39.str_5212
+
+@ExperimentalResourceApi
+internal val Res.string.str_5213: StringResource
+  get() = String39.str_5213
+
+@ExperimentalResourceApi
+internal val Res.string.str_5214: StringResource
+  get() = String39.str_5214
+
+@ExperimentalResourceApi
+internal val Res.string.str_5215: StringResource
+  get() = String39.str_5215
+
+@ExperimentalResourceApi
+internal val Res.string.str_5216: StringResource
+  get() = String39.str_5216
+
+@ExperimentalResourceApi
+internal val Res.string.str_5217: StringResource
+  get() = String39.str_5217
+
+@ExperimentalResourceApi
+internal val Res.string.str_5218: StringResource
+  get() = String39.str_5218
+
+@ExperimentalResourceApi
+internal val Res.string.str_5219: StringResource
+  get() = String39.str_5219
+
+@ExperimentalResourceApi
+internal val Res.string.str_522: StringResource
+  get() = String39.str_522
+
+@ExperimentalResourceApi
+internal val Res.string.str_5220: StringResource
+  get() = String39.str_5220
+
+@ExperimentalResourceApi
+internal val Res.string.str_5221: StringResource
+  get() = String39.str_5221
+
+@ExperimentalResourceApi
+internal val Res.string.str_5222: StringResource
+  get() = String39.str_5222
+
+@ExperimentalResourceApi
+internal val Res.string.str_5223: StringResource
+  get() = String39.str_5223
+
+@ExperimentalResourceApi
+internal val Res.string.str_5224: StringResource
+  get() = String39.str_5224
+
+@ExperimentalResourceApi
+internal val Res.string.str_5225: StringResource
+  get() = String39.str_5225
+
+@ExperimentalResourceApi
+internal val Res.string.str_5226: StringResource
+  get() = String39.str_5226
+
+@ExperimentalResourceApi
+internal val Res.string.str_5227: StringResource
+  get() = String39.str_5227
+
+@ExperimentalResourceApi
+internal val Res.string.str_5228: StringResource
+  get() = String39.str_5228
+
+@ExperimentalResourceApi
+internal val Res.string.str_5229: StringResource
+  get() = String39.str_5229
+
+@ExperimentalResourceApi
+internal val Res.string.str_523: StringResource
+  get() = String39.str_523
+
+@ExperimentalResourceApi
+internal val Res.string.str_5230: StringResource
+  get() = String39.str_5230
+
+@ExperimentalResourceApi
+internal val Res.string.str_5231: StringResource
+  get() = String39.str_5231
+
+@ExperimentalResourceApi
+internal val Res.string.str_5232: StringResource
+  get() = String39.str_5232
+
+@ExperimentalResourceApi
+internal val Res.string.str_5233: StringResource
+  get() = String39.str_5233
+
+@ExperimentalResourceApi
+internal val Res.string.str_5234: StringResource
+  get() = String39.str_5234
+
+@ExperimentalResourceApi
+internal val Res.string.str_5235: StringResource
+  get() = String39.str_5235
+
+@ExperimentalResourceApi
+internal val Res.string.str_5236: StringResource
+  get() = String39.str_5236
+
+@ExperimentalResourceApi
+internal val Res.string.str_5237: StringResource
+  get() = String39.str_5237
+
+@ExperimentalResourceApi
+internal val Res.string.str_5238: StringResource
+  get() = String39.str_5238
+
+@ExperimentalResourceApi
+internal val Res.string.str_5239: StringResource
+  get() = String39.str_5239
+
+@ExperimentalResourceApi
+internal val Res.string.str_524: StringResource
+  get() = String39.str_524
+
+@ExperimentalResourceApi
+internal val Res.string.str_5240: StringResource
+  get() = String39.str_5240
+
+@ExperimentalResourceApi
+internal val Res.string.str_5241: StringResource
+  get() = String39.str_5241
+
+@ExperimentalResourceApi
+internal val Res.string.str_5242: StringResource
+  get() = String39.str_5242
+
+@ExperimentalResourceApi
+internal val Res.string.str_5243: StringResource
+  get() = String39.str_5243
+
+@ExperimentalResourceApi
+internal val Res.string.str_5244: StringResource
+  get() = String39.str_5244
+
+@ExperimentalResourceApi
+internal val Res.string.str_5245: StringResource
+  get() = String39.str_5245
+
+@ExperimentalResourceApi
+internal val Res.string.str_5246: StringResource
+  get() = String39.str_5246
+
+@ExperimentalResourceApi
+internal val Res.string.str_5247: StringResource
+  get() = String39.str_5247
+
+@ExperimentalResourceApi
+internal val Res.string.str_5248: StringResource
+  get() = String39.str_5248
+
+@ExperimentalResourceApi
+internal val Res.string.str_5249: StringResource
+  get() = String39.str_5249
+
+@ExperimentalResourceApi
+internal val Res.string.str_525: StringResource
+  get() = String39.str_525
+
+@ExperimentalResourceApi
+internal val Res.string.str_5250: StringResource
+  get() = String39.str_5250
+
+@ExperimentalResourceApi
+internal val Res.string.str_5251: StringResource
+  get() = String39.str_5251
+
+@ExperimentalResourceApi
+internal val Res.string.str_5252: StringResource
+  get() = String39.str_5252
+
+@ExperimentalResourceApi
+internal val Res.string.str_5253: StringResource
+  get() = String39.str_5253
+
+@ExperimentalResourceApi
+internal val Res.string.str_5254: StringResource
+  get() = String39.str_5254
+
+@ExperimentalResourceApi
+internal val Res.string.str_5255: StringResource
+  get() = String39.str_5255
+
+@ExperimentalResourceApi
+internal val Res.string.str_5256: StringResource
+  get() = String39.str_5256
+
+@ExperimentalResourceApi
+internal val Res.string.str_5257: StringResource
+  get() = String39.str_5257
+
+@ExperimentalResourceApi
+internal val Res.string.str_5258: StringResource
+  get() = String39.str_5258
+
+@ExperimentalResourceApi
+internal val Res.string.str_5259: StringResource
+  get() = String39.str_5259
+
+@ExperimentalResourceApi
+internal val Res.string.str_526: StringResource
+  get() = String39.str_526
+
+@ExperimentalResourceApi
+internal val Res.string.str_5260: StringResource
+  get() = String39.str_5260
+
+@ExperimentalResourceApi
+internal val Res.string.str_5261: StringResource
+  get() = String39.str_5261
+
+@ExperimentalResourceApi
+internal val Res.string.str_5262: StringResource
+  get() = String39.str_5262
+
+@ExperimentalResourceApi
+internal val Res.string.str_5263: StringResource
+  get() = String39.str_5263
+
+@ExperimentalResourceApi
+internal val Res.string.str_5264: StringResource
+  get() = String39.str_5264
+
+@ExperimentalResourceApi
+internal val Res.string.str_5265: StringResource
+  get() = String39.str_5265
+
+@ExperimentalResourceApi
+internal val Res.string.str_5266: StringResource
+  get() = String39.str_5266
+
+@ExperimentalResourceApi
+internal val Res.string.str_5267: StringResource
+  get() = String39.str_5267
+
+@ExperimentalResourceApi
+internal val Res.string.str_5268: StringResource
+  get() = String39.str_5268
+
+@ExperimentalResourceApi
+internal val Res.string.str_5269: StringResource
+  get() = String39.str_5269
+
+@ExperimentalResourceApi
+internal val Res.string.str_527: StringResource
+  get() = String39.str_527
+
+@ExperimentalResourceApi
+internal val Res.string.str_5270: StringResource
+  get() = String39.str_5270
+
+@ExperimentalResourceApi
+internal val Res.string.str_5271: StringResource
+  get() = String39.str_5271
+
+@ExperimentalResourceApi
+internal val Res.string.str_5272: StringResource
+  get() = String39.str_5272
+
+@ExperimentalResourceApi
+internal val Res.string.str_5273: StringResource
+  get() = String39.str_5273
+
+@ExperimentalResourceApi
+internal val Res.string.str_5274: StringResource
+  get() = String39.str_5274
+
+@ExperimentalResourceApi
+internal val Res.string.str_5275: StringResource
+  get() = String39.str_5275
+
+@ExperimentalResourceApi
+internal val Res.string.str_5276: StringResource
+  get() = String39.str_5276
+
+@ExperimentalResourceApi
+internal val Res.string.str_5277: StringResource
+  get() = String39.str_5277
+
+@ExperimentalResourceApi
+internal val Res.string.str_5278: StringResource
+  get() = String39.str_5278
+
+@ExperimentalResourceApi
+internal val Res.string.str_5279: StringResource
+  get() = String39.str_5279
+
+@ExperimentalResourceApi
+internal val Res.string.str_528: StringResource
+  get() = String39.str_528
+
+@ExperimentalResourceApi
+internal val Res.string.str_5280: StringResource
+  get() = String39.str_5280
+
+@ExperimentalResourceApi
+internal val Res.string.str_5281: StringResource
+  get() = String39.str_5281
+
+@ExperimentalResourceApi
+internal val Res.string.str_5282: StringResource
+  get() = String39.str_5282
+
+@ExperimentalResourceApi
+internal val Res.string.str_5283: StringResource
+  get() = String39.str_5283
+
+@ExperimentalResourceApi
+internal val Res.string.str_5284: StringResource
+  get() = String39.str_5284
+
+@ExperimentalResourceApi
+internal val Res.string.str_5285: StringResource
+  get() = String39.str_5285
+
+@ExperimentalResourceApi
+internal val Res.string.str_5286: StringResource
+  get() = String39.str_5286
+
+@ExperimentalResourceApi
+internal val Res.string.str_5287: StringResource
+  get() = String39.str_5287
+
+@ExperimentalResourceApi
+internal val Res.string.str_5288: StringResource
+  get() = String39.str_5288
+
+@ExperimentalResourceApi
+internal val Res.string.str_5289: StringResource
+  get() = String39.str_5289
+
+@ExperimentalResourceApi
+internal val Res.string.str_529: StringResource
+  get() = String39.str_529
+
+@ExperimentalResourceApi
+internal val Res.string.str_5290: StringResource
+  get() = String39.str_5290
+
+@ExperimentalResourceApi
+internal val Res.string.str_5291: StringResource
+  get() = String39.str_5291
+
+@ExperimentalResourceApi
+internal val Res.string.str_5292: StringResource
+  get() = String39.str_5292
+
+@ExperimentalResourceApi
+internal val Res.string.str_5293: StringResource
+  get() = String39.str_5293
+
+@ExperimentalResourceApi
+internal val Res.string.str_5294: StringResource
+  get() = String39.str_5294
+
+@ExperimentalResourceApi
+internal val Res.string.str_5295: StringResource
+  get() = String39.str_5295
+
+@ExperimentalResourceApi
+internal val Res.string.str_5296: StringResource
+  get() = String39.str_5296
+
+@ExperimentalResourceApi
+internal val Res.string.str_5297: StringResource
+  get() = String39.str_5297
+
+@ExperimentalResourceApi
+internal val Res.string.str_5298: StringResource
+  get() = String39.str_5298
+
+@ExperimentalResourceApi
+internal val Res.string.str_5299: StringResource
+  get() = String39.str_5299
+
+@ExperimentalResourceApi
+internal val Res.string.str_53: StringResource
+  get() = String39.str_53
+
+@ExperimentalResourceApi
+internal val Res.string.str_530: StringResource
+  get() = String39.str_530
+
+@ExperimentalResourceApi
+internal val Res.string.str_5300: StringResource
+  get() = String39.str_5300
+
+@ExperimentalResourceApi
+internal val Res.string.str_5301: StringResource
+  get() = String39.str_5301
+
+@ExperimentalResourceApi
+internal val Res.string.str_5302: StringResource
+  get() = String39.str_5302
+
+@ExperimentalResourceApi
+internal val Res.string.str_5303: StringResource
+  get() = String39.str_5303
+
+@ExperimentalResourceApi
+internal val Res.string.str_5304: StringResource
+  get() = String39.str_5304
+
+@ExperimentalResourceApi
+internal val Res.string.str_5305: StringResource
+  get() = String39.str_5305
+
+@ExperimentalResourceApi
+internal val Res.string.str_5306: StringResource
+  get() = String39.str_5306
+
+@ExperimentalResourceApi
+internal val Res.string.str_5307: StringResource
+  get() = String39.str_5307
+
+@ExperimentalResourceApi
+internal val Res.string.str_5308: StringResource
+  get() = String39.str_5308
+
+@ExperimentalResourceApi
+internal val Res.string.str_5309: StringResource
+  get() = String39.str_5309
+
+@ExperimentalResourceApi
+internal val Res.string.str_531: StringResource
+  get() = String39.str_531
+
+@ExperimentalResourceApi
+internal val Res.string.str_5310: StringResource
+  get() = String39.str_5310
+
+@ExperimentalResourceApi
+internal val Res.string.str_5311: StringResource
+  get() = String39.str_5311
+
+@ExperimentalResourceApi
+internal val Res.string.str_5312: StringResource
+  get() = String39.str_5312
+
+@ExperimentalResourceApi
+internal val Res.string.str_5313: StringResource
+  get() = String39.str_5313
+
+@ExperimentalResourceApi
+internal val Res.string.str_5314: StringResource
+  get() = String39.str_5314
+
+@ExperimentalResourceApi
+internal val Res.string.str_5315: StringResource
+  get() = String39.str_5315
+
+@ExperimentalResourceApi
+internal val Res.string.str_5316: StringResource
+  get() = String39.str_5316
+
+@ExperimentalResourceApi
+internal val Res.string.str_5317: StringResource
+  get() = String39.str_5317
+
+@ExperimentalResourceApi
+internal val Res.string.str_5318: StringResource
+  get() = String39.str_5318
+
+@ExperimentalResourceApi
+internal val Res.string.str_5319: StringResource
+  get() = String39.str_5319
+
+@ExperimentalResourceApi
+internal val Res.string.str_532: StringResource
+  get() = String39.str_532
+
+@ExperimentalResourceApi
+internal val Res.string.str_5320: StringResource
+  get() = String39.str_5320
+
+@ExperimentalResourceApi
+internal val Res.string.str_5321: StringResource
+  get() = String39.str_5321
+
+@ExperimentalResourceApi
+internal val Res.string.str_5322: StringResource
+  get() = String39.str_5322
+
+@ExperimentalResourceApi
+internal val Res.string.str_5323: StringResource
+  get() = String39.str_5323
+
+@ExperimentalResourceApi
+internal val Res.string.str_5324: StringResource
+  get() = String39.str_5324
+
+@ExperimentalResourceApi
+internal val Res.string.str_5325: StringResource
+  get() = String39.str_5325
+
+@ExperimentalResourceApi
+internal val Res.string.str_5326: StringResource
+  get() = String39.str_5326
+
+@ExperimentalResourceApi
+internal val Res.string.str_5327: StringResource
+  get() = String39.str_5327
+
+@ExperimentalResourceApi
+internal val Res.string.str_5328: StringResource
+  get() = String39.str_5328
+
+@ExperimentalResourceApi
+internal val Res.string.str_5329: StringResource
+  get() = String39.str_5329
+
+@ExperimentalResourceApi
+internal val Res.string.str_533: StringResource
+  get() = String39.str_533
+
+@ExperimentalResourceApi
+internal val Res.string.str_5330: StringResource
+  get() = String39.str_5330
+
+@ExperimentalResourceApi
+internal val Res.string.str_5331: StringResource
+  get() = String39.str_5331
+
+@ExperimentalResourceApi
+internal val Res.string.str_5332: StringResource
+  get() = String39.str_5332
+
+@ExperimentalResourceApi
+internal val Res.string.str_5333: StringResource
+  get() = String39.str_5333
+
+@ExperimentalResourceApi
+internal val Res.string.str_5334: StringResource
+  get() = String39.str_5334
+
+@ExperimentalResourceApi
+internal val Res.string.str_5335: StringResource
+  get() = String39.str_5335
+
+@ExperimentalResourceApi
+internal val Res.string.str_5336: StringResource
+  get() = String39.str_5336
+
+@ExperimentalResourceApi
+internal val Res.string.str_5337: StringResource
+  get() = String39.str_5337
+
+@ExperimentalResourceApi
+internal val Res.string.str_5338: StringResource
+  get() = String39.str_5338
+
+@ExperimentalResourceApi
+internal val Res.string.str_5339: StringResource
+  get() = String39.str_5339
+
+@ExperimentalResourceApi
+internal val Res.string.str_534: StringResource
+  get() = String39.str_534
+
+@ExperimentalResourceApi
+internal val Res.string.str_5340: StringResource
+  get() = String39.str_5340
+
+@ExperimentalResourceApi
+internal val Res.string.str_5341: StringResource
+  get() = String39.str_5341
+
+@ExperimentalResourceApi
+internal val Res.string.str_5342: StringResource
+  get() = String39.str_5342
+
+@ExperimentalResourceApi
+internal val Res.string.str_5343: StringResource
+  get() = String39.str_5343
+
+@ExperimentalResourceApi
+internal val Res.string.str_5344: StringResource
+  get() = String39.str_5344
+
+@ExperimentalResourceApi
+internal val Res.string.str_5345: StringResource
+  get() = String39.str_5345
+
+@ExperimentalResourceApi
+internal val Res.string.str_5346: StringResource
+  get() = String39.str_5346
+
+@ExperimentalResourceApi
+internal val Res.string.str_5347: StringResource
+  get() = String39.str_5347
+
+@ExperimentalResourceApi
+internal val Res.string.str_5348: StringResource
+  get() = String39.str_5348
+
+@ExperimentalResourceApi
+internal val Res.string.str_5349: StringResource
+  get() = String39.str_5349
+
+@ExperimentalResourceApi
+internal val Res.string.str_535: StringResource
+  get() = String39.str_535
+
+@ExperimentalResourceApi
+internal val Res.string.str_5350: StringResource
+  get() = String39.str_5350
+
+@ExperimentalResourceApi
+internal val Res.string.str_5351: StringResource
+  get() = String39.str_5351
+
+@ExperimentalResourceApi
+internal val Res.string.str_5352: StringResource
+  get() = String39.str_5352
+
+@ExperimentalResourceApi
+internal val Res.string.str_5353: StringResource
+  get() = String39.str_5353
+
+@ExperimentalResourceApi
+internal val Res.string.str_5354: StringResource
+  get() = String39.str_5354
+
+@ExperimentalResourceApi
+internal val Res.string.str_5355: StringResource
+  get() = String39.str_5355
+
+@ExperimentalResourceApi
+internal val Res.string.str_5356: StringResource
+  get() = String39.str_5356
+
+@ExperimentalResourceApi
+internal val Res.string.str_5357: StringResource
+  get() = String39.str_5357
+
+@ExperimentalResourceApi
+internal val Res.string.str_5358: StringResource
+  get() = String39.str_5358
+
+@ExperimentalResourceApi
+internal val Res.string.str_5359: StringResource
+  get() = String39.str_5359
+
+@ExperimentalResourceApi
+internal val Res.string.str_536: StringResource
+  get() = String39.str_536
+
+@ExperimentalResourceApi
+internal val Res.string.str_5360: StringResource
+  get() = String39.str_5360
+
+@ExperimentalResourceApi
+internal val Res.string.str_5361: StringResource
+  get() = String39.str_5361
+
+@ExperimentalResourceApi
+internal val Res.string.str_5362: StringResource
+  get() = String39.str_5362
+
+@ExperimentalResourceApi
+internal val Res.string.str_5363: StringResource
+  get() = String39.str_5363
+
+@ExperimentalResourceApi
+internal val Res.string.str_5364: StringResource
+  get() = String39.str_5364
+
+@ExperimentalResourceApi
+internal val Res.string.str_5365: StringResource
+  get() = String39.str_5365
+
+@ExperimentalResourceApi
+internal val Res.string.str_5366: StringResource
+  get() = String39.str_5366
+
+@ExperimentalResourceApi
+internal val Res.string.str_5367: StringResource
+  get() = String39.str_5367
+
+@ExperimentalResourceApi
+internal val Res.string.str_5368: StringResource
+  get() = String39.str_5368
+
+@ExperimentalResourceApi
+internal val Res.string.str_5369: StringResource
+  get() = String39.str_5369
+
+@ExperimentalResourceApi
+internal val Res.string.str_537: StringResource
+  get() = String39.str_537
+
+@ExperimentalResourceApi
+internal val Res.string.str_5370: StringResource
+  get() = String39.str_5370
+
+@ExperimentalResourceApi
+internal val Res.string.str_5371: StringResource
+  get() = String39.str_5371
+
+@ExperimentalResourceApi
+internal val Res.string.str_5372: StringResource
+  get() = String39.str_5372
+
+@ExperimentalResourceApi
+internal val Res.string.str_5373: StringResource
+  get() = String39.str_5373
+
+@ExperimentalResourceApi
+internal val Res.string.str_5374: StringResource
+  get() = String39.str_5374
+
+@ExperimentalResourceApi
+internal val Res.string.str_5375: StringResource
+  get() = String39.str_5375
+
+@ExperimentalResourceApi
+internal val Res.string.str_5376: StringResource
+  get() = String39.str_5376
+
+@ExperimentalResourceApi
+internal val Res.string.str_5377: StringResource
+  get() = String39.str_5377
+
+@ExperimentalResourceApi
+internal val Res.string.str_5378: StringResource
+  get() = String39.str_5378
+
+@ExperimentalResourceApi
+internal val Res.string.str_5379: StringResource
+  get() = String39.str_5379
+
+@ExperimentalResourceApi
+internal val Res.string.str_538: StringResource
+  get() = String39.str_538
+
+@ExperimentalResourceApi
+internal val Res.string.str_5380: StringResource
+  get() = String39.str_5380
+
+@ExperimentalResourceApi
+internal val Res.string.str_5381: StringResource
+  get() = String39.str_5381
+
+@ExperimentalResourceApi
+internal val Res.string.str_5382: StringResource
+  get() = String39.str_5382
+
+@ExperimentalResourceApi
+internal val Res.string.str_5383: StringResource
+  get() = String39.str_5383
+
+@ExperimentalResourceApi
+internal val Res.string.str_5384: StringResource
+  get() = String39.str_5384
+
+@ExperimentalResourceApi
+internal val Res.string.str_5385: StringResource
+  get() = String39.str_5385
+
+@ExperimentalResourceApi
+internal val Res.string.str_5386: StringResource
+  get() = String39.str_5386
+
+@ExperimentalResourceApi
+internal val Res.string.str_5387: StringResource
+  get() = String39.str_5387
+
+@ExperimentalResourceApi
+internal val Res.string.str_5388: StringResource
+  get() = String39.str_5388
+
+@ExperimentalResourceApi
+internal val Res.string.str_5389: StringResource
+  get() = String39.str_5389
+
+@ExperimentalResourceApi
+internal val Res.string.str_539: StringResource
+  get() = String39.str_539
+
+@ExperimentalResourceApi
+internal val Res.string.str_5390: StringResource
+  get() = String39.str_5390
+
+@ExperimentalResourceApi
+internal val Res.string.str_5391: StringResource
+  get() = String39.str_5391
+
+@ExperimentalResourceApi
+internal val Res.string.str_5392: StringResource
+  get() = String39.str_5392
+
+@ExperimentalResourceApi
+internal val Res.string.str_5393: StringResource
+  get() = String39.str_5393
+
+@ExperimentalResourceApi
+internal val Res.string.str_5394: StringResource
+  get() = String39.str_5394
+
+@ExperimentalResourceApi
+internal val Res.string.str_5395: StringResource
+  get() = String39.str_5395
+
+@ExperimentalResourceApi
+internal val Res.string.str_5396: StringResource
+  get() = String39.str_5396
+
+@ExperimentalResourceApi
+internal val Res.string.str_5397: StringResource
+  get() = String39.str_5397
+
+@ExperimentalResourceApi
+internal val Res.string.str_5398: StringResource
+  get() = String39.str_5398
+
+@ExperimentalResourceApi
+internal val Res.string.str_5399: StringResource
+  get() = String39.str_5399
+
+@ExperimentalResourceApi
+internal val Res.string.str_54: StringResource
+  get() = String39.str_54
+
+@ExperimentalResourceApi
+internal val Res.string.str_540: StringResource
+  get() = String39.str_540
+
+@ExperimentalResourceApi
+internal val Res.string.str_5400: StringResource
+  get() = String39.str_5400
+
+@ExperimentalResourceApi
+internal val Res.string.str_5401: StringResource
+  get() = String39.str_5401
+
+@ExperimentalResourceApi
+internal val Res.string.str_5402: StringResource
+  get() = String39.str_5402
+
+@ExperimentalResourceApi
+internal val Res.string.str_5403: StringResource
+  get() = String39.str_5403
+
+@ExperimentalResourceApi
+internal val Res.string.str_5404: StringResource
+  get() = String39.str_5404
+
+@ExperimentalResourceApi
+internal val Res.string.str_5405: StringResource
+  get() = String39.str_5405
+
+@ExperimentalResourceApi
+internal val Res.string.str_5406: StringResource
+  get() = String39.str_5406
+
+@ExperimentalResourceApi
+internal val Res.string.str_5407: StringResource
+  get() = String39.str_5407
+
+@ExperimentalResourceApi
+internal val Res.string.str_5408: StringResource
+  get() = String39.str_5408
+
+@ExperimentalResourceApi
+internal val Res.string.str_5409: StringResource
+  get() = String39.str_5409
+
+@ExperimentalResourceApi
+internal val Res.string.str_541: StringResource
+  get() = String39.str_541
+
+@ExperimentalResourceApi
+internal val Res.string.str_5410: StringResource
+  get() = String39.str_5410
+
+@ExperimentalResourceApi
+internal val Res.string.str_5411: StringResource
+  get() = String39.str_5411
+
+@ExperimentalResourceApi
+internal val Res.string.str_5412: StringResource
+  get() = String39.str_5412
+
+@ExperimentalResourceApi
+internal val Res.string.str_5413: StringResource
+  get() = String39.str_5413
+
+@ExperimentalResourceApi
+internal val Res.string.str_5414: StringResource
+  get() = String39.str_5414
+
+@ExperimentalResourceApi
+internal val Res.string.str_5415: StringResource
+  get() = String39.str_5415
+
+@ExperimentalResourceApi
+internal val Res.string.str_5416: StringResource
+  get() = String39.str_5416
+
+@ExperimentalResourceApi
+internal val Res.string.str_5417: StringResource
+  get() = String39.str_5417
+
+@ExperimentalResourceApi
+internal val Res.string.str_5418: StringResource
+  get() = String39.str_5418
+
+@ExperimentalResourceApi
+internal val Res.string.str_5419: StringResource
+  get() = String39.str_5419
+
+@ExperimentalResourceApi
+internal val Res.string.str_542: StringResource
+  get() = String39.str_542
+
+@ExperimentalResourceApi
+internal val Res.string.str_5420: StringResource
+  get() = String39.str_5420
+
+@ExperimentalResourceApi
+internal val Res.string.str_5421: StringResource
+  get() = String39.str_5421
+
+@ExperimentalResourceApi
+internal val Res.string.str_5422: StringResource
+  get() = String39.str_5422
+
+@ExperimentalResourceApi
+internal val Res.string.str_5423: StringResource
+  get() = String39.str_5423
+
+@ExperimentalResourceApi
+internal val Res.string.str_5424: StringResource
+  get() = String39.str_5424
+
+@ExperimentalResourceApi
+internal val Res.string.str_5425: StringResource
+  get() = String39.str_5425
+
+@ExperimentalResourceApi
+internal val Res.string.str_5426: StringResource
+  get() = String39.str_5426
+
+@ExperimentalResourceApi
+internal val Res.string.str_5427: StringResource
+  get() = String39.str_5427
+
+@ExperimentalResourceApi
+internal val Res.string.str_5428: StringResource
+  get() = String39.str_5428
+
+@ExperimentalResourceApi
+internal val Res.string.str_5429: StringResource
+  get() = String39.str_5429
+
+@ExperimentalResourceApi
+internal val Res.string.str_543: StringResource
+  get() = String39.str_543
+
+@ExperimentalResourceApi
+internal val Res.string.str_5430: StringResource
+  get() = String39.str_5430
+
+@ExperimentalResourceApi
+internal val Res.string.str_5431: StringResource
+  get() = String39.str_5431
+
+@ExperimentalResourceApi
+internal val Res.string.str_5432: StringResource
+  get() = String39.str_5432
+
+@ExperimentalResourceApi
+internal val Res.string.str_5433: StringResource
+  get() = String39.str_5433
+
+@ExperimentalResourceApi
+internal val Res.string.str_5434: StringResource
+  get() = String39.str_5434
+
+@ExperimentalResourceApi
+internal val Res.string.str_5435: StringResource
+  get() = String39.str_5435
+
+@ExperimentalResourceApi
+internal val Res.string.str_5436: StringResource
+  get() = String39.str_5436
+
+@ExperimentalResourceApi
+internal val Res.string.str_5437: StringResource
+  get() = String39.str_5437
+
+@ExperimentalResourceApi
+internal val Res.string.str_5438: StringResource
+  get() = String39.str_5438
+
+@ExperimentalResourceApi
+internal val Res.string.str_5439: StringResource
+  get() = String39.str_5439
+
+@ExperimentalResourceApi
+internal val Res.string.str_544: StringResource
+  get() = String39.str_544
+
+@ExperimentalResourceApi
+internal val Res.string.str_5440: StringResource
+  get() = String39.str_5440
+
+@ExperimentalResourceApi
+internal val Res.string.str_5441: StringResource
+  get() = String39.str_5441
+
+@ExperimentalResourceApi
+internal val Res.string.str_5442: StringResource
+  get() = String39.str_5442
+
+@ExperimentalResourceApi
+internal val Res.string.str_5443: StringResource
+  get() = String39.str_5443
+
+@ExperimentalResourceApi
+internal val Res.string.str_5444: StringResource
+  get() = String39.str_5444
+
+@ExperimentalResourceApi
+internal val Res.string.str_5445: StringResource
+  get() = String39.str_5445
+
+@ExperimentalResourceApi
+internal val Res.string.str_5446: StringResource
+  get() = String39.str_5446
+
+@ExperimentalResourceApi
+internal val Res.string.str_5447: StringResource
+  get() = String39.str_5447
+
+@ExperimentalResourceApi
+internal val Res.string.str_5448: StringResource
+  get() = String39.str_5448
+
+@ExperimentalResourceApi
+internal val Res.string.str_5449: StringResource
+  get() = String39.str_5449
+
+@ExperimentalResourceApi
+internal val Res.string.str_545: StringResource
+  get() = String39.str_545
+
+@ExperimentalResourceApi
+internal val Res.string.str_5450: StringResource
+  get() = String39.str_5450
+
+@ExperimentalResourceApi
+internal val Res.string.str_5451: StringResource
+  get() = String39.str_5451
+
+@ExperimentalResourceApi
+internal val Res.string.str_5452: StringResource
+  get() = String39.str_5452
+
+@ExperimentalResourceApi
+internal val Res.string.str_5453: StringResource
+  get() = String39.str_5453
+
+@ExperimentalResourceApi
+internal val Res.string.str_5454: StringResource
+  get() = String39.str_5454
+
+@ExperimentalResourceApi
+internal val Res.string.str_5455: StringResource
+  get() = String39.str_5455
+
+@ExperimentalResourceApi
+internal val Res.string.str_5456: StringResource
+  get() = String39.str_5456
+
+@ExperimentalResourceApi
+internal val Res.string.str_5457: StringResource
+  get() = String39.str_5457
+
+@ExperimentalResourceApi
+internal val Res.string.str_5458: StringResource
+  get() = String39.str_5458
+
+@ExperimentalResourceApi
+internal val Res.string.str_5459: StringResource
+  get() = String39.str_5459
+
+@ExperimentalResourceApi
+internal val Res.string.str_546: StringResource
+  get() = String39.str_546
+
+@ExperimentalResourceApi
+internal val Res.string.str_5460: StringResource
+  get() = String39.str_5460
+
+@ExperimentalResourceApi
+internal val Res.string.str_5461: StringResource
+  get() = String39.str_5461
+
+@ExperimentalResourceApi
+internal val Res.string.str_5462: StringResource
+  get() = String39.str_5462
+
+@ExperimentalResourceApi
+internal val Res.string.str_5463: StringResource
+  get() = String39.str_5463
+
+@ExperimentalResourceApi
+internal val Res.string.str_5464: StringResource
+  get() = String39.str_5464
+
+@ExperimentalResourceApi
+internal val Res.string.str_5465: StringResource
+  get() = String39.str_5465
+
+@ExperimentalResourceApi
+internal val Res.string.str_5466: StringResource
+  get() = String39.str_5466
+
+@ExperimentalResourceApi
+internal val Res.string.str_5467: StringResource
+  get() = String39.str_5467
+
+@ExperimentalResourceApi
+internal val Res.string.str_5468: StringResource
+  get() = String39.str_5468
+
+@ExperimentalResourceApi
+internal val Res.string.str_5469: StringResource
+  get() = String39.str_5469
+
+@ExperimentalResourceApi
+internal val Res.string.str_547: StringResource
+  get() = String39.str_547
+
+@ExperimentalResourceApi
+internal val Res.string.str_5470: StringResource
+  get() = String39.str_5470
+
+@ExperimentalResourceApi
+internal val Res.string.str_5471: StringResource
+  get() = String39.str_5471
+
+@ExperimentalResourceApi
+internal val Res.string.str_5472: StringResource
+  get() = String39.str_5472
+
+@ExperimentalResourceApi
+internal val Res.string.str_5473: StringResource
+  get() = String39.str_5473
+
+@ExperimentalResourceApi
+internal val Res.string.str_5474: StringResource
+  get() = String39.str_5474
+
+@ExperimentalResourceApi
+internal val Res.string.str_5475: StringResource
+  get() = String39.str_5475
+
+@ExperimentalResourceApi
+internal val Res.string.str_5476: StringResource
+  get() = String39.str_5476
+
+@ExperimentalResourceApi
+internal val Res.string.str_5477: StringResource
+  get() = String39.str_5477
+
+@ExperimentalResourceApi
+internal val Res.string.str_5478: StringResource
+  get() = String39.str_5478
+
+@ExperimentalResourceApi
+internal val Res.string.str_5479: StringResource
+  get() = String39.str_5479
+
+@ExperimentalResourceApi
+internal val Res.string.str_548: StringResource
+  get() = String39.str_548
+
+@ExperimentalResourceApi
+internal val Res.string.str_5480: StringResource
+  get() = String39.str_5480
+
+@ExperimentalResourceApi
+internal val Res.string.str_5481: StringResource
+  get() = String39.str_5481
+
+@ExperimentalResourceApi
+internal val Res.string.str_5482: StringResource
+  get() = String39.str_5482
+
+@ExperimentalResourceApi
+internal val Res.string.str_5483: StringResource
+  get() = String39.str_5483
+
+@ExperimentalResourceApi
+internal val Res.string.str_5484: StringResource
+  get() = String39.str_5484
+
+@ExperimentalResourceApi
+internal val Res.string.str_5485: StringResource
+  get() = String39.str_5485
+
+@ExperimentalResourceApi
+internal val Res.string.str_5486: StringResource
+  get() = String39.str_5486
+
+@ExperimentalResourceApi
+internal val Res.string.str_5487: StringResource
+  get() = String39.str_5487
+
+@ExperimentalResourceApi
+internal val Res.string.str_5488: StringResource
+  get() = String39.str_5488
+
+@ExperimentalResourceApi
+internal val Res.string.str_5489: StringResource
+  get() = String39.str_5489
+
+@ExperimentalResourceApi
+internal val Res.string.str_549: StringResource
+  get() = String39.str_549
+
+@ExperimentalResourceApi
+internal val Res.string.str_5490: StringResource
+  get() = String39.str_5490
+
+@ExperimentalResourceApi
+internal val Res.string.str_5491: StringResource
+  get() = String39.str_5491
+
+@ExperimentalResourceApi
+internal val Res.string.str_5492: StringResource
+  get() = String39.str_5492
+
+@ExperimentalResourceApi
+internal val Res.string.str_5493: StringResource
+  get() = String39.str_5493
+
+@ExperimentalResourceApi
+internal val Res.string.str_5494: StringResource
+  get() = String39.str_5494
+
+@ExperimentalResourceApi
+internal val Res.string.str_5495: StringResource
+  get() = String39.str_5495
+
+@ExperimentalResourceApi
+internal val Res.string.str_5496: StringResource
+  get() = String39.str_5496
+
+@ExperimentalResourceApi
+internal val Res.string.str_5497: StringResource
+  get() = String39.str_5497
+
+@ExperimentalResourceApi
+internal val Res.string.str_5498: StringResource
+  get() = String39.str_5498

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String4.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String4.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String4 {
+  public val str_11798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11798", "str_11798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11799", "str_11799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_118", "str_118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1180", "str_1180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11800", "str_11800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11801", "str_11801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11802", "str_11802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11803", "str_11803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11804", "str_11804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11805", "str_11805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11806", "str_11806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11807", "str_11807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11808", "str_11808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11809", "str_11809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1181", "str_1181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11810", "str_11810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11811", "str_11811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11812", "str_11812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11813", "str_11813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11814", "str_11814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11815", "str_11815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11816", "str_11816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11817", "str_11817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11818", "str_11818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11819", "str_11819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1182", "str_1182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11820", "str_11820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11821", "str_11821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11822", "str_11822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11823", "str_11823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11824", "str_11824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11825", "str_11825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11826", "str_11826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11827", "str_11827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11828", "str_11828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11829", "str_11829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1183", "str_1183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11830", "str_11830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11831", "str_11831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11832", "str_11832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11833", "str_11833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11834", "str_11834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11835", "str_11835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11836", "str_11836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11837", "str_11837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11838", "str_11838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11839", "str_11839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1184", "str_1184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11840", "str_11840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11841", "str_11841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11842", "str_11842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11843", "str_11843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11844", "str_11844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11845", "str_11845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11846", "str_11846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11847", "str_11847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11848", "str_11848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11849", "str_11849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1185", "str_1185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11850", "str_11850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11851", "str_11851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11852", "str_11852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11853", "str_11853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11854", "str_11854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11855", "str_11855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11856", "str_11856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11857", "str_11857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11858", "str_11858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11859", "str_11859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1186", "str_1186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11860", "str_11860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11861", "str_11861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11862", "str_11862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11863", "str_11863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11864", "str_11864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11865", "str_11865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11866", "str_11866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11867", "str_11867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11868", "str_11868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11869", "str_11869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1187", "str_1187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11870", "str_11870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11871", "str_11871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11872", "str_11872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11873", "str_11873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11874", "str_11874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11875", "str_11875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11876", "str_11876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11877", "str_11877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11878", "str_11878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11879", "str_11879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1188", "str_1188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11880", "str_11880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11881", "str_11881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11882", "str_11882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11883", "str_11883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11884", "str_11884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11885", "str_11885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11886", "str_11886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11887", "str_11887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11888", "str_11888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11889", "str_11889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1189", "str_1189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11890", "str_11890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11891", "str_11891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11892", "str_11892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11893", "str_11893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11894", "str_11894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11895", "str_11895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11896", "str_11896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11897", "str_11897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11898", "str_11898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11899", "str_11899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_119", "str_119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1190", "str_1190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11900", "str_11900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11901", "str_11901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11902", "str_11902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11903", "str_11903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11904", "str_11904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11905", "str_11905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11906", "str_11906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11907", "str_11907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11908", "str_11908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11909", "str_11909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1191", "str_1191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11910", "str_11910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11911", "str_11911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11912", "str_11912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11913", "str_11913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11914", "str_11914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11915", "str_11915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11916", "str_11916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11917", "str_11917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11918", "str_11918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11919", "str_11919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1192", "str_1192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11920", "str_11920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11921", "str_11921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11922", "str_11922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11923", "str_11923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11924", "str_11924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11925", "str_11925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11926", "str_11926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11927", "str_11927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11928", "str_11928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11929", "str_11929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1193", "str_1193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11930", "str_11930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11931", "str_11931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11932", "str_11932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11933", "str_11933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11934", "str_11934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11935", "str_11935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11936", "str_11936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11937", "str_11937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11938", "str_11938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11939", "str_11939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1194", "str_1194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11940", "str_11940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11941", "str_11941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11942", "str_11942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11943", "str_11943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11944", "str_11944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11945", "str_11945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11946", "str_11946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11947", "str_11947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11948", "str_11948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11949", "str_11949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1195", "str_1195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11950", "str_11950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11951", "str_11951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11952", "str_11952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11953", "str_11953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11954", "str_11954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11955", "str_11955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11956", "str_11956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11957", "str_11957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11958", "str_11958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11959", "str_11959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1196", "str_1196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11960", "str_11960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11961", "str_11961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11962", "str_11962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11963", "str_11963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11964", "str_11964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11965", "str_11965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11966", "str_11966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11967", "str_11967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11968", "str_11968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11969", "str_11969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1197", "str_1197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11970", "str_11970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11971", "str_11971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11972", "str_11972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11973", "str_11973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11974", "str_11974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11975", "str_11975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11976", "str_11976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11977", "str_11977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11978", "str_11978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11979", "str_11979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1198", "str_1198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11980", "str_11980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11981", "str_11981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11982", "str_11982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11983", "str_11983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11984", "str_11984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11985", "str_11985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11986", "str_11986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11987", "str_11987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11988", "str_11988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11989", "str_11989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1199", "str_1199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11990", "str_11990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11991", "str_11991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11992", "str_11992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11993", "str_11993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11994", "str_11994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11995", "str_11995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11996", "str_11996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11997", "str_11997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11998", "str_11998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_11999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_11999", "str_11999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12", "str_12",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_120", "str_120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1200", "str_1200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12000", "str_12000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12001", "str_12001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12002", "str_12002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12003", "str_12003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12004", "str_12004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12005", "str_12005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12006", "str_12006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12007", "str_12007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12008", "str_12008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12009", "str_12009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1201", "str_1201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12010", "str_12010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12011", "str_12011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12012", "str_12012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12013", "str_12013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12014", "str_12014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12015", "str_12015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12016", "str_12016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12017", "str_12017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12018", "str_12018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12019", "str_12019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1202", "str_1202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12020", "str_12020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12021", "str_12021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12022", "str_12022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12023", "str_12023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12024", "str_12024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12025", "str_12025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12026", "str_12026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12027", "str_12027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12028", "str_12028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12029", "str_12029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1203", "str_1203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12030", "str_12030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12031", "str_12031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12032", "str_12032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12033", "str_12033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12034", "str_12034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12035", "str_12035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12036", "str_12036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12037", "str_12037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12038", "str_12038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12039", "str_12039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1204", "str_1204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12040", "str_12040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12041", "str_12041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12042", "str_12042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12043", "str_12043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12044", "str_12044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12045", "str_12045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12046", "str_12046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12047", "str_12047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12048", "str_12048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12049", "str_12049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1205", "str_1205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12050", "str_12050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12051", "str_12051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12052", "str_12052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12053", "str_12053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12054", "str_12054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12055", "str_12055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12056", "str_12056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12057", "str_12057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12058", "str_12058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12059", "str_12059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1206", "str_1206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12060", "str_12060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12061", "str_12061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12062", "str_12062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12063", "str_12063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12064", "str_12064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12065", "str_12065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12066", "str_12066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12067", "str_12067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12068", "str_12068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12069", "str_12069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1207", "str_1207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12070", "str_12070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12071", "str_12071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12072", "str_12072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12073", "str_12073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12074", "str_12074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12075", "str_12075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12076", "str_12076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12077", "str_12077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12078", "str_12078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12079", "str_12079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1208", "str_1208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12080", "str_12080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12081", "str_12081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12082", "str_12082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12083", "str_12083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12084", "str_12084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12085", "str_12085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12086", "str_12086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12087", "str_12087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12088", "str_12088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12089", "str_12089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1209", "str_1209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12090", "str_12090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12091", "str_12091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12092", "str_12092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12093", "str_12093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12094", "str_12094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12095", "str_12095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12096", "str_12096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12097", "str_12097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12098", "str_12098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12099", "str_12099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_121", "str_121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1210", "str_1210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12100", "str_12100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12101", "str_12101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12102", "str_12102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12103", "str_12103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12104", "str_12104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12105", "str_12105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12106", "str_12106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12107", "str_12107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12108", "str_12108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12109", "str_12109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1211", "str_1211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12110", "str_12110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12111", "str_12111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12112", "str_12112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12113", "str_12113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12114", "str_12114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12115", "str_12115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12116", "str_12116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12117", "str_12117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12118", "str_12118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12119", "str_12119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1212", "str_1212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12120", "str_12120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12121", "str_12121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12122", "str_12122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12123", "str_12123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12124", "str_12124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12125", "str_12125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12126", "str_12126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12127", "str_12127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12128", "str_12128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12129", "str_12129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1213", "str_1213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12130", "str_12130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12131", "str_12131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12132", "str_12132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12133", "str_12133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12134", "str_12134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12135", "str_12135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12136", "str_12136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12137", "str_12137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12138", "str_12138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12139", "str_12139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1214", "str_1214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12140", "str_12140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12141", "str_12141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12142", "str_12142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12143", "str_12143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12144", "str_12144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12145", "str_12145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12146", "str_12146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12147", "str_12147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12148", "str_12148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12149", "str_12149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1215", "str_1215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12150", "str_12150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12151", "str_12151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12152", "str_12152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12153", "str_12153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12154", "str_12154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12155", "str_12155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12156", "str_12156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12157", "str_12157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12158", "str_12158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12159", "str_12159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1216", "str_1216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12160", "str_12160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12161", "str_12161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12162", "str_12162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12163", "str_12163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12164", "str_12164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12165", "str_12165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12166", "str_12166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12167", "str_12167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12168", "str_12168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12169", "str_12169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1217", "str_1217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12170", "str_12170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12171", "str_12171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12172", "str_12172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12173", "str_12173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12174", "str_12174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12175", "str_12175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12176", "str_12176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12177", "str_12177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12178", "str_12178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12179", "str_12179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1218", "str_1218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12180", "str_12180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12181", "str_12181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12182", "str_12182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12183", "str_12183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12184", "str_12184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12185", "str_12185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12186", "str_12186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12187", "str_12187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12188", "str_12188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12189", "str_12189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1219", "str_1219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12190", "str_12190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12191", "str_12191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12192", "str_12192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12193", "str_12193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12194", "str_12194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12195", "str_12195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12196", "str_12196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12197", "str_12197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12198", "str_12198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12199", "str_12199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_122", "str_122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1220", "str_1220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12200", "str_12200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12201", "str_12201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12202", "str_12202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12203", "str_12203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12204", "str_12204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12205", "str_12205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12206", "str_12206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12207", "str_12207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12208", "str_12208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12209", "str_12209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1221", "str_1221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12210", "str_12210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12211", "str_12211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12212", "str_12212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12213", "str_12213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12214", "str_12214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12215", "str_12215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12216", "str_12216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12217", "str_12217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12218", "str_12218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12219", "str_12219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1222", "str_1222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12220", "str_12220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12221", "str_12221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12222", "str_12222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12223", "str_12223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12224", "str_12224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12225", "str_12225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12226", "str_12226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12227", "str_12227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12228", "str_12228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12229", "str_12229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1223", "str_1223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12230", "str_12230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12231", "str_12231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12232", "str_12232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12233", "str_12233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12234", "str_12234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12235", "str_12235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12236", "str_12236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12237", "str_12237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12238", "str_12238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12239", "str_12239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1224", "str_1224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12240", "str_12240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12241", "str_12241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12242", "str_12242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12243", "str_12243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12244", "str_12244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12245", "str_12245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12246", "str_12246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_11798: StringResource
+  get() = String4.str_11798
+
+@ExperimentalResourceApi
+internal val Res.string.str_11799: StringResource
+  get() = String4.str_11799
+
+@ExperimentalResourceApi
+internal val Res.string.str_118: StringResource
+  get() = String4.str_118
+
+@ExperimentalResourceApi
+internal val Res.string.str_1180: StringResource
+  get() = String4.str_1180
+
+@ExperimentalResourceApi
+internal val Res.string.str_11800: StringResource
+  get() = String4.str_11800
+
+@ExperimentalResourceApi
+internal val Res.string.str_11801: StringResource
+  get() = String4.str_11801
+
+@ExperimentalResourceApi
+internal val Res.string.str_11802: StringResource
+  get() = String4.str_11802
+
+@ExperimentalResourceApi
+internal val Res.string.str_11803: StringResource
+  get() = String4.str_11803
+
+@ExperimentalResourceApi
+internal val Res.string.str_11804: StringResource
+  get() = String4.str_11804
+
+@ExperimentalResourceApi
+internal val Res.string.str_11805: StringResource
+  get() = String4.str_11805
+
+@ExperimentalResourceApi
+internal val Res.string.str_11806: StringResource
+  get() = String4.str_11806
+
+@ExperimentalResourceApi
+internal val Res.string.str_11807: StringResource
+  get() = String4.str_11807
+
+@ExperimentalResourceApi
+internal val Res.string.str_11808: StringResource
+  get() = String4.str_11808
+
+@ExperimentalResourceApi
+internal val Res.string.str_11809: StringResource
+  get() = String4.str_11809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1181: StringResource
+  get() = String4.str_1181
+
+@ExperimentalResourceApi
+internal val Res.string.str_11810: StringResource
+  get() = String4.str_11810
+
+@ExperimentalResourceApi
+internal val Res.string.str_11811: StringResource
+  get() = String4.str_11811
+
+@ExperimentalResourceApi
+internal val Res.string.str_11812: StringResource
+  get() = String4.str_11812
+
+@ExperimentalResourceApi
+internal val Res.string.str_11813: StringResource
+  get() = String4.str_11813
+
+@ExperimentalResourceApi
+internal val Res.string.str_11814: StringResource
+  get() = String4.str_11814
+
+@ExperimentalResourceApi
+internal val Res.string.str_11815: StringResource
+  get() = String4.str_11815
+
+@ExperimentalResourceApi
+internal val Res.string.str_11816: StringResource
+  get() = String4.str_11816
+
+@ExperimentalResourceApi
+internal val Res.string.str_11817: StringResource
+  get() = String4.str_11817
+
+@ExperimentalResourceApi
+internal val Res.string.str_11818: StringResource
+  get() = String4.str_11818
+
+@ExperimentalResourceApi
+internal val Res.string.str_11819: StringResource
+  get() = String4.str_11819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1182: StringResource
+  get() = String4.str_1182
+
+@ExperimentalResourceApi
+internal val Res.string.str_11820: StringResource
+  get() = String4.str_11820
+
+@ExperimentalResourceApi
+internal val Res.string.str_11821: StringResource
+  get() = String4.str_11821
+
+@ExperimentalResourceApi
+internal val Res.string.str_11822: StringResource
+  get() = String4.str_11822
+
+@ExperimentalResourceApi
+internal val Res.string.str_11823: StringResource
+  get() = String4.str_11823
+
+@ExperimentalResourceApi
+internal val Res.string.str_11824: StringResource
+  get() = String4.str_11824
+
+@ExperimentalResourceApi
+internal val Res.string.str_11825: StringResource
+  get() = String4.str_11825
+
+@ExperimentalResourceApi
+internal val Res.string.str_11826: StringResource
+  get() = String4.str_11826
+
+@ExperimentalResourceApi
+internal val Res.string.str_11827: StringResource
+  get() = String4.str_11827
+
+@ExperimentalResourceApi
+internal val Res.string.str_11828: StringResource
+  get() = String4.str_11828
+
+@ExperimentalResourceApi
+internal val Res.string.str_11829: StringResource
+  get() = String4.str_11829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1183: StringResource
+  get() = String4.str_1183
+
+@ExperimentalResourceApi
+internal val Res.string.str_11830: StringResource
+  get() = String4.str_11830
+
+@ExperimentalResourceApi
+internal val Res.string.str_11831: StringResource
+  get() = String4.str_11831
+
+@ExperimentalResourceApi
+internal val Res.string.str_11832: StringResource
+  get() = String4.str_11832
+
+@ExperimentalResourceApi
+internal val Res.string.str_11833: StringResource
+  get() = String4.str_11833
+
+@ExperimentalResourceApi
+internal val Res.string.str_11834: StringResource
+  get() = String4.str_11834
+
+@ExperimentalResourceApi
+internal val Res.string.str_11835: StringResource
+  get() = String4.str_11835
+
+@ExperimentalResourceApi
+internal val Res.string.str_11836: StringResource
+  get() = String4.str_11836
+
+@ExperimentalResourceApi
+internal val Res.string.str_11837: StringResource
+  get() = String4.str_11837
+
+@ExperimentalResourceApi
+internal val Res.string.str_11838: StringResource
+  get() = String4.str_11838
+
+@ExperimentalResourceApi
+internal val Res.string.str_11839: StringResource
+  get() = String4.str_11839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1184: StringResource
+  get() = String4.str_1184
+
+@ExperimentalResourceApi
+internal val Res.string.str_11840: StringResource
+  get() = String4.str_11840
+
+@ExperimentalResourceApi
+internal val Res.string.str_11841: StringResource
+  get() = String4.str_11841
+
+@ExperimentalResourceApi
+internal val Res.string.str_11842: StringResource
+  get() = String4.str_11842
+
+@ExperimentalResourceApi
+internal val Res.string.str_11843: StringResource
+  get() = String4.str_11843
+
+@ExperimentalResourceApi
+internal val Res.string.str_11844: StringResource
+  get() = String4.str_11844
+
+@ExperimentalResourceApi
+internal val Res.string.str_11845: StringResource
+  get() = String4.str_11845
+
+@ExperimentalResourceApi
+internal val Res.string.str_11846: StringResource
+  get() = String4.str_11846
+
+@ExperimentalResourceApi
+internal val Res.string.str_11847: StringResource
+  get() = String4.str_11847
+
+@ExperimentalResourceApi
+internal val Res.string.str_11848: StringResource
+  get() = String4.str_11848
+
+@ExperimentalResourceApi
+internal val Res.string.str_11849: StringResource
+  get() = String4.str_11849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1185: StringResource
+  get() = String4.str_1185
+
+@ExperimentalResourceApi
+internal val Res.string.str_11850: StringResource
+  get() = String4.str_11850
+
+@ExperimentalResourceApi
+internal val Res.string.str_11851: StringResource
+  get() = String4.str_11851
+
+@ExperimentalResourceApi
+internal val Res.string.str_11852: StringResource
+  get() = String4.str_11852
+
+@ExperimentalResourceApi
+internal val Res.string.str_11853: StringResource
+  get() = String4.str_11853
+
+@ExperimentalResourceApi
+internal val Res.string.str_11854: StringResource
+  get() = String4.str_11854
+
+@ExperimentalResourceApi
+internal val Res.string.str_11855: StringResource
+  get() = String4.str_11855
+
+@ExperimentalResourceApi
+internal val Res.string.str_11856: StringResource
+  get() = String4.str_11856
+
+@ExperimentalResourceApi
+internal val Res.string.str_11857: StringResource
+  get() = String4.str_11857
+
+@ExperimentalResourceApi
+internal val Res.string.str_11858: StringResource
+  get() = String4.str_11858
+
+@ExperimentalResourceApi
+internal val Res.string.str_11859: StringResource
+  get() = String4.str_11859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1186: StringResource
+  get() = String4.str_1186
+
+@ExperimentalResourceApi
+internal val Res.string.str_11860: StringResource
+  get() = String4.str_11860
+
+@ExperimentalResourceApi
+internal val Res.string.str_11861: StringResource
+  get() = String4.str_11861
+
+@ExperimentalResourceApi
+internal val Res.string.str_11862: StringResource
+  get() = String4.str_11862
+
+@ExperimentalResourceApi
+internal val Res.string.str_11863: StringResource
+  get() = String4.str_11863
+
+@ExperimentalResourceApi
+internal val Res.string.str_11864: StringResource
+  get() = String4.str_11864
+
+@ExperimentalResourceApi
+internal val Res.string.str_11865: StringResource
+  get() = String4.str_11865
+
+@ExperimentalResourceApi
+internal val Res.string.str_11866: StringResource
+  get() = String4.str_11866
+
+@ExperimentalResourceApi
+internal val Res.string.str_11867: StringResource
+  get() = String4.str_11867
+
+@ExperimentalResourceApi
+internal val Res.string.str_11868: StringResource
+  get() = String4.str_11868
+
+@ExperimentalResourceApi
+internal val Res.string.str_11869: StringResource
+  get() = String4.str_11869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1187: StringResource
+  get() = String4.str_1187
+
+@ExperimentalResourceApi
+internal val Res.string.str_11870: StringResource
+  get() = String4.str_11870
+
+@ExperimentalResourceApi
+internal val Res.string.str_11871: StringResource
+  get() = String4.str_11871
+
+@ExperimentalResourceApi
+internal val Res.string.str_11872: StringResource
+  get() = String4.str_11872
+
+@ExperimentalResourceApi
+internal val Res.string.str_11873: StringResource
+  get() = String4.str_11873
+
+@ExperimentalResourceApi
+internal val Res.string.str_11874: StringResource
+  get() = String4.str_11874
+
+@ExperimentalResourceApi
+internal val Res.string.str_11875: StringResource
+  get() = String4.str_11875
+
+@ExperimentalResourceApi
+internal val Res.string.str_11876: StringResource
+  get() = String4.str_11876
+
+@ExperimentalResourceApi
+internal val Res.string.str_11877: StringResource
+  get() = String4.str_11877
+
+@ExperimentalResourceApi
+internal val Res.string.str_11878: StringResource
+  get() = String4.str_11878
+
+@ExperimentalResourceApi
+internal val Res.string.str_11879: StringResource
+  get() = String4.str_11879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1188: StringResource
+  get() = String4.str_1188
+
+@ExperimentalResourceApi
+internal val Res.string.str_11880: StringResource
+  get() = String4.str_11880
+
+@ExperimentalResourceApi
+internal val Res.string.str_11881: StringResource
+  get() = String4.str_11881
+
+@ExperimentalResourceApi
+internal val Res.string.str_11882: StringResource
+  get() = String4.str_11882
+
+@ExperimentalResourceApi
+internal val Res.string.str_11883: StringResource
+  get() = String4.str_11883
+
+@ExperimentalResourceApi
+internal val Res.string.str_11884: StringResource
+  get() = String4.str_11884
+
+@ExperimentalResourceApi
+internal val Res.string.str_11885: StringResource
+  get() = String4.str_11885
+
+@ExperimentalResourceApi
+internal val Res.string.str_11886: StringResource
+  get() = String4.str_11886
+
+@ExperimentalResourceApi
+internal val Res.string.str_11887: StringResource
+  get() = String4.str_11887
+
+@ExperimentalResourceApi
+internal val Res.string.str_11888: StringResource
+  get() = String4.str_11888
+
+@ExperimentalResourceApi
+internal val Res.string.str_11889: StringResource
+  get() = String4.str_11889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1189: StringResource
+  get() = String4.str_1189
+
+@ExperimentalResourceApi
+internal val Res.string.str_11890: StringResource
+  get() = String4.str_11890
+
+@ExperimentalResourceApi
+internal val Res.string.str_11891: StringResource
+  get() = String4.str_11891
+
+@ExperimentalResourceApi
+internal val Res.string.str_11892: StringResource
+  get() = String4.str_11892
+
+@ExperimentalResourceApi
+internal val Res.string.str_11893: StringResource
+  get() = String4.str_11893
+
+@ExperimentalResourceApi
+internal val Res.string.str_11894: StringResource
+  get() = String4.str_11894
+
+@ExperimentalResourceApi
+internal val Res.string.str_11895: StringResource
+  get() = String4.str_11895
+
+@ExperimentalResourceApi
+internal val Res.string.str_11896: StringResource
+  get() = String4.str_11896
+
+@ExperimentalResourceApi
+internal val Res.string.str_11897: StringResource
+  get() = String4.str_11897
+
+@ExperimentalResourceApi
+internal val Res.string.str_11898: StringResource
+  get() = String4.str_11898
+
+@ExperimentalResourceApi
+internal val Res.string.str_11899: StringResource
+  get() = String4.str_11899
+
+@ExperimentalResourceApi
+internal val Res.string.str_119: StringResource
+  get() = String4.str_119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1190: StringResource
+  get() = String4.str_1190
+
+@ExperimentalResourceApi
+internal val Res.string.str_11900: StringResource
+  get() = String4.str_11900
+
+@ExperimentalResourceApi
+internal val Res.string.str_11901: StringResource
+  get() = String4.str_11901
+
+@ExperimentalResourceApi
+internal val Res.string.str_11902: StringResource
+  get() = String4.str_11902
+
+@ExperimentalResourceApi
+internal val Res.string.str_11903: StringResource
+  get() = String4.str_11903
+
+@ExperimentalResourceApi
+internal val Res.string.str_11904: StringResource
+  get() = String4.str_11904
+
+@ExperimentalResourceApi
+internal val Res.string.str_11905: StringResource
+  get() = String4.str_11905
+
+@ExperimentalResourceApi
+internal val Res.string.str_11906: StringResource
+  get() = String4.str_11906
+
+@ExperimentalResourceApi
+internal val Res.string.str_11907: StringResource
+  get() = String4.str_11907
+
+@ExperimentalResourceApi
+internal val Res.string.str_11908: StringResource
+  get() = String4.str_11908
+
+@ExperimentalResourceApi
+internal val Res.string.str_11909: StringResource
+  get() = String4.str_11909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1191: StringResource
+  get() = String4.str_1191
+
+@ExperimentalResourceApi
+internal val Res.string.str_11910: StringResource
+  get() = String4.str_11910
+
+@ExperimentalResourceApi
+internal val Res.string.str_11911: StringResource
+  get() = String4.str_11911
+
+@ExperimentalResourceApi
+internal val Res.string.str_11912: StringResource
+  get() = String4.str_11912
+
+@ExperimentalResourceApi
+internal val Res.string.str_11913: StringResource
+  get() = String4.str_11913
+
+@ExperimentalResourceApi
+internal val Res.string.str_11914: StringResource
+  get() = String4.str_11914
+
+@ExperimentalResourceApi
+internal val Res.string.str_11915: StringResource
+  get() = String4.str_11915
+
+@ExperimentalResourceApi
+internal val Res.string.str_11916: StringResource
+  get() = String4.str_11916
+
+@ExperimentalResourceApi
+internal val Res.string.str_11917: StringResource
+  get() = String4.str_11917
+
+@ExperimentalResourceApi
+internal val Res.string.str_11918: StringResource
+  get() = String4.str_11918
+
+@ExperimentalResourceApi
+internal val Res.string.str_11919: StringResource
+  get() = String4.str_11919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1192: StringResource
+  get() = String4.str_1192
+
+@ExperimentalResourceApi
+internal val Res.string.str_11920: StringResource
+  get() = String4.str_11920
+
+@ExperimentalResourceApi
+internal val Res.string.str_11921: StringResource
+  get() = String4.str_11921
+
+@ExperimentalResourceApi
+internal val Res.string.str_11922: StringResource
+  get() = String4.str_11922
+
+@ExperimentalResourceApi
+internal val Res.string.str_11923: StringResource
+  get() = String4.str_11923
+
+@ExperimentalResourceApi
+internal val Res.string.str_11924: StringResource
+  get() = String4.str_11924
+
+@ExperimentalResourceApi
+internal val Res.string.str_11925: StringResource
+  get() = String4.str_11925
+
+@ExperimentalResourceApi
+internal val Res.string.str_11926: StringResource
+  get() = String4.str_11926
+
+@ExperimentalResourceApi
+internal val Res.string.str_11927: StringResource
+  get() = String4.str_11927
+
+@ExperimentalResourceApi
+internal val Res.string.str_11928: StringResource
+  get() = String4.str_11928
+
+@ExperimentalResourceApi
+internal val Res.string.str_11929: StringResource
+  get() = String4.str_11929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1193: StringResource
+  get() = String4.str_1193
+
+@ExperimentalResourceApi
+internal val Res.string.str_11930: StringResource
+  get() = String4.str_11930
+
+@ExperimentalResourceApi
+internal val Res.string.str_11931: StringResource
+  get() = String4.str_11931
+
+@ExperimentalResourceApi
+internal val Res.string.str_11932: StringResource
+  get() = String4.str_11932
+
+@ExperimentalResourceApi
+internal val Res.string.str_11933: StringResource
+  get() = String4.str_11933
+
+@ExperimentalResourceApi
+internal val Res.string.str_11934: StringResource
+  get() = String4.str_11934
+
+@ExperimentalResourceApi
+internal val Res.string.str_11935: StringResource
+  get() = String4.str_11935
+
+@ExperimentalResourceApi
+internal val Res.string.str_11936: StringResource
+  get() = String4.str_11936
+
+@ExperimentalResourceApi
+internal val Res.string.str_11937: StringResource
+  get() = String4.str_11937
+
+@ExperimentalResourceApi
+internal val Res.string.str_11938: StringResource
+  get() = String4.str_11938
+
+@ExperimentalResourceApi
+internal val Res.string.str_11939: StringResource
+  get() = String4.str_11939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1194: StringResource
+  get() = String4.str_1194
+
+@ExperimentalResourceApi
+internal val Res.string.str_11940: StringResource
+  get() = String4.str_11940
+
+@ExperimentalResourceApi
+internal val Res.string.str_11941: StringResource
+  get() = String4.str_11941
+
+@ExperimentalResourceApi
+internal val Res.string.str_11942: StringResource
+  get() = String4.str_11942
+
+@ExperimentalResourceApi
+internal val Res.string.str_11943: StringResource
+  get() = String4.str_11943
+
+@ExperimentalResourceApi
+internal val Res.string.str_11944: StringResource
+  get() = String4.str_11944
+
+@ExperimentalResourceApi
+internal val Res.string.str_11945: StringResource
+  get() = String4.str_11945
+
+@ExperimentalResourceApi
+internal val Res.string.str_11946: StringResource
+  get() = String4.str_11946
+
+@ExperimentalResourceApi
+internal val Res.string.str_11947: StringResource
+  get() = String4.str_11947
+
+@ExperimentalResourceApi
+internal val Res.string.str_11948: StringResource
+  get() = String4.str_11948
+
+@ExperimentalResourceApi
+internal val Res.string.str_11949: StringResource
+  get() = String4.str_11949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1195: StringResource
+  get() = String4.str_1195
+
+@ExperimentalResourceApi
+internal val Res.string.str_11950: StringResource
+  get() = String4.str_11950
+
+@ExperimentalResourceApi
+internal val Res.string.str_11951: StringResource
+  get() = String4.str_11951
+
+@ExperimentalResourceApi
+internal val Res.string.str_11952: StringResource
+  get() = String4.str_11952
+
+@ExperimentalResourceApi
+internal val Res.string.str_11953: StringResource
+  get() = String4.str_11953
+
+@ExperimentalResourceApi
+internal val Res.string.str_11954: StringResource
+  get() = String4.str_11954
+
+@ExperimentalResourceApi
+internal val Res.string.str_11955: StringResource
+  get() = String4.str_11955
+
+@ExperimentalResourceApi
+internal val Res.string.str_11956: StringResource
+  get() = String4.str_11956
+
+@ExperimentalResourceApi
+internal val Res.string.str_11957: StringResource
+  get() = String4.str_11957
+
+@ExperimentalResourceApi
+internal val Res.string.str_11958: StringResource
+  get() = String4.str_11958
+
+@ExperimentalResourceApi
+internal val Res.string.str_11959: StringResource
+  get() = String4.str_11959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1196: StringResource
+  get() = String4.str_1196
+
+@ExperimentalResourceApi
+internal val Res.string.str_11960: StringResource
+  get() = String4.str_11960
+
+@ExperimentalResourceApi
+internal val Res.string.str_11961: StringResource
+  get() = String4.str_11961
+
+@ExperimentalResourceApi
+internal val Res.string.str_11962: StringResource
+  get() = String4.str_11962
+
+@ExperimentalResourceApi
+internal val Res.string.str_11963: StringResource
+  get() = String4.str_11963
+
+@ExperimentalResourceApi
+internal val Res.string.str_11964: StringResource
+  get() = String4.str_11964
+
+@ExperimentalResourceApi
+internal val Res.string.str_11965: StringResource
+  get() = String4.str_11965
+
+@ExperimentalResourceApi
+internal val Res.string.str_11966: StringResource
+  get() = String4.str_11966
+
+@ExperimentalResourceApi
+internal val Res.string.str_11967: StringResource
+  get() = String4.str_11967
+
+@ExperimentalResourceApi
+internal val Res.string.str_11968: StringResource
+  get() = String4.str_11968
+
+@ExperimentalResourceApi
+internal val Res.string.str_11969: StringResource
+  get() = String4.str_11969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1197: StringResource
+  get() = String4.str_1197
+
+@ExperimentalResourceApi
+internal val Res.string.str_11970: StringResource
+  get() = String4.str_11970
+
+@ExperimentalResourceApi
+internal val Res.string.str_11971: StringResource
+  get() = String4.str_11971
+
+@ExperimentalResourceApi
+internal val Res.string.str_11972: StringResource
+  get() = String4.str_11972
+
+@ExperimentalResourceApi
+internal val Res.string.str_11973: StringResource
+  get() = String4.str_11973
+
+@ExperimentalResourceApi
+internal val Res.string.str_11974: StringResource
+  get() = String4.str_11974
+
+@ExperimentalResourceApi
+internal val Res.string.str_11975: StringResource
+  get() = String4.str_11975
+
+@ExperimentalResourceApi
+internal val Res.string.str_11976: StringResource
+  get() = String4.str_11976
+
+@ExperimentalResourceApi
+internal val Res.string.str_11977: StringResource
+  get() = String4.str_11977
+
+@ExperimentalResourceApi
+internal val Res.string.str_11978: StringResource
+  get() = String4.str_11978
+
+@ExperimentalResourceApi
+internal val Res.string.str_11979: StringResource
+  get() = String4.str_11979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1198: StringResource
+  get() = String4.str_1198
+
+@ExperimentalResourceApi
+internal val Res.string.str_11980: StringResource
+  get() = String4.str_11980
+
+@ExperimentalResourceApi
+internal val Res.string.str_11981: StringResource
+  get() = String4.str_11981
+
+@ExperimentalResourceApi
+internal val Res.string.str_11982: StringResource
+  get() = String4.str_11982
+
+@ExperimentalResourceApi
+internal val Res.string.str_11983: StringResource
+  get() = String4.str_11983
+
+@ExperimentalResourceApi
+internal val Res.string.str_11984: StringResource
+  get() = String4.str_11984
+
+@ExperimentalResourceApi
+internal val Res.string.str_11985: StringResource
+  get() = String4.str_11985
+
+@ExperimentalResourceApi
+internal val Res.string.str_11986: StringResource
+  get() = String4.str_11986
+
+@ExperimentalResourceApi
+internal val Res.string.str_11987: StringResource
+  get() = String4.str_11987
+
+@ExperimentalResourceApi
+internal val Res.string.str_11988: StringResource
+  get() = String4.str_11988
+
+@ExperimentalResourceApi
+internal val Res.string.str_11989: StringResource
+  get() = String4.str_11989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1199: StringResource
+  get() = String4.str_1199
+
+@ExperimentalResourceApi
+internal val Res.string.str_11990: StringResource
+  get() = String4.str_11990
+
+@ExperimentalResourceApi
+internal val Res.string.str_11991: StringResource
+  get() = String4.str_11991
+
+@ExperimentalResourceApi
+internal val Res.string.str_11992: StringResource
+  get() = String4.str_11992
+
+@ExperimentalResourceApi
+internal val Res.string.str_11993: StringResource
+  get() = String4.str_11993
+
+@ExperimentalResourceApi
+internal val Res.string.str_11994: StringResource
+  get() = String4.str_11994
+
+@ExperimentalResourceApi
+internal val Res.string.str_11995: StringResource
+  get() = String4.str_11995
+
+@ExperimentalResourceApi
+internal val Res.string.str_11996: StringResource
+  get() = String4.str_11996
+
+@ExperimentalResourceApi
+internal val Res.string.str_11997: StringResource
+  get() = String4.str_11997
+
+@ExperimentalResourceApi
+internal val Res.string.str_11998: StringResource
+  get() = String4.str_11998
+
+@ExperimentalResourceApi
+internal val Res.string.str_11999: StringResource
+  get() = String4.str_11999
+
+@ExperimentalResourceApi
+internal val Res.string.str_12: StringResource
+  get() = String4.str_12
+
+@ExperimentalResourceApi
+internal val Res.string.str_120: StringResource
+  get() = String4.str_120
+
+@ExperimentalResourceApi
+internal val Res.string.str_1200: StringResource
+  get() = String4.str_1200
+
+@ExperimentalResourceApi
+internal val Res.string.str_12000: StringResource
+  get() = String4.str_12000
+
+@ExperimentalResourceApi
+internal val Res.string.str_12001: StringResource
+  get() = String4.str_12001
+
+@ExperimentalResourceApi
+internal val Res.string.str_12002: StringResource
+  get() = String4.str_12002
+
+@ExperimentalResourceApi
+internal val Res.string.str_12003: StringResource
+  get() = String4.str_12003
+
+@ExperimentalResourceApi
+internal val Res.string.str_12004: StringResource
+  get() = String4.str_12004
+
+@ExperimentalResourceApi
+internal val Res.string.str_12005: StringResource
+  get() = String4.str_12005
+
+@ExperimentalResourceApi
+internal val Res.string.str_12006: StringResource
+  get() = String4.str_12006
+
+@ExperimentalResourceApi
+internal val Res.string.str_12007: StringResource
+  get() = String4.str_12007
+
+@ExperimentalResourceApi
+internal val Res.string.str_12008: StringResource
+  get() = String4.str_12008
+
+@ExperimentalResourceApi
+internal val Res.string.str_12009: StringResource
+  get() = String4.str_12009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1201: StringResource
+  get() = String4.str_1201
+
+@ExperimentalResourceApi
+internal val Res.string.str_12010: StringResource
+  get() = String4.str_12010
+
+@ExperimentalResourceApi
+internal val Res.string.str_12011: StringResource
+  get() = String4.str_12011
+
+@ExperimentalResourceApi
+internal val Res.string.str_12012: StringResource
+  get() = String4.str_12012
+
+@ExperimentalResourceApi
+internal val Res.string.str_12013: StringResource
+  get() = String4.str_12013
+
+@ExperimentalResourceApi
+internal val Res.string.str_12014: StringResource
+  get() = String4.str_12014
+
+@ExperimentalResourceApi
+internal val Res.string.str_12015: StringResource
+  get() = String4.str_12015
+
+@ExperimentalResourceApi
+internal val Res.string.str_12016: StringResource
+  get() = String4.str_12016
+
+@ExperimentalResourceApi
+internal val Res.string.str_12017: StringResource
+  get() = String4.str_12017
+
+@ExperimentalResourceApi
+internal val Res.string.str_12018: StringResource
+  get() = String4.str_12018
+
+@ExperimentalResourceApi
+internal val Res.string.str_12019: StringResource
+  get() = String4.str_12019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1202: StringResource
+  get() = String4.str_1202
+
+@ExperimentalResourceApi
+internal val Res.string.str_12020: StringResource
+  get() = String4.str_12020
+
+@ExperimentalResourceApi
+internal val Res.string.str_12021: StringResource
+  get() = String4.str_12021
+
+@ExperimentalResourceApi
+internal val Res.string.str_12022: StringResource
+  get() = String4.str_12022
+
+@ExperimentalResourceApi
+internal val Res.string.str_12023: StringResource
+  get() = String4.str_12023
+
+@ExperimentalResourceApi
+internal val Res.string.str_12024: StringResource
+  get() = String4.str_12024
+
+@ExperimentalResourceApi
+internal val Res.string.str_12025: StringResource
+  get() = String4.str_12025
+
+@ExperimentalResourceApi
+internal val Res.string.str_12026: StringResource
+  get() = String4.str_12026
+
+@ExperimentalResourceApi
+internal val Res.string.str_12027: StringResource
+  get() = String4.str_12027
+
+@ExperimentalResourceApi
+internal val Res.string.str_12028: StringResource
+  get() = String4.str_12028
+
+@ExperimentalResourceApi
+internal val Res.string.str_12029: StringResource
+  get() = String4.str_12029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1203: StringResource
+  get() = String4.str_1203
+
+@ExperimentalResourceApi
+internal val Res.string.str_12030: StringResource
+  get() = String4.str_12030
+
+@ExperimentalResourceApi
+internal val Res.string.str_12031: StringResource
+  get() = String4.str_12031
+
+@ExperimentalResourceApi
+internal val Res.string.str_12032: StringResource
+  get() = String4.str_12032
+
+@ExperimentalResourceApi
+internal val Res.string.str_12033: StringResource
+  get() = String4.str_12033
+
+@ExperimentalResourceApi
+internal val Res.string.str_12034: StringResource
+  get() = String4.str_12034
+
+@ExperimentalResourceApi
+internal val Res.string.str_12035: StringResource
+  get() = String4.str_12035
+
+@ExperimentalResourceApi
+internal val Res.string.str_12036: StringResource
+  get() = String4.str_12036
+
+@ExperimentalResourceApi
+internal val Res.string.str_12037: StringResource
+  get() = String4.str_12037
+
+@ExperimentalResourceApi
+internal val Res.string.str_12038: StringResource
+  get() = String4.str_12038
+
+@ExperimentalResourceApi
+internal val Res.string.str_12039: StringResource
+  get() = String4.str_12039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1204: StringResource
+  get() = String4.str_1204
+
+@ExperimentalResourceApi
+internal val Res.string.str_12040: StringResource
+  get() = String4.str_12040
+
+@ExperimentalResourceApi
+internal val Res.string.str_12041: StringResource
+  get() = String4.str_12041
+
+@ExperimentalResourceApi
+internal val Res.string.str_12042: StringResource
+  get() = String4.str_12042
+
+@ExperimentalResourceApi
+internal val Res.string.str_12043: StringResource
+  get() = String4.str_12043
+
+@ExperimentalResourceApi
+internal val Res.string.str_12044: StringResource
+  get() = String4.str_12044
+
+@ExperimentalResourceApi
+internal val Res.string.str_12045: StringResource
+  get() = String4.str_12045
+
+@ExperimentalResourceApi
+internal val Res.string.str_12046: StringResource
+  get() = String4.str_12046
+
+@ExperimentalResourceApi
+internal val Res.string.str_12047: StringResource
+  get() = String4.str_12047
+
+@ExperimentalResourceApi
+internal val Res.string.str_12048: StringResource
+  get() = String4.str_12048
+
+@ExperimentalResourceApi
+internal val Res.string.str_12049: StringResource
+  get() = String4.str_12049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1205: StringResource
+  get() = String4.str_1205
+
+@ExperimentalResourceApi
+internal val Res.string.str_12050: StringResource
+  get() = String4.str_12050
+
+@ExperimentalResourceApi
+internal val Res.string.str_12051: StringResource
+  get() = String4.str_12051
+
+@ExperimentalResourceApi
+internal val Res.string.str_12052: StringResource
+  get() = String4.str_12052
+
+@ExperimentalResourceApi
+internal val Res.string.str_12053: StringResource
+  get() = String4.str_12053
+
+@ExperimentalResourceApi
+internal val Res.string.str_12054: StringResource
+  get() = String4.str_12054
+
+@ExperimentalResourceApi
+internal val Res.string.str_12055: StringResource
+  get() = String4.str_12055
+
+@ExperimentalResourceApi
+internal val Res.string.str_12056: StringResource
+  get() = String4.str_12056
+
+@ExperimentalResourceApi
+internal val Res.string.str_12057: StringResource
+  get() = String4.str_12057
+
+@ExperimentalResourceApi
+internal val Res.string.str_12058: StringResource
+  get() = String4.str_12058
+
+@ExperimentalResourceApi
+internal val Res.string.str_12059: StringResource
+  get() = String4.str_12059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1206: StringResource
+  get() = String4.str_1206
+
+@ExperimentalResourceApi
+internal val Res.string.str_12060: StringResource
+  get() = String4.str_12060
+
+@ExperimentalResourceApi
+internal val Res.string.str_12061: StringResource
+  get() = String4.str_12061
+
+@ExperimentalResourceApi
+internal val Res.string.str_12062: StringResource
+  get() = String4.str_12062
+
+@ExperimentalResourceApi
+internal val Res.string.str_12063: StringResource
+  get() = String4.str_12063
+
+@ExperimentalResourceApi
+internal val Res.string.str_12064: StringResource
+  get() = String4.str_12064
+
+@ExperimentalResourceApi
+internal val Res.string.str_12065: StringResource
+  get() = String4.str_12065
+
+@ExperimentalResourceApi
+internal val Res.string.str_12066: StringResource
+  get() = String4.str_12066
+
+@ExperimentalResourceApi
+internal val Res.string.str_12067: StringResource
+  get() = String4.str_12067
+
+@ExperimentalResourceApi
+internal val Res.string.str_12068: StringResource
+  get() = String4.str_12068
+
+@ExperimentalResourceApi
+internal val Res.string.str_12069: StringResource
+  get() = String4.str_12069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1207: StringResource
+  get() = String4.str_1207
+
+@ExperimentalResourceApi
+internal val Res.string.str_12070: StringResource
+  get() = String4.str_12070
+
+@ExperimentalResourceApi
+internal val Res.string.str_12071: StringResource
+  get() = String4.str_12071
+
+@ExperimentalResourceApi
+internal val Res.string.str_12072: StringResource
+  get() = String4.str_12072
+
+@ExperimentalResourceApi
+internal val Res.string.str_12073: StringResource
+  get() = String4.str_12073
+
+@ExperimentalResourceApi
+internal val Res.string.str_12074: StringResource
+  get() = String4.str_12074
+
+@ExperimentalResourceApi
+internal val Res.string.str_12075: StringResource
+  get() = String4.str_12075
+
+@ExperimentalResourceApi
+internal val Res.string.str_12076: StringResource
+  get() = String4.str_12076
+
+@ExperimentalResourceApi
+internal val Res.string.str_12077: StringResource
+  get() = String4.str_12077
+
+@ExperimentalResourceApi
+internal val Res.string.str_12078: StringResource
+  get() = String4.str_12078
+
+@ExperimentalResourceApi
+internal val Res.string.str_12079: StringResource
+  get() = String4.str_12079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1208: StringResource
+  get() = String4.str_1208
+
+@ExperimentalResourceApi
+internal val Res.string.str_12080: StringResource
+  get() = String4.str_12080
+
+@ExperimentalResourceApi
+internal val Res.string.str_12081: StringResource
+  get() = String4.str_12081
+
+@ExperimentalResourceApi
+internal val Res.string.str_12082: StringResource
+  get() = String4.str_12082
+
+@ExperimentalResourceApi
+internal val Res.string.str_12083: StringResource
+  get() = String4.str_12083
+
+@ExperimentalResourceApi
+internal val Res.string.str_12084: StringResource
+  get() = String4.str_12084
+
+@ExperimentalResourceApi
+internal val Res.string.str_12085: StringResource
+  get() = String4.str_12085
+
+@ExperimentalResourceApi
+internal val Res.string.str_12086: StringResource
+  get() = String4.str_12086
+
+@ExperimentalResourceApi
+internal val Res.string.str_12087: StringResource
+  get() = String4.str_12087
+
+@ExperimentalResourceApi
+internal val Res.string.str_12088: StringResource
+  get() = String4.str_12088
+
+@ExperimentalResourceApi
+internal val Res.string.str_12089: StringResource
+  get() = String4.str_12089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1209: StringResource
+  get() = String4.str_1209
+
+@ExperimentalResourceApi
+internal val Res.string.str_12090: StringResource
+  get() = String4.str_12090
+
+@ExperimentalResourceApi
+internal val Res.string.str_12091: StringResource
+  get() = String4.str_12091
+
+@ExperimentalResourceApi
+internal val Res.string.str_12092: StringResource
+  get() = String4.str_12092
+
+@ExperimentalResourceApi
+internal val Res.string.str_12093: StringResource
+  get() = String4.str_12093
+
+@ExperimentalResourceApi
+internal val Res.string.str_12094: StringResource
+  get() = String4.str_12094
+
+@ExperimentalResourceApi
+internal val Res.string.str_12095: StringResource
+  get() = String4.str_12095
+
+@ExperimentalResourceApi
+internal val Res.string.str_12096: StringResource
+  get() = String4.str_12096
+
+@ExperimentalResourceApi
+internal val Res.string.str_12097: StringResource
+  get() = String4.str_12097
+
+@ExperimentalResourceApi
+internal val Res.string.str_12098: StringResource
+  get() = String4.str_12098
+
+@ExperimentalResourceApi
+internal val Res.string.str_12099: StringResource
+  get() = String4.str_12099
+
+@ExperimentalResourceApi
+internal val Res.string.str_121: StringResource
+  get() = String4.str_121
+
+@ExperimentalResourceApi
+internal val Res.string.str_1210: StringResource
+  get() = String4.str_1210
+
+@ExperimentalResourceApi
+internal val Res.string.str_12100: StringResource
+  get() = String4.str_12100
+
+@ExperimentalResourceApi
+internal val Res.string.str_12101: StringResource
+  get() = String4.str_12101
+
+@ExperimentalResourceApi
+internal val Res.string.str_12102: StringResource
+  get() = String4.str_12102
+
+@ExperimentalResourceApi
+internal val Res.string.str_12103: StringResource
+  get() = String4.str_12103
+
+@ExperimentalResourceApi
+internal val Res.string.str_12104: StringResource
+  get() = String4.str_12104
+
+@ExperimentalResourceApi
+internal val Res.string.str_12105: StringResource
+  get() = String4.str_12105
+
+@ExperimentalResourceApi
+internal val Res.string.str_12106: StringResource
+  get() = String4.str_12106
+
+@ExperimentalResourceApi
+internal val Res.string.str_12107: StringResource
+  get() = String4.str_12107
+
+@ExperimentalResourceApi
+internal val Res.string.str_12108: StringResource
+  get() = String4.str_12108
+
+@ExperimentalResourceApi
+internal val Res.string.str_12109: StringResource
+  get() = String4.str_12109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1211: StringResource
+  get() = String4.str_1211
+
+@ExperimentalResourceApi
+internal val Res.string.str_12110: StringResource
+  get() = String4.str_12110
+
+@ExperimentalResourceApi
+internal val Res.string.str_12111: StringResource
+  get() = String4.str_12111
+
+@ExperimentalResourceApi
+internal val Res.string.str_12112: StringResource
+  get() = String4.str_12112
+
+@ExperimentalResourceApi
+internal val Res.string.str_12113: StringResource
+  get() = String4.str_12113
+
+@ExperimentalResourceApi
+internal val Res.string.str_12114: StringResource
+  get() = String4.str_12114
+
+@ExperimentalResourceApi
+internal val Res.string.str_12115: StringResource
+  get() = String4.str_12115
+
+@ExperimentalResourceApi
+internal val Res.string.str_12116: StringResource
+  get() = String4.str_12116
+
+@ExperimentalResourceApi
+internal val Res.string.str_12117: StringResource
+  get() = String4.str_12117
+
+@ExperimentalResourceApi
+internal val Res.string.str_12118: StringResource
+  get() = String4.str_12118
+
+@ExperimentalResourceApi
+internal val Res.string.str_12119: StringResource
+  get() = String4.str_12119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1212: StringResource
+  get() = String4.str_1212
+
+@ExperimentalResourceApi
+internal val Res.string.str_12120: StringResource
+  get() = String4.str_12120
+
+@ExperimentalResourceApi
+internal val Res.string.str_12121: StringResource
+  get() = String4.str_12121
+
+@ExperimentalResourceApi
+internal val Res.string.str_12122: StringResource
+  get() = String4.str_12122
+
+@ExperimentalResourceApi
+internal val Res.string.str_12123: StringResource
+  get() = String4.str_12123
+
+@ExperimentalResourceApi
+internal val Res.string.str_12124: StringResource
+  get() = String4.str_12124
+
+@ExperimentalResourceApi
+internal val Res.string.str_12125: StringResource
+  get() = String4.str_12125
+
+@ExperimentalResourceApi
+internal val Res.string.str_12126: StringResource
+  get() = String4.str_12126
+
+@ExperimentalResourceApi
+internal val Res.string.str_12127: StringResource
+  get() = String4.str_12127
+
+@ExperimentalResourceApi
+internal val Res.string.str_12128: StringResource
+  get() = String4.str_12128
+
+@ExperimentalResourceApi
+internal val Res.string.str_12129: StringResource
+  get() = String4.str_12129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1213: StringResource
+  get() = String4.str_1213
+
+@ExperimentalResourceApi
+internal val Res.string.str_12130: StringResource
+  get() = String4.str_12130
+
+@ExperimentalResourceApi
+internal val Res.string.str_12131: StringResource
+  get() = String4.str_12131
+
+@ExperimentalResourceApi
+internal val Res.string.str_12132: StringResource
+  get() = String4.str_12132
+
+@ExperimentalResourceApi
+internal val Res.string.str_12133: StringResource
+  get() = String4.str_12133
+
+@ExperimentalResourceApi
+internal val Res.string.str_12134: StringResource
+  get() = String4.str_12134
+
+@ExperimentalResourceApi
+internal val Res.string.str_12135: StringResource
+  get() = String4.str_12135
+
+@ExperimentalResourceApi
+internal val Res.string.str_12136: StringResource
+  get() = String4.str_12136
+
+@ExperimentalResourceApi
+internal val Res.string.str_12137: StringResource
+  get() = String4.str_12137
+
+@ExperimentalResourceApi
+internal val Res.string.str_12138: StringResource
+  get() = String4.str_12138
+
+@ExperimentalResourceApi
+internal val Res.string.str_12139: StringResource
+  get() = String4.str_12139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1214: StringResource
+  get() = String4.str_1214
+
+@ExperimentalResourceApi
+internal val Res.string.str_12140: StringResource
+  get() = String4.str_12140
+
+@ExperimentalResourceApi
+internal val Res.string.str_12141: StringResource
+  get() = String4.str_12141
+
+@ExperimentalResourceApi
+internal val Res.string.str_12142: StringResource
+  get() = String4.str_12142
+
+@ExperimentalResourceApi
+internal val Res.string.str_12143: StringResource
+  get() = String4.str_12143
+
+@ExperimentalResourceApi
+internal val Res.string.str_12144: StringResource
+  get() = String4.str_12144
+
+@ExperimentalResourceApi
+internal val Res.string.str_12145: StringResource
+  get() = String4.str_12145
+
+@ExperimentalResourceApi
+internal val Res.string.str_12146: StringResource
+  get() = String4.str_12146
+
+@ExperimentalResourceApi
+internal val Res.string.str_12147: StringResource
+  get() = String4.str_12147
+
+@ExperimentalResourceApi
+internal val Res.string.str_12148: StringResource
+  get() = String4.str_12148
+
+@ExperimentalResourceApi
+internal val Res.string.str_12149: StringResource
+  get() = String4.str_12149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1215: StringResource
+  get() = String4.str_1215
+
+@ExperimentalResourceApi
+internal val Res.string.str_12150: StringResource
+  get() = String4.str_12150
+
+@ExperimentalResourceApi
+internal val Res.string.str_12151: StringResource
+  get() = String4.str_12151
+
+@ExperimentalResourceApi
+internal val Res.string.str_12152: StringResource
+  get() = String4.str_12152
+
+@ExperimentalResourceApi
+internal val Res.string.str_12153: StringResource
+  get() = String4.str_12153
+
+@ExperimentalResourceApi
+internal val Res.string.str_12154: StringResource
+  get() = String4.str_12154
+
+@ExperimentalResourceApi
+internal val Res.string.str_12155: StringResource
+  get() = String4.str_12155
+
+@ExperimentalResourceApi
+internal val Res.string.str_12156: StringResource
+  get() = String4.str_12156
+
+@ExperimentalResourceApi
+internal val Res.string.str_12157: StringResource
+  get() = String4.str_12157
+
+@ExperimentalResourceApi
+internal val Res.string.str_12158: StringResource
+  get() = String4.str_12158
+
+@ExperimentalResourceApi
+internal val Res.string.str_12159: StringResource
+  get() = String4.str_12159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1216: StringResource
+  get() = String4.str_1216
+
+@ExperimentalResourceApi
+internal val Res.string.str_12160: StringResource
+  get() = String4.str_12160
+
+@ExperimentalResourceApi
+internal val Res.string.str_12161: StringResource
+  get() = String4.str_12161
+
+@ExperimentalResourceApi
+internal val Res.string.str_12162: StringResource
+  get() = String4.str_12162
+
+@ExperimentalResourceApi
+internal val Res.string.str_12163: StringResource
+  get() = String4.str_12163
+
+@ExperimentalResourceApi
+internal val Res.string.str_12164: StringResource
+  get() = String4.str_12164
+
+@ExperimentalResourceApi
+internal val Res.string.str_12165: StringResource
+  get() = String4.str_12165
+
+@ExperimentalResourceApi
+internal val Res.string.str_12166: StringResource
+  get() = String4.str_12166
+
+@ExperimentalResourceApi
+internal val Res.string.str_12167: StringResource
+  get() = String4.str_12167
+
+@ExperimentalResourceApi
+internal val Res.string.str_12168: StringResource
+  get() = String4.str_12168
+
+@ExperimentalResourceApi
+internal val Res.string.str_12169: StringResource
+  get() = String4.str_12169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1217: StringResource
+  get() = String4.str_1217
+
+@ExperimentalResourceApi
+internal val Res.string.str_12170: StringResource
+  get() = String4.str_12170
+
+@ExperimentalResourceApi
+internal val Res.string.str_12171: StringResource
+  get() = String4.str_12171
+
+@ExperimentalResourceApi
+internal val Res.string.str_12172: StringResource
+  get() = String4.str_12172
+
+@ExperimentalResourceApi
+internal val Res.string.str_12173: StringResource
+  get() = String4.str_12173
+
+@ExperimentalResourceApi
+internal val Res.string.str_12174: StringResource
+  get() = String4.str_12174
+
+@ExperimentalResourceApi
+internal val Res.string.str_12175: StringResource
+  get() = String4.str_12175
+
+@ExperimentalResourceApi
+internal val Res.string.str_12176: StringResource
+  get() = String4.str_12176
+
+@ExperimentalResourceApi
+internal val Res.string.str_12177: StringResource
+  get() = String4.str_12177
+
+@ExperimentalResourceApi
+internal val Res.string.str_12178: StringResource
+  get() = String4.str_12178
+
+@ExperimentalResourceApi
+internal val Res.string.str_12179: StringResource
+  get() = String4.str_12179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1218: StringResource
+  get() = String4.str_1218
+
+@ExperimentalResourceApi
+internal val Res.string.str_12180: StringResource
+  get() = String4.str_12180
+
+@ExperimentalResourceApi
+internal val Res.string.str_12181: StringResource
+  get() = String4.str_12181
+
+@ExperimentalResourceApi
+internal val Res.string.str_12182: StringResource
+  get() = String4.str_12182
+
+@ExperimentalResourceApi
+internal val Res.string.str_12183: StringResource
+  get() = String4.str_12183
+
+@ExperimentalResourceApi
+internal val Res.string.str_12184: StringResource
+  get() = String4.str_12184
+
+@ExperimentalResourceApi
+internal val Res.string.str_12185: StringResource
+  get() = String4.str_12185
+
+@ExperimentalResourceApi
+internal val Res.string.str_12186: StringResource
+  get() = String4.str_12186
+
+@ExperimentalResourceApi
+internal val Res.string.str_12187: StringResource
+  get() = String4.str_12187
+
+@ExperimentalResourceApi
+internal val Res.string.str_12188: StringResource
+  get() = String4.str_12188
+
+@ExperimentalResourceApi
+internal val Res.string.str_12189: StringResource
+  get() = String4.str_12189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1219: StringResource
+  get() = String4.str_1219
+
+@ExperimentalResourceApi
+internal val Res.string.str_12190: StringResource
+  get() = String4.str_12190
+
+@ExperimentalResourceApi
+internal val Res.string.str_12191: StringResource
+  get() = String4.str_12191
+
+@ExperimentalResourceApi
+internal val Res.string.str_12192: StringResource
+  get() = String4.str_12192
+
+@ExperimentalResourceApi
+internal val Res.string.str_12193: StringResource
+  get() = String4.str_12193
+
+@ExperimentalResourceApi
+internal val Res.string.str_12194: StringResource
+  get() = String4.str_12194
+
+@ExperimentalResourceApi
+internal val Res.string.str_12195: StringResource
+  get() = String4.str_12195
+
+@ExperimentalResourceApi
+internal val Res.string.str_12196: StringResource
+  get() = String4.str_12196
+
+@ExperimentalResourceApi
+internal val Res.string.str_12197: StringResource
+  get() = String4.str_12197
+
+@ExperimentalResourceApi
+internal val Res.string.str_12198: StringResource
+  get() = String4.str_12198
+
+@ExperimentalResourceApi
+internal val Res.string.str_12199: StringResource
+  get() = String4.str_12199
+
+@ExperimentalResourceApi
+internal val Res.string.str_122: StringResource
+  get() = String4.str_122
+
+@ExperimentalResourceApi
+internal val Res.string.str_1220: StringResource
+  get() = String4.str_1220
+
+@ExperimentalResourceApi
+internal val Res.string.str_12200: StringResource
+  get() = String4.str_12200
+
+@ExperimentalResourceApi
+internal val Res.string.str_12201: StringResource
+  get() = String4.str_12201
+
+@ExperimentalResourceApi
+internal val Res.string.str_12202: StringResource
+  get() = String4.str_12202
+
+@ExperimentalResourceApi
+internal val Res.string.str_12203: StringResource
+  get() = String4.str_12203
+
+@ExperimentalResourceApi
+internal val Res.string.str_12204: StringResource
+  get() = String4.str_12204
+
+@ExperimentalResourceApi
+internal val Res.string.str_12205: StringResource
+  get() = String4.str_12205
+
+@ExperimentalResourceApi
+internal val Res.string.str_12206: StringResource
+  get() = String4.str_12206
+
+@ExperimentalResourceApi
+internal val Res.string.str_12207: StringResource
+  get() = String4.str_12207
+
+@ExperimentalResourceApi
+internal val Res.string.str_12208: StringResource
+  get() = String4.str_12208
+
+@ExperimentalResourceApi
+internal val Res.string.str_12209: StringResource
+  get() = String4.str_12209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1221: StringResource
+  get() = String4.str_1221
+
+@ExperimentalResourceApi
+internal val Res.string.str_12210: StringResource
+  get() = String4.str_12210
+
+@ExperimentalResourceApi
+internal val Res.string.str_12211: StringResource
+  get() = String4.str_12211
+
+@ExperimentalResourceApi
+internal val Res.string.str_12212: StringResource
+  get() = String4.str_12212
+
+@ExperimentalResourceApi
+internal val Res.string.str_12213: StringResource
+  get() = String4.str_12213
+
+@ExperimentalResourceApi
+internal val Res.string.str_12214: StringResource
+  get() = String4.str_12214
+
+@ExperimentalResourceApi
+internal val Res.string.str_12215: StringResource
+  get() = String4.str_12215
+
+@ExperimentalResourceApi
+internal val Res.string.str_12216: StringResource
+  get() = String4.str_12216
+
+@ExperimentalResourceApi
+internal val Res.string.str_12217: StringResource
+  get() = String4.str_12217
+
+@ExperimentalResourceApi
+internal val Res.string.str_12218: StringResource
+  get() = String4.str_12218
+
+@ExperimentalResourceApi
+internal val Res.string.str_12219: StringResource
+  get() = String4.str_12219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1222: StringResource
+  get() = String4.str_1222
+
+@ExperimentalResourceApi
+internal val Res.string.str_12220: StringResource
+  get() = String4.str_12220
+
+@ExperimentalResourceApi
+internal val Res.string.str_12221: StringResource
+  get() = String4.str_12221
+
+@ExperimentalResourceApi
+internal val Res.string.str_12222: StringResource
+  get() = String4.str_12222
+
+@ExperimentalResourceApi
+internal val Res.string.str_12223: StringResource
+  get() = String4.str_12223
+
+@ExperimentalResourceApi
+internal val Res.string.str_12224: StringResource
+  get() = String4.str_12224
+
+@ExperimentalResourceApi
+internal val Res.string.str_12225: StringResource
+  get() = String4.str_12225
+
+@ExperimentalResourceApi
+internal val Res.string.str_12226: StringResource
+  get() = String4.str_12226
+
+@ExperimentalResourceApi
+internal val Res.string.str_12227: StringResource
+  get() = String4.str_12227
+
+@ExperimentalResourceApi
+internal val Res.string.str_12228: StringResource
+  get() = String4.str_12228
+
+@ExperimentalResourceApi
+internal val Res.string.str_12229: StringResource
+  get() = String4.str_12229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1223: StringResource
+  get() = String4.str_1223
+
+@ExperimentalResourceApi
+internal val Res.string.str_12230: StringResource
+  get() = String4.str_12230
+
+@ExperimentalResourceApi
+internal val Res.string.str_12231: StringResource
+  get() = String4.str_12231
+
+@ExperimentalResourceApi
+internal val Res.string.str_12232: StringResource
+  get() = String4.str_12232
+
+@ExperimentalResourceApi
+internal val Res.string.str_12233: StringResource
+  get() = String4.str_12233
+
+@ExperimentalResourceApi
+internal val Res.string.str_12234: StringResource
+  get() = String4.str_12234
+
+@ExperimentalResourceApi
+internal val Res.string.str_12235: StringResource
+  get() = String4.str_12235
+
+@ExperimentalResourceApi
+internal val Res.string.str_12236: StringResource
+  get() = String4.str_12236
+
+@ExperimentalResourceApi
+internal val Res.string.str_12237: StringResource
+  get() = String4.str_12237
+
+@ExperimentalResourceApi
+internal val Res.string.str_12238: StringResource
+  get() = String4.str_12238
+
+@ExperimentalResourceApi
+internal val Res.string.str_12239: StringResource
+  get() = String4.str_12239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1224: StringResource
+  get() = String4.str_1224
+
+@ExperimentalResourceApi
+internal val Res.string.str_12240: StringResource
+  get() = String4.str_12240
+
+@ExperimentalResourceApi
+internal val Res.string.str_12241: StringResource
+  get() = String4.str_12241
+
+@ExperimentalResourceApi
+internal val Res.string.str_12242: StringResource
+  get() = String4.str_12242
+
+@ExperimentalResourceApi
+internal val Res.string.str_12243: StringResource
+  get() = String4.str_12243
+
+@ExperimentalResourceApi
+internal val Res.string.str_12244: StringResource
+  get() = String4.str_12244
+
+@ExperimentalResourceApi
+internal val Res.string.str_12245: StringResource
+  get() = String4.str_12245
+
+@ExperimentalResourceApi
+internal val Res.string.str_12246: StringResource
+  get() = String4.str_12246

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String40.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String40.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String40 {
+  public val str_5499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5499", "str_5499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_55: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_55", "str_55",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_550", "str_550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5500", "str_5500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5501", "str_5501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5502", "str_5502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5503", "str_5503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5504", "str_5504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5505", "str_5505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5506", "str_5506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5507", "str_5507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5508", "str_5508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5509", "str_5509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_551", "str_551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5510", "str_5510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5511", "str_5511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5512", "str_5512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5513", "str_5513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5514", "str_5514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5515", "str_5515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5516", "str_5516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5517", "str_5517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5518", "str_5518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5519", "str_5519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_552", "str_552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5520", "str_5520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5521", "str_5521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5522", "str_5522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5523", "str_5523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5524", "str_5524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5525", "str_5525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5526", "str_5526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5527", "str_5527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5528", "str_5528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5529", "str_5529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_553", "str_553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5530", "str_5530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5531", "str_5531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5532", "str_5532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5533", "str_5533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5534", "str_5534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5535", "str_5535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5536", "str_5536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5537", "str_5537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5538", "str_5538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5539", "str_5539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_554", "str_554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5540", "str_5540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5541", "str_5541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5542", "str_5542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5543", "str_5543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5544", "str_5544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5545", "str_5545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5546", "str_5546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5547", "str_5547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5548", "str_5548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5549", "str_5549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_555", "str_555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5550", "str_5550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5551", "str_5551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5552", "str_5552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5553", "str_5553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5554", "str_5554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5555", "str_5555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5556", "str_5556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5557", "str_5557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5558", "str_5558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5559", "str_5559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_556", "str_556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5560", "str_5560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5561", "str_5561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5562", "str_5562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5563", "str_5563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5564", "str_5564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5565", "str_5565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5566", "str_5566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5567", "str_5567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5568", "str_5568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5569", "str_5569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_557", "str_557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5570", "str_5570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5571", "str_5571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5572", "str_5572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5573", "str_5573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5574", "str_5574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5575", "str_5575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5576", "str_5576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5577", "str_5577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5578", "str_5578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5579", "str_5579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_558", "str_558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5580", "str_5580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5581", "str_5581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5582", "str_5582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5583", "str_5583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5584", "str_5584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5585", "str_5585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5586", "str_5586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5587", "str_5587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5588", "str_5588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5589", "str_5589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_559", "str_559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5590", "str_5590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5591", "str_5591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5592", "str_5592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5593", "str_5593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5594", "str_5594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5595", "str_5595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5596", "str_5596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5597", "str_5597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5598", "str_5598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5599", "str_5599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_56: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_56", "str_56",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_560", "str_560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5600", "str_5600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5601", "str_5601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5602", "str_5602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5603", "str_5603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5604", "str_5604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5605", "str_5605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5606", "str_5606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5607", "str_5607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5608", "str_5608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5609", "str_5609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_561", "str_561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5610", "str_5610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5611", "str_5611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5612", "str_5612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5613", "str_5613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5614", "str_5614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5615", "str_5615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5616", "str_5616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5617", "str_5617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5618", "str_5618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5619", "str_5619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_562", "str_562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5620", "str_5620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5621", "str_5621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5622", "str_5622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5623", "str_5623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5624", "str_5624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5625", "str_5625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5626", "str_5626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5627", "str_5627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5628", "str_5628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5629", "str_5629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_563", "str_563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5630", "str_5630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5631", "str_5631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5632", "str_5632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5633", "str_5633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5634", "str_5634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5635", "str_5635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5636", "str_5636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5637", "str_5637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5638", "str_5638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5639", "str_5639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_564", "str_564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5640", "str_5640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5641", "str_5641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5642", "str_5642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5643", "str_5643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5644", "str_5644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5645", "str_5645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5646", "str_5646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5647", "str_5647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5648", "str_5648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5649", "str_5649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_565", "str_565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5650", "str_5650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5651", "str_5651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5652", "str_5652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5653", "str_5653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5654", "str_5654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5655", "str_5655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5656", "str_5656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5657", "str_5657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5658", "str_5658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5659", "str_5659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_566", "str_566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5660", "str_5660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5661", "str_5661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5662", "str_5662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5663", "str_5663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5664", "str_5664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5665", "str_5665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5666", "str_5666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5667", "str_5667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5668", "str_5668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5669", "str_5669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_567", "str_567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5670", "str_5670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5671", "str_5671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5672", "str_5672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5673", "str_5673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5674", "str_5674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5675", "str_5675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5676", "str_5676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5677", "str_5677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5678", "str_5678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5679", "str_5679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_568", "str_568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5680", "str_5680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5681", "str_5681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5682", "str_5682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5683", "str_5683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5684", "str_5684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5685", "str_5685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5686", "str_5686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5687", "str_5687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5688", "str_5688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5689", "str_5689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_569", "str_569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5690", "str_5690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5691", "str_5691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5692", "str_5692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5693", "str_5693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5694", "str_5694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5695", "str_5695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5696", "str_5696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5697", "str_5697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5698", "str_5698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5699", "str_5699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_57: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_57", "str_57",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_570", "str_570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5700", "str_5700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5701", "str_5701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5702", "str_5702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5703", "str_5703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5704", "str_5704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5705", "str_5705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5706", "str_5706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5707", "str_5707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5708", "str_5708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5709", "str_5709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_571", "str_571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5710", "str_5710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5711", "str_5711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5712", "str_5712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5713", "str_5713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5714", "str_5714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5715", "str_5715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5716", "str_5716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5717", "str_5717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5718", "str_5718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5719", "str_5719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_572", "str_572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5720", "str_5720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5721", "str_5721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5722", "str_5722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5723", "str_5723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5724", "str_5724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5725", "str_5725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5726", "str_5726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5727", "str_5727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5728", "str_5728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5729", "str_5729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_573", "str_573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5730", "str_5730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5731", "str_5731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5732", "str_5732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5733", "str_5733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5734", "str_5734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5735", "str_5735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5736", "str_5736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5737", "str_5737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5738", "str_5738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5739", "str_5739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_574", "str_574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5740", "str_5740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5741", "str_5741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5742", "str_5742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5743", "str_5743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5744", "str_5744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5745", "str_5745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5746", "str_5746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5747", "str_5747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5748", "str_5748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5749", "str_5749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_575", "str_575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5750", "str_5750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5751", "str_5751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5752", "str_5752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5753", "str_5753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5754", "str_5754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5755", "str_5755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5756", "str_5756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5757", "str_5757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5758", "str_5758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5759", "str_5759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_576", "str_576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5760", "str_5760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5761", "str_5761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5762", "str_5762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5763", "str_5763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5764", "str_5764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5765", "str_5765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5766", "str_5766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5767", "str_5767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5768", "str_5768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5769", "str_5769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_577", "str_577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5770", "str_5770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5771", "str_5771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5772", "str_5772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5773", "str_5773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5774", "str_5774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5775", "str_5775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5776", "str_5776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5777", "str_5777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5778", "str_5778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5779", "str_5779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_578", "str_578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5780", "str_5780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5781", "str_5781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5782", "str_5782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5783", "str_5783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5784", "str_5784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5785", "str_5785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5786", "str_5786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5787", "str_5787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5788", "str_5788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5789", "str_5789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_579", "str_579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5790", "str_5790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5791", "str_5791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5792", "str_5792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5793", "str_5793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5794", "str_5794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5795", "str_5795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5796", "str_5796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5797", "str_5797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5798", "str_5798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5799", "str_5799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_58: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_58", "str_58",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_580", "str_580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5800", "str_5800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5801", "str_5801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5802", "str_5802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5803", "str_5803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5804", "str_5804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5805", "str_5805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5806", "str_5806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5807", "str_5807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5808", "str_5808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5809", "str_5809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_581", "str_581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5810", "str_5810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5811", "str_5811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5812", "str_5812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5813", "str_5813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5814", "str_5814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5815", "str_5815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5816", "str_5816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5817", "str_5817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5818", "str_5818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5819", "str_5819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_582", "str_582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5820", "str_5820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5821", "str_5821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5822", "str_5822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5823", "str_5823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5824", "str_5824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5825", "str_5825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5826", "str_5826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5827", "str_5827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5828", "str_5828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5829", "str_5829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_583", "str_583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5830", "str_5830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5831", "str_5831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5832", "str_5832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5833", "str_5833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5834", "str_5834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5835", "str_5835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5836", "str_5836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5837", "str_5837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5838", "str_5838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5839", "str_5839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_584", "str_584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5840", "str_5840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5841", "str_5841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5842", "str_5842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5843", "str_5843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5844", "str_5844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5845", "str_5845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5846", "str_5846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5847", "str_5847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5848", "str_5848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5849", "str_5849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_585", "str_585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5850", "str_5850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5851", "str_5851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5852", "str_5852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5853", "str_5853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5854", "str_5854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5855", "str_5855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5856", "str_5856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5857", "str_5857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5858", "str_5858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5859", "str_5859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_586", "str_586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5860", "str_5860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5861", "str_5861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5862", "str_5862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5863", "str_5863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5864", "str_5864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5865", "str_5865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5866", "str_5866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5867", "str_5867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5868", "str_5868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5869", "str_5869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_587", "str_587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5870", "str_5870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5871", "str_5871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5872", "str_5872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5873", "str_5873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5874", "str_5874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5875", "str_5875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5876", "str_5876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5877", "str_5877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5878", "str_5878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5879", "str_5879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_588", "str_588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5880", "str_5880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5881", "str_5881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5882", "str_5882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5883", "str_5883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5884", "str_5884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5885", "str_5885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5886", "str_5886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5887", "str_5887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5888", "str_5888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5889", "str_5889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_589", "str_589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5890", "str_5890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5891", "str_5891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5892", "str_5892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5893", "str_5893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5894", "str_5894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5895", "str_5895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5896", "str_5896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5897", "str_5897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5898", "str_5898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5899", "str_5899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_59: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_59", "str_59",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_590", "str_590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5900", "str_5900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5901", "str_5901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5902", "str_5902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5903", "str_5903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5904", "str_5904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5905", "str_5905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5906", "str_5906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5907", "str_5907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5908", "str_5908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5909", "str_5909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_591", "str_591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5910", "str_5910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5911", "str_5911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5912", "str_5912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5913", "str_5913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5914", "str_5914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5915", "str_5915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5916", "str_5916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5917", "str_5917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5918", "str_5918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5919", "str_5919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_592", "str_592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5920", "str_5920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5921", "str_5921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5922", "str_5922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5923", "str_5923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5924", "str_5924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5925", "str_5925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5926", "str_5926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5927", "str_5927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5928", "str_5928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5929", "str_5929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_593", "str_593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5930", "str_5930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5931", "str_5931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5932", "str_5932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5933", "str_5933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5934", "str_5934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5935", "str_5935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5936", "str_5936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5937", "str_5937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5938", "str_5938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5939", "str_5939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_594", "str_594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5940", "str_5940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5941", "str_5941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5942", "str_5942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5943", "str_5943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5944", "str_5944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5945", "str_5945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5946", "str_5946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5947", "str_5947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5948", "str_5948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_5499: StringResource
+  get() = String40.str_5499
+
+@ExperimentalResourceApi
+internal val Res.string.str_55: StringResource
+  get() = String40.str_55
+
+@ExperimentalResourceApi
+internal val Res.string.str_550: StringResource
+  get() = String40.str_550
+
+@ExperimentalResourceApi
+internal val Res.string.str_5500: StringResource
+  get() = String40.str_5500
+
+@ExperimentalResourceApi
+internal val Res.string.str_5501: StringResource
+  get() = String40.str_5501
+
+@ExperimentalResourceApi
+internal val Res.string.str_5502: StringResource
+  get() = String40.str_5502
+
+@ExperimentalResourceApi
+internal val Res.string.str_5503: StringResource
+  get() = String40.str_5503
+
+@ExperimentalResourceApi
+internal val Res.string.str_5504: StringResource
+  get() = String40.str_5504
+
+@ExperimentalResourceApi
+internal val Res.string.str_5505: StringResource
+  get() = String40.str_5505
+
+@ExperimentalResourceApi
+internal val Res.string.str_5506: StringResource
+  get() = String40.str_5506
+
+@ExperimentalResourceApi
+internal val Res.string.str_5507: StringResource
+  get() = String40.str_5507
+
+@ExperimentalResourceApi
+internal val Res.string.str_5508: StringResource
+  get() = String40.str_5508
+
+@ExperimentalResourceApi
+internal val Res.string.str_5509: StringResource
+  get() = String40.str_5509
+
+@ExperimentalResourceApi
+internal val Res.string.str_551: StringResource
+  get() = String40.str_551
+
+@ExperimentalResourceApi
+internal val Res.string.str_5510: StringResource
+  get() = String40.str_5510
+
+@ExperimentalResourceApi
+internal val Res.string.str_5511: StringResource
+  get() = String40.str_5511
+
+@ExperimentalResourceApi
+internal val Res.string.str_5512: StringResource
+  get() = String40.str_5512
+
+@ExperimentalResourceApi
+internal val Res.string.str_5513: StringResource
+  get() = String40.str_5513
+
+@ExperimentalResourceApi
+internal val Res.string.str_5514: StringResource
+  get() = String40.str_5514
+
+@ExperimentalResourceApi
+internal val Res.string.str_5515: StringResource
+  get() = String40.str_5515
+
+@ExperimentalResourceApi
+internal val Res.string.str_5516: StringResource
+  get() = String40.str_5516
+
+@ExperimentalResourceApi
+internal val Res.string.str_5517: StringResource
+  get() = String40.str_5517
+
+@ExperimentalResourceApi
+internal val Res.string.str_5518: StringResource
+  get() = String40.str_5518
+
+@ExperimentalResourceApi
+internal val Res.string.str_5519: StringResource
+  get() = String40.str_5519
+
+@ExperimentalResourceApi
+internal val Res.string.str_552: StringResource
+  get() = String40.str_552
+
+@ExperimentalResourceApi
+internal val Res.string.str_5520: StringResource
+  get() = String40.str_5520
+
+@ExperimentalResourceApi
+internal val Res.string.str_5521: StringResource
+  get() = String40.str_5521
+
+@ExperimentalResourceApi
+internal val Res.string.str_5522: StringResource
+  get() = String40.str_5522
+
+@ExperimentalResourceApi
+internal val Res.string.str_5523: StringResource
+  get() = String40.str_5523
+
+@ExperimentalResourceApi
+internal val Res.string.str_5524: StringResource
+  get() = String40.str_5524
+
+@ExperimentalResourceApi
+internal val Res.string.str_5525: StringResource
+  get() = String40.str_5525
+
+@ExperimentalResourceApi
+internal val Res.string.str_5526: StringResource
+  get() = String40.str_5526
+
+@ExperimentalResourceApi
+internal val Res.string.str_5527: StringResource
+  get() = String40.str_5527
+
+@ExperimentalResourceApi
+internal val Res.string.str_5528: StringResource
+  get() = String40.str_5528
+
+@ExperimentalResourceApi
+internal val Res.string.str_5529: StringResource
+  get() = String40.str_5529
+
+@ExperimentalResourceApi
+internal val Res.string.str_553: StringResource
+  get() = String40.str_553
+
+@ExperimentalResourceApi
+internal val Res.string.str_5530: StringResource
+  get() = String40.str_5530
+
+@ExperimentalResourceApi
+internal val Res.string.str_5531: StringResource
+  get() = String40.str_5531
+
+@ExperimentalResourceApi
+internal val Res.string.str_5532: StringResource
+  get() = String40.str_5532
+
+@ExperimentalResourceApi
+internal val Res.string.str_5533: StringResource
+  get() = String40.str_5533
+
+@ExperimentalResourceApi
+internal val Res.string.str_5534: StringResource
+  get() = String40.str_5534
+
+@ExperimentalResourceApi
+internal val Res.string.str_5535: StringResource
+  get() = String40.str_5535
+
+@ExperimentalResourceApi
+internal val Res.string.str_5536: StringResource
+  get() = String40.str_5536
+
+@ExperimentalResourceApi
+internal val Res.string.str_5537: StringResource
+  get() = String40.str_5537
+
+@ExperimentalResourceApi
+internal val Res.string.str_5538: StringResource
+  get() = String40.str_5538
+
+@ExperimentalResourceApi
+internal val Res.string.str_5539: StringResource
+  get() = String40.str_5539
+
+@ExperimentalResourceApi
+internal val Res.string.str_554: StringResource
+  get() = String40.str_554
+
+@ExperimentalResourceApi
+internal val Res.string.str_5540: StringResource
+  get() = String40.str_5540
+
+@ExperimentalResourceApi
+internal val Res.string.str_5541: StringResource
+  get() = String40.str_5541
+
+@ExperimentalResourceApi
+internal val Res.string.str_5542: StringResource
+  get() = String40.str_5542
+
+@ExperimentalResourceApi
+internal val Res.string.str_5543: StringResource
+  get() = String40.str_5543
+
+@ExperimentalResourceApi
+internal val Res.string.str_5544: StringResource
+  get() = String40.str_5544
+
+@ExperimentalResourceApi
+internal val Res.string.str_5545: StringResource
+  get() = String40.str_5545
+
+@ExperimentalResourceApi
+internal val Res.string.str_5546: StringResource
+  get() = String40.str_5546
+
+@ExperimentalResourceApi
+internal val Res.string.str_5547: StringResource
+  get() = String40.str_5547
+
+@ExperimentalResourceApi
+internal val Res.string.str_5548: StringResource
+  get() = String40.str_5548
+
+@ExperimentalResourceApi
+internal val Res.string.str_5549: StringResource
+  get() = String40.str_5549
+
+@ExperimentalResourceApi
+internal val Res.string.str_555: StringResource
+  get() = String40.str_555
+
+@ExperimentalResourceApi
+internal val Res.string.str_5550: StringResource
+  get() = String40.str_5550
+
+@ExperimentalResourceApi
+internal val Res.string.str_5551: StringResource
+  get() = String40.str_5551
+
+@ExperimentalResourceApi
+internal val Res.string.str_5552: StringResource
+  get() = String40.str_5552
+
+@ExperimentalResourceApi
+internal val Res.string.str_5553: StringResource
+  get() = String40.str_5553
+
+@ExperimentalResourceApi
+internal val Res.string.str_5554: StringResource
+  get() = String40.str_5554
+
+@ExperimentalResourceApi
+internal val Res.string.str_5555: StringResource
+  get() = String40.str_5555
+
+@ExperimentalResourceApi
+internal val Res.string.str_5556: StringResource
+  get() = String40.str_5556
+
+@ExperimentalResourceApi
+internal val Res.string.str_5557: StringResource
+  get() = String40.str_5557
+
+@ExperimentalResourceApi
+internal val Res.string.str_5558: StringResource
+  get() = String40.str_5558
+
+@ExperimentalResourceApi
+internal val Res.string.str_5559: StringResource
+  get() = String40.str_5559
+
+@ExperimentalResourceApi
+internal val Res.string.str_556: StringResource
+  get() = String40.str_556
+
+@ExperimentalResourceApi
+internal val Res.string.str_5560: StringResource
+  get() = String40.str_5560
+
+@ExperimentalResourceApi
+internal val Res.string.str_5561: StringResource
+  get() = String40.str_5561
+
+@ExperimentalResourceApi
+internal val Res.string.str_5562: StringResource
+  get() = String40.str_5562
+
+@ExperimentalResourceApi
+internal val Res.string.str_5563: StringResource
+  get() = String40.str_5563
+
+@ExperimentalResourceApi
+internal val Res.string.str_5564: StringResource
+  get() = String40.str_5564
+
+@ExperimentalResourceApi
+internal val Res.string.str_5565: StringResource
+  get() = String40.str_5565
+
+@ExperimentalResourceApi
+internal val Res.string.str_5566: StringResource
+  get() = String40.str_5566
+
+@ExperimentalResourceApi
+internal val Res.string.str_5567: StringResource
+  get() = String40.str_5567
+
+@ExperimentalResourceApi
+internal val Res.string.str_5568: StringResource
+  get() = String40.str_5568
+
+@ExperimentalResourceApi
+internal val Res.string.str_5569: StringResource
+  get() = String40.str_5569
+
+@ExperimentalResourceApi
+internal val Res.string.str_557: StringResource
+  get() = String40.str_557
+
+@ExperimentalResourceApi
+internal val Res.string.str_5570: StringResource
+  get() = String40.str_5570
+
+@ExperimentalResourceApi
+internal val Res.string.str_5571: StringResource
+  get() = String40.str_5571
+
+@ExperimentalResourceApi
+internal val Res.string.str_5572: StringResource
+  get() = String40.str_5572
+
+@ExperimentalResourceApi
+internal val Res.string.str_5573: StringResource
+  get() = String40.str_5573
+
+@ExperimentalResourceApi
+internal val Res.string.str_5574: StringResource
+  get() = String40.str_5574
+
+@ExperimentalResourceApi
+internal val Res.string.str_5575: StringResource
+  get() = String40.str_5575
+
+@ExperimentalResourceApi
+internal val Res.string.str_5576: StringResource
+  get() = String40.str_5576
+
+@ExperimentalResourceApi
+internal val Res.string.str_5577: StringResource
+  get() = String40.str_5577
+
+@ExperimentalResourceApi
+internal val Res.string.str_5578: StringResource
+  get() = String40.str_5578
+
+@ExperimentalResourceApi
+internal val Res.string.str_5579: StringResource
+  get() = String40.str_5579
+
+@ExperimentalResourceApi
+internal val Res.string.str_558: StringResource
+  get() = String40.str_558
+
+@ExperimentalResourceApi
+internal val Res.string.str_5580: StringResource
+  get() = String40.str_5580
+
+@ExperimentalResourceApi
+internal val Res.string.str_5581: StringResource
+  get() = String40.str_5581
+
+@ExperimentalResourceApi
+internal val Res.string.str_5582: StringResource
+  get() = String40.str_5582
+
+@ExperimentalResourceApi
+internal val Res.string.str_5583: StringResource
+  get() = String40.str_5583
+
+@ExperimentalResourceApi
+internal val Res.string.str_5584: StringResource
+  get() = String40.str_5584
+
+@ExperimentalResourceApi
+internal val Res.string.str_5585: StringResource
+  get() = String40.str_5585
+
+@ExperimentalResourceApi
+internal val Res.string.str_5586: StringResource
+  get() = String40.str_5586
+
+@ExperimentalResourceApi
+internal val Res.string.str_5587: StringResource
+  get() = String40.str_5587
+
+@ExperimentalResourceApi
+internal val Res.string.str_5588: StringResource
+  get() = String40.str_5588
+
+@ExperimentalResourceApi
+internal val Res.string.str_5589: StringResource
+  get() = String40.str_5589
+
+@ExperimentalResourceApi
+internal val Res.string.str_559: StringResource
+  get() = String40.str_559
+
+@ExperimentalResourceApi
+internal val Res.string.str_5590: StringResource
+  get() = String40.str_5590
+
+@ExperimentalResourceApi
+internal val Res.string.str_5591: StringResource
+  get() = String40.str_5591
+
+@ExperimentalResourceApi
+internal val Res.string.str_5592: StringResource
+  get() = String40.str_5592
+
+@ExperimentalResourceApi
+internal val Res.string.str_5593: StringResource
+  get() = String40.str_5593
+
+@ExperimentalResourceApi
+internal val Res.string.str_5594: StringResource
+  get() = String40.str_5594
+
+@ExperimentalResourceApi
+internal val Res.string.str_5595: StringResource
+  get() = String40.str_5595
+
+@ExperimentalResourceApi
+internal val Res.string.str_5596: StringResource
+  get() = String40.str_5596
+
+@ExperimentalResourceApi
+internal val Res.string.str_5597: StringResource
+  get() = String40.str_5597
+
+@ExperimentalResourceApi
+internal val Res.string.str_5598: StringResource
+  get() = String40.str_5598
+
+@ExperimentalResourceApi
+internal val Res.string.str_5599: StringResource
+  get() = String40.str_5599
+
+@ExperimentalResourceApi
+internal val Res.string.str_56: StringResource
+  get() = String40.str_56
+
+@ExperimentalResourceApi
+internal val Res.string.str_560: StringResource
+  get() = String40.str_560
+
+@ExperimentalResourceApi
+internal val Res.string.str_5600: StringResource
+  get() = String40.str_5600
+
+@ExperimentalResourceApi
+internal val Res.string.str_5601: StringResource
+  get() = String40.str_5601
+
+@ExperimentalResourceApi
+internal val Res.string.str_5602: StringResource
+  get() = String40.str_5602
+
+@ExperimentalResourceApi
+internal val Res.string.str_5603: StringResource
+  get() = String40.str_5603
+
+@ExperimentalResourceApi
+internal val Res.string.str_5604: StringResource
+  get() = String40.str_5604
+
+@ExperimentalResourceApi
+internal val Res.string.str_5605: StringResource
+  get() = String40.str_5605
+
+@ExperimentalResourceApi
+internal val Res.string.str_5606: StringResource
+  get() = String40.str_5606
+
+@ExperimentalResourceApi
+internal val Res.string.str_5607: StringResource
+  get() = String40.str_5607
+
+@ExperimentalResourceApi
+internal val Res.string.str_5608: StringResource
+  get() = String40.str_5608
+
+@ExperimentalResourceApi
+internal val Res.string.str_5609: StringResource
+  get() = String40.str_5609
+
+@ExperimentalResourceApi
+internal val Res.string.str_561: StringResource
+  get() = String40.str_561
+
+@ExperimentalResourceApi
+internal val Res.string.str_5610: StringResource
+  get() = String40.str_5610
+
+@ExperimentalResourceApi
+internal val Res.string.str_5611: StringResource
+  get() = String40.str_5611
+
+@ExperimentalResourceApi
+internal val Res.string.str_5612: StringResource
+  get() = String40.str_5612
+
+@ExperimentalResourceApi
+internal val Res.string.str_5613: StringResource
+  get() = String40.str_5613
+
+@ExperimentalResourceApi
+internal val Res.string.str_5614: StringResource
+  get() = String40.str_5614
+
+@ExperimentalResourceApi
+internal val Res.string.str_5615: StringResource
+  get() = String40.str_5615
+
+@ExperimentalResourceApi
+internal val Res.string.str_5616: StringResource
+  get() = String40.str_5616
+
+@ExperimentalResourceApi
+internal val Res.string.str_5617: StringResource
+  get() = String40.str_5617
+
+@ExperimentalResourceApi
+internal val Res.string.str_5618: StringResource
+  get() = String40.str_5618
+
+@ExperimentalResourceApi
+internal val Res.string.str_5619: StringResource
+  get() = String40.str_5619
+
+@ExperimentalResourceApi
+internal val Res.string.str_562: StringResource
+  get() = String40.str_562
+
+@ExperimentalResourceApi
+internal val Res.string.str_5620: StringResource
+  get() = String40.str_5620
+
+@ExperimentalResourceApi
+internal val Res.string.str_5621: StringResource
+  get() = String40.str_5621
+
+@ExperimentalResourceApi
+internal val Res.string.str_5622: StringResource
+  get() = String40.str_5622
+
+@ExperimentalResourceApi
+internal val Res.string.str_5623: StringResource
+  get() = String40.str_5623
+
+@ExperimentalResourceApi
+internal val Res.string.str_5624: StringResource
+  get() = String40.str_5624
+
+@ExperimentalResourceApi
+internal val Res.string.str_5625: StringResource
+  get() = String40.str_5625
+
+@ExperimentalResourceApi
+internal val Res.string.str_5626: StringResource
+  get() = String40.str_5626
+
+@ExperimentalResourceApi
+internal val Res.string.str_5627: StringResource
+  get() = String40.str_5627
+
+@ExperimentalResourceApi
+internal val Res.string.str_5628: StringResource
+  get() = String40.str_5628
+
+@ExperimentalResourceApi
+internal val Res.string.str_5629: StringResource
+  get() = String40.str_5629
+
+@ExperimentalResourceApi
+internal val Res.string.str_563: StringResource
+  get() = String40.str_563
+
+@ExperimentalResourceApi
+internal val Res.string.str_5630: StringResource
+  get() = String40.str_5630
+
+@ExperimentalResourceApi
+internal val Res.string.str_5631: StringResource
+  get() = String40.str_5631
+
+@ExperimentalResourceApi
+internal val Res.string.str_5632: StringResource
+  get() = String40.str_5632
+
+@ExperimentalResourceApi
+internal val Res.string.str_5633: StringResource
+  get() = String40.str_5633
+
+@ExperimentalResourceApi
+internal val Res.string.str_5634: StringResource
+  get() = String40.str_5634
+
+@ExperimentalResourceApi
+internal val Res.string.str_5635: StringResource
+  get() = String40.str_5635
+
+@ExperimentalResourceApi
+internal val Res.string.str_5636: StringResource
+  get() = String40.str_5636
+
+@ExperimentalResourceApi
+internal val Res.string.str_5637: StringResource
+  get() = String40.str_5637
+
+@ExperimentalResourceApi
+internal val Res.string.str_5638: StringResource
+  get() = String40.str_5638
+
+@ExperimentalResourceApi
+internal val Res.string.str_5639: StringResource
+  get() = String40.str_5639
+
+@ExperimentalResourceApi
+internal val Res.string.str_564: StringResource
+  get() = String40.str_564
+
+@ExperimentalResourceApi
+internal val Res.string.str_5640: StringResource
+  get() = String40.str_5640
+
+@ExperimentalResourceApi
+internal val Res.string.str_5641: StringResource
+  get() = String40.str_5641
+
+@ExperimentalResourceApi
+internal val Res.string.str_5642: StringResource
+  get() = String40.str_5642
+
+@ExperimentalResourceApi
+internal val Res.string.str_5643: StringResource
+  get() = String40.str_5643
+
+@ExperimentalResourceApi
+internal val Res.string.str_5644: StringResource
+  get() = String40.str_5644
+
+@ExperimentalResourceApi
+internal val Res.string.str_5645: StringResource
+  get() = String40.str_5645
+
+@ExperimentalResourceApi
+internal val Res.string.str_5646: StringResource
+  get() = String40.str_5646
+
+@ExperimentalResourceApi
+internal val Res.string.str_5647: StringResource
+  get() = String40.str_5647
+
+@ExperimentalResourceApi
+internal val Res.string.str_5648: StringResource
+  get() = String40.str_5648
+
+@ExperimentalResourceApi
+internal val Res.string.str_5649: StringResource
+  get() = String40.str_5649
+
+@ExperimentalResourceApi
+internal val Res.string.str_565: StringResource
+  get() = String40.str_565
+
+@ExperimentalResourceApi
+internal val Res.string.str_5650: StringResource
+  get() = String40.str_5650
+
+@ExperimentalResourceApi
+internal val Res.string.str_5651: StringResource
+  get() = String40.str_5651
+
+@ExperimentalResourceApi
+internal val Res.string.str_5652: StringResource
+  get() = String40.str_5652
+
+@ExperimentalResourceApi
+internal val Res.string.str_5653: StringResource
+  get() = String40.str_5653
+
+@ExperimentalResourceApi
+internal val Res.string.str_5654: StringResource
+  get() = String40.str_5654
+
+@ExperimentalResourceApi
+internal val Res.string.str_5655: StringResource
+  get() = String40.str_5655
+
+@ExperimentalResourceApi
+internal val Res.string.str_5656: StringResource
+  get() = String40.str_5656
+
+@ExperimentalResourceApi
+internal val Res.string.str_5657: StringResource
+  get() = String40.str_5657
+
+@ExperimentalResourceApi
+internal val Res.string.str_5658: StringResource
+  get() = String40.str_5658
+
+@ExperimentalResourceApi
+internal val Res.string.str_5659: StringResource
+  get() = String40.str_5659
+
+@ExperimentalResourceApi
+internal val Res.string.str_566: StringResource
+  get() = String40.str_566
+
+@ExperimentalResourceApi
+internal val Res.string.str_5660: StringResource
+  get() = String40.str_5660
+
+@ExperimentalResourceApi
+internal val Res.string.str_5661: StringResource
+  get() = String40.str_5661
+
+@ExperimentalResourceApi
+internal val Res.string.str_5662: StringResource
+  get() = String40.str_5662
+
+@ExperimentalResourceApi
+internal val Res.string.str_5663: StringResource
+  get() = String40.str_5663
+
+@ExperimentalResourceApi
+internal val Res.string.str_5664: StringResource
+  get() = String40.str_5664
+
+@ExperimentalResourceApi
+internal val Res.string.str_5665: StringResource
+  get() = String40.str_5665
+
+@ExperimentalResourceApi
+internal val Res.string.str_5666: StringResource
+  get() = String40.str_5666
+
+@ExperimentalResourceApi
+internal val Res.string.str_5667: StringResource
+  get() = String40.str_5667
+
+@ExperimentalResourceApi
+internal val Res.string.str_5668: StringResource
+  get() = String40.str_5668
+
+@ExperimentalResourceApi
+internal val Res.string.str_5669: StringResource
+  get() = String40.str_5669
+
+@ExperimentalResourceApi
+internal val Res.string.str_567: StringResource
+  get() = String40.str_567
+
+@ExperimentalResourceApi
+internal val Res.string.str_5670: StringResource
+  get() = String40.str_5670
+
+@ExperimentalResourceApi
+internal val Res.string.str_5671: StringResource
+  get() = String40.str_5671
+
+@ExperimentalResourceApi
+internal val Res.string.str_5672: StringResource
+  get() = String40.str_5672
+
+@ExperimentalResourceApi
+internal val Res.string.str_5673: StringResource
+  get() = String40.str_5673
+
+@ExperimentalResourceApi
+internal val Res.string.str_5674: StringResource
+  get() = String40.str_5674
+
+@ExperimentalResourceApi
+internal val Res.string.str_5675: StringResource
+  get() = String40.str_5675
+
+@ExperimentalResourceApi
+internal val Res.string.str_5676: StringResource
+  get() = String40.str_5676
+
+@ExperimentalResourceApi
+internal val Res.string.str_5677: StringResource
+  get() = String40.str_5677
+
+@ExperimentalResourceApi
+internal val Res.string.str_5678: StringResource
+  get() = String40.str_5678
+
+@ExperimentalResourceApi
+internal val Res.string.str_5679: StringResource
+  get() = String40.str_5679
+
+@ExperimentalResourceApi
+internal val Res.string.str_568: StringResource
+  get() = String40.str_568
+
+@ExperimentalResourceApi
+internal val Res.string.str_5680: StringResource
+  get() = String40.str_5680
+
+@ExperimentalResourceApi
+internal val Res.string.str_5681: StringResource
+  get() = String40.str_5681
+
+@ExperimentalResourceApi
+internal val Res.string.str_5682: StringResource
+  get() = String40.str_5682
+
+@ExperimentalResourceApi
+internal val Res.string.str_5683: StringResource
+  get() = String40.str_5683
+
+@ExperimentalResourceApi
+internal val Res.string.str_5684: StringResource
+  get() = String40.str_5684
+
+@ExperimentalResourceApi
+internal val Res.string.str_5685: StringResource
+  get() = String40.str_5685
+
+@ExperimentalResourceApi
+internal val Res.string.str_5686: StringResource
+  get() = String40.str_5686
+
+@ExperimentalResourceApi
+internal val Res.string.str_5687: StringResource
+  get() = String40.str_5687
+
+@ExperimentalResourceApi
+internal val Res.string.str_5688: StringResource
+  get() = String40.str_5688
+
+@ExperimentalResourceApi
+internal val Res.string.str_5689: StringResource
+  get() = String40.str_5689
+
+@ExperimentalResourceApi
+internal val Res.string.str_569: StringResource
+  get() = String40.str_569
+
+@ExperimentalResourceApi
+internal val Res.string.str_5690: StringResource
+  get() = String40.str_5690
+
+@ExperimentalResourceApi
+internal val Res.string.str_5691: StringResource
+  get() = String40.str_5691
+
+@ExperimentalResourceApi
+internal val Res.string.str_5692: StringResource
+  get() = String40.str_5692
+
+@ExperimentalResourceApi
+internal val Res.string.str_5693: StringResource
+  get() = String40.str_5693
+
+@ExperimentalResourceApi
+internal val Res.string.str_5694: StringResource
+  get() = String40.str_5694
+
+@ExperimentalResourceApi
+internal val Res.string.str_5695: StringResource
+  get() = String40.str_5695
+
+@ExperimentalResourceApi
+internal val Res.string.str_5696: StringResource
+  get() = String40.str_5696
+
+@ExperimentalResourceApi
+internal val Res.string.str_5697: StringResource
+  get() = String40.str_5697
+
+@ExperimentalResourceApi
+internal val Res.string.str_5698: StringResource
+  get() = String40.str_5698
+
+@ExperimentalResourceApi
+internal val Res.string.str_5699: StringResource
+  get() = String40.str_5699
+
+@ExperimentalResourceApi
+internal val Res.string.str_57: StringResource
+  get() = String40.str_57
+
+@ExperimentalResourceApi
+internal val Res.string.str_570: StringResource
+  get() = String40.str_570
+
+@ExperimentalResourceApi
+internal val Res.string.str_5700: StringResource
+  get() = String40.str_5700
+
+@ExperimentalResourceApi
+internal val Res.string.str_5701: StringResource
+  get() = String40.str_5701
+
+@ExperimentalResourceApi
+internal val Res.string.str_5702: StringResource
+  get() = String40.str_5702
+
+@ExperimentalResourceApi
+internal val Res.string.str_5703: StringResource
+  get() = String40.str_5703
+
+@ExperimentalResourceApi
+internal val Res.string.str_5704: StringResource
+  get() = String40.str_5704
+
+@ExperimentalResourceApi
+internal val Res.string.str_5705: StringResource
+  get() = String40.str_5705
+
+@ExperimentalResourceApi
+internal val Res.string.str_5706: StringResource
+  get() = String40.str_5706
+
+@ExperimentalResourceApi
+internal val Res.string.str_5707: StringResource
+  get() = String40.str_5707
+
+@ExperimentalResourceApi
+internal val Res.string.str_5708: StringResource
+  get() = String40.str_5708
+
+@ExperimentalResourceApi
+internal val Res.string.str_5709: StringResource
+  get() = String40.str_5709
+
+@ExperimentalResourceApi
+internal val Res.string.str_571: StringResource
+  get() = String40.str_571
+
+@ExperimentalResourceApi
+internal val Res.string.str_5710: StringResource
+  get() = String40.str_5710
+
+@ExperimentalResourceApi
+internal val Res.string.str_5711: StringResource
+  get() = String40.str_5711
+
+@ExperimentalResourceApi
+internal val Res.string.str_5712: StringResource
+  get() = String40.str_5712
+
+@ExperimentalResourceApi
+internal val Res.string.str_5713: StringResource
+  get() = String40.str_5713
+
+@ExperimentalResourceApi
+internal val Res.string.str_5714: StringResource
+  get() = String40.str_5714
+
+@ExperimentalResourceApi
+internal val Res.string.str_5715: StringResource
+  get() = String40.str_5715
+
+@ExperimentalResourceApi
+internal val Res.string.str_5716: StringResource
+  get() = String40.str_5716
+
+@ExperimentalResourceApi
+internal val Res.string.str_5717: StringResource
+  get() = String40.str_5717
+
+@ExperimentalResourceApi
+internal val Res.string.str_5718: StringResource
+  get() = String40.str_5718
+
+@ExperimentalResourceApi
+internal val Res.string.str_5719: StringResource
+  get() = String40.str_5719
+
+@ExperimentalResourceApi
+internal val Res.string.str_572: StringResource
+  get() = String40.str_572
+
+@ExperimentalResourceApi
+internal val Res.string.str_5720: StringResource
+  get() = String40.str_5720
+
+@ExperimentalResourceApi
+internal val Res.string.str_5721: StringResource
+  get() = String40.str_5721
+
+@ExperimentalResourceApi
+internal val Res.string.str_5722: StringResource
+  get() = String40.str_5722
+
+@ExperimentalResourceApi
+internal val Res.string.str_5723: StringResource
+  get() = String40.str_5723
+
+@ExperimentalResourceApi
+internal val Res.string.str_5724: StringResource
+  get() = String40.str_5724
+
+@ExperimentalResourceApi
+internal val Res.string.str_5725: StringResource
+  get() = String40.str_5725
+
+@ExperimentalResourceApi
+internal val Res.string.str_5726: StringResource
+  get() = String40.str_5726
+
+@ExperimentalResourceApi
+internal val Res.string.str_5727: StringResource
+  get() = String40.str_5727
+
+@ExperimentalResourceApi
+internal val Res.string.str_5728: StringResource
+  get() = String40.str_5728
+
+@ExperimentalResourceApi
+internal val Res.string.str_5729: StringResource
+  get() = String40.str_5729
+
+@ExperimentalResourceApi
+internal val Res.string.str_573: StringResource
+  get() = String40.str_573
+
+@ExperimentalResourceApi
+internal val Res.string.str_5730: StringResource
+  get() = String40.str_5730
+
+@ExperimentalResourceApi
+internal val Res.string.str_5731: StringResource
+  get() = String40.str_5731
+
+@ExperimentalResourceApi
+internal val Res.string.str_5732: StringResource
+  get() = String40.str_5732
+
+@ExperimentalResourceApi
+internal val Res.string.str_5733: StringResource
+  get() = String40.str_5733
+
+@ExperimentalResourceApi
+internal val Res.string.str_5734: StringResource
+  get() = String40.str_5734
+
+@ExperimentalResourceApi
+internal val Res.string.str_5735: StringResource
+  get() = String40.str_5735
+
+@ExperimentalResourceApi
+internal val Res.string.str_5736: StringResource
+  get() = String40.str_5736
+
+@ExperimentalResourceApi
+internal val Res.string.str_5737: StringResource
+  get() = String40.str_5737
+
+@ExperimentalResourceApi
+internal val Res.string.str_5738: StringResource
+  get() = String40.str_5738
+
+@ExperimentalResourceApi
+internal val Res.string.str_5739: StringResource
+  get() = String40.str_5739
+
+@ExperimentalResourceApi
+internal val Res.string.str_574: StringResource
+  get() = String40.str_574
+
+@ExperimentalResourceApi
+internal val Res.string.str_5740: StringResource
+  get() = String40.str_5740
+
+@ExperimentalResourceApi
+internal val Res.string.str_5741: StringResource
+  get() = String40.str_5741
+
+@ExperimentalResourceApi
+internal val Res.string.str_5742: StringResource
+  get() = String40.str_5742
+
+@ExperimentalResourceApi
+internal val Res.string.str_5743: StringResource
+  get() = String40.str_5743
+
+@ExperimentalResourceApi
+internal val Res.string.str_5744: StringResource
+  get() = String40.str_5744
+
+@ExperimentalResourceApi
+internal val Res.string.str_5745: StringResource
+  get() = String40.str_5745
+
+@ExperimentalResourceApi
+internal val Res.string.str_5746: StringResource
+  get() = String40.str_5746
+
+@ExperimentalResourceApi
+internal val Res.string.str_5747: StringResource
+  get() = String40.str_5747
+
+@ExperimentalResourceApi
+internal val Res.string.str_5748: StringResource
+  get() = String40.str_5748
+
+@ExperimentalResourceApi
+internal val Res.string.str_5749: StringResource
+  get() = String40.str_5749
+
+@ExperimentalResourceApi
+internal val Res.string.str_575: StringResource
+  get() = String40.str_575
+
+@ExperimentalResourceApi
+internal val Res.string.str_5750: StringResource
+  get() = String40.str_5750
+
+@ExperimentalResourceApi
+internal val Res.string.str_5751: StringResource
+  get() = String40.str_5751
+
+@ExperimentalResourceApi
+internal val Res.string.str_5752: StringResource
+  get() = String40.str_5752
+
+@ExperimentalResourceApi
+internal val Res.string.str_5753: StringResource
+  get() = String40.str_5753
+
+@ExperimentalResourceApi
+internal val Res.string.str_5754: StringResource
+  get() = String40.str_5754
+
+@ExperimentalResourceApi
+internal val Res.string.str_5755: StringResource
+  get() = String40.str_5755
+
+@ExperimentalResourceApi
+internal val Res.string.str_5756: StringResource
+  get() = String40.str_5756
+
+@ExperimentalResourceApi
+internal val Res.string.str_5757: StringResource
+  get() = String40.str_5757
+
+@ExperimentalResourceApi
+internal val Res.string.str_5758: StringResource
+  get() = String40.str_5758
+
+@ExperimentalResourceApi
+internal val Res.string.str_5759: StringResource
+  get() = String40.str_5759
+
+@ExperimentalResourceApi
+internal val Res.string.str_576: StringResource
+  get() = String40.str_576
+
+@ExperimentalResourceApi
+internal val Res.string.str_5760: StringResource
+  get() = String40.str_5760
+
+@ExperimentalResourceApi
+internal val Res.string.str_5761: StringResource
+  get() = String40.str_5761
+
+@ExperimentalResourceApi
+internal val Res.string.str_5762: StringResource
+  get() = String40.str_5762
+
+@ExperimentalResourceApi
+internal val Res.string.str_5763: StringResource
+  get() = String40.str_5763
+
+@ExperimentalResourceApi
+internal val Res.string.str_5764: StringResource
+  get() = String40.str_5764
+
+@ExperimentalResourceApi
+internal val Res.string.str_5765: StringResource
+  get() = String40.str_5765
+
+@ExperimentalResourceApi
+internal val Res.string.str_5766: StringResource
+  get() = String40.str_5766
+
+@ExperimentalResourceApi
+internal val Res.string.str_5767: StringResource
+  get() = String40.str_5767
+
+@ExperimentalResourceApi
+internal val Res.string.str_5768: StringResource
+  get() = String40.str_5768
+
+@ExperimentalResourceApi
+internal val Res.string.str_5769: StringResource
+  get() = String40.str_5769
+
+@ExperimentalResourceApi
+internal val Res.string.str_577: StringResource
+  get() = String40.str_577
+
+@ExperimentalResourceApi
+internal val Res.string.str_5770: StringResource
+  get() = String40.str_5770
+
+@ExperimentalResourceApi
+internal val Res.string.str_5771: StringResource
+  get() = String40.str_5771
+
+@ExperimentalResourceApi
+internal val Res.string.str_5772: StringResource
+  get() = String40.str_5772
+
+@ExperimentalResourceApi
+internal val Res.string.str_5773: StringResource
+  get() = String40.str_5773
+
+@ExperimentalResourceApi
+internal val Res.string.str_5774: StringResource
+  get() = String40.str_5774
+
+@ExperimentalResourceApi
+internal val Res.string.str_5775: StringResource
+  get() = String40.str_5775
+
+@ExperimentalResourceApi
+internal val Res.string.str_5776: StringResource
+  get() = String40.str_5776
+
+@ExperimentalResourceApi
+internal val Res.string.str_5777: StringResource
+  get() = String40.str_5777
+
+@ExperimentalResourceApi
+internal val Res.string.str_5778: StringResource
+  get() = String40.str_5778
+
+@ExperimentalResourceApi
+internal val Res.string.str_5779: StringResource
+  get() = String40.str_5779
+
+@ExperimentalResourceApi
+internal val Res.string.str_578: StringResource
+  get() = String40.str_578
+
+@ExperimentalResourceApi
+internal val Res.string.str_5780: StringResource
+  get() = String40.str_5780
+
+@ExperimentalResourceApi
+internal val Res.string.str_5781: StringResource
+  get() = String40.str_5781
+
+@ExperimentalResourceApi
+internal val Res.string.str_5782: StringResource
+  get() = String40.str_5782
+
+@ExperimentalResourceApi
+internal val Res.string.str_5783: StringResource
+  get() = String40.str_5783
+
+@ExperimentalResourceApi
+internal val Res.string.str_5784: StringResource
+  get() = String40.str_5784
+
+@ExperimentalResourceApi
+internal val Res.string.str_5785: StringResource
+  get() = String40.str_5785
+
+@ExperimentalResourceApi
+internal val Res.string.str_5786: StringResource
+  get() = String40.str_5786
+
+@ExperimentalResourceApi
+internal val Res.string.str_5787: StringResource
+  get() = String40.str_5787
+
+@ExperimentalResourceApi
+internal val Res.string.str_5788: StringResource
+  get() = String40.str_5788
+
+@ExperimentalResourceApi
+internal val Res.string.str_5789: StringResource
+  get() = String40.str_5789
+
+@ExperimentalResourceApi
+internal val Res.string.str_579: StringResource
+  get() = String40.str_579
+
+@ExperimentalResourceApi
+internal val Res.string.str_5790: StringResource
+  get() = String40.str_5790
+
+@ExperimentalResourceApi
+internal val Res.string.str_5791: StringResource
+  get() = String40.str_5791
+
+@ExperimentalResourceApi
+internal val Res.string.str_5792: StringResource
+  get() = String40.str_5792
+
+@ExperimentalResourceApi
+internal val Res.string.str_5793: StringResource
+  get() = String40.str_5793
+
+@ExperimentalResourceApi
+internal val Res.string.str_5794: StringResource
+  get() = String40.str_5794
+
+@ExperimentalResourceApi
+internal val Res.string.str_5795: StringResource
+  get() = String40.str_5795
+
+@ExperimentalResourceApi
+internal val Res.string.str_5796: StringResource
+  get() = String40.str_5796
+
+@ExperimentalResourceApi
+internal val Res.string.str_5797: StringResource
+  get() = String40.str_5797
+
+@ExperimentalResourceApi
+internal val Res.string.str_5798: StringResource
+  get() = String40.str_5798
+
+@ExperimentalResourceApi
+internal val Res.string.str_5799: StringResource
+  get() = String40.str_5799
+
+@ExperimentalResourceApi
+internal val Res.string.str_58: StringResource
+  get() = String40.str_58
+
+@ExperimentalResourceApi
+internal val Res.string.str_580: StringResource
+  get() = String40.str_580
+
+@ExperimentalResourceApi
+internal val Res.string.str_5800: StringResource
+  get() = String40.str_5800
+
+@ExperimentalResourceApi
+internal val Res.string.str_5801: StringResource
+  get() = String40.str_5801
+
+@ExperimentalResourceApi
+internal val Res.string.str_5802: StringResource
+  get() = String40.str_5802
+
+@ExperimentalResourceApi
+internal val Res.string.str_5803: StringResource
+  get() = String40.str_5803
+
+@ExperimentalResourceApi
+internal val Res.string.str_5804: StringResource
+  get() = String40.str_5804
+
+@ExperimentalResourceApi
+internal val Res.string.str_5805: StringResource
+  get() = String40.str_5805
+
+@ExperimentalResourceApi
+internal val Res.string.str_5806: StringResource
+  get() = String40.str_5806
+
+@ExperimentalResourceApi
+internal val Res.string.str_5807: StringResource
+  get() = String40.str_5807
+
+@ExperimentalResourceApi
+internal val Res.string.str_5808: StringResource
+  get() = String40.str_5808
+
+@ExperimentalResourceApi
+internal val Res.string.str_5809: StringResource
+  get() = String40.str_5809
+
+@ExperimentalResourceApi
+internal val Res.string.str_581: StringResource
+  get() = String40.str_581
+
+@ExperimentalResourceApi
+internal val Res.string.str_5810: StringResource
+  get() = String40.str_5810
+
+@ExperimentalResourceApi
+internal val Res.string.str_5811: StringResource
+  get() = String40.str_5811
+
+@ExperimentalResourceApi
+internal val Res.string.str_5812: StringResource
+  get() = String40.str_5812
+
+@ExperimentalResourceApi
+internal val Res.string.str_5813: StringResource
+  get() = String40.str_5813
+
+@ExperimentalResourceApi
+internal val Res.string.str_5814: StringResource
+  get() = String40.str_5814
+
+@ExperimentalResourceApi
+internal val Res.string.str_5815: StringResource
+  get() = String40.str_5815
+
+@ExperimentalResourceApi
+internal val Res.string.str_5816: StringResource
+  get() = String40.str_5816
+
+@ExperimentalResourceApi
+internal val Res.string.str_5817: StringResource
+  get() = String40.str_5817
+
+@ExperimentalResourceApi
+internal val Res.string.str_5818: StringResource
+  get() = String40.str_5818
+
+@ExperimentalResourceApi
+internal val Res.string.str_5819: StringResource
+  get() = String40.str_5819
+
+@ExperimentalResourceApi
+internal val Res.string.str_582: StringResource
+  get() = String40.str_582
+
+@ExperimentalResourceApi
+internal val Res.string.str_5820: StringResource
+  get() = String40.str_5820
+
+@ExperimentalResourceApi
+internal val Res.string.str_5821: StringResource
+  get() = String40.str_5821
+
+@ExperimentalResourceApi
+internal val Res.string.str_5822: StringResource
+  get() = String40.str_5822
+
+@ExperimentalResourceApi
+internal val Res.string.str_5823: StringResource
+  get() = String40.str_5823
+
+@ExperimentalResourceApi
+internal val Res.string.str_5824: StringResource
+  get() = String40.str_5824
+
+@ExperimentalResourceApi
+internal val Res.string.str_5825: StringResource
+  get() = String40.str_5825
+
+@ExperimentalResourceApi
+internal val Res.string.str_5826: StringResource
+  get() = String40.str_5826
+
+@ExperimentalResourceApi
+internal val Res.string.str_5827: StringResource
+  get() = String40.str_5827
+
+@ExperimentalResourceApi
+internal val Res.string.str_5828: StringResource
+  get() = String40.str_5828
+
+@ExperimentalResourceApi
+internal val Res.string.str_5829: StringResource
+  get() = String40.str_5829
+
+@ExperimentalResourceApi
+internal val Res.string.str_583: StringResource
+  get() = String40.str_583
+
+@ExperimentalResourceApi
+internal val Res.string.str_5830: StringResource
+  get() = String40.str_5830
+
+@ExperimentalResourceApi
+internal val Res.string.str_5831: StringResource
+  get() = String40.str_5831
+
+@ExperimentalResourceApi
+internal val Res.string.str_5832: StringResource
+  get() = String40.str_5832
+
+@ExperimentalResourceApi
+internal val Res.string.str_5833: StringResource
+  get() = String40.str_5833
+
+@ExperimentalResourceApi
+internal val Res.string.str_5834: StringResource
+  get() = String40.str_5834
+
+@ExperimentalResourceApi
+internal val Res.string.str_5835: StringResource
+  get() = String40.str_5835
+
+@ExperimentalResourceApi
+internal val Res.string.str_5836: StringResource
+  get() = String40.str_5836
+
+@ExperimentalResourceApi
+internal val Res.string.str_5837: StringResource
+  get() = String40.str_5837
+
+@ExperimentalResourceApi
+internal val Res.string.str_5838: StringResource
+  get() = String40.str_5838
+
+@ExperimentalResourceApi
+internal val Res.string.str_5839: StringResource
+  get() = String40.str_5839
+
+@ExperimentalResourceApi
+internal val Res.string.str_584: StringResource
+  get() = String40.str_584
+
+@ExperimentalResourceApi
+internal val Res.string.str_5840: StringResource
+  get() = String40.str_5840
+
+@ExperimentalResourceApi
+internal val Res.string.str_5841: StringResource
+  get() = String40.str_5841
+
+@ExperimentalResourceApi
+internal val Res.string.str_5842: StringResource
+  get() = String40.str_5842
+
+@ExperimentalResourceApi
+internal val Res.string.str_5843: StringResource
+  get() = String40.str_5843
+
+@ExperimentalResourceApi
+internal val Res.string.str_5844: StringResource
+  get() = String40.str_5844
+
+@ExperimentalResourceApi
+internal val Res.string.str_5845: StringResource
+  get() = String40.str_5845
+
+@ExperimentalResourceApi
+internal val Res.string.str_5846: StringResource
+  get() = String40.str_5846
+
+@ExperimentalResourceApi
+internal val Res.string.str_5847: StringResource
+  get() = String40.str_5847
+
+@ExperimentalResourceApi
+internal val Res.string.str_5848: StringResource
+  get() = String40.str_5848
+
+@ExperimentalResourceApi
+internal val Res.string.str_5849: StringResource
+  get() = String40.str_5849
+
+@ExperimentalResourceApi
+internal val Res.string.str_585: StringResource
+  get() = String40.str_585
+
+@ExperimentalResourceApi
+internal val Res.string.str_5850: StringResource
+  get() = String40.str_5850
+
+@ExperimentalResourceApi
+internal val Res.string.str_5851: StringResource
+  get() = String40.str_5851
+
+@ExperimentalResourceApi
+internal val Res.string.str_5852: StringResource
+  get() = String40.str_5852
+
+@ExperimentalResourceApi
+internal val Res.string.str_5853: StringResource
+  get() = String40.str_5853
+
+@ExperimentalResourceApi
+internal val Res.string.str_5854: StringResource
+  get() = String40.str_5854
+
+@ExperimentalResourceApi
+internal val Res.string.str_5855: StringResource
+  get() = String40.str_5855
+
+@ExperimentalResourceApi
+internal val Res.string.str_5856: StringResource
+  get() = String40.str_5856
+
+@ExperimentalResourceApi
+internal val Res.string.str_5857: StringResource
+  get() = String40.str_5857
+
+@ExperimentalResourceApi
+internal val Res.string.str_5858: StringResource
+  get() = String40.str_5858
+
+@ExperimentalResourceApi
+internal val Res.string.str_5859: StringResource
+  get() = String40.str_5859
+
+@ExperimentalResourceApi
+internal val Res.string.str_586: StringResource
+  get() = String40.str_586
+
+@ExperimentalResourceApi
+internal val Res.string.str_5860: StringResource
+  get() = String40.str_5860
+
+@ExperimentalResourceApi
+internal val Res.string.str_5861: StringResource
+  get() = String40.str_5861
+
+@ExperimentalResourceApi
+internal val Res.string.str_5862: StringResource
+  get() = String40.str_5862
+
+@ExperimentalResourceApi
+internal val Res.string.str_5863: StringResource
+  get() = String40.str_5863
+
+@ExperimentalResourceApi
+internal val Res.string.str_5864: StringResource
+  get() = String40.str_5864
+
+@ExperimentalResourceApi
+internal val Res.string.str_5865: StringResource
+  get() = String40.str_5865
+
+@ExperimentalResourceApi
+internal val Res.string.str_5866: StringResource
+  get() = String40.str_5866
+
+@ExperimentalResourceApi
+internal val Res.string.str_5867: StringResource
+  get() = String40.str_5867
+
+@ExperimentalResourceApi
+internal val Res.string.str_5868: StringResource
+  get() = String40.str_5868
+
+@ExperimentalResourceApi
+internal val Res.string.str_5869: StringResource
+  get() = String40.str_5869
+
+@ExperimentalResourceApi
+internal val Res.string.str_587: StringResource
+  get() = String40.str_587
+
+@ExperimentalResourceApi
+internal val Res.string.str_5870: StringResource
+  get() = String40.str_5870
+
+@ExperimentalResourceApi
+internal val Res.string.str_5871: StringResource
+  get() = String40.str_5871
+
+@ExperimentalResourceApi
+internal val Res.string.str_5872: StringResource
+  get() = String40.str_5872
+
+@ExperimentalResourceApi
+internal val Res.string.str_5873: StringResource
+  get() = String40.str_5873
+
+@ExperimentalResourceApi
+internal val Res.string.str_5874: StringResource
+  get() = String40.str_5874
+
+@ExperimentalResourceApi
+internal val Res.string.str_5875: StringResource
+  get() = String40.str_5875
+
+@ExperimentalResourceApi
+internal val Res.string.str_5876: StringResource
+  get() = String40.str_5876
+
+@ExperimentalResourceApi
+internal val Res.string.str_5877: StringResource
+  get() = String40.str_5877
+
+@ExperimentalResourceApi
+internal val Res.string.str_5878: StringResource
+  get() = String40.str_5878
+
+@ExperimentalResourceApi
+internal val Res.string.str_5879: StringResource
+  get() = String40.str_5879
+
+@ExperimentalResourceApi
+internal val Res.string.str_588: StringResource
+  get() = String40.str_588
+
+@ExperimentalResourceApi
+internal val Res.string.str_5880: StringResource
+  get() = String40.str_5880
+
+@ExperimentalResourceApi
+internal val Res.string.str_5881: StringResource
+  get() = String40.str_5881
+
+@ExperimentalResourceApi
+internal val Res.string.str_5882: StringResource
+  get() = String40.str_5882
+
+@ExperimentalResourceApi
+internal val Res.string.str_5883: StringResource
+  get() = String40.str_5883
+
+@ExperimentalResourceApi
+internal val Res.string.str_5884: StringResource
+  get() = String40.str_5884
+
+@ExperimentalResourceApi
+internal val Res.string.str_5885: StringResource
+  get() = String40.str_5885
+
+@ExperimentalResourceApi
+internal val Res.string.str_5886: StringResource
+  get() = String40.str_5886
+
+@ExperimentalResourceApi
+internal val Res.string.str_5887: StringResource
+  get() = String40.str_5887
+
+@ExperimentalResourceApi
+internal val Res.string.str_5888: StringResource
+  get() = String40.str_5888
+
+@ExperimentalResourceApi
+internal val Res.string.str_5889: StringResource
+  get() = String40.str_5889
+
+@ExperimentalResourceApi
+internal val Res.string.str_589: StringResource
+  get() = String40.str_589
+
+@ExperimentalResourceApi
+internal val Res.string.str_5890: StringResource
+  get() = String40.str_5890
+
+@ExperimentalResourceApi
+internal val Res.string.str_5891: StringResource
+  get() = String40.str_5891
+
+@ExperimentalResourceApi
+internal val Res.string.str_5892: StringResource
+  get() = String40.str_5892
+
+@ExperimentalResourceApi
+internal val Res.string.str_5893: StringResource
+  get() = String40.str_5893
+
+@ExperimentalResourceApi
+internal val Res.string.str_5894: StringResource
+  get() = String40.str_5894
+
+@ExperimentalResourceApi
+internal val Res.string.str_5895: StringResource
+  get() = String40.str_5895
+
+@ExperimentalResourceApi
+internal val Res.string.str_5896: StringResource
+  get() = String40.str_5896
+
+@ExperimentalResourceApi
+internal val Res.string.str_5897: StringResource
+  get() = String40.str_5897
+
+@ExperimentalResourceApi
+internal val Res.string.str_5898: StringResource
+  get() = String40.str_5898
+
+@ExperimentalResourceApi
+internal val Res.string.str_5899: StringResource
+  get() = String40.str_5899
+
+@ExperimentalResourceApi
+internal val Res.string.str_59: StringResource
+  get() = String40.str_59
+
+@ExperimentalResourceApi
+internal val Res.string.str_590: StringResource
+  get() = String40.str_590
+
+@ExperimentalResourceApi
+internal val Res.string.str_5900: StringResource
+  get() = String40.str_5900
+
+@ExperimentalResourceApi
+internal val Res.string.str_5901: StringResource
+  get() = String40.str_5901
+
+@ExperimentalResourceApi
+internal val Res.string.str_5902: StringResource
+  get() = String40.str_5902
+
+@ExperimentalResourceApi
+internal val Res.string.str_5903: StringResource
+  get() = String40.str_5903
+
+@ExperimentalResourceApi
+internal val Res.string.str_5904: StringResource
+  get() = String40.str_5904
+
+@ExperimentalResourceApi
+internal val Res.string.str_5905: StringResource
+  get() = String40.str_5905
+
+@ExperimentalResourceApi
+internal val Res.string.str_5906: StringResource
+  get() = String40.str_5906
+
+@ExperimentalResourceApi
+internal val Res.string.str_5907: StringResource
+  get() = String40.str_5907
+
+@ExperimentalResourceApi
+internal val Res.string.str_5908: StringResource
+  get() = String40.str_5908
+
+@ExperimentalResourceApi
+internal val Res.string.str_5909: StringResource
+  get() = String40.str_5909
+
+@ExperimentalResourceApi
+internal val Res.string.str_591: StringResource
+  get() = String40.str_591
+
+@ExperimentalResourceApi
+internal val Res.string.str_5910: StringResource
+  get() = String40.str_5910
+
+@ExperimentalResourceApi
+internal val Res.string.str_5911: StringResource
+  get() = String40.str_5911
+
+@ExperimentalResourceApi
+internal val Res.string.str_5912: StringResource
+  get() = String40.str_5912
+
+@ExperimentalResourceApi
+internal val Res.string.str_5913: StringResource
+  get() = String40.str_5913
+
+@ExperimentalResourceApi
+internal val Res.string.str_5914: StringResource
+  get() = String40.str_5914
+
+@ExperimentalResourceApi
+internal val Res.string.str_5915: StringResource
+  get() = String40.str_5915
+
+@ExperimentalResourceApi
+internal val Res.string.str_5916: StringResource
+  get() = String40.str_5916
+
+@ExperimentalResourceApi
+internal val Res.string.str_5917: StringResource
+  get() = String40.str_5917
+
+@ExperimentalResourceApi
+internal val Res.string.str_5918: StringResource
+  get() = String40.str_5918
+
+@ExperimentalResourceApi
+internal val Res.string.str_5919: StringResource
+  get() = String40.str_5919
+
+@ExperimentalResourceApi
+internal val Res.string.str_592: StringResource
+  get() = String40.str_592
+
+@ExperimentalResourceApi
+internal val Res.string.str_5920: StringResource
+  get() = String40.str_5920
+
+@ExperimentalResourceApi
+internal val Res.string.str_5921: StringResource
+  get() = String40.str_5921
+
+@ExperimentalResourceApi
+internal val Res.string.str_5922: StringResource
+  get() = String40.str_5922
+
+@ExperimentalResourceApi
+internal val Res.string.str_5923: StringResource
+  get() = String40.str_5923
+
+@ExperimentalResourceApi
+internal val Res.string.str_5924: StringResource
+  get() = String40.str_5924
+
+@ExperimentalResourceApi
+internal val Res.string.str_5925: StringResource
+  get() = String40.str_5925
+
+@ExperimentalResourceApi
+internal val Res.string.str_5926: StringResource
+  get() = String40.str_5926
+
+@ExperimentalResourceApi
+internal val Res.string.str_5927: StringResource
+  get() = String40.str_5927
+
+@ExperimentalResourceApi
+internal val Res.string.str_5928: StringResource
+  get() = String40.str_5928
+
+@ExperimentalResourceApi
+internal val Res.string.str_5929: StringResource
+  get() = String40.str_5929
+
+@ExperimentalResourceApi
+internal val Res.string.str_593: StringResource
+  get() = String40.str_593
+
+@ExperimentalResourceApi
+internal val Res.string.str_5930: StringResource
+  get() = String40.str_5930
+
+@ExperimentalResourceApi
+internal val Res.string.str_5931: StringResource
+  get() = String40.str_5931
+
+@ExperimentalResourceApi
+internal val Res.string.str_5932: StringResource
+  get() = String40.str_5932
+
+@ExperimentalResourceApi
+internal val Res.string.str_5933: StringResource
+  get() = String40.str_5933
+
+@ExperimentalResourceApi
+internal val Res.string.str_5934: StringResource
+  get() = String40.str_5934
+
+@ExperimentalResourceApi
+internal val Res.string.str_5935: StringResource
+  get() = String40.str_5935
+
+@ExperimentalResourceApi
+internal val Res.string.str_5936: StringResource
+  get() = String40.str_5936
+
+@ExperimentalResourceApi
+internal val Res.string.str_5937: StringResource
+  get() = String40.str_5937
+
+@ExperimentalResourceApi
+internal val Res.string.str_5938: StringResource
+  get() = String40.str_5938
+
+@ExperimentalResourceApi
+internal val Res.string.str_5939: StringResource
+  get() = String40.str_5939
+
+@ExperimentalResourceApi
+internal val Res.string.str_594: StringResource
+  get() = String40.str_594
+
+@ExperimentalResourceApi
+internal val Res.string.str_5940: StringResource
+  get() = String40.str_5940
+
+@ExperimentalResourceApi
+internal val Res.string.str_5941: StringResource
+  get() = String40.str_5941
+
+@ExperimentalResourceApi
+internal val Res.string.str_5942: StringResource
+  get() = String40.str_5942
+
+@ExperimentalResourceApi
+internal val Res.string.str_5943: StringResource
+  get() = String40.str_5943
+
+@ExperimentalResourceApi
+internal val Res.string.str_5944: StringResource
+  get() = String40.str_5944
+
+@ExperimentalResourceApi
+internal val Res.string.str_5945: StringResource
+  get() = String40.str_5945
+
+@ExperimentalResourceApi
+internal val Res.string.str_5946: StringResource
+  get() = String40.str_5946
+
+@ExperimentalResourceApi
+internal val Res.string.str_5947: StringResource
+  get() = String40.str_5947
+
+@ExperimentalResourceApi
+internal val Res.string.str_5948: StringResource
+  get() = String40.str_5948

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String41.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String41.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String41 {
+  public val str_5949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5949", "str_5949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_595", "str_595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5950", "str_5950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5951", "str_5951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5952", "str_5952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5953", "str_5953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5954", "str_5954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5955", "str_5955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5956", "str_5956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5957", "str_5957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5958", "str_5958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5959", "str_5959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_596", "str_596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5960", "str_5960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5961", "str_5961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5962", "str_5962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5963", "str_5963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5964", "str_5964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5965", "str_5965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5966", "str_5966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5967", "str_5967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5968", "str_5968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5969", "str_5969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_597", "str_597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5970", "str_5970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5971", "str_5971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5972", "str_5972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5973", "str_5973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5974", "str_5974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5975", "str_5975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5976", "str_5976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5977", "str_5977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5978", "str_5978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5979", "str_5979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_598", "str_598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5980", "str_5980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5981", "str_5981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5982", "str_5982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5983", "str_5983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5984", "str_5984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5985", "str_5985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5986", "str_5986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5987", "str_5987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5988", "str_5988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5989", "str_5989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_599", "str_599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5990", "str_5990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5991", "str_5991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5992", "str_5992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5993", "str_5993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5994", "str_5994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5995", "str_5995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5996", "str_5996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5997", "str_5997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5998", "str_5998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_5999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_5999", "str_5999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6", "str_6",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_60: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_60", "str_60",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_600", "str_600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6000", "str_6000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6001", "str_6001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6002", "str_6002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6003", "str_6003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6004", "str_6004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6005", "str_6005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6006", "str_6006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6007", "str_6007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6008", "str_6008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6009", "str_6009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_601", "str_601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6010", "str_6010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6011", "str_6011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6012", "str_6012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6013", "str_6013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6014", "str_6014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6015", "str_6015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6016", "str_6016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6017", "str_6017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6018", "str_6018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6019", "str_6019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_602", "str_602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6020", "str_6020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6021", "str_6021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6022", "str_6022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6023", "str_6023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6024", "str_6024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6025", "str_6025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6026", "str_6026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6027", "str_6027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6028", "str_6028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6029", "str_6029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_603", "str_603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6030", "str_6030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6031", "str_6031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6032", "str_6032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6033", "str_6033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6034", "str_6034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6035", "str_6035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6036", "str_6036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6037", "str_6037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6038", "str_6038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6039", "str_6039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_604", "str_604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6040", "str_6040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6041", "str_6041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6042", "str_6042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6043", "str_6043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6044", "str_6044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6045", "str_6045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6046", "str_6046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6047", "str_6047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6048", "str_6048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6049", "str_6049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_605", "str_605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6050", "str_6050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6051", "str_6051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6052", "str_6052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6053", "str_6053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6054", "str_6054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6055", "str_6055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6056", "str_6056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6057", "str_6057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6058", "str_6058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6059", "str_6059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_606", "str_606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6060", "str_6060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6061", "str_6061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6062", "str_6062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6063", "str_6063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6064", "str_6064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6065", "str_6065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6066", "str_6066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6067", "str_6067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6068", "str_6068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6069", "str_6069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_607", "str_607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6070", "str_6070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6071", "str_6071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6072", "str_6072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6073", "str_6073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6074", "str_6074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6075", "str_6075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6076", "str_6076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6077", "str_6077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6078", "str_6078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6079", "str_6079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_608", "str_608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6080", "str_6080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6081", "str_6081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6082", "str_6082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6083", "str_6083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6084", "str_6084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6085", "str_6085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6086", "str_6086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6087", "str_6087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6088", "str_6088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6089", "str_6089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_609", "str_609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6090", "str_6090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6091", "str_6091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6092", "str_6092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6093", "str_6093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6094", "str_6094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6095", "str_6095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6096", "str_6096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6097", "str_6097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6098", "str_6098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6099", "str_6099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_61: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_61", "str_61",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_610", "str_610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6100", "str_6100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6101", "str_6101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6102", "str_6102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6103", "str_6103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6104", "str_6104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6105", "str_6105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6106", "str_6106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6107", "str_6107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6108", "str_6108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6109", "str_6109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_611", "str_611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6110", "str_6110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6111", "str_6111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6112", "str_6112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6113", "str_6113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6114", "str_6114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6115", "str_6115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6116", "str_6116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6117", "str_6117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6118", "str_6118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6119", "str_6119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_612", "str_612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6120", "str_6120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6121", "str_6121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6122", "str_6122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6123", "str_6123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6124", "str_6124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6125", "str_6125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6126", "str_6126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6127", "str_6127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6128", "str_6128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6129", "str_6129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_613", "str_613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6130", "str_6130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6131", "str_6131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6132", "str_6132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6133", "str_6133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6134", "str_6134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6135", "str_6135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6136", "str_6136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6137", "str_6137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6138", "str_6138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6139", "str_6139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_614", "str_614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6140", "str_6140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6141", "str_6141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6142", "str_6142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6143", "str_6143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6144", "str_6144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6145", "str_6145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6146", "str_6146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6147", "str_6147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6148", "str_6148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6149", "str_6149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_615", "str_615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6150", "str_6150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6151", "str_6151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6152", "str_6152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6153", "str_6153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6154", "str_6154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6155", "str_6155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6156", "str_6156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6157", "str_6157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6158", "str_6158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6159", "str_6159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_616", "str_616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6160", "str_6160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6161", "str_6161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6162", "str_6162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6163", "str_6163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6164", "str_6164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6165", "str_6165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6166", "str_6166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6167", "str_6167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6168", "str_6168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6169", "str_6169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_617", "str_617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6170", "str_6170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6171", "str_6171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6172", "str_6172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6173", "str_6173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6174", "str_6174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6175", "str_6175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6176", "str_6176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6177", "str_6177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6178", "str_6178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6179", "str_6179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_618", "str_618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6180", "str_6180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6181", "str_6181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6182", "str_6182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6183", "str_6183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6184", "str_6184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6185", "str_6185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6186", "str_6186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6187", "str_6187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6188", "str_6188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6189", "str_6189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_619", "str_619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6190", "str_6190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6191", "str_6191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6192", "str_6192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6193", "str_6193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6194", "str_6194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6195", "str_6195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6196", "str_6196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6197", "str_6197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6198", "str_6198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6199", "str_6199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_62: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_62", "str_62",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_620", "str_620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6200", "str_6200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6201", "str_6201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6202", "str_6202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6203", "str_6203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6204", "str_6204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6205", "str_6205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6206", "str_6206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6207", "str_6207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6208", "str_6208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6209", "str_6209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_621", "str_621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6210", "str_6210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6211", "str_6211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6212", "str_6212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6213", "str_6213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6214", "str_6214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6215", "str_6215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6216", "str_6216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6217", "str_6217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6218", "str_6218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6219", "str_6219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_622", "str_622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6220", "str_6220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6221", "str_6221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6222", "str_6222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6223", "str_6223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6224", "str_6224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6225", "str_6225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6226", "str_6226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6227", "str_6227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6228", "str_6228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6229", "str_6229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_623", "str_623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6230", "str_6230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6231", "str_6231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6232", "str_6232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6233", "str_6233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6234", "str_6234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6235", "str_6235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6236", "str_6236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6237", "str_6237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6238", "str_6238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6239", "str_6239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_624", "str_624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6240", "str_6240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6241", "str_6241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6242", "str_6242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6243", "str_6243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6244", "str_6244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6245", "str_6245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6246", "str_6246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6247", "str_6247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6248", "str_6248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6249", "str_6249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_625", "str_625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6250", "str_6250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6251", "str_6251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6252", "str_6252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6253", "str_6253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6254", "str_6254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6255", "str_6255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6256", "str_6256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6257", "str_6257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6258", "str_6258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6259", "str_6259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_626", "str_626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6260", "str_6260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6261", "str_6261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6262", "str_6262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6263", "str_6263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6264", "str_6264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6265", "str_6265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6266", "str_6266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6267", "str_6267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6268", "str_6268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6269", "str_6269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_627", "str_627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6270", "str_6270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6271", "str_6271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6272", "str_6272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6273", "str_6273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6274", "str_6274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6275", "str_6275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6276", "str_6276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6277", "str_6277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6278", "str_6278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6279", "str_6279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_628", "str_628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6280", "str_6280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6281", "str_6281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6282", "str_6282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6283", "str_6283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6284", "str_6284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6285", "str_6285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6286", "str_6286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6287", "str_6287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6288", "str_6288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6289", "str_6289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_629", "str_629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6290", "str_6290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6291", "str_6291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6292", "str_6292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6293", "str_6293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6294", "str_6294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6295", "str_6295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6296", "str_6296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6297", "str_6297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6298", "str_6298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6299", "str_6299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_63: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_63", "str_63",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_630", "str_630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6300", "str_6300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6301", "str_6301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6302", "str_6302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6303", "str_6303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6304", "str_6304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6305", "str_6305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6306", "str_6306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6307", "str_6307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6308", "str_6308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6309", "str_6309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_631", "str_631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6310", "str_6310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6311", "str_6311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6312", "str_6312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6313", "str_6313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6314", "str_6314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6315", "str_6315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6316", "str_6316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6317", "str_6317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6318", "str_6318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6319", "str_6319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_632", "str_632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6320", "str_6320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6321", "str_6321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6322", "str_6322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6323", "str_6323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6324", "str_6324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6325", "str_6325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6326", "str_6326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6327", "str_6327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6328", "str_6328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6329", "str_6329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_633", "str_633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6330", "str_6330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6331", "str_6331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6332", "str_6332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6333", "str_6333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6334", "str_6334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6335", "str_6335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6336", "str_6336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6337", "str_6337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6338", "str_6338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6339", "str_6339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_634", "str_634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6340", "str_6340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6341", "str_6341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6342", "str_6342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6343", "str_6343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6344", "str_6344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6345", "str_6345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6346", "str_6346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6347", "str_6347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6348", "str_6348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6349", "str_6349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_635", "str_635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6350", "str_6350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6351", "str_6351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6352", "str_6352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6353", "str_6353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6354", "str_6354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6355", "str_6355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6356", "str_6356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6357", "str_6357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6358", "str_6358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6359", "str_6359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_636", "str_636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6360", "str_6360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6361", "str_6361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6362", "str_6362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6363", "str_6363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6364", "str_6364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6365", "str_6365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6366", "str_6366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6367", "str_6367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6368", "str_6368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6369", "str_6369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_637", "str_637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6370", "str_6370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6371", "str_6371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6372", "str_6372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6373", "str_6373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6374", "str_6374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6375", "str_6375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6376", "str_6376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6377", "str_6377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6378", "str_6378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6379", "str_6379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_638", "str_638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6380", "str_6380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6381", "str_6381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6382", "str_6382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6383", "str_6383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6384", "str_6384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6385", "str_6385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6386", "str_6386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6387", "str_6387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6388", "str_6388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6389", "str_6389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_639", "str_639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6390", "str_6390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6391", "str_6391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6392", "str_6392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6393", "str_6393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6394", "str_6394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6395", "str_6395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6396", "str_6396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6397", "str_6397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6398", "str_6398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_5949: StringResource
+  get() = String41.str_5949
+
+@ExperimentalResourceApi
+internal val Res.string.str_595: StringResource
+  get() = String41.str_595
+
+@ExperimentalResourceApi
+internal val Res.string.str_5950: StringResource
+  get() = String41.str_5950
+
+@ExperimentalResourceApi
+internal val Res.string.str_5951: StringResource
+  get() = String41.str_5951
+
+@ExperimentalResourceApi
+internal val Res.string.str_5952: StringResource
+  get() = String41.str_5952
+
+@ExperimentalResourceApi
+internal val Res.string.str_5953: StringResource
+  get() = String41.str_5953
+
+@ExperimentalResourceApi
+internal val Res.string.str_5954: StringResource
+  get() = String41.str_5954
+
+@ExperimentalResourceApi
+internal val Res.string.str_5955: StringResource
+  get() = String41.str_5955
+
+@ExperimentalResourceApi
+internal val Res.string.str_5956: StringResource
+  get() = String41.str_5956
+
+@ExperimentalResourceApi
+internal val Res.string.str_5957: StringResource
+  get() = String41.str_5957
+
+@ExperimentalResourceApi
+internal val Res.string.str_5958: StringResource
+  get() = String41.str_5958
+
+@ExperimentalResourceApi
+internal val Res.string.str_5959: StringResource
+  get() = String41.str_5959
+
+@ExperimentalResourceApi
+internal val Res.string.str_596: StringResource
+  get() = String41.str_596
+
+@ExperimentalResourceApi
+internal val Res.string.str_5960: StringResource
+  get() = String41.str_5960
+
+@ExperimentalResourceApi
+internal val Res.string.str_5961: StringResource
+  get() = String41.str_5961
+
+@ExperimentalResourceApi
+internal val Res.string.str_5962: StringResource
+  get() = String41.str_5962
+
+@ExperimentalResourceApi
+internal val Res.string.str_5963: StringResource
+  get() = String41.str_5963
+
+@ExperimentalResourceApi
+internal val Res.string.str_5964: StringResource
+  get() = String41.str_5964
+
+@ExperimentalResourceApi
+internal val Res.string.str_5965: StringResource
+  get() = String41.str_5965
+
+@ExperimentalResourceApi
+internal val Res.string.str_5966: StringResource
+  get() = String41.str_5966
+
+@ExperimentalResourceApi
+internal val Res.string.str_5967: StringResource
+  get() = String41.str_5967
+
+@ExperimentalResourceApi
+internal val Res.string.str_5968: StringResource
+  get() = String41.str_5968
+
+@ExperimentalResourceApi
+internal val Res.string.str_5969: StringResource
+  get() = String41.str_5969
+
+@ExperimentalResourceApi
+internal val Res.string.str_597: StringResource
+  get() = String41.str_597
+
+@ExperimentalResourceApi
+internal val Res.string.str_5970: StringResource
+  get() = String41.str_5970
+
+@ExperimentalResourceApi
+internal val Res.string.str_5971: StringResource
+  get() = String41.str_5971
+
+@ExperimentalResourceApi
+internal val Res.string.str_5972: StringResource
+  get() = String41.str_5972
+
+@ExperimentalResourceApi
+internal val Res.string.str_5973: StringResource
+  get() = String41.str_5973
+
+@ExperimentalResourceApi
+internal val Res.string.str_5974: StringResource
+  get() = String41.str_5974
+
+@ExperimentalResourceApi
+internal val Res.string.str_5975: StringResource
+  get() = String41.str_5975
+
+@ExperimentalResourceApi
+internal val Res.string.str_5976: StringResource
+  get() = String41.str_5976
+
+@ExperimentalResourceApi
+internal val Res.string.str_5977: StringResource
+  get() = String41.str_5977
+
+@ExperimentalResourceApi
+internal val Res.string.str_5978: StringResource
+  get() = String41.str_5978
+
+@ExperimentalResourceApi
+internal val Res.string.str_5979: StringResource
+  get() = String41.str_5979
+
+@ExperimentalResourceApi
+internal val Res.string.str_598: StringResource
+  get() = String41.str_598
+
+@ExperimentalResourceApi
+internal val Res.string.str_5980: StringResource
+  get() = String41.str_5980
+
+@ExperimentalResourceApi
+internal val Res.string.str_5981: StringResource
+  get() = String41.str_5981
+
+@ExperimentalResourceApi
+internal val Res.string.str_5982: StringResource
+  get() = String41.str_5982
+
+@ExperimentalResourceApi
+internal val Res.string.str_5983: StringResource
+  get() = String41.str_5983
+
+@ExperimentalResourceApi
+internal val Res.string.str_5984: StringResource
+  get() = String41.str_5984
+
+@ExperimentalResourceApi
+internal val Res.string.str_5985: StringResource
+  get() = String41.str_5985
+
+@ExperimentalResourceApi
+internal val Res.string.str_5986: StringResource
+  get() = String41.str_5986
+
+@ExperimentalResourceApi
+internal val Res.string.str_5987: StringResource
+  get() = String41.str_5987
+
+@ExperimentalResourceApi
+internal val Res.string.str_5988: StringResource
+  get() = String41.str_5988
+
+@ExperimentalResourceApi
+internal val Res.string.str_5989: StringResource
+  get() = String41.str_5989
+
+@ExperimentalResourceApi
+internal val Res.string.str_599: StringResource
+  get() = String41.str_599
+
+@ExperimentalResourceApi
+internal val Res.string.str_5990: StringResource
+  get() = String41.str_5990
+
+@ExperimentalResourceApi
+internal val Res.string.str_5991: StringResource
+  get() = String41.str_5991
+
+@ExperimentalResourceApi
+internal val Res.string.str_5992: StringResource
+  get() = String41.str_5992
+
+@ExperimentalResourceApi
+internal val Res.string.str_5993: StringResource
+  get() = String41.str_5993
+
+@ExperimentalResourceApi
+internal val Res.string.str_5994: StringResource
+  get() = String41.str_5994
+
+@ExperimentalResourceApi
+internal val Res.string.str_5995: StringResource
+  get() = String41.str_5995
+
+@ExperimentalResourceApi
+internal val Res.string.str_5996: StringResource
+  get() = String41.str_5996
+
+@ExperimentalResourceApi
+internal val Res.string.str_5997: StringResource
+  get() = String41.str_5997
+
+@ExperimentalResourceApi
+internal val Res.string.str_5998: StringResource
+  get() = String41.str_5998
+
+@ExperimentalResourceApi
+internal val Res.string.str_5999: StringResource
+  get() = String41.str_5999
+
+@ExperimentalResourceApi
+internal val Res.string.str_6: StringResource
+  get() = String41.str_6
+
+@ExperimentalResourceApi
+internal val Res.string.str_60: StringResource
+  get() = String41.str_60
+
+@ExperimentalResourceApi
+internal val Res.string.str_600: StringResource
+  get() = String41.str_600
+
+@ExperimentalResourceApi
+internal val Res.string.str_6000: StringResource
+  get() = String41.str_6000
+
+@ExperimentalResourceApi
+internal val Res.string.str_6001: StringResource
+  get() = String41.str_6001
+
+@ExperimentalResourceApi
+internal val Res.string.str_6002: StringResource
+  get() = String41.str_6002
+
+@ExperimentalResourceApi
+internal val Res.string.str_6003: StringResource
+  get() = String41.str_6003
+
+@ExperimentalResourceApi
+internal val Res.string.str_6004: StringResource
+  get() = String41.str_6004
+
+@ExperimentalResourceApi
+internal val Res.string.str_6005: StringResource
+  get() = String41.str_6005
+
+@ExperimentalResourceApi
+internal val Res.string.str_6006: StringResource
+  get() = String41.str_6006
+
+@ExperimentalResourceApi
+internal val Res.string.str_6007: StringResource
+  get() = String41.str_6007
+
+@ExperimentalResourceApi
+internal val Res.string.str_6008: StringResource
+  get() = String41.str_6008
+
+@ExperimentalResourceApi
+internal val Res.string.str_6009: StringResource
+  get() = String41.str_6009
+
+@ExperimentalResourceApi
+internal val Res.string.str_601: StringResource
+  get() = String41.str_601
+
+@ExperimentalResourceApi
+internal val Res.string.str_6010: StringResource
+  get() = String41.str_6010
+
+@ExperimentalResourceApi
+internal val Res.string.str_6011: StringResource
+  get() = String41.str_6011
+
+@ExperimentalResourceApi
+internal val Res.string.str_6012: StringResource
+  get() = String41.str_6012
+
+@ExperimentalResourceApi
+internal val Res.string.str_6013: StringResource
+  get() = String41.str_6013
+
+@ExperimentalResourceApi
+internal val Res.string.str_6014: StringResource
+  get() = String41.str_6014
+
+@ExperimentalResourceApi
+internal val Res.string.str_6015: StringResource
+  get() = String41.str_6015
+
+@ExperimentalResourceApi
+internal val Res.string.str_6016: StringResource
+  get() = String41.str_6016
+
+@ExperimentalResourceApi
+internal val Res.string.str_6017: StringResource
+  get() = String41.str_6017
+
+@ExperimentalResourceApi
+internal val Res.string.str_6018: StringResource
+  get() = String41.str_6018
+
+@ExperimentalResourceApi
+internal val Res.string.str_6019: StringResource
+  get() = String41.str_6019
+
+@ExperimentalResourceApi
+internal val Res.string.str_602: StringResource
+  get() = String41.str_602
+
+@ExperimentalResourceApi
+internal val Res.string.str_6020: StringResource
+  get() = String41.str_6020
+
+@ExperimentalResourceApi
+internal val Res.string.str_6021: StringResource
+  get() = String41.str_6021
+
+@ExperimentalResourceApi
+internal val Res.string.str_6022: StringResource
+  get() = String41.str_6022
+
+@ExperimentalResourceApi
+internal val Res.string.str_6023: StringResource
+  get() = String41.str_6023
+
+@ExperimentalResourceApi
+internal val Res.string.str_6024: StringResource
+  get() = String41.str_6024
+
+@ExperimentalResourceApi
+internal val Res.string.str_6025: StringResource
+  get() = String41.str_6025
+
+@ExperimentalResourceApi
+internal val Res.string.str_6026: StringResource
+  get() = String41.str_6026
+
+@ExperimentalResourceApi
+internal val Res.string.str_6027: StringResource
+  get() = String41.str_6027
+
+@ExperimentalResourceApi
+internal val Res.string.str_6028: StringResource
+  get() = String41.str_6028
+
+@ExperimentalResourceApi
+internal val Res.string.str_6029: StringResource
+  get() = String41.str_6029
+
+@ExperimentalResourceApi
+internal val Res.string.str_603: StringResource
+  get() = String41.str_603
+
+@ExperimentalResourceApi
+internal val Res.string.str_6030: StringResource
+  get() = String41.str_6030
+
+@ExperimentalResourceApi
+internal val Res.string.str_6031: StringResource
+  get() = String41.str_6031
+
+@ExperimentalResourceApi
+internal val Res.string.str_6032: StringResource
+  get() = String41.str_6032
+
+@ExperimentalResourceApi
+internal val Res.string.str_6033: StringResource
+  get() = String41.str_6033
+
+@ExperimentalResourceApi
+internal val Res.string.str_6034: StringResource
+  get() = String41.str_6034
+
+@ExperimentalResourceApi
+internal val Res.string.str_6035: StringResource
+  get() = String41.str_6035
+
+@ExperimentalResourceApi
+internal val Res.string.str_6036: StringResource
+  get() = String41.str_6036
+
+@ExperimentalResourceApi
+internal val Res.string.str_6037: StringResource
+  get() = String41.str_6037
+
+@ExperimentalResourceApi
+internal val Res.string.str_6038: StringResource
+  get() = String41.str_6038
+
+@ExperimentalResourceApi
+internal val Res.string.str_6039: StringResource
+  get() = String41.str_6039
+
+@ExperimentalResourceApi
+internal val Res.string.str_604: StringResource
+  get() = String41.str_604
+
+@ExperimentalResourceApi
+internal val Res.string.str_6040: StringResource
+  get() = String41.str_6040
+
+@ExperimentalResourceApi
+internal val Res.string.str_6041: StringResource
+  get() = String41.str_6041
+
+@ExperimentalResourceApi
+internal val Res.string.str_6042: StringResource
+  get() = String41.str_6042
+
+@ExperimentalResourceApi
+internal val Res.string.str_6043: StringResource
+  get() = String41.str_6043
+
+@ExperimentalResourceApi
+internal val Res.string.str_6044: StringResource
+  get() = String41.str_6044
+
+@ExperimentalResourceApi
+internal val Res.string.str_6045: StringResource
+  get() = String41.str_6045
+
+@ExperimentalResourceApi
+internal val Res.string.str_6046: StringResource
+  get() = String41.str_6046
+
+@ExperimentalResourceApi
+internal val Res.string.str_6047: StringResource
+  get() = String41.str_6047
+
+@ExperimentalResourceApi
+internal val Res.string.str_6048: StringResource
+  get() = String41.str_6048
+
+@ExperimentalResourceApi
+internal val Res.string.str_6049: StringResource
+  get() = String41.str_6049
+
+@ExperimentalResourceApi
+internal val Res.string.str_605: StringResource
+  get() = String41.str_605
+
+@ExperimentalResourceApi
+internal val Res.string.str_6050: StringResource
+  get() = String41.str_6050
+
+@ExperimentalResourceApi
+internal val Res.string.str_6051: StringResource
+  get() = String41.str_6051
+
+@ExperimentalResourceApi
+internal val Res.string.str_6052: StringResource
+  get() = String41.str_6052
+
+@ExperimentalResourceApi
+internal val Res.string.str_6053: StringResource
+  get() = String41.str_6053
+
+@ExperimentalResourceApi
+internal val Res.string.str_6054: StringResource
+  get() = String41.str_6054
+
+@ExperimentalResourceApi
+internal val Res.string.str_6055: StringResource
+  get() = String41.str_6055
+
+@ExperimentalResourceApi
+internal val Res.string.str_6056: StringResource
+  get() = String41.str_6056
+
+@ExperimentalResourceApi
+internal val Res.string.str_6057: StringResource
+  get() = String41.str_6057
+
+@ExperimentalResourceApi
+internal val Res.string.str_6058: StringResource
+  get() = String41.str_6058
+
+@ExperimentalResourceApi
+internal val Res.string.str_6059: StringResource
+  get() = String41.str_6059
+
+@ExperimentalResourceApi
+internal val Res.string.str_606: StringResource
+  get() = String41.str_606
+
+@ExperimentalResourceApi
+internal val Res.string.str_6060: StringResource
+  get() = String41.str_6060
+
+@ExperimentalResourceApi
+internal val Res.string.str_6061: StringResource
+  get() = String41.str_6061
+
+@ExperimentalResourceApi
+internal val Res.string.str_6062: StringResource
+  get() = String41.str_6062
+
+@ExperimentalResourceApi
+internal val Res.string.str_6063: StringResource
+  get() = String41.str_6063
+
+@ExperimentalResourceApi
+internal val Res.string.str_6064: StringResource
+  get() = String41.str_6064
+
+@ExperimentalResourceApi
+internal val Res.string.str_6065: StringResource
+  get() = String41.str_6065
+
+@ExperimentalResourceApi
+internal val Res.string.str_6066: StringResource
+  get() = String41.str_6066
+
+@ExperimentalResourceApi
+internal val Res.string.str_6067: StringResource
+  get() = String41.str_6067
+
+@ExperimentalResourceApi
+internal val Res.string.str_6068: StringResource
+  get() = String41.str_6068
+
+@ExperimentalResourceApi
+internal val Res.string.str_6069: StringResource
+  get() = String41.str_6069
+
+@ExperimentalResourceApi
+internal val Res.string.str_607: StringResource
+  get() = String41.str_607
+
+@ExperimentalResourceApi
+internal val Res.string.str_6070: StringResource
+  get() = String41.str_6070
+
+@ExperimentalResourceApi
+internal val Res.string.str_6071: StringResource
+  get() = String41.str_6071
+
+@ExperimentalResourceApi
+internal val Res.string.str_6072: StringResource
+  get() = String41.str_6072
+
+@ExperimentalResourceApi
+internal val Res.string.str_6073: StringResource
+  get() = String41.str_6073
+
+@ExperimentalResourceApi
+internal val Res.string.str_6074: StringResource
+  get() = String41.str_6074
+
+@ExperimentalResourceApi
+internal val Res.string.str_6075: StringResource
+  get() = String41.str_6075
+
+@ExperimentalResourceApi
+internal val Res.string.str_6076: StringResource
+  get() = String41.str_6076
+
+@ExperimentalResourceApi
+internal val Res.string.str_6077: StringResource
+  get() = String41.str_6077
+
+@ExperimentalResourceApi
+internal val Res.string.str_6078: StringResource
+  get() = String41.str_6078
+
+@ExperimentalResourceApi
+internal val Res.string.str_6079: StringResource
+  get() = String41.str_6079
+
+@ExperimentalResourceApi
+internal val Res.string.str_608: StringResource
+  get() = String41.str_608
+
+@ExperimentalResourceApi
+internal val Res.string.str_6080: StringResource
+  get() = String41.str_6080
+
+@ExperimentalResourceApi
+internal val Res.string.str_6081: StringResource
+  get() = String41.str_6081
+
+@ExperimentalResourceApi
+internal val Res.string.str_6082: StringResource
+  get() = String41.str_6082
+
+@ExperimentalResourceApi
+internal val Res.string.str_6083: StringResource
+  get() = String41.str_6083
+
+@ExperimentalResourceApi
+internal val Res.string.str_6084: StringResource
+  get() = String41.str_6084
+
+@ExperimentalResourceApi
+internal val Res.string.str_6085: StringResource
+  get() = String41.str_6085
+
+@ExperimentalResourceApi
+internal val Res.string.str_6086: StringResource
+  get() = String41.str_6086
+
+@ExperimentalResourceApi
+internal val Res.string.str_6087: StringResource
+  get() = String41.str_6087
+
+@ExperimentalResourceApi
+internal val Res.string.str_6088: StringResource
+  get() = String41.str_6088
+
+@ExperimentalResourceApi
+internal val Res.string.str_6089: StringResource
+  get() = String41.str_6089
+
+@ExperimentalResourceApi
+internal val Res.string.str_609: StringResource
+  get() = String41.str_609
+
+@ExperimentalResourceApi
+internal val Res.string.str_6090: StringResource
+  get() = String41.str_6090
+
+@ExperimentalResourceApi
+internal val Res.string.str_6091: StringResource
+  get() = String41.str_6091
+
+@ExperimentalResourceApi
+internal val Res.string.str_6092: StringResource
+  get() = String41.str_6092
+
+@ExperimentalResourceApi
+internal val Res.string.str_6093: StringResource
+  get() = String41.str_6093
+
+@ExperimentalResourceApi
+internal val Res.string.str_6094: StringResource
+  get() = String41.str_6094
+
+@ExperimentalResourceApi
+internal val Res.string.str_6095: StringResource
+  get() = String41.str_6095
+
+@ExperimentalResourceApi
+internal val Res.string.str_6096: StringResource
+  get() = String41.str_6096
+
+@ExperimentalResourceApi
+internal val Res.string.str_6097: StringResource
+  get() = String41.str_6097
+
+@ExperimentalResourceApi
+internal val Res.string.str_6098: StringResource
+  get() = String41.str_6098
+
+@ExperimentalResourceApi
+internal val Res.string.str_6099: StringResource
+  get() = String41.str_6099
+
+@ExperimentalResourceApi
+internal val Res.string.str_61: StringResource
+  get() = String41.str_61
+
+@ExperimentalResourceApi
+internal val Res.string.str_610: StringResource
+  get() = String41.str_610
+
+@ExperimentalResourceApi
+internal val Res.string.str_6100: StringResource
+  get() = String41.str_6100
+
+@ExperimentalResourceApi
+internal val Res.string.str_6101: StringResource
+  get() = String41.str_6101
+
+@ExperimentalResourceApi
+internal val Res.string.str_6102: StringResource
+  get() = String41.str_6102
+
+@ExperimentalResourceApi
+internal val Res.string.str_6103: StringResource
+  get() = String41.str_6103
+
+@ExperimentalResourceApi
+internal val Res.string.str_6104: StringResource
+  get() = String41.str_6104
+
+@ExperimentalResourceApi
+internal val Res.string.str_6105: StringResource
+  get() = String41.str_6105
+
+@ExperimentalResourceApi
+internal val Res.string.str_6106: StringResource
+  get() = String41.str_6106
+
+@ExperimentalResourceApi
+internal val Res.string.str_6107: StringResource
+  get() = String41.str_6107
+
+@ExperimentalResourceApi
+internal val Res.string.str_6108: StringResource
+  get() = String41.str_6108
+
+@ExperimentalResourceApi
+internal val Res.string.str_6109: StringResource
+  get() = String41.str_6109
+
+@ExperimentalResourceApi
+internal val Res.string.str_611: StringResource
+  get() = String41.str_611
+
+@ExperimentalResourceApi
+internal val Res.string.str_6110: StringResource
+  get() = String41.str_6110
+
+@ExperimentalResourceApi
+internal val Res.string.str_6111: StringResource
+  get() = String41.str_6111
+
+@ExperimentalResourceApi
+internal val Res.string.str_6112: StringResource
+  get() = String41.str_6112
+
+@ExperimentalResourceApi
+internal val Res.string.str_6113: StringResource
+  get() = String41.str_6113
+
+@ExperimentalResourceApi
+internal val Res.string.str_6114: StringResource
+  get() = String41.str_6114
+
+@ExperimentalResourceApi
+internal val Res.string.str_6115: StringResource
+  get() = String41.str_6115
+
+@ExperimentalResourceApi
+internal val Res.string.str_6116: StringResource
+  get() = String41.str_6116
+
+@ExperimentalResourceApi
+internal val Res.string.str_6117: StringResource
+  get() = String41.str_6117
+
+@ExperimentalResourceApi
+internal val Res.string.str_6118: StringResource
+  get() = String41.str_6118
+
+@ExperimentalResourceApi
+internal val Res.string.str_6119: StringResource
+  get() = String41.str_6119
+
+@ExperimentalResourceApi
+internal val Res.string.str_612: StringResource
+  get() = String41.str_612
+
+@ExperimentalResourceApi
+internal val Res.string.str_6120: StringResource
+  get() = String41.str_6120
+
+@ExperimentalResourceApi
+internal val Res.string.str_6121: StringResource
+  get() = String41.str_6121
+
+@ExperimentalResourceApi
+internal val Res.string.str_6122: StringResource
+  get() = String41.str_6122
+
+@ExperimentalResourceApi
+internal val Res.string.str_6123: StringResource
+  get() = String41.str_6123
+
+@ExperimentalResourceApi
+internal val Res.string.str_6124: StringResource
+  get() = String41.str_6124
+
+@ExperimentalResourceApi
+internal val Res.string.str_6125: StringResource
+  get() = String41.str_6125
+
+@ExperimentalResourceApi
+internal val Res.string.str_6126: StringResource
+  get() = String41.str_6126
+
+@ExperimentalResourceApi
+internal val Res.string.str_6127: StringResource
+  get() = String41.str_6127
+
+@ExperimentalResourceApi
+internal val Res.string.str_6128: StringResource
+  get() = String41.str_6128
+
+@ExperimentalResourceApi
+internal val Res.string.str_6129: StringResource
+  get() = String41.str_6129
+
+@ExperimentalResourceApi
+internal val Res.string.str_613: StringResource
+  get() = String41.str_613
+
+@ExperimentalResourceApi
+internal val Res.string.str_6130: StringResource
+  get() = String41.str_6130
+
+@ExperimentalResourceApi
+internal val Res.string.str_6131: StringResource
+  get() = String41.str_6131
+
+@ExperimentalResourceApi
+internal val Res.string.str_6132: StringResource
+  get() = String41.str_6132
+
+@ExperimentalResourceApi
+internal val Res.string.str_6133: StringResource
+  get() = String41.str_6133
+
+@ExperimentalResourceApi
+internal val Res.string.str_6134: StringResource
+  get() = String41.str_6134
+
+@ExperimentalResourceApi
+internal val Res.string.str_6135: StringResource
+  get() = String41.str_6135
+
+@ExperimentalResourceApi
+internal val Res.string.str_6136: StringResource
+  get() = String41.str_6136
+
+@ExperimentalResourceApi
+internal val Res.string.str_6137: StringResource
+  get() = String41.str_6137
+
+@ExperimentalResourceApi
+internal val Res.string.str_6138: StringResource
+  get() = String41.str_6138
+
+@ExperimentalResourceApi
+internal val Res.string.str_6139: StringResource
+  get() = String41.str_6139
+
+@ExperimentalResourceApi
+internal val Res.string.str_614: StringResource
+  get() = String41.str_614
+
+@ExperimentalResourceApi
+internal val Res.string.str_6140: StringResource
+  get() = String41.str_6140
+
+@ExperimentalResourceApi
+internal val Res.string.str_6141: StringResource
+  get() = String41.str_6141
+
+@ExperimentalResourceApi
+internal val Res.string.str_6142: StringResource
+  get() = String41.str_6142
+
+@ExperimentalResourceApi
+internal val Res.string.str_6143: StringResource
+  get() = String41.str_6143
+
+@ExperimentalResourceApi
+internal val Res.string.str_6144: StringResource
+  get() = String41.str_6144
+
+@ExperimentalResourceApi
+internal val Res.string.str_6145: StringResource
+  get() = String41.str_6145
+
+@ExperimentalResourceApi
+internal val Res.string.str_6146: StringResource
+  get() = String41.str_6146
+
+@ExperimentalResourceApi
+internal val Res.string.str_6147: StringResource
+  get() = String41.str_6147
+
+@ExperimentalResourceApi
+internal val Res.string.str_6148: StringResource
+  get() = String41.str_6148
+
+@ExperimentalResourceApi
+internal val Res.string.str_6149: StringResource
+  get() = String41.str_6149
+
+@ExperimentalResourceApi
+internal val Res.string.str_615: StringResource
+  get() = String41.str_615
+
+@ExperimentalResourceApi
+internal val Res.string.str_6150: StringResource
+  get() = String41.str_6150
+
+@ExperimentalResourceApi
+internal val Res.string.str_6151: StringResource
+  get() = String41.str_6151
+
+@ExperimentalResourceApi
+internal val Res.string.str_6152: StringResource
+  get() = String41.str_6152
+
+@ExperimentalResourceApi
+internal val Res.string.str_6153: StringResource
+  get() = String41.str_6153
+
+@ExperimentalResourceApi
+internal val Res.string.str_6154: StringResource
+  get() = String41.str_6154
+
+@ExperimentalResourceApi
+internal val Res.string.str_6155: StringResource
+  get() = String41.str_6155
+
+@ExperimentalResourceApi
+internal val Res.string.str_6156: StringResource
+  get() = String41.str_6156
+
+@ExperimentalResourceApi
+internal val Res.string.str_6157: StringResource
+  get() = String41.str_6157
+
+@ExperimentalResourceApi
+internal val Res.string.str_6158: StringResource
+  get() = String41.str_6158
+
+@ExperimentalResourceApi
+internal val Res.string.str_6159: StringResource
+  get() = String41.str_6159
+
+@ExperimentalResourceApi
+internal val Res.string.str_616: StringResource
+  get() = String41.str_616
+
+@ExperimentalResourceApi
+internal val Res.string.str_6160: StringResource
+  get() = String41.str_6160
+
+@ExperimentalResourceApi
+internal val Res.string.str_6161: StringResource
+  get() = String41.str_6161
+
+@ExperimentalResourceApi
+internal val Res.string.str_6162: StringResource
+  get() = String41.str_6162
+
+@ExperimentalResourceApi
+internal val Res.string.str_6163: StringResource
+  get() = String41.str_6163
+
+@ExperimentalResourceApi
+internal val Res.string.str_6164: StringResource
+  get() = String41.str_6164
+
+@ExperimentalResourceApi
+internal val Res.string.str_6165: StringResource
+  get() = String41.str_6165
+
+@ExperimentalResourceApi
+internal val Res.string.str_6166: StringResource
+  get() = String41.str_6166
+
+@ExperimentalResourceApi
+internal val Res.string.str_6167: StringResource
+  get() = String41.str_6167
+
+@ExperimentalResourceApi
+internal val Res.string.str_6168: StringResource
+  get() = String41.str_6168
+
+@ExperimentalResourceApi
+internal val Res.string.str_6169: StringResource
+  get() = String41.str_6169
+
+@ExperimentalResourceApi
+internal val Res.string.str_617: StringResource
+  get() = String41.str_617
+
+@ExperimentalResourceApi
+internal val Res.string.str_6170: StringResource
+  get() = String41.str_6170
+
+@ExperimentalResourceApi
+internal val Res.string.str_6171: StringResource
+  get() = String41.str_6171
+
+@ExperimentalResourceApi
+internal val Res.string.str_6172: StringResource
+  get() = String41.str_6172
+
+@ExperimentalResourceApi
+internal val Res.string.str_6173: StringResource
+  get() = String41.str_6173
+
+@ExperimentalResourceApi
+internal val Res.string.str_6174: StringResource
+  get() = String41.str_6174
+
+@ExperimentalResourceApi
+internal val Res.string.str_6175: StringResource
+  get() = String41.str_6175
+
+@ExperimentalResourceApi
+internal val Res.string.str_6176: StringResource
+  get() = String41.str_6176
+
+@ExperimentalResourceApi
+internal val Res.string.str_6177: StringResource
+  get() = String41.str_6177
+
+@ExperimentalResourceApi
+internal val Res.string.str_6178: StringResource
+  get() = String41.str_6178
+
+@ExperimentalResourceApi
+internal val Res.string.str_6179: StringResource
+  get() = String41.str_6179
+
+@ExperimentalResourceApi
+internal val Res.string.str_618: StringResource
+  get() = String41.str_618
+
+@ExperimentalResourceApi
+internal val Res.string.str_6180: StringResource
+  get() = String41.str_6180
+
+@ExperimentalResourceApi
+internal val Res.string.str_6181: StringResource
+  get() = String41.str_6181
+
+@ExperimentalResourceApi
+internal val Res.string.str_6182: StringResource
+  get() = String41.str_6182
+
+@ExperimentalResourceApi
+internal val Res.string.str_6183: StringResource
+  get() = String41.str_6183
+
+@ExperimentalResourceApi
+internal val Res.string.str_6184: StringResource
+  get() = String41.str_6184
+
+@ExperimentalResourceApi
+internal val Res.string.str_6185: StringResource
+  get() = String41.str_6185
+
+@ExperimentalResourceApi
+internal val Res.string.str_6186: StringResource
+  get() = String41.str_6186
+
+@ExperimentalResourceApi
+internal val Res.string.str_6187: StringResource
+  get() = String41.str_6187
+
+@ExperimentalResourceApi
+internal val Res.string.str_6188: StringResource
+  get() = String41.str_6188
+
+@ExperimentalResourceApi
+internal val Res.string.str_6189: StringResource
+  get() = String41.str_6189
+
+@ExperimentalResourceApi
+internal val Res.string.str_619: StringResource
+  get() = String41.str_619
+
+@ExperimentalResourceApi
+internal val Res.string.str_6190: StringResource
+  get() = String41.str_6190
+
+@ExperimentalResourceApi
+internal val Res.string.str_6191: StringResource
+  get() = String41.str_6191
+
+@ExperimentalResourceApi
+internal val Res.string.str_6192: StringResource
+  get() = String41.str_6192
+
+@ExperimentalResourceApi
+internal val Res.string.str_6193: StringResource
+  get() = String41.str_6193
+
+@ExperimentalResourceApi
+internal val Res.string.str_6194: StringResource
+  get() = String41.str_6194
+
+@ExperimentalResourceApi
+internal val Res.string.str_6195: StringResource
+  get() = String41.str_6195
+
+@ExperimentalResourceApi
+internal val Res.string.str_6196: StringResource
+  get() = String41.str_6196
+
+@ExperimentalResourceApi
+internal val Res.string.str_6197: StringResource
+  get() = String41.str_6197
+
+@ExperimentalResourceApi
+internal val Res.string.str_6198: StringResource
+  get() = String41.str_6198
+
+@ExperimentalResourceApi
+internal val Res.string.str_6199: StringResource
+  get() = String41.str_6199
+
+@ExperimentalResourceApi
+internal val Res.string.str_62: StringResource
+  get() = String41.str_62
+
+@ExperimentalResourceApi
+internal val Res.string.str_620: StringResource
+  get() = String41.str_620
+
+@ExperimentalResourceApi
+internal val Res.string.str_6200: StringResource
+  get() = String41.str_6200
+
+@ExperimentalResourceApi
+internal val Res.string.str_6201: StringResource
+  get() = String41.str_6201
+
+@ExperimentalResourceApi
+internal val Res.string.str_6202: StringResource
+  get() = String41.str_6202
+
+@ExperimentalResourceApi
+internal val Res.string.str_6203: StringResource
+  get() = String41.str_6203
+
+@ExperimentalResourceApi
+internal val Res.string.str_6204: StringResource
+  get() = String41.str_6204
+
+@ExperimentalResourceApi
+internal val Res.string.str_6205: StringResource
+  get() = String41.str_6205
+
+@ExperimentalResourceApi
+internal val Res.string.str_6206: StringResource
+  get() = String41.str_6206
+
+@ExperimentalResourceApi
+internal val Res.string.str_6207: StringResource
+  get() = String41.str_6207
+
+@ExperimentalResourceApi
+internal val Res.string.str_6208: StringResource
+  get() = String41.str_6208
+
+@ExperimentalResourceApi
+internal val Res.string.str_6209: StringResource
+  get() = String41.str_6209
+
+@ExperimentalResourceApi
+internal val Res.string.str_621: StringResource
+  get() = String41.str_621
+
+@ExperimentalResourceApi
+internal val Res.string.str_6210: StringResource
+  get() = String41.str_6210
+
+@ExperimentalResourceApi
+internal val Res.string.str_6211: StringResource
+  get() = String41.str_6211
+
+@ExperimentalResourceApi
+internal val Res.string.str_6212: StringResource
+  get() = String41.str_6212
+
+@ExperimentalResourceApi
+internal val Res.string.str_6213: StringResource
+  get() = String41.str_6213
+
+@ExperimentalResourceApi
+internal val Res.string.str_6214: StringResource
+  get() = String41.str_6214
+
+@ExperimentalResourceApi
+internal val Res.string.str_6215: StringResource
+  get() = String41.str_6215
+
+@ExperimentalResourceApi
+internal val Res.string.str_6216: StringResource
+  get() = String41.str_6216
+
+@ExperimentalResourceApi
+internal val Res.string.str_6217: StringResource
+  get() = String41.str_6217
+
+@ExperimentalResourceApi
+internal val Res.string.str_6218: StringResource
+  get() = String41.str_6218
+
+@ExperimentalResourceApi
+internal val Res.string.str_6219: StringResource
+  get() = String41.str_6219
+
+@ExperimentalResourceApi
+internal val Res.string.str_622: StringResource
+  get() = String41.str_622
+
+@ExperimentalResourceApi
+internal val Res.string.str_6220: StringResource
+  get() = String41.str_6220
+
+@ExperimentalResourceApi
+internal val Res.string.str_6221: StringResource
+  get() = String41.str_6221
+
+@ExperimentalResourceApi
+internal val Res.string.str_6222: StringResource
+  get() = String41.str_6222
+
+@ExperimentalResourceApi
+internal val Res.string.str_6223: StringResource
+  get() = String41.str_6223
+
+@ExperimentalResourceApi
+internal val Res.string.str_6224: StringResource
+  get() = String41.str_6224
+
+@ExperimentalResourceApi
+internal val Res.string.str_6225: StringResource
+  get() = String41.str_6225
+
+@ExperimentalResourceApi
+internal val Res.string.str_6226: StringResource
+  get() = String41.str_6226
+
+@ExperimentalResourceApi
+internal val Res.string.str_6227: StringResource
+  get() = String41.str_6227
+
+@ExperimentalResourceApi
+internal val Res.string.str_6228: StringResource
+  get() = String41.str_6228
+
+@ExperimentalResourceApi
+internal val Res.string.str_6229: StringResource
+  get() = String41.str_6229
+
+@ExperimentalResourceApi
+internal val Res.string.str_623: StringResource
+  get() = String41.str_623
+
+@ExperimentalResourceApi
+internal val Res.string.str_6230: StringResource
+  get() = String41.str_6230
+
+@ExperimentalResourceApi
+internal val Res.string.str_6231: StringResource
+  get() = String41.str_6231
+
+@ExperimentalResourceApi
+internal val Res.string.str_6232: StringResource
+  get() = String41.str_6232
+
+@ExperimentalResourceApi
+internal val Res.string.str_6233: StringResource
+  get() = String41.str_6233
+
+@ExperimentalResourceApi
+internal val Res.string.str_6234: StringResource
+  get() = String41.str_6234
+
+@ExperimentalResourceApi
+internal val Res.string.str_6235: StringResource
+  get() = String41.str_6235
+
+@ExperimentalResourceApi
+internal val Res.string.str_6236: StringResource
+  get() = String41.str_6236
+
+@ExperimentalResourceApi
+internal val Res.string.str_6237: StringResource
+  get() = String41.str_6237
+
+@ExperimentalResourceApi
+internal val Res.string.str_6238: StringResource
+  get() = String41.str_6238
+
+@ExperimentalResourceApi
+internal val Res.string.str_6239: StringResource
+  get() = String41.str_6239
+
+@ExperimentalResourceApi
+internal val Res.string.str_624: StringResource
+  get() = String41.str_624
+
+@ExperimentalResourceApi
+internal val Res.string.str_6240: StringResource
+  get() = String41.str_6240
+
+@ExperimentalResourceApi
+internal val Res.string.str_6241: StringResource
+  get() = String41.str_6241
+
+@ExperimentalResourceApi
+internal val Res.string.str_6242: StringResource
+  get() = String41.str_6242
+
+@ExperimentalResourceApi
+internal val Res.string.str_6243: StringResource
+  get() = String41.str_6243
+
+@ExperimentalResourceApi
+internal val Res.string.str_6244: StringResource
+  get() = String41.str_6244
+
+@ExperimentalResourceApi
+internal val Res.string.str_6245: StringResource
+  get() = String41.str_6245
+
+@ExperimentalResourceApi
+internal val Res.string.str_6246: StringResource
+  get() = String41.str_6246
+
+@ExperimentalResourceApi
+internal val Res.string.str_6247: StringResource
+  get() = String41.str_6247
+
+@ExperimentalResourceApi
+internal val Res.string.str_6248: StringResource
+  get() = String41.str_6248
+
+@ExperimentalResourceApi
+internal val Res.string.str_6249: StringResource
+  get() = String41.str_6249
+
+@ExperimentalResourceApi
+internal val Res.string.str_625: StringResource
+  get() = String41.str_625
+
+@ExperimentalResourceApi
+internal val Res.string.str_6250: StringResource
+  get() = String41.str_6250
+
+@ExperimentalResourceApi
+internal val Res.string.str_6251: StringResource
+  get() = String41.str_6251
+
+@ExperimentalResourceApi
+internal val Res.string.str_6252: StringResource
+  get() = String41.str_6252
+
+@ExperimentalResourceApi
+internal val Res.string.str_6253: StringResource
+  get() = String41.str_6253
+
+@ExperimentalResourceApi
+internal val Res.string.str_6254: StringResource
+  get() = String41.str_6254
+
+@ExperimentalResourceApi
+internal val Res.string.str_6255: StringResource
+  get() = String41.str_6255
+
+@ExperimentalResourceApi
+internal val Res.string.str_6256: StringResource
+  get() = String41.str_6256
+
+@ExperimentalResourceApi
+internal val Res.string.str_6257: StringResource
+  get() = String41.str_6257
+
+@ExperimentalResourceApi
+internal val Res.string.str_6258: StringResource
+  get() = String41.str_6258
+
+@ExperimentalResourceApi
+internal val Res.string.str_6259: StringResource
+  get() = String41.str_6259
+
+@ExperimentalResourceApi
+internal val Res.string.str_626: StringResource
+  get() = String41.str_626
+
+@ExperimentalResourceApi
+internal val Res.string.str_6260: StringResource
+  get() = String41.str_6260
+
+@ExperimentalResourceApi
+internal val Res.string.str_6261: StringResource
+  get() = String41.str_6261
+
+@ExperimentalResourceApi
+internal val Res.string.str_6262: StringResource
+  get() = String41.str_6262
+
+@ExperimentalResourceApi
+internal val Res.string.str_6263: StringResource
+  get() = String41.str_6263
+
+@ExperimentalResourceApi
+internal val Res.string.str_6264: StringResource
+  get() = String41.str_6264
+
+@ExperimentalResourceApi
+internal val Res.string.str_6265: StringResource
+  get() = String41.str_6265
+
+@ExperimentalResourceApi
+internal val Res.string.str_6266: StringResource
+  get() = String41.str_6266
+
+@ExperimentalResourceApi
+internal val Res.string.str_6267: StringResource
+  get() = String41.str_6267
+
+@ExperimentalResourceApi
+internal val Res.string.str_6268: StringResource
+  get() = String41.str_6268
+
+@ExperimentalResourceApi
+internal val Res.string.str_6269: StringResource
+  get() = String41.str_6269
+
+@ExperimentalResourceApi
+internal val Res.string.str_627: StringResource
+  get() = String41.str_627
+
+@ExperimentalResourceApi
+internal val Res.string.str_6270: StringResource
+  get() = String41.str_6270
+
+@ExperimentalResourceApi
+internal val Res.string.str_6271: StringResource
+  get() = String41.str_6271
+
+@ExperimentalResourceApi
+internal val Res.string.str_6272: StringResource
+  get() = String41.str_6272
+
+@ExperimentalResourceApi
+internal val Res.string.str_6273: StringResource
+  get() = String41.str_6273
+
+@ExperimentalResourceApi
+internal val Res.string.str_6274: StringResource
+  get() = String41.str_6274
+
+@ExperimentalResourceApi
+internal val Res.string.str_6275: StringResource
+  get() = String41.str_6275
+
+@ExperimentalResourceApi
+internal val Res.string.str_6276: StringResource
+  get() = String41.str_6276
+
+@ExperimentalResourceApi
+internal val Res.string.str_6277: StringResource
+  get() = String41.str_6277
+
+@ExperimentalResourceApi
+internal val Res.string.str_6278: StringResource
+  get() = String41.str_6278
+
+@ExperimentalResourceApi
+internal val Res.string.str_6279: StringResource
+  get() = String41.str_6279
+
+@ExperimentalResourceApi
+internal val Res.string.str_628: StringResource
+  get() = String41.str_628
+
+@ExperimentalResourceApi
+internal val Res.string.str_6280: StringResource
+  get() = String41.str_6280
+
+@ExperimentalResourceApi
+internal val Res.string.str_6281: StringResource
+  get() = String41.str_6281
+
+@ExperimentalResourceApi
+internal val Res.string.str_6282: StringResource
+  get() = String41.str_6282
+
+@ExperimentalResourceApi
+internal val Res.string.str_6283: StringResource
+  get() = String41.str_6283
+
+@ExperimentalResourceApi
+internal val Res.string.str_6284: StringResource
+  get() = String41.str_6284
+
+@ExperimentalResourceApi
+internal val Res.string.str_6285: StringResource
+  get() = String41.str_6285
+
+@ExperimentalResourceApi
+internal val Res.string.str_6286: StringResource
+  get() = String41.str_6286
+
+@ExperimentalResourceApi
+internal val Res.string.str_6287: StringResource
+  get() = String41.str_6287
+
+@ExperimentalResourceApi
+internal val Res.string.str_6288: StringResource
+  get() = String41.str_6288
+
+@ExperimentalResourceApi
+internal val Res.string.str_6289: StringResource
+  get() = String41.str_6289
+
+@ExperimentalResourceApi
+internal val Res.string.str_629: StringResource
+  get() = String41.str_629
+
+@ExperimentalResourceApi
+internal val Res.string.str_6290: StringResource
+  get() = String41.str_6290
+
+@ExperimentalResourceApi
+internal val Res.string.str_6291: StringResource
+  get() = String41.str_6291
+
+@ExperimentalResourceApi
+internal val Res.string.str_6292: StringResource
+  get() = String41.str_6292
+
+@ExperimentalResourceApi
+internal val Res.string.str_6293: StringResource
+  get() = String41.str_6293
+
+@ExperimentalResourceApi
+internal val Res.string.str_6294: StringResource
+  get() = String41.str_6294
+
+@ExperimentalResourceApi
+internal val Res.string.str_6295: StringResource
+  get() = String41.str_6295
+
+@ExperimentalResourceApi
+internal val Res.string.str_6296: StringResource
+  get() = String41.str_6296
+
+@ExperimentalResourceApi
+internal val Res.string.str_6297: StringResource
+  get() = String41.str_6297
+
+@ExperimentalResourceApi
+internal val Res.string.str_6298: StringResource
+  get() = String41.str_6298
+
+@ExperimentalResourceApi
+internal val Res.string.str_6299: StringResource
+  get() = String41.str_6299
+
+@ExperimentalResourceApi
+internal val Res.string.str_63: StringResource
+  get() = String41.str_63
+
+@ExperimentalResourceApi
+internal val Res.string.str_630: StringResource
+  get() = String41.str_630
+
+@ExperimentalResourceApi
+internal val Res.string.str_6300: StringResource
+  get() = String41.str_6300
+
+@ExperimentalResourceApi
+internal val Res.string.str_6301: StringResource
+  get() = String41.str_6301
+
+@ExperimentalResourceApi
+internal val Res.string.str_6302: StringResource
+  get() = String41.str_6302
+
+@ExperimentalResourceApi
+internal val Res.string.str_6303: StringResource
+  get() = String41.str_6303
+
+@ExperimentalResourceApi
+internal val Res.string.str_6304: StringResource
+  get() = String41.str_6304
+
+@ExperimentalResourceApi
+internal val Res.string.str_6305: StringResource
+  get() = String41.str_6305
+
+@ExperimentalResourceApi
+internal val Res.string.str_6306: StringResource
+  get() = String41.str_6306
+
+@ExperimentalResourceApi
+internal val Res.string.str_6307: StringResource
+  get() = String41.str_6307
+
+@ExperimentalResourceApi
+internal val Res.string.str_6308: StringResource
+  get() = String41.str_6308
+
+@ExperimentalResourceApi
+internal val Res.string.str_6309: StringResource
+  get() = String41.str_6309
+
+@ExperimentalResourceApi
+internal val Res.string.str_631: StringResource
+  get() = String41.str_631
+
+@ExperimentalResourceApi
+internal val Res.string.str_6310: StringResource
+  get() = String41.str_6310
+
+@ExperimentalResourceApi
+internal val Res.string.str_6311: StringResource
+  get() = String41.str_6311
+
+@ExperimentalResourceApi
+internal val Res.string.str_6312: StringResource
+  get() = String41.str_6312
+
+@ExperimentalResourceApi
+internal val Res.string.str_6313: StringResource
+  get() = String41.str_6313
+
+@ExperimentalResourceApi
+internal val Res.string.str_6314: StringResource
+  get() = String41.str_6314
+
+@ExperimentalResourceApi
+internal val Res.string.str_6315: StringResource
+  get() = String41.str_6315
+
+@ExperimentalResourceApi
+internal val Res.string.str_6316: StringResource
+  get() = String41.str_6316
+
+@ExperimentalResourceApi
+internal val Res.string.str_6317: StringResource
+  get() = String41.str_6317
+
+@ExperimentalResourceApi
+internal val Res.string.str_6318: StringResource
+  get() = String41.str_6318
+
+@ExperimentalResourceApi
+internal val Res.string.str_6319: StringResource
+  get() = String41.str_6319
+
+@ExperimentalResourceApi
+internal val Res.string.str_632: StringResource
+  get() = String41.str_632
+
+@ExperimentalResourceApi
+internal val Res.string.str_6320: StringResource
+  get() = String41.str_6320
+
+@ExperimentalResourceApi
+internal val Res.string.str_6321: StringResource
+  get() = String41.str_6321
+
+@ExperimentalResourceApi
+internal val Res.string.str_6322: StringResource
+  get() = String41.str_6322
+
+@ExperimentalResourceApi
+internal val Res.string.str_6323: StringResource
+  get() = String41.str_6323
+
+@ExperimentalResourceApi
+internal val Res.string.str_6324: StringResource
+  get() = String41.str_6324
+
+@ExperimentalResourceApi
+internal val Res.string.str_6325: StringResource
+  get() = String41.str_6325
+
+@ExperimentalResourceApi
+internal val Res.string.str_6326: StringResource
+  get() = String41.str_6326
+
+@ExperimentalResourceApi
+internal val Res.string.str_6327: StringResource
+  get() = String41.str_6327
+
+@ExperimentalResourceApi
+internal val Res.string.str_6328: StringResource
+  get() = String41.str_6328
+
+@ExperimentalResourceApi
+internal val Res.string.str_6329: StringResource
+  get() = String41.str_6329
+
+@ExperimentalResourceApi
+internal val Res.string.str_633: StringResource
+  get() = String41.str_633
+
+@ExperimentalResourceApi
+internal val Res.string.str_6330: StringResource
+  get() = String41.str_6330
+
+@ExperimentalResourceApi
+internal val Res.string.str_6331: StringResource
+  get() = String41.str_6331
+
+@ExperimentalResourceApi
+internal val Res.string.str_6332: StringResource
+  get() = String41.str_6332
+
+@ExperimentalResourceApi
+internal val Res.string.str_6333: StringResource
+  get() = String41.str_6333
+
+@ExperimentalResourceApi
+internal val Res.string.str_6334: StringResource
+  get() = String41.str_6334
+
+@ExperimentalResourceApi
+internal val Res.string.str_6335: StringResource
+  get() = String41.str_6335
+
+@ExperimentalResourceApi
+internal val Res.string.str_6336: StringResource
+  get() = String41.str_6336
+
+@ExperimentalResourceApi
+internal val Res.string.str_6337: StringResource
+  get() = String41.str_6337
+
+@ExperimentalResourceApi
+internal val Res.string.str_6338: StringResource
+  get() = String41.str_6338
+
+@ExperimentalResourceApi
+internal val Res.string.str_6339: StringResource
+  get() = String41.str_6339
+
+@ExperimentalResourceApi
+internal val Res.string.str_634: StringResource
+  get() = String41.str_634
+
+@ExperimentalResourceApi
+internal val Res.string.str_6340: StringResource
+  get() = String41.str_6340
+
+@ExperimentalResourceApi
+internal val Res.string.str_6341: StringResource
+  get() = String41.str_6341
+
+@ExperimentalResourceApi
+internal val Res.string.str_6342: StringResource
+  get() = String41.str_6342
+
+@ExperimentalResourceApi
+internal val Res.string.str_6343: StringResource
+  get() = String41.str_6343
+
+@ExperimentalResourceApi
+internal val Res.string.str_6344: StringResource
+  get() = String41.str_6344
+
+@ExperimentalResourceApi
+internal val Res.string.str_6345: StringResource
+  get() = String41.str_6345
+
+@ExperimentalResourceApi
+internal val Res.string.str_6346: StringResource
+  get() = String41.str_6346
+
+@ExperimentalResourceApi
+internal val Res.string.str_6347: StringResource
+  get() = String41.str_6347
+
+@ExperimentalResourceApi
+internal val Res.string.str_6348: StringResource
+  get() = String41.str_6348
+
+@ExperimentalResourceApi
+internal val Res.string.str_6349: StringResource
+  get() = String41.str_6349
+
+@ExperimentalResourceApi
+internal val Res.string.str_635: StringResource
+  get() = String41.str_635
+
+@ExperimentalResourceApi
+internal val Res.string.str_6350: StringResource
+  get() = String41.str_6350
+
+@ExperimentalResourceApi
+internal val Res.string.str_6351: StringResource
+  get() = String41.str_6351
+
+@ExperimentalResourceApi
+internal val Res.string.str_6352: StringResource
+  get() = String41.str_6352
+
+@ExperimentalResourceApi
+internal val Res.string.str_6353: StringResource
+  get() = String41.str_6353
+
+@ExperimentalResourceApi
+internal val Res.string.str_6354: StringResource
+  get() = String41.str_6354
+
+@ExperimentalResourceApi
+internal val Res.string.str_6355: StringResource
+  get() = String41.str_6355
+
+@ExperimentalResourceApi
+internal val Res.string.str_6356: StringResource
+  get() = String41.str_6356
+
+@ExperimentalResourceApi
+internal val Res.string.str_6357: StringResource
+  get() = String41.str_6357
+
+@ExperimentalResourceApi
+internal val Res.string.str_6358: StringResource
+  get() = String41.str_6358
+
+@ExperimentalResourceApi
+internal val Res.string.str_6359: StringResource
+  get() = String41.str_6359
+
+@ExperimentalResourceApi
+internal val Res.string.str_636: StringResource
+  get() = String41.str_636
+
+@ExperimentalResourceApi
+internal val Res.string.str_6360: StringResource
+  get() = String41.str_6360
+
+@ExperimentalResourceApi
+internal val Res.string.str_6361: StringResource
+  get() = String41.str_6361
+
+@ExperimentalResourceApi
+internal val Res.string.str_6362: StringResource
+  get() = String41.str_6362
+
+@ExperimentalResourceApi
+internal val Res.string.str_6363: StringResource
+  get() = String41.str_6363
+
+@ExperimentalResourceApi
+internal val Res.string.str_6364: StringResource
+  get() = String41.str_6364
+
+@ExperimentalResourceApi
+internal val Res.string.str_6365: StringResource
+  get() = String41.str_6365
+
+@ExperimentalResourceApi
+internal val Res.string.str_6366: StringResource
+  get() = String41.str_6366
+
+@ExperimentalResourceApi
+internal val Res.string.str_6367: StringResource
+  get() = String41.str_6367
+
+@ExperimentalResourceApi
+internal val Res.string.str_6368: StringResource
+  get() = String41.str_6368
+
+@ExperimentalResourceApi
+internal val Res.string.str_6369: StringResource
+  get() = String41.str_6369
+
+@ExperimentalResourceApi
+internal val Res.string.str_637: StringResource
+  get() = String41.str_637
+
+@ExperimentalResourceApi
+internal val Res.string.str_6370: StringResource
+  get() = String41.str_6370
+
+@ExperimentalResourceApi
+internal val Res.string.str_6371: StringResource
+  get() = String41.str_6371
+
+@ExperimentalResourceApi
+internal val Res.string.str_6372: StringResource
+  get() = String41.str_6372
+
+@ExperimentalResourceApi
+internal val Res.string.str_6373: StringResource
+  get() = String41.str_6373
+
+@ExperimentalResourceApi
+internal val Res.string.str_6374: StringResource
+  get() = String41.str_6374
+
+@ExperimentalResourceApi
+internal val Res.string.str_6375: StringResource
+  get() = String41.str_6375
+
+@ExperimentalResourceApi
+internal val Res.string.str_6376: StringResource
+  get() = String41.str_6376
+
+@ExperimentalResourceApi
+internal val Res.string.str_6377: StringResource
+  get() = String41.str_6377
+
+@ExperimentalResourceApi
+internal val Res.string.str_6378: StringResource
+  get() = String41.str_6378
+
+@ExperimentalResourceApi
+internal val Res.string.str_6379: StringResource
+  get() = String41.str_6379
+
+@ExperimentalResourceApi
+internal val Res.string.str_638: StringResource
+  get() = String41.str_638
+
+@ExperimentalResourceApi
+internal val Res.string.str_6380: StringResource
+  get() = String41.str_6380
+
+@ExperimentalResourceApi
+internal val Res.string.str_6381: StringResource
+  get() = String41.str_6381
+
+@ExperimentalResourceApi
+internal val Res.string.str_6382: StringResource
+  get() = String41.str_6382
+
+@ExperimentalResourceApi
+internal val Res.string.str_6383: StringResource
+  get() = String41.str_6383
+
+@ExperimentalResourceApi
+internal val Res.string.str_6384: StringResource
+  get() = String41.str_6384
+
+@ExperimentalResourceApi
+internal val Res.string.str_6385: StringResource
+  get() = String41.str_6385
+
+@ExperimentalResourceApi
+internal val Res.string.str_6386: StringResource
+  get() = String41.str_6386
+
+@ExperimentalResourceApi
+internal val Res.string.str_6387: StringResource
+  get() = String41.str_6387
+
+@ExperimentalResourceApi
+internal val Res.string.str_6388: StringResource
+  get() = String41.str_6388
+
+@ExperimentalResourceApi
+internal val Res.string.str_6389: StringResource
+  get() = String41.str_6389
+
+@ExperimentalResourceApi
+internal val Res.string.str_639: StringResource
+  get() = String41.str_639
+
+@ExperimentalResourceApi
+internal val Res.string.str_6390: StringResource
+  get() = String41.str_6390
+
+@ExperimentalResourceApi
+internal val Res.string.str_6391: StringResource
+  get() = String41.str_6391
+
+@ExperimentalResourceApi
+internal val Res.string.str_6392: StringResource
+  get() = String41.str_6392
+
+@ExperimentalResourceApi
+internal val Res.string.str_6393: StringResource
+  get() = String41.str_6393
+
+@ExperimentalResourceApi
+internal val Res.string.str_6394: StringResource
+  get() = String41.str_6394
+
+@ExperimentalResourceApi
+internal val Res.string.str_6395: StringResource
+  get() = String41.str_6395
+
+@ExperimentalResourceApi
+internal val Res.string.str_6396: StringResource
+  get() = String41.str_6396
+
+@ExperimentalResourceApi
+internal val Res.string.str_6397: StringResource
+  get() = String41.str_6397
+
+@ExperimentalResourceApi
+internal val Res.string.str_6398: StringResource
+  get() = String41.str_6398

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String42.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String42.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String42 {
+  public val str_6399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6399", "str_6399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_64: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_64", "str_64",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_640", "str_640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6400", "str_6400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6401", "str_6401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6402", "str_6402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6403", "str_6403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6404", "str_6404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6405", "str_6405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6406", "str_6406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6407", "str_6407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6408", "str_6408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6409", "str_6409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_641", "str_641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6410", "str_6410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6411", "str_6411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6412", "str_6412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6413", "str_6413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6414", "str_6414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6415", "str_6415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6416", "str_6416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6417", "str_6417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6418", "str_6418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6419", "str_6419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_642", "str_642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6420", "str_6420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6421", "str_6421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6422", "str_6422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6423", "str_6423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6424", "str_6424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6425", "str_6425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6426", "str_6426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6427", "str_6427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6428", "str_6428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6429", "str_6429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_643", "str_643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6430", "str_6430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6431", "str_6431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6432", "str_6432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6433", "str_6433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6434", "str_6434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6435", "str_6435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6436", "str_6436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6437", "str_6437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6438", "str_6438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6439", "str_6439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_644", "str_644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6440", "str_6440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6441", "str_6441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6442", "str_6442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6443", "str_6443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6444", "str_6444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6445", "str_6445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6446", "str_6446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6447", "str_6447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6448", "str_6448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6449", "str_6449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_645", "str_645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6450", "str_6450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6451", "str_6451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6452", "str_6452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6453", "str_6453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6454", "str_6454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6455", "str_6455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6456", "str_6456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6457", "str_6457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6458", "str_6458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6459", "str_6459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_646", "str_646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6460", "str_6460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6461", "str_6461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6462", "str_6462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6463", "str_6463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6464", "str_6464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6465", "str_6465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6466", "str_6466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6467", "str_6467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6468", "str_6468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6469", "str_6469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_647", "str_647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6470", "str_6470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6471", "str_6471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6472", "str_6472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6473", "str_6473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6474", "str_6474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6475", "str_6475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6476", "str_6476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6477", "str_6477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6478", "str_6478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6479", "str_6479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_648", "str_648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6480", "str_6480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6481", "str_6481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6482", "str_6482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6483", "str_6483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6484", "str_6484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6485", "str_6485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6486", "str_6486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6487", "str_6487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6488", "str_6488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6489", "str_6489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_649", "str_649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6490", "str_6490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6491", "str_6491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6492", "str_6492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6493", "str_6493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6494", "str_6494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6495", "str_6495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6496", "str_6496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6497", "str_6497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6498", "str_6498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6499", "str_6499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_65: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_65", "str_65",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_650", "str_650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6500", "str_6500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6501", "str_6501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6502", "str_6502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6503", "str_6503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6504", "str_6504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6505", "str_6505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6506", "str_6506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6507", "str_6507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6508", "str_6508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6509", "str_6509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_651", "str_651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6510", "str_6510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6511", "str_6511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6512", "str_6512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6513", "str_6513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6514", "str_6514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6515", "str_6515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6516", "str_6516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6517", "str_6517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6518", "str_6518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6519", "str_6519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_652", "str_652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6520", "str_6520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6521", "str_6521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6522", "str_6522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6523", "str_6523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6524", "str_6524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6525", "str_6525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6526", "str_6526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6527", "str_6527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6528", "str_6528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6529", "str_6529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_653", "str_653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6530", "str_6530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6531", "str_6531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6532", "str_6532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6533", "str_6533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6534", "str_6534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6535", "str_6535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6536", "str_6536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6537", "str_6537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6538", "str_6538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6539", "str_6539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_654", "str_654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6540", "str_6540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6541", "str_6541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6542", "str_6542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6543", "str_6543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6544", "str_6544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6545", "str_6545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6546", "str_6546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6547", "str_6547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6548", "str_6548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6549", "str_6549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_655", "str_655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6550", "str_6550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6551", "str_6551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6552", "str_6552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6553", "str_6553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6554", "str_6554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6555", "str_6555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6556", "str_6556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6557", "str_6557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6558", "str_6558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6559", "str_6559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_656", "str_656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6560", "str_6560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6561", "str_6561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6562", "str_6562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6563", "str_6563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6564", "str_6564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6565", "str_6565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6566", "str_6566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6567", "str_6567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6568", "str_6568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6569", "str_6569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_657", "str_657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6570", "str_6570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6571", "str_6571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6572", "str_6572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6573", "str_6573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6574", "str_6574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6575", "str_6575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6576", "str_6576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6577", "str_6577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6578", "str_6578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6579", "str_6579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_658", "str_658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6580", "str_6580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6581", "str_6581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6582", "str_6582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6583", "str_6583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6584", "str_6584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6585", "str_6585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6586", "str_6586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6587", "str_6587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6588", "str_6588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6589", "str_6589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_659", "str_659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6590", "str_6590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6591", "str_6591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6592", "str_6592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6593", "str_6593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6594", "str_6594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6595", "str_6595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6596", "str_6596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6597", "str_6597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6598", "str_6598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6599", "str_6599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_66: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_66", "str_66",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_660", "str_660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6600", "str_6600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6601", "str_6601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6602", "str_6602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6603", "str_6603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6604", "str_6604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6605", "str_6605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6606", "str_6606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6607", "str_6607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6608", "str_6608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6609", "str_6609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_661", "str_661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6610", "str_6610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6611", "str_6611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6612", "str_6612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6613", "str_6613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6614", "str_6614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6615", "str_6615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6616", "str_6616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6617", "str_6617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6618", "str_6618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6619", "str_6619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_662", "str_662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6620", "str_6620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6621", "str_6621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6622", "str_6622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6623", "str_6623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6624", "str_6624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6625", "str_6625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6626", "str_6626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6627", "str_6627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6628", "str_6628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6629", "str_6629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_663", "str_663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6630", "str_6630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6631", "str_6631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6632", "str_6632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6633", "str_6633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6634", "str_6634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6635", "str_6635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6636", "str_6636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6637", "str_6637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6638", "str_6638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6639", "str_6639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_664", "str_664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6640", "str_6640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6641", "str_6641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6642", "str_6642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6643", "str_6643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6644", "str_6644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6645", "str_6645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6646", "str_6646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6647", "str_6647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6648", "str_6648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6649", "str_6649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_665", "str_665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6650", "str_6650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6651", "str_6651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6652", "str_6652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6653", "str_6653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6654", "str_6654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6655", "str_6655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6656", "str_6656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6657", "str_6657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6658", "str_6658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6659", "str_6659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_666", "str_666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6660", "str_6660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6661", "str_6661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6662", "str_6662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6663", "str_6663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6664", "str_6664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6665", "str_6665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6666", "str_6666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6667", "str_6667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6668", "str_6668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6669", "str_6669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_667", "str_667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6670", "str_6670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6671", "str_6671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6672", "str_6672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6673", "str_6673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6674", "str_6674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6675", "str_6675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6676", "str_6676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6677", "str_6677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6678", "str_6678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6679", "str_6679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_668", "str_668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6680", "str_6680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6681", "str_6681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6682", "str_6682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6683", "str_6683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6684", "str_6684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6685", "str_6685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6686", "str_6686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6687", "str_6687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6688", "str_6688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6689", "str_6689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_669", "str_669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6690", "str_6690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6691", "str_6691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6692", "str_6692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6693", "str_6693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6694", "str_6694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6695", "str_6695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6696", "str_6696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6697", "str_6697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6698", "str_6698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6699", "str_6699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_67: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_67", "str_67",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_670", "str_670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6700", "str_6700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6701", "str_6701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6702", "str_6702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6703", "str_6703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6704", "str_6704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6705", "str_6705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6706", "str_6706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6707", "str_6707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6708", "str_6708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6709", "str_6709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_671", "str_671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6710", "str_6710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6711", "str_6711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6712", "str_6712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6713", "str_6713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6714", "str_6714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6715", "str_6715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6716", "str_6716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6717", "str_6717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6718", "str_6718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6719", "str_6719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_672", "str_672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6720", "str_6720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6721", "str_6721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6722", "str_6722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6723", "str_6723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6724", "str_6724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6725", "str_6725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6726", "str_6726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6727", "str_6727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6728", "str_6728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6729", "str_6729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_673", "str_673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6730", "str_6730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6731", "str_6731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6732", "str_6732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6733", "str_6733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6734", "str_6734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6735", "str_6735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6736", "str_6736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6737", "str_6737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6738", "str_6738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6739", "str_6739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_674", "str_674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6740", "str_6740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6741", "str_6741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6742", "str_6742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6743", "str_6743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6744", "str_6744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6745", "str_6745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6746", "str_6746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6747", "str_6747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6748", "str_6748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6749", "str_6749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_675", "str_675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6750", "str_6750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6751", "str_6751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6752", "str_6752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6753", "str_6753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6754", "str_6754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6755", "str_6755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6756", "str_6756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6757", "str_6757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6758", "str_6758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6759", "str_6759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_676", "str_676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6760", "str_6760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6761", "str_6761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6762", "str_6762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6763", "str_6763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6764", "str_6764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6765", "str_6765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6766", "str_6766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6767", "str_6767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6768", "str_6768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6769", "str_6769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_677", "str_677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6770", "str_6770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6771", "str_6771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6772", "str_6772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6773", "str_6773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6774", "str_6774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6775", "str_6775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6776", "str_6776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6777", "str_6777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6778", "str_6778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6779", "str_6779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_678", "str_678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6780", "str_6780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6781", "str_6781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6782", "str_6782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6783", "str_6783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6784", "str_6784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6785", "str_6785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6786", "str_6786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6787", "str_6787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6788", "str_6788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6789", "str_6789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_679", "str_679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6790", "str_6790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6791", "str_6791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6792", "str_6792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6793", "str_6793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6794", "str_6794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6795", "str_6795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6796", "str_6796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6797", "str_6797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6798", "str_6798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6799", "str_6799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_68: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_68", "str_68",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_680", "str_680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6800", "str_6800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6801", "str_6801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6802", "str_6802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6803", "str_6803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6804", "str_6804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6805", "str_6805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6806", "str_6806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6807", "str_6807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6808", "str_6808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6809", "str_6809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_681", "str_681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6810", "str_6810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6811", "str_6811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6812", "str_6812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6813", "str_6813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6814", "str_6814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6815", "str_6815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6816", "str_6816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6817", "str_6817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6818", "str_6818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6819", "str_6819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_682", "str_682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6820", "str_6820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6821", "str_6821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6822", "str_6822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6823", "str_6823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6824", "str_6824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6825", "str_6825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6826", "str_6826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6827", "str_6827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6828", "str_6828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6829", "str_6829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_683", "str_683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6830", "str_6830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6831", "str_6831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6832", "str_6832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6833", "str_6833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6834", "str_6834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6835", "str_6835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6836", "str_6836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6837", "str_6837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6838", "str_6838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6839", "str_6839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_684", "str_684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6840", "str_6840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6841", "str_6841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6842", "str_6842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6843", "str_6843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6844", "str_6844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6845", "str_6845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6846", "str_6846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6847", "str_6847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6848", "str_6848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_6399: StringResource
+  get() = String42.str_6399
+
+@ExperimentalResourceApi
+internal val Res.string.str_64: StringResource
+  get() = String42.str_64
+
+@ExperimentalResourceApi
+internal val Res.string.str_640: StringResource
+  get() = String42.str_640
+
+@ExperimentalResourceApi
+internal val Res.string.str_6400: StringResource
+  get() = String42.str_6400
+
+@ExperimentalResourceApi
+internal val Res.string.str_6401: StringResource
+  get() = String42.str_6401
+
+@ExperimentalResourceApi
+internal val Res.string.str_6402: StringResource
+  get() = String42.str_6402
+
+@ExperimentalResourceApi
+internal val Res.string.str_6403: StringResource
+  get() = String42.str_6403
+
+@ExperimentalResourceApi
+internal val Res.string.str_6404: StringResource
+  get() = String42.str_6404
+
+@ExperimentalResourceApi
+internal val Res.string.str_6405: StringResource
+  get() = String42.str_6405
+
+@ExperimentalResourceApi
+internal val Res.string.str_6406: StringResource
+  get() = String42.str_6406
+
+@ExperimentalResourceApi
+internal val Res.string.str_6407: StringResource
+  get() = String42.str_6407
+
+@ExperimentalResourceApi
+internal val Res.string.str_6408: StringResource
+  get() = String42.str_6408
+
+@ExperimentalResourceApi
+internal val Res.string.str_6409: StringResource
+  get() = String42.str_6409
+
+@ExperimentalResourceApi
+internal val Res.string.str_641: StringResource
+  get() = String42.str_641
+
+@ExperimentalResourceApi
+internal val Res.string.str_6410: StringResource
+  get() = String42.str_6410
+
+@ExperimentalResourceApi
+internal val Res.string.str_6411: StringResource
+  get() = String42.str_6411
+
+@ExperimentalResourceApi
+internal val Res.string.str_6412: StringResource
+  get() = String42.str_6412
+
+@ExperimentalResourceApi
+internal val Res.string.str_6413: StringResource
+  get() = String42.str_6413
+
+@ExperimentalResourceApi
+internal val Res.string.str_6414: StringResource
+  get() = String42.str_6414
+
+@ExperimentalResourceApi
+internal val Res.string.str_6415: StringResource
+  get() = String42.str_6415
+
+@ExperimentalResourceApi
+internal val Res.string.str_6416: StringResource
+  get() = String42.str_6416
+
+@ExperimentalResourceApi
+internal val Res.string.str_6417: StringResource
+  get() = String42.str_6417
+
+@ExperimentalResourceApi
+internal val Res.string.str_6418: StringResource
+  get() = String42.str_6418
+
+@ExperimentalResourceApi
+internal val Res.string.str_6419: StringResource
+  get() = String42.str_6419
+
+@ExperimentalResourceApi
+internal val Res.string.str_642: StringResource
+  get() = String42.str_642
+
+@ExperimentalResourceApi
+internal val Res.string.str_6420: StringResource
+  get() = String42.str_6420
+
+@ExperimentalResourceApi
+internal val Res.string.str_6421: StringResource
+  get() = String42.str_6421
+
+@ExperimentalResourceApi
+internal val Res.string.str_6422: StringResource
+  get() = String42.str_6422
+
+@ExperimentalResourceApi
+internal val Res.string.str_6423: StringResource
+  get() = String42.str_6423
+
+@ExperimentalResourceApi
+internal val Res.string.str_6424: StringResource
+  get() = String42.str_6424
+
+@ExperimentalResourceApi
+internal val Res.string.str_6425: StringResource
+  get() = String42.str_6425
+
+@ExperimentalResourceApi
+internal val Res.string.str_6426: StringResource
+  get() = String42.str_6426
+
+@ExperimentalResourceApi
+internal val Res.string.str_6427: StringResource
+  get() = String42.str_6427
+
+@ExperimentalResourceApi
+internal val Res.string.str_6428: StringResource
+  get() = String42.str_6428
+
+@ExperimentalResourceApi
+internal val Res.string.str_6429: StringResource
+  get() = String42.str_6429
+
+@ExperimentalResourceApi
+internal val Res.string.str_643: StringResource
+  get() = String42.str_643
+
+@ExperimentalResourceApi
+internal val Res.string.str_6430: StringResource
+  get() = String42.str_6430
+
+@ExperimentalResourceApi
+internal val Res.string.str_6431: StringResource
+  get() = String42.str_6431
+
+@ExperimentalResourceApi
+internal val Res.string.str_6432: StringResource
+  get() = String42.str_6432
+
+@ExperimentalResourceApi
+internal val Res.string.str_6433: StringResource
+  get() = String42.str_6433
+
+@ExperimentalResourceApi
+internal val Res.string.str_6434: StringResource
+  get() = String42.str_6434
+
+@ExperimentalResourceApi
+internal val Res.string.str_6435: StringResource
+  get() = String42.str_6435
+
+@ExperimentalResourceApi
+internal val Res.string.str_6436: StringResource
+  get() = String42.str_6436
+
+@ExperimentalResourceApi
+internal val Res.string.str_6437: StringResource
+  get() = String42.str_6437
+
+@ExperimentalResourceApi
+internal val Res.string.str_6438: StringResource
+  get() = String42.str_6438
+
+@ExperimentalResourceApi
+internal val Res.string.str_6439: StringResource
+  get() = String42.str_6439
+
+@ExperimentalResourceApi
+internal val Res.string.str_644: StringResource
+  get() = String42.str_644
+
+@ExperimentalResourceApi
+internal val Res.string.str_6440: StringResource
+  get() = String42.str_6440
+
+@ExperimentalResourceApi
+internal val Res.string.str_6441: StringResource
+  get() = String42.str_6441
+
+@ExperimentalResourceApi
+internal val Res.string.str_6442: StringResource
+  get() = String42.str_6442
+
+@ExperimentalResourceApi
+internal val Res.string.str_6443: StringResource
+  get() = String42.str_6443
+
+@ExperimentalResourceApi
+internal val Res.string.str_6444: StringResource
+  get() = String42.str_6444
+
+@ExperimentalResourceApi
+internal val Res.string.str_6445: StringResource
+  get() = String42.str_6445
+
+@ExperimentalResourceApi
+internal val Res.string.str_6446: StringResource
+  get() = String42.str_6446
+
+@ExperimentalResourceApi
+internal val Res.string.str_6447: StringResource
+  get() = String42.str_6447
+
+@ExperimentalResourceApi
+internal val Res.string.str_6448: StringResource
+  get() = String42.str_6448
+
+@ExperimentalResourceApi
+internal val Res.string.str_6449: StringResource
+  get() = String42.str_6449
+
+@ExperimentalResourceApi
+internal val Res.string.str_645: StringResource
+  get() = String42.str_645
+
+@ExperimentalResourceApi
+internal val Res.string.str_6450: StringResource
+  get() = String42.str_6450
+
+@ExperimentalResourceApi
+internal val Res.string.str_6451: StringResource
+  get() = String42.str_6451
+
+@ExperimentalResourceApi
+internal val Res.string.str_6452: StringResource
+  get() = String42.str_6452
+
+@ExperimentalResourceApi
+internal val Res.string.str_6453: StringResource
+  get() = String42.str_6453
+
+@ExperimentalResourceApi
+internal val Res.string.str_6454: StringResource
+  get() = String42.str_6454
+
+@ExperimentalResourceApi
+internal val Res.string.str_6455: StringResource
+  get() = String42.str_6455
+
+@ExperimentalResourceApi
+internal val Res.string.str_6456: StringResource
+  get() = String42.str_6456
+
+@ExperimentalResourceApi
+internal val Res.string.str_6457: StringResource
+  get() = String42.str_6457
+
+@ExperimentalResourceApi
+internal val Res.string.str_6458: StringResource
+  get() = String42.str_6458
+
+@ExperimentalResourceApi
+internal val Res.string.str_6459: StringResource
+  get() = String42.str_6459
+
+@ExperimentalResourceApi
+internal val Res.string.str_646: StringResource
+  get() = String42.str_646
+
+@ExperimentalResourceApi
+internal val Res.string.str_6460: StringResource
+  get() = String42.str_6460
+
+@ExperimentalResourceApi
+internal val Res.string.str_6461: StringResource
+  get() = String42.str_6461
+
+@ExperimentalResourceApi
+internal val Res.string.str_6462: StringResource
+  get() = String42.str_6462
+
+@ExperimentalResourceApi
+internal val Res.string.str_6463: StringResource
+  get() = String42.str_6463
+
+@ExperimentalResourceApi
+internal val Res.string.str_6464: StringResource
+  get() = String42.str_6464
+
+@ExperimentalResourceApi
+internal val Res.string.str_6465: StringResource
+  get() = String42.str_6465
+
+@ExperimentalResourceApi
+internal val Res.string.str_6466: StringResource
+  get() = String42.str_6466
+
+@ExperimentalResourceApi
+internal val Res.string.str_6467: StringResource
+  get() = String42.str_6467
+
+@ExperimentalResourceApi
+internal val Res.string.str_6468: StringResource
+  get() = String42.str_6468
+
+@ExperimentalResourceApi
+internal val Res.string.str_6469: StringResource
+  get() = String42.str_6469
+
+@ExperimentalResourceApi
+internal val Res.string.str_647: StringResource
+  get() = String42.str_647
+
+@ExperimentalResourceApi
+internal val Res.string.str_6470: StringResource
+  get() = String42.str_6470
+
+@ExperimentalResourceApi
+internal val Res.string.str_6471: StringResource
+  get() = String42.str_6471
+
+@ExperimentalResourceApi
+internal val Res.string.str_6472: StringResource
+  get() = String42.str_6472
+
+@ExperimentalResourceApi
+internal val Res.string.str_6473: StringResource
+  get() = String42.str_6473
+
+@ExperimentalResourceApi
+internal val Res.string.str_6474: StringResource
+  get() = String42.str_6474
+
+@ExperimentalResourceApi
+internal val Res.string.str_6475: StringResource
+  get() = String42.str_6475
+
+@ExperimentalResourceApi
+internal val Res.string.str_6476: StringResource
+  get() = String42.str_6476
+
+@ExperimentalResourceApi
+internal val Res.string.str_6477: StringResource
+  get() = String42.str_6477
+
+@ExperimentalResourceApi
+internal val Res.string.str_6478: StringResource
+  get() = String42.str_6478
+
+@ExperimentalResourceApi
+internal val Res.string.str_6479: StringResource
+  get() = String42.str_6479
+
+@ExperimentalResourceApi
+internal val Res.string.str_648: StringResource
+  get() = String42.str_648
+
+@ExperimentalResourceApi
+internal val Res.string.str_6480: StringResource
+  get() = String42.str_6480
+
+@ExperimentalResourceApi
+internal val Res.string.str_6481: StringResource
+  get() = String42.str_6481
+
+@ExperimentalResourceApi
+internal val Res.string.str_6482: StringResource
+  get() = String42.str_6482
+
+@ExperimentalResourceApi
+internal val Res.string.str_6483: StringResource
+  get() = String42.str_6483
+
+@ExperimentalResourceApi
+internal val Res.string.str_6484: StringResource
+  get() = String42.str_6484
+
+@ExperimentalResourceApi
+internal val Res.string.str_6485: StringResource
+  get() = String42.str_6485
+
+@ExperimentalResourceApi
+internal val Res.string.str_6486: StringResource
+  get() = String42.str_6486
+
+@ExperimentalResourceApi
+internal val Res.string.str_6487: StringResource
+  get() = String42.str_6487
+
+@ExperimentalResourceApi
+internal val Res.string.str_6488: StringResource
+  get() = String42.str_6488
+
+@ExperimentalResourceApi
+internal val Res.string.str_6489: StringResource
+  get() = String42.str_6489
+
+@ExperimentalResourceApi
+internal val Res.string.str_649: StringResource
+  get() = String42.str_649
+
+@ExperimentalResourceApi
+internal val Res.string.str_6490: StringResource
+  get() = String42.str_6490
+
+@ExperimentalResourceApi
+internal val Res.string.str_6491: StringResource
+  get() = String42.str_6491
+
+@ExperimentalResourceApi
+internal val Res.string.str_6492: StringResource
+  get() = String42.str_6492
+
+@ExperimentalResourceApi
+internal val Res.string.str_6493: StringResource
+  get() = String42.str_6493
+
+@ExperimentalResourceApi
+internal val Res.string.str_6494: StringResource
+  get() = String42.str_6494
+
+@ExperimentalResourceApi
+internal val Res.string.str_6495: StringResource
+  get() = String42.str_6495
+
+@ExperimentalResourceApi
+internal val Res.string.str_6496: StringResource
+  get() = String42.str_6496
+
+@ExperimentalResourceApi
+internal val Res.string.str_6497: StringResource
+  get() = String42.str_6497
+
+@ExperimentalResourceApi
+internal val Res.string.str_6498: StringResource
+  get() = String42.str_6498
+
+@ExperimentalResourceApi
+internal val Res.string.str_6499: StringResource
+  get() = String42.str_6499
+
+@ExperimentalResourceApi
+internal val Res.string.str_65: StringResource
+  get() = String42.str_65
+
+@ExperimentalResourceApi
+internal val Res.string.str_650: StringResource
+  get() = String42.str_650
+
+@ExperimentalResourceApi
+internal val Res.string.str_6500: StringResource
+  get() = String42.str_6500
+
+@ExperimentalResourceApi
+internal val Res.string.str_6501: StringResource
+  get() = String42.str_6501
+
+@ExperimentalResourceApi
+internal val Res.string.str_6502: StringResource
+  get() = String42.str_6502
+
+@ExperimentalResourceApi
+internal val Res.string.str_6503: StringResource
+  get() = String42.str_6503
+
+@ExperimentalResourceApi
+internal val Res.string.str_6504: StringResource
+  get() = String42.str_6504
+
+@ExperimentalResourceApi
+internal val Res.string.str_6505: StringResource
+  get() = String42.str_6505
+
+@ExperimentalResourceApi
+internal val Res.string.str_6506: StringResource
+  get() = String42.str_6506
+
+@ExperimentalResourceApi
+internal val Res.string.str_6507: StringResource
+  get() = String42.str_6507
+
+@ExperimentalResourceApi
+internal val Res.string.str_6508: StringResource
+  get() = String42.str_6508
+
+@ExperimentalResourceApi
+internal val Res.string.str_6509: StringResource
+  get() = String42.str_6509
+
+@ExperimentalResourceApi
+internal val Res.string.str_651: StringResource
+  get() = String42.str_651
+
+@ExperimentalResourceApi
+internal val Res.string.str_6510: StringResource
+  get() = String42.str_6510
+
+@ExperimentalResourceApi
+internal val Res.string.str_6511: StringResource
+  get() = String42.str_6511
+
+@ExperimentalResourceApi
+internal val Res.string.str_6512: StringResource
+  get() = String42.str_6512
+
+@ExperimentalResourceApi
+internal val Res.string.str_6513: StringResource
+  get() = String42.str_6513
+
+@ExperimentalResourceApi
+internal val Res.string.str_6514: StringResource
+  get() = String42.str_6514
+
+@ExperimentalResourceApi
+internal val Res.string.str_6515: StringResource
+  get() = String42.str_6515
+
+@ExperimentalResourceApi
+internal val Res.string.str_6516: StringResource
+  get() = String42.str_6516
+
+@ExperimentalResourceApi
+internal val Res.string.str_6517: StringResource
+  get() = String42.str_6517
+
+@ExperimentalResourceApi
+internal val Res.string.str_6518: StringResource
+  get() = String42.str_6518
+
+@ExperimentalResourceApi
+internal val Res.string.str_6519: StringResource
+  get() = String42.str_6519
+
+@ExperimentalResourceApi
+internal val Res.string.str_652: StringResource
+  get() = String42.str_652
+
+@ExperimentalResourceApi
+internal val Res.string.str_6520: StringResource
+  get() = String42.str_6520
+
+@ExperimentalResourceApi
+internal val Res.string.str_6521: StringResource
+  get() = String42.str_6521
+
+@ExperimentalResourceApi
+internal val Res.string.str_6522: StringResource
+  get() = String42.str_6522
+
+@ExperimentalResourceApi
+internal val Res.string.str_6523: StringResource
+  get() = String42.str_6523
+
+@ExperimentalResourceApi
+internal val Res.string.str_6524: StringResource
+  get() = String42.str_6524
+
+@ExperimentalResourceApi
+internal val Res.string.str_6525: StringResource
+  get() = String42.str_6525
+
+@ExperimentalResourceApi
+internal val Res.string.str_6526: StringResource
+  get() = String42.str_6526
+
+@ExperimentalResourceApi
+internal val Res.string.str_6527: StringResource
+  get() = String42.str_6527
+
+@ExperimentalResourceApi
+internal val Res.string.str_6528: StringResource
+  get() = String42.str_6528
+
+@ExperimentalResourceApi
+internal val Res.string.str_6529: StringResource
+  get() = String42.str_6529
+
+@ExperimentalResourceApi
+internal val Res.string.str_653: StringResource
+  get() = String42.str_653
+
+@ExperimentalResourceApi
+internal val Res.string.str_6530: StringResource
+  get() = String42.str_6530
+
+@ExperimentalResourceApi
+internal val Res.string.str_6531: StringResource
+  get() = String42.str_6531
+
+@ExperimentalResourceApi
+internal val Res.string.str_6532: StringResource
+  get() = String42.str_6532
+
+@ExperimentalResourceApi
+internal val Res.string.str_6533: StringResource
+  get() = String42.str_6533
+
+@ExperimentalResourceApi
+internal val Res.string.str_6534: StringResource
+  get() = String42.str_6534
+
+@ExperimentalResourceApi
+internal val Res.string.str_6535: StringResource
+  get() = String42.str_6535
+
+@ExperimentalResourceApi
+internal val Res.string.str_6536: StringResource
+  get() = String42.str_6536
+
+@ExperimentalResourceApi
+internal val Res.string.str_6537: StringResource
+  get() = String42.str_6537
+
+@ExperimentalResourceApi
+internal val Res.string.str_6538: StringResource
+  get() = String42.str_6538
+
+@ExperimentalResourceApi
+internal val Res.string.str_6539: StringResource
+  get() = String42.str_6539
+
+@ExperimentalResourceApi
+internal val Res.string.str_654: StringResource
+  get() = String42.str_654
+
+@ExperimentalResourceApi
+internal val Res.string.str_6540: StringResource
+  get() = String42.str_6540
+
+@ExperimentalResourceApi
+internal val Res.string.str_6541: StringResource
+  get() = String42.str_6541
+
+@ExperimentalResourceApi
+internal val Res.string.str_6542: StringResource
+  get() = String42.str_6542
+
+@ExperimentalResourceApi
+internal val Res.string.str_6543: StringResource
+  get() = String42.str_6543
+
+@ExperimentalResourceApi
+internal val Res.string.str_6544: StringResource
+  get() = String42.str_6544
+
+@ExperimentalResourceApi
+internal val Res.string.str_6545: StringResource
+  get() = String42.str_6545
+
+@ExperimentalResourceApi
+internal val Res.string.str_6546: StringResource
+  get() = String42.str_6546
+
+@ExperimentalResourceApi
+internal val Res.string.str_6547: StringResource
+  get() = String42.str_6547
+
+@ExperimentalResourceApi
+internal val Res.string.str_6548: StringResource
+  get() = String42.str_6548
+
+@ExperimentalResourceApi
+internal val Res.string.str_6549: StringResource
+  get() = String42.str_6549
+
+@ExperimentalResourceApi
+internal val Res.string.str_655: StringResource
+  get() = String42.str_655
+
+@ExperimentalResourceApi
+internal val Res.string.str_6550: StringResource
+  get() = String42.str_6550
+
+@ExperimentalResourceApi
+internal val Res.string.str_6551: StringResource
+  get() = String42.str_6551
+
+@ExperimentalResourceApi
+internal val Res.string.str_6552: StringResource
+  get() = String42.str_6552
+
+@ExperimentalResourceApi
+internal val Res.string.str_6553: StringResource
+  get() = String42.str_6553
+
+@ExperimentalResourceApi
+internal val Res.string.str_6554: StringResource
+  get() = String42.str_6554
+
+@ExperimentalResourceApi
+internal val Res.string.str_6555: StringResource
+  get() = String42.str_6555
+
+@ExperimentalResourceApi
+internal val Res.string.str_6556: StringResource
+  get() = String42.str_6556
+
+@ExperimentalResourceApi
+internal val Res.string.str_6557: StringResource
+  get() = String42.str_6557
+
+@ExperimentalResourceApi
+internal val Res.string.str_6558: StringResource
+  get() = String42.str_6558
+
+@ExperimentalResourceApi
+internal val Res.string.str_6559: StringResource
+  get() = String42.str_6559
+
+@ExperimentalResourceApi
+internal val Res.string.str_656: StringResource
+  get() = String42.str_656
+
+@ExperimentalResourceApi
+internal val Res.string.str_6560: StringResource
+  get() = String42.str_6560
+
+@ExperimentalResourceApi
+internal val Res.string.str_6561: StringResource
+  get() = String42.str_6561
+
+@ExperimentalResourceApi
+internal val Res.string.str_6562: StringResource
+  get() = String42.str_6562
+
+@ExperimentalResourceApi
+internal val Res.string.str_6563: StringResource
+  get() = String42.str_6563
+
+@ExperimentalResourceApi
+internal val Res.string.str_6564: StringResource
+  get() = String42.str_6564
+
+@ExperimentalResourceApi
+internal val Res.string.str_6565: StringResource
+  get() = String42.str_6565
+
+@ExperimentalResourceApi
+internal val Res.string.str_6566: StringResource
+  get() = String42.str_6566
+
+@ExperimentalResourceApi
+internal val Res.string.str_6567: StringResource
+  get() = String42.str_6567
+
+@ExperimentalResourceApi
+internal val Res.string.str_6568: StringResource
+  get() = String42.str_6568
+
+@ExperimentalResourceApi
+internal val Res.string.str_6569: StringResource
+  get() = String42.str_6569
+
+@ExperimentalResourceApi
+internal val Res.string.str_657: StringResource
+  get() = String42.str_657
+
+@ExperimentalResourceApi
+internal val Res.string.str_6570: StringResource
+  get() = String42.str_6570
+
+@ExperimentalResourceApi
+internal val Res.string.str_6571: StringResource
+  get() = String42.str_6571
+
+@ExperimentalResourceApi
+internal val Res.string.str_6572: StringResource
+  get() = String42.str_6572
+
+@ExperimentalResourceApi
+internal val Res.string.str_6573: StringResource
+  get() = String42.str_6573
+
+@ExperimentalResourceApi
+internal val Res.string.str_6574: StringResource
+  get() = String42.str_6574
+
+@ExperimentalResourceApi
+internal val Res.string.str_6575: StringResource
+  get() = String42.str_6575
+
+@ExperimentalResourceApi
+internal val Res.string.str_6576: StringResource
+  get() = String42.str_6576
+
+@ExperimentalResourceApi
+internal val Res.string.str_6577: StringResource
+  get() = String42.str_6577
+
+@ExperimentalResourceApi
+internal val Res.string.str_6578: StringResource
+  get() = String42.str_6578
+
+@ExperimentalResourceApi
+internal val Res.string.str_6579: StringResource
+  get() = String42.str_6579
+
+@ExperimentalResourceApi
+internal val Res.string.str_658: StringResource
+  get() = String42.str_658
+
+@ExperimentalResourceApi
+internal val Res.string.str_6580: StringResource
+  get() = String42.str_6580
+
+@ExperimentalResourceApi
+internal val Res.string.str_6581: StringResource
+  get() = String42.str_6581
+
+@ExperimentalResourceApi
+internal val Res.string.str_6582: StringResource
+  get() = String42.str_6582
+
+@ExperimentalResourceApi
+internal val Res.string.str_6583: StringResource
+  get() = String42.str_6583
+
+@ExperimentalResourceApi
+internal val Res.string.str_6584: StringResource
+  get() = String42.str_6584
+
+@ExperimentalResourceApi
+internal val Res.string.str_6585: StringResource
+  get() = String42.str_6585
+
+@ExperimentalResourceApi
+internal val Res.string.str_6586: StringResource
+  get() = String42.str_6586
+
+@ExperimentalResourceApi
+internal val Res.string.str_6587: StringResource
+  get() = String42.str_6587
+
+@ExperimentalResourceApi
+internal val Res.string.str_6588: StringResource
+  get() = String42.str_6588
+
+@ExperimentalResourceApi
+internal val Res.string.str_6589: StringResource
+  get() = String42.str_6589
+
+@ExperimentalResourceApi
+internal val Res.string.str_659: StringResource
+  get() = String42.str_659
+
+@ExperimentalResourceApi
+internal val Res.string.str_6590: StringResource
+  get() = String42.str_6590
+
+@ExperimentalResourceApi
+internal val Res.string.str_6591: StringResource
+  get() = String42.str_6591
+
+@ExperimentalResourceApi
+internal val Res.string.str_6592: StringResource
+  get() = String42.str_6592
+
+@ExperimentalResourceApi
+internal val Res.string.str_6593: StringResource
+  get() = String42.str_6593
+
+@ExperimentalResourceApi
+internal val Res.string.str_6594: StringResource
+  get() = String42.str_6594
+
+@ExperimentalResourceApi
+internal val Res.string.str_6595: StringResource
+  get() = String42.str_6595
+
+@ExperimentalResourceApi
+internal val Res.string.str_6596: StringResource
+  get() = String42.str_6596
+
+@ExperimentalResourceApi
+internal val Res.string.str_6597: StringResource
+  get() = String42.str_6597
+
+@ExperimentalResourceApi
+internal val Res.string.str_6598: StringResource
+  get() = String42.str_6598
+
+@ExperimentalResourceApi
+internal val Res.string.str_6599: StringResource
+  get() = String42.str_6599
+
+@ExperimentalResourceApi
+internal val Res.string.str_66: StringResource
+  get() = String42.str_66
+
+@ExperimentalResourceApi
+internal val Res.string.str_660: StringResource
+  get() = String42.str_660
+
+@ExperimentalResourceApi
+internal val Res.string.str_6600: StringResource
+  get() = String42.str_6600
+
+@ExperimentalResourceApi
+internal val Res.string.str_6601: StringResource
+  get() = String42.str_6601
+
+@ExperimentalResourceApi
+internal val Res.string.str_6602: StringResource
+  get() = String42.str_6602
+
+@ExperimentalResourceApi
+internal val Res.string.str_6603: StringResource
+  get() = String42.str_6603
+
+@ExperimentalResourceApi
+internal val Res.string.str_6604: StringResource
+  get() = String42.str_6604
+
+@ExperimentalResourceApi
+internal val Res.string.str_6605: StringResource
+  get() = String42.str_6605
+
+@ExperimentalResourceApi
+internal val Res.string.str_6606: StringResource
+  get() = String42.str_6606
+
+@ExperimentalResourceApi
+internal val Res.string.str_6607: StringResource
+  get() = String42.str_6607
+
+@ExperimentalResourceApi
+internal val Res.string.str_6608: StringResource
+  get() = String42.str_6608
+
+@ExperimentalResourceApi
+internal val Res.string.str_6609: StringResource
+  get() = String42.str_6609
+
+@ExperimentalResourceApi
+internal val Res.string.str_661: StringResource
+  get() = String42.str_661
+
+@ExperimentalResourceApi
+internal val Res.string.str_6610: StringResource
+  get() = String42.str_6610
+
+@ExperimentalResourceApi
+internal val Res.string.str_6611: StringResource
+  get() = String42.str_6611
+
+@ExperimentalResourceApi
+internal val Res.string.str_6612: StringResource
+  get() = String42.str_6612
+
+@ExperimentalResourceApi
+internal val Res.string.str_6613: StringResource
+  get() = String42.str_6613
+
+@ExperimentalResourceApi
+internal val Res.string.str_6614: StringResource
+  get() = String42.str_6614
+
+@ExperimentalResourceApi
+internal val Res.string.str_6615: StringResource
+  get() = String42.str_6615
+
+@ExperimentalResourceApi
+internal val Res.string.str_6616: StringResource
+  get() = String42.str_6616
+
+@ExperimentalResourceApi
+internal val Res.string.str_6617: StringResource
+  get() = String42.str_6617
+
+@ExperimentalResourceApi
+internal val Res.string.str_6618: StringResource
+  get() = String42.str_6618
+
+@ExperimentalResourceApi
+internal val Res.string.str_6619: StringResource
+  get() = String42.str_6619
+
+@ExperimentalResourceApi
+internal val Res.string.str_662: StringResource
+  get() = String42.str_662
+
+@ExperimentalResourceApi
+internal val Res.string.str_6620: StringResource
+  get() = String42.str_6620
+
+@ExperimentalResourceApi
+internal val Res.string.str_6621: StringResource
+  get() = String42.str_6621
+
+@ExperimentalResourceApi
+internal val Res.string.str_6622: StringResource
+  get() = String42.str_6622
+
+@ExperimentalResourceApi
+internal val Res.string.str_6623: StringResource
+  get() = String42.str_6623
+
+@ExperimentalResourceApi
+internal val Res.string.str_6624: StringResource
+  get() = String42.str_6624
+
+@ExperimentalResourceApi
+internal val Res.string.str_6625: StringResource
+  get() = String42.str_6625
+
+@ExperimentalResourceApi
+internal val Res.string.str_6626: StringResource
+  get() = String42.str_6626
+
+@ExperimentalResourceApi
+internal val Res.string.str_6627: StringResource
+  get() = String42.str_6627
+
+@ExperimentalResourceApi
+internal val Res.string.str_6628: StringResource
+  get() = String42.str_6628
+
+@ExperimentalResourceApi
+internal val Res.string.str_6629: StringResource
+  get() = String42.str_6629
+
+@ExperimentalResourceApi
+internal val Res.string.str_663: StringResource
+  get() = String42.str_663
+
+@ExperimentalResourceApi
+internal val Res.string.str_6630: StringResource
+  get() = String42.str_6630
+
+@ExperimentalResourceApi
+internal val Res.string.str_6631: StringResource
+  get() = String42.str_6631
+
+@ExperimentalResourceApi
+internal val Res.string.str_6632: StringResource
+  get() = String42.str_6632
+
+@ExperimentalResourceApi
+internal val Res.string.str_6633: StringResource
+  get() = String42.str_6633
+
+@ExperimentalResourceApi
+internal val Res.string.str_6634: StringResource
+  get() = String42.str_6634
+
+@ExperimentalResourceApi
+internal val Res.string.str_6635: StringResource
+  get() = String42.str_6635
+
+@ExperimentalResourceApi
+internal val Res.string.str_6636: StringResource
+  get() = String42.str_6636
+
+@ExperimentalResourceApi
+internal val Res.string.str_6637: StringResource
+  get() = String42.str_6637
+
+@ExperimentalResourceApi
+internal val Res.string.str_6638: StringResource
+  get() = String42.str_6638
+
+@ExperimentalResourceApi
+internal val Res.string.str_6639: StringResource
+  get() = String42.str_6639
+
+@ExperimentalResourceApi
+internal val Res.string.str_664: StringResource
+  get() = String42.str_664
+
+@ExperimentalResourceApi
+internal val Res.string.str_6640: StringResource
+  get() = String42.str_6640
+
+@ExperimentalResourceApi
+internal val Res.string.str_6641: StringResource
+  get() = String42.str_6641
+
+@ExperimentalResourceApi
+internal val Res.string.str_6642: StringResource
+  get() = String42.str_6642
+
+@ExperimentalResourceApi
+internal val Res.string.str_6643: StringResource
+  get() = String42.str_6643
+
+@ExperimentalResourceApi
+internal val Res.string.str_6644: StringResource
+  get() = String42.str_6644
+
+@ExperimentalResourceApi
+internal val Res.string.str_6645: StringResource
+  get() = String42.str_6645
+
+@ExperimentalResourceApi
+internal val Res.string.str_6646: StringResource
+  get() = String42.str_6646
+
+@ExperimentalResourceApi
+internal val Res.string.str_6647: StringResource
+  get() = String42.str_6647
+
+@ExperimentalResourceApi
+internal val Res.string.str_6648: StringResource
+  get() = String42.str_6648
+
+@ExperimentalResourceApi
+internal val Res.string.str_6649: StringResource
+  get() = String42.str_6649
+
+@ExperimentalResourceApi
+internal val Res.string.str_665: StringResource
+  get() = String42.str_665
+
+@ExperimentalResourceApi
+internal val Res.string.str_6650: StringResource
+  get() = String42.str_6650
+
+@ExperimentalResourceApi
+internal val Res.string.str_6651: StringResource
+  get() = String42.str_6651
+
+@ExperimentalResourceApi
+internal val Res.string.str_6652: StringResource
+  get() = String42.str_6652
+
+@ExperimentalResourceApi
+internal val Res.string.str_6653: StringResource
+  get() = String42.str_6653
+
+@ExperimentalResourceApi
+internal val Res.string.str_6654: StringResource
+  get() = String42.str_6654
+
+@ExperimentalResourceApi
+internal val Res.string.str_6655: StringResource
+  get() = String42.str_6655
+
+@ExperimentalResourceApi
+internal val Res.string.str_6656: StringResource
+  get() = String42.str_6656
+
+@ExperimentalResourceApi
+internal val Res.string.str_6657: StringResource
+  get() = String42.str_6657
+
+@ExperimentalResourceApi
+internal val Res.string.str_6658: StringResource
+  get() = String42.str_6658
+
+@ExperimentalResourceApi
+internal val Res.string.str_6659: StringResource
+  get() = String42.str_6659
+
+@ExperimentalResourceApi
+internal val Res.string.str_666: StringResource
+  get() = String42.str_666
+
+@ExperimentalResourceApi
+internal val Res.string.str_6660: StringResource
+  get() = String42.str_6660
+
+@ExperimentalResourceApi
+internal val Res.string.str_6661: StringResource
+  get() = String42.str_6661
+
+@ExperimentalResourceApi
+internal val Res.string.str_6662: StringResource
+  get() = String42.str_6662
+
+@ExperimentalResourceApi
+internal val Res.string.str_6663: StringResource
+  get() = String42.str_6663
+
+@ExperimentalResourceApi
+internal val Res.string.str_6664: StringResource
+  get() = String42.str_6664
+
+@ExperimentalResourceApi
+internal val Res.string.str_6665: StringResource
+  get() = String42.str_6665
+
+@ExperimentalResourceApi
+internal val Res.string.str_6666: StringResource
+  get() = String42.str_6666
+
+@ExperimentalResourceApi
+internal val Res.string.str_6667: StringResource
+  get() = String42.str_6667
+
+@ExperimentalResourceApi
+internal val Res.string.str_6668: StringResource
+  get() = String42.str_6668
+
+@ExperimentalResourceApi
+internal val Res.string.str_6669: StringResource
+  get() = String42.str_6669
+
+@ExperimentalResourceApi
+internal val Res.string.str_667: StringResource
+  get() = String42.str_667
+
+@ExperimentalResourceApi
+internal val Res.string.str_6670: StringResource
+  get() = String42.str_6670
+
+@ExperimentalResourceApi
+internal val Res.string.str_6671: StringResource
+  get() = String42.str_6671
+
+@ExperimentalResourceApi
+internal val Res.string.str_6672: StringResource
+  get() = String42.str_6672
+
+@ExperimentalResourceApi
+internal val Res.string.str_6673: StringResource
+  get() = String42.str_6673
+
+@ExperimentalResourceApi
+internal val Res.string.str_6674: StringResource
+  get() = String42.str_6674
+
+@ExperimentalResourceApi
+internal val Res.string.str_6675: StringResource
+  get() = String42.str_6675
+
+@ExperimentalResourceApi
+internal val Res.string.str_6676: StringResource
+  get() = String42.str_6676
+
+@ExperimentalResourceApi
+internal val Res.string.str_6677: StringResource
+  get() = String42.str_6677
+
+@ExperimentalResourceApi
+internal val Res.string.str_6678: StringResource
+  get() = String42.str_6678
+
+@ExperimentalResourceApi
+internal val Res.string.str_6679: StringResource
+  get() = String42.str_6679
+
+@ExperimentalResourceApi
+internal val Res.string.str_668: StringResource
+  get() = String42.str_668
+
+@ExperimentalResourceApi
+internal val Res.string.str_6680: StringResource
+  get() = String42.str_6680
+
+@ExperimentalResourceApi
+internal val Res.string.str_6681: StringResource
+  get() = String42.str_6681
+
+@ExperimentalResourceApi
+internal val Res.string.str_6682: StringResource
+  get() = String42.str_6682
+
+@ExperimentalResourceApi
+internal val Res.string.str_6683: StringResource
+  get() = String42.str_6683
+
+@ExperimentalResourceApi
+internal val Res.string.str_6684: StringResource
+  get() = String42.str_6684
+
+@ExperimentalResourceApi
+internal val Res.string.str_6685: StringResource
+  get() = String42.str_6685
+
+@ExperimentalResourceApi
+internal val Res.string.str_6686: StringResource
+  get() = String42.str_6686
+
+@ExperimentalResourceApi
+internal val Res.string.str_6687: StringResource
+  get() = String42.str_6687
+
+@ExperimentalResourceApi
+internal val Res.string.str_6688: StringResource
+  get() = String42.str_6688
+
+@ExperimentalResourceApi
+internal val Res.string.str_6689: StringResource
+  get() = String42.str_6689
+
+@ExperimentalResourceApi
+internal val Res.string.str_669: StringResource
+  get() = String42.str_669
+
+@ExperimentalResourceApi
+internal val Res.string.str_6690: StringResource
+  get() = String42.str_6690
+
+@ExperimentalResourceApi
+internal val Res.string.str_6691: StringResource
+  get() = String42.str_6691
+
+@ExperimentalResourceApi
+internal val Res.string.str_6692: StringResource
+  get() = String42.str_6692
+
+@ExperimentalResourceApi
+internal val Res.string.str_6693: StringResource
+  get() = String42.str_6693
+
+@ExperimentalResourceApi
+internal val Res.string.str_6694: StringResource
+  get() = String42.str_6694
+
+@ExperimentalResourceApi
+internal val Res.string.str_6695: StringResource
+  get() = String42.str_6695
+
+@ExperimentalResourceApi
+internal val Res.string.str_6696: StringResource
+  get() = String42.str_6696
+
+@ExperimentalResourceApi
+internal val Res.string.str_6697: StringResource
+  get() = String42.str_6697
+
+@ExperimentalResourceApi
+internal val Res.string.str_6698: StringResource
+  get() = String42.str_6698
+
+@ExperimentalResourceApi
+internal val Res.string.str_6699: StringResource
+  get() = String42.str_6699
+
+@ExperimentalResourceApi
+internal val Res.string.str_67: StringResource
+  get() = String42.str_67
+
+@ExperimentalResourceApi
+internal val Res.string.str_670: StringResource
+  get() = String42.str_670
+
+@ExperimentalResourceApi
+internal val Res.string.str_6700: StringResource
+  get() = String42.str_6700
+
+@ExperimentalResourceApi
+internal val Res.string.str_6701: StringResource
+  get() = String42.str_6701
+
+@ExperimentalResourceApi
+internal val Res.string.str_6702: StringResource
+  get() = String42.str_6702
+
+@ExperimentalResourceApi
+internal val Res.string.str_6703: StringResource
+  get() = String42.str_6703
+
+@ExperimentalResourceApi
+internal val Res.string.str_6704: StringResource
+  get() = String42.str_6704
+
+@ExperimentalResourceApi
+internal val Res.string.str_6705: StringResource
+  get() = String42.str_6705
+
+@ExperimentalResourceApi
+internal val Res.string.str_6706: StringResource
+  get() = String42.str_6706
+
+@ExperimentalResourceApi
+internal val Res.string.str_6707: StringResource
+  get() = String42.str_6707
+
+@ExperimentalResourceApi
+internal val Res.string.str_6708: StringResource
+  get() = String42.str_6708
+
+@ExperimentalResourceApi
+internal val Res.string.str_6709: StringResource
+  get() = String42.str_6709
+
+@ExperimentalResourceApi
+internal val Res.string.str_671: StringResource
+  get() = String42.str_671
+
+@ExperimentalResourceApi
+internal val Res.string.str_6710: StringResource
+  get() = String42.str_6710
+
+@ExperimentalResourceApi
+internal val Res.string.str_6711: StringResource
+  get() = String42.str_6711
+
+@ExperimentalResourceApi
+internal val Res.string.str_6712: StringResource
+  get() = String42.str_6712
+
+@ExperimentalResourceApi
+internal val Res.string.str_6713: StringResource
+  get() = String42.str_6713
+
+@ExperimentalResourceApi
+internal val Res.string.str_6714: StringResource
+  get() = String42.str_6714
+
+@ExperimentalResourceApi
+internal val Res.string.str_6715: StringResource
+  get() = String42.str_6715
+
+@ExperimentalResourceApi
+internal val Res.string.str_6716: StringResource
+  get() = String42.str_6716
+
+@ExperimentalResourceApi
+internal val Res.string.str_6717: StringResource
+  get() = String42.str_6717
+
+@ExperimentalResourceApi
+internal val Res.string.str_6718: StringResource
+  get() = String42.str_6718
+
+@ExperimentalResourceApi
+internal val Res.string.str_6719: StringResource
+  get() = String42.str_6719
+
+@ExperimentalResourceApi
+internal val Res.string.str_672: StringResource
+  get() = String42.str_672
+
+@ExperimentalResourceApi
+internal val Res.string.str_6720: StringResource
+  get() = String42.str_6720
+
+@ExperimentalResourceApi
+internal val Res.string.str_6721: StringResource
+  get() = String42.str_6721
+
+@ExperimentalResourceApi
+internal val Res.string.str_6722: StringResource
+  get() = String42.str_6722
+
+@ExperimentalResourceApi
+internal val Res.string.str_6723: StringResource
+  get() = String42.str_6723
+
+@ExperimentalResourceApi
+internal val Res.string.str_6724: StringResource
+  get() = String42.str_6724
+
+@ExperimentalResourceApi
+internal val Res.string.str_6725: StringResource
+  get() = String42.str_6725
+
+@ExperimentalResourceApi
+internal val Res.string.str_6726: StringResource
+  get() = String42.str_6726
+
+@ExperimentalResourceApi
+internal val Res.string.str_6727: StringResource
+  get() = String42.str_6727
+
+@ExperimentalResourceApi
+internal val Res.string.str_6728: StringResource
+  get() = String42.str_6728
+
+@ExperimentalResourceApi
+internal val Res.string.str_6729: StringResource
+  get() = String42.str_6729
+
+@ExperimentalResourceApi
+internal val Res.string.str_673: StringResource
+  get() = String42.str_673
+
+@ExperimentalResourceApi
+internal val Res.string.str_6730: StringResource
+  get() = String42.str_6730
+
+@ExperimentalResourceApi
+internal val Res.string.str_6731: StringResource
+  get() = String42.str_6731
+
+@ExperimentalResourceApi
+internal val Res.string.str_6732: StringResource
+  get() = String42.str_6732
+
+@ExperimentalResourceApi
+internal val Res.string.str_6733: StringResource
+  get() = String42.str_6733
+
+@ExperimentalResourceApi
+internal val Res.string.str_6734: StringResource
+  get() = String42.str_6734
+
+@ExperimentalResourceApi
+internal val Res.string.str_6735: StringResource
+  get() = String42.str_6735
+
+@ExperimentalResourceApi
+internal val Res.string.str_6736: StringResource
+  get() = String42.str_6736
+
+@ExperimentalResourceApi
+internal val Res.string.str_6737: StringResource
+  get() = String42.str_6737
+
+@ExperimentalResourceApi
+internal val Res.string.str_6738: StringResource
+  get() = String42.str_6738
+
+@ExperimentalResourceApi
+internal val Res.string.str_6739: StringResource
+  get() = String42.str_6739
+
+@ExperimentalResourceApi
+internal val Res.string.str_674: StringResource
+  get() = String42.str_674
+
+@ExperimentalResourceApi
+internal val Res.string.str_6740: StringResource
+  get() = String42.str_6740
+
+@ExperimentalResourceApi
+internal val Res.string.str_6741: StringResource
+  get() = String42.str_6741
+
+@ExperimentalResourceApi
+internal val Res.string.str_6742: StringResource
+  get() = String42.str_6742
+
+@ExperimentalResourceApi
+internal val Res.string.str_6743: StringResource
+  get() = String42.str_6743
+
+@ExperimentalResourceApi
+internal val Res.string.str_6744: StringResource
+  get() = String42.str_6744
+
+@ExperimentalResourceApi
+internal val Res.string.str_6745: StringResource
+  get() = String42.str_6745
+
+@ExperimentalResourceApi
+internal val Res.string.str_6746: StringResource
+  get() = String42.str_6746
+
+@ExperimentalResourceApi
+internal val Res.string.str_6747: StringResource
+  get() = String42.str_6747
+
+@ExperimentalResourceApi
+internal val Res.string.str_6748: StringResource
+  get() = String42.str_6748
+
+@ExperimentalResourceApi
+internal val Res.string.str_6749: StringResource
+  get() = String42.str_6749
+
+@ExperimentalResourceApi
+internal val Res.string.str_675: StringResource
+  get() = String42.str_675
+
+@ExperimentalResourceApi
+internal val Res.string.str_6750: StringResource
+  get() = String42.str_6750
+
+@ExperimentalResourceApi
+internal val Res.string.str_6751: StringResource
+  get() = String42.str_6751
+
+@ExperimentalResourceApi
+internal val Res.string.str_6752: StringResource
+  get() = String42.str_6752
+
+@ExperimentalResourceApi
+internal val Res.string.str_6753: StringResource
+  get() = String42.str_6753
+
+@ExperimentalResourceApi
+internal val Res.string.str_6754: StringResource
+  get() = String42.str_6754
+
+@ExperimentalResourceApi
+internal val Res.string.str_6755: StringResource
+  get() = String42.str_6755
+
+@ExperimentalResourceApi
+internal val Res.string.str_6756: StringResource
+  get() = String42.str_6756
+
+@ExperimentalResourceApi
+internal val Res.string.str_6757: StringResource
+  get() = String42.str_6757
+
+@ExperimentalResourceApi
+internal val Res.string.str_6758: StringResource
+  get() = String42.str_6758
+
+@ExperimentalResourceApi
+internal val Res.string.str_6759: StringResource
+  get() = String42.str_6759
+
+@ExperimentalResourceApi
+internal val Res.string.str_676: StringResource
+  get() = String42.str_676
+
+@ExperimentalResourceApi
+internal val Res.string.str_6760: StringResource
+  get() = String42.str_6760
+
+@ExperimentalResourceApi
+internal val Res.string.str_6761: StringResource
+  get() = String42.str_6761
+
+@ExperimentalResourceApi
+internal val Res.string.str_6762: StringResource
+  get() = String42.str_6762
+
+@ExperimentalResourceApi
+internal val Res.string.str_6763: StringResource
+  get() = String42.str_6763
+
+@ExperimentalResourceApi
+internal val Res.string.str_6764: StringResource
+  get() = String42.str_6764
+
+@ExperimentalResourceApi
+internal val Res.string.str_6765: StringResource
+  get() = String42.str_6765
+
+@ExperimentalResourceApi
+internal val Res.string.str_6766: StringResource
+  get() = String42.str_6766
+
+@ExperimentalResourceApi
+internal val Res.string.str_6767: StringResource
+  get() = String42.str_6767
+
+@ExperimentalResourceApi
+internal val Res.string.str_6768: StringResource
+  get() = String42.str_6768
+
+@ExperimentalResourceApi
+internal val Res.string.str_6769: StringResource
+  get() = String42.str_6769
+
+@ExperimentalResourceApi
+internal val Res.string.str_677: StringResource
+  get() = String42.str_677
+
+@ExperimentalResourceApi
+internal val Res.string.str_6770: StringResource
+  get() = String42.str_6770
+
+@ExperimentalResourceApi
+internal val Res.string.str_6771: StringResource
+  get() = String42.str_6771
+
+@ExperimentalResourceApi
+internal val Res.string.str_6772: StringResource
+  get() = String42.str_6772
+
+@ExperimentalResourceApi
+internal val Res.string.str_6773: StringResource
+  get() = String42.str_6773
+
+@ExperimentalResourceApi
+internal val Res.string.str_6774: StringResource
+  get() = String42.str_6774
+
+@ExperimentalResourceApi
+internal val Res.string.str_6775: StringResource
+  get() = String42.str_6775
+
+@ExperimentalResourceApi
+internal val Res.string.str_6776: StringResource
+  get() = String42.str_6776
+
+@ExperimentalResourceApi
+internal val Res.string.str_6777: StringResource
+  get() = String42.str_6777
+
+@ExperimentalResourceApi
+internal val Res.string.str_6778: StringResource
+  get() = String42.str_6778
+
+@ExperimentalResourceApi
+internal val Res.string.str_6779: StringResource
+  get() = String42.str_6779
+
+@ExperimentalResourceApi
+internal val Res.string.str_678: StringResource
+  get() = String42.str_678
+
+@ExperimentalResourceApi
+internal val Res.string.str_6780: StringResource
+  get() = String42.str_6780
+
+@ExperimentalResourceApi
+internal val Res.string.str_6781: StringResource
+  get() = String42.str_6781
+
+@ExperimentalResourceApi
+internal val Res.string.str_6782: StringResource
+  get() = String42.str_6782
+
+@ExperimentalResourceApi
+internal val Res.string.str_6783: StringResource
+  get() = String42.str_6783
+
+@ExperimentalResourceApi
+internal val Res.string.str_6784: StringResource
+  get() = String42.str_6784
+
+@ExperimentalResourceApi
+internal val Res.string.str_6785: StringResource
+  get() = String42.str_6785
+
+@ExperimentalResourceApi
+internal val Res.string.str_6786: StringResource
+  get() = String42.str_6786
+
+@ExperimentalResourceApi
+internal val Res.string.str_6787: StringResource
+  get() = String42.str_6787
+
+@ExperimentalResourceApi
+internal val Res.string.str_6788: StringResource
+  get() = String42.str_6788
+
+@ExperimentalResourceApi
+internal val Res.string.str_6789: StringResource
+  get() = String42.str_6789
+
+@ExperimentalResourceApi
+internal val Res.string.str_679: StringResource
+  get() = String42.str_679
+
+@ExperimentalResourceApi
+internal val Res.string.str_6790: StringResource
+  get() = String42.str_6790
+
+@ExperimentalResourceApi
+internal val Res.string.str_6791: StringResource
+  get() = String42.str_6791
+
+@ExperimentalResourceApi
+internal val Res.string.str_6792: StringResource
+  get() = String42.str_6792
+
+@ExperimentalResourceApi
+internal val Res.string.str_6793: StringResource
+  get() = String42.str_6793
+
+@ExperimentalResourceApi
+internal val Res.string.str_6794: StringResource
+  get() = String42.str_6794
+
+@ExperimentalResourceApi
+internal val Res.string.str_6795: StringResource
+  get() = String42.str_6795
+
+@ExperimentalResourceApi
+internal val Res.string.str_6796: StringResource
+  get() = String42.str_6796
+
+@ExperimentalResourceApi
+internal val Res.string.str_6797: StringResource
+  get() = String42.str_6797
+
+@ExperimentalResourceApi
+internal val Res.string.str_6798: StringResource
+  get() = String42.str_6798
+
+@ExperimentalResourceApi
+internal val Res.string.str_6799: StringResource
+  get() = String42.str_6799
+
+@ExperimentalResourceApi
+internal val Res.string.str_68: StringResource
+  get() = String42.str_68
+
+@ExperimentalResourceApi
+internal val Res.string.str_680: StringResource
+  get() = String42.str_680
+
+@ExperimentalResourceApi
+internal val Res.string.str_6800: StringResource
+  get() = String42.str_6800
+
+@ExperimentalResourceApi
+internal val Res.string.str_6801: StringResource
+  get() = String42.str_6801
+
+@ExperimentalResourceApi
+internal val Res.string.str_6802: StringResource
+  get() = String42.str_6802
+
+@ExperimentalResourceApi
+internal val Res.string.str_6803: StringResource
+  get() = String42.str_6803
+
+@ExperimentalResourceApi
+internal val Res.string.str_6804: StringResource
+  get() = String42.str_6804
+
+@ExperimentalResourceApi
+internal val Res.string.str_6805: StringResource
+  get() = String42.str_6805
+
+@ExperimentalResourceApi
+internal val Res.string.str_6806: StringResource
+  get() = String42.str_6806
+
+@ExperimentalResourceApi
+internal val Res.string.str_6807: StringResource
+  get() = String42.str_6807
+
+@ExperimentalResourceApi
+internal val Res.string.str_6808: StringResource
+  get() = String42.str_6808
+
+@ExperimentalResourceApi
+internal val Res.string.str_6809: StringResource
+  get() = String42.str_6809
+
+@ExperimentalResourceApi
+internal val Res.string.str_681: StringResource
+  get() = String42.str_681
+
+@ExperimentalResourceApi
+internal val Res.string.str_6810: StringResource
+  get() = String42.str_6810
+
+@ExperimentalResourceApi
+internal val Res.string.str_6811: StringResource
+  get() = String42.str_6811
+
+@ExperimentalResourceApi
+internal val Res.string.str_6812: StringResource
+  get() = String42.str_6812
+
+@ExperimentalResourceApi
+internal val Res.string.str_6813: StringResource
+  get() = String42.str_6813
+
+@ExperimentalResourceApi
+internal val Res.string.str_6814: StringResource
+  get() = String42.str_6814
+
+@ExperimentalResourceApi
+internal val Res.string.str_6815: StringResource
+  get() = String42.str_6815
+
+@ExperimentalResourceApi
+internal val Res.string.str_6816: StringResource
+  get() = String42.str_6816
+
+@ExperimentalResourceApi
+internal val Res.string.str_6817: StringResource
+  get() = String42.str_6817
+
+@ExperimentalResourceApi
+internal val Res.string.str_6818: StringResource
+  get() = String42.str_6818
+
+@ExperimentalResourceApi
+internal val Res.string.str_6819: StringResource
+  get() = String42.str_6819
+
+@ExperimentalResourceApi
+internal val Res.string.str_682: StringResource
+  get() = String42.str_682
+
+@ExperimentalResourceApi
+internal val Res.string.str_6820: StringResource
+  get() = String42.str_6820
+
+@ExperimentalResourceApi
+internal val Res.string.str_6821: StringResource
+  get() = String42.str_6821
+
+@ExperimentalResourceApi
+internal val Res.string.str_6822: StringResource
+  get() = String42.str_6822
+
+@ExperimentalResourceApi
+internal val Res.string.str_6823: StringResource
+  get() = String42.str_6823
+
+@ExperimentalResourceApi
+internal val Res.string.str_6824: StringResource
+  get() = String42.str_6824
+
+@ExperimentalResourceApi
+internal val Res.string.str_6825: StringResource
+  get() = String42.str_6825
+
+@ExperimentalResourceApi
+internal val Res.string.str_6826: StringResource
+  get() = String42.str_6826
+
+@ExperimentalResourceApi
+internal val Res.string.str_6827: StringResource
+  get() = String42.str_6827
+
+@ExperimentalResourceApi
+internal val Res.string.str_6828: StringResource
+  get() = String42.str_6828
+
+@ExperimentalResourceApi
+internal val Res.string.str_6829: StringResource
+  get() = String42.str_6829
+
+@ExperimentalResourceApi
+internal val Res.string.str_683: StringResource
+  get() = String42.str_683
+
+@ExperimentalResourceApi
+internal val Res.string.str_6830: StringResource
+  get() = String42.str_6830
+
+@ExperimentalResourceApi
+internal val Res.string.str_6831: StringResource
+  get() = String42.str_6831
+
+@ExperimentalResourceApi
+internal val Res.string.str_6832: StringResource
+  get() = String42.str_6832
+
+@ExperimentalResourceApi
+internal val Res.string.str_6833: StringResource
+  get() = String42.str_6833
+
+@ExperimentalResourceApi
+internal val Res.string.str_6834: StringResource
+  get() = String42.str_6834
+
+@ExperimentalResourceApi
+internal val Res.string.str_6835: StringResource
+  get() = String42.str_6835
+
+@ExperimentalResourceApi
+internal val Res.string.str_6836: StringResource
+  get() = String42.str_6836
+
+@ExperimentalResourceApi
+internal val Res.string.str_6837: StringResource
+  get() = String42.str_6837
+
+@ExperimentalResourceApi
+internal val Res.string.str_6838: StringResource
+  get() = String42.str_6838
+
+@ExperimentalResourceApi
+internal val Res.string.str_6839: StringResource
+  get() = String42.str_6839
+
+@ExperimentalResourceApi
+internal val Res.string.str_684: StringResource
+  get() = String42.str_684
+
+@ExperimentalResourceApi
+internal val Res.string.str_6840: StringResource
+  get() = String42.str_6840
+
+@ExperimentalResourceApi
+internal val Res.string.str_6841: StringResource
+  get() = String42.str_6841
+
+@ExperimentalResourceApi
+internal val Res.string.str_6842: StringResource
+  get() = String42.str_6842
+
+@ExperimentalResourceApi
+internal val Res.string.str_6843: StringResource
+  get() = String42.str_6843
+
+@ExperimentalResourceApi
+internal val Res.string.str_6844: StringResource
+  get() = String42.str_6844
+
+@ExperimentalResourceApi
+internal val Res.string.str_6845: StringResource
+  get() = String42.str_6845
+
+@ExperimentalResourceApi
+internal val Res.string.str_6846: StringResource
+  get() = String42.str_6846
+
+@ExperimentalResourceApi
+internal val Res.string.str_6847: StringResource
+  get() = String42.str_6847
+
+@ExperimentalResourceApi
+internal val Res.string.str_6848: StringResource
+  get() = String42.str_6848

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String43.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String43.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String43 {
+  public val str_6849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6849", "str_6849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_685", "str_685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6850", "str_6850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6851", "str_6851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6852", "str_6852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6853", "str_6853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6854", "str_6854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6855", "str_6855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6856", "str_6856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6857", "str_6857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6858", "str_6858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6859", "str_6859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_686", "str_686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6860", "str_6860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6861", "str_6861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6862", "str_6862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6863", "str_6863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6864", "str_6864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6865", "str_6865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6866", "str_6866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6867", "str_6867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6868", "str_6868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6869", "str_6869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_687", "str_687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6870", "str_6870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6871", "str_6871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6872", "str_6872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6873", "str_6873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6874", "str_6874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6875", "str_6875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6876", "str_6876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6877", "str_6877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6878", "str_6878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6879", "str_6879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_688", "str_688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6880", "str_6880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6881", "str_6881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6882", "str_6882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6883", "str_6883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6884", "str_6884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6885", "str_6885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6886", "str_6886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6887", "str_6887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6888", "str_6888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6889", "str_6889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_689", "str_689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6890", "str_6890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6891", "str_6891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6892", "str_6892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6893", "str_6893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6894", "str_6894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6895", "str_6895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6896", "str_6896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6897", "str_6897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6898", "str_6898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6899", "str_6899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_69: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_69", "str_69",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_690", "str_690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6900", "str_6900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6901", "str_6901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6902", "str_6902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6903", "str_6903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6904", "str_6904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6905", "str_6905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6906", "str_6906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6907", "str_6907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6908", "str_6908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6909", "str_6909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_691", "str_691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6910", "str_6910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6911", "str_6911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6912", "str_6912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6913", "str_6913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6914", "str_6914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6915", "str_6915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6916", "str_6916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6917", "str_6917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6918", "str_6918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6919", "str_6919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_692", "str_692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6920", "str_6920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6921", "str_6921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6922", "str_6922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6923", "str_6923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6924", "str_6924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6925", "str_6925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6926", "str_6926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6927", "str_6927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6928", "str_6928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6929", "str_6929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_693", "str_693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6930", "str_6930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6931", "str_6931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6932", "str_6932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6933", "str_6933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6934", "str_6934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6935", "str_6935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6936", "str_6936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6937", "str_6937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6938", "str_6938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6939", "str_6939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_694", "str_694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6940", "str_6940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6941", "str_6941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6942", "str_6942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6943", "str_6943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6944", "str_6944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6945", "str_6945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6946", "str_6946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6947", "str_6947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6948", "str_6948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6949", "str_6949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_695", "str_695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6950", "str_6950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6951", "str_6951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6952", "str_6952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6953", "str_6953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6954", "str_6954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6955", "str_6955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6956", "str_6956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6957", "str_6957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6958", "str_6958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6959", "str_6959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_696", "str_696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6960", "str_6960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6961", "str_6961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6962", "str_6962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6963", "str_6963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6964", "str_6964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6965", "str_6965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6966", "str_6966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6967", "str_6967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6968", "str_6968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6969", "str_6969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_697", "str_697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6970", "str_6970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6971", "str_6971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6972", "str_6972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6973", "str_6973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6974", "str_6974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6975", "str_6975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6976", "str_6976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6977", "str_6977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6978", "str_6978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6979", "str_6979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_698", "str_698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6980", "str_6980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6981", "str_6981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6982", "str_6982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6983", "str_6983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6984", "str_6984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6985", "str_6985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6986", "str_6986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6987", "str_6987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6988", "str_6988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6989", "str_6989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_699", "str_699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6990", "str_6990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6991", "str_6991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6992", "str_6992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6993", "str_6993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6994", "str_6994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6995", "str_6995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6996", "str_6996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6997", "str_6997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6998", "str_6998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_6999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_6999", "str_6999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7", "str_7",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_70: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_70", "str_70",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_700", "str_700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7000", "str_7000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7001", "str_7001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7002", "str_7002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7003", "str_7003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7004", "str_7004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7005", "str_7005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7006", "str_7006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7007", "str_7007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7008", "str_7008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7009", "str_7009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_701", "str_701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7010", "str_7010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7011", "str_7011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7012", "str_7012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7013", "str_7013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7014", "str_7014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7015", "str_7015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7016", "str_7016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7017", "str_7017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7018", "str_7018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7019", "str_7019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_702", "str_702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7020", "str_7020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7021", "str_7021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7022", "str_7022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7023", "str_7023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7024", "str_7024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7025", "str_7025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7026", "str_7026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7027", "str_7027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7028", "str_7028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7029", "str_7029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_703", "str_703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7030", "str_7030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7031", "str_7031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7032", "str_7032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7033", "str_7033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7034", "str_7034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7035", "str_7035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7036", "str_7036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7037", "str_7037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7038", "str_7038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7039", "str_7039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_704", "str_704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7040", "str_7040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7041", "str_7041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7042", "str_7042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7043", "str_7043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7044", "str_7044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7045", "str_7045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7046", "str_7046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7047", "str_7047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7048", "str_7048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7049", "str_7049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_705", "str_705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7050", "str_7050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7051", "str_7051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7052", "str_7052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7053", "str_7053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7054", "str_7054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7055", "str_7055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7056", "str_7056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7057", "str_7057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7058", "str_7058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7059", "str_7059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_706", "str_706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7060", "str_7060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7061", "str_7061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7062", "str_7062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7063", "str_7063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7064", "str_7064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7065", "str_7065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7066", "str_7066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7067", "str_7067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7068", "str_7068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7069", "str_7069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_707", "str_707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7070", "str_7070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7071", "str_7071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7072", "str_7072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7073", "str_7073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7074", "str_7074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7075", "str_7075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7076", "str_7076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7077", "str_7077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7078", "str_7078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7079", "str_7079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_708", "str_708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7080", "str_7080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7081", "str_7081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7082", "str_7082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7083", "str_7083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7084", "str_7084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7085", "str_7085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7086", "str_7086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7087", "str_7087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7088", "str_7088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7089", "str_7089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_709", "str_709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7090", "str_7090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7091", "str_7091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7092", "str_7092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7093", "str_7093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7094", "str_7094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7095", "str_7095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7096", "str_7096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7097", "str_7097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7098", "str_7098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7099", "str_7099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_71: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_71", "str_71",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_710", "str_710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7100", "str_7100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7101", "str_7101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7102", "str_7102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7103", "str_7103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7104", "str_7104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7105", "str_7105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7106", "str_7106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7107", "str_7107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7108", "str_7108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7109", "str_7109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_711", "str_711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7110", "str_7110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7111", "str_7111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7112", "str_7112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7113", "str_7113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7114", "str_7114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7115", "str_7115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7116", "str_7116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7117", "str_7117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7118", "str_7118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7119", "str_7119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_712", "str_712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7120", "str_7120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7121", "str_7121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7122", "str_7122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7123", "str_7123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7124", "str_7124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7125", "str_7125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7126", "str_7126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7127", "str_7127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7128", "str_7128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7129", "str_7129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_713", "str_713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7130", "str_7130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7131", "str_7131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7132", "str_7132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7133", "str_7133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7134", "str_7134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7135", "str_7135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7136", "str_7136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7137", "str_7137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7138", "str_7138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7139", "str_7139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_714", "str_714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7140", "str_7140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7141", "str_7141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7142", "str_7142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7143", "str_7143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7144", "str_7144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7145", "str_7145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7146", "str_7146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7147", "str_7147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7148", "str_7148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7149", "str_7149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_715", "str_715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7150", "str_7150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7151", "str_7151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7152", "str_7152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7153", "str_7153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7154", "str_7154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7155", "str_7155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7156", "str_7156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7157", "str_7157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7158", "str_7158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7159", "str_7159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_716", "str_716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7160", "str_7160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7161", "str_7161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7162", "str_7162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7163", "str_7163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7164", "str_7164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7165", "str_7165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7166", "str_7166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7167", "str_7167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7168", "str_7168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7169", "str_7169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_717", "str_717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7170", "str_7170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7171", "str_7171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7172", "str_7172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7173", "str_7173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7174", "str_7174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7175", "str_7175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7176", "str_7176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7177", "str_7177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7178", "str_7178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7179", "str_7179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_718", "str_718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7180", "str_7180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7181", "str_7181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7182", "str_7182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7183", "str_7183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7184", "str_7184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7185", "str_7185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7186", "str_7186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7187", "str_7187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7188", "str_7188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7189", "str_7189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_719", "str_719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7190", "str_7190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7191", "str_7191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7192", "str_7192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7193", "str_7193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7194", "str_7194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7195", "str_7195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7196", "str_7196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7197", "str_7197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7198", "str_7198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7199", "str_7199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_72: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_72", "str_72",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_720", "str_720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7200", "str_7200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7201", "str_7201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7202", "str_7202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7203", "str_7203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7204", "str_7204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7205", "str_7205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7206", "str_7206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7207", "str_7207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7208", "str_7208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7209", "str_7209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_721", "str_721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7210", "str_7210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7211", "str_7211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7212", "str_7212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7213", "str_7213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7214", "str_7214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7215", "str_7215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7216", "str_7216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7217", "str_7217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7218", "str_7218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7219", "str_7219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_722", "str_722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7220", "str_7220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7221", "str_7221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7222", "str_7222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7223", "str_7223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7224", "str_7224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7225", "str_7225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7226", "str_7226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7227", "str_7227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7228", "str_7228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7229", "str_7229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_723", "str_723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7230", "str_7230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7231", "str_7231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7232", "str_7232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7233", "str_7233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7234", "str_7234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7235", "str_7235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7236", "str_7236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7237", "str_7237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7238", "str_7238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7239", "str_7239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_724", "str_724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7240", "str_7240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7241", "str_7241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7242", "str_7242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7243", "str_7243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7244", "str_7244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7245", "str_7245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7246", "str_7246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7247", "str_7247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7248", "str_7248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7249", "str_7249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_725", "str_725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7250", "str_7250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7251", "str_7251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7252", "str_7252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7253", "str_7253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7254", "str_7254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7255", "str_7255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7256", "str_7256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7257", "str_7257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7258", "str_7258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7259", "str_7259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_726", "str_726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7260", "str_7260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7261", "str_7261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7262", "str_7262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7263", "str_7263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7264", "str_7264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7265", "str_7265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7266", "str_7266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7267", "str_7267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7268", "str_7268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7269", "str_7269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_727", "str_727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7270", "str_7270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7271", "str_7271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7272", "str_7272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7273", "str_7273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7274", "str_7274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7275", "str_7275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7276", "str_7276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7277", "str_7277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7278", "str_7278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7279", "str_7279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_728", "str_728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7280", "str_7280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7281", "str_7281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7282", "str_7282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7283", "str_7283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7284", "str_7284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7285", "str_7285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7286", "str_7286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7287", "str_7287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7288", "str_7288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7289", "str_7289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_729", "str_729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7290", "str_7290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7291", "str_7291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7292", "str_7292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7293", "str_7293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7294", "str_7294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7295", "str_7295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7296", "str_7296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7297", "str_7297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7298", "str_7298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_6849: StringResource
+  get() = String43.str_6849
+
+@ExperimentalResourceApi
+internal val Res.string.str_685: StringResource
+  get() = String43.str_685
+
+@ExperimentalResourceApi
+internal val Res.string.str_6850: StringResource
+  get() = String43.str_6850
+
+@ExperimentalResourceApi
+internal val Res.string.str_6851: StringResource
+  get() = String43.str_6851
+
+@ExperimentalResourceApi
+internal val Res.string.str_6852: StringResource
+  get() = String43.str_6852
+
+@ExperimentalResourceApi
+internal val Res.string.str_6853: StringResource
+  get() = String43.str_6853
+
+@ExperimentalResourceApi
+internal val Res.string.str_6854: StringResource
+  get() = String43.str_6854
+
+@ExperimentalResourceApi
+internal val Res.string.str_6855: StringResource
+  get() = String43.str_6855
+
+@ExperimentalResourceApi
+internal val Res.string.str_6856: StringResource
+  get() = String43.str_6856
+
+@ExperimentalResourceApi
+internal val Res.string.str_6857: StringResource
+  get() = String43.str_6857
+
+@ExperimentalResourceApi
+internal val Res.string.str_6858: StringResource
+  get() = String43.str_6858
+
+@ExperimentalResourceApi
+internal val Res.string.str_6859: StringResource
+  get() = String43.str_6859
+
+@ExperimentalResourceApi
+internal val Res.string.str_686: StringResource
+  get() = String43.str_686
+
+@ExperimentalResourceApi
+internal val Res.string.str_6860: StringResource
+  get() = String43.str_6860
+
+@ExperimentalResourceApi
+internal val Res.string.str_6861: StringResource
+  get() = String43.str_6861
+
+@ExperimentalResourceApi
+internal val Res.string.str_6862: StringResource
+  get() = String43.str_6862
+
+@ExperimentalResourceApi
+internal val Res.string.str_6863: StringResource
+  get() = String43.str_6863
+
+@ExperimentalResourceApi
+internal val Res.string.str_6864: StringResource
+  get() = String43.str_6864
+
+@ExperimentalResourceApi
+internal val Res.string.str_6865: StringResource
+  get() = String43.str_6865
+
+@ExperimentalResourceApi
+internal val Res.string.str_6866: StringResource
+  get() = String43.str_6866
+
+@ExperimentalResourceApi
+internal val Res.string.str_6867: StringResource
+  get() = String43.str_6867
+
+@ExperimentalResourceApi
+internal val Res.string.str_6868: StringResource
+  get() = String43.str_6868
+
+@ExperimentalResourceApi
+internal val Res.string.str_6869: StringResource
+  get() = String43.str_6869
+
+@ExperimentalResourceApi
+internal val Res.string.str_687: StringResource
+  get() = String43.str_687
+
+@ExperimentalResourceApi
+internal val Res.string.str_6870: StringResource
+  get() = String43.str_6870
+
+@ExperimentalResourceApi
+internal val Res.string.str_6871: StringResource
+  get() = String43.str_6871
+
+@ExperimentalResourceApi
+internal val Res.string.str_6872: StringResource
+  get() = String43.str_6872
+
+@ExperimentalResourceApi
+internal val Res.string.str_6873: StringResource
+  get() = String43.str_6873
+
+@ExperimentalResourceApi
+internal val Res.string.str_6874: StringResource
+  get() = String43.str_6874
+
+@ExperimentalResourceApi
+internal val Res.string.str_6875: StringResource
+  get() = String43.str_6875
+
+@ExperimentalResourceApi
+internal val Res.string.str_6876: StringResource
+  get() = String43.str_6876
+
+@ExperimentalResourceApi
+internal val Res.string.str_6877: StringResource
+  get() = String43.str_6877
+
+@ExperimentalResourceApi
+internal val Res.string.str_6878: StringResource
+  get() = String43.str_6878
+
+@ExperimentalResourceApi
+internal val Res.string.str_6879: StringResource
+  get() = String43.str_6879
+
+@ExperimentalResourceApi
+internal val Res.string.str_688: StringResource
+  get() = String43.str_688
+
+@ExperimentalResourceApi
+internal val Res.string.str_6880: StringResource
+  get() = String43.str_6880
+
+@ExperimentalResourceApi
+internal val Res.string.str_6881: StringResource
+  get() = String43.str_6881
+
+@ExperimentalResourceApi
+internal val Res.string.str_6882: StringResource
+  get() = String43.str_6882
+
+@ExperimentalResourceApi
+internal val Res.string.str_6883: StringResource
+  get() = String43.str_6883
+
+@ExperimentalResourceApi
+internal val Res.string.str_6884: StringResource
+  get() = String43.str_6884
+
+@ExperimentalResourceApi
+internal val Res.string.str_6885: StringResource
+  get() = String43.str_6885
+
+@ExperimentalResourceApi
+internal val Res.string.str_6886: StringResource
+  get() = String43.str_6886
+
+@ExperimentalResourceApi
+internal val Res.string.str_6887: StringResource
+  get() = String43.str_6887
+
+@ExperimentalResourceApi
+internal val Res.string.str_6888: StringResource
+  get() = String43.str_6888
+
+@ExperimentalResourceApi
+internal val Res.string.str_6889: StringResource
+  get() = String43.str_6889
+
+@ExperimentalResourceApi
+internal val Res.string.str_689: StringResource
+  get() = String43.str_689
+
+@ExperimentalResourceApi
+internal val Res.string.str_6890: StringResource
+  get() = String43.str_6890
+
+@ExperimentalResourceApi
+internal val Res.string.str_6891: StringResource
+  get() = String43.str_6891
+
+@ExperimentalResourceApi
+internal val Res.string.str_6892: StringResource
+  get() = String43.str_6892
+
+@ExperimentalResourceApi
+internal val Res.string.str_6893: StringResource
+  get() = String43.str_6893
+
+@ExperimentalResourceApi
+internal val Res.string.str_6894: StringResource
+  get() = String43.str_6894
+
+@ExperimentalResourceApi
+internal val Res.string.str_6895: StringResource
+  get() = String43.str_6895
+
+@ExperimentalResourceApi
+internal val Res.string.str_6896: StringResource
+  get() = String43.str_6896
+
+@ExperimentalResourceApi
+internal val Res.string.str_6897: StringResource
+  get() = String43.str_6897
+
+@ExperimentalResourceApi
+internal val Res.string.str_6898: StringResource
+  get() = String43.str_6898
+
+@ExperimentalResourceApi
+internal val Res.string.str_6899: StringResource
+  get() = String43.str_6899
+
+@ExperimentalResourceApi
+internal val Res.string.str_69: StringResource
+  get() = String43.str_69
+
+@ExperimentalResourceApi
+internal val Res.string.str_690: StringResource
+  get() = String43.str_690
+
+@ExperimentalResourceApi
+internal val Res.string.str_6900: StringResource
+  get() = String43.str_6900
+
+@ExperimentalResourceApi
+internal val Res.string.str_6901: StringResource
+  get() = String43.str_6901
+
+@ExperimentalResourceApi
+internal val Res.string.str_6902: StringResource
+  get() = String43.str_6902
+
+@ExperimentalResourceApi
+internal val Res.string.str_6903: StringResource
+  get() = String43.str_6903
+
+@ExperimentalResourceApi
+internal val Res.string.str_6904: StringResource
+  get() = String43.str_6904
+
+@ExperimentalResourceApi
+internal val Res.string.str_6905: StringResource
+  get() = String43.str_6905
+
+@ExperimentalResourceApi
+internal val Res.string.str_6906: StringResource
+  get() = String43.str_6906
+
+@ExperimentalResourceApi
+internal val Res.string.str_6907: StringResource
+  get() = String43.str_6907
+
+@ExperimentalResourceApi
+internal val Res.string.str_6908: StringResource
+  get() = String43.str_6908
+
+@ExperimentalResourceApi
+internal val Res.string.str_6909: StringResource
+  get() = String43.str_6909
+
+@ExperimentalResourceApi
+internal val Res.string.str_691: StringResource
+  get() = String43.str_691
+
+@ExperimentalResourceApi
+internal val Res.string.str_6910: StringResource
+  get() = String43.str_6910
+
+@ExperimentalResourceApi
+internal val Res.string.str_6911: StringResource
+  get() = String43.str_6911
+
+@ExperimentalResourceApi
+internal val Res.string.str_6912: StringResource
+  get() = String43.str_6912
+
+@ExperimentalResourceApi
+internal val Res.string.str_6913: StringResource
+  get() = String43.str_6913
+
+@ExperimentalResourceApi
+internal val Res.string.str_6914: StringResource
+  get() = String43.str_6914
+
+@ExperimentalResourceApi
+internal val Res.string.str_6915: StringResource
+  get() = String43.str_6915
+
+@ExperimentalResourceApi
+internal val Res.string.str_6916: StringResource
+  get() = String43.str_6916
+
+@ExperimentalResourceApi
+internal val Res.string.str_6917: StringResource
+  get() = String43.str_6917
+
+@ExperimentalResourceApi
+internal val Res.string.str_6918: StringResource
+  get() = String43.str_6918
+
+@ExperimentalResourceApi
+internal val Res.string.str_6919: StringResource
+  get() = String43.str_6919
+
+@ExperimentalResourceApi
+internal val Res.string.str_692: StringResource
+  get() = String43.str_692
+
+@ExperimentalResourceApi
+internal val Res.string.str_6920: StringResource
+  get() = String43.str_6920
+
+@ExperimentalResourceApi
+internal val Res.string.str_6921: StringResource
+  get() = String43.str_6921
+
+@ExperimentalResourceApi
+internal val Res.string.str_6922: StringResource
+  get() = String43.str_6922
+
+@ExperimentalResourceApi
+internal val Res.string.str_6923: StringResource
+  get() = String43.str_6923
+
+@ExperimentalResourceApi
+internal val Res.string.str_6924: StringResource
+  get() = String43.str_6924
+
+@ExperimentalResourceApi
+internal val Res.string.str_6925: StringResource
+  get() = String43.str_6925
+
+@ExperimentalResourceApi
+internal val Res.string.str_6926: StringResource
+  get() = String43.str_6926
+
+@ExperimentalResourceApi
+internal val Res.string.str_6927: StringResource
+  get() = String43.str_6927
+
+@ExperimentalResourceApi
+internal val Res.string.str_6928: StringResource
+  get() = String43.str_6928
+
+@ExperimentalResourceApi
+internal val Res.string.str_6929: StringResource
+  get() = String43.str_6929
+
+@ExperimentalResourceApi
+internal val Res.string.str_693: StringResource
+  get() = String43.str_693
+
+@ExperimentalResourceApi
+internal val Res.string.str_6930: StringResource
+  get() = String43.str_6930
+
+@ExperimentalResourceApi
+internal val Res.string.str_6931: StringResource
+  get() = String43.str_6931
+
+@ExperimentalResourceApi
+internal val Res.string.str_6932: StringResource
+  get() = String43.str_6932
+
+@ExperimentalResourceApi
+internal val Res.string.str_6933: StringResource
+  get() = String43.str_6933
+
+@ExperimentalResourceApi
+internal val Res.string.str_6934: StringResource
+  get() = String43.str_6934
+
+@ExperimentalResourceApi
+internal val Res.string.str_6935: StringResource
+  get() = String43.str_6935
+
+@ExperimentalResourceApi
+internal val Res.string.str_6936: StringResource
+  get() = String43.str_6936
+
+@ExperimentalResourceApi
+internal val Res.string.str_6937: StringResource
+  get() = String43.str_6937
+
+@ExperimentalResourceApi
+internal val Res.string.str_6938: StringResource
+  get() = String43.str_6938
+
+@ExperimentalResourceApi
+internal val Res.string.str_6939: StringResource
+  get() = String43.str_6939
+
+@ExperimentalResourceApi
+internal val Res.string.str_694: StringResource
+  get() = String43.str_694
+
+@ExperimentalResourceApi
+internal val Res.string.str_6940: StringResource
+  get() = String43.str_6940
+
+@ExperimentalResourceApi
+internal val Res.string.str_6941: StringResource
+  get() = String43.str_6941
+
+@ExperimentalResourceApi
+internal val Res.string.str_6942: StringResource
+  get() = String43.str_6942
+
+@ExperimentalResourceApi
+internal val Res.string.str_6943: StringResource
+  get() = String43.str_6943
+
+@ExperimentalResourceApi
+internal val Res.string.str_6944: StringResource
+  get() = String43.str_6944
+
+@ExperimentalResourceApi
+internal val Res.string.str_6945: StringResource
+  get() = String43.str_6945
+
+@ExperimentalResourceApi
+internal val Res.string.str_6946: StringResource
+  get() = String43.str_6946
+
+@ExperimentalResourceApi
+internal val Res.string.str_6947: StringResource
+  get() = String43.str_6947
+
+@ExperimentalResourceApi
+internal val Res.string.str_6948: StringResource
+  get() = String43.str_6948
+
+@ExperimentalResourceApi
+internal val Res.string.str_6949: StringResource
+  get() = String43.str_6949
+
+@ExperimentalResourceApi
+internal val Res.string.str_695: StringResource
+  get() = String43.str_695
+
+@ExperimentalResourceApi
+internal val Res.string.str_6950: StringResource
+  get() = String43.str_6950
+
+@ExperimentalResourceApi
+internal val Res.string.str_6951: StringResource
+  get() = String43.str_6951
+
+@ExperimentalResourceApi
+internal val Res.string.str_6952: StringResource
+  get() = String43.str_6952
+
+@ExperimentalResourceApi
+internal val Res.string.str_6953: StringResource
+  get() = String43.str_6953
+
+@ExperimentalResourceApi
+internal val Res.string.str_6954: StringResource
+  get() = String43.str_6954
+
+@ExperimentalResourceApi
+internal val Res.string.str_6955: StringResource
+  get() = String43.str_6955
+
+@ExperimentalResourceApi
+internal val Res.string.str_6956: StringResource
+  get() = String43.str_6956
+
+@ExperimentalResourceApi
+internal val Res.string.str_6957: StringResource
+  get() = String43.str_6957
+
+@ExperimentalResourceApi
+internal val Res.string.str_6958: StringResource
+  get() = String43.str_6958
+
+@ExperimentalResourceApi
+internal val Res.string.str_6959: StringResource
+  get() = String43.str_6959
+
+@ExperimentalResourceApi
+internal val Res.string.str_696: StringResource
+  get() = String43.str_696
+
+@ExperimentalResourceApi
+internal val Res.string.str_6960: StringResource
+  get() = String43.str_6960
+
+@ExperimentalResourceApi
+internal val Res.string.str_6961: StringResource
+  get() = String43.str_6961
+
+@ExperimentalResourceApi
+internal val Res.string.str_6962: StringResource
+  get() = String43.str_6962
+
+@ExperimentalResourceApi
+internal val Res.string.str_6963: StringResource
+  get() = String43.str_6963
+
+@ExperimentalResourceApi
+internal val Res.string.str_6964: StringResource
+  get() = String43.str_6964
+
+@ExperimentalResourceApi
+internal val Res.string.str_6965: StringResource
+  get() = String43.str_6965
+
+@ExperimentalResourceApi
+internal val Res.string.str_6966: StringResource
+  get() = String43.str_6966
+
+@ExperimentalResourceApi
+internal val Res.string.str_6967: StringResource
+  get() = String43.str_6967
+
+@ExperimentalResourceApi
+internal val Res.string.str_6968: StringResource
+  get() = String43.str_6968
+
+@ExperimentalResourceApi
+internal val Res.string.str_6969: StringResource
+  get() = String43.str_6969
+
+@ExperimentalResourceApi
+internal val Res.string.str_697: StringResource
+  get() = String43.str_697
+
+@ExperimentalResourceApi
+internal val Res.string.str_6970: StringResource
+  get() = String43.str_6970
+
+@ExperimentalResourceApi
+internal val Res.string.str_6971: StringResource
+  get() = String43.str_6971
+
+@ExperimentalResourceApi
+internal val Res.string.str_6972: StringResource
+  get() = String43.str_6972
+
+@ExperimentalResourceApi
+internal val Res.string.str_6973: StringResource
+  get() = String43.str_6973
+
+@ExperimentalResourceApi
+internal val Res.string.str_6974: StringResource
+  get() = String43.str_6974
+
+@ExperimentalResourceApi
+internal val Res.string.str_6975: StringResource
+  get() = String43.str_6975
+
+@ExperimentalResourceApi
+internal val Res.string.str_6976: StringResource
+  get() = String43.str_6976
+
+@ExperimentalResourceApi
+internal val Res.string.str_6977: StringResource
+  get() = String43.str_6977
+
+@ExperimentalResourceApi
+internal val Res.string.str_6978: StringResource
+  get() = String43.str_6978
+
+@ExperimentalResourceApi
+internal val Res.string.str_6979: StringResource
+  get() = String43.str_6979
+
+@ExperimentalResourceApi
+internal val Res.string.str_698: StringResource
+  get() = String43.str_698
+
+@ExperimentalResourceApi
+internal val Res.string.str_6980: StringResource
+  get() = String43.str_6980
+
+@ExperimentalResourceApi
+internal val Res.string.str_6981: StringResource
+  get() = String43.str_6981
+
+@ExperimentalResourceApi
+internal val Res.string.str_6982: StringResource
+  get() = String43.str_6982
+
+@ExperimentalResourceApi
+internal val Res.string.str_6983: StringResource
+  get() = String43.str_6983
+
+@ExperimentalResourceApi
+internal val Res.string.str_6984: StringResource
+  get() = String43.str_6984
+
+@ExperimentalResourceApi
+internal val Res.string.str_6985: StringResource
+  get() = String43.str_6985
+
+@ExperimentalResourceApi
+internal val Res.string.str_6986: StringResource
+  get() = String43.str_6986
+
+@ExperimentalResourceApi
+internal val Res.string.str_6987: StringResource
+  get() = String43.str_6987
+
+@ExperimentalResourceApi
+internal val Res.string.str_6988: StringResource
+  get() = String43.str_6988
+
+@ExperimentalResourceApi
+internal val Res.string.str_6989: StringResource
+  get() = String43.str_6989
+
+@ExperimentalResourceApi
+internal val Res.string.str_699: StringResource
+  get() = String43.str_699
+
+@ExperimentalResourceApi
+internal val Res.string.str_6990: StringResource
+  get() = String43.str_6990
+
+@ExperimentalResourceApi
+internal val Res.string.str_6991: StringResource
+  get() = String43.str_6991
+
+@ExperimentalResourceApi
+internal val Res.string.str_6992: StringResource
+  get() = String43.str_6992
+
+@ExperimentalResourceApi
+internal val Res.string.str_6993: StringResource
+  get() = String43.str_6993
+
+@ExperimentalResourceApi
+internal val Res.string.str_6994: StringResource
+  get() = String43.str_6994
+
+@ExperimentalResourceApi
+internal val Res.string.str_6995: StringResource
+  get() = String43.str_6995
+
+@ExperimentalResourceApi
+internal val Res.string.str_6996: StringResource
+  get() = String43.str_6996
+
+@ExperimentalResourceApi
+internal val Res.string.str_6997: StringResource
+  get() = String43.str_6997
+
+@ExperimentalResourceApi
+internal val Res.string.str_6998: StringResource
+  get() = String43.str_6998
+
+@ExperimentalResourceApi
+internal val Res.string.str_6999: StringResource
+  get() = String43.str_6999
+
+@ExperimentalResourceApi
+internal val Res.string.str_7: StringResource
+  get() = String43.str_7
+
+@ExperimentalResourceApi
+internal val Res.string.str_70: StringResource
+  get() = String43.str_70
+
+@ExperimentalResourceApi
+internal val Res.string.str_700: StringResource
+  get() = String43.str_700
+
+@ExperimentalResourceApi
+internal val Res.string.str_7000: StringResource
+  get() = String43.str_7000
+
+@ExperimentalResourceApi
+internal val Res.string.str_7001: StringResource
+  get() = String43.str_7001
+
+@ExperimentalResourceApi
+internal val Res.string.str_7002: StringResource
+  get() = String43.str_7002
+
+@ExperimentalResourceApi
+internal val Res.string.str_7003: StringResource
+  get() = String43.str_7003
+
+@ExperimentalResourceApi
+internal val Res.string.str_7004: StringResource
+  get() = String43.str_7004
+
+@ExperimentalResourceApi
+internal val Res.string.str_7005: StringResource
+  get() = String43.str_7005
+
+@ExperimentalResourceApi
+internal val Res.string.str_7006: StringResource
+  get() = String43.str_7006
+
+@ExperimentalResourceApi
+internal val Res.string.str_7007: StringResource
+  get() = String43.str_7007
+
+@ExperimentalResourceApi
+internal val Res.string.str_7008: StringResource
+  get() = String43.str_7008
+
+@ExperimentalResourceApi
+internal val Res.string.str_7009: StringResource
+  get() = String43.str_7009
+
+@ExperimentalResourceApi
+internal val Res.string.str_701: StringResource
+  get() = String43.str_701
+
+@ExperimentalResourceApi
+internal val Res.string.str_7010: StringResource
+  get() = String43.str_7010
+
+@ExperimentalResourceApi
+internal val Res.string.str_7011: StringResource
+  get() = String43.str_7011
+
+@ExperimentalResourceApi
+internal val Res.string.str_7012: StringResource
+  get() = String43.str_7012
+
+@ExperimentalResourceApi
+internal val Res.string.str_7013: StringResource
+  get() = String43.str_7013
+
+@ExperimentalResourceApi
+internal val Res.string.str_7014: StringResource
+  get() = String43.str_7014
+
+@ExperimentalResourceApi
+internal val Res.string.str_7015: StringResource
+  get() = String43.str_7015
+
+@ExperimentalResourceApi
+internal val Res.string.str_7016: StringResource
+  get() = String43.str_7016
+
+@ExperimentalResourceApi
+internal val Res.string.str_7017: StringResource
+  get() = String43.str_7017
+
+@ExperimentalResourceApi
+internal val Res.string.str_7018: StringResource
+  get() = String43.str_7018
+
+@ExperimentalResourceApi
+internal val Res.string.str_7019: StringResource
+  get() = String43.str_7019
+
+@ExperimentalResourceApi
+internal val Res.string.str_702: StringResource
+  get() = String43.str_702
+
+@ExperimentalResourceApi
+internal val Res.string.str_7020: StringResource
+  get() = String43.str_7020
+
+@ExperimentalResourceApi
+internal val Res.string.str_7021: StringResource
+  get() = String43.str_7021
+
+@ExperimentalResourceApi
+internal val Res.string.str_7022: StringResource
+  get() = String43.str_7022
+
+@ExperimentalResourceApi
+internal val Res.string.str_7023: StringResource
+  get() = String43.str_7023
+
+@ExperimentalResourceApi
+internal val Res.string.str_7024: StringResource
+  get() = String43.str_7024
+
+@ExperimentalResourceApi
+internal val Res.string.str_7025: StringResource
+  get() = String43.str_7025
+
+@ExperimentalResourceApi
+internal val Res.string.str_7026: StringResource
+  get() = String43.str_7026
+
+@ExperimentalResourceApi
+internal val Res.string.str_7027: StringResource
+  get() = String43.str_7027
+
+@ExperimentalResourceApi
+internal val Res.string.str_7028: StringResource
+  get() = String43.str_7028
+
+@ExperimentalResourceApi
+internal val Res.string.str_7029: StringResource
+  get() = String43.str_7029
+
+@ExperimentalResourceApi
+internal val Res.string.str_703: StringResource
+  get() = String43.str_703
+
+@ExperimentalResourceApi
+internal val Res.string.str_7030: StringResource
+  get() = String43.str_7030
+
+@ExperimentalResourceApi
+internal val Res.string.str_7031: StringResource
+  get() = String43.str_7031
+
+@ExperimentalResourceApi
+internal val Res.string.str_7032: StringResource
+  get() = String43.str_7032
+
+@ExperimentalResourceApi
+internal val Res.string.str_7033: StringResource
+  get() = String43.str_7033
+
+@ExperimentalResourceApi
+internal val Res.string.str_7034: StringResource
+  get() = String43.str_7034
+
+@ExperimentalResourceApi
+internal val Res.string.str_7035: StringResource
+  get() = String43.str_7035
+
+@ExperimentalResourceApi
+internal val Res.string.str_7036: StringResource
+  get() = String43.str_7036
+
+@ExperimentalResourceApi
+internal val Res.string.str_7037: StringResource
+  get() = String43.str_7037
+
+@ExperimentalResourceApi
+internal val Res.string.str_7038: StringResource
+  get() = String43.str_7038
+
+@ExperimentalResourceApi
+internal val Res.string.str_7039: StringResource
+  get() = String43.str_7039
+
+@ExperimentalResourceApi
+internal val Res.string.str_704: StringResource
+  get() = String43.str_704
+
+@ExperimentalResourceApi
+internal val Res.string.str_7040: StringResource
+  get() = String43.str_7040
+
+@ExperimentalResourceApi
+internal val Res.string.str_7041: StringResource
+  get() = String43.str_7041
+
+@ExperimentalResourceApi
+internal val Res.string.str_7042: StringResource
+  get() = String43.str_7042
+
+@ExperimentalResourceApi
+internal val Res.string.str_7043: StringResource
+  get() = String43.str_7043
+
+@ExperimentalResourceApi
+internal val Res.string.str_7044: StringResource
+  get() = String43.str_7044
+
+@ExperimentalResourceApi
+internal val Res.string.str_7045: StringResource
+  get() = String43.str_7045
+
+@ExperimentalResourceApi
+internal val Res.string.str_7046: StringResource
+  get() = String43.str_7046
+
+@ExperimentalResourceApi
+internal val Res.string.str_7047: StringResource
+  get() = String43.str_7047
+
+@ExperimentalResourceApi
+internal val Res.string.str_7048: StringResource
+  get() = String43.str_7048
+
+@ExperimentalResourceApi
+internal val Res.string.str_7049: StringResource
+  get() = String43.str_7049
+
+@ExperimentalResourceApi
+internal val Res.string.str_705: StringResource
+  get() = String43.str_705
+
+@ExperimentalResourceApi
+internal val Res.string.str_7050: StringResource
+  get() = String43.str_7050
+
+@ExperimentalResourceApi
+internal val Res.string.str_7051: StringResource
+  get() = String43.str_7051
+
+@ExperimentalResourceApi
+internal val Res.string.str_7052: StringResource
+  get() = String43.str_7052
+
+@ExperimentalResourceApi
+internal val Res.string.str_7053: StringResource
+  get() = String43.str_7053
+
+@ExperimentalResourceApi
+internal val Res.string.str_7054: StringResource
+  get() = String43.str_7054
+
+@ExperimentalResourceApi
+internal val Res.string.str_7055: StringResource
+  get() = String43.str_7055
+
+@ExperimentalResourceApi
+internal val Res.string.str_7056: StringResource
+  get() = String43.str_7056
+
+@ExperimentalResourceApi
+internal val Res.string.str_7057: StringResource
+  get() = String43.str_7057
+
+@ExperimentalResourceApi
+internal val Res.string.str_7058: StringResource
+  get() = String43.str_7058
+
+@ExperimentalResourceApi
+internal val Res.string.str_7059: StringResource
+  get() = String43.str_7059
+
+@ExperimentalResourceApi
+internal val Res.string.str_706: StringResource
+  get() = String43.str_706
+
+@ExperimentalResourceApi
+internal val Res.string.str_7060: StringResource
+  get() = String43.str_7060
+
+@ExperimentalResourceApi
+internal val Res.string.str_7061: StringResource
+  get() = String43.str_7061
+
+@ExperimentalResourceApi
+internal val Res.string.str_7062: StringResource
+  get() = String43.str_7062
+
+@ExperimentalResourceApi
+internal val Res.string.str_7063: StringResource
+  get() = String43.str_7063
+
+@ExperimentalResourceApi
+internal val Res.string.str_7064: StringResource
+  get() = String43.str_7064
+
+@ExperimentalResourceApi
+internal val Res.string.str_7065: StringResource
+  get() = String43.str_7065
+
+@ExperimentalResourceApi
+internal val Res.string.str_7066: StringResource
+  get() = String43.str_7066
+
+@ExperimentalResourceApi
+internal val Res.string.str_7067: StringResource
+  get() = String43.str_7067
+
+@ExperimentalResourceApi
+internal val Res.string.str_7068: StringResource
+  get() = String43.str_7068
+
+@ExperimentalResourceApi
+internal val Res.string.str_7069: StringResource
+  get() = String43.str_7069
+
+@ExperimentalResourceApi
+internal val Res.string.str_707: StringResource
+  get() = String43.str_707
+
+@ExperimentalResourceApi
+internal val Res.string.str_7070: StringResource
+  get() = String43.str_7070
+
+@ExperimentalResourceApi
+internal val Res.string.str_7071: StringResource
+  get() = String43.str_7071
+
+@ExperimentalResourceApi
+internal val Res.string.str_7072: StringResource
+  get() = String43.str_7072
+
+@ExperimentalResourceApi
+internal val Res.string.str_7073: StringResource
+  get() = String43.str_7073
+
+@ExperimentalResourceApi
+internal val Res.string.str_7074: StringResource
+  get() = String43.str_7074
+
+@ExperimentalResourceApi
+internal val Res.string.str_7075: StringResource
+  get() = String43.str_7075
+
+@ExperimentalResourceApi
+internal val Res.string.str_7076: StringResource
+  get() = String43.str_7076
+
+@ExperimentalResourceApi
+internal val Res.string.str_7077: StringResource
+  get() = String43.str_7077
+
+@ExperimentalResourceApi
+internal val Res.string.str_7078: StringResource
+  get() = String43.str_7078
+
+@ExperimentalResourceApi
+internal val Res.string.str_7079: StringResource
+  get() = String43.str_7079
+
+@ExperimentalResourceApi
+internal val Res.string.str_708: StringResource
+  get() = String43.str_708
+
+@ExperimentalResourceApi
+internal val Res.string.str_7080: StringResource
+  get() = String43.str_7080
+
+@ExperimentalResourceApi
+internal val Res.string.str_7081: StringResource
+  get() = String43.str_7081
+
+@ExperimentalResourceApi
+internal val Res.string.str_7082: StringResource
+  get() = String43.str_7082
+
+@ExperimentalResourceApi
+internal val Res.string.str_7083: StringResource
+  get() = String43.str_7083
+
+@ExperimentalResourceApi
+internal val Res.string.str_7084: StringResource
+  get() = String43.str_7084
+
+@ExperimentalResourceApi
+internal val Res.string.str_7085: StringResource
+  get() = String43.str_7085
+
+@ExperimentalResourceApi
+internal val Res.string.str_7086: StringResource
+  get() = String43.str_7086
+
+@ExperimentalResourceApi
+internal val Res.string.str_7087: StringResource
+  get() = String43.str_7087
+
+@ExperimentalResourceApi
+internal val Res.string.str_7088: StringResource
+  get() = String43.str_7088
+
+@ExperimentalResourceApi
+internal val Res.string.str_7089: StringResource
+  get() = String43.str_7089
+
+@ExperimentalResourceApi
+internal val Res.string.str_709: StringResource
+  get() = String43.str_709
+
+@ExperimentalResourceApi
+internal val Res.string.str_7090: StringResource
+  get() = String43.str_7090
+
+@ExperimentalResourceApi
+internal val Res.string.str_7091: StringResource
+  get() = String43.str_7091
+
+@ExperimentalResourceApi
+internal val Res.string.str_7092: StringResource
+  get() = String43.str_7092
+
+@ExperimentalResourceApi
+internal val Res.string.str_7093: StringResource
+  get() = String43.str_7093
+
+@ExperimentalResourceApi
+internal val Res.string.str_7094: StringResource
+  get() = String43.str_7094
+
+@ExperimentalResourceApi
+internal val Res.string.str_7095: StringResource
+  get() = String43.str_7095
+
+@ExperimentalResourceApi
+internal val Res.string.str_7096: StringResource
+  get() = String43.str_7096
+
+@ExperimentalResourceApi
+internal val Res.string.str_7097: StringResource
+  get() = String43.str_7097
+
+@ExperimentalResourceApi
+internal val Res.string.str_7098: StringResource
+  get() = String43.str_7098
+
+@ExperimentalResourceApi
+internal val Res.string.str_7099: StringResource
+  get() = String43.str_7099
+
+@ExperimentalResourceApi
+internal val Res.string.str_71: StringResource
+  get() = String43.str_71
+
+@ExperimentalResourceApi
+internal val Res.string.str_710: StringResource
+  get() = String43.str_710
+
+@ExperimentalResourceApi
+internal val Res.string.str_7100: StringResource
+  get() = String43.str_7100
+
+@ExperimentalResourceApi
+internal val Res.string.str_7101: StringResource
+  get() = String43.str_7101
+
+@ExperimentalResourceApi
+internal val Res.string.str_7102: StringResource
+  get() = String43.str_7102
+
+@ExperimentalResourceApi
+internal val Res.string.str_7103: StringResource
+  get() = String43.str_7103
+
+@ExperimentalResourceApi
+internal val Res.string.str_7104: StringResource
+  get() = String43.str_7104
+
+@ExperimentalResourceApi
+internal val Res.string.str_7105: StringResource
+  get() = String43.str_7105
+
+@ExperimentalResourceApi
+internal val Res.string.str_7106: StringResource
+  get() = String43.str_7106
+
+@ExperimentalResourceApi
+internal val Res.string.str_7107: StringResource
+  get() = String43.str_7107
+
+@ExperimentalResourceApi
+internal val Res.string.str_7108: StringResource
+  get() = String43.str_7108
+
+@ExperimentalResourceApi
+internal val Res.string.str_7109: StringResource
+  get() = String43.str_7109
+
+@ExperimentalResourceApi
+internal val Res.string.str_711: StringResource
+  get() = String43.str_711
+
+@ExperimentalResourceApi
+internal val Res.string.str_7110: StringResource
+  get() = String43.str_7110
+
+@ExperimentalResourceApi
+internal val Res.string.str_7111: StringResource
+  get() = String43.str_7111
+
+@ExperimentalResourceApi
+internal val Res.string.str_7112: StringResource
+  get() = String43.str_7112
+
+@ExperimentalResourceApi
+internal val Res.string.str_7113: StringResource
+  get() = String43.str_7113
+
+@ExperimentalResourceApi
+internal val Res.string.str_7114: StringResource
+  get() = String43.str_7114
+
+@ExperimentalResourceApi
+internal val Res.string.str_7115: StringResource
+  get() = String43.str_7115
+
+@ExperimentalResourceApi
+internal val Res.string.str_7116: StringResource
+  get() = String43.str_7116
+
+@ExperimentalResourceApi
+internal val Res.string.str_7117: StringResource
+  get() = String43.str_7117
+
+@ExperimentalResourceApi
+internal val Res.string.str_7118: StringResource
+  get() = String43.str_7118
+
+@ExperimentalResourceApi
+internal val Res.string.str_7119: StringResource
+  get() = String43.str_7119
+
+@ExperimentalResourceApi
+internal val Res.string.str_712: StringResource
+  get() = String43.str_712
+
+@ExperimentalResourceApi
+internal val Res.string.str_7120: StringResource
+  get() = String43.str_7120
+
+@ExperimentalResourceApi
+internal val Res.string.str_7121: StringResource
+  get() = String43.str_7121
+
+@ExperimentalResourceApi
+internal val Res.string.str_7122: StringResource
+  get() = String43.str_7122
+
+@ExperimentalResourceApi
+internal val Res.string.str_7123: StringResource
+  get() = String43.str_7123
+
+@ExperimentalResourceApi
+internal val Res.string.str_7124: StringResource
+  get() = String43.str_7124
+
+@ExperimentalResourceApi
+internal val Res.string.str_7125: StringResource
+  get() = String43.str_7125
+
+@ExperimentalResourceApi
+internal val Res.string.str_7126: StringResource
+  get() = String43.str_7126
+
+@ExperimentalResourceApi
+internal val Res.string.str_7127: StringResource
+  get() = String43.str_7127
+
+@ExperimentalResourceApi
+internal val Res.string.str_7128: StringResource
+  get() = String43.str_7128
+
+@ExperimentalResourceApi
+internal val Res.string.str_7129: StringResource
+  get() = String43.str_7129
+
+@ExperimentalResourceApi
+internal val Res.string.str_713: StringResource
+  get() = String43.str_713
+
+@ExperimentalResourceApi
+internal val Res.string.str_7130: StringResource
+  get() = String43.str_7130
+
+@ExperimentalResourceApi
+internal val Res.string.str_7131: StringResource
+  get() = String43.str_7131
+
+@ExperimentalResourceApi
+internal val Res.string.str_7132: StringResource
+  get() = String43.str_7132
+
+@ExperimentalResourceApi
+internal val Res.string.str_7133: StringResource
+  get() = String43.str_7133
+
+@ExperimentalResourceApi
+internal val Res.string.str_7134: StringResource
+  get() = String43.str_7134
+
+@ExperimentalResourceApi
+internal val Res.string.str_7135: StringResource
+  get() = String43.str_7135
+
+@ExperimentalResourceApi
+internal val Res.string.str_7136: StringResource
+  get() = String43.str_7136
+
+@ExperimentalResourceApi
+internal val Res.string.str_7137: StringResource
+  get() = String43.str_7137
+
+@ExperimentalResourceApi
+internal val Res.string.str_7138: StringResource
+  get() = String43.str_7138
+
+@ExperimentalResourceApi
+internal val Res.string.str_7139: StringResource
+  get() = String43.str_7139
+
+@ExperimentalResourceApi
+internal val Res.string.str_714: StringResource
+  get() = String43.str_714
+
+@ExperimentalResourceApi
+internal val Res.string.str_7140: StringResource
+  get() = String43.str_7140
+
+@ExperimentalResourceApi
+internal val Res.string.str_7141: StringResource
+  get() = String43.str_7141
+
+@ExperimentalResourceApi
+internal val Res.string.str_7142: StringResource
+  get() = String43.str_7142
+
+@ExperimentalResourceApi
+internal val Res.string.str_7143: StringResource
+  get() = String43.str_7143
+
+@ExperimentalResourceApi
+internal val Res.string.str_7144: StringResource
+  get() = String43.str_7144
+
+@ExperimentalResourceApi
+internal val Res.string.str_7145: StringResource
+  get() = String43.str_7145
+
+@ExperimentalResourceApi
+internal val Res.string.str_7146: StringResource
+  get() = String43.str_7146
+
+@ExperimentalResourceApi
+internal val Res.string.str_7147: StringResource
+  get() = String43.str_7147
+
+@ExperimentalResourceApi
+internal val Res.string.str_7148: StringResource
+  get() = String43.str_7148
+
+@ExperimentalResourceApi
+internal val Res.string.str_7149: StringResource
+  get() = String43.str_7149
+
+@ExperimentalResourceApi
+internal val Res.string.str_715: StringResource
+  get() = String43.str_715
+
+@ExperimentalResourceApi
+internal val Res.string.str_7150: StringResource
+  get() = String43.str_7150
+
+@ExperimentalResourceApi
+internal val Res.string.str_7151: StringResource
+  get() = String43.str_7151
+
+@ExperimentalResourceApi
+internal val Res.string.str_7152: StringResource
+  get() = String43.str_7152
+
+@ExperimentalResourceApi
+internal val Res.string.str_7153: StringResource
+  get() = String43.str_7153
+
+@ExperimentalResourceApi
+internal val Res.string.str_7154: StringResource
+  get() = String43.str_7154
+
+@ExperimentalResourceApi
+internal val Res.string.str_7155: StringResource
+  get() = String43.str_7155
+
+@ExperimentalResourceApi
+internal val Res.string.str_7156: StringResource
+  get() = String43.str_7156
+
+@ExperimentalResourceApi
+internal val Res.string.str_7157: StringResource
+  get() = String43.str_7157
+
+@ExperimentalResourceApi
+internal val Res.string.str_7158: StringResource
+  get() = String43.str_7158
+
+@ExperimentalResourceApi
+internal val Res.string.str_7159: StringResource
+  get() = String43.str_7159
+
+@ExperimentalResourceApi
+internal val Res.string.str_716: StringResource
+  get() = String43.str_716
+
+@ExperimentalResourceApi
+internal val Res.string.str_7160: StringResource
+  get() = String43.str_7160
+
+@ExperimentalResourceApi
+internal val Res.string.str_7161: StringResource
+  get() = String43.str_7161
+
+@ExperimentalResourceApi
+internal val Res.string.str_7162: StringResource
+  get() = String43.str_7162
+
+@ExperimentalResourceApi
+internal val Res.string.str_7163: StringResource
+  get() = String43.str_7163
+
+@ExperimentalResourceApi
+internal val Res.string.str_7164: StringResource
+  get() = String43.str_7164
+
+@ExperimentalResourceApi
+internal val Res.string.str_7165: StringResource
+  get() = String43.str_7165
+
+@ExperimentalResourceApi
+internal val Res.string.str_7166: StringResource
+  get() = String43.str_7166
+
+@ExperimentalResourceApi
+internal val Res.string.str_7167: StringResource
+  get() = String43.str_7167
+
+@ExperimentalResourceApi
+internal val Res.string.str_7168: StringResource
+  get() = String43.str_7168
+
+@ExperimentalResourceApi
+internal val Res.string.str_7169: StringResource
+  get() = String43.str_7169
+
+@ExperimentalResourceApi
+internal val Res.string.str_717: StringResource
+  get() = String43.str_717
+
+@ExperimentalResourceApi
+internal val Res.string.str_7170: StringResource
+  get() = String43.str_7170
+
+@ExperimentalResourceApi
+internal val Res.string.str_7171: StringResource
+  get() = String43.str_7171
+
+@ExperimentalResourceApi
+internal val Res.string.str_7172: StringResource
+  get() = String43.str_7172
+
+@ExperimentalResourceApi
+internal val Res.string.str_7173: StringResource
+  get() = String43.str_7173
+
+@ExperimentalResourceApi
+internal val Res.string.str_7174: StringResource
+  get() = String43.str_7174
+
+@ExperimentalResourceApi
+internal val Res.string.str_7175: StringResource
+  get() = String43.str_7175
+
+@ExperimentalResourceApi
+internal val Res.string.str_7176: StringResource
+  get() = String43.str_7176
+
+@ExperimentalResourceApi
+internal val Res.string.str_7177: StringResource
+  get() = String43.str_7177
+
+@ExperimentalResourceApi
+internal val Res.string.str_7178: StringResource
+  get() = String43.str_7178
+
+@ExperimentalResourceApi
+internal val Res.string.str_7179: StringResource
+  get() = String43.str_7179
+
+@ExperimentalResourceApi
+internal val Res.string.str_718: StringResource
+  get() = String43.str_718
+
+@ExperimentalResourceApi
+internal val Res.string.str_7180: StringResource
+  get() = String43.str_7180
+
+@ExperimentalResourceApi
+internal val Res.string.str_7181: StringResource
+  get() = String43.str_7181
+
+@ExperimentalResourceApi
+internal val Res.string.str_7182: StringResource
+  get() = String43.str_7182
+
+@ExperimentalResourceApi
+internal val Res.string.str_7183: StringResource
+  get() = String43.str_7183
+
+@ExperimentalResourceApi
+internal val Res.string.str_7184: StringResource
+  get() = String43.str_7184
+
+@ExperimentalResourceApi
+internal val Res.string.str_7185: StringResource
+  get() = String43.str_7185
+
+@ExperimentalResourceApi
+internal val Res.string.str_7186: StringResource
+  get() = String43.str_7186
+
+@ExperimentalResourceApi
+internal val Res.string.str_7187: StringResource
+  get() = String43.str_7187
+
+@ExperimentalResourceApi
+internal val Res.string.str_7188: StringResource
+  get() = String43.str_7188
+
+@ExperimentalResourceApi
+internal val Res.string.str_7189: StringResource
+  get() = String43.str_7189
+
+@ExperimentalResourceApi
+internal val Res.string.str_719: StringResource
+  get() = String43.str_719
+
+@ExperimentalResourceApi
+internal val Res.string.str_7190: StringResource
+  get() = String43.str_7190
+
+@ExperimentalResourceApi
+internal val Res.string.str_7191: StringResource
+  get() = String43.str_7191
+
+@ExperimentalResourceApi
+internal val Res.string.str_7192: StringResource
+  get() = String43.str_7192
+
+@ExperimentalResourceApi
+internal val Res.string.str_7193: StringResource
+  get() = String43.str_7193
+
+@ExperimentalResourceApi
+internal val Res.string.str_7194: StringResource
+  get() = String43.str_7194
+
+@ExperimentalResourceApi
+internal val Res.string.str_7195: StringResource
+  get() = String43.str_7195
+
+@ExperimentalResourceApi
+internal val Res.string.str_7196: StringResource
+  get() = String43.str_7196
+
+@ExperimentalResourceApi
+internal val Res.string.str_7197: StringResource
+  get() = String43.str_7197
+
+@ExperimentalResourceApi
+internal val Res.string.str_7198: StringResource
+  get() = String43.str_7198
+
+@ExperimentalResourceApi
+internal val Res.string.str_7199: StringResource
+  get() = String43.str_7199
+
+@ExperimentalResourceApi
+internal val Res.string.str_72: StringResource
+  get() = String43.str_72
+
+@ExperimentalResourceApi
+internal val Res.string.str_720: StringResource
+  get() = String43.str_720
+
+@ExperimentalResourceApi
+internal val Res.string.str_7200: StringResource
+  get() = String43.str_7200
+
+@ExperimentalResourceApi
+internal val Res.string.str_7201: StringResource
+  get() = String43.str_7201
+
+@ExperimentalResourceApi
+internal val Res.string.str_7202: StringResource
+  get() = String43.str_7202
+
+@ExperimentalResourceApi
+internal val Res.string.str_7203: StringResource
+  get() = String43.str_7203
+
+@ExperimentalResourceApi
+internal val Res.string.str_7204: StringResource
+  get() = String43.str_7204
+
+@ExperimentalResourceApi
+internal val Res.string.str_7205: StringResource
+  get() = String43.str_7205
+
+@ExperimentalResourceApi
+internal val Res.string.str_7206: StringResource
+  get() = String43.str_7206
+
+@ExperimentalResourceApi
+internal val Res.string.str_7207: StringResource
+  get() = String43.str_7207
+
+@ExperimentalResourceApi
+internal val Res.string.str_7208: StringResource
+  get() = String43.str_7208
+
+@ExperimentalResourceApi
+internal val Res.string.str_7209: StringResource
+  get() = String43.str_7209
+
+@ExperimentalResourceApi
+internal val Res.string.str_721: StringResource
+  get() = String43.str_721
+
+@ExperimentalResourceApi
+internal val Res.string.str_7210: StringResource
+  get() = String43.str_7210
+
+@ExperimentalResourceApi
+internal val Res.string.str_7211: StringResource
+  get() = String43.str_7211
+
+@ExperimentalResourceApi
+internal val Res.string.str_7212: StringResource
+  get() = String43.str_7212
+
+@ExperimentalResourceApi
+internal val Res.string.str_7213: StringResource
+  get() = String43.str_7213
+
+@ExperimentalResourceApi
+internal val Res.string.str_7214: StringResource
+  get() = String43.str_7214
+
+@ExperimentalResourceApi
+internal val Res.string.str_7215: StringResource
+  get() = String43.str_7215
+
+@ExperimentalResourceApi
+internal val Res.string.str_7216: StringResource
+  get() = String43.str_7216
+
+@ExperimentalResourceApi
+internal val Res.string.str_7217: StringResource
+  get() = String43.str_7217
+
+@ExperimentalResourceApi
+internal val Res.string.str_7218: StringResource
+  get() = String43.str_7218
+
+@ExperimentalResourceApi
+internal val Res.string.str_7219: StringResource
+  get() = String43.str_7219
+
+@ExperimentalResourceApi
+internal val Res.string.str_722: StringResource
+  get() = String43.str_722
+
+@ExperimentalResourceApi
+internal val Res.string.str_7220: StringResource
+  get() = String43.str_7220
+
+@ExperimentalResourceApi
+internal val Res.string.str_7221: StringResource
+  get() = String43.str_7221
+
+@ExperimentalResourceApi
+internal val Res.string.str_7222: StringResource
+  get() = String43.str_7222
+
+@ExperimentalResourceApi
+internal val Res.string.str_7223: StringResource
+  get() = String43.str_7223
+
+@ExperimentalResourceApi
+internal val Res.string.str_7224: StringResource
+  get() = String43.str_7224
+
+@ExperimentalResourceApi
+internal val Res.string.str_7225: StringResource
+  get() = String43.str_7225
+
+@ExperimentalResourceApi
+internal val Res.string.str_7226: StringResource
+  get() = String43.str_7226
+
+@ExperimentalResourceApi
+internal val Res.string.str_7227: StringResource
+  get() = String43.str_7227
+
+@ExperimentalResourceApi
+internal val Res.string.str_7228: StringResource
+  get() = String43.str_7228
+
+@ExperimentalResourceApi
+internal val Res.string.str_7229: StringResource
+  get() = String43.str_7229
+
+@ExperimentalResourceApi
+internal val Res.string.str_723: StringResource
+  get() = String43.str_723
+
+@ExperimentalResourceApi
+internal val Res.string.str_7230: StringResource
+  get() = String43.str_7230
+
+@ExperimentalResourceApi
+internal val Res.string.str_7231: StringResource
+  get() = String43.str_7231
+
+@ExperimentalResourceApi
+internal val Res.string.str_7232: StringResource
+  get() = String43.str_7232
+
+@ExperimentalResourceApi
+internal val Res.string.str_7233: StringResource
+  get() = String43.str_7233
+
+@ExperimentalResourceApi
+internal val Res.string.str_7234: StringResource
+  get() = String43.str_7234
+
+@ExperimentalResourceApi
+internal val Res.string.str_7235: StringResource
+  get() = String43.str_7235
+
+@ExperimentalResourceApi
+internal val Res.string.str_7236: StringResource
+  get() = String43.str_7236
+
+@ExperimentalResourceApi
+internal val Res.string.str_7237: StringResource
+  get() = String43.str_7237
+
+@ExperimentalResourceApi
+internal val Res.string.str_7238: StringResource
+  get() = String43.str_7238
+
+@ExperimentalResourceApi
+internal val Res.string.str_7239: StringResource
+  get() = String43.str_7239
+
+@ExperimentalResourceApi
+internal val Res.string.str_724: StringResource
+  get() = String43.str_724
+
+@ExperimentalResourceApi
+internal val Res.string.str_7240: StringResource
+  get() = String43.str_7240
+
+@ExperimentalResourceApi
+internal val Res.string.str_7241: StringResource
+  get() = String43.str_7241
+
+@ExperimentalResourceApi
+internal val Res.string.str_7242: StringResource
+  get() = String43.str_7242
+
+@ExperimentalResourceApi
+internal val Res.string.str_7243: StringResource
+  get() = String43.str_7243
+
+@ExperimentalResourceApi
+internal val Res.string.str_7244: StringResource
+  get() = String43.str_7244
+
+@ExperimentalResourceApi
+internal val Res.string.str_7245: StringResource
+  get() = String43.str_7245
+
+@ExperimentalResourceApi
+internal val Res.string.str_7246: StringResource
+  get() = String43.str_7246
+
+@ExperimentalResourceApi
+internal val Res.string.str_7247: StringResource
+  get() = String43.str_7247
+
+@ExperimentalResourceApi
+internal val Res.string.str_7248: StringResource
+  get() = String43.str_7248
+
+@ExperimentalResourceApi
+internal val Res.string.str_7249: StringResource
+  get() = String43.str_7249
+
+@ExperimentalResourceApi
+internal val Res.string.str_725: StringResource
+  get() = String43.str_725
+
+@ExperimentalResourceApi
+internal val Res.string.str_7250: StringResource
+  get() = String43.str_7250
+
+@ExperimentalResourceApi
+internal val Res.string.str_7251: StringResource
+  get() = String43.str_7251
+
+@ExperimentalResourceApi
+internal val Res.string.str_7252: StringResource
+  get() = String43.str_7252
+
+@ExperimentalResourceApi
+internal val Res.string.str_7253: StringResource
+  get() = String43.str_7253
+
+@ExperimentalResourceApi
+internal val Res.string.str_7254: StringResource
+  get() = String43.str_7254
+
+@ExperimentalResourceApi
+internal val Res.string.str_7255: StringResource
+  get() = String43.str_7255
+
+@ExperimentalResourceApi
+internal val Res.string.str_7256: StringResource
+  get() = String43.str_7256
+
+@ExperimentalResourceApi
+internal val Res.string.str_7257: StringResource
+  get() = String43.str_7257
+
+@ExperimentalResourceApi
+internal val Res.string.str_7258: StringResource
+  get() = String43.str_7258
+
+@ExperimentalResourceApi
+internal val Res.string.str_7259: StringResource
+  get() = String43.str_7259
+
+@ExperimentalResourceApi
+internal val Res.string.str_726: StringResource
+  get() = String43.str_726
+
+@ExperimentalResourceApi
+internal val Res.string.str_7260: StringResource
+  get() = String43.str_7260
+
+@ExperimentalResourceApi
+internal val Res.string.str_7261: StringResource
+  get() = String43.str_7261
+
+@ExperimentalResourceApi
+internal val Res.string.str_7262: StringResource
+  get() = String43.str_7262
+
+@ExperimentalResourceApi
+internal val Res.string.str_7263: StringResource
+  get() = String43.str_7263
+
+@ExperimentalResourceApi
+internal val Res.string.str_7264: StringResource
+  get() = String43.str_7264
+
+@ExperimentalResourceApi
+internal val Res.string.str_7265: StringResource
+  get() = String43.str_7265
+
+@ExperimentalResourceApi
+internal val Res.string.str_7266: StringResource
+  get() = String43.str_7266
+
+@ExperimentalResourceApi
+internal val Res.string.str_7267: StringResource
+  get() = String43.str_7267
+
+@ExperimentalResourceApi
+internal val Res.string.str_7268: StringResource
+  get() = String43.str_7268
+
+@ExperimentalResourceApi
+internal val Res.string.str_7269: StringResource
+  get() = String43.str_7269
+
+@ExperimentalResourceApi
+internal val Res.string.str_727: StringResource
+  get() = String43.str_727
+
+@ExperimentalResourceApi
+internal val Res.string.str_7270: StringResource
+  get() = String43.str_7270
+
+@ExperimentalResourceApi
+internal val Res.string.str_7271: StringResource
+  get() = String43.str_7271
+
+@ExperimentalResourceApi
+internal val Res.string.str_7272: StringResource
+  get() = String43.str_7272
+
+@ExperimentalResourceApi
+internal val Res.string.str_7273: StringResource
+  get() = String43.str_7273
+
+@ExperimentalResourceApi
+internal val Res.string.str_7274: StringResource
+  get() = String43.str_7274
+
+@ExperimentalResourceApi
+internal val Res.string.str_7275: StringResource
+  get() = String43.str_7275
+
+@ExperimentalResourceApi
+internal val Res.string.str_7276: StringResource
+  get() = String43.str_7276
+
+@ExperimentalResourceApi
+internal val Res.string.str_7277: StringResource
+  get() = String43.str_7277
+
+@ExperimentalResourceApi
+internal val Res.string.str_7278: StringResource
+  get() = String43.str_7278
+
+@ExperimentalResourceApi
+internal val Res.string.str_7279: StringResource
+  get() = String43.str_7279
+
+@ExperimentalResourceApi
+internal val Res.string.str_728: StringResource
+  get() = String43.str_728
+
+@ExperimentalResourceApi
+internal val Res.string.str_7280: StringResource
+  get() = String43.str_7280
+
+@ExperimentalResourceApi
+internal val Res.string.str_7281: StringResource
+  get() = String43.str_7281
+
+@ExperimentalResourceApi
+internal val Res.string.str_7282: StringResource
+  get() = String43.str_7282
+
+@ExperimentalResourceApi
+internal val Res.string.str_7283: StringResource
+  get() = String43.str_7283
+
+@ExperimentalResourceApi
+internal val Res.string.str_7284: StringResource
+  get() = String43.str_7284
+
+@ExperimentalResourceApi
+internal val Res.string.str_7285: StringResource
+  get() = String43.str_7285
+
+@ExperimentalResourceApi
+internal val Res.string.str_7286: StringResource
+  get() = String43.str_7286
+
+@ExperimentalResourceApi
+internal val Res.string.str_7287: StringResource
+  get() = String43.str_7287
+
+@ExperimentalResourceApi
+internal val Res.string.str_7288: StringResource
+  get() = String43.str_7288
+
+@ExperimentalResourceApi
+internal val Res.string.str_7289: StringResource
+  get() = String43.str_7289
+
+@ExperimentalResourceApi
+internal val Res.string.str_729: StringResource
+  get() = String43.str_729
+
+@ExperimentalResourceApi
+internal val Res.string.str_7290: StringResource
+  get() = String43.str_7290
+
+@ExperimentalResourceApi
+internal val Res.string.str_7291: StringResource
+  get() = String43.str_7291
+
+@ExperimentalResourceApi
+internal val Res.string.str_7292: StringResource
+  get() = String43.str_7292
+
+@ExperimentalResourceApi
+internal val Res.string.str_7293: StringResource
+  get() = String43.str_7293
+
+@ExperimentalResourceApi
+internal val Res.string.str_7294: StringResource
+  get() = String43.str_7294
+
+@ExperimentalResourceApi
+internal val Res.string.str_7295: StringResource
+  get() = String43.str_7295
+
+@ExperimentalResourceApi
+internal val Res.string.str_7296: StringResource
+  get() = String43.str_7296
+
+@ExperimentalResourceApi
+internal val Res.string.str_7297: StringResource
+  get() = String43.str_7297
+
+@ExperimentalResourceApi
+internal val Res.string.str_7298: StringResource
+  get() = String43.str_7298

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String44.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String44.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String44 {
+  public val str_7299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7299", "str_7299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_73: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_73", "str_73",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_730", "str_730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7300", "str_7300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7301", "str_7301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7302", "str_7302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7303", "str_7303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7304", "str_7304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7305", "str_7305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7306", "str_7306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7307", "str_7307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7308", "str_7308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7309", "str_7309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_731", "str_731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7310", "str_7310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7311", "str_7311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7312", "str_7312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7313", "str_7313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7314", "str_7314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7315", "str_7315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7316", "str_7316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7317", "str_7317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7318", "str_7318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7319", "str_7319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_732", "str_732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7320", "str_7320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7321", "str_7321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7322", "str_7322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7323", "str_7323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7324", "str_7324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7325", "str_7325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7326", "str_7326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7327", "str_7327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7328", "str_7328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7329", "str_7329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_733", "str_733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7330", "str_7330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7331", "str_7331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7332", "str_7332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7333", "str_7333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7334", "str_7334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7335", "str_7335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7336", "str_7336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7337", "str_7337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7338", "str_7338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7339", "str_7339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_734", "str_734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7340", "str_7340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7341", "str_7341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7342", "str_7342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7343", "str_7343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7344", "str_7344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7345", "str_7345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7346", "str_7346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7347", "str_7347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7348", "str_7348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7349", "str_7349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_735", "str_735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7350", "str_7350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7351", "str_7351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7352", "str_7352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7353", "str_7353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7354", "str_7354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7355", "str_7355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7356", "str_7356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7357", "str_7357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7358", "str_7358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7359", "str_7359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_736", "str_736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7360", "str_7360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7361", "str_7361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7362", "str_7362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7363", "str_7363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7364", "str_7364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7365", "str_7365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7366", "str_7366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7367", "str_7367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7368", "str_7368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7369", "str_7369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_737", "str_737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7370", "str_7370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7371", "str_7371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7372", "str_7372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7373", "str_7373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7374", "str_7374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7375", "str_7375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7376", "str_7376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7377", "str_7377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7378", "str_7378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7379", "str_7379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_738", "str_738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7380", "str_7380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7381", "str_7381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7382", "str_7382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7383", "str_7383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7384", "str_7384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7385", "str_7385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7386", "str_7386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7387", "str_7387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7388", "str_7388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7389", "str_7389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_739", "str_739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7390", "str_7390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7391", "str_7391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7392", "str_7392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7393", "str_7393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7394", "str_7394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7395", "str_7395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7396", "str_7396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7397", "str_7397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7398", "str_7398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7399", "str_7399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_74: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_74", "str_74",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_740", "str_740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7400", "str_7400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7401", "str_7401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7402", "str_7402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7403", "str_7403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7404", "str_7404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7405", "str_7405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7406", "str_7406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7407", "str_7407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7408", "str_7408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7409", "str_7409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_741", "str_741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7410", "str_7410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7411", "str_7411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7412", "str_7412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7413", "str_7413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7414", "str_7414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7415", "str_7415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7416", "str_7416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7417", "str_7417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7418", "str_7418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7419", "str_7419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_742", "str_742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7420", "str_7420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7421", "str_7421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7422", "str_7422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7423", "str_7423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7424", "str_7424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7425", "str_7425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7426", "str_7426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7427", "str_7427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7428", "str_7428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7429", "str_7429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_743", "str_743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7430", "str_7430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7431", "str_7431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7432", "str_7432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7433", "str_7433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7434", "str_7434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7435", "str_7435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7436", "str_7436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7437", "str_7437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7438", "str_7438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7439", "str_7439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_744", "str_744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7440", "str_7440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7441", "str_7441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7442", "str_7442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7443", "str_7443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7444", "str_7444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7445", "str_7445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7446", "str_7446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7447", "str_7447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7448", "str_7448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7449", "str_7449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_745", "str_745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7450", "str_7450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7451", "str_7451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7452", "str_7452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7453", "str_7453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7454", "str_7454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7455", "str_7455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7456", "str_7456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7457", "str_7457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7458", "str_7458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7459", "str_7459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_746", "str_746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7460", "str_7460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7461", "str_7461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7462", "str_7462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7463", "str_7463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7464", "str_7464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7465", "str_7465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7466", "str_7466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7467", "str_7467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7468", "str_7468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7469", "str_7469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_747", "str_747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7470", "str_7470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7471", "str_7471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7472", "str_7472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7473", "str_7473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7474", "str_7474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7475", "str_7475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7476", "str_7476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7477", "str_7477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7478", "str_7478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7479", "str_7479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_748", "str_748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7480", "str_7480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7481", "str_7481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7482", "str_7482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7483", "str_7483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7484", "str_7484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7485", "str_7485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7486", "str_7486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7487", "str_7487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7488", "str_7488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7489", "str_7489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_749", "str_749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7490", "str_7490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7491", "str_7491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7492", "str_7492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7493", "str_7493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7494", "str_7494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7495", "str_7495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7496", "str_7496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7497", "str_7497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7498", "str_7498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7499", "str_7499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_75: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_75", "str_75",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_750", "str_750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7500", "str_7500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7501", "str_7501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7502", "str_7502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7503", "str_7503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7504", "str_7504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7505", "str_7505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7506", "str_7506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7507", "str_7507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7508", "str_7508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7509", "str_7509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_751", "str_751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7510", "str_7510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7511", "str_7511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7512", "str_7512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7513", "str_7513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7514", "str_7514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7515", "str_7515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7516", "str_7516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7517", "str_7517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7518", "str_7518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7519", "str_7519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_752", "str_752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7520", "str_7520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7521", "str_7521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7522", "str_7522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7523", "str_7523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7524", "str_7524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7525", "str_7525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7526", "str_7526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7527", "str_7527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7528", "str_7528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7529", "str_7529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_753", "str_753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7530", "str_7530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7531", "str_7531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7532", "str_7532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7533", "str_7533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7534", "str_7534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7535", "str_7535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7536", "str_7536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7537", "str_7537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7538", "str_7538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7539", "str_7539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_754", "str_754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7540", "str_7540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7541", "str_7541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7542", "str_7542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7543", "str_7543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7544", "str_7544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7545", "str_7545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7546", "str_7546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7547", "str_7547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7548", "str_7548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7549", "str_7549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_755", "str_755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7550", "str_7550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7551", "str_7551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7552", "str_7552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7553", "str_7553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7554", "str_7554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7555", "str_7555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7556", "str_7556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7557", "str_7557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7558", "str_7558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7559", "str_7559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_756", "str_756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7560", "str_7560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7561", "str_7561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7562", "str_7562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7563", "str_7563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7564", "str_7564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7565", "str_7565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7566", "str_7566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7567", "str_7567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7568", "str_7568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7569", "str_7569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_757", "str_757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7570", "str_7570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7571", "str_7571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7572", "str_7572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7573", "str_7573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7574", "str_7574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7575", "str_7575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7576", "str_7576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7577", "str_7577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7578", "str_7578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7579", "str_7579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_758", "str_758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7580", "str_7580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7581", "str_7581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7582", "str_7582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7583", "str_7583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7584", "str_7584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7585", "str_7585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7586", "str_7586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7587", "str_7587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7588", "str_7588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7589", "str_7589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_759", "str_759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7590", "str_7590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7591", "str_7591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7592", "str_7592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7593", "str_7593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7594", "str_7594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7595", "str_7595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7596", "str_7596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7597", "str_7597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7598", "str_7598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7599", "str_7599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_76: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_76", "str_76",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_760", "str_760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7600", "str_7600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7601", "str_7601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7602", "str_7602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7603", "str_7603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7604", "str_7604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7605", "str_7605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7606", "str_7606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7607", "str_7607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7608", "str_7608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7609", "str_7609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_761", "str_761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7610", "str_7610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7611", "str_7611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7612", "str_7612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7613", "str_7613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7614", "str_7614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7615", "str_7615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7616", "str_7616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7617", "str_7617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7618", "str_7618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7619", "str_7619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_762", "str_762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7620", "str_7620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7621", "str_7621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7622", "str_7622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7623", "str_7623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7624", "str_7624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7625", "str_7625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7626", "str_7626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7627", "str_7627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7628", "str_7628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7629", "str_7629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_763", "str_763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7630", "str_7630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7631", "str_7631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7632", "str_7632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7633", "str_7633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7634", "str_7634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7635", "str_7635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7636", "str_7636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7637", "str_7637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7638", "str_7638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7639", "str_7639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_764", "str_764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7640", "str_7640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7641", "str_7641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7642", "str_7642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7643", "str_7643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7644", "str_7644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7645", "str_7645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7646", "str_7646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7647", "str_7647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7648", "str_7648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7649", "str_7649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_765", "str_765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7650", "str_7650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7651", "str_7651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7652", "str_7652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7653", "str_7653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7654", "str_7654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7655", "str_7655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7656", "str_7656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7657", "str_7657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7658", "str_7658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7659", "str_7659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_766", "str_766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7660", "str_7660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7661", "str_7661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7662", "str_7662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7663", "str_7663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7664", "str_7664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7665", "str_7665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7666", "str_7666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7667", "str_7667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7668", "str_7668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7669", "str_7669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_767", "str_767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7670", "str_7670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7671", "str_7671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7672", "str_7672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7673", "str_7673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7674", "str_7674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7675", "str_7675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7676", "str_7676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7677", "str_7677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7678", "str_7678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7679", "str_7679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_768", "str_768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7680", "str_7680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7681", "str_7681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7682", "str_7682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7683", "str_7683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7684", "str_7684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7685", "str_7685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7686", "str_7686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7687", "str_7687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7688", "str_7688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7689", "str_7689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_769", "str_769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7690", "str_7690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7691", "str_7691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7692", "str_7692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7693", "str_7693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7694", "str_7694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7695", "str_7695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7696", "str_7696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7697", "str_7697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7698", "str_7698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7699", "str_7699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_77: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_77", "str_77",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_770", "str_770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7700", "str_7700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7701", "str_7701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7702", "str_7702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7703", "str_7703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7704", "str_7704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7705", "str_7705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7706", "str_7706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7707", "str_7707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7708", "str_7708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7709", "str_7709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_771", "str_771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7710", "str_7710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7711", "str_7711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7712", "str_7712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7713", "str_7713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7714", "str_7714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7715", "str_7715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7716", "str_7716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7717", "str_7717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7718", "str_7718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7719", "str_7719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_772", "str_772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7720", "str_7720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7721", "str_7721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7722", "str_7722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7723", "str_7723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7724", "str_7724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7725", "str_7725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7726", "str_7726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7727", "str_7727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7728", "str_7728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7729", "str_7729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_773", "str_773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7730", "str_7730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7731", "str_7731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7732", "str_7732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7733", "str_7733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7734", "str_7734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7735", "str_7735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7736", "str_7736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7737", "str_7737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7738", "str_7738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7739", "str_7739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_774", "str_774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7740", "str_7740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7741", "str_7741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7742", "str_7742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7743", "str_7743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7744", "str_7744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7745", "str_7745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7746", "str_7746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7747", "str_7747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7748", "str_7748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_7299: StringResource
+  get() = String44.str_7299
+
+@ExperimentalResourceApi
+internal val Res.string.str_73: StringResource
+  get() = String44.str_73
+
+@ExperimentalResourceApi
+internal val Res.string.str_730: StringResource
+  get() = String44.str_730
+
+@ExperimentalResourceApi
+internal val Res.string.str_7300: StringResource
+  get() = String44.str_7300
+
+@ExperimentalResourceApi
+internal val Res.string.str_7301: StringResource
+  get() = String44.str_7301
+
+@ExperimentalResourceApi
+internal val Res.string.str_7302: StringResource
+  get() = String44.str_7302
+
+@ExperimentalResourceApi
+internal val Res.string.str_7303: StringResource
+  get() = String44.str_7303
+
+@ExperimentalResourceApi
+internal val Res.string.str_7304: StringResource
+  get() = String44.str_7304
+
+@ExperimentalResourceApi
+internal val Res.string.str_7305: StringResource
+  get() = String44.str_7305
+
+@ExperimentalResourceApi
+internal val Res.string.str_7306: StringResource
+  get() = String44.str_7306
+
+@ExperimentalResourceApi
+internal val Res.string.str_7307: StringResource
+  get() = String44.str_7307
+
+@ExperimentalResourceApi
+internal val Res.string.str_7308: StringResource
+  get() = String44.str_7308
+
+@ExperimentalResourceApi
+internal val Res.string.str_7309: StringResource
+  get() = String44.str_7309
+
+@ExperimentalResourceApi
+internal val Res.string.str_731: StringResource
+  get() = String44.str_731
+
+@ExperimentalResourceApi
+internal val Res.string.str_7310: StringResource
+  get() = String44.str_7310
+
+@ExperimentalResourceApi
+internal val Res.string.str_7311: StringResource
+  get() = String44.str_7311
+
+@ExperimentalResourceApi
+internal val Res.string.str_7312: StringResource
+  get() = String44.str_7312
+
+@ExperimentalResourceApi
+internal val Res.string.str_7313: StringResource
+  get() = String44.str_7313
+
+@ExperimentalResourceApi
+internal val Res.string.str_7314: StringResource
+  get() = String44.str_7314
+
+@ExperimentalResourceApi
+internal val Res.string.str_7315: StringResource
+  get() = String44.str_7315
+
+@ExperimentalResourceApi
+internal val Res.string.str_7316: StringResource
+  get() = String44.str_7316
+
+@ExperimentalResourceApi
+internal val Res.string.str_7317: StringResource
+  get() = String44.str_7317
+
+@ExperimentalResourceApi
+internal val Res.string.str_7318: StringResource
+  get() = String44.str_7318
+
+@ExperimentalResourceApi
+internal val Res.string.str_7319: StringResource
+  get() = String44.str_7319
+
+@ExperimentalResourceApi
+internal val Res.string.str_732: StringResource
+  get() = String44.str_732
+
+@ExperimentalResourceApi
+internal val Res.string.str_7320: StringResource
+  get() = String44.str_7320
+
+@ExperimentalResourceApi
+internal val Res.string.str_7321: StringResource
+  get() = String44.str_7321
+
+@ExperimentalResourceApi
+internal val Res.string.str_7322: StringResource
+  get() = String44.str_7322
+
+@ExperimentalResourceApi
+internal val Res.string.str_7323: StringResource
+  get() = String44.str_7323
+
+@ExperimentalResourceApi
+internal val Res.string.str_7324: StringResource
+  get() = String44.str_7324
+
+@ExperimentalResourceApi
+internal val Res.string.str_7325: StringResource
+  get() = String44.str_7325
+
+@ExperimentalResourceApi
+internal val Res.string.str_7326: StringResource
+  get() = String44.str_7326
+
+@ExperimentalResourceApi
+internal val Res.string.str_7327: StringResource
+  get() = String44.str_7327
+
+@ExperimentalResourceApi
+internal val Res.string.str_7328: StringResource
+  get() = String44.str_7328
+
+@ExperimentalResourceApi
+internal val Res.string.str_7329: StringResource
+  get() = String44.str_7329
+
+@ExperimentalResourceApi
+internal val Res.string.str_733: StringResource
+  get() = String44.str_733
+
+@ExperimentalResourceApi
+internal val Res.string.str_7330: StringResource
+  get() = String44.str_7330
+
+@ExperimentalResourceApi
+internal val Res.string.str_7331: StringResource
+  get() = String44.str_7331
+
+@ExperimentalResourceApi
+internal val Res.string.str_7332: StringResource
+  get() = String44.str_7332
+
+@ExperimentalResourceApi
+internal val Res.string.str_7333: StringResource
+  get() = String44.str_7333
+
+@ExperimentalResourceApi
+internal val Res.string.str_7334: StringResource
+  get() = String44.str_7334
+
+@ExperimentalResourceApi
+internal val Res.string.str_7335: StringResource
+  get() = String44.str_7335
+
+@ExperimentalResourceApi
+internal val Res.string.str_7336: StringResource
+  get() = String44.str_7336
+
+@ExperimentalResourceApi
+internal val Res.string.str_7337: StringResource
+  get() = String44.str_7337
+
+@ExperimentalResourceApi
+internal val Res.string.str_7338: StringResource
+  get() = String44.str_7338
+
+@ExperimentalResourceApi
+internal val Res.string.str_7339: StringResource
+  get() = String44.str_7339
+
+@ExperimentalResourceApi
+internal val Res.string.str_734: StringResource
+  get() = String44.str_734
+
+@ExperimentalResourceApi
+internal val Res.string.str_7340: StringResource
+  get() = String44.str_7340
+
+@ExperimentalResourceApi
+internal val Res.string.str_7341: StringResource
+  get() = String44.str_7341
+
+@ExperimentalResourceApi
+internal val Res.string.str_7342: StringResource
+  get() = String44.str_7342
+
+@ExperimentalResourceApi
+internal val Res.string.str_7343: StringResource
+  get() = String44.str_7343
+
+@ExperimentalResourceApi
+internal val Res.string.str_7344: StringResource
+  get() = String44.str_7344
+
+@ExperimentalResourceApi
+internal val Res.string.str_7345: StringResource
+  get() = String44.str_7345
+
+@ExperimentalResourceApi
+internal val Res.string.str_7346: StringResource
+  get() = String44.str_7346
+
+@ExperimentalResourceApi
+internal val Res.string.str_7347: StringResource
+  get() = String44.str_7347
+
+@ExperimentalResourceApi
+internal val Res.string.str_7348: StringResource
+  get() = String44.str_7348
+
+@ExperimentalResourceApi
+internal val Res.string.str_7349: StringResource
+  get() = String44.str_7349
+
+@ExperimentalResourceApi
+internal val Res.string.str_735: StringResource
+  get() = String44.str_735
+
+@ExperimentalResourceApi
+internal val Res.string.str_7350: StringResource
+  get() = String44.str_7350
+
+@ExperimentalResourceApi
+internal val Res.string.str_7351: StringResource
+  get() = String44.str_7351
+
+@ExperimentalResourceApi
+internal val Res.string.str_7352: StringResource
+  get() = String44.str_7352
+
+@ExperimentalResourceApi
+internal val Res.string.str_7353: StringResource
+  get() = String44.str_7353
+
+@ExperimentalResourceApi
+internal val Res.string.str_7354: StringResource
+  get() = String44.str_7354
+
+@ExperimentalResourceApi
+internal val Res.string.str_7355: StringResource
+  get() = String44.str_7355
+
+@ExperimentalResourceApi
+internal val Res.string.str_7356: StringResource
+  get() = String44.str_7356
+
+@ExperimentalResourceApi
+internal val Res.string.str_7357: StringResource
+  get() = String44.str_7357
+
+@ExperimentalResourceApi
+internal val Res.string.str_7358: StringResource
+  get() = String44.str_7358
+
+@ExperimentalResourceApi
+internal val Res.string.str_7359: StringResource
+  get() = String44.str_7359
+
+@ExperimentalResourceApi
+internal val Res.string.str_736: StringResource
+  get() = String44.str_736
+
+@ExperimentalResourceApi
+internal val Res.string.str_7360: StringResource
+  get() = String44.str_7360
+
+@ExperimentalResourceApi
+internal val Res.string.str_7361: StringResource
+  get() = String44.str_7361
+
+@ExperimentalResourceApi
+internal val Res.string.str_7362: StringResource
+  get() = String44.str_7362
+
+@ExperimentalResourceApi
+internal val Res.string.str_7363: StringResource
+  get() = String44.str_7363
+
+@ExperimentalResourceApi
+internal val Res.string.str_7364: StringResource
+  get() = String44.str_7364
+
+@ExperimentalResourceApi
+internal val Res.string.str_7365: StringResource
+  get() = String44.str_7365
+
+@ExperimentalResourceApi
+internal val Res.string.str_7366: StringResource
+  get() = String44.str_7366
+
+@ExperimentalResourceApi
+internal val Res.string.str_7367: StringResource
+  get() = String44.str_7367
+
+@ExperimentalResourceApi
+internal val Res.string.str_7368: StringResource
+  get() = String44.str_7368
+
+@ExperimentalResourceApi
+internal val Res.string.str_7369: StringResource
+  get() = String44.str_7369
+
+@ExperimentalResourceApi
+internal val Res.string.str_737: StringResource
+  get() = String44.str_737
+
+@ExperimentalResourceApi
+internal val Res.string.str_7370: StringResource
+  get() = String44.str_7370
+
+@ExperimentalResourceApi
+internal val Res.string.str_7371: StringResource
+  get() = String44.str_7371
+
+@ExperimentalResourceApi
+internal val Res.string.str_7372: StringResource
+  get() = String44.str_7372
+
+@ExperimentalResourceApi
+internal val Res.string.str_7373: StringResource
+  get() = String44.str_7373
+
+@ExperimentalResourceApi
+internal val Res.string.str_7374: StringResource
+  get() = String44.str_7374
+
+@ExperimentalResourceApi
+internal val Res.string.str_7375: StringResource
+  get() = String44.str_7375
+
+@ExperimentalResourceApi
+internal val Res.string.str_7376: StringResource
+  get() = String44.str_7376
+
+@ExperimentalResourceApi
+internal val Res.string.str_7377: StringResource
+  get() = String44.str_7377
+
+@ExperimentalResourceApi
+internal val Res.string.str_7378: StringResource
+  get() = String44.str_7378
+
+@ExperimentalResourceApi
+internal val Res.string.str_7379: StringResource
+  get() = String44.str_7379
+
+@ExperimentalResourceApi
+internal val Res.string.str_738: StringResource
+  get() = String44.str_738
+
+@ExperimentalResourceApi
+internal val Res.string.str_7380: StringResource
+  get() = String44.str_7380
+
+@ExperimentalResourceApi
+internal val Res.string.str_7381: StringResource
+  get() = String44.str_7381
+
+@ExperimentalResourceApi
+internal val Res.string.str_7382: StringResource
+  get() = String44.str_7382
+
+@ExperimentalResourceApi
+internal val Res.string.str_7383: StringResource
+  get() = String44.str_7383
+
+@ExperimentalResourceApi
+internal val Res.string.str_7384: StringResource
+  get() = String44.str_7384
+
+@ExperimentalResourceApi
+internal val Res.string.str_7385: StringResource
+  get() = String44.str_7385
+
+@ExperimentalResourceApi
+internal val Res.string.str_7386: StringResource
+  get() = String44.str_7386
+
+@ExperimentalResourceApi
+internal val Res.string.str_7387: StringResource
+  get() = String44.str_7387
+
+@ExperimentalResourceApi
+internal val Res.string.str_7388: StringResource
+  get() = String44.str_7388
+
+@ExperimentalResourceApi
+internal val Res.string.str_7389: StringResource
+  get() = String44.str_7389
+
+@ExperimentalResourceApi
+internal val Res.string.str_739: StringResource
+  get() = String44.str_739
+
+@ExperimentalResourceApi
+internal val Res.string.str_7390: StringResource
+  get() = String44.str_7390
+
+@ExperimentalResourceApi
+internal val Res.string.str_7391: StringResource
+  get() = String44.str_7391
+
+@ExperimentalResourceApi
+internal val Res.string.str_7392: StringResource
+  get() = String44.str_7392
+
+@ExperimentalResourceApi
+internal val Res.string.str_7393: StringResource
+  get() = String44.str_7393
+
+@ExperimentalResourceApi
+internal val Res.string.str_7394: StringResource
+  get() = String44.str_7394
+
+@ExperimentalResourceApi
+internal val Res.string.str_7395: StringResource
+  get() = String44.str_7395
+
+@ExperimentalResourceApi
+internal val Res.string.str_7396: StringResource
+  get() = String44.str_7396
+
+@ExperimentalResourceApi
+internal val Res.string.str_7397: StringResource
+  get() = String44.str_7397
+
+@ExperimentalResourceApi
+internal val Res.string.str_7398: StringResource
+  get() = String44.str_7398
+
+@ExperimentalResourceApi
+internal val Res.string.str_7399: StringResource
+  get() = String44.str_7399
+
+@ExperimentalResourceApi
+internal val Res.string.str_74: StringResource
+  get() = String44.str_74
+
+@ExperimentalResourceApi
+internal val Res.string.str_740: StringResource
+  get() = String44.str_740
+
+@ExperimentalResourceApi
+internal val Res.string.str_7400: StringResource
+  get() = String44.str_7400
+
+@ExperimentalResourceApi
+internal val Res.string.str_7401: StringResource
+  get() = String44.str_7401
+
+@ExperimentalResourceApi
+internal val Res.string.str_7402: StringResource
+  get() = String44.str_7402
+
+@ExperimentalResourceApi
+internal val Res.string.str_7403: StringResource
+  get() = String44.str_7403
+
+@ExperimentalResourceApi
+internal val Res.string.str_7404: StringResource
+  get() = String44.str_7404
+
+@ExperimentalResourceApi
+internal val Res.string.str_7405: StringResource
+  get() = String44.str_7405
+
+@ExperimentalResourceApi
+internal val Res.string.str_7406: StringResource
+  get() = String44.str_7406
+
+@ExperimentalResourceApi
+internal val Res.string.str_7407: StringResource
+  get() = String44.str_7407
+
+@ExperimentalResourceApi
+internal val Res.string.str_7408: StringResource
+  get() = String44.str_7408
+
+@ExperimentalResourceApi
+internal val Res.string.str_7409: StringResource
+  get() = String44.str_7409
+
+@ExperimentalResourceApi
+internal val Res.string.str_741: StringResource
+  get() = String44.str_741
+
+@ExperimentalResourceApi
+internal val Res.string.str_7410: StringResource
+  get() = String44.str_7410
+
+@ExperimentalResourceApi
+internal val Res.string.str_7411: StringResource
+  get() = String44.str_7411
+
+@ExperimentalResourceApi
+internal val Res.string.str_7412: StringResource
+  get() = String44.str_7412
+
+@ExperimentalResourceApi
+internal val Res.string.str_7413: StringResource
+  get() = String44.str_7413
+
+@ExperimentalResourceApi
+internal val Res.string.str_7414: StringResource
+  get() = String44.str_7414
+
+@ExperimentalResourceApi
+internal val Res.string.str_7415: StringResource
+  get() = String44.str_7415
+
+@ExperimentalResourceApi
+internal val Res.string.str_7416: StringResource
+  get() = String44.str_7416
+
+@ExperimentalResourceApi
+internal val Res.string.str_7417: StringResource
+  get() = String44.str_7417
+
+@ExperimentalResourceApi
+internal val Res.string.str_7418: StringResource
+  get() = String44.str_7418
+
+@ExperimentalResourceApi
+internal val Res.string.str_7419: StringResource
+  get() = String44.str_7419
+
+@ExperimentalResourceApi
+internal val Res.string.str_742: StringResource
+  get() = String44.str_742
+
+@ExperimentalResourceApi
+internal val Res.string.str_7420: StringResource
+  get() = String44.str_7420
+
+@ExperimentalResourceApi
+internal val Res.string.str_7421: StringResource
+  get() = String44.str_7421
+
+@ExperimentalResourceApi
+internal val Res.string.str_7422: StringResource
+  get() = String44.str_7422
+
+@ExperimentalResourceApi
+internal val Res.string.str_7423: StringResource
+  get() = String44.str_7423
+
+@ExperimentalResourceApi
+internal val Res.string.str_7424: StringResource
+  get() = String44.str_7424
+
+@ExperimentalResourceApi
+internal val Res.string.str_7425: StringResource
+  get() = String44.str_7425
+
+@ExperimentalResourceApi
+internal val Res.string.str_7426: StringResource
+  get() = String44.str_7426
+
+@ExperimentalResourceApi
+internal val Res.string.str_7427: StringResource
+  get() = String44.str_7427
+
+@ExperimentalResourceApi
+internal val Res.string.str_7428: StringResource
+  get() = String44.str_7428
+
+@ExperimentalResourceApi
+internal val Res.string.str_7429: StringResource
+  get() = String44.str_7429
+
+@ExperimentalResourceApi
+internal val Res.string.str_743: StringResource
+  get() = String44.str_743
+
+@ExperimentalResourceApi
+internal val Res.string.str_7430: StringResource
+  get() = String44.str_7430
+
+@ExperimentalResourceApi
+internal val Res.string.str_7431: StringResource
+  get() = String44.str_7431
+
+@ExperimentalResourceApi
+internal val Res.string.str_7432: StringResource
+  get() = String44.str_7432
+
+@ExperimentalResourceApi
+internal val Res.string.str_7433: StringResource
+  get() = String44.str_7433
+
+@ExperimentalResourceApi
+internal val Res.string.str_7434: StringResource
+  get() = String44.str_7434
+
+@ExperimentalResourceApi
+internal val Res.string.str_7435: StringResource
+  get() = String44.str_7435
+
+@ExperimentalResourceApi
+internal val Res.string.str_7436: StringResource
+  get() = String44.str_7436
+
+@ExperimentalResourceApi
+internal val Res.string.str_7437: StringResource
+  get() = String44.str_7437
+
+@ExperimentalResourceApi
+internal val Res.string.str_7438: StringResource
+  get() = String44.str_7438
+
+@ExperimentalResourceApi
+internal val Res.string.str_7439: StringResource
+  get() = String44.str_7439
+
+@ExperimentalResourceApi
+internal val Res.string.str_744: StringResource
+  get() = String44.str_744
+
+@ExperimentalResourceApi
+internal val Res.string.str_7440: StringResource
+  get() = String44.str_7440
+
+@ExperimentalResourceApi
+internal val Res.string.str_7441: StringResource
+  get() = String44.str_7441
+
+@ExperimentalResourceApi
+internal val Res.string.str_7442: StringResource
+  get() = String44.str_7442
+
+@ExperimentalResourceApi
+internal val Res.string.str_7443: StringResource
+  get() = String44.str_7443
+
+@ExperimentalResourceApi
+internal val Res.string.str_7444: StringResource
+  get() = String44.str_7444
+
+@ExperimentalResourceApi
+internal val Res.string.str_7445: StringResource
+  get() = String44.str_7445
+
+@ExperimentalResourceApi
+internal val Res.string.str_7446: StringResource
+  get() = String44.str_7446
+
+@ExperimentalResourceApi
+internal val Res.string.str_7447: StringResource
+  get() = String44.str_7447
+
+@ExperimentalResourceApi
+internal val Res.string.str_7448: StringResource
+  get() = String44.str_7448
+
+@ExperimentalResourceApi
+internal val Res.string.str_7449: StringResource
+  get() = String44.str_7449
+
+@ExperimentalResourceApi
+internal val Res.string.str_745: StringResource
+  get() = String44.str_745
+
+@ExperimentalResourceApi
+internal val Res.string.str_7450: StringResource
+  get() = String44.str_7450
+
+@ExperimentalResourceApi
+internal val Res.string.str_7451: StringResource
+  get() = String44.str_7451
+
+@ExperimentalResourceApi
+internal val Res.string.str_7452: StringResource
+  get() = String44.str_7452
+
+@ExperimentalResourceApi
+internal val Res.string.str_7453: StringResource
+  get() = String44.str_7453
+
+@ExperimentalResourceApi
+internal val Res.string.str_7454: StringResource
+  get() = String44.str_7454
+
+@ExperimentalResourceApi
+internal val Res.string.str_7455: StringResource
+  get() = String44.str_7455
+
+@ExperimentalResourceApi
+internal val Res.string.str_7456: StringResource
+  get() = String44.str_7456
+
+@ExperimentalResourceApi
+internal val Res.string.str_7457: StringResource
+  get() = String44.str_7457
+
+@ExperimentalResourceApi
+internal val Res.string.str_7458: StringResource
+  get() = String44.str_7458
+
+@ExperimentalResourceApi
+internal val Res.string.str_7459: StringResource
+  get() = String44.str_7459
+
+@ExperimentalResourceApi
+internal val Res.string.str_746: StringResource
+  get() = String44.str_746
+
+@ExperimentalResourceApi
+internal val Res.string.str_7460: StringResource
+  get() = String44.str_7460
+
+@ExperimentalResourceApi
+internal val Res.string.str_7461: StringResource
+  get() = String44.str_7461
+
+@ExperimentalResourceApi
+internal val Res.string.str_7462: StringResource
+  get() = String44.str_7462
+
+@ExperimentalResourceApi
+internal val Res.string.str_7463: StringResource
+  get() = String44.str_7463
+
+@ExperimentalResourceApi
+internal val Res.string.str_7464: StringResource
+  get() = String44.str_7464
+
+@ExperimentalResourceApi
+internal val Res.string.str_7465: StringResource
+  get() = String44.str_7465
+
+@ExperimentalResourceApi
+internal val Res.string.str_7466: StringResource
+  get() = String44.str_7466
+
+@ExperimentalResourceApi
+internal val Res.string.str_7467: StringResource
+  get() = String44.str_7467
+
+@ExperimentalResourceApi
+internal val Res.string.str_7468: StringResource
+  get() = String44.str_7468
+
+@ExperimentalResourceApi
+internal val Res.string.str_7469: StringResource
+  get() = String44.str_7469
+
+@ExperimentalResourceApi
+internal val Res.string.str_747: StringResource
+  get() = String44.str_747
+
+@ExperimentalResourceApi
+internal val Res.string.str_7470: StringResource
+  get() = String44.str_7470
+
+@ExperimentalResourceApi
+internal val Res.string.str_7471: StringResource
+  get() = String44.str_7471
+
+@ExperimentalResourceApi
+internal val Res.string.str_7472: StringResource
+  get() = String44.str_7472
+
+@ExperimentalResourceApi
+internal val Res.string.str_7473: StringResource
+  get() = String44.str_7473
+
+@ExperimentalResourceApi
+internal val Res.string.str_7474: StringResource
+  get() = String44.str_7474
+
+@ExperimentalResourceApi
+internal val Res.string.str_7475: StringResource
+  get() = String44.str_7475
+
+@ExperimentalResourceApi
+internal val Res.string.str_7476: StringResource
+  get() = String44.str_7476
+
+@ExperimentalResourceApi
+internal val Res.string.str_7477: StringResource
+  get() = String44.str_7477
+
+@ExperimentalResourceApi
+internal val Res.string.str_7478: StringResource
+  get() = String44.str_7478
+
+@ExperimentalResourceApi
+internal val Res.string.str_7479: StringResource
+  get() = String44.str_7479
+
+@ExperimentalResourceApi
+internal val Res.string.str_748: StringResource
+  get() = String44.str_748
+
+@ExperimentalResourceApi
+internal val Res.string.str_7480: StringResource
+  get() = String44.str_7480
+
+@ExperimentalResourceApi
+internal val Res.string.str_7481: StringResource
+  get() = String44.str_7481
+
+@ExperimentalResourceApi
+internal val Res.string.str_7482: StringResource
+  get() = String44.str_7482
+
+@ExperimentalResourceApi
+internal val Res.string.str_7483: StringResource
+  get() = String44.str_7483
+
+@ExperimentalResourceApi
+internal val Res.string.str_7484: StringResource
+  get() = String44.str_7484
+
+@ExperimentalResourceApi
+internal val Res.string.str_7485: StringResource
+  get() = String44.str_7485
+
+@ExperimentalResourceApi
+internal val Res.string.str_7486: StringResource
+  get() = String44.str_7486
+
+@ExperimentalResourceApi
+internal val Res.string.str_7487: StringResource
+  get() = String44.str_7487
+
+@ExperimentalResourceApi
+internal val Res.string.str_7488: StringResource
+  get() = String44.str_7488
+
+@ExperimentalResourceApi
+internal val Res.string.str_7489: StringResource
+  get() = String44.str_7489
+
+@ExperimentalResourceApi
+internal val Res.string.str_749: StringResource
+  get() = String44.str_749
+
+@ExperimentalResourceApi
+internal val Res.string.str_7490: StringResource
+  get() = String44.str_7490
+
+@ExperimentalResourceApi
+internal val Res.string.str_7491: StringResource
+  get() = String44.str_7491
+
+@ExperimentalResourceApi
+internal val Res.string.str_7492: StringResource
+  get() = String44.str_7492
+
+@ExperimentalResourceApi
+internal val Res.string.str_7493: StringResource
+  get() = String44.str_7493
+
+@ExperimentalResourceApi
+internal val Res.string.str_7494: StringResource
+  get() = String44.str_7494
+
+@ExperimentalResourceApi
+internal val Res.string.str_7495: StringResource
+  get() = String44.str_7495
+
+@ExperimentalResourceApi
+internal val Res.string.str_7496: StringResource
+  get() = String44.str_7496
+
+@ExperimentalResourceApi
+internal val Res.string.str_7497: StringResource
+  get() = String44.str_7497
+
+@ExperimentalResourceApi
+internal val Res.string.str_7498: StringResource
+  get() = String44.str_7498
+
+@ExperimentalResourceApi
+internal val Res.string.str_7499: StringResource
+  get() = String44.str_7499
+
+@ExperimentalResourceApi
+internal val Res.string.str_75: StringResource
+  get() = String44.str_75
+
+@ExperimentalResourceApi
+internal val Res.string.str_750: StringResource
+  get() = String44.str_750
+
+@ExperimentalResourceApi
+internal val Res.string.str_7500: StringResource
+  get() = String44.str_7500
+
+@ExperimentalResourceApi
+internal val Res.string.str_7501: StringResource
+  get() = String44.str_7501
+
+@ExperimentalResourceApi
+internal val Res.string.str_7502: StringResource
+  get() = String44.str_7502
+
+@ExperimentalResourceApi
+internal val Res.string.str_7503: StringResource
+  get() = String44.str_7503
+
+@ExperimentalResourceApi
+internal val Res.string.str_7504: StringResource
+  get() = String44.str_7504
+
+@ExperimentalResourceApi
+internal val Res.string.str_7505: StringResource
+  get() = String44.str_7505
+
+@ExperimentalResourceApi
+internal val Res.string.str_7506: StringResource
+  get() = String44.str_7506
+
+@ExperimentalResourceApi
+internal val Res.string.str_7507: StringResource
+  get() = String44.str_7507
+
+@ExperimentalResourceApi
+internal val Res.string.str_7508: StringResource
+  get() = String44.str_7508
+
+@ExperimentalResourceApi
+internal val Res.string.str_7509: StringResource
+  get() = String44.str_7509
+
+@ExperimentalResourceApi
+internal val Res.string.str_751: StringResource
+  get() = String44.str_751
+
+@ExperimentalResourceApi
+internal val Res.string.str_7510: StringResource
+  get() = String44.str_7510
+
+@ExperimentalResourceApi
+internal val Res.string.str_7511: StringResource
+  get() = String44.str_7511
+
+@ExperimentalResourceApi
+internal val Res.string.str_7512: StringResource
+  get() = String44.str_7512
+
+@ExperimentalResourceApi
+internal val Res.string.str_7513: StringResource
+  get() = String44.str_7513
+
+@ExperimentalResourceApi
+internal val Res.string.str_7514: StringResource
+  get() = String44.str_7514
+
+@ExperimentalResourceApi
+internal val Res.string.str_7515: StringResource
+  get() = String44.str_7515
+
+@ExperimentalResourceApi
+internal val Res.string.str_7516: StringResource
+  get() = String44.str_7516
+
+@ExperimentalResourceApi
+internal val Res.string.str_7517: StringResource
+  get() = String44.str_7517
+
+@ExperimentalResourceApi
+internal val Res.string.str_7518: StringResource
+  get() = String44.str_7518
+
+@ExperimentalResourceApi
+internal val Res.string.str_7519: StringResource
+  get() = String44.str_7519
+
+@ExperimentalResourceApi
+internal val Res.string.str_752: StringResource
+  get() = String44.str_752
+
+@ExperimentalResourceApi
+internal val Res.string.str_7520: StringResource
+  get() = String44.str_7520
+
+@ExperimentalResourceApi
+internal val Res.string.str_7521: StringResource
+  get() = String44.str_7521
+
+@ExperimentalResourceApi
+internal val Res.string.str_7522: StringResource
+  get() = String44.str_7522
+
+@ExperimentalResourceApi
+internal val Res.string.str_7523: StringResource
+  get() = String44.str_7523
+
+@ExperimentalResourceApi
+internal val Res.string.str_7524: StringResource
+  get() = String44.str_7524
+
+@ExperimentalResourceApi
+internal val Res.string.str_7525: StringResource
+  get() = String44.str_7525
+
+@ExperimentalResourceApi
+internal val Res.string.str_7526: StringResource
+  get() = String44.str_7526
+
+@ExperimentalResourceApi
+internal val Res.string.str_7527: StringResource
+  get() = String44.str_7527
+
+@ExperimentalResourceApi
+internal val Res.string.str_7528: StringResource
+  get() = String44.str_7528
+
+@ExperimentalResourceApi
+internal val Res.string.str_7529: StringResource
+  get() = String44.str_7529
+
+@ExperimentalResourceApi
+internal val Res.string.str_753: StringResource
+  get() = String44.str_753
+
+@ExperimentalResourceApi
+internal val Res.string.str_7530: StringResource
+  get() = String44.str_7530
+
+@ExperimentalResourceApi
+internal val Res.string.str_7531: StringResource
+  get() = String44.str_7531
+
+@ExperimentalResourceApi
+internal val Res.string.str_7532: StringResource
+  get() = String44.str_7532
+
+@ExperimentalResourceApi
+internal val Res.string.str_7533: StringResource
+  get() = String44.str_7533
+
+@ExperimentalResourceApi
+internal val Res.string.str_7534: StringResource
+  get() = String44.str_7534
+
+@ExperimentalResourceApi
+internal val Res.string.str_7535: StringResource
+  get() = String44.str_7535
+
+@ExperimentalResourceApi
+internal val Res.string.str_7536: StringResource
+  get() = String44.str_7536
+
+@ExperimentalResourceApi
+internal val Res.string.str_7537: StringResource
+  get() = String44.str_7537
+
+@ExperimentalResourceApi
+internal val Res.string.str_7538: StringResource
+  get() = String44.str_7538
+
+@ExperimentalResourceApi
+internal val Res.string.str_7539: StringResource
+  get() = String44.str_7539
+
+@ExperimentalResourceApi
+internal val Res.string.str_754: StringResource
+  get() = String44.str_754
+
+@ExperimentalResourceApi
+internal val Res.string.str_7540: StringResource
+  get() = String44.str_7540
+
+@ExperimentalResourceApi
+internal val Res.string.str_7541: StringResource
+  get() = String44.str_7541
+
+@ExperimentalResourceApi
+internal val Res.string.str_7542: StringResource
+  get() = String44.str_7542
+
+@ExperimentalResourceApi
+internal val Res.string.str_7543: StringResource
+  get() = String44.str_7543
+
+@ExperimentalResourceApi
+internal val Res.string.str_7544: StringResource
+  get() = String44.str_7544
+
+@ExperimentalResourceApi
+internal val Res.string.str_7545: StringResource
+  get() = String44.str_7545
+
+@ExperimentalResourceApi
+internal val Res.string.str_7546: StringResource
+  get() = String44.str_7546
+
+@ExperimentalResourceApi
+internal val Res.string.str_7547: StringResource
+  get() = String44.str_7547
+
+@ExperimentalResourceApi
+internal val Res.string.str_7548: StringResource
+  get() = String44.str_7548
+
+@ExperimentalResourceApi
+internal val Res.string.str_7549: StringResource
+  get() = String44.str_7549
+
+@ExperimentalResourceApi
+internal val Res.string.str_755: StringResource
+  get() = String44.str_755
+
+@ExperimentalResourceApi
+internal val Res.string.str_7550: StringResource
+  get() = String44.str_7550
+
+@ExperimentalResourceApi
+internal val Res.string.str_7551: StringResource
+  get() = String44.str_7551
+
+@ExperimentalResourceApi
+internal val Res.string.str_7552: StringResource
+  get() = String44.str_7552
+
+@ExperimentalResourceApi
+internal val Res.string.str_7553: StringResource
+  get() = String44.str_7553
+
+@ExperimentalResourceApi
+internal val Res.string.str_7554: StringResource
+  get() = String44.str_7554
+
+@ExperimentalResourceApi
+internal val Res.string.str_7555: StringResource
+  get() = String44.str_7555
+
+@ExperimentalResourceApi
+internal val Res.string.str_7556: StringResource
+  get() = String44.str_7556
+
+@ExperimentalResourceApi
+internal val Res.string.str_7557: StringResource
+  get() = String44.str_7557
+
+@ExperimentalResourceApi
+internal val Res.string.str_7558: StringResource
+  get() = String44.str_7558
+
+@ExperimentalResourceApi
+internal val Res.string.str_7559: StringResource
+  get() = String44.str_7559
+
+@ExperimentalResourceApi
+internal val Res.string.str_756: StringResource
+  get() = String44.str_756
+
+@ExperimentalResourceApi
+internal val Res.string.str_7560: StringResource
+  get() = String44.str_7560
+
+@ExperimentalResourceApi
+internal val Res.string.str_7561: StringResource
+  get() = String44.str_7561
+
+@ExperimentalResourceApi
+internal val Res.string.str_7562: StringResource
+  get() = String44.str_7562
+
+@ExperimentalResourceApi
+internal val Res.string.str_7563: StringResource
+  get() = String44.str_7563
+
+@ExperimentalResourceApi
+internal val Res.string.str_7564: StringResource
+  get() = String44.str_7564
+
+@ExperimentalResourceApi
+internal val Res.string.str_7565: StringResource
+  get() = String44.str_7565
+
+@ExperimentalResourceApi
+internal val Res.string.str_7566: StringResource
+  get() = String44.str_7566
+
+@ExperimentalResourceApi
+internal val Res.string.str_7567: StringResource
+  get() = String44.str_7567
+
+@ExperimentalResourceApi
+internal val Res.string.str_7568: StringResource
+  get() = String44.str_7568
+
+@ExperimentalResourceApi
+internal val Res.string.str_7569: StringResource
+  get() = String44.str_7569
+
+@ExperimentalResourceApi
+internal val Res.string.str_757: StringResource
+  get() = String44.str_757
+
+@ExperimentalResourceApi
+internal val Res.string.str_7570: StringResource
+  get() = String44.str_7570
+
+@ExperimentalResourceApi
+internal val Res.string.str_7571: StringResource
+  get() = String44.str_7571
+
+@ExperimentalResourceApi
+internal val Res.string.str_7572: StringResource
+  get() = String44.str_7572
+
+@ExperimentalResourceApi
+internal val Res.string.str_7573: StringResource
+  get() = String44.str_7573
+
+@ExperimentalResourceApi
+internal val Res.string.str_7574: StringResource
+  get() = String44.str_7574
+
+@ExperimentalResourceApi
+internal val Res.string.str_7575: StringResource
+  get() = String44.str_7575
+
+@ExperimentalResourceApi
+internal val Res.string.str_7576: StringResource
+  get() = String44.str_7576
+
+@ExperimentalResourceApi
+internal val Res.string.str_7577: StringResource
+  get() = String44.str_7577
+
+@ExperimentalResourceApi
+internal val Res.string.str_7578: StringResource
+  get() = String44.str_7578
+
+@ExperimentalResourceApi
+internal val Res.string.str_7579: StringResource
+  get() = String44.str_7579
+
+@ExperimentalResourceApi
+internal val Res.string.str_758: StringResource
+  get() = String44.str_758
+
+@ExperimentalResourceApi
+internal val Res.string.str_7580: StringResource
+  get() = String44.str_7580
+
+@ExperimentalResourceApi
+internal val Res.string.str_7581: StringResource
+  get() = String44.str_7581
+
+@ExperimentalResourceApi
+internal val Res.string.str_7582: StringResource
+  get() = String44.str_7582
+
+@ExperimentalResourceApi
+internal val Res.string.str_7583: StringResource
+  get() = String44.str_7583
+
+@ExperimentalResourceApi
+internal val Res.string.str_7584: StringResource
+  get() = String44.str_7584
+
+@ExperimentalResourceApi
+internal val Res.string.str_7585: StringResource
+  get() = String44.str_7585
+
+@ExperimentalResourceApi
+internal val Res.string.str_7586: StringResource
+  get() = String44.str_7586
+
+@ExperimentalResourceApi
+internal val Res.string.str_7587: StringResource
+  get() = String44.str_7587
+
+@ExperimentalResourceApi
+internal val Res.string.str_7588: StringResource
+  get() = String44.str_7588
+
+@ExperimentalResourceApi
+internal val Res.string.str_7589: StringResource
+  get() = String44.str_7589
+
+@ExperimentalResourceApi
+internal val Res.string.str_759: StringResource
+  get() = String44.str_759
+
+@ExperimentalResourceApi
+internal val Res.string.str_7590: StringResource
+  get() = String44.str_7590
+
+@ExperimentalResourceApi
+internal val Res.string.str_7591: StringResource
+  get() = String44.str_7591
+
+@ExperimentalResourceApi
+internal val Res.string.str_7592: StringResource
+  get() = String44.str_7592
+
+@ExperimentalResourceApi
+internal val Res.string.str_7593: StringResource
+  get() = String44.str_7593
+
+@ExperimentalResourceApi
+internal val Res.string.str_7594: StringResource
+  get() = String44.str_7594
+
+@ExperimentalResourceApi
+internal val Res.string.str_7595: StringResource
+  get() = String44.str_7595
+
+@ExperimentalResourceApi
+internal val Res.string.str_7596: StringResource
+  get() = String44.str_7596
+
+@ExperimentalResourceApi
+internal val Res.string.str_7597: StringResource
+  get() = String44.str_7597
+
+@ExperimentalResourceApi
+internal val Res.string.str_7598: StringResource
+  get() = String44.str_7598
+
+@ExperimentalResourceApi
+internal val Res.string.str_7599: StringResource
+  get() = String44.str_7599
+
+@ExperimentalResourceApi
+internal val Res.string.str_76: StringResource
+  get() = String44.str_76
+
+@ExperimentalResourceApi
+internal val Res.string.str_760: StringResource
+  get() = String44.str_760
+
+@ExperimentalResourceApi
+internal val Res.string.str_7600: StringResource
+  get() = String44.str_7600
+
+@ExperimentalResourceApi
+internal val Res.string.str_7601: StringResource
+  get() = String44.str_7601
+
+@ExperimentalResourceApi
+internal val Res.string.str_7602: StringResource
+  get() = String44.str_7602
+
+@ExperimentalResourceApi
+internal val Res.string.str_7603: StringResource
+  get() = String44.str_7603
+
+@ExperimentalResourceApi
+internal val Res.string.str_7604: StringResource
+  get() = String44.str_7604
+
+@ExperimentalResourceApi
+internal val Res.string.str_7605: StringResource
+  get() = String44.str_7605
+
+@ExperimentalResourceApi
+internal val Res.string.str_7606: StringResource
+  get() = String44.str_7606
+
+@ExperimentalResourceApi
+internal val Res.string.str_7607: StringResource
+  get() = String44.str_7607
+
+@ExperimentalResourceApi
+internal val Res.string.str_7608: StringResource
+  get() = String44.str_7608
+
+@ExperimentalResourceApi
+internal val Res.string.str_7609: StringResource
+  get() = String44.str_7609
+
+@ExperimentalResourceApi
+internal val Res.string.str_761: StringResource
+  get() = String44.str_761
+
+@ExperimentalResourceApi
+internal val Res.string.str_7610: StringResource
+  get() = String44.str_7610
+
+@ExperimentalResourceApi
+internal val Res.string.str_7611: StringResource
+  get() = String44.str_7611
+
+@ExperimentalResourceApi
+internal val Res.string.str_7612: StringResource
+  get() = String44.str_7612
+
+@ExperimentalResourceApi
+internal val Res.string.str_7613: StringResource
+  get() = String44.str_7613
+
+@ExperimentalResourceApi
+internal val Res.string.str_7614: StringResource
+  get() = String44.str_7614
+
+@ExperimentalResourceApi
+internal val Res.string.str_7615: StringResource
+  get() = String44.str_7615
+
+@ExperimentalResourceApi
+internal val Res.string.str_7616: StringResource
+  get() = String44.str_7616
+
+@ExperimentalResourceApi
+internal val Res.string.str_7617: StringResource
+  get() = String44.str_7617
+
+@ExperimentalResourceApi
+internal val Res.string.str_7618: StringResource
+  get() = String44.str_7618
+
+@ExperimentalResourceApi
+internal val Res.string.str_7619: StringResource
+  get() = String44.str_7619
+
+@ExperimentalResourceApi
+internal val Res.string.str_762: StringResource
+  get() = String44.str_762
+
+@ExperimentalResourceApi
+internal val Res.string.str_7620: StringResource
+  get() = String44.str_7620
+
+@ExperimentalResourceApi
+internal val Res.string.str_7621: StringResource
+  get() = String44.str_7621
+
+@ExperimentalResourceApi
+internal val Res.string.str_7622: StringResource
+  get() = String44.str_7622
+
+@ExperimentalResourceApi
+internal val Res.string.str_7623: StringResource
+  get() = String44.str_7623
+
+@ExperimentalResourceApi
+internal val Res.string.str_7624: StringResource
+  get() = String44.str_7624
+
+@ExperimentalResourceApi
+internal val Res.string.str_7625: StringResource
+  get() = String44.str_7625
+
+@ExperimentalResourceApi
+internal val Res.string.str_7626: StringResource
+  get() = String44.str_7626
+
+@ExperimentalResourceApi
+internal val Res.string.str_7627: StringResource
+  get() = String44.str_7627
+
+@ExperimentalResourceApi
+internal val Res.string.str_7628: StringResource
+  get() = String44.str_7628
+
+@ExperimentalResourceApi
+internal val Res.string.str_7629: StringResource
+  get() = String44.str_7629
+
+@ExperimentalResourceApi
+internal val Res.string.str_763: StringResource
+  get() = String44.str_763
+
+@ExperimentalResourceApi
+internal val Res.string.str_7630: StringResource
+  get() = String44.str_7630
+
+@ExperimentalResourceApi
+internal val Res.string.str_7631: StringResource
+  get() = String44.str_7631
+
+@ExperimentalResourceApi
+internal val Res.string.str_7632: StringResource
+  get() = String44.str_7632
+
+@ExperimentalResourceApi
+internal val Res.string.str_7633: StringResource
+  get() = String44.str_7633
+
+@ExperimentalResourceApi
+internal val Res.string.str_7634: StringResource
+  get() = String44.str_7634
+
+@ExperimentalResourceApi
+internal val Res.string.str_7635: StringResource
+  get() = String44.str_7635
+
+@ExperimentalResourceApi
+internal val Res.string.str_7636: StringResource
+  get() = String44.str_7636
+
+@ExperimentalResourceApi
+internal val Res.string.str_7637: StringResource
+  get() = String44.str_7637
+
+@ExperimentalResourceApi
+internal val Res.string.str_7638: StringResource
+  get() = String44.str_7638
+
+@ExperimentalResourceApi
+internal val Res.string.str_7639: StringResource
+  get() = String44.str_7639
+
+@ExperimentalResourceApi
+internal val Res.string.str_764: StringResource
+  get() = String44.str_764
+
+@ExperimentalResourceApi
+internal val Res.string.str_7640: StringResource
+  get() = String44.str_7640
+
+@ExperimentalResourceApi
+internal val Res.string.str_7641: StringResource
+  get() = String44.str_7641
+
+@ExperimentalResourceApi
+internal val Res.string.str_7642: StringResource
+  get() = String44.str_7642
+
+@ExperimentalResourceApi
+internal val Res.string.str_7643: StringResource
+  get() = String44.str_7643
+
+@ExperimentalResourceApi
+internal val Res.string.str_7644: StringResource
+  get() = String44.str_7644
+
+@ExperimentalResourceApi
+internal val Res.string.str_7645: StringResource
+  get() = String44.str_7645
+
+@ExperimentalResourceApi
+internal val Res.string.str_7646: StringResource
+  get() = String44.str_7646
+
+@ExperimentalResourceApi
+internal val Res.string.str_7647: StringResource
+  get() = String44.str_7647
+
+@ExperimentalResourceApi
+internal val Res.string.str_7648: StringResource
+  get() = String44.str_7648
+
+@ExperimentalResourceApi
+internal val Res.string.str_7649: StringResource
+  get() = String44.str_7649
+
+@ExperimentalResourceApi
+internal val Res.string.str_765: StringResource
+  get() = String44.str_765
+
+@ExperimentalResourceApi
+internal val Res.string.str_7650: StringResource
+  get() = String44.str_7650
+
+@ExperimentalResourceApi
+internal val Res.string.str_7651: StringResource
+  get() = String44.str_7651
+
+@ExperimentalResourceApi
+internal val Res.string.str_7652: StringResource
+  get() = String44.str_7652
+
+@ExperimentalResourceApi
+internal val Res.string.str_7653: StringResource
+  get() = String44.str_7653
+
+@ExperimentalResourceApi
+internal val Res.string.str_7654: StringResource
+  get() = String44.str_7654
+
+@ExperimentalResourceApi
+internal val Res.string.str_7655: StringResource
+  get() = String44.str_7655
+
+@ExperimentalResourceApi
+internal val Res.string.str_7656: StringResource
+  get() = String44.str_7656
+
+@ExperimentalResourceApi
+internal val Res.string.str_7657: StringResource
+  get() = String44.str_7657
+
+@ExperimentalResourceApi
+internal val Res.string.str_7658: StringResource
+  get() = String44.str_7658
+
+@ExperimentalResourceApi
+internal val Res.string.str_7659: StringResource
+  get() = String44.str_7659
+
+@ExperimentalResourceApi
+internal val Res.string.str_766: StringResource
+  get() = String44.str_766
+
+@ExperimentalResourceApi
+internal val Res.string.str_7660: StringResource
+  get() = String44.str_7660
+
+@ExperimentalResourceApi
+internal val Res.string.str_7661: StringResource
+  get() = String44.str_7661
+
+@ExperimentalResourceApi
+internal val Res.string.str_7662: StringResource
+  get() = String44.str_7662
+
+@ExperimentalResourceApi
+internal val Res.string.str_7663: StringResource
+  get() = String44.str_7663
+
+@ExperimentalResourceApi
+internal val Res.string.str_7664: StringResource
+  get() = String44.str_7664
+
+@ExperimentalResourceApi
+internal val Res.string.str_7665: StringResource
+  get() = String44.str_7665
+
+@ExperimentalResourceApi
+internal val Res.string.str_7666: StringResource
+  get() = String44.str_7666
+
+@ExperimentalResourceApi
+internal val Res.string.str_7667: StringResource
+  get() = String44.str_7667
+
+@ExperimentalResourceApi
+internal val Res.string.str_7668: StringResource
+  get() = String44.str_7668
+
+@ExperimentalResourceApi
+internal val Res.string.str_7669: StringResource
+  get() = String44.str_7669
+
+@ExperimentalResourceApi
+internal val Res.string.str_767: StringResource
+  get() = String44.str_767
+
+@ExperimentalResourceApi
+internal val Res.string.str_7670: StringResource
+  get() = String44.str_7670
+
+@ExperimentalResourceApi
+internal val Res.string.str_7671: StringResource
+  get() = String44.str_7671
+
+@ExperimentalResourceApi
+internal val Res.string.str_7672: StringResource
+  get() = String44.str_7672
+
+@ExperimentalResourceApi
+internal val Res.string.str_7673: StringResource
+  get() = String44.str_7673
+
+@ExperimentalResourceApi
+internal val Res.string.str_7674: StringResource
+  get() = String44.str_7674
+
+@ExperimentalResourceApi
+internal val Res.string.str_7675: StringResource
+  get() = String44.str_7675
+
+@ExperimentalResourceApi
+internal val Res.string.str_7676: StringResource
+  get() = String44.str_7676
+
+@ExperimentalResourceApi
+internal val Res.string.str_7677: StringResource
+  get() = String44.str_7677
+
+@ExperimentalResourceApi
+internal val Res.string.str_7678: StringResource
+  get() = String44.str_7678
+
+@ExperimentalResourceApi
+internal val Res.string.str_7679: StringResource
+  get() = String44.str_7679
+
+@ExperimentalResourceApi
+internal val Res.string.str_768: StringResource
+  get() = String44.str_768
+
+@ExperimentalResourceApi
+internal val Res.string.str_7680: StringResource
+  get() = String44.str_7680
+
+@ExperimentalResourceApi
+internal val Res.string.str_7681: StringResource
+  get() = String44.str_7681
+
+@ExperimentalResourceApi
+internal val Res.string.str_7682: StringResource
+  get() = String44.str_7682
+
+@ExperimentalResourceApi
+internal val Res.string.str_7683: StringResource
+  get() = String44.str_7683
+
+@ExperimentalResourceApi
+internal val Res.string.str_7684: StringResource
+  get() = String44.str_7684
+
+@ExperimentalResourceApi
+internal val Res.string.str_7685: StringResource
+  get() = String44.str_7685
+
+@ExperimentalResourceApi
+internal val Res.string.str_7686: StringResource
+  get() = String44.str_7686
+
+@ExperimentalResourceApi
+internal val Res.string.str_7687: StringResource
+  get() = String44.str_7687
+
+@ExperimentalResourceApi
+internal val Res.string.str_7688: StringResource
+  get() = String44.str_7688
+
+@ExperimentalResourceApi
+internal val Res.string.str_7689: StringResource
+  get() = String44.str_7689
+
+@ExperimentalResourceApi
+internal val Res.string.str_769: StringResource
+  get() = String44.str_769
+
+@ExperimentalResourceApi
+internal val Res.string.str_7690: StringResource
+  get() = String44.str_7690
+
+@ExperimentalResourceApi
+internal val Res.string.str_7691: StringResource
+  get() = String44.str_7691
+
+@ExperimentalResourceApi
+internal val Res.string.str_7692: StringResource
+  get() = String44.str_7692
+
+@ExperimentalResourceApi
+internal val Res.string.str_7693: StringResource
+  get() = String44.str_7693
+
+@ExperimentalResourceApi
+internal val Res.string.str_7694: StringResource
+  get() = String44.str_7694
+
+@ExperimentalResourceApi
+internal val Res.string.str_7695: StringResource
+  get() = String44.str_7695
+
+@ExperimentalResourceApi
+internal val Res.string.str_7696: StringResource
+  get() = String44.str_7696
+
+@ExperimentalResourceApi
+internal val Res.string.str_7697: StringResource
+  get() = String44.str_7697
+
+@ExperimentalResourceApi
+internal val Res.string.str_7698: StringResource
+  get() = String44.str_7698
+
+@ExperimentalResourceApi
+internal val Res.string.str_7699: StringResource
+  get() = String44.str_7699
+
+@ExperimentalResourceApi
+internal val Res.string.str_77: StringResource
+  get() = String44.str_77
+
+@ExperimentalResourceApi
+internal val Res.string.str_770: StringResource
+  get() = String44.str_770
+
+@ExperimentalResourceApi
+internal val Res.string.str_7700: StringResource
+  get() = String44.str_7700
+
+@ExperimentalResourceApi
+internal val Res.string.str_7701: StringResource
+  get() = String44.str_7701
+
+@ExperimentalResourceApi
+internal val Res.string.str_7702: StringResource
+  get() = String44.str_7702
+
+@ExperimentalResourceApi
+internal val Res.string.str_7703: StringResource
+  get() = String44.str_7703
+
+@ExperimentalResourceApi
+internal val Res.string.str_7704: StringResource
+  get() = String44.str_7704
+
+@ExperimentalResourceApi
+internal val Res.string.str_7705: StringResource
+  get() = String44.str_7705
+
+@ExperimentalResourceApi
+internal val Res.string.str_7706: StringResource
+  get() = String44.str_7706
+
+@ExperimentalResourceApi
+internal val Res.string.str_7707: StringResource
+  get() = String44.str_7707
+
+@ExperimentalResourceApi
+internal val Res.string.str_7708: StringResource
+  get() = String44.str_7708
+
+@ExperimentalResourceApi
+internal val Res.string.str_7709: StringResource
+  get() = String44.str_7709
+
+@ExperimentalResourceApi
+internal val Res.string.str_771: StringResource
+  get() = String44.str_771
+
+@ExperimentalResourceApi
+internal val Res.string.str_7710: StringResource
+  get() = String44.str_7710
+
+@ExperimentalResourceApi
+internal val Res.string.str_7711: StringResource
+  get() = String44.str_7711
+
+@ExperimentalResourceApi
+internal val Res.string.str_7712: StringResource
+  get() = String44.str_7712
+
+@ExperimentalResourceApi
+internal val Res.string.str_7713: StringResource
+  get() = String44.str_7713
+
+@ExperimentalResourceApi
+internal val Res.string.str_7714: StringResource
+  get() = String44.str_7714
+
+@ExperimentalResourceApi
+internal val Res.string.str_7715: StringResource
+  get() = String44.str_7715
+
+@ExperimentalResourceApi
+internal val Res.string.str_7716: StringResource
+  get() = String44.str_7716
+
+@ExperimentalResourceApi
+internal val Res.string.str_7717: StringResource
+  get() = String44.str_7717
+
+@ExperimentalResourceApi
+internal val Res.string.str_7718: StringResource
+  get() = String44.str_7718
+
+@ExperimentalResourceApi
+internal val Res.string.str_7719: StringResource
+  get() = String44.str_7719
+
+@ExperimentalResourceApi
+internal val Res.string.str_772: StringResource
+  get() = String44.str_772
+
+@ExperimentalResourceApi
+internal val Res.string.str_7720: StringResource
+  get() = String44.str_7720
+
+@ExperimentalResourceApi
+internal val Res.string.str_7721: StringResource
+  get() = String44.str_7721
+
+@ExperimentalResourceApi
+internal val Res.string.str_7722: StringResource
+  get() = String44.str_7722
+
+@ExperimentalResourceApi
+internal val Res.string.str_7723: StringResource
+  get() = String44.str_7723
+
+@ExperimentalResourceApi
+internal val Res.string.str_7724: StringResource
+  get() = String44.str_7724
+
+@ExperimentalResourceApi
+internal val Res.string.str_7725: StringResource
+  get() = String44.str_7725
+
+@ExperimentalResourceApi
+internal val Res.string.str_7726: StringResource
+  get() = String44.str_7726
+
+@ExperimentalResourceApi
+internal val Res.string.str_7727: StringResource
+  get() = String44.str_7727
+
+@ExperimentalResourceApi
+internal val Res.string.str_7728: StringResource
+  get() = String44.str_7728
+
+@ExperimentalResourceApi
+internal val Res.string.str_7729: StringResource
+  get() = String44.str_7729
+
+@ExperimentalResourceApi
+internal val Res.string.str_773: StringResource
+  get() = String44.str_773
+
+@ExperimentalResourceApi
+internal val Res.string.str_7730: StringResource
+  get() = String44.str_7730
+
+@ExperimentalResourceApi
+internal val Res.string.str_7731: StringResource
+  get() = String44.str_7731
+
+@ExperimentalResourceApi
+internal val Res.string.str_7732: StringResource
+  get() = String44.str_7732
+
+@ExperimentalResourceApi
+internal val Res.string.str_7733: StringResource
+  get() = String44.str_7733
+
+@ExperimentalResourceApi
+internal val Res.string.str_7734: StringResource
+  get() = String44.str_7734
+
+@ExperimentalResourceApi
+internal val Res.string.str_7735: StringResource
+  get() = String44.str_7735
+
+@ExperimentalResourceApi
+internal val Res.string.str_7736: StringResource
+  get() = String44.str_7736
+
+@ExperimentalResourceApi
+internal val Res.string.str_7737: StringResource
+  get() = String44.str_7737
+
+@ExperimentalResourceApi
+internal val Res.string.str_7738: StringResource
+  get() = String44.str_7738
+
+@ExperimentalResourceApi
+internal val Res.string.str_7739: StringResource
+  get() = String44.str_7739
+
+@ExperimentalResourceApi
+internal val Res.string.str_774: StringResource
+  get() = String44.str_774
+
+@ExperimentalResourceApi
+internal val Res.string.str_7740: StringResource
+  get() = String44.str_7740
+
+@ExperimentalResourceApi
+internal val Res.string.str_7741: StringResource
+  get() = String44.str_7741
+
+@ExperimentalResourceApi
+internal val Res.string.str_7742: StringResource
+  get() = String44.str_7742
+
+@ExperimentalResourceApi
+internal val Res.string.str_7743: StringResource
+  get() = String44.str_7743
+
+@ExperimentalResourceApi
+internal val Res.string.str_7744: StringResource
+  get() = String44.str_7744
+
+@ExperimentalResourceApi
+internal val Res.string.str_7745: StringResource
+  get() = String44.str_7745
+
+@ExperimentalResourceApi
+internal val Res.string.str_7746: StringResource
+  get() = String44.str_7746
+
+@ExperimentalResourceApi
+internal val Res.string.str_7747: StringResource
+  get() = String44.str_7747
+
+@ExperimentalResourceApi
+internal val Res.string.str_7748: StringResource
+  get() = String44.str_7748

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String45.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String45.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String45 {
+  public val str_7749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7749", "str_7749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_775", "str_775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7750", "str_7750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7751", "str_7751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7752", "str_7752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7753", "str_7753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7754", "str_7754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7755", "str_7755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7756", "str_7756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7757", "str_7757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7758", "str_7758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7759", "str_7759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_776", "str_776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7760", "str_7760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7761", "str_7761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7762", "str_7762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7763", "str_7763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7764", "str_7764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7765", "str_7765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7766", "str_7766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7767", "str_7767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7768", "str_7768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7769", "str_7769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_777", "str_777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7770", "str_7770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7771", "str_7771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7772", "str_7772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7773", "str_7773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7774", "str_7774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7775", "str_7775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7776", "str_7776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7777", "str_7777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7778", "str_7778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7779", "str_7779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_778", "str_778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7780", "str_7780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7781", "str_7781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7782", "str_7782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7783", "str_7783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7784", "str_7784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7785", "str_7785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7786", "str_7786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7787", "str_7787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7788", "str_7788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7789", "str_7789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_779", "str_779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7790", "str_7790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7791", "str_7791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7792", "str_7792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7793", "str_7793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7794", "str_7794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7795", "str_7795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7796", "str_7796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7797", "str_7797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7798", "str_7798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7799", "str_7799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_78: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_78", "str_78",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_780", "str_780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7800", "str_7800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7801", "str_7801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7802", "str_7802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7803", "str_7803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7804", "str_7804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7805", "str_7805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7806", "str_7806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7807", "str_7807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7808", "str_7808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7809", "str_7809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_781", "str_781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7810", "str_7810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7811", "str_7811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7812", "str_7812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7813", "str_7813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7814", "str_7814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7815", "str_7815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7816", "str_7816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7817", "str_7817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7818", "str_7818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7819", "str_7819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_782", "str_782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7820", "str_7820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7821", "str_7821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7822", "str_7822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7823", "str_7823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7824", "str_7824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7825", "str_7825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7826", "str_7826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7827", "str_7827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7828", "str_7828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7829", "str_7829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_783", "str_783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7830", "str_7830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7831", "str_7831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7832", "str_7832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7833", "str_7833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7834", "str_7834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7835", "str_7835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7836", "str_7836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7837", "str_7837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7838", "str_7838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7839", "str_7839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_784", "str_784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7840", "str_7840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7841", "str_7841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7842", "str_7842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7843", "str_7843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7844", "str_7844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7845", "str_7845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7846", "str_7846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7847", "str_7847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7848", "str_7848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7849", "str_7849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_785", "str_785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7850", "str_7850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7851", "str_7851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7852", "str_7852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7853", "str_7853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7854", "str_7854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7855", "str_7855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7856", "str_7856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7857", "str_7857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7858", "str_7858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7859", "str_7859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_786", "str_786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7860", "str_7860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7861", "str_7861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7862", "str_7862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7863", "str_7863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7864", "str_7864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7865", "str_7865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7866", "str_7866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7867", "str_7867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7868", "str_7868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7869", "str_7869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_787", "str_787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7870", "str_7870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7871", "str_7871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7872", "str_7872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7873", "str_7873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7874", "str_7874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7875", "str_7875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7876", "str_7876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7877", "str_7877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7878", "str_7878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7879", "str_7879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_788", "str_788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7880", "str_7880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7881", "str_7881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7882", "str_7882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7883", "str_7883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7884", "str_7884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7885", "str_7885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7886", "str_7886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7887", "str_7887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7888", "str_7888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7889", "str_7889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_789", "str_789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7890", "str_7890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7891", "str_7891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7892", "str_7892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7893", "str_7893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7894", "str_7894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7895", "str_7895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7896", "str_7896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7897", "str_7897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7898", "str_7898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7899", "str_7899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_79: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_79", "str_79",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_790", "str_790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7900", "str_7900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7901", "str_7901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7902", "str_7902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7903", "str_7903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7904", "str_7904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7905", "str_7905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7906", "str_7906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7907", "str_7907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7908", "str_7908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7909", "str_7909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_791", "str_791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7910", "str_7910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7911", "str_7911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7912", "str_7912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7913", "str_7913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7914", "str_7914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7915", "str_7915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7916", "str_7916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7917", "str_7917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7918", "str_7918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7919", "str_7919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_792", "str_792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7920", "str_7920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7921", "str_7921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7922", "str_7922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7923", "str_7923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7924", "str_7924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7925", "str_7925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7926", "str_7926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7927", "str_7927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7928", "str_7928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7929", "str_7929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_793", "str_793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7930", "str_7930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7931", "str_7931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7932", "str_7932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7933", "str_7933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7934", "str_7934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7935", "str_7935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7936", "str_7936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7937", "str_7937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7938", "str_7938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7939", "str_7939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_794", "str_794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7940", "str_7940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7941", "str_7941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7942", "str_7942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7943", "str_7943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7944", "str_7944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7945", "str_7945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7946", "str_7946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7947", "str_7947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7948", "str_7948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7949", "str_7949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_795", "str_795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7950", "str_7950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7951", "str_7951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7952", "str_7952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7953", "str_7953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7954", "str_7954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7955", "str_7955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7956", "str_7956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7957", "str_7957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7958", "str_7958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7959", "str_7959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_796", "str_796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7960", "str_7960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7961", "str_7961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7962", "str_7962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7963", "str_7963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7964", "str_7964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7965", "str_7965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7966", "str_7966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7967", "str_7967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7968", "str_7968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7969", "str_7969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_797", "str_797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7970", "str_7970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7971", "str_7971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7972", "str_7972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7973", "str_7973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7974", "str_7974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7975", "str_7975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7976", "str_7976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7977", "str_7977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7978", "str_7978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7979", "str_7979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_798", "str_798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7980", "str_7980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7981", "str_7981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7982", "str_7982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7983", "str_7983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7984", "str_7984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7985", "str_7985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7986", "str_7986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7987", "str_7987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7988", "str_7988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7989", "str_7989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_799", "str_799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7990", "str_7990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7991", "str_7991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7992", "str_7992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7993", "str_7993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7994", "str_7994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7995", "str_7995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7996", "str_7996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7997", "str_7997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7998", "str_7998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_7999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_7999", "str_7999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8", "str_8",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_80: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_80", "str_80",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_800", "str_800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8000", "str_8000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8001", "str_8001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8002", "str_8002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8003", "str_8003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8004", "str_8004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8005", "str_8005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8006", "str_8006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8007", "str_8007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8008", "str_8008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8009", "str_8009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_801", "str_801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8010", "str_8010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8011", "str_8011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8012", "str_8012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8013", "str_8013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8014", "str_8014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8015", "str_8015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8016", "str_8016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8017", "str_8017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8018", "str_8018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8019", "str_8019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_802", "str_802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8020", "str_8020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8021", "str_8021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8022", "str_8022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8023", "str_8023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8024", "str_8024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8025", "str_8025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8026", "str_8026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8027", "str_8027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8028", "str_8028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8029", "str_8029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_803", "str_803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8030", "str_8030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8031", "str_8031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8032", "str_8032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8033", "str_8033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8034", "str_8034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8035", "str_8035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8036", "str_8036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8037", "str_8037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8038", "str_8038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8039", "str_8039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_804", "str_804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8040", "str_8040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8041", "str_8041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8042", "str_8042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8043", "str_8043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8044", "str_8044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8045", "str_8045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8046", "str_8046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8047", "str_8047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8048", "str_8048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8049", "str_8049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_805", "str_805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8050", "str_8050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8051", "str_8051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8052", "str_8052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8053", "str_8053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8054", "str_8054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8055", "str_8055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8056", "str_8056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8057", "str_8057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8058", "str_8058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8059", "str_8059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_806", "str_806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8060", "str_8060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8061", "str_8061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8062", "str_8062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8063", "str_8063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8064", "str_8064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8065", "str_8065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8066", "str_8066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8067", "str_8067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8068", "str_8068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8069", "str_8069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_807", "str_807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8070", "str_8070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8071", "str_8071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8072", "str_8072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8073", "str_8073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8074", "str_8074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8075", "str_8075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8076", "str_8076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8077", "str_8077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8078", "str_8078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8079", "str_8079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_808", "str_808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8080", "str_8080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8081", "str_8081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8082", "str_8082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8083", "str_8083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8084", "str_8084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8085", "str_8085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8086", "str_8086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8087", "str_8087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8088", "str_8088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8089", "str_8089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_809", "str_809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8090", "str_8090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8091", "str_8091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8092", "str_8092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8093", "str_8093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8094", "str_8094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8095", "str_8095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8096", "str_8096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8097", "str_8097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8098", "str_8098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8099", "str_8099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_81: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_81", "str_81",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_810", "str_810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8100", "str_8100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8101", "str_8101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8102", "str_8102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8103", "str_8103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8104", "str_8104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8105", "str_8105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8106", "str_8106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8107", "str_8107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8108", "str_8108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8109", "str_8109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_811", "str_811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8110", "str_8110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8111", "str_8111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8112", "str_8112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8113", "str_8113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8114", "str_8114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8115", "str_8115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8116", "str_8116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8117", "str_8117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8118", "str_8118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8119", "str_8119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_812", "str_812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8120", "str_8120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8121", "str_8121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8122", "str_8122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8123", "str_8123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8124", "str_8124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8125", "str_8125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8126", "str_8126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8127", "str_8127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8128", "str_8128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8129", "str_8129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_813", "str_813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8130", "str_8130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8131", "str_8131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8132", "str_8132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8133", "str_8133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8134", "str_8134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8135", "str_8135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8136", "str_8136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8137", "str_8137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8138", "str_8138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8139", "str_8139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_814", "str_814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8140", "str_8140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8141", "str_8141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8142", "str_8142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8143", "str_8143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8144", "str_8144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8145", "str_8145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8146", "str_8146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8147", "str_8147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8148", "str_8148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8149", "str_8149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_815", "str_815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8150", "str_8150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8151", "str_8151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8152", "str_8152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8153", "str_8153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8154", "str_8154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8155", "str_8155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8156", "str_8156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8157", "str_8157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8158", "str_8158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8159", "str_8159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_816", "str_816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8160", "str_8160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8161", "str_8161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8162", "str_8162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8163", "str_8163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8164", "str_8164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8165", "str_8165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8166", "str_8166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8167", "str_8167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8168", "str_8168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8169", "str_8169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_817", "str_817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8170", "str_8170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8171", "str_8171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8172", "str_8172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8173", "str_8173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8174", "str_8174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8175", "str_8175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8176", "str_8176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8177", "str_8177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8178", "str_8178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8179", "str_8179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_818", "str_818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8180", "str_8180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8181", "str_8181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8182", "str_8182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8183", "str_8183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8184", "str_8184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8185", "str_8185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8186", "str_8186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8187", "str_8187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8188", "str_8188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8189", "str_8189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_819", "str_819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8190", "str_8190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8191", "str_8191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8192", "str_8192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8193", "str_8193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8194", "str_8194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8195", "str_8195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8196", "str_8196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8197", "str_8197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8198", "str_8198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_7749: StringResource
+  get() = String45.str_7749
+
+@ExperimentalResourceApi
+internal val Res.string.str_775: StringResource
+  get() = String45.str_775
+
+@ExperimentalResourceApi
+internal val Res.string.str_7750: StringResource
+  get() = String45.str_7750
+
+@ExperimentalResourceApi
+internal val Res.string.str_7751: StringResource
+  get() = String45.str_7751
+
+@ExperimentalResourceApi
+internal val Res.string.str_7752: StringResource
+  get() = String45.str_7752
+
+@ExperimentalResourceApi
+internal val Res.string.str_7753: StringResource
+  get() = String45.str_7753
+
+@ExperimentalResourceApi
+internal val Res.string.str_7754: StringResource
+  get() = String45.str_7754
+
+@ExperimentalResourceApi
+internal val Res.string.str_7755: StringResource
+  get() = String45.str_7755
+
+@ExperimentalResourceApi
+internal val Res.string.str_7756: StringResource
+  get() = String45.str_7756
+
+@ExperimentalResourceApi
+internal val Res.string.str_7757: StringResource
+  get() = String45.str_7757
+
+@ExperimentalResourceApi
+internal val Res.string.str_7758: StringResource
+  get() = String45.str_7758
+
+@ExperimentalResourceApi
+internal val Res.string.str_7759: StringResource
+  get() = String45.str_7759
+
+@ExperimentalResourceApi
+internal val Res.string.str_776: StringResource
+  get() = String45.str_776
+
+@ExperimentalResourceApi
+internal val Res.string.str_7760: StringResource
+  get() = String45.str_7760
+
+@ExperimentalResourceApi
+internal val Res.string.str_7761: StringResource
+  get() = String45.str_7761
+
+@ExperimentalResourceApi
+internal val Res.string.str_7762: StringResource
+  get() = String45.str_7762
+
+@ExperimentalResourceApi
+internal val Res.string.str_7763: StringResource
+  get() = String45.str_7763
+
+@ExperimentalResourceApi
+internal val Res.string.str_7764: StringResource
+  get() = String45.str_7764
+
+@ExperimentalResourceApi
+internal val Res.string.str_7765: StringResource
+  get() = String45.str_7765
+
+@ExperimentalResourceApi
+internal val Res.string.str_7766: StringResource
+  get() = String45.str_7766
+
+@ExperimentalResourceApi
+internal val Res.string.str_7767: StringResource
+  get() = String45.str_7767
+
+@ExperimentalResourceApi
+internal val Res.string.str_7768: StringResource
+  get() = String45.str_7768
+
+@ExperimentalResourceApi
+internal val Res.string.str_7769: StringResource
+  get() = String45.str_7769
+
+@ExperimentalResourceApi
+internal val Res.string.str_777: StringResource
+  get() = String45.str_777
+
+@ExperimentalResourceApi
+internal val Res.string.str_7770: StringResource
+  get() = String45.str_7770
+
+@ExperimentalResourceApi
+internal val Res.string.str_7771: StringResource
+  get() = String45.str_7771
+
+@ExperimentalResourceApi
+internal val Res.string.str_7772: StringResource
+  get() = String45.str_7772
+
+@ExperimentalResourceApi
+internal val Res.string.str_7773: StringResource
+  get() = String45.str_7773
+
+@ExperimentalResourceApi
+internal val Res.string.str_7774: StringResource
+  get() = String45.str_7774
+
+@ExperimentalResourceApi
+internal val Res.string.str_7775: StringResource
+  get() = String45.str_7775
+
+@ExperimentalResourceApi
+internal val Res.string.str_7776: StringResource
+  get() = String45.str_7776
+
+@ExperimentalResourceApi
+internal val Res.string.str_7777: StringResource
+  get() = String45.str_7777
+
+@ExperimentalResourceApi
+internal val Res.string.str_7778: StringResource
+  get() = String45.str_7778
+
+@ExperimentalResourceApi
+internal val Res.string.str_7779: StringResource
+  get() = String45.str_7779
+
+@ExperimentalResourceApi
+internal val Res.string.str_778: StringResource
+  get() = String45.str_778
+
+@ExperimentalResourceApi
+internal val Res.string.str_7780: StringResource
+  get() = String45.str_7780
+
+@ExperimentalResourceApi
+internal val Res.string.str_7781: StringResource
+  get() = String45.str_7781
+
+@ExperimentalResourceApi
+internal val Res.string.str_7782: StringResource
+  get() = String45.str_7782
+
+@ExperimentalResourceApi
+internal val Res.string.str_7783: StringResource
+  get() = String45.str_7783
+
+@ExperimentalResourceApi
+internal val Res.string.str_7784: StringResource
+  get() = String45.str_7784
+
+@ExperimentalResourceApi
+internal val Res.string.str_7785: StringResource
+  get() = String45.str_7785
+
+@ExperimentalResourceApi
+internal val Res.string.str_7786: StringResource
+  get() = String45.str_7786
+
+@ExperimentalResourceApi
+internal val Res.string.str_7787: StringResource
+  get() = String45.str_7787
+
+@ExperimentalResourceApi
+internal val Res.string.str_7788: StringResource
+  get() = String45.str_7788
+
+@ExperimentalResourceApi
+internal val Res.string.str_7789: StringResource
+  get() = String45.str_7789
+
+@ExperimentalResourceApi
+internal val Res.string.str_779: StringResource
+  get() = String45.str_779
+
+@ExperimentalResourceApi
+internal val Res.string.str_7790: StringResource
+  get() = String45.str_7790
+
+@ExperimentalResourceApi
+internal val Res.string.str_7791: StringResource
+  get() = String45.str_7791
+
+@ExperimentalResourceApi
+internal val Res.string.str_7792: StringResource
+  get() = String45.str_7792
+
+@ExperimentalResourceApi
+internal val Res.string.str_7793: StringResource
+  get() = String45.str_7793
+
+@ExperimentalResourceApi
+internal val Res.string.str_7794: StringResource
+  get() = String45.str_7794
+
+@ExperimentalResourceApi
+internal val Res.string.str_7795: StringResource
+  get() = String45.str_7795
+
+@ExperimentalResourceApi
+internal val Res.string.str_7796: StringResource
+  get() = String45.str_7796
+
+@ExperimentalResourceApi
+internal val Res.string.str_7797: StringResource
+  get() = String45.str_7797
+
+@ExperimentalResourceApi
+internal val Res.string.str_7798: StringResource
+  get() = String45.str_7798
+
+@ExperimentalResourceApi
+internal val Res.string.str_7799: StringResource
+  get() = String45.str_7799
+
+@ExperimentalResourceApi
+internal val Res.string.str_78: StringResource
+  get() = String45.str_78
+
+@ExperimentalResourceApi
+internal val Res.string.str_780: StringResource
+  get() = String45.str_780
+
+@ExperimentalResourceApi
+internal val Res.string.str_7800: StringResource
+  get() = String45.str_7800
+
+@ExperimentalResourceApi
+internal val Res.string.str_7801: StringResource
+  get() = String45.str_7801
+
+@ExperimentalResourceApi
+internal val Res.string.str_7802: StringResource
+  get() = String45.str_7802
+
+@ExperimentalResourceApi
+internal val Res.string.str_7803: StringResource
+  get() = String45.str_7803
+
+@ExperimentalResourceApi
+internal val Res.string.str_7804: StringResource
+  get() = String45.str_7804
+
+@ExperimentalResourceApi
+internal val Res.string.str_7805: StringResource
+  get() = String45.str_7805
+
+@ExperimentalResourceApi
+internal val Res.string.str_7806: StringResource
+  get() = String45.str_7806
+
+@ExperimentalResourceApi
+internal val Res.string.str_7807: StringResource
+  get() = String45.str_7807
+
+@ExperimentalResourceApi
+internal val Res.string.str_7808: StringResource
+  get() = String45.str_7808
+
+@ExperimentalResourceApi
+internal val Res.string.str_7809: StringResource
+  get() = String45.str_7809
+
+@ExperimentalResourceApi
+internal val Res.string.str_781: StringResource
+  get() = String45.str_781
+
+@ExperimentalResourceApi
+internal val Res.string.str_7810: StringResource
+  get() = String45.str_7810
+
+@ExperimentalResourceApi
+internal val Res.string.str_7811: StringResource
+  get() = String45.str_7811
+
+@ExperimentalResourceApi
+internal val Res.string.str_7812: StringResource
+  get() = String45.str_7812
+
+@ExperimentalResourceApi
+internal val Res.string.str_7813: StringResource
+  get() = String45.str_7813
+
+@ExperimentalResourceApi
+internal val Res.string.str_7814: StringResource
+  get() = String45.str_7814
+
+@ExperimentalResourceApi
+internal val Res.string.str_7815: StringResource
+  get() = String45.str_7815
+
+@ExperimentalResourceApi
+internal val Res.string.str_7816: StringResource
+  get() = String45.str_7816
+
+@ExperimentalResourceApi
+internal val Res.string.str_7817: StringResource
+  get() = String45.str_7817
+
+@ExperimentalResourceApi
+internal val Res.string.str_7818: StringResource
+  get() = String45.str_7818
+
+@ExperimentalResourceApi
+internal val Res.string.str_7819: StringResource
+  get() = String45.str_7819
+
+@ExperimentalResourceApi
+internal val Res.string.str_782: StringResource
+  get() = String45.str_782
+
+@ExperimentalResourceApi
+internal val Res.string.str_7820: StringResource
+  get() = String45.str_7820
+
+@ExperimentalResourceApi
+internal val Res.string.str_7821: StringResource
+  get() = String45.str_7821
+
+@ExperimentalResourceApi
+internal val Res.string.str_7822: StringResource
+  get() = String45.str_7822
+
+@ExperimentalResourceApi
+internal val Res.string.str_7823: StringResource
+  get() = String45.str_7823
+
+@ExperimentalResourceApi
+internal val Res.string.str_7824: StringResource
+  get() = String45.str_7824
+
+@ExperimentalResourceApi
+internal val Res.string.str_7825: StringResource
+  get() = String45.str_7825
+
+@ExperimentalResourceApi
+internal val Res.string.str_7826: StringResource
+  get() = String45.str_7826
+
+@ExperimentalResourceApi
+internal val Res.string.str_7827: StringResource
+  get() = String45.str_7827
+
+@ExperimentalResourceApi
+internal val Res.string.str_7828: StringResource
+  get() = String45.str_7828
+
+@ExperimentalResourceApi
+internal val Res.string.str_7829: StringResource
+  get() = String45.str_7829
+
+@ExperimentalResourceApi
+internal val Res.string.str_783: StringResource
+  get() = String45.str_783
+
+@ExperimentalResourceApi
+internal val Res.string.str_7830: StringResource
+  get() = String45.str_7830
+
+@ExperimentalResourceApi
+internal val Res.string.str_7831: StringResource
+  get() = String45.str_7831
+
+@ExperimentalResourceApi
+internal val Res.string.str_7832: StringResource
+  get() = String45.str_7832
+
+@ExperimentalResourceApi
+internal val Res.string.str_7833: StringResource
+  get() = String45.str_7833
+
+@ExperimentalResourceApi
+internal val Res.string.str_7834: StringResource
+  get() = String45.str_7834
+
+@ExperimentalResourceApi
+internal val Res.string.str_7835: StringResource
+  get() = String45.str_7835
+
+@ExperimentalResourceApi
+internal val Res.string.str_7836: StringResource
+  get() = String45.str_7836
+
+@ExperimentalResourceApi
+internal val Res.string.str_7837: StringResource
+  get() = String45.str_7837
+
+@ExperimentalResourceApi
+internal val Res.string.str_7838: StringResource
+  get() = String45.str_7838
+
+@ExperimentalResourceApi
+internal val Res.string.str_7839: StringResource
+  get() = String45.str_7839
+
+@ExperimentalResourceApi
+internal val Res.string.str_784: StringResource
+  get() = String45.str_784
+
+@ExperimentalResourceApi
+internal val Res.string.str_7840: StringResource
+  get() = String45.str_7840
+
+@ExperimentalResourceApi
+internal val Res.string.str_7841: StringResource
+  get() = String45.str_7841
+
+@ExperimentalResourceApi
+internal val Res.string.str_7842: StringResource
+  get() = String45.str_7842
+
+@ExperimentalResourceApi
+internal val Res.string.str_7843: StringResource
+  get() = String45.str_7843
+
+@ExperimentalResourceApi
+internal val Res.string.str_7844: StringResource
+  get() = String45.str_7844
+
+@ExperimentalResourceApi
+internal val Res.string.str_7845: StringResource
+  get() = String45.str_7845
+
+@ExperimentalResourceApi
+internal val Res.string.str_7846: StringResource
+  get() = String45.str_7846
+
+@ExperimentalResourceApi
+internal val Res.string.str_7847: StringResource
+  get() = String45.str_7847
+
+@ExperimentalResourceApi
+internal val Res.string.str_7848: StringResource
+  get() = String45.str_7848
+
+@ExperimentalResourceApi
+internal val Res.string.str_7849: StringResource
+  get() = String45.str_7849
+
+@ExperimentalResourceApi
+internal val Res.string.str_785: StringResource
+  get() = String45.str_785
+
+@ExperimentalResourceApi
+internal val Res.string.str_7850: StringResource
+  get() = String45.str_7850
+
+@ExperimentalResourceApi
+internal val Res.string.str_7851: StringResource
+  get() = String45.str_7851
+
+@ExperimentalResourceApi
+internal val Res.string.str_7852: StringResource
+  get() = String45.str_7852
+
+@ExperimentalResourceApi
+internal val Res.string.str_7853: StringResource
+  get() = String45.str_7853
+
+@ExperimentalResourceApi
+internal val Res.string.str_7854: StringResource
+  get() = String45.str_7854
+
+@ExperimentalResourceApi
+internal val Res.string.str_7855: StringResource
+  get() = String45.str_7855
+
+@ExperimentalResourceApi
+internal val Res.string.str_7856: StringResource
+  get() = String45.str_7856
+
+@ExperimentalResourceApi
+internal val Res.string.str_7857: StringResource
+  get() = String45.str_7857
+
+@ExperimentalResourceApi
+internal val Res.string.str_7858: StringResource
+  get() = String45.str_7858
+
+@ExperimentalResourceApi
+internal val Res.string.str_7859: StringResource
+  get() = String45.str_7859
+
+@ExperimentalResourceApi
+internal val Res.string.str_786: StringResource
+  get() = String45.str_786
+
+@ExperimentalResourceApi
+internal val Res.string.str_7860: StringResource
+  get() = String45.str_7860
+
+@ExperimentalResourceApi
+internal val Res.string.str_7861: StringResource
+  get() = String45.str_7861
+
+@ExperimentalResourceApi
+internal val Res.string.str_7862: StringResource
+  get() = String45.str_7862
+
+@ExperimentalResourceApi
+internal val Res.string.str_7863: StringResource
+  get() = String45.str_7863
+
+@ExperimentalResourceApi
+internal val Res.string.str_7864: StringResource
+  get() = String45.str_7864
+
+@ExperimentalResourceApi
+internal val Res.string.str_7865: StringResource
+  get() = String45.str_7865
+
+@ExperimentalResourceApi
+internal val Res.string.str_7866: StringResource
+  get() = String45.str_7866
+
+@ExperimentalResourceApi
+internal val Res.string.str_7867: StringResource
+  get() = String45.str_7867
+
+@ExperimentalResourceApi
+internal val Res.string.str_7868: StringResource
+  get() = String45.str_7868
+
+@ExperimentalResourceApi
+internal val Res.string.str_7869: StringResource
+  get() = String45.str_7869
+
+@ExperimentalResourceApi
+internal val Res.string.str_787: StringResource
+  get() = String45.str_787
+
+@ExperimentalResourceApi
+internal val Res.string.str_7870: StringResource
+  get() = String45.str_7870
+
+@ExperimentalResourceApi
+internal val Res.string.str_7871: StringResource
+  get() = String45.str_7871
+
+@ExperimentalResourceApi
+internal val Res.string.str_7872: StringResource
+  get() = String45.str_7872
+
+@ExperimentalResourceApi
+internal val Res.string.str_7873: StringResource
+  get() = String45.str_7873
+
+@ExperimentalResourceApi
+internal val Res.string.str_7874: StringResource
+  get() = String45.str_7874
+
+@ExperimentalResourceApi
+internal val Res.string.str_7875: StringResource
+  get() = String45.str_7875
+
+@ExperimentalResourceApi
+internal val Res.string.str_7876: StringResource
+  get() = String45.str_7876
+
+@ExperimentalResourceApi
+internal val Res.string.str_7877: StringResource
+  get() = String45.str_7877
+
+@ExperimentalResourceApi
+internal val Res.string.str_7878: StringResource
+  get() = String45.str_7878
+
+@ExperimentalResourceApi
+internal val Res.string.str_7879: StringResource
+  get() = String45.str_7879
+
+@ExperimentalResourceApi
+internal val Res.string.str_788: StringResource
+  get() = String45.str_788
+
+@ExperimentalResourceApi
+internal val Res.string.str_7880: StringResource
+  get() = String45.str_7880
+
+@ExperimentalResourceApi
+internal val Res.string.str_7881: StringResource
+  get() = String45.str_7881
+
+@ExperimentalResourceApi
+internal val Res.string.str_7882: StringResource
+  get() = String45.str_7882
+
+@ExperimentalResourceApi
+internal val Res.string.str_7883: StringResource
+  get() = String45.str_7883
+
+@ExperimentalResourceApi
+internal val Res.string.str_7884: StringResource
+  get() = String45.str_7884
+
+@ExperimentalResourceApi
+internal val Res.string.str_7885: StringResource
+  get() = String45.str_7885
+
+@ExperimentalResourceApi
+internal val Res.string.str_7886: StringResource
+  get() = String45.str_7886
+
+@ExperimentalResourceApi
+internal val Res.string.str_7887: StringResource
+  get() = String45.str_7887
+
+@ExperimentalResourceApi
+internal val Res.string.str_7888: StringResource
+  get() = String45.str_7888
+
+@ExperimentalResourceApi
+internal val Res.string.str_7889: StringResource
+  get() = String45.str_7889
+
+@ExperimentalResourceApi
+internal val Res.string.str_789: StringResource
+  get() = String45.str_789
+
+@ExperimentalResourceApi
+internal val Res.string.str_7890: StringResource
+  get() = String45.str_7890
+
+@ExperimentalResourceApi
+internal val Res.string.str_7891: StringResource
+  get() = String45.str_7891
+
+@ExperimentalResourceApi
+internal val Res.string.str_7892: StringResource
+  get() = String45.str_7892
+
+@ExperimentalResourceApi
+internal val Res.string.str_7893: StringResource
+  get() = String45.str_7893
+
+@ExperimentalResourceApi
+internal val Res.string.str_7894: StringResource
+  get() = String45.str_7894
+
+@ExperimentalResourceApi
+internal val Res.string.str_7895: StringResource
+  get() = String45.str_7895
+
+@ExperimentalResourceApi
+internal val Res.string.str_7896: StringResource
+  get() = String45.str_7896
+
+@ExperimentalResourceApi
+internal val Res.string.str_7897: StringResource
+  get() = String45.str_7897
+
+@ExperimentalResourceApi
+internal val Res.string.str_7898: StringResource
+  get() = String45.str_7898
+
+@ExperimentalResourceApi
+internal val Res.string.str_7899: StringResource
+  get() = String45.str_7899
+
+@ExperimentalResourceApi
+internal val Res.string.str_79: StringResource
+  get() = String45.str_79
+
+@ExperimentalResourceApi
+internal val Res.string.str_790: StringResource
+  get() = String45.str_790
+
+@ExperimentalResourceApi
+internal val Res.string.str_7900: StringResource
+  get() = String45.str_7900
+
+@ExperimentalResourceApi
+internal val Res.string.str_7901: StringResource
+  get() = String45.str_7901
+
+@ExperimentalResourceApi
+internal val Res.string.str_7902: StringResource
+  get() = String45.str_7902
+
+@ExperimentalResourceApi
+internal val Res.string.str_7903: StringResource
+  get() = String45.str_7903
+
+@ExperimentalResourceApi
+internal val Res.string.str_7904: StringResource
+  get() = String45.str_7904
+
+@ExperimentalResourceApi
+internal val Res.string.str_7905: StringResource
+  get() = String45.str_7905
+
+@ExperimentalResourceApi
+internal val Res.string.str_7906: StringResource
+  get() = String45.str_7906
+
+@ExperimentalResourceApi
+internal val Res.string.str_7907: StringResource
+  get() = String45.str_7907
+
+@ExperimentalResourceApi
+internal val Res.string.str_7908: StringResource
+  get() = String45.str_7908
+
+@ExperimentalResourceApi
+internal val Res.string.str_7909: StringResource
+  get() = String45.str_7909
+
+@ExperimentalResourceApi
+internal val Res.string.str_791: StringResource
+  get() = String45.str_791
+
+@ExperimentalResourceApi
+internal val Res.string.str_7910: StringResource
+  get() = String45.str_7910
+
+@ExperimentalResourceApi
+internal val Res.string.str_7911: StringResource
+  get() = String45.str_7911
+
+@ExperimentalResourceApi
+internal val Res.string.str_7912: StringResource
+  get() = String45.str_7912
+
+@ExperimentalResourceApi
+internal val Res.string.str_7913: StringResource
+  get() = String45.str_7913
+
+@ExperimentalResourceApi
+internal val Res.string.str_7914: StringResource
+  get() = String45.str_7914
+
+@ExperimentalResourceApi
+internal val Res.string.str_7915: StringResource
+  get() = String45.str_7915
+
+@ExperimentalResourceApi
+internal val Res.string.str_7916: StringResource
+  get() = String45.str_7916
+
+@ExperimentalResourceApi
+internal val Res.string.str_7917: StringResource
+  get() = String45.str_7917
+
+@ExperimentalResourceApi
+internal val Res.string.str_7918: StringResource
+  get() = String45.str_7918
+
+@ExperimentalResourceApi
+internal val Res.string.str_7919: StringResource
+  get() = String45.str_7919
+
+@ExperimentalResourceApi
+internal val Res.string.str_792: StringResource
+  get() = String45.str_792
+
+@ExperimentalResourceApi
+internal val Res.string.str_7920: StringResource
+  get() = String45.str_7920
+
+@ExperimentalResourceApi
+internal val Res.string.str_7921: StringResource
+  get() = String45.str_7921
+
+@ExperimentalResourceApi
+internal val Res.string.str_7922: StringResource
+  get() = String45.str_7922
+
+@ExperimentalResourceApi
+internal val Res.string.str_7923: StringResource
+  get() = String45.str_7923
+
+@ExperimentalResourceApi
+internal val Res.string.str_7924: StringResource
+  get() = String45.str_7924
+
+@ExperimentalResourceApi
+internal val Res.string.str_7925: StringResource
+  get() = String45.str_7925
+
+@ExperimentalResourceApi
+internal val Res.string.str_7926: StringResource
+  get() = String45.str_7926
+
+@ExperimentalResourceApi
+internal val Res.string.str_7927: StringResource
+  get() = String45.str_7927
+
+@ExperimentalResourceApi
+internal val Res.string.str_7928: StringResource
+  get() = String45.str_7928
+
+@ExperimentalResourceApi
+internal val Res.string.str_7929: StringResource
+  get() = String45.str_7929
+
+@ExperimentalResourceApi
+internal val Res.string.str_793: StringResource
+  get() = String45.str_793
+
+@ExperimentalResourceApi
+internal val Res.string.str_7930: StringResource
+  get() = String45.str_7930
+
+@ExperimentalResourceApi
+internal val Res.string.str_7931: StringResource
+  get() = String45.str_7931
+
+@ExperimentalResourceApi
+internal val Res.string.str_7932: StringResource
+  get() = String45.str_7932
+
+@ExperimentalResourceApi
+internal val Res.string.str_7933: StringResource
+  get() = String45.str_7933
+
+@ExperimentalResourceApi
+internal val Res.string.str_7934: StringResource
+  get() = String45.str_7934
+
+@ExperimentalResourceApi
+internal val Res.string.str_7935: StringResource
+  get() = String45.str_7935
+
+@ExperimentalResourceApi
+internal val Res.string.str_7936: StringResource
+  get() = String45.str_7936
+
+@ExperimentalResourceApi
+internal val Res.string.str_7937: StringResource
+  get() = String45.str_7937
+
+@ExperimentalResourceApi
+internal val Res.string.str_7938: StringResource
+  get() = String45.str_7938
+
+@ExperimentalResourceApi
+internal val Res.string.str_7939: StringResource
+  get() = String45.str_7939
+
+@ExperimentalResourceApi
+internal val Res.string.str_794: StringResource
+  get() = String45.str_794
+
+@ExperimentalResourceApi
+internal val Res.string.str_7940: StringResource
+  get() = String45.str_7940
+
+@ExperimentalResourceApi
+internal val Res.string.str_7941: StringResource
+  get() = String45.str_7941
+
+@ExperimentalResourceApi
+internal val Res.string.str_7942: StringResource
+  get() = String45.str_7942
+
+@ExperimentalResourceApi
+internal val Res.string.str_7943: StringResource
+  get() = String45.str_7943
+
+@ExperimentalResourceApi
+internal val Res.string.str_7944: StringResource
+  get() = String45.str_7944
+
+@ExperimentalResourceApi
+internal val Res.string.str_7945: StringResource
+  get() = String45.str_7945
+
+@ExperimentalResourceApi
+internal val Res.string.str_7946: StringResource
+  get() = String45.str_7946
+
+@ExperimentalResourceApi
+internal val Res.string.str_7947: StringResource
+  get() = String45.str_7947
+
+@ExperimentalResourceApi
+internal val Res.string.str_7948: StringResource
+  get() = String45.str_7948
+
+@ExperimentalResourceApi
+internal val Res.string.str_7949: StringResource
+  get() = String45.str_7949
+
+@ExperimentalResourceApi
+internal val Res.string.str_795: StringResource
+  get() = String45.str_795
+
+@ExperimentalResourceApi
+internal val Res.string.str_7950: StringResource
+  get() = String45.str_7950
+
+@ExperimentalResourceApi
+internal val Res.string.str_7951: StringResource
+  get() = String45.str_7951
+
+@ExperimentalResourceApi
+internal val Res.string.str_7952: StringResource
+  get() = String45.str_7952
+
+@ExperimentalResourceApi
+internal val Res.string.str_7953: StringResource
+  get() = String45.str_7953
+
+@ExperimentalResourceApi
+internal val Res.string.str_7954: StringResource
+  get() = String45.str_7954
+
+@ExperimentalResourceApi
+internal val Res.string.str_7955: StringResource
+  get() = String45.str_7955
+
+@ExperimentalResourceApi
+internal val Res.string.str_7956: StringResource
+  get() = String45.str_7956
+
+@ExperimentalResourceApi
+internal val Res.string.str_7957: StringResource
+  get() = String45.str_7957
+
+@ExperimentalResourceApi
+internal val Res.string.str_7958: StringResource
+  get() = String45.str_7958
+
+@ExperimentalResourceApi
+internal val Res.string.str_7959: StringResource
+  get() = String45.str_7959
+
+@ExperimentalResourceApi
+internal val Res.string.str_796: StringResource
+  get() = String45.str_796
+
+@ExperimentalResourceApi
+internal val Res.string.str_7960: StringResource
+  get() = String45.str_7960
+
+@ExperimentalResourceApi
+internal val Res.string.str_7961: StringResource
+  get() = String45.str_7961
+
+@ExperimentalResourceApi
+internal val Res.string.str_7962: StringResource
+  get() = String45.str_7962
+
+@ExperimentalResourceApi
+internal val Res.string.str_7963: StringResource
+  get() = String45.str_7963
+
+@ExperimentalResourceApi
+internal val Res.string.str_7964: StringResource
+  get() = String45.str_7964
+
+@ExperimentalResourceApi
+internal val Res.string.str_7965: StringResource
+  get() = String45.str_7965
+
+@ExperimentalResourceApi
+internal val Res.string.str_7966: StringResource
+  get() = String45.str_7966
+
+@ExperimentalResourceApi
+internal val Res.string.str_7967: StringResource
+  get() = String45.str_7967
+
+@ExperimentalResourceApi
+internal val Res.string.str_7968: StringResource
+  get() = String45.str_7968
+
+@ExperimentalResourceApi
+internal val Res.string.str_7969: StringResource
+  get() = String45.str_7969
+
+@ExperimentalResourceApi
+internal val Res.string.str_797: StringResource
+  get() = String45.str_797
+
+@ExperimentalResourceApi
+internal val Res.string.str_7970: StringResource
+  get() = String45.str_7970
+
+@ExperimentalResourceApi
+internal val Res.string.str_7971: StringResource
+  get() = String45.str_7971
+
+@ExperimentalResourceApi
+internal val Res.string.str_7972: StringResource
+  get() = String45.str_7972
+
+@ExperimentalResourceApi
+internal val Res.string.str_7973: StringResource
+  get() = String45.str_7973
+
+@ExperimentalResourceApi
+internal val Res.string.str_7974: StringResource
+  get() = String45.str_7974
+
+@ExperimentalResourceApi
+internal val Res.string.str_7975: StringResource
+  get() = String45.str_7975
+
+@ExperimentalResourceApi
+internal val Res.string.str_7976: StringResource
+  get() = String45.str_7976
+
+@ExperimentalResourceApi
+internal val Res.string.str_7977: StringResource
+  get() = String45.str_7977
+
+@ExperimentalResourceApi
+internal val Res.string.str_7978: StringResource
+  get() = String45.str_7978
+
+@ExperimentalResourceApi
+internal val Res.string.str_7979: StringResource
+  get() = String45.str_7979
+
+@ExperimentalResourceApi
+internal val Res.string.str_798: StringResource
+  get() = String45.str_798
+
+@ExperimentalResourceApi
+internal val Res.string.str_7980: StringResource
+  get() = String45.str_7980
+
+@ExperimentalResourceApi
+internal val Res.string.str_7981: StringResource
+  get() = String45.str_7981
+
+@ExperimentalResourceApi
+internal val Res.string.str_7982: StringResource
+  get() = String45.str_7982
+
+@ExperimentalResourceApi
+internal val Res.string.str_7983: StringResource
+  get() = String45.str_7983
+
+@ExperimentalResourceApi
+internal val Res.string.str_7984: StringResource
+  get() = String45.str_7984
+
+@ExperimentalResourceApi
+internal val Res.string.str_7985: StringResource
+  get() = String45.str_7985
+
+@ExperimentalResourceApi
+internal val Res.string.str_7986: StringResource
+  get() = String45.str_7986
+
+@ExperimentalResourceApi
+internal val Res.string.str_7987: StringResource
+  get() = String45.str_7987
+
+@ExperimentalResourceApi
+internal val Res.string.str_7988: StringResource
+  get() = String45.str_7988
+
+@ExperimentalResourceApi
+internal val Res.string.str_7989: StringResource
+  get() = String45.str_7989
+
+@ExperimentalResourceApi
+internal val Res.string.str_799: StringResource
+  get() = String45.str_799
+
+@ExperimentalResourceApi
+internal val Res.string.str_7990: StringResource
+  get() = String45.str_7990
+
+@ExperimentalResourceApi
+internal val Res.string.str_7991: StringResource
+  get() = String45.str_7991
+
+@ExperimentalResourceApi
+internal val Res.string.str_7992: StringResource
+  get() = String45.str_7992
+
+@ExperimentalResourceApi
+internal val Res.string.str_7993: StringResource
+  get() = String45.str_7993
+
+@ExperimentalResourceApi
+internal val Res.string.str_7994: StringResource
+  get() = String45.str_7994
+
+@ExperimentalResourceApi
+internal val Res.string.str_7995: StringResource
+  get() = String45.str_7995
+
+@ExperimentalResourceApi
+internal val Res.string.str_7996: StringResource
+  get() = String45.str_7996
+
+@ExperimentalResourceApi
+internal val Res.string.str_7997: StringResource
+  get() = String45.str_7997
+
+@ExperimentalResourceApi
+internal val Res.string.str_7998: StringResource
+  get() = String45.str_7998
+
+@ExperimentalResourceApi
+internal val Res.string.str_7999: StringResource
+  get() = String45.str_7999
+
+@ExperimentalResourceApi
+internal val Res.string.str_8: StringResource
+  get() = String45.str_8
+
+@ExperimentalResourceApi
+internal val Res.string.str_80: StringResource
+  get() = String45.str_80
+
+@ExperimentalResourceApi
+internal val Res.string.str_800: StringResource
+  get() = String45.str_800
+
+@ExperimentalResourceApi
+internal val Res.string.str_8000: StringResource
+  get() = String45.str_8000
+
+@ExperimentalResourceApi
+internal val Res.string.str_8001: StringResource
+  get() = String45.str_8001
+
+@ExperimentalResourceApi
+internal val Res.string.str_8002: StringResource
+  get() = String45.str_8002
+
+@ExperimentalResourceApi
+internal val Res.string.str_8003: StringResource
+  get() = String45.str_8003
+
+@ExperimentalResourceApi
+internal val Res.string.str_8004: StringResource
+  get() = String45.str_8004
+
+@ExperimentalResourceApi
+internal val Res.string.str_8005: StringResource
+  get() = String45.str_8005
+
+@ExperimentalResourceApi
+internal val Res.string.str_8006: StringResource
+  get() = String45.str_8006
+
+@ExperimentalResourceApi
+internal val Res.string.str_8007: StringResource
+  get() = String45.str_8007
+
+@ExperimentalResourceApi
+internal val Res.string.str_8008: StringResource
+  get() = String45.str_8008
+
+@ExperimentalResourceApi
+internal val Res.string.str_8009: StringResource
+  get() = String45.str_8009
+
+@ExperimentalResourceApi
+internal val Res.string.str_801: StringResource
+  get() = String45.str_801
+
+@ExperimentalResourceApi
+internal val Res.string.str_8010: StringResource
+  get() = String45.str_8010
+
+@ExperimentalResourceApi
+internal val Res.string.str_8011: StringResource
+  get() = String45.str_8011
+
+@ExperimentalResourceApi
+internal val Res.string.str_8012: StringResource
+  get() = String45.str_8012
+
+@ExperimentalResourceApi
+internal val Res.string.str_8013: StringResource
+  get() = String45.str_8013
+
+@ExperimentalResourceApi
+internal val Res.string.str_8014: StringResource
+  get() = String45.str_8014
+
+@ExperimentalResourceApi
+internal val Res.string.str_8015: StringResource
+  get() = String45.str_8015
+
+@ExperimentalResourceApi
+internal val Res.string.str_8016: StringResource
+  get() = String45.str_8016
+
+@ExperimentalResourceApi
+internal val Res.string.str_8017: StringResource
+  get() = String45.str_8017
+
+@ExperimentalResourceApi
+internal val Res.string.str_8018: StringResource
+  get() = String45.str_8018
+
+@ExperimentalResourceApi
+internal val Res.string.str_8019: StringResource
+  get() = String45.str_8019
+
+@ExperimentalResourceApi
+internal val Res.string.str_802: StringResource
+  get() = String45.str_802
+
+@ExperimentalResourceApi
+internal val Res.string.str_8020: StringResource
+  get() = String45.str_8020
+
+@ExperimentalResourceApi
+internal val Res.string.str_8021: StringResource
+  get() = String45.str_8021
+
+@ExperimentalResourceApi
+internal val Res.string.str_8022: StringResource
+  get() = String45.str_8022
+
+@ExperimentalResourceApi
+internal val Res.string.str_8023: StringResource
+  get() = String45.str_8023
+
+@ExperimentalResourceApi
+internal val Res.string.str_8024: StringResource
+  get() = String45.str_8024
+
+@ExperimentalResourceApi
+internal val Res.string.str_8025: StringResource
+  get() = String45.str_8025
+
+@ExperimentalResourceApi
+internal val Res.string.str_8026: StringResource
+  get() = String45.str_8026
+
+@ExperimentalResourceApi
+internal val Res.string.str_8027: StringResource
+  get() = String45.str_8027
+
+@ExperimentalResourceApi
+internal val Res.string.str_8028: StringResource
+  get() = String45.str_8028
+
+@ExperimentalResourceApi
+internal val Res.string.str_8029: StringResource
+  get() = String45.str_8029
+
+@ExperimentalResourceApi
+internal val Res.string.str_803: StringResource
+  get() = String45.str_803
+
+@ExperimentalResourceApi
+internal val Res.string.str_8030: StringResource
+  get() = String45.str_8030
+
+@ExperimentalResourceApi
+internal val Res.string.str_8031: StringResource
+  get() = String45.str_8031
+
+@ExperimentalResourceApi
+internal val Res.string.str_8032: StringResource
+  get() = String45.str_8032
+
+@ExperimentalResourceApi
+internal val Res.string.str_8033: StringResource
+  get() = String45.str_8033
+
+@ExperimentalResourceApi
+internal val Res.string.str_8034: StringResource
+  get() = String45.str_8034
+
+@ExperimentalResourceApi
+internal val Res.string.str_8035: StringResource
+  get() = String45.str_8035
+
+@ExperimentalResourceApi
+internal val Res.string.str_8036: StringResource
+  get() = String45.str_8036
+
+@ExperimentalResourceApi
+internal val Res.string.str_8037: StringResource
+  get() = String45.str_8037
+
+@ExperimentalResourceApi
+internal val Res.string.str_8038: StringResource
+  get() = String45.str_8038
+
+@ExperimentalResourceApi
+internal val Res.string.str_8039: StringResource
+  get() = String45.str_8039
+
+@ExperimentalResourceApi
+internal val Res.string.str_804: StringResource
+  get() = String45.str_804
+
+@ExperimentalResourceApi
+internal val Res.string.str_8040: StringResource
+  get() = String45.str_8040
+
+@ExperimentalResourceApi
+internal val Res.string.str_8041: StringResource
+  get() = String45.str_8041
+
+@ExperimentalResourceApi
+internal val Res.string.str_8042: StringResource
+  get() = String45.str_8042
+
+@ExperimentalResourceApi
+internal val Res.string.str_8043: StringResource
+  get() = String45.str_8043
+
+@ExperimentalResourceApi
+internal val Res.string.str_8044: StringResource
+  get() = String45.str_8044
+
+@ExperimentalResourceApi
+internal val Res.string.str_8045: StringResource
+  get() = String45.str_8045
+
+@ExperimentalResourceApi
+internal val Res.string.str_8046: StringResource
+  get() = String45.str_8046
+
+@ExperimentalResourceApi
+internal val Res.string.str_8047: StringResource
+  get() = String45.str_8047
+
+@ExperimentalResourceApi
+internal val Res.string.str_8048: StringResource
+  get() = String45.str_8048
+
+@ExperimentalResourceApi
+internal val Res.string.str_8049: StringResource
+  get() = String45.str_8049
+
+@ExperimentalResourceApi
+internal val Res.string.str_805: StringResource
+  get() = String45.str_805
+
+@ExperimentalResourceApi
+internal val Res.string.str_8050: StringResource
+  get() = String45.str_8050
+
+@ExperimentalResourceApi
+internal val Res.string.str_8051: StringResource
+  get() = String45.str_8051
+
+@ExperimentalResourceApi
+internal val Res.string.str_8052: StringResource
+  get() = String45.str_8052
+
+@ExperimentalResourceApi
+internal val Res.string.str_8053: StringResource
+  get() = String45.str_8053
+
+@ExperimentalResourceApi
+internal val Res.string.str_8054: StringResource
+  get() = String45.str_8054
+
+@ExperimentalResourceApi
+internal val Res.string.str_8055: StringResource
+  get() = String45.str_8055
+
+@ExperimentalResourceApi
+internal val Res.string.str_8056: StringResource
+  get() = String45.str_8056
+
+@ExperimentalResourceApi
+internal val Res.string.str_8057: StringResource
+  get() = String45.str_8057
+
+@ExperimentalResourceApi
+internal val Res.string.str_8058: StringResource
+  get() = String45.str_8058
+
+@ExperimentalResourceApi
+internal val Res.string.str_8059: StringResource
+  get() = String45.str_8059
+
+@ExperimentalResourceApi
+internal val Res.string.str_806: StringResource
+  get() = String45.str_806
+
+@ExperimentalResourceApi
+internal val Res.string.str_8060: StringResource
+  get() = String45.str_8060
+
+@ExperimentalResourceApi
+internal val Res.string.str_8061: StringResource
+  get() = String45.str_8061
+
+@ExperimentalResourceApi
+internal val Res.string.str_8062: StringResource
+  get() = String45.str_8062
+
+@ExperimentalResourceApi
+internal val Res.string.str_8063: StringResource
+  get() = String45.str_8063
+
+@ExperimentalResourceApi
+internal val Res.string.str_8064: StringResource
+  get() = String45.str_8064
+
+@ExperimentalResourceApi
+internal val Res.string.str_8065: StringResource
+  get() = String45.str_8065
+
+@ExperimentalResourceApi
+internal val Res.string.str_8066: StringResource
+  get() = String45.str_8066
+
+@ExperimentalResourceApi
+internal val Res.string.str_8067: StringResource
+  get() = String45.str_8067
+
+@ExperimentalResourceApi
+internal val Res.string.str_8068: StringResource
+  get() = String45.str_8068
+
+@ExperimentalResourceApi
+internal val Res.string.str_8069: StringResource
+  get() = String45.str_8069
+
+@ExperimentalResourceApi
+internal val Res.string.str_807: StringResource
+  get() = String45.str_807
+
+@ExperimentalResourceApi
+internal val Res.string.str_8070: StringResource
+  get() = String45.str_8070
+
+@ExperimentalResourceApi
+internal val Res.string.str_8071: StringResource
+  get() = String45.str_8071
+
+@ExperimentalResourceApi
+internal val Res.string.str_8072: StringResource
+  get() = String45.str_8072
+
+@ExperimentalResourceApi
+internal val Res.string.str_8073: StringResource
+  get() = String45.str_8073
+
+@ExperimentalResourceApi
+internal val Res.string.str_8074: StringResource
+  get() = String45.str_8074
+
+@ExperimentalResourceApi
+internal val Res.string.str_8075: StringResource
+  get() = String45.str_8075
+
+@ExperimentalResourceApi
+internal val Res.string.str_8076: StringResource
+  get() = String45.str_8076
+
+@ExperimentalResourceApi
+internal val Res.string.str_8077: StringResource
+  get() = String45.str_8077
+
+@ExperimentalResourceApi
+internal val Res.string.str_8078: StringResource
+  get() = String45.str_8078
+
+@ExperimentalResourceApi
+internal val Res.string.str_8079: StringResource
+  get() = String45.str_8079
+
+@ExperimentalResourceApi
+internal val Res.string.str_808: StringResource
+  get() = String45.str_808
+
+@ExperimentalResourceApi
+internal val Res.string.str_8080: StringResource
+  get() = String45.str_8080
+
+@ExperimentalResourceApi
+internal val Res.string.str_8081: StringResource
+  get() = String45.str_8081
+
+@ExperimentalResourceApi
+internal val Res.string.str_8082: StringResource
+  get() = String45.str_8082
+
+@ExperimentalResourceApi
+internal val Res.string.str_8083: StringResource
+  get() = String45.str_8083
+
+@ExperimentalResourceApi
+internal val Res.string.str_8084: StringResource
+  get() = String45.str_8084
+
+@ExperimentalResourceApi
+internal val Res.string.str_8085: StringResource
+  get() = String45.str_8085
+
+@ExperimentalResourceApi
+internal val Res.string.str_8086: StringResource
+  get() = String45.str_8086
+
+@ExperimentalResourceApi
+internal val Res.string.str_8087: StringResource
+  get() = String45.str_8087
+
+@ExperimentalResourceApi
+internal val Res.string.str_8088: StringResource
+  get() = String45.str_8088
+
+@ExperimentalResourceApi
+internal val Res.string.str_8089: StringResource
+  get() = String45.str_8089
+
+@ExperimentalResourceApi
+internal val Res.string.str_809: StringResource
+  get() = String45.str_809
+
+@ExperimentalResourceApi
+internal val Res.string.str_8090: StringResource
+  get() = String45.str_8090
+
+@ExperimentalResourceApi
+internal val Res.string.str_8091: StringResource
+  get() = String45.str_8091
+
+@ExperimentalResourceApi
+internal val Res.string.str_8092: StringResource
+  get() = String45.str_8092
+
+@ExperimentalResourceApi
+internal val Res.string.str_8093: StringResource
+  get() = String45.str_8093
+
+@ExperimentalResourceApi
+internal val Res.string.str_8094: StringResource
+  get() = String45.str_8094
+
+@ExperimentalResourceApi
+internal val Res.string.str_8095: StringResource
+  get() = String45.str_8095
+
+@ExperimentalResourceApi
+internal val Res.string.str_8096: StringResource
+  get() = String45.str_8096
+
+@ExperimentalResourceApi
+internal val Res.string.str_8097: StringResource
+  get() = String45.str_8097
+
+@ExperimentalResourceApi
+internal val Res.string.str_8098: StringResource
+  get() = String45.str_8098
+
+@ExperimentalResourceApi
+internal val Res.string.str_8099: StringResource
+  get() = String45.str_8099
+
+@ExperimentalResourceApi
+internal val Res.string.str_81: StringResource
+  get() = String45.str_81
+
+@ExperimentalResourceApi
+internal val Res.string.str_810: StringResource
+  get() = String45.str_810
+
+@ExperimentalResourceApi
+internal val Res.string.str_8100: StringResource
+  get() = String45.str_8100
+
+@ExperimentalResourceApi
+internal val Res.string.str_8101: StringResource
+  get() = String45.str_8101
+
+@ExperimentalResourceApi
+internal val Res.string.str_8102: StringResource
+  get() = String45.str_8102
+
+@ExperimentalResourceApi
+internal val Res.string.str_8103: StringResource
+  get() = String45.str_8103
+
+@ExperimentalResourceApi
+internal val Res.string.str_8104: StringResource
+  get() = String45.str_8104
+
+@ExperimentalResourceApi
+internal val Res.string.str_8105: StringResource
+  get() = String45.str_8105
+
+@ExperimentalResourceApi
+internal val Res.string.str_8106: StringResource
+  get() = String45.str_8106
+
+@ExperimentalResourceApi
+internal val Res.string.str_8107: StringResource
+  get() = String45.str_8107
+
+@ExperimentalResourceApi
+internal val Res.string.str_8108: StringResource
+  get() = String45.str_8108
+
+@ExperimentalResourceApi
+internal val Res.string.str_8109: StringResource
+  get() = String45.str_8109
+
+@ExperimentalResourceApi
+internal val Res.string.str_811: StringResource
+  get() = String45.str_811
+
+@ExperimentalResourceApi
+internal val Res.string.str_8110: StringResource
+  get() = String45.str_8110
+
+@ExperimentalResourceApi
+internal val Res.string.str_8111: StringResource
+  get() = String45.str_8111
+
+@ExperimentalResourceApi
+internal val Res.string.str_8112: StringResource
+  get() = String45.str_8112
+
+@ExperimentalResourceApi
+internal val Res.string.str_8113: StringResource
+  get() = String45.str_8113
+
+@ExperimentalResourceApi
+internal val Res.string.str_8114: StringResource
+  get() = String45.str_8114
+
+@ExperimentalResourceApi
+internal val Res.string.str_8115: StringResource
+  get() = String45.str_8115
+
+@ExperimentalResourceApi
+internal val Res.string.str_8116: StringResource
+  get() = String45.str_8116
+
+@ExperimentalResourceApi
+internal val Res.string.str_8117: StringResource
+  get() = String45.str_8117
+
+@ExperimentalResourceApi
+internal val Res.string.str_8118: StringResource
+  get() = String45.str_8118
+
+@ExperimentalResourceApi
+internal val Res.string.str_8119: StringResource
+  get() = String45.str_8119
+
+@ExperimentalResourceApi
+internal val Res.string.str_812: StringResource
+  get() = String45.str_812
+
+@ExperimentalResourceApi
+internal val Res.string.str_8120: StringResource
+  get() = String45.str_8120
+
+@ExperimentalResourceApi
+internal val Res.string.str_8121: StringResource
+  get() = String45.str_8121
+
+@ExperimentalResourceApi
+internal val Res.string.str_8122: StringResource
+  get() = String45.str_8122
+
+@ExperimentalResourceApi
+internal val Res.string.str_8123: StringResource
+  get() = String45.str_8123
+
+@ExperimentalResourceApi
+internal val Res.string.str_8124: StringResource
+  get() = String45.str_8124
+
+@ExperimentalResourceApi
+internal val Res.string.str_8125: StringResource
+  get() = String45.str_8125
+
+@ExperimentalResourceApi
+internal val Res.string.str_8126: StringResource
+  get() = String45.str_8126
+
+@ExperimentalResourceApi
+internal val Res.string.str_8127: StringResource
+  get() = String45.str_8127
+
+@ExperimentalResourceApi
+internal val Res.string.str_8128: StringResource
+  get() = String45.str_8128
+
+@ExperimentalResourceApi
+internal val Res.string.str_8129: StringResource
+  get() = String45.str_8129
+
+@ExperimentalResourceApi
+internal val Res.string.str_813: StringResource
+  get() = String45.str_813
+
+@ExperimentalResourceApi
+internal val Res.string.str_8130: StringResource
+  get() = String45.str_8130
+
+@ExperimentalResourceApi
+internal val Res.string.str_8131: StringResource
+  get() = String45.str_8131
+
+@ExperimentalResourceApi
+internal val Res.string.str_8132: StringResource
+  get() = String45.str_8132
+
+@ExperimentalResourceApi
+internal val Res.string.str_8133: StringResource
+  get() = String45.str_8133
+
+@ExperimentalResourceApi
+internal val Res.string.str_8134: StringResource
+  get() = String45.str_8134
+
+@ExperimentalResourceApi
+internal val Res.string.str_8135: StringResource
+  get() = String45.str_8135
+
+@ExperimentalResourceApi
+internal val Res.string.str_8136: StringResource
+  get() = String45.str_8136
+
+@ExperimentalResourceApi
+internal val Res.string.str_8137: StringResource
+  get() = String45.str_8137
+
+@ExperimentalResourceApi
+internal val Res.string.str_8138: StringResource
+  get() = String45.str_8138
+
+@ExperimentalResourceApi
+internal val Res.string.str_8139: StringResource
+  get() = String45.str_8139
+
+@ExperimentalResourceApi
+internal val Res.string.str_814: StringResource
+  get() = String45.str_814
+
+@ExperimentalResourceApi
+internal val Res.string.str_8140: StringResource
+  get() = String45.str_8140
+
+@ExperimentalResourceApi
+internal val Res.string.str_8141: StringResource
+  get() = String45.str_8141
+
+@ExperimentalResourceApi
+internal val Res.string.str_8142: StringResource
+  get() = String45.str_8142
+
+@ExperimentalResourceApi
+internal val Res.string.str_8143: StringResource
+  get() = String45.str_8143
+
+@ExperimentalResourceApi
+internal val Res.string.str_8144: StringResource
+  get() = String45.str_8144
+
+@ExperimentalResourceApi
+internal val Res.string.str_8145: StringResource
+  get() = String45.str_8145
+
+@ExperimentalResourceApi
+internal val Res.string.str_8146: StringResource
+  get() = String45.str_8146
+
+@ExperimentalResourceApi
+internal val Res.string.str_8147: StringResource
+  get() = String45.str_8147
+
+@ExperimentalResourceApi
+internal val Res.string.str_8148: StringResource
+  get() = String45.str_8148
+
+@ExperimentalResourceApi
+internal val Res.string.str_8149: StringResource
+  get() = String45.str_8149
+
+@ExperimentalResourceApi
+internal val Res.string.str_815: StringResource
+  get() = String45.str_815
+
+@ExperimentalResourceApi
+internal val Res.string.str_8150: StringResource
+  get() = String45.str_8150
+
+@ExperimentalResourceApi
+internal val Res.string.str_8151: StringResource
+  get() = String45.str_8151
+
+@ExperimentalResourceApi
+internal val Res.string.str_8152: StringResource
+  get() = String45.str_8152
+
+@ExperimentalResourceApi
+internal val Res.string.str_8153: StringResource
+  get() = String45.str_8153
+
+@ExperimentalResourceApi
+internal val Res.string.str_8154: StringResource
+  get() = String45.str_8154
+
+@ExperimentalResourceApi
+internal val Res.string.str_8155: StringResource
+  get() = String45.str_8155
+
+@ExperimentalResourceApi
+internal val Res.string.str_8156: StringResource
+  get() = String45.str_8156
+
+@ExperimentalResourceApi
+internal val Res.string.str_8157: StringResource
+  get() = String45.str_8157
+
+@ExperimentalResourceApi
+internal val Res.string.str_8158: StringResource
+  get() = String45.str_8158
+
+@ExperimentalResourceApi
+internal val Res.string.str_8159: StringResource
+  get() = String45.str_8159
+
+@ExperimentalResourceApi
+internal val Res.string.str_816: StringResource
+  get() = String45.str_816
+
+@ExperimentalResourceApi
+internal val Res.string.str_8160: StringResource
+  get() = String45.str_8160
+
+@ExperimentalResourceApi
+internal val Res.string.str_8161: StringResource
+  get() = String45.str_8161
+
+@ExperimentalResourceApi
+internal val Res.string.str_8162: StringResource
+  get() = String45.str_8162
+
+@ExperimentalResourceApi
+internal val Res.string.str_8163: StringResource
+  get() = String45.str_8163
+
+@ExperimentalResourceApi
+internal val Res.string.str_8164: StringResource
+  get() = String45.str_8164
+
+@ExperimentalResourceApi
+internal val Res.string.str_8165: StringResource
+  get() = String45.str_8165
+
+@ExperimentalResourceApi
+internal val Res.string.str_8166: StringResource
+  get() = String45.str_8166
+
+@ExperimentalResourceApi
+internal val Res.string.str_8167: StringResource
+  get() = String45.str_8167
+
+@ExperimentalResourceApi
+internal val Res.string.str_8168: StringResource
+  get() = String45.str_8168
+
+@ExperimentalResourceApi
+internal val Res.string.str_8169: StringResource
+  get() = String45.str_8169
+
+@ExperimentalResourceApi
+internal val Res.string.str_817: StringResource
+  get() = String45.str_817
+
+@ExperimentalResourceApi
+internal val Res.string.str_8170: StringResource
+  get() = String45.str_8170
+
+@ExperimentalResourceApi
+internal val Res.string.str_8171: StringResource
+  get() = String45.str_8171
+
+@ExperimentalResourceApi
+internal val Res.string.str_8172: StringResource
+  get() = String45.str_8172
+
+@ExperimentalResourceApi
+internal val Res.string.str_8173: StringResource
+  get() = String45.str_8173
+
+@ExperimentalResourceApi
+internal val Res.string.str_8174: StringResource
+  get() = String45.str_8174
+
+@ExperimentalResourceApi
+internal val Res.string.str_8175: StringResource
+  get() = String45.str_8175
+
+@ExperimentalResourceApi
+internal val Res.string.str_8176: StringResource
+  get() = String45.str_8176
+
+@ExperimentalResourceApi
+internal val Res.string.str_8177: StringResource
+  get() = String45.str_8177
+
+@ExperimentalResourceApi
+internal val Res.string.str_8178: StringResource
+  get() = String45.str_8178
+
+@ExperimentalResourceApi
+internal val Res.string.str_8179: StringResource
+  get() = String45.str_8179
+
+@ExperimentalResourceApi
+internal val Res.string.str_818: StringResource
+  get() = String45.str_818
+
+@ExperimentalResourceApi
+internal val Res.string.str_8180: StringResource
+  get() = String45.str_8180
+
+@ExperimentalResourceApi
+internal val Res.string.str_8181: StringResource
+  get() = String45.str_8181
+
+@ExperimentalResourceApi
+internal val Res.string.str_8182: StringResource
+  get() = String45.str_8182
+
+@ExperimentalResourceApi
+internal val Res.string.str_8183: StringResource
+  get() = String45.str_8183
+
+@ExperimentalResourceApi
+internal val Res.string.str_8184: StringResource
+  get() = String45.str_8184
+
+@ExperimentalResourceApi
+internal val Res.string.str_8185: StringResource
+  get() = String45.str_8185
+
+@ExperimentalResourceApi
+internal val Res.string.str_8186: StringResource
+  get() = String45.str_8186
+
+@ExperimentalResourceApi
+internal val Res.string.str_8187: StringResource
+  get() = String45.str_8187
+
+@ExperimentalResourceApi
+internal val Res.string.str_8188: StringResource
+  get() = String45.str_8188
+
+@ExperimentalResourceApi
+internal val Res.string.str_8189: StringResource
+  get() = String45.str_8189
+
+@ExperimentalResourceApi
+internal val Res.string.str_819: StringResource
+  get() = String45.str_819
+
+@ExperimentalResourceApi
+internal val Res.string.str_8190: StringResource
+  get() = String45.str_8190
+
+@ExperimentalResourceApi
+internal val Res.string.str_8191: StringResource
+  get() = String45.str_8191
+
+@ExperimentalResourceApi
+internal val Res.string.str_8192: StringResource
+  get() = String45.str_8192
+
+@ExperimentalResourceApi
+internal val Res.string.str_8193: StringResource
+  get() = String45.str_8193
+
+@ExperimentalResourceApi
+internal val Res.string.str_8194: StringResource
+  get() = String45.str_8194
+
+@ExperimentalResourceApi
+internal val Res.string.str_8195: StringResource
+  get() = String45.str_8195
+
+@ExperimentalResourceApi
+internal val Res.string.str_8196: StringResource
+  get() = String45.str_8196
+
+@ExperimentalResourceApi
+internal val Res.string.str_8197: StringResource
+  get() = String45.str_8197
+
+@ExperimentalResourceApi
+internal val Res.string.str_8198: StringResource
+  get() = String45.str_8198

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String46.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String46.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String46 {
+  public val str_8199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8199", "str_8199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_82: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_82", "str_82",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_820", "str_820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8200", "str_8200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8201", "str_8201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8202", "str_8202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8203", "str_8203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8204", "str_8204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8205", "str_8205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8206", "str_8206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8207", "str_8207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8208", "str_8208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8209", "str_8209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_821", "str_821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8210", "str_8210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8211", "str_8211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8212", "str_8212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8213", "str_8213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8214", "str_8214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8215", "str_8215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8216", "str_8216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8217", "str_8217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8218", "str_8218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8219", "str_8219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_822", "str_822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8220", "str_8220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8221", "str_8221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8222", "str_8222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8223", "str_8223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8224", "str_8224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8225", "str_8225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8226", "str_8226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8227", "str_8227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8228", "str_8228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8229", "str_8229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_823", "str_823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8230", "str_8230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8231", "str_8231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8232", "str_8232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8233", "str_8233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8234", "str_8234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8235", "str_8235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8236", "str_8236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8237", "str_8237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8238", "str_8238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8239", "str_8239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_824", "str_824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8240", "str_8240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8241", "str_8241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8242", "str_8242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8243", "str_8243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8244", "str_8244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8245", "str_8245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8246", "str_8246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8247", "str_8247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8248", "str_8248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8249", "str_8249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_825", "str_825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8250", "str_8250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8251", "str_8251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8252", "str_8252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8253", "str_8253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8254", "str_8254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8255", "str_8255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8256", "str_8256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8257", "str_8257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8258", "str_8258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8259", "str_8259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_826", "str_826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8260", "str_8260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8261", "str_8261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8262", "str_8262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8263", "str_8263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8264", "str_8264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8265", "str_8265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8266", "str_8266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8267", "str_8267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8268", "str_8268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8269", "str_8269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_827", "str_827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8270", "str_8270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8271", "str_8271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8272", "str_8272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8273", "str_8273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8274", "str_8274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8275", "str_8275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8276", "str_8276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8277", "str_8277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8278", "str_8278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8279", "str_8279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_828", "str_828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8280", "str_8280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8281", "str_8281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8282", "str_8282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8283", "str_8283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8284", "str_8284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8285", "str_8285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8286", "str_8286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8287", "str_8287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8288", "str_8288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8289", "str_8289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_829", "str_829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8290", "str_8290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8291", "str_8291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8292", "str_8292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8293", "str_8293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8294", "str_8294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8295", "str_8295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8296", "str_8296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8297", "str_8297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8298", "str_8298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8299", "str_8299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_83: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_83", "str_83",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_830", "str_830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8300", "str_8300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8301", "str_8301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8302", "str_8302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8303", "str_8303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8304", "str_8304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8305", "str_8305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8306", "str_8306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8307", "str_8307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8308", "str_8308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8309", "str_8309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_831", "str_831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8310", "str_8310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8311", "str_8311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8312", "str_8312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8313", "str_8313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8314", "str_8314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8315", "str_8315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8316", "str_8316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8317", "str_8317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8318", "str_8318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8319", "str_8319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_832", "str_832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8320", "str_8320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8321", "str_8321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8322", "str_8322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8323", "str_8323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8324", "str_8324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8325", "str_8325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8326", "str_8326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8327", "str_8327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8328", "str_8328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8329", "str_8329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_833", "str_833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8330", "str_8330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8331", "str_8331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8332", "str_8332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8333", "str_8333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8334", "str_8334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8335", "str_8335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8336", "str_8336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8337", "str_8337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8338", "str_8338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8339", "str_8339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_834", "str_834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8340", "str_8340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8341", "str_8341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8342", "str_8342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8343", "str_8343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8344", "str_8344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8345", "str_8345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8346", "str_8346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8347", "str_8347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8348", "str_8348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8349", "str_8349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_835", "str_835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8350", "str_8350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8351", "str_8351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8352", "str_8352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8353", "str_8353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8354", "str_8354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8355", "str_8355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8356", "str_8356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8357", "str_8357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8358", "str_8358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8359", "str_8359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_836", "str_836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8360", "str_8360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8361", "str_8361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8362", "str_8362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8363", "str_8363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8364", "str_8364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8365", "str_8365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8366", "str_8366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8367", "str_8367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8368", "str_8368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8369", "str_8369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_837", "str_837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8370", "str_8370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8371", "str_8371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8372", "str_8372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8373", "str_8373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8374", "str_8374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8375", "str_8375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8376", "str_8376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8377", "str_8377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8378", "str_8378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8379", "str_8379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_838", "str_838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8380", "str_8380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8381", "str_8381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8382", "str_8382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8383", "str_8383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8384", "str_8384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8385", "str_8385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8386", "str_8386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8387", "str_8387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8388", "str_8388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8389", "str_8389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_839", "str_839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8390", "str_8390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8391", "str_8391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8392", "str_8392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8393", "str_8393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8394", "str_8394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8395", "str_8395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8396", "str_8396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8397", "str_8397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8398", "str_8398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8399", "str_8399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_84: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_84", "str_84",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_840", "str_840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8400", "str_8400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8401", "str_8401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8402", "str_8402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8403", "str_8403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8404", "str_8404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8405", "str_8405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8406", "str_8406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8407", "str_8407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8408", "str_8408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8409", "str_8409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_841", "str_841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8410", "str_8410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8411", "str_8411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8412", "str_8412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8413", "str_8413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8414", "str_8414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8415", "str_8415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8416", "str_8416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8417", "str_8417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8418", "str_8418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8419", "str_8419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_842", "str_842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8420", "str_8420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8421", "str_8421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8422", "str_8422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8423", "str_8423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8424", "str_8424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8425", "str_8425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8426", "str_8426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8427", "str_8427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8428", "str_8428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8429", "str_8429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_843", "str_843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8430", "str_8430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8431", "str_8431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8432", "str_8432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8433", "str_8433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8434", "str_8434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8435", "str_8435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8436", "str_8436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8437", "str_8437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8438", "str_8438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8439", "str_8439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_844", "str_844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8440", "str_8440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8441", "str_8441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8442", "str_8442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8443", "str_8443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8444", "str_8444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8445", "str_8445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8446", "str_8446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8447", "str_8447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8448", "str_8448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8449", "str_8449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_845", "str_845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8450", "str_8450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8451", "str_8451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8452", "str_8452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8453", "str_8453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8454", "str_8454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8455", "str_8455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8456", "str_8456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8457", "str_8457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8458", "str_8458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8459", "str_8459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_846", "str_846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8460", "str_8460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8461", "str_8461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8462", "str_8462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8463", "str_8463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8464", "str_8464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8465", "str_8465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8466", "str_8466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8467", "str_8467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8468", "str_8468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8469", "str_8469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_847", "str_847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8470", "str_8470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8471", "str_8471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8472", "str_8472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8473", "str_8473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8474", "str_8474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8475", "str_8475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8476", "str_8476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8477", "str_8477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8478", "str_8478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8479", "str_8479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_848", "str_848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8480", "str_8480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8481", "str_8481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8482", "str_8482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8483", "str_8483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8484", "str_8484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8485", "str_8485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8486", "str_8486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8487", "str_8487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8488", "str_8488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8489", "str_8489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_849", "str_849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8490", "str_8490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8491", "str_8491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8492", "str_8492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8493", "str_8493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8494", "str_8494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8495", "str_8495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8496", "str_8496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8497", "str_8497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8498", "str_8498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8499", "str_8499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_85: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_85", "str_85",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_850", "str_850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8500", "str_8500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8501", "str_8501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8502", "str_8502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8503", "str_8503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8504", "str_8504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8505", "str_8505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8506", "str_8506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8507", "str_8507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8508", "str_8508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8509", "str_8509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_851", "str_851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8510", "str_8510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8511", "str_8511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8512", "str_8512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8513", "str_8513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8514", "str_8514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8515", "str_8515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8516", "str_8516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8517", "str_8517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8518", "str_8518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8519", "str_8519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_852", "str_852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8520", "str_8520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8521", "str_8521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8522", "str_8522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8523", "str_8523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8524", "str_8524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8525", "str_8525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8526", "str_8526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8527", "str_8527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8528", "str_8528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8529", "str_8529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_853", "str_853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8530", "str_8530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8531", "str_8531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8532", "str_8532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8533", "str_8533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8534", "str_8534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8535", "str_8535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8536", "str_8536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8537", "str_8537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8538", "str_8538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8539", "str_8539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_854", "str_854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8540", "str_8540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8541", "str_8541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8542", "str_8542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8543", "str_8543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8544", "str_8544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8545", "str_8545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8546", "str_8546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8547", "str_8547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8548", "str_8548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8549", "str_8549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_855", "str_855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8550", "str_8550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8551", "str_8551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8552", "str_8552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8553", "str_8553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8554", "str_8554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8555", "str_8555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8556", "str_8556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8557", "str_8557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8558", "str_8558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8559", "str_8559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_856", "str_856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8560", "str_8560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8561", "str_8561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8562", "str_8562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8563", "str_8563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8564", "str_8564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8565", "str_8565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8566", "str_8566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8567", "str_8567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8568", "str_8568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8569", "str_8569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_857", "str_857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8570", "str_8570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8571", "str_8571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8572", "str_8572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8573", "str_8573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8574", "str_8574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8575", "str_8575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8576", "str_8576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8577", "str_8577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8578", "str_8578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8579", "str_8579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_858", "str_858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8580", "str_8580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8581", "str_8581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8582", "str_8582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8583", "str_8583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8584", "str_8584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8585", "str_8585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8586", "str_8586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8587", "str_8587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8588", "str_8588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8589", "str_8589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_859", "str_859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8590", "str_8590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8591", "str_8591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8592", "str_8592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8593", "str_8593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8594", "str_8594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8595", "str_8595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8596", "str_8596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8597", "str_8597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8598", "str_8598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8599", "str_8599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_86: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_86", "str_86",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_860", "str_860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8600", "str_8600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8601", "str_8601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8602", "str_8602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8603", "str_8603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8604", "str_8604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8605", "str_8605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8606", "str_8606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8607", "str_8607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8608", "str_8608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8609", "str_8609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_861", "str_861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8610", "str_8610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8611", "str_8611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8612", "str_8612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8613", "str_8613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8614", "str_8614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8615", "str_8615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8616", "str_8616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8617", "str_8617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8618", "str_8618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8619", "str_8619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_862", "str_862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8620", "str_8620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8621", "str_8621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8622", "str_8622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8623", "str_8623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8624", "str_8624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8625", "str_8625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8626", "str_8626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8627", "str_8627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8628", "str_8628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8629", "str_8629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_863", "str_863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8630", "str_8630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8631", "str_8631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8632", "str_8632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8633", "str_8633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8634", "str_8634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8635", "str_8635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8636", "str_8636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8637", "str_8637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8638", "str_8638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8639", "str_8639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_864", "str_864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8640", "str_8640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8641", "str_8641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8642", "str_8642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8643", "str_8643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8644", "str_8644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8645", "str_8645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8646", "str_8646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8647", "str_8647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8648", "str_8648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_8199: StringResource
+  get() = String46.str_8199
+
+@ExperimentalResourceApi
+internal val Res.string.str_82: StringResource
+  get() = String46.str_82
+
+@ExperimentalResourceApi
+internal val Res.string.str_820: StringResource
+  get() = String46.str_820
+
+@ExperimentalResourceApi
+internal val Res.string.str_8200: StringResource
+  get() = String46.str_8200
+
+@ExperimentalResourceApi
+internal val Res.string.str_8201: StringResource
+  get() = String46.str_8201
+
+@ExperimentalResourceApi
+internal val Res.string.str_8202: StringResource
+  get() = String46.str_8202
+
+@ExperimentalResourceApi
+internal val Res.string.str_8203: StringResource
+  get() = String46.str_8203
+
+@ExperimentalResourceApi
+internal val Res.string.str_8204: StringResource
+  get() = String46.str_8204
+
+@ExperimentalResourceApi
+internal val Res.string.str_8205: StringResource
+  get() = String46.str_8205
+
+@ExperimentalResourceApi
+internal val Res.string.str_8206: StringResource
+  get() = String46.str_8206
+
+@ExperimentalResourceApi
+internal val Res.string.str_8207: StringResource
+  get() = String46.str_8207
+
+@ExperimentalResourceApi
+internal val Res.string.str_8208: StringResource
+  get() = String46.str_8208
+
+@ExperimentalResourceApi
+internal val Res.string.str_8209: StringResource
+  get() = String46.str_8209
+
+@ExperimentalResourceApi
+internal val Res.string.str_821: StringResource
+  get() = String46.str_821
+
+@ExperimentalResourceApi
+internal val Res.string.str_8210: StringResource
+  get() = String46.str_8210
+
+@ExperimentalResourceApi
+internal val Res.string.str_8211: StringResource
+  get() = String46.str_8211
+
+@ExperimentalResourceApi
+internal val Res.string.str_8212: StringResource
+  get() = String46.str_8212
+
+@ExperimentalResourceApi
+internal val Res.string.str_8213: StringResource
+  get() = String46.str_8213
+
+@ExperimentalResourceApi
+internal val Res.string.str_8214: StringResource
+  get() = String46.str_8214
+
+@ExperimentalResourceApi
+internal val Res.string.str_8215: StringResource
+  get() = String46.str_8215
+
+@ExperimentalResourceApi
+internal val Res.string.str_8216: StringResource
+  get() = String46.str_8216
+
+@ExperimentalResourceApi
+internal val Res.string.str_8217: StringResource
+  get() = String46.str_8217
+
+@ExperimentalResourceApi
+internal val Res.string.str_8218: StringResource
+  get() = String46.str_8218
+
+@ExperimentalResourceApi
+internal val Res.string.str_8219: StringResource
+  get() = String46.str_8219
+
+@ExperimentalResourceApi
+internal val Res.string.str_822: StringResource
+  get() = String46.str_822
+
+@ExperimentalResourceApi
+internal val Res.string.str_8220: StringResource
+  get() = String46.str_8220
+
+@ExperimentalResourceApi
+internal val Res.string.str_8221: StringResource
+  get() = String46.str_8221
+
+@ExperimentalResourceApi
+internal val Res.string.str_8222: StringResource
+  get() = String46.str_8222
+
+@ExperimentalResourceApi
+internal val Res.string.str_8223: StringResource
+  get() = String46.str_8223
+
+@ExperimentalResourceApi
+internal val Res.string.str_8224: StringResource
+  get() = String46.str_8224
+
+@ExperimentalResourceApi
+internal val Res.string.str_8225: StringResource
+  get() = String46.str_8225
+
+@ExperimentalResourceApi
+internal val Res.string.str_8226: StringResource
+  get() = String46.str_8226
+
+@ExperimentalResourceApi
+internal val Res.string.str_8227: StringResource
+  get() = String46.str_8227
+
+@ExperimentalResourceApi
+internal val Res.string.str_8228: StringResource
+  get() = String46.str_8228
+
+@ExperimentalResourceApi
+internal val Res.string.str_8229: StringResource
+  get() = String46.str_8229
+
+@ExperimentalResourceApi
+internal val Res.string.str_823: StringResource
+  get() = String46.str_823
+
+@ExperimentalResourceApi
+internal val Res.string.str_8230: StringResource
+  get() = String46.str_8230
+
+@ExperimentalResourceApi
+internal val Res.string.str_8231: StringResource
+  get() = String46.str_8231
+
+@ExperimentalResourceApi
+internal val Res.string.str_8232: StringResource
+  get() = String46.str_8232
+
+@ExperimentalResourceApi
+internal val Res.string.str_8233: StringResource
+  get() = String46.str_8233
+
+@ExperimentalResourceApi
+internal val Res.string.str_8234: StringResource
+  get() = String46.str_8234
+
+@ExperimentalResourceApi
+internal val Res.string.str_8235: StringResource
+  get() = String46.str_8235
+
+@ExperimentalResourceApi
+internal val Res.string.str_8236: StringResource
+  get() = String46.str_8236
+
+@ExperimentalResourceApi
+internal val Res.string.str_8237: StringResource
+  get() = String46.str_8237
+
+@ExperimentalResourceApi
+internal val Res.string.str_8238: StringResource
+  get() = String46.str_8238
+
+@ExperimentalResourceApi
+internal val Res.string.str_8239: StringResource
+  get() = String46.str_8239
+
+@ExperimentalResourceApi
+internal val Res.string.str_824: StringResource
+  get() = String46.str_824
+
+@ExperimentalResourceApi
+internal val Res.string.str_8240: StringResource
+  get() = String46.str_8240
+
+@ExperimentalResourceApi
+internal val Res.string.str_8241: StringResource
+  get() = String46.str_8241
+
+@ExperimentalResourceApi
+internal val Res.string.str_8242: StringResource
+  get() = String46.str_8242
+
+@ExperimentalResourceApi
+internal val Res.string.str_8243: StringResource
+  get() = String46.str_8243
+
+@ExperimentalResourceApi
+internal val Res.string.str_8244: StringResource
+  get() = String46.str_8244
+
+@ExperimentalResourceApi
+internal val Res.string.str_8245: StringResource
+  get() = String46.str_8245
+
+@ExperimentalResourceApi
+internal val Res.string.str_8246: StringResource
+  get() = String46.str_8246
+
+@ExperimentalResourceApi
+internal val Res.string.str_8247: StringResource
+  get() = String46.str_8247
+
+@ExperimentalResourceApi
+internal val Res.string.str_8248: StringResource
+  get() = String46.str_8248
+
+@ExperimentalResourceApi
+internal val Res.string.str_8249: StringResource
+  get() = String46.str_8249
+
+@ExperimentalResourceApi
+internal val Res.string.str_825: StringResource
+  get() = String46.str_825
+
+@ExperimentalResourceApi
+internal val Res.string.str_8250: StringResource
+  get() = String46.str_8250
+
+@ExperimentalResourceApi
+internal val Res.string.str_8251: StringResource
+  get() = String46.str_8251
+
+@ExperimentalResourceApi
+internal val Res.string.str_8252: StringResource
+  get() = String46.str_8252
+
+@ExperimentalResourceApi
+internal val Res.string.str_8253: StringResource
+  get() = String46.str_8253
+
+@ExperimentalResourceApi
+internal val Res.string.str_8254: StringResource
+  get() = String46.str_8254
+
+@ExperimentalResourceApi
+internal val Res.string.str_8255: StringResource
+  get() = String46.str_8255
+
+@ExperimentalResourceApi
+internal val Res.string.str_8256: StringResource
+  get() = String46.str_8256
+
+@ExperimentalResourceApi
+internal val Res.string.str_8257: StringResource
+  get() = String46.str_8257
+
+@ExperimentalResourceApi
+internal val Res.string.str_8258: StringResource
+  get() = String46.str_8258
+
+@ExperimentalResourceApi
+internal val Res.string.str_8259: StringResource
+  get() = String46.str_8259
+
+@ExperimentalResourceApi
+internal val Res.string.str_826: StringResource
+  get() = String46.str_826
+
+@ExperimentalResourceApi
+internal val Res.string.str_8260: StringResource
+  get() = String46.str_8260
+
+@ExperimentalResourceApi
+internal val Res.string.str_8261: StringResource
+  get() = String46.str_8261
+
+@ExperimentalResourceApi
+internal val Res.string.str_8262: StringResource
+  get() = String46.str_8262
+
+@ExperimentalResourceApi
+internal val Res.string.str_8263: StringResource
+  get() = String46.str_8263
+
+@ExperimentalResourceApi
+internal val Res.string.str_8264: StringResource
+  get() = String46.str_8264
+
+@ExperimentalResourceApi
+internal val Res.string.str_8265: StringResource
+  get() = String46.str_8265
+
+@ExperimentalResourceApi
+internal val Res.string.str_8266: StringResource
+  get() = String46.str_8266
+
+@ExperimentalResourceApi
+internal val Res.string.str_8267: StringResource
+  get() = String46.str_8267
+
+@ExperimentalResourceApi
+internal val Res.string.str_8268: StringResource
+  get() = String46.str_8268
+
+@ExperimentalResourceApi
+internal val Res.string.str_8269: StringResource
+  get() = String46.str_8269
+
+@ExperimentalResourceApi
+internal val Res.string.str_827: StringResource
+  get() = String46.str_827
+
+@ExperimentalResourceApi
+internal val Res.string.str_8270: StringResource
+  get() = String46.str_8270
+
+@ExperimentalResourceApi
+internal val Res.string.str_8271: StringResource
+  get() = String46.str_8271
+
+@ExperimentalResourceApi
+internal val Res.string.str_8272: StringResource
+  get() = String46.str_8272
+
+@ExperimentalResourceApi
+internal val Res.string.str_8273: StringResource
+  get() = String46.str_8273
+
+@ExperimentalResourceApi
+internal val Res.string.str_8274: StringResource
+  get() = String46.str_8274
+
+@ExperimentalResourceApi
+internal val Res.string.str_8275: StringResource
+  get() = String46.str_8275
+
+@ExperimentalResourceApi
+internal val Res.string.str_8276: StringResource
+  get() = String46.str_8276
+
+@ExperimentalResourceApi
+internal val Res.string.str_8277: StringResource
+  get() = String46.str_8277
+
+@ExperimentalResourceApi
+internal val Res.string.str_8278: StringResource
+  get() = String46.str_8278
+
+@ExperimentalResourceApi
+internal val Res.string.str_8279: StringResource
+  get() = String46.str_8279
+
+@ExperimentalResourceApi
+internal val Res.string.str_828: StringResource
+  get() = String46.str_828
+
+@ExperimentalResourceApi
+internal val Res.string.str_8280: StringResource
+  get() = String46.str_8280
+
+@ExperimentalResourceApi
+internal val Res.string.str_8281: StringResource
+  get() = String46.str_8281
+
+@ExperimentalResourceApi
+internal val Res.string.str_8282: StringResource
+  get() = String46.str_8282
+
+@ExperimentalResourceApi
+internal val Res.string.str_8283: StringResource
+  get() = String46.str_8283
+
+@ExperimentalResourceApi
+internal val Res.string.str_8284: StringResource
+  get() = String46.str_8284
+
+@ExperimentalResourceApi
+internal val Res.string.str_8285: StringResource
+  get() = String46.str_8285
+
+@ExperimentalResourceApi
+internal val Res.string.str_8286: StringResource
+  get() = String46.str_8286
+
+@ExperimentalResourceApi
+internal val Res.string.str_8287: StringResource
+  get() = String46.str_8287
+
+@ExperimentalResourceApi
+internal val Res.string.str_8288: StringResource
+  get() = String46.str_8288
+
+@ExperimentalResourceApi
+internal val Res.string.str_8289: StringResource
+  get() = String46.str_8289
+
+@ExperimentalResourceApi
+internal val Res.string.str_829: StringResource
+  get() = String46.str_829
+
+@ExperimentalResourceApi
+internal val Res.string.str_8290: StringResource
+  get() = String46.str_8290
+
+@ExperimentalResourceApi
+internal val Res.string.str_8291: StringResource
+  get() = String46.str_8291
+
+@ExperimentalResourceApi
+internal val Res.string.str_8292: StringResource
+  get() = String46.str_8292
+
+@ExperimentalResourceApi
+internal val Res.string.str_8293: StringResource
+  get() = String46.str_8293
+
+@ExperimentalResourceApi
+internal val Res.string.str_8294: StringResource
+  get() = String46.str_8294
+
+@ExperimentalResourceApi
+internal val Res.string.str_8295: StringResource
+  get() = String46.str_8295
+
+@ExperimentalResourceApi
+internal val Res.string.str_8296: StringResource
+  get() = String46.str_8296
+
+@ExperimentalResourceApi
+internal val Res.string.str_8297: StringResource
+  get() = String46.str_8297
+
+@ExperimentalResourceApi
+internal val Res.string.str_8298: StringResource
+  get() = String46.str_8298
+
+@ExperimentalResourceApi
+internal val Res.string.str_8299: StringResource
+  get() = String46.str_8299
+
+@ExperimentalResourceApi
+internal val Res.string.str_83: StringResource
+  get() = String46.str_83
+
+@ExperimentalResourceApi
+internal val Res.string.str_830: StringResource
+  get() = String46.str_830
+
+@ExperimentalResourceApi
+internal val Res.string.str_8300: StringResource
+  get() = String46.str_8300
+
+@ExperimentalResourceApi
+internal val Res.string.str_8301: StringResource
+  get() = String46.str_8301
+
+@ExperimentalResourceApi
+internal val Res.string.str_8302: StringResource
+  get() = String46.str_8302
+
+@ExperimentalResourceApi
+internal val Res.string.str_8303: StringResource
+  get() = String46.str_8303
+
+@ExperimentalResourceApi
+internal val Res.string.str_8304: StringResource
+  get() = String46.str_8304
+
+@ExperimentalResourceApi
+internal val Res.string.str_8305: StringResource
+  get() = String46.str_8305
+
+@ExperimentalResourceApi
+internal val Res.string.str_8306: StringResource
+  get() = String46.str_8306
+
+@ExperimentalResourceApi
+internal val Res.string.str_8307: StringResource
+  get() = String46.str_8307
+
+@ExperimentalResourceApi
+internal val Res.string.str_8308: StringResource
+  get() = String46.str_8308
+
+@ExperimentalResourceApi
+internal val Res.string.str_8309: StringResource
+  get() = String46.str_8309
+
+@ExperimentalResourceApi
+internal val Res.string.str_831: StringResource
+  get() = String46.str_831
+
+@ExperimentalResourceApi
+internal val Res.string.str_8310: StringResource
+  get() = String46.str_8310
+
+@ExperimentalResourceApi
+internal val Res.string.str_8311: StringResource
+  get() = String46.str_8311
+
+@ExperimentalResourceApi
+internal val Res.string.str_8312: StringResource
+  get() = String46.str_8312
+
+@ExperimentalResourceApi
+internal val Res.string.str_8313: StringResource
+  get() = String46.str_8313
+
+@ExperimentalResourceApi
+internal val Res.string.str_8314: StringResource
+  get() = String46.str_8314
+
+@ExperimentalResourceApi
+internal val Res.string.str_8315: StringResource
+  get() = String46.str_8315
+
+@ExperimentalResourceApi
+internal val Res.string.str_8316: StringResource
+  get() = String46.str_8316
+
+@ExperimentalResourceApi
+internal val Res.string.str_8317: StringResource
+  get() = String46.str_8317
+
+@ExperimentalResourceApi
+internal val Res.string.str_8318: StringResource
+  get() = String46.str_8318
+
+@ExperimentalResourceApi
+internal val Res.string.str_8319: StringResource
+  get() = String46.str_8319
+
+@ExperimentalResourceApi
+internal val Res.string.str_832: StringResource
+  get() = String46.str_832
+
+@ExperimentalResourceApi
+internal val Res.string.str_8320: StringResource
+  get() = String46.str_8320
+
+@ExperimentalResourceApi
+internal val Res.string.str_8321: StringResource
+  get() = String46.str_8321
+
+@ExperimentalResourceApi
+internal val Res.string.str_8322: StringResource
+  get() = String46.str_8322
+
+@ExperimentalResourceApi
+internal val Res.string.str_8323: StringResource
+  get() = String46.str_8323
+
+@ExperimentalResourceApi
+internal val Res.string.str_8324: StringResource
+  get() = String46.str_8324
+
+@ExperimentalResourceApi
+internal val Res.string.str_8325: StringResource
+  get() = String46.str_8325
+
+@ExperimentalResourceApi
+internal val Res.string.str_8326: StringResource
+  get() = String46.str_8326
+
+@ExperimentalResourceApi
+internal val Res.string.str_8327: StringResource
+  get() = String46.str_8327
+
+@ExperimentalResourceApi
+internal val Res.string.str_8328: StringResource
+  get() = String46.str_8328
+
+@ExperimentalResourceApi
+internal val Res.string.str_8329: StringResource
+  get() = String46.str_8329
+
+@ExperimentalResourceApi
+internal val Res.string.str_833: StringResource
+  get() = String46.str_833
+
+@ExperimentalResourceApi
+internal val Res.string.str_8330: StringResource
+  get() = String46.str_8330
+
+@ExperimentalResourceApi
+internal val Res.string.str_8331: StringResource
+  get() = String46.str_8331
+
+@ExperimentalResourceApi
+internal val Res.string.str_8332: StringResource
+  get() = String46.str_8332
+
+@ExperimentalResourceApi
+internal val Res.string.str_8333: StringResource
+  get() = String46.str_8333
+
+@ExperimentalResourceApi
+internal val Res.string.str_8334: StringResource
+  get() = String46.str_8334
+
+@ExperimentalResourceApi
+internal val Res.string.str_8335: StringResource
+  get() = String46.str_8335
+
+@ExperimentalResourceApi
+internal val Res.string.str_8336: StringResource
+  get() = String46.str_8336
+
+@ExperimentalResourceApi
+internal val Res.string.str_8337: StringResource
+  get() = String46.str_8337
+
+@ExperimentalResourceApi
+internal val Res.string.str_8338: StringResource
+  get() = String46.str_8338
+
+@ExperimentalResourceApi
+internal val Res.string.str_8339: StringResource
+  get() = String46.str_8339
+
+@ExperimentalResourceApi
+internal val Res.string.str_834: StringResource
+  get() = String46.str_834
+
+@ExperimentalResourceApi
+internal val Res.string.str_8340: StringResource
+  get() = String46.str_8340
+
+@ExperimentalResourceApi
+internal val Res.string.str_8341: StringResource
+  get() = String46.str_8341
+
+@ExperimentalResourceApi
+internal val Res.string.str_8342: StringResource
+  get() = String46.str_8342
+
+@ExperimentalResourceApi
+internal val Res.string.str_8343: StringResource
+  get() = String46.str_8343
+
+@ExperimentalResourceApi
+internal val Res.string.str_8344: StringResource
+  get() = String46.str_8344
+
+@ExperimentalResourceApi
+internal val Res.string.str_8345: StringResource
+  get() = String46.str_8345
+
+@ExperimentalResourceApi
+internal val Res.string.str_8346: StringResource
+  get() = String46.str_8346
+
+@ExperimentalResourceApi
+internal val Res.string.str_8347: StringResource
+  get() = String46.str_8347
+
+@ExperimentalResourceApi
+internal val Res.string.str_8348: StringResource
+  get() = String46.str_8348
+
+@ExperimentalResourceApi
+internal val Res.string.str_8349: StringResource
+  get() = String46.str_8349
+
+@ExperimentalResourceApi
+internal val Res.string.str_835: StringResource
+  get() = String46.str_835
+
+@ExperimentalResourceApi
+internal val Res.string.str_8350: StringResource
+  get() = String46.str_8350
+
+@ExperimentalResourceApi
+internal val Res.string.str_8351: StringResource
+  get() = String46.str_8351
+
+@ExperimentalResourceApi
+internal val Res.string.str_8352: StringResource
+  get() = String46.str_8352
+
+@ExperimentalResourceApi
+internal val Res.string.str_8353: StringResource
+  get() = String46.str_8353
+
+@ExperimentalResourceApi
+internal val Res.string.str_8354: StringResource
+  get() = String46.str_8354
+
+@ExperimentalResourceApi
+internal val Res.string.str_8355: StringResource
+  get() = String46.str_8355
+
+@ExperimentalResourceApi
+internal val Res.string.str_8356: StringResource
+  get() = String46.str_8356
+
+@ExperimentalResourceApi
+internal val Res.string.str_8357: StringResource
+  get() = String46.str_8357
+
+@ExperimentalResourceApi
+internal val Res.string.str_8358: StringResource
+  get() = String46.str_8358
+
+@ExperimentalResourceApi
+internal val Res.string.str_8359: StringResource
+  get() = String46.str_8359
+
+@ExperimentalResourceApi
+internal val Res.string.str_836: StringResource
+  get() = String46.str_836
+
+@ExperimentalResourceApi
+internal val Res.string.str_8360: StringResource
+  get() = String46.str_8360
+
+@ExperimentalResourceApi
+internal val Res.string.str_8361: StringResource
+  get() = String46.str_8361
+
+@ExperimentalResourceApi
+internal val Res.string.str_8362: StringResource
+  get() = String46.str_8362
+
+@ExperimentalResourceApi
+internal val Res.string.str_8363: StringResource
+  get() = String46.str_8363
+
+@ExperimentalResourceApi
+internal val Res.string.str_8364: StringResource
+  get() = String46.str_8364
+
+@ExperimentalResourceApi
+internal val Res.string.str_8365: StringResource
+  get() = String46.str_8365
+
+@ExperimentalResourceApi
+internal val Res.string.str_8366: StringResource
+  get() = String46.str_8366
+
+@ExperimentalResourceApi
+internal val Res.string.str_8367: StringResource
+  get() = String46.str_8367
+
+@ExperimentalResourceApi
+internal val Res.string.str_8368: StringResource
+  get() = String46.str_8368
+
+@ExperimentalResourceApi
+internal val Res.string.str_8369: StringResource
+  get() = String46.str_8369
+
+@ExperimentalResourceApi
+internal val Res.string.str_837: StringResource
+  get() = String46.str_837
+
+@ExperimentalResourceApi
+internal val Res.string.str_8370: StringResource
+  get() = String46.str_8370
+
+@ExperimentalResourceApi
+internal val Res.string.str_8371: StringResource
+  get() = String46.str_8371
+
+@ExperimentalResourceApi
+internal val Res.string.str_8372: StringResource
+  get() = String46.str_8372
+
+@ExperimentalResourceApi
+internal val Res.string.str_8373: StringResource
+  get() = String46.str_8373
+
+@ExperimentalResourceApi
+internal val Res.string.str_8374: StringResource
+  get() = String46.str_8374
+
+@ExperimentalResourceApi
+internal val Res.string.str_8375: StringResource
+  get() = String46.str_8375
+
+@ExperimentalResourceApi
+internal val Res.string.str_8376: StringResource
+  get() = String46.str_8376
+
+@ExperimentalResourceApi
+internal val Res.string.str_8377: StringResource
+  get() = String46.str_8377
+
+@ExperimentalResourceApi
+internal val Res.string.str_8378: StringResource
+  get() = String46.str_8378
+
+@ExperimentalResourceApi
+internal val Res.string.str_8379: StringResource
+  get() = String46.str_8379
+
+@ExperimentalResourceApi
+internal val Res.string.str_838: StringResource
+  get() = String46.str_838
+
+@ExperimentalResourceApi
+internal val Res.string.str_8380: StringResource
+  get() = String46.str_8380
+
+@ExperimentalResourceApi
+internal val Res.string.str_8381: StringResource
+  get() = String46.str_8381
+
+@ExperimentalResourceApi
+internal val Res.string.str_8382: StringResource
+  get() = String46.str_8382
+
+@ExperimentalResourceApi
+internal val Res.string.str_8383: StringResource
+  get() = String46.str_8383
+
+@ExperimentalResourceApi
+internal val Res.string.str_8384: StringResource
+  get() = String46.str_8384
+
+@ExperimentalResourceApi
+internal val Res.string.str_8385: StringResource
+  get() = String46.str_8385
+
+@ExperimentalResourceApi
+internal val Res.string.str_8386: StringResource
+  get() = String46.str_8386
+
+@ExperimentalResourceApi
+internal val Res.string.str_8387: StringResource
+  get() = String46.str_8387
+
+@ExperimentalResourceApi
+internal val Res.string.str_8388: StringResource
+  get() = String46.str_8388
+
+@ExperimentalResourceApi
+internal val Res.string.str_8389: StringResource
+  get() = String46.str_8389
+
+@ExperimentalResourceApi
+internal val Res.string.str_839: StringResource
+  get() = String46.str_839
+
+@ExperimentalResourceApi
+internal val Res.string.str_8390: StringResource
+  get() = String46.str_8390
+
+@ExperimentalResourceApi
+internal val Res.string.str_8391: StringResource
+  get() = String46.str_8391
+
+@ExperimentalResourceApi
+internal val Res.string.str_8392: StringResource
+  get() = String46.str_8392
+
+@ExperimentalResourceApi
+internal val Res.string.str_8393: StringResource
+  get() = String46.str_8393
+
+@ExperimentalResourceApi
+internal val Res.string.str_8394: StringResource
+  get() = String46.str_8394
+
+@ExperimentalResourceApi
+internal val Res.string.str_8395: StringResource
+  get() = String46.str_8395
+
+@ExperimentalResourceApi
+internal val Res.string.str_8396: StringResource
+  get() = String46.str_8396
+
+@ExperimentalResourceApi
+internal val Res.string.str_8397: StringResource
+  get() = String46.str_8397
+
+@ExperimentalResourceApi
+internal val Res.string.str_8398: StringResource
+  get() = String46.str_8398
+
+@ExperimentalResourceApi
+internal val Res.string.str_8399: StringResource
+  get() = String46.str_8399
+
+@ExperimentalResourceApi
+internal val Res.string.str_84: StringResource
+  get() = String46.str_84
+
+@ExperimentalResourceApi
+internal val Res.string.str_840: StringResource
+  get() = String46.str_840
+
+@ExperimentalResourceApi
+internal val Res.string.str_8400: StringResource
+  get() = String46.str_8400
+
+@ExperimentalResourceApi
+internal val Res.string.str_8401: StringResource
+  get() = String46.str_8401
+
+@ExperimentalResourceApi
+internal val Res.string.str_8402: StringResource
+  get() = String46.str_8402
+
+@ExperimentalResourceApi
+internal val Res.string.str_8403: StringResource
+  get() = String46.str_8403
+
+@ExperimentalResourceApi
+internal val Res.string.str_8404: StringResource
+  get() = String46.str_8404
+
+@ExperimentalResourceApi
+internal val Res.string.str_8405: StringResource
+  get() = String46.str_8405
+
+@ExperimentalResourceApi
+internal val Res.string.str_8406: StringResource
+  get() = String46.str_8406
+
+@ExperimentalResourceApi
+internal val Res.string.str_8407: StringResource
+  get() = String46.str_8407
+
+@ExperimentalResourceApi
+internal val Res.string.str_8408: StringResource
+  get() = String46.str_8408
+
+@ExperimentalResourceApi
+internal val Res.string.str_8409: StringResource
+  get() = String46.str_8409
+
+@ExperimentalResourceApi
+internal val Res.string.str_841: StringResource
+  get() = String46.str_841
+
+@ExperimentalResourceApi
+internal val Res.string.str_8410: StringResource
+  get() = String46.str_8410
+
+@ExperimentalResourceApi
+internal val Res.string.str_8411: StringResource
+  get() = String46.str_8411
+
+@ExperimentalResourceApi
+internal val Res.string.str_8412: StringResource
+  get() = String46.str_8412
+
+@ExperimentalResourceApi
+internal val Res.string.str_8413: StringResource
+  get() = String46.str_8413
+
+@ExperimentalResourceApi
+internal val Res.string.str_8414: StringResource
+  get() = String46.str_8414
+
+@ExperimentalResourceApi
+internal val Res.string.str_8415: StringResource
+  get() = String46.str_8415
+
+@ExperimentalResourceApi
+internal val Res.string.str_8416: StringResource
+  get() = String46.str_8416
+
+@ExperimentalResourceApi
+internal val Res.string.str_8417: StringResource
+  get() = String46.str_8417
+
+@ExperimentalResourceApi
+internal val Res.string.str_8418: StringResource
+  get() = String46.str_8418
+
+@ExperimentalResourceApi
+internal val Res.string.str_8419: StringResource
+  get() = String46.str_8419
+
+@ExperimentalResourceApi
+internal val Res.string.str_842: StringResource
+  get() = String46.str_842
+
+@ExperimentalResourceApi
+internal val Res.string.str_8420: StringResource
+  get() = String46.str_8420
+
+@ExperimentalResourceApi
+internal val Res.string.str_8421: StringResource
+  get() = String46.str_8421
+
+@ExperimentalResourceApi
+internal val Res.string.str_8422: StringResource
+  get() = String46.str_8422
+
+@ExperimentalResourceApi
+internal val Res.string.str_8423: StringResource
+  get() = String46.str_8423
+
+@ExperimentalResourceApi
+internal val Res.string.str_8424: StringResource
+  get() = String46.str_8424
+
+@ExperimentalResourceApi
+internal val Res.string.str_8425: StringResource
+  get() = String46.str_8425
+
+@ExperimentalResourceApi
+internal val Res.string.str_8426: StringResource
+  get() = String46.str_8426
+
+@ExperimentalResourceApi
+internal val Res.string.str_8427: StringResource
+  get() = String46.str_8427
+
+@ExperimentalResourceApi
+internal val Res.string.str_8428: StringResource
+  get() = String46.str_8428
+
+@ExperimentalResourceApi
+internal val Res.string.str_8429: StringResource
+  get() = String46.str_8429
+
+@ExperimentalResourceApi
+internal val Res.string.str_843: StringResource
+  get() = String46.str_843
+
+@ExperimentalResourceApi
+internal val Res.string.str_8430: StringResource
+  get() = String46.str_8430
+
+@ExperimentalResourceApi
+internal val Res.string.str_8431: StringResource
+  get() = String46.str_8431
+
+@ExperimentalResourceApi
+internal val Res.string.str_8432: StringResource
+  get() = String46.str_8432
+
+@ExperimentalResourceApi
+internal val Res.string.str_8433: StringResource
+  get() = String46.str_8433
+
+@ExperimentalResourceApi
+internal val Res.string.str_8434: StringResource
+  get() = String46.str_8434
+
+@ExperimentalResourceApi
+internal val Res.string.str_8435: StringResource
+  get() = String46.str_8435
+
+@ExperimentalResourceApi
+internal val Res.string.str_8436: StringResource
+  get() = String46.str_8436
+
+@ExperimentalResourceApi
+internal val Res.string.str_8437: StringResource
+  get() = String46.str_8437
+
+@ExperimentalResourceApi
+internal val Res.string.str_8438: StringResource
+  get() = String46.str_8438
+
+@ExperimentalResourceApi
+internal val Res.string.str_8439: StringResource
+  get() = String46.str_8439
+
+@ExperimentalResourceApi
+internal val Res.string.str_844: StringResource
+  get() = String46.str_844
+
+@ExperimentalResourceApi
+internal val Res.string.str_8440: StringResource
+  get() = String46.str_8440
+
+@ExperimentalResourceApi
+internal val Res.string.str_8441: StringResource
+  get() = String46.str_8441
+
+@ExperimentalResourceApi
+internal val Res.string.str_8442: StringResource
+  get() = String46.str_8442
+
+@ExperimentalResourceApi
+internal val Res.string.str_8443: StringResource
+  get() = String46.str_8443
+
+@ExperimentalResourceApi
+internal val Res.string.str_8444: StringResource
+  get() = String46.str_8444
+
+@ExperimentalResourceApi
+internal val Res.string.str_8445: StringResource
+  get() = String46.str_8445
+
+@ExperimentalResourceApi
+internal val Res.string.str_8446: StringResource
+  get() = String46.str_8446
+
+@ExperimentalResourceApi
+internal val Res.string.str_8447: StringResource
+  get() = String46.str_8447
+
+@ExperimentalResourceApi
+internal val Res.string.str_8448: StringResource
+  get() = String46.str_8448
+
+@ExperimentalResourceApi
+internal val Res.string.str_8449: StringResource
+  get() = String46.str_8449
+
+@ExperimentalResourceApi
+internal val Res.string.str_845: StringResource
+  get() = String46.str_845
+
+@ExperimentalResourceApi
+internal val Res.string.str_8450: StringResource
+  get() = String46.str_8450
+
+@ExperimentalResourceApi
+internal val Res.string.str_8451: StringResource
+  get() = String46.str_8451
+
+@ExperimentalResourceApi
+internal val Res.string.str_8452: StringResource
+  get() = String46.str_8452
+
+@ExperimentalResourceApi
+internal val Res.string.str_8453: StringResource
+  get() = String46.str_8453
+
+@ExperimentalResourceApi
+internal val Res.string.str_8454: StringResource
+  get() = String46.str_8454
+
+@ExperimentalResourceApi
+internal val Res.string.str_8455: StringResource
+  get() = String46.str_8455
+
+@ExperimentalResourceApi
+internal val Res.string.str_8456: StringResource
+  get() = String46.str_8456
+
+@ExperimentalResourceApi
+internal val Res.string.str_8457: StringResource
+  get() = String46.str_8457
+
+@ExperimentalResourceApi
+internal val Res.string.str_8458: StringResource
+  get() = String46.str_8458
+
+@ExperimentalResourceApi
+internal val Res.string.str_8459: StringResource
+  get() = String46.str_8459
+
+@ExperimentalResourceApi
+internal val Res.string.str_846: StringResource
+  get() = String46.str_846
+
+@ExperimentalResourceApi
+internal val Res.string.str_8460: StringResource
+  get() = String46.str_8460
+
+@ExperimentalResourceApi
+internal val Res.string.str_8461: StringResource
+  get() = String46.str_8461
+
+@ExperimentalResourceApi
+internal val Res.string.str_8462: StringResource
+  get() = String46.str_8462
+
+@ExperimentalResourceApi
+internal val Res.string.str_8463: StringResource
+  get() = String46.str_8463
+
+@ExperimentalResourceApi
+internal val Res.string.str_8464: StringResource
+  get() = String46.str_8464
+
+@ExperimentalResourceApi
+internal val Res.string.str_8465: StringResource
+  get() = String46.str_8465
+
+@ExperimentalResourceApi
+internal val Res.string.str_8466: StringResource
+  get() = String46.str_8466
+
+@ExperimentalResourceApi
+internal val Res.string.str_8467: StringResource
+  get() = String46.str_8467
+
+@ExperimentalResourceApi
+internal val Res.string.str_8468: StringResource
+  get() = String46.str_8468
+
+@ExperimentalResourceApi
+internal val Res.string.str_8469: StringResource
+  get() = String46.str_8469
+
+@ExperimentalResourceApi
+internal val Res.string.str_847: StringResource
+  get() = String46.str_847
+
+@ExperimentalResourceApi
+internal val Res.string.str_8470: StringResource
+  get() = String46.str_8470
+
+@ExperimentalResourceApi
+internal val Res.string.str_8471: StringResource
+  get() = String46.str_8471
+
+@ExperimentalResourceApi
+internal val Res.string.str_8472: StringResource
+  get() = String46.str_8472
+
+@ExperimentalResourceApi
+internal val Res.string.str_8473: StringResource
+  get() = String46.str_8473
+
+@ExperimentalResourceApi
+internal val Res.string.str_8474: StringResource
+  get() = String46.str_8474
+
+@ExperimentalResourceApi
+internal val Res.string.str_8475: StringResource
+  get() = String46.str_8475
+
+@ExperimentalResourceApi
+internal val Res.string.str_8476: StringResource
+  get() = String46.str_8476
+
+@ExperimentalResourceApi
+internal val Res.string.str_8477: StringResource
+  get() = String46.str_8477
+
+@ExperimentalResourceApi
+internal val Res.string.str_8478: StringResource
+  get() = String46.str_8478
+
+@ExperimentalResourceApi
+internal val Res.string.str_8479: StringResource
+  get() = String46.str_8479
+
+@ExperimentalResourceApi
+internal val Res.string.str_848: StringResource
+  get() = String46.str_848
+
+@ExperimentalResourceApi
+internal val Res.string.str_8480: StringResource
+  get() = String46.str_8480
+
+@ExperimentalResourceApi
+internal val Res.string.str_8481: StringResource
+  get() = String46.str_8481
+
+@ExperimentalResourceApi
+internal val Res.string.str_8482: StringResource
+  get() = String46.str_8482
+
+@ExperimentalResourceApi
+internal val Res.string.str_8483: StringResource
+  get() = String46.str_8483
+
+@ExperimentalResourceApi
+internal val Res.string.str_8484: StringResource
+  get() = String46.str_8484
+
+@ExperimentalResourceApi
+internal val Res.string.str_8485: StringResource
+  get() = String46.str_8485
+
+@ExperimentalResourceApi
+internal val Res.string.str_8486: StringResource
+  get() = String46.str_8486
+
+@ExperimentalResourceApi
+internal val Res.string.str_8487: StringResource
+  get() = String46.str_8487
+
+@ExperimentalResourceApi
+internal val Res.string.str_8488: StringResource
+  get() = String46.str_8488
+
+@ExperimentalResourceApi
+internal val Res.string.str_8489: StringResource
+  get() = String46.str_8489
+
+@ExperimentalResourceApi
+internal val Res.string.str_849: StringResource
+  get() = String46.str_849
+
+@ExperimentalResourceApi
+internal val Res.string.str_8490: StringResource
+  get() = String46.str_8490
+
+@ExperimentalResourceApi
+internal val Res.string.str_8491: StringResource
+  get() = String46.str_8491
+
+@ExperimentalResourceApi
+internal val Res.string.str_8492: StringResource
+  get() = String46.str_8492
+
+@ExperimentalResourceApi
+internal val Res.string.str_8493: StringResource
+  get() = String46.str_8493
+
+@ExperimentalResourceApi
+internal val Res.string.str_8494: StringResource
+  get() = String46.str_8494
+
+@ExperimentalResourceApi
+internal val Res.string.str_8495: StringResource
+  get() = String46.str_8495
+
+@ExperimentalResourceApi
+internal val Res.string.str_8496: StringResource
+  get() = String46.str_8496
+
+@ExperimentalResourceApi
+internal val Res.string.str_8497: StringResource
+  get() = String46.str_8497
+
+@ExperimentalResourceApi
+internal val Res.string.str_8498: StringResource
+  get() = String46.str_8498
+
+@ExperimentalResourceApi
+internal val Res.string.str_8499: StringResource
+  get() = String46.str_8499
+
+@ExperimentalResourceApi
+internal val Res.string.str_85: StringResource
+  get() = String46.str_85
+
+@ExperimentalResourceApi
+internal val Res.string.str_850: StringResource
+  get() = String46.str_850
+
+@ExperimentalResourceApi
+internal val Res.string.str_8500: StringResource
+  get() = String46.str_8500
+
+@ExperimentalResourceApi
+internal val Res.string.str_8501: StringResource
+  get() = String46.str_8501
+
+@ExperimentalResourceApi
+internal val Res.string.str_8502: StringResource
+  get() = String46.str_8502
+
+@ExperimentalResourceApi
+internal val Res.string.str_8503: StringResource
+  get() = String46.str_8503
+
+@ExperimentalResourceApi
+internal val Res.string.str_8504: StringResource
+  get() = String46.str_8504
+
+@ExperimentalResourceApi
+internal val Res.string.str_8505: StringResource
+  get() = String46.str_8505
+
+@ExperimentalResourceApi
+internal val Res.string.str_8506: StringResource
+  get() = String46.str_8506
+
+@ExperimentalResourceApi
+internal val Res.string.str_8507: StringResource
+  get() = String46.str_8507
+
+@ExperimentalResourceApi
+internal val Res.string.str_8508: StringResource
+  get() = String46.str_8508
+
+@ExperimentalResourceApi
+internal val Res.string.str_8509: StringResource
+  get() = String46.str_8509
+
+@ExperimentalResourceApi
+internal val Res.string.str_851: StringResource
+  get() = String46.str_851
+
+@ExperimentalResourceApi
+internal val Res.string.str_8510: StringResource
+  get() = String46.str_8510
+
+@ExperimentalResourceApi
+internal val Res.string.str_8511: StringResource
+  get() = String46.str_8511
+
+@ExperimentalResourceApi
+internal val Res.string.str_8512: StringResource
+  get() = String46.str_8512
+
+@ExperimentalResourceApi
+internal val Res.string.str_8513: StringResource
+  get() = String46.str_8513
+
+@ExperimentalResourceApi
+internal val Res.string.str_8514: StringResource
+  get() = String46.str_8514
+
+@ExperimentalResourceApi
+internal val Res.string.str_8515: StringResource
+  get() = String46.str_8515
+
+@ExperimentalResourceApi
+internal val Res.string.str_8516: StringResource
+  get() = String46.str_8516
+
+@ExperimentalResourceApi
+internal val Res.string.str_8517: StringResource
+  get() = String46.str_8517
+
+@ExperimentalResourceApi
+internal val Res.string.str_8518: StringResource
+  get() = String46.str_8518
+
+@ExperimentalResourceApi
+internal val Res.string.str_8519: StringResource
+  get() = String46.str_8519
+
+@ExperimentalResourceApi
+internal val Res.string.str_852: StringResource
+  get() = String46.str_852
+
+@ExperimentalResourceApi
+internal val Res.string.str_8520: StringResource
+  get() = String46.str_8520
+
+@ExperimentalResourceApi
+internal val Res.string.str_8521: StringResource
+  get() = String46.str_8521
+
+@ExperimentalResourceApi
+internal val Res.string.str_8522: StringResource
+  get() = String46.str_8522
+
+@ExperimentalResourceApi
+internal val Res.string.str_8523: StringResource
+  get() = String46.str_8523
+
+@ExperimentalResourceApi
+internal val Res.string.str_8524: StringResource
+  get() = String46.str_8524
+
+@ExperimentalResourceApi
+internal val Res.string.str_8525: StringResource
+  get() = String46.str_8525
+
+@ExperimentalResourceApi
+internal val Res.string.str_8526: StringResource
+  get() = String46.str_8526
+
+@ExperimentalResourceApi
+internal val Res.string.str_8527: StringResource
+  get() = String46.str_8527
+
+@ExperimentalResourceApi
+internal val Res.string.str_8528: StringResource
+  get() = String46.str_8528
+
+@ExperimentalResourceApi
+internal val Res.string.str_8529: StringResource
+  get() = String46.str_8529
+
+@ExperimentalResourceApi
+internal val Res.string.str_853: StringResource
+  get() = String46.str_853
+
+@ExperimentalResourceApi
+internal val Res.string.str_8530: StringResource
+  get() = String46.str_8530
+
+@ExperimentalResourceApi
+internal val Res.string.str_8531: StringResource
+  get() = String46.str_8531
+
+@ExperimentalResourceApi
+internal val Res.string.str_8532: StringResource
+  get() = String46.str_8532
+
+@ExperimentalResourceApi
+internal val Res.string.str_8533: StringResource
+  get() = String46.str_8533
+
+@ExperimentalResourceApi
+internal val Res.string.str_8534: StringResource
+  get() = String46.str_8534
+
+@ExperimentalResourceApi
+internal val Res.string.str_8535: StringResource
+  get() = String46.str_8535
+
+@ExperimentalResourceApi
+internal val Res.string.str_8536: StringResource
+  get() = String46.str_8536
+
+@ExperimentalResourceApi
+internal val Res.string.str_8537: StringResource
+  get() = String46.str_8537
+
+@ExperimentalResourceApi
+internal val Res.string.str_8538: StringResource
+  get() = String46.str_8538
+
+@ExperimentalResourceApi
+internal val Res.string.str_8539: StringResource
+  get() = String46.str_8539
+
+@ExperimentalResourceApi
+internal val Res.string.str_854: StringResource
+  get() = String46.str_854
+
+@ExperimentalResourceApi
+internal val Res.string.str_8540: StringResource
+  get() = String46.str_8540
+
+@ExperimentalResourceApi
+internal val Res.string.str_8541: StringResource
+  get() = String46.str_8541
+
+@ExperimentalResourceApi
+internal val Res.string.str_8542: StringResource
+  get() = String46.str_8542
+
+@ExperimentalResourceApi
+internal val Res.string.str_8543: StringResource
+  get() = String46.str_8543
+
+@ExperimentalResourceApi
+internal val Res.string.str_8544: StringResource
+  get() = String46.str_8544
+
+@ExperimentalResourceApi
+internal val Res.string.str_8545: StringResource
+  get() = String46.str_8545
+
+@ExperimentalResourceApi
+internal val Res.string.str_8546: StringResource
+  get() = String46.str_8546
+
+@ExperimentalResourceApi
+internal val Res.string.str_8547: StringResource
+  get() = String46.str_8547
+
+@ExperimentalResourceApi
+internal val Res.string.str_8548: StringResource
+  get() = String46.str_8548
+
+@ExperimentalResourceApi
+internal val Res.string.str_8549: StringResource
+  get() = String46.str_8549
+
+@ExperimentalResourceApi
+internal val Res.string.str_855: StringResource
+  get() = String46.str_855
+
+@ExperimentalResourceApi
+internal val Res.string.str_8550: StringResource
+  get() = String46.str_8550
+
+@ExperimentalResourceApi
+internal val Res.string.str_8551: StringResource
+  get() = String46.str_8551
+
+@ExperimentalResourceApi
+internal val Res.string.str_8552: StringResource
+  get() = String46.str_8552
+
+@ExperimentalResourceApi
+internal val Res.string.str_8553: StringResource
+  get() = String46.str_8553
+
+@ExperimentalResourceApi
+internal val Res.string.str_8554: StringResource
+  get() = String46.str_8554
+
+@ExperimentalResourceApi
+internal val Res.string.str_8555: StringResource
+  get() = String46.str_8555
+
+@ExperimentalResourceApi
+internal val Res.string.str_8556: StringResource
+  get() = String46.str_8556
+
+@ExperimentalResourceApi
+internal val Res.string.str_8557: StringResource
+  get() = String46.str_8557
+
+@ExperimentalResourceApi
+internal val Res.string.str_8558: StringResource
+  get() = String46.str_8558
+
+@ExperimentalResourceApi
+internal val Res.string.str_8559: StringResource
+  get() = String46.str_8559
+
+@ExperimentalResourceApi
+internal val Res.string.str_856: StringResource
+  get() = String46.str_856
+
+@ExperimentalResourceApi
+internal val Res.string.str_8560: StringResource
+  get() = String46.str_8560
+
+@ExperimentalResourceApi
+internal val Res.string.str_8561: StringResource
+  get() = String46.str_8561
+
+@ExperimentalResourceApi
+internal val Res.string.str_8562: StringResource
+  get() = String46.str_8562
+
+@ExperimentalResourceApi
+internal val Res.string.str_8563: StringResource
+  get() = String46.str_8563
+
+@ExperimentalResourceApi
+internal val Res.string.str_8564: StringResource
+  get() = String46.str_8564
+
+@ExperimentalResourceApi
+internal val Res.string.str_8565: StringResource
+  get() = String46.str_8565
+
+@ExperimentalResourceApi
+internal val Res.string.str_8566: StringResource
+  get() = String46.str_8566
+
+@ExperimentalResourceApi
+internal val Res.string.str_8567: StringResource
+  get() = String46.str_8567
+
+@ExperimentalResourceApi
+internal val Res.string.str_8568: StringResource
+  get() = String46.str_8568
+
+@ExperimentalResourceApi
+internal val Res.string.str_8569: StringResource
+  get() = String46.str_8569
+
+@ExperimentalResourceApi
+internal val Res.string.str_857: StringResource
+  get() = String46.str_857
+
+@ExperimentalResourceApi
+internal val Res.string.str_8570: StringResource
+  get() = String46.str_8570
+
+@ExperimentalResourceApi
+internal val Res.string.str_8571: StringResource
+  get() = String46.str_8571
+
+@ExperimentalResourceApi
+internal val Res.string.str_8572: StringResource
+  get() = String46.str_8572
+
+@ExperimentalResourceApi
+internal val Res.string.str_8573: StringResource
+  get() = String46.str_8573
+
+@ExperimentalResourceApi
+internal val Res.string.str_8574: StringResource
+  get() = String46.str_8574
+
+@ExperimentalResourceApi
+internal val Res.string.str_8575: StringResource
+  get() = String46.str_8575
+
+@ExperimentalResourceApi
+internal val Res.string.str_8576: StringResource
+  get() = String46.str_8576
+
+@ExperimentalResourceApi
+internal val Res.string.str_8577: StringResource
+  get() = String46.str_8577
+
+@ExperimentalResourceApi
+internal val Res.string.str_8578: StringResource
+  get() = String46.str_8578
+
+@ExperimentalResourceApi
+internal val Res.string.str_8579: StringResource
+  get() = String46.str_8579
+
+@ExperimentalResourceApi
+internal val Res.string.str_858: StringResource
+  get() = String46.str_858
+
+@ExperimentalResourceApi
+internal val Res.string.str_8580: StringResource
+  get() = String46.str_8580
+
+@ExperimentalResourceApi
+internal val Res.string.str_8581: StringResource
+  get() = String46.str_8581
+
+@ExperimentalResourceApi
+internal val Res.string.str_8582: StringResource
+  get() = String46.str_8582
+
+@ExperimentalResourceApi
+internal val Res.string.str_8583: StringResource
+  get() = String46.str_8583
+
+@ExperimentalResourceApi
+internal val Res.string.str_8584: StringResource
+  get() = String46.str_8584
+
+@ExperimentalResourceApi
+internal val Res.string.str_8585: StringResource
+  get() = String46.str_8585
+
+@ExperimentalResourceApi
+internal val Res.string.str_8586: StringResource
+  get() = String46.str_8586
+
+@ExperimentalResourceApi
+internal val Res.string.str_8587: StringResource
+  get() = String46.str_8587
+
+@ExperimentalResourceApi
+internal val Res.string.str_8588: StringResource
+  get() = String46.str_8588
+
+@ExperimentalResourceApi
+internal val Res.string.str_8589: StringResource
+  get() = String46.str_8589
+
+@ExperimentalResourceApi
+internal val Res.string.str_859: StringResource
+  get() = String46.str_859
+
+@ExperimentalResourceApi
+internal val Res.string.str_8590: StringResource
+  get() = String46.str_8590
+
+@ExperimentalResourceApi
+internal val Res.string.str_8591: StringResource
+  get() = String46.str_8591
+
+@ExperimentalResourceApi
+internal val Res.string.str_8592: StringResource
+  get() = String46.str_8592
+
+@ExperimentalResourceApi
+internal val Res.string.str_8593: StringResource
+  get() = String46.str_8593
+
+@ExperimentalResourceApi
+internal val Res.string.str_8594: StringResource
+  get() = String46.str_8594
+
+@ExperimentalResourceApi
+internal val Res.string.str_8595: StringResource
+  get() = String46.str_8595
+
+@ExperimentalResourceApi
+internal val Res.string.str_8596: StringResource
+  get() = String46.str_8596
+
+@ExperimentalResourceApi
+internal val Res.string.str_8597: StringResource
+  get() = String46.str_8597
+
+@ExperimentalResourceApi
+internal val Res.string.str_8598: StringResource
+  get() = String46.str_8598
+
+@ExperimentalResourceApi
+internal val Res.string.str_8599: StringResource
+  get() = String46.str_8599
+
+@ExperimentalResourceApi
+internal val Res.string.str_86: StringResource
+  get() = String46.str_86
+
+@ExperimentalResourceApi
+internal val Res.string.str_860: StringResource
+  get() = String46.str_860
+
+@ExperimentalResourceApi
+internal val Res.string.str_8600: StringResource
+  get() = String46.str_8600
+
+@ExperimentalResourceApi
+internal val Res.string.str_8601: StringResource
+  get() = String46.str_8601
+
+@ExperimentalResourceApi
+internal val Res.string.str_8602: StringResource
+  get() = String46.str_8602
+
+@ExperimentalResourceApi
+internal val Res.string.str_8603: StringResource
+  get() = String46.str_8603
+
+@ExperimentalResourceApi
+internal val Res.string.str_8604: StringResource
+  get() = String46.str_8604
+
+@ExperimentalResourceApi
+internal val Res.string.str_8605: StringResource
+  get() = String46.str_8605
+
+@ExperimentalResourceApi
+internal val Res.string.str_8606: StringResource
+  get() = String46.str_8606
+
+@ExperimentalResourceApi
+internal val Res.string.str_8607: StringResource
+  get() = String46.str_8607
+
+@ExperimentalResourceApi
+internal val Res.string.str_8608: StringResource
+  get() = String46.str_8608
+
+@ExperimentalResourceApi
+internal val Res.string.str_8609: StringResource
+  get() = String46.str_8609
+
+@ExperimentalResourceApi
+internal val Res.string.str_861: StringResource
+  get() = String46.str_861
+
+@ExperimentalResourceApi
+internal val Res.string.str_8610: StringResource
+  get() = String46.str_8610
+
+@ExperimentalResourceApi
+internal val Res.string.str_8611: StringResource
+  get() = String46.str_8611
+
+@ExperimentalResourceApi
+internal val Res.string.str_8612: StringResource
+  get() = String46.str_8612
+
+@ExperimentalResourceApi
+internal val Res.string.str_8613: StringResource
+  get() = String46.str_8613
+
+@ExperimentalResourceApi
+internal val Res.string.str_8614: StringResource
+  get() = String46.str_8614
+
+@ExperimentalResourceApi
+internal val Res.string.str_8615: StringResource
+  get() = String46.str_8615
+
+@ExperimentalResourceApi
+internal val Res.string.str_8616: StringResource
+  get() = String46.str_8616
+
+@ExperimentalResourceApi
+internal val Res.string.str_8617: StringResource
+  get() = String46.str_8617
+
+@ExperimentalResourceApi
+internal val Res.string.str_8618: StringResource
+  get() = String46.str_8618
+
+@ExperimentalResourceApi
+internal val Res.string.str_8619: StringResource
+  get() = String46.str_8619
+
+@ExperimentalResourceApi
+internal val Res.string.str_862: StringResource
+  get() = String46.str_862
+
+@ExperimentalResourceApi
+internal val Res.string.str_8620: StringResource
+  get() = String46.str_8620
+
+@ExperimentalResourceApi
+internal val Res.string.str_8621: StringResource
+  get() = String46.str_8621
+
+@ExperimentalResourceApi
+internal val Res.string.str_8622: StringResource
+  get() = String46.str_8622
+
+@ExperimentalResourceApi
+internal val Res.string.str_8623: StringResource
+  get() = String46.str_8623
+
+@ExperimentalResourceApi
+internal val Res.string.str_8624: StringResource
+  get() = String46.str_8624
+
+@ExperimentalResourceApi
+internal val Res.string.str_8625: StringResource
+  get() = String46.str_8625
+
+@ExperimentalResourceApi
+internal val Res.string.str_8626: StringResource
+  get() = String46.str_8626
+
+@ExperimentalResourceApi
+internal val Res.string.str_8627: StringResource
+  get() = String46.str_8627
+
+@ExperimentalResourceApi
+internal val Res.string.str_8628: StringResource
+  get() = String46.str_8628
+
+@ExperimentalResourceApi
+internal val Res.string.str_8629: StringResource
+  get() = String46.str_8629
+
+@ExperimentalResourceApi
+internal val Res.string.str_863: StringResource
+  get() = String46.str_863
+
+@ExperimentalResourceApi
+internal val Res.string.str_8630: StringResource
+  get() = String46.str_8630
+
+@ExperimentalResourceApi
+internal val Res.string.str_8631: StringResource
+  get() = String46.str_8631
+
+@ExperimentalResourceApi
+internal val Res.string.str_8632: StringResource
+  get() = String46.str_8632
+
+@ExperimentalResourceApi
+internal val Res.string.str_8633: StringResource
+  get() = String46.str_8633
+
+@ExperimentalResourceApi
+internal val Res.string.str_8634: StringResource
+  get() = String46.str_8634
+
+@ExperimentalResourceApi
+internal val Res.string.str_8635: StringResource
+  get() = String46.str_8635
+
+@ExperimentalResourceApi
+internal val Res.string.str_8636: StringResource
+  get() = String46.str_8636
+
+@ExperimentalResourceApi
+internal val Res.string.str_8637: StringResource
+  get() = String46.str_8637
+
+@ExperimentalResourceApi
+internal val Res.string.str_8638: StringResource
+  get() = String46.str_8638
+
+@ExperimentalResourceApi
+internal val Res.string.str_8639: StringResource
+  get() = String46.str_8639
+
+@ExperimentalResourceApi
+internal val Res.string.str_864: StringResource
+  get() = String46.str_864
+
+@ExperimentalResourceApi
+internal val Res.string.str_8640: StringResource
+  get() = String46.str_8640
+
+@ExperimentalResourceApi
+internal val Res.string.str_8641: StringResource
+  get() = String46.str_8641
+
+@ExperimentalResourceApi
+internal val Res.string.str_8642: StringResource
+  get() = String46.str_8642
+
+@ExperimentalResourceApi
+internal val Res.string.str_8643: StringResource
+  get() = String46.str_8643
+
+@ExperimentalResourceApi
+internal val Res.string.str_8644: StringResource
+  get() = String46.str_8644
+
+@ExperimentalResourceApi
+internal val Res.string.str_8645: StringResource
+  get() = String46.str_8645
+
+@ExperimentalResourceApi
+internal val Res.string.str_8646: StringResource
+  get() = String46.str_8646
+
+@ExperimentalResourceApi
+internal val Res.string.str_8647: StringResource
+  get() = String46.str_8647
+
+@ExperimentalResourceApi
+internal val Res.string.str_8648: StringResource
+  get() = String46.str_8648

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String47.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String47.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String47 {
+  public val str_8649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8649", "str_8649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_865", "str_865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8650", "str_8650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8651", "str_8651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8652", "str_8652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8653", "str_8653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8654", "str_8654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8655", "str_8655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8656", "str_8656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8657", "str_8657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8658", "str_8658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8659", "str_8659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_866", "str_866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8660", "str_8660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8661", "str_8661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8662", "str_8662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8663", "str_8663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8664", "str_8664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8665", "str_8665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8666", "str_8666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8667", "str_8667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8668", "str_8668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8669", "str_8669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_867", "str_867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8670", "str_8670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8671", "str_8671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8672", "str_8672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8673", "str_8673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8674", "str_8674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8675", "str_8675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8676", "str_8676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8677", "str_8677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8678", "str_8678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8679", "str_8679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_868", "str_868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8680", "str_8680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8681", "str_8681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8682", "str_8682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8683", "str_8683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8684", "str_8684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8685", "str_8685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8686", "str_8686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8687", "str_8687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8688", "str_8688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8689", "str_8689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_869", "str_869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8690", "str_8690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8691", "str_8691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8692", "str_8692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8693", "str_8693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8694", "str_8694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8695", "str_8695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8696", "str_8696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8697", "str_8697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8698", "str_8698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8699", "str_8699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_87: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_87", "str_87",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_870", "str_870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8700", "str_8700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8701", "str_8701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8702", "str_8702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8703", "str_8703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8704", "str_8704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8705", "str_8705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8706", "str_8706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8707", "str_8707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8708", "str_8708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8709", "str_8709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_871", "str_871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8710", "str_8710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8711", "str_8711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8712", "str_8712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8713", "str_8713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8714", "str_8714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8715", "str_8715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8716", "str_8716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8717", "str_8717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8718", "str_8718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8719", "str_8719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_872", "str_872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8720", "str_8720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8721", "str_8721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8722", "str_8722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8723", "str_8723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8724", "str_8724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8725", "str_8725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8726", "str_8726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8727", "str_8727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8728", "str_8728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8729", "str_8729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_873", "str_873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8730", "str_8730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8731", "str_8731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8732", "str_8732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8733", "str_8733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8734", "str_8734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8735", "str_8735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8736", "str_8736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8737", "str_8737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8738", "str_8738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8739", "str_8739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_874", "str_874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8740", "str_8740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8741", "str_8741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8742", "str_8742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8743", "str_8743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8744", "str_8744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8745", "str_8745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8746", "str_8746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8747", "str_8747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8748", "str_8748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8749", "str_8749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_875", "str_875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8750", "str_8750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8751", "str_8751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8752", "str_8752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8753", "str_8753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8754", "str_8754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8755", "str_8755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8756", "str_8756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8757", "str_8757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8758", "str_8758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8759", "str_8759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_876", "str_876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8760", "str_8760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8761", "str_8761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8762", "str_8762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8763", "str_8763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8764", "str_8764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8765", "str_8765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8766", "str_8766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8767", "str_8767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8768", "str_8768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8769", "str_8769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_877", "str_877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8770", "str_8770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8771", "str_8771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8772", "str_8772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8773", "str_8773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8774", "str_8774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8775", "str_8775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8776", "str_8776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8777", "str_8777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8778", "str_8778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8779", "str_8779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_878", "str_878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8780", "str_8780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8781", "str_8781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8782", "str_8782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8783", "str_8783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8784", "str_8784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8785", "str_8785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8786", "str_8786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8787", "str_8787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8788", "str_8788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8789", "str_8789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_879", "str_879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8790", "str_8790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8791", "str_8791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8792", "str_8792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8793", "str_8793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8794", "str_8794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8795", "str_8795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8796", "str_8796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8797", "str_8797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8798", "str_8798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8799", "str_8799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_88: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_88", "str_88",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_880", "str_880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8800", "str_8800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8801", "str_8801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8802", "str_8802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8803", "str_8803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8804", "str_8804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8805", "str_8805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8806", "str_8806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8807", "str_8807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8808", "str_8808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8809", "str_8809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_881", "str_881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8810", "str_8810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8811", "str_8811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8812", "str_8812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8813", "str_8813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8814", "str_8814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8815", "str_8815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8816", "str_8816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8817", "str_8817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8818", "str_8818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8819", "str_8819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_882", "str_882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8820", "str_8820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8821", "str_8821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8822", "str_8822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8823", "str_8823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8824", "str_8824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8825", "str_8825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8826", "str_8826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8827", "str_8827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8828", "str_8828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8829", "str_8829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_883", "str_883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8830", "str_8830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8831", "str_8831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8832", "str_8832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8833", "str_8833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8834", "str_8834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8835", "str_8835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8836", "str_8836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8837", "str_8837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8838", "str_8838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8839", "str_8839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_884", "str_884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8840", "str_8840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8841", "str_8841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8842", "str_8842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8843", "str_8843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8844", "str_8844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8845", "str_8845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8846", "str_8846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8847", "str_8847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8848", "str_8848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8849", "str_8849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_885", "str_885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8850", "str_8850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8851", "str_8851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8852", "str_8852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8853", "str_8853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8854", "str_8854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8855", "str_8855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8856", "str_8856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8857", "str_8857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8858", "str_8858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8859", "str_8859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_886", "str_886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8860", "str_8860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8861", "str_8861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8862", "str_8862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8863", "str_8863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8864", "str_8864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8865", "str_8865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8866", "str_8866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8867", "str_8867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8868", "str_8868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8869", "str_8869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_887", "str_887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8870", "str_8870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8871", "str_8871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8872", "str_8872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8873", "str_8873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8874", "str_8874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8875", "str_8875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8876", "str_8876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8877", "str_8877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8878", "str_8878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8879", "str_8879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_888", "str_888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8880", "str_8880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8881", "str_8881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8882", "str_8882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8883", "str_8883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8884", "str_8884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8885", "str_8885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8886", "str_8886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8887", "str_8887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8888", "str_8888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8889", "str_8889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_889", "str_889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8890", "str_8890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8891", "str_8891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8892", "str_8892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8893", "str_8893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8894", "str_8894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8895", "str_8895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8896", "str_8896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8897", "str_8897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8898", "str_8898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8899", "str_8899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_89: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_89", "str_89",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_890", "str_890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8900", "str_8900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8901", "str_8901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8902", "str_8902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8903", "str_8903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8904", "str_8904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8905", "str_8905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8906", "str_8906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8907", "str_8907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8908", "str_8908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8909", "str_8909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_891", "str_891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8910", "str_8910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8911", "str_8911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8912", "str_8912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8913", "str_8913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8914", "str_8914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8915", "str_8915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8916", "str_8916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8917", "str_8917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8918", "str_8918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8919", "str_8919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_892", "str_892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8920", "str_8920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8921", "str_8921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8922", "str_8922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8923", "str_8923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8924", "str_8924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8925", "str_8925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8926", "str_8926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8927", "str_8927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8928", "str_8928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8929", "str_8929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_893", "str_893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8930", "str_8930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8931", "str_8931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8932", "str_8932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8933", "str_8933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8934", "str_8934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8935", "str_8935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8936", "str_8936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8937", "str_8937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8938", "str_8938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8939", "str_8939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_894", "str_894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8940", "str_8940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8941", "str_8941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8942", "str_8942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8943", "str_8943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8944", "str_8944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8945", "str_8945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8946", "str_8946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8947", "str_8947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8948", "str_8948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8949", "str_8949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_895", "str_895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8950", "str_8950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8951", "str_8951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8952", "str_8952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8953", "str_8953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8954", "str_8954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8955", "str_8955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8956", "str_8956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8957", "str_8957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8958", "str_8958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8959", "str_8959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_896", "str_896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8960", "str_8960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8961", "str_8961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8962", "str_8962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8963", "str_8963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8964", "str_8964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8965", "str_8965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8966", "str_8966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8967", "str_8967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8968", "str_8968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8969", "str_8969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_897", "str_897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8970", "str_8970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8971", "str_8971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8972", "str_8972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8973", "str_8973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8974", "str_8974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8975", "str_8975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8976", "str_8976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8977", "str_8977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8978", "str_8978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8979", "str_8979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_898", "str_898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8980", "str_8980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8981", "str_8981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8982", "str_8982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8983", "str_8983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8984", "str_8984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8985", "str_8985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8986", "str_8986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8987", "str_8987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8988", "str_8988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8989", "str_8989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_899", "str_899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8990", "str_8990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8991", "str_8991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8992", "str_8992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8993", "str_8993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8994", "str_8994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8995", "str_8995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8996", "str_8996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8997", "str_8997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8998", "str_8998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_8999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_8999", "str_8999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9", "str_9",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_90: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_90", "str_90",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_900", "str_900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9000", "str_9000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9001", "str_9001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9002", "str_9002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9003", "str_9003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9004", "str_9004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9005", "str_9005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9006", "str_9006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9007", "str_9007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9008", "str_9008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9009", "str_9009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_901", "str_901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9010", "str_9010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9011", "str_9011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9012", "str_9012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9013", "str_9013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9014", "str_9014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9015", "str_9015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9016", "str_9016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9017", "str_9017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9018", "str_9018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9019", "str_9019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_902", "str_902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9020", "str_9020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9021", "str_9021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9022", "str_9022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9023", "str_9023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9024", "str_9024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9025", "str_9025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9026", "str_9026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9027", "str_9027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9028", "str_9028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9029", "str_9029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_903", "str_903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9030", "str_9030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9031", "str_9031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9032", "str_9032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9033", "str_9033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9034", "str_9034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9035", "str_9035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9036", "str_9036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9037", "str_9037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9038", "str_9038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9039", "str_9039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_904", "str_904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9040", "str_9040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9041", "str_9041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9042", "str_9042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9043", "str_9043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9044", "str_9044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9045", "str_9045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9046", "str_9046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9047", "str_9047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9048", "str_9048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9049", "str_9049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_905", "str_905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9050", "str_9050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9051", "str_9051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9052", "str_9052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9053", "str_9053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9054", "str_9054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9055", "str_9055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9056", "str_9056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9057", "str_9057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9058", "str_9058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9059", "str_9059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_906", "str_906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9060", "str_9060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9061", "str_9061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9062", "str_9062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9063", "str_9063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9064", "str_9064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9065", "str_9065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9066", "str_9066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9067", "str_9067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9068", "str_9068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9069", "str_9069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_907", "str_907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9070", "str_9070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9071", "str_9071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9072", "str_9072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9073", "str_9073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9074", "str_9074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9075", "str_9075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9076", "str_9076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9077", "str_9077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9078", "str_9078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9079", "str_9079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_908", "str_908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9080", "str_9080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9081", "str_9081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9082", "str_9082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9083", "str_9083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9084", "str_9084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9085", "str_9085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9086", "str_9086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9087", "str_9087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9088", "str_9088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9089", "str_9089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_909", "str_909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9090", "str_9090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9091", "str_9091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9092", "str_9092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9093", "str_9093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9094", "str_9094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9095", "str_9095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9096", "str_9096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9097", "str_9097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9098", "str_9098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_8649: StringResource
+  get() = String47.str_8649
+
+@ExperimentalResourceApi
+internal val Res.string.str_865: StringResource
+  get() = String47.str_865
+
+@ExperimentalResourceApi
+internal val Res.string.str_8650: StringResource
+  get() = String47.str_8650
+
+@ExperimentalResourceApi
+internal val Res.string.str_8651: StringResource
+  get() = String47.str_8651
+
+@ExperimentalResourceApi
+internal val Res.string.str_8652: StringResource
+  get() = String47.str_8652
+
+@ExperimentalResourceApi
+internal val Res.string.str_8653: StringResource
+  get() = String47.str_8653
+
+@ExperimentalResourceApi
+internal val Res.string.str_8654: StringResource
+  get() = String47.str_8654
+
+@ExperimentalResourceApi
+internal val Res.string.str_8655: StringResource
+  get() = String47.str_8655
+
+@ExperimentalResourceApi
+internal val Res.string.str_8656: StringResource
+  get() = String47.str_8656
+
+@ExperimentalResourceApi
+internal val Res.string.str_8657: StringResource
+  get() = String47.str_8657
+
+@ExperimentalResourceApi
+internal val Res.string.str_8658: StringResource
+  get() = String47.str_8658
+
+@ExperimentalResourceApi
+internal val Res.string.str_8659: StringResource
+  get() = String47.str_8659
+
+@ExperimentalResourceApi
+internal val Res.string.str_866: StringResource
+  get() = String47.str_866
+
+@ExperimentalResourceApi
+internal val Res.string.str_8660: StringResource
+  get() = String47.str_8660
+
+@ExperimentalResourceApi
+internal val Res.string.str_8661: StringResource
+  get() = String47.str_8661
+
+@ExperimentalResourceApi
+internal val Res.string.str_8662: StringResource
+  get() = String47.str_8662
+
+@ExperimentalResourceApi
+internal val Res.string.str_8663: StringResource
+  get() = String47.str_8663
+
+@ExperimentalResourceApi
+internal val Res.string.str_8664: StringResource
+  get() = String47.str_8664
+
+@ExperimentalResourceApi
+internal val Res.string.str_8665: StringResource
+  get() = String47.str_8665
+
+@ExperimentalResourceApi
+internal val Res.string.str_8666: StringResource
+  get() = String47.str_8666
+
+@ExperimentalResourceApi
+internal val Res.string.str_8667: StringResource
+  get() = String47.str_8667
+
+@ExperimentalResourceApi
+internal val Res.string.str_8668: StringResource
+  get() = String47.str_8668
+
+@ExperimentalResourceApi
+internal val Res.string.str_8669: StringResource
+  get() = String47.str_8669
+
+@ExperimentalResourceApi
+internal val Res.string.str_867: StringResource
+  get() = String47.str_867
+
+@ExperimentalResourceApi
+internal val Res.string.str_8670: StringResource
+  get() = String47.str_8670
+
+@ExperimentalResourceApi
+internal val Res.string.str_8671: StringResource
+  get() = String47.str_8671
+
+@ExperimentalResourceApi
+internal val Res.string.str_8672: StringResource
+  get() = String47.str_8672
+
+@ExperimentalResourceApi
+internal val Res.string.str_8673: StringResource
+  get() = String47.str_8673
+
+@ExperimentalResourceApi
+internal val Res.string.str_8674: StringResource
+  get() = String47.str_8674
+
+@ExperimentalResourceApi
+internal val Res.string.str_8675: StringResource
+  get() = String47.str_8675
+
+@ExperimentalResourceApi
+internal val Res.string.str_8676: StringResource
+  get() = String47.str_8676
+
+@ExperimentalResourceApi
+internal val Res.string.str_8677: StringResource
+  get() = String47.str_8677
+
+@ExperimentalResourceApi
+internal val Res.string.str_8678: StringResource
+  get() = String47.str_8678
+
+@ExperimentalResourceApi
+internal val Res.string.str_8679: StringResource
+  get() = String47.str_8679
+
+@ExperimentalResourceApi
+internal val Res.string.str_868: StringResource
+  get() = String47.str_868
+
+@ExperimentalResourceApi
+internal val Res.string.str_8680: StringResource
+  get() = String47.str_8680
+
+@ExperimentalResourceApi
+internal val Res.string.str_8681: StringResource
+  get() = String47.str_8681
+
+@ExperimentalResourceApi
+internal val Res.string.str_8682: StringResource
+  get() = String47.str_8682
+
+@ExperimentalResourceApi
+internal val Res.string.str_8683: StringResource
+  get() = String47.str_8683
+
+@ExperimentalResourceApi
+internal val Res.string.str_8684: StringResource
+  get() = String47.str_8684
+
+@ExperimentalResourceApi
+internal val Res.string.str_8685: StringResource
+  get() = String47.str_8685
+
+@ExperimentalResourceApi
+internal val Res.string.str_8686: StringResource
+  get() = String47.str_8686
+
+@ExperimentalResourceApi
+internal val Res.string.str_8687: StringResource
+  get() = String47.str_8687
+
+@ExperimentalResourceApi
+internal val Res.string.str_8688: StringResource
+  get() = String47.str_8688
+
+@ExperimentalResourceApi
+internal val Res.string.str_8689: StringResource
+  get() = String47.str_8689
+
+@ExperimentalResourceApi
+internal val Res.string.str_869: StringResource
+  get() = String47.str_869
+
+@ExperimentalResourceApi
+internal val Res.string.str_8690: StringResource
+  get() = String47.str_8690
+
+@ExperimentalResourceApi
+internal val Res.string.str_8691: StringResource
+  get() = String47.str_8691
+
+@ExperimentalResourceApi
+internal val Res.string.str_8692: StringResource
+  get() = String47.str_8692
+
+@ExperimentalResourceApi
+internal val Res.string.str_8693: StringResource
+  get() = String47.str_8693
+
+@ExperimentalResourceApi
+internal val Res.string.str_8694: StringResource
+  get() = String47.str_8694
+
+@ExperimentalResourceApi
+internal val Res.string.str_8695: StringResource
+  get() = String47.str_8695
+
+@ExperimentalResourceApi
+internal val Res.string.str_8696: StringResource
+  get() = String47.str_8696
+
+@ExperimentalResourceApi
+internal val Res.string.str_8697: StringResource
+  get() = String47.str_8697
+
+@ExperimentalResourceApi
+internal val Res.string.str_8698: StringResource
+  get() = String47.str_8698
+
+@ExperimentalResourceApi
+internal val Res.string.str_8699: StringResource
+  get() = String47.str_8699
+
+@ExperimentalResourceApi
+internal val Res.string.str_87: StringResource
+  get() = String47.str_87
+
+@ExperimentalResourceApi
+internal val Res.string.str_870: StringResource
+  get() = String47.str_870
+
+@ExperimentalResourceApi
+internal val Res.string.str_8700: StringResource
+  get() = String47.str_8700
+
+@ExperimentalResourceApi
+internal val Res.string.str_8701: StringResource
+  get() = String47.str_8701
+
+@ExperimentalResourceApi
+internal val Res.string.str_8702: StringResource
+  get() = String47.str_8702
+
+@ExperimentalResourceApi
+internal val Res.string.str_8703: StringResource
+  get() = String47.str_8703
+
+@ExperimentalResourceApi
+internal val Res.string.str_8704: StringResource
+  get() = String47.str_8704
+
+@ExperimentalResourceApi
+internal val Res.string.str_8705: StringResource
+  get() = String47.str_8705
+
+@ExperimentalResourceApi
+internal val Res.string.str_8706: StringResource
+  get() = String47.str_8706
+
+@ExperimentalResourceApi
+internal val Res.string.str_8707: StringResource
+  get() = String47.str_8707
+
+@ExperimentalResourceApi
+internal val Res.string.str_8708: StringResource
+  get() = String47.str_8708
+
+@ExperimentalResourceApi
+internal val Res.string.str_8709: StringResource
+  get() = String47.str_8709
+
+@ExperimentalResourceApi
+internal val Res.string.str_871: StringResource
+  get() = String47.str_871
+
+@ExperimentalResourceApi
+internal val Res.string.str_8710: StringResource
+  get() = String47.str_8710
+
+@ExperimentalResourceApi
+internal val Res.string.str_8711: StringResource
+  get() = String47.str_8711
+
+@ExperimentalResourceApi
+internal val Res.string.str_8712: StringResource
+  get() = String47.str_8712
+
+@ExperimentalResourceApi
+internal val Res.string.str_8713: StringResource
+  get() = String47.str_8713
+
+@ExperimentalResourceApi
+internal val Res.string.str_8714: StringResource
+  get() = String47.str_8714
+
+@ExperimentalResourceApi
+internal val Res.string.str_8715: StringResource
+  get() = String47.str_8715
+
+@ExperimentalResourceApi
+internal val Res.string.str_8716: StringResource
+  get() = String47.str_8716
+
+@ExperimentalResourceApi
+internal val Res.string.str_8717: StringResource
+  get() = String47.str_8717
+
+@ExperimentalResourceApi
+internal val Res.string.str_8718: StringResource
+  get() = String47.str_8718
+
+@ExperimentalResourceApi
+internal val Res.string.str_8719: StringResource
+  get() = String47.str_8719
+
+@ExperimentalResourceApi
+internal val Res.string.str_872: StringResource
+  get() = String47.str_872
+
+@ExperimentalResourceApi
+internal val Res.string.str_8720: StringResource
+  get() = String47.str_8720
+
+@ExperimentalResourceApi
+internal val Res.string.str_8721: StringResource
+  get() = String47.str_8721
+
+@ExperimentalResourceApi
+internal val Res.string.str_8722: StringResource
+  get() = String47.str_8722
+
+@ExperimentalResourceApi
+internal val Res.string.str_8723: StringResource
+  get() = String47.str_8723
+
+@ExperimentalResourceApi
+internal val Res.string.str_8724: StringResource
+  get() = String47.str_8724
+
+@ExperimentalResourceApi
+internal val Res.string.str_8725: StringResource
+  get() = String47.str_8725
+
+@ExperimentalResourceApi
+internal val Res.string.str_8726: StringResource
+  get() = String47.str_8726
+
+@ExperimentalResourceApi
+internal val Res.string.str_8727: StringResource
+  get() = String47.str_8727
+
+@ExperimentalResourceApi
+internal val Res.string.str_8728: StringResource
+  get() = String47.str_8728
+
+@ExperimentalResourceApi
+internal val Res.string.str_8729: StringResource
+  get() = String47.str_8729
+
+@ExperimentalResourceApi
+internal val Res.string.str_873: StringResource
+  get() = String47.str_873
+
+@ExperimentalResourceApi
+internal val Res.string.str_8730: StringResource
+  get() = String47.str_8730
+
+@ExperimentalResourceApi
+internal val Res.string.str_8731: StringResource
+  get() = String47.str_8731
+
+@ExperimentalResourceApi
+internal val Res.string.str_8732: StringResource
+  get() = String47.str_8732
+
+@ExperimentalResourceApi
+internal val Res.string.str_8733: StringResource
+  get() = String47.str_8733
+
+@ExperimentalResourceApi
+internal val Res.string.str_8734: StringResource
+  get() = String47.str_8734
+
+@ExperimentalResourceApi
+internal val Res.string.str_8735: StringResource
+  get() = String47.str_8735
+
+@ExperimentalResourceApi
+internal val Res.string.str_8736: StringResource
+  get() = String47.str_8736
+
+@ExperimentalResourceApi
+internal val Res.string.str_8737: StringResource
+  get() = String47.str_8737
+
+@ExperimentalResourceApi
+internal val Res.string.str_8738: StringResource
+  get() = String47.str_8738
+
+@ExperimentalResourceApi
+internal val Res.string.str_8739: StringResource
+  get() = String47.str_8739
+
+@ExperimentalResourceApi
+internal val Res.string.str_874: StringResource
+  get() = String47.str_874
+
+@ExperimentalResourceApi
+internal val Res.string.str_8740: StringResource
+  get() = String47.str_8740
+
+@ExperimentalResourceApi
+internal val Res.string.str_8741: StringResource
+  get() = String47.str_8741
+
+@ExperimentalResourceApi
+internal val Res.string.str_8742: StringResource
+  get() = String47.str_8742
+
+@ExperimentalResourceApi
+internal val Res.string.str_8743: StringResource
+  get() = String47.str_8743
+
+@ExperimentalResourceApi
+internal val Res.string.str_8744: StringResource
+  get() = String47.str_8744
+
+@ExperimentalResourceApi
+internal val Res.string.str_8745: StringResource
+  get() = String47.str_8745
+
+@ExperimentalResourceApi
+internal val Res.string.str_8746: StringResource
+  get() = String47.str_8746
+
+@ExperimentalResourceApi
+internal val Res.string.str_8747: StringResource
+  get() = String47.str_8747
+
+@ExperimentalResourceApi
+internal val Res.string.str_8748: StringResource
+  get() = String47.str_8748
+
+@ExperimentalResourceApi
+internal val Res.string.str_8749: StringResource
+  get() = String47.str_8749
+
+@ExperimentalResourceApi
+internal val Res.string.str_875: StringResource
+  get() = String47.str_875
+
+@ExperimentalResourceApi
+internal val Res.string.str_8750: StringResource
+  get() = String47.str_8750
+
+@ExperimentalResourceApi
+internal val Res.string.str_8751: StringResource
+  get() = String47.str_8751
+
+@ExperimentalResourceApi
+internal val Res.string.str_8752: StringResource
+  get() = String47.str_8752
+
+@ExperimentalResourceApi
+internal val Res.string.str_8753: StringResource
+  get() = String47.str_8753
+
+@ExperimentalResourceApi
+internal val Res.string.str_8754: StringResource
+  get() = String47.str_8754
+
+@ExperimentalResourceApi
+internal val Res.string.str_8755: StringResource
+  get() = String47.str_8755
+
+@ExperimentalResourceApi
+internal val Res.string.str_8756: StringResource
+  get() = String47.str_8756
+
+@ExperimentalResourceApi
+internal val Res.string.str_8757: StringResource
+  get() = String47.str_8757
+
+@ExperimentalResourceApi
+internal val Res.string.str_8758: StringResource
+  get() = String47.str_8758
+
+@ExperimentalResourceApi
+internal val Res.string.str_8759: StringResource
+  get() = String47.str_8759
+
+@ExperimentalResourceApi
+internal val Res.string.str_876: StringResource
+  get() = String47.str_876
+
+@ExperimentalResourceApi
+internal val Res.string.str_8760: StringResource
+  get() = String47.str_8760
+
+@ExperimentalResourceApi
+internal val Res.string.str_8761: StringResource
+  get() = String47.str_8761
+
+@ExperimentalResourceApi
+internal val Res.string.str_8762: StringResource
+  get() = String47.str_8762
+
+@ExperimentalResourceApi
+internal val Res.string.str_8763: StringResource
+  get() = String47.str_8763
+
+@ExperimentalResourceApi
+internal val Res.string.str_8764: StringResource
+  get() = String47.str_8764
+
+@ExperimentalResourceApi
+internal val Res.string.str_8765: StringResource
+  get() = String47.str_8765
+
+@ExperimentalResourceApi
+internal val Res.string.str_8766: StringResource
+  get() = String47.str_8766
+
+@ExperimentalResourceApi
+internal val Res.string.str_8767: StringResource
+  get() = String47.str_8767
+
+@ExperimentalResourceApi
+internal val Res.string.str_8768: StringResource
+  get() = String47.str_8768
+
+@ExperimentalResourceApi
+internal val Res.string.str_8769: StringResource
+  get() = String47.str_8769
+
+@ExperimentalResourceApi
+internal val Res.string.str_877: StringResource
+  get() = String47.str_877
+
+@ExperimentalResourceApi
+internal val Res.string.str_8770: StringResource
+  get() = String47.str_8770
+
+@ExperimentalResourceApi
+internal val Res.string.str_8771: StringResource
+  get() = String47.str_8771
+
+@ExperimentalResourceApi
+internal val Res.string.str_8772: StringResource
+  get() = String47.str_8772
+
+@ExperimentalResourceApi
+internal val Res.string.str_8773: StringResource
+  get() = String47.str_8773
+
+@ExperimentalResourceApi
+internal val Res.string.str_8774: StringResource
+  get() = String47.str_8774
+
+@ExperimentalResourceApi
+internal val Res.string.str_8775: StringResource
+  get() = String47.str_8775
+
+@ExperimentalResourceApi
+internal val Res.string.str_8776: StringResource
+  get() = String47.str_8776
+
+@ExperimentalResourceApi
+internal val Res.string.str_8777: StringResource
+  get() = String47.str_8777
+
+@ExperimentalResourceApi
+internal val Res.string.str_8778: StringResource
+  get() = String47.str_8778
+
+@ExperimentalResourceApi
+internal val Res.string.str_8779: StringResource
+  get() = String47.str_8779
+
+@ExperimentalResourceApi
+internal val Res.string.str_878: StringResource
+  get() = String47.str_878
+
+@ExperimentalResourceApi
+internal val Res.string.str_8780: StringResource
+  get() = String47.str_8780
+
+@ExperimentalResourceApi
+internal val Res.string.str_8781: StringResource
+  get() = String47.str_8781
+
+@ExperimentalResourceApi
+internal val Res.string.str_8782: StringResource
+  get() = String47.str_8782
+
+@ExperimentalResourceApi
+internal val Res.string.str_8783: StringResource
+  get() = String47.str_8783
+
+@ExperimentalResourceApi
+internal val Res.string.str_8784: StringResource
+  get() = String47.str_8784
+
+@ExperimentalResourceApi
+internal val Res.string.str_8785: StringResource
+  get() = String47.str_8785
+
+@ExperimentalResourceApi
+internal val Res.string.str_8786: StringResource
+  get() = String47.str_8786
+
+@ExperimentalResourceApi
+internal val Res.string.str_8787: StringResource
+  get() = String47.str_8787
+
+@ExperimentalResourceApi
+internal val Res.string.str_8788: StringResource
+  get() = String47.str_8788
+
+@ExperimentalResourceApi
+internal val Res.string.str_8789: StringResource
+  get() = String47.str_8789
+
+@ExperimentalResourceApi
+internal val Res.string.str_879: StringResource
+  get() = String47.str_879
+
+@ExperimentalResourceApi
+internal val Res.string.str_8790: StringResource
+  get() = String47.str_8790
+
+@ExperimentalResourceApi
+internal val Res.string.str_8791: StringResource
+  get() = String47.str_8791
+
+@ExperimentalResourceApi
+internal val Res.string.str_8792: StringResource
+  get() = String47.str_8792
+
+@ExperimentalResourceApi
+internal val Res.string.str_8793: StringResource
+  get() = String47.str_8793
+
+@ExperimentalResourceApi
+internal val Res.string.str_8794: StringResource
+  get() = String47.str_8794
+
+@ExperimentalResourceApi
+internal val Res.string.str_8795: StringResource
+  get() = String47.str_8795
+
+@ExperimentalResourceApi
+internal val Res.string.str_8796: StringResource
+  get() = String47.str_8796
+
+@ExperimentalResourceApi
+internal val Res.string.str_8797: StringResource
+  get() = String47.str_8797
+
+@ExperimentalResourceApi
+internal val Res.string.str_8798: StringResource
+  get() = String47.str_8798
+
+@ExperimentalResourceApi
+internal val Res.string.str_8799: StringResource
+  get() = String47.str_8799
+
+@ExperimentalResourceApi
+internal val Res.string.str_88: StringResource
+  get() = String47.str_88
+
+@ExperimentalResourceApi
+internal val Res.string.str_880: StringResource
+  get() = String47.str_880
+
+@ExperimentalResourceApi
+internal val Res.string.str_8800: StringResource
+  get() = String47.str_8800
+
+@ExperimentalResourceApi
+internal val Res.string.str_8801: StringResource
+  get() = String47.str_8801
+
+@ExperimentalResourceApi
+internal val Res.string.str_8802: StringResource
+  get() = String47.str_8802
+
+@ExperimentalResourceApi
+internal val Res.string.str_8803: StringResource
+  get() = String47.str_8803
+
+@ExperimentalResourceApi
+internal val Res.string.str_8804: StringResource
+  get() = String47.str_8804
+
+@ExperimentalResourceApi
+internal val Res.string.str_8805: StringResource
+  get() = String47.str_8805
+
+@ExperimentalResourceApi
+internal val Res.string.str_8806: StringResource
+  get() = String47.str_8806
+
+@ExperimentalResourceApi
+internal val Res.string.str_8807: StringResource
+  get() = String47.str_8807
+
+@ExperimentalResourceApi
+internal val Res.string.str_8808: StringResource
+  get() = String47.str_8808
+
+@ExperimentalResourceApi
+internal val Res.string.str_8809: StringResource
+  get() = String47.str_8809
+
+@ExperimentalResourceApi
+internal val Res.string.str_881: StringResource
+  get() = String47.str_881
+
+@ExperimentalResourceApi
+internal val Res.string.str_8810: StringResource
+  get() = String47.str_8810
+
+@ExperimentalResourceApi
+internal val Res.string.str_8811: StringResource
+  get() = String47.str_8811
+
+@ExperimentalResourceApi
+internal val Res.string.str_8812: StringResource
+  get() = String47.str_8812
+
+@ExperimentalResourceApi
+internal val Res.string.str_8813: StringResource
+  get() = String47.str_8813
+
+@ExperimentalResourceApi
+internal val Res.string.str_8814: StringResource
+  get() = String47.str_8814
+
+@ExperimentalResourceApi
+internal val Res.string.str_8815: StringResource
+  get() = String47.str_8815
+
+@ExperimentalResourceApi
+internal val Res.string.str_8816: StringResource
+  get() = String47.str_8816
+
+@ExperimentalResourceApi
+internal val Res.string.str_8817: StringResource
+  get() = String47.str_8817
+
+@ExperimentalResourceApi
+internal val Res.string.str_8818: StringResource
+  get() = String47.str_8818
+
+@ExperimentalResourceApi
+internal val Res.string.str_8819: StringResource
+  get() = String47.str_8819
+
+@ExperimentalResourceApi
+internal val Res.string.str_882: StringResource
+  get() = String47.str_882
+
+@ExperimentalResourceApi
+internal val Res.string.str_8820: StringResource
+  get() = String47.str_8820
+
+@ExperimentalResourceApi
+internal val Res.string.str_8821: StringResource
+  get() = String47.str_8821
+
+@ExperimentalResourceApi
+internal val Res.string.str_8822: StringResource
+  get() = String47.str_8822
+
+@ExperimentalResourceApi
+internal val Res.string.str_8823: StringResource
+  get() = String47.str_8823
+
+@ExperimentalResourceApi
+internal val Res.string.str_8824: StringResource
+  get() = String47.str_8824
+
+@ExperimentalResourceApi
+internal val Res.string.str_8825: StringResource
+  get() = String47.str_8825
+
+@ExperimentalResourceApi
+internal val Res.string.str_8826: StringResource
+  get() = String47.str_8826
+
+@ExperimentalResourceApi
+internal val Res.string.str_8827: StringResource
+  get() = String47.str_8827
+
+@ExperimentalResourceApi
+internal val Res.string.str_8828: StringResource
+  get() = String47.str_8828
+
+@ExperimentalResourceApi
+internal val Res.string.str_8829: StringResource
+  get() = String47.str_8829
+
+@ExperimentalResourceApi
+internal val Res.string.str_883: StringResource
+  get() = String47.str_883
+
+@ExperimentalResourceApi
+internal val Res.string.str_8830: StringResource
+  get() = String47.str_8830
+
+@ExperimentalResourceApi
+internal val Res.string.str_8831: StringResource
+  get() = String47.str_8831
+
+@ExperimentalResourceApi
+internal val Res.string.str_8832: StringResource
+  get() = String47.str_8832
+
+@ExperimentalResourceApi
+internal val Res.string.str_8833: StringResource
+  get() = String47.str_8833
+
+@ExperimentalResourceApi
+internal val Res.string.str_8834: StringResource
+  get() = String47.str_8834
+
+@ExperimentalResourceApi
+internal val Res.string.str_8835: StringResource
+  get() = String47.str_8835
+
+@ExperimentalResourceApi
+internal val Res.string.str_8836: StringResource
+  get() = String47.str_8836
+
+@ExperimentalResourceApi
+internal val Res.string.str_8837: StringResource
+  get() = String47.str_8837
+
+@ExperimentalResourceApi
+internal val Res.string.str_8838: StringResource
+  get() = String47.str_8838
+
+@ExperimentalResourceApi
+internal val Res.string.str_8839: StringResource
+  get() = String47.str_8839
+
+@ExperimentalResourceApi
+internal val Res.string.str_884: StringResource
+  get() = String47.str_884
+
+@ExperimentalResourceApi
+internal val Res.string.str_8840: StringResource
+  get() = String47.str_8840
+
+@ExperimentalResourceApi
+internal val Res.string.str_8841: StringResource
+  get() = String47.str_8841
+
+@ExperimentalResourceApi
+internal val Res.string.str_8842: StringResource
+  get() = String47.str_8842
+
+@ExperimentalResourceApi
+internal val Res.string.str_8843: StringResource
+  get() = String47.str_8843
+
+@ExperimentalResourceApi
+internal val Res.string.str_8844: StringResource
+  get() = String47.str_8844
+
+@ExperimentalResourceApi
+internal val Res.string.str_8845: StringResource
+  get() = String47.str_8845
+
+@ExperimentalResourceApi
+internal val Res.string.str_8846: StringResource
+  get() = String47.str_8846
+
+@ExperimentalResourceApi
+internal val Res.string.str_8847: StringResource
+  get() = String47.str_8847
+
+@ExperimentalResourceApi
+internal val Res.string.str_8848: StringResource
+  get() = String47.str_8848
+
+@ExperimentalResourceApi
+internal val Res.string.str_8849: StringResource
+  get() = String47.str_8849
+
+@ExperimentalResourceApi
+internal val Res.string.str_885: StringResource
+  get() = String47.str_885
+
+@ExperimentalResourceApi
+internal val Res.string.str_8850: StringResource
+  get() = String47.str_8850
+
+@ExperimentalResourceApi
+internal val Res.string.str_8851: StringResource
+  get() = String47.str_8851
+
+@ExperimentalResourceApi
+internal val Res.string.str_8852: StringResource
+  get() = String47.str_8852
+
+@ExperimentalResourceApi
+internal val Res.string.str_8853: StringResource
+  get() = String47.str_8853
+
+@ExperimentalResourceApi
+internal val Res.string.str_8854: StringResource
+  get() = String47.str_8854
+
+@ExperimentalResourceApi
+internal val Res.string.str_8855: StringResource
+  get() = String47.str_8855
+
+@ExperimentalResourceApi
+internal val Res.string.str_8856: StringResource
+  get() = String47.str_8856
+
+@ExperimentalResourceApi
+internal val Res.string.str_8857: StringResource
+  get() = String47.str_8857
+
+@ExperimentalResourceApi
+internal val Res.string.str_8858: StringResource
+  get() = String47.str_8858
+
+@ExperimentalResourceApi
+internal val Res.string.str_8859: StringResource
+  get() = String47.str_8859
+
+@ExperimentalResourceApi
+internal val Res.string.str_886: StringResource
+  get() = String47.str_886
+
+@ExperimentalResourceApi
+internal val Res.string.str_8860: StringResource
+  get() = String47.str_8860
+
+@ExperimentalResourceApi
+internal val Res.string.str_8861: StringResource
+  get() = String47.str_8861
+
+@ExperimentalResourceApi
+internal val Res.string.str_8862: StringResource
+  get() = String47.str_8862
+
+@ExperimentalResourceApi
+internal val Res.string.str_8863: StringResource
+  get() = String47.str_8863
+
+@ExperimentalResourceApi
+internal val Res.string.str_8864: StringResource
+  get() = String47.str_8864
+
+@ExperimentalResourceApi
+internal val Res.string.str_8865: StringResource
+  get() = String47.str_8865
+
+@ExperimentalResourceApi
+internal val Res.string.str_8866: StringResource
+  get() = String47.str_8866
+
+@ExperimentalResourceApi
+internal val Res.string.str_8867: StringResource
+  get() = String47.str_8867
+
+@ExperimentalResourceApi
+internal val Res.string.str_8868: StringResource
+  get() = String47.str_8868
+
+@ExperimentalResourceApi
+internal val Res.string.str_8869: StringResource
+  get() = String47.str_8869
+
+@ExperimentalResourceApi
+internal val Res.string.str_887: StringResource
+  get() = String47.str_887
+
+@ExperimentalResourceApi
+internal val Res.string.str_8870: StringResource
+  get() = String47.str_8870
+
+@ExperimentalResourceApi
+internal val Res.string.str_8871: StringResource
+  get() = String47.str_8871
+
+@ExperimentalResourceApi
+internal val Res.string.str_8872: StringResource
+  get() = String47.str_8872
+
+@ExperimentalResourceApi
+internal val Res.string.str_8873: StringResource
+  get() = String47.str_8873
+
+@ExperimentalResourceApi
+internal val Res.string.str_8874: StringResource
+  get() = String47.str_8874
+
+@ExperimentalResourceApi
+internal val Res.string.str_8875: StringResource
+  get() = String47.str_8875
+
+@ExperimentalResourceApi
+internal val Res.string.str_8876: StringResource
+  get() = String47.str_8876
+
+@ExperimentalResourceApi
+internal val Res.string.str_8877: StringResource
+  get() = String47.str_8877
+
+@ExperimentalResourceApi
+internal val Res.string.str_8878: StringResource
+  get() = String47.str_8878
+
+@ExperimentalResourceApi
+internal val Res.string.str_8879: StringResource
+  get() = String47.str_8879
+
+@ExperimentalResourceApi
+internal val Res.string.str_888: StringResource
+  get() = String47.str_888
+
+@ExperimentalResourceApi
+internal val Res.string.str_8880: StringResource
+  get() = String47.str_8880
+
+@ExperimentalResourceApi
+internal val Res.string.str_8881: StringResource
+  get() = String47.str_8881
+
+@ExperimentalResourceApi
+internal val Res.string.str_8882: StringResource
+  get() = String47.str_8882
+
+@ExperimentalResourceApi
+internal val Res.string.str_8883: StringResource
+  get() = String47.str_8883
+
+@ExperimentalResourceApi
+internal val Res.string.str_8884: StringResource
+  get() = String47.str_8884
+
+@ExperimentalResourceApi
+internal val Res.string.str_8885: StringResource
+  get() = String47.str_8885
+
+@ExperimentalResourceApi
+internal val Res.string.str_8886: StringResource
+  get() = String47.str_8886
+
+@ExperimentalResourceApi
+internal val Res.string.str_8887: StringResource
+  get() = String47.str_8887
+
+@ExperimentalResourceApi
+internal val Res.string.str_8888: StringResource
+  get() = String47.str_8888
+
+@ExperimentalResourceApi
+internal val Res.string.str_8889: StringResource
+  get() = String47.str_8889
+
+@ExperimentalResourceApi
+internal val Res.string.str_889: StringResource
+  get() = String47.str_889
+
+@ExperimentalResourceApi
+internal val Res.string.str_8890: StringResource
+  get() = String47.str_8890
+
+@ExperimentalResourceApi
+internal val Res.string.str_8891: StringResource
+  get() = String47.str_8891
+
+@ExperimentalResourceApi
+internal val Res.string.str_8892: StringResource
+  get() = String47.str_8892
+
+@ExperimentalResourceApi
+internal val Res.string.str_8893: StringResource
+  get() = String47.str_8893
+
+@ExperimentalResourceApi
+internal val Res.string.str_8894: StringResource
+  get() = String47.str_8894
+
+@ExperimentalResourceApi
+internal val Res.string.str_8895: StringResource
+  get() = String47.str_8895
+
+@ExperimentalResourceApi
+internal val Res.string.str_8896: StringResource
+  get() = String47.str_8896
+
+@ExperimentalResourceApi
+internal val Res.string.str_8897: StringResource
+  get() = String47.str_8897
+
+@ExperimentalResourceApi
+internal val Res.string.str_8898: StringResource
+  get() = String47.str_8898
+
+@ExperimentalResourceApi
+internal val Res.string.str_8899: StringResource
+  get() = String47.str_8899
+
+@ExperimentalResourceApi
+internal val Res.string.str_89: StringResource
+  get() = String47.str_89
+
+@ExperimentalResourceApi
+internal val Res.string.str_890: StringResource
+  get() = String47.str_890
+
+@ExperimentalResourceApi
+internal val Res.string.str_8900: StringResource
+  get() = String47.str_8900
+
+@ExperimentalResourceApi
+internal val Res.string.str_8901: StringResource
+  get() = String47.str_8901
+
+@ExperimentalResourceApi
+internal val Res.string.str_8902: StringResource
+  get() = String47.str_8902
+
+@ExperimentalResourceApi
+internal val Res.string.str_8903: StringResource
+  get() = String47.str_8903
+
+@ExperimentalResourceApi
+internal val Res.string.str_8904: StringResource
+  get() = String47.str_8904
+
+@ExperimentalResourceApi
+internal val Res.string.str_8905: StringResource
+  get() = String47.str_8905
+
+@ExperimentalResourceApi
+internal val Res.string.str_8906: StringResource
+  get() = String47.str_8906
+
+@ExperimentalResourceApi
+internal val Res.string.str_8907: StringResource
+  get() = String47.str_8907
+
+@ExperimentalResourceApi
+internal val Res.string.str_8908: StringResource
+  get() = String47.str_8908
+
+@ExperimentalResourceApi
+internal val Res.string.str_8909: StringResource
+  get() = String47.str_8909
+
+@ExperimentalResourceApi
+internal val Res.string.str_891: StringResource
+  get() = String47.str_891
+
+@ExperimentalResourceApi
+internal val Res.string.str_8910: StringResource
+  get() = String47.str_8910
+
+@ExperimentalResourceApi
+internal val Res.string.str_8911: StringResource
+  get() = String47.str_8911
+
+@ExperimentalResourceApi
+internal val Res.string.str_8912: StringResource
+  get() = String47.str_8912
+
+@ExperimentalResourceApi
+internal val Res.string.str_8913: StringResource
+  get() = String47.str_8913
+
+@ExperimentalResourceApi
+internal val Res.string.str_8914: StringResource
+  get() = String47.str_8914
+
+@ExperimentalResourceApi
+internal val Res.string.str_8915: StringResource
+  get() = String47.str_8915
+
+@ExperimentalResourceApi
+internal val Res.string.str_8916: StringResource
+  get() = String47.str_8916
+
+@ExperimentalResourceApi
+internal val Res.string.str_8917: StringResource
+  get() = String47.str_8917
+
+@ExperimentalResourceApi
+internal val Res.string.str_8918: StringResource
+  get() = String47.str_8918
+
+@ExperimentalResourceApi
+internal val Res.string.str_8919: StringResource
+  get() = String47.str_8919
+
+@ExperimentalResourceApi
+internal val Res.string.str_892: StringResource
+  get() = String47.str_892
+
+@ExperimentalResourceApi
+internal val Res.string.str_8920: StringResource
+  get() = String47.str_8920
+
+@ExperimentalResourceApi
+internal val Res.string.str_8921: StringResource
+  get() = String47.str_8921
+
+@ExperimentalResourceApi
+internal val Res.string.str_8922: StringResource
+  get() = String47.str_8922
+
+@ExperimentalResourceApi
+internal val Res.string.str_8923: StringResource
+  get() = String47.str_8923
+
+@ExperimentalResourceApi
+internal val Res.string.str_8924: StringResource
+  get() = String47.str_8924
+
+@ExperimentalResourceApi
+internal val Res.string.str_8925: StringResource
+  get() = String47.str_8925
+
+@ExperimentalResourceApi
+internal val Res.string.str_8926: StringResource
+  get() = String47.str_8926
+
+@ExperimentalResourceApi
+internal val Res.string.str_8927: StringResource
+  get() = String47.str_8927
+
+@ExperimentalResourceApi
+internal val Res.string.str_8928: StringResource
+  get() = String47.str_8928
+
+@ExperimentalResourceApi
+internal val Res.string.str_8929: StringResource
+  get() = String47.str_8929
+
+@ExperimentalResourceApi
+internal val Res.string.str_893: StringResource
+  get() = String47.str_893
+
+@ExperimentalResourceApi
+internal val Res.string.str_8930: StringResource
+  get() = String47.str_8930
+
+@ExperimentalResourceApi
+internal val Res.string.str_8931: StringResource
+  get() = String47.str_8931
+
+@ExperimentalResourceApi
+internal val Res.string.str_8932: StringResource
+  get() = String47.str_8932
+
+@ExperimentalResourceApi
+internal val Res.string.str_8933: StringResource
+  get() = String47.str_8933
+
+@ExperimentalResourceApi
+internal val Res.string.str_8934: StringResource
+  get() = String47.str_8934
+
+@ExperimentalResourceApi
+internal val Res.string.str_8935: StringResource
+  get() = String47.str_8935
+
+@ExperimentalResourceApi
+internal val Res.string.str_8936: StringResource
+  get() = String47.str_8936
+
+@ExperimentalResourceApi
+internal val Res.string.str_8937: StringResource
+  get() = String47.str_8937
+
+@ExperimentalResourceApi
+internal val Res.string.str_8938: StringResource
+  get() = String47.str_8938
+
+@ExperimentalResourceApi
+internal val Res.string.str_8939: StringResource
+  get() = String47.str_8939
+
+@ExperimentalResourceApi
+internal val Res.string.str_894: StringResource
+  get() = String47.str_894
+
+@ExperimentalResourceApi
+internal val Res.string.str_8940: StringResource
+  get() = String47.str_8940
+
+@ExperimentalResourceApi
+internal val Res.string.str_8941: StringResource
+  get() = String47.str_8941
+
+@ExperimentalResourceApi
+internal val Res.string.str_8942: StringResource
+  get() = String47.str_8942
+
+@ExperimentalResourceApi
+internal val Res.string.str_8943: StringResource
+  get() = String47.str_8943
+
+@ExperimentalResourceApi
+internal val Res.string.str_8944: StringResource
+  get() = String47.str_8944
+
+@ExperimentalResourceApi
+internal val Res.string.str_8945: StringResource
+  get() = String47.str_8945
+
+@ExperimentalResourceApi
+internal val Res.string.str_8946: StringResource
+  get() = String47.str_8946
+
+@ExperimentalResourceApi
+internal val Res.string.str_8947: StringResource
+  get() = String47.str_8947
+
+@ExperimentalResourceApi
+internal val Res.string.str_8948: StringResource
+  get() = String47.str_8948
+
+@ExperimentalResourceApi
+internal val Res.string.str_8949: StringResource
+  get() = String47.str_8949
+
+@ExperimentalResourceApi
+internal val Res.string.str_895: StringResource
+  get() = String47.str_895
+
+@ExperimentalResourceApi
+internal val Res.string.str_8950: StringResource
+  get() = String47.str_8950
+
+@ExperimentalResourceApi
+internal val Res.string.str_8951: StringResource
+  get() = String47.str_8951
+
+@ExperimentalResourceApi
+internal val Res.string.str_8952: StringResource
+  get() = String47.str_8952
+
+@ExperimentalResourceApi
+internal val Res.string.str_8953: StringResource
+  get() = String47.str_8953
+
+@ExperimentalResourceApi
+internal val Res.string.str_8954: StringResource
+  get() = String47.str_8954
+
+@ExperimentalResourceApi
+internal val Res.string.str_8955: StringResource
+  get() = String47.str_8955
+
+@ExperimentalResourceApi
+internal val Res.string.str_8956: StringResource
+  get() = String47.str_8956
+
+@ExperimentalResourceApi
+internal val Res.string.str_8957: StringResource
+  get() = String47.str_8957
+
+@ExperimentalResourceApi
+internal val Res.string.str_8958: StringResource
+  get() = String47.str_8958
+
+@ExperimentalResourceApi
+internal val Res.string.str_8959: StringResource
+  get() = String47.str_8959
+
+@ExperimentalResourceApi
+internal val Res.string.str_896: StringResource
+  get() = String47.str_896
+
+@ExperimentalResourceApi
+internal val Res.string.str_8960: StringResource
+  get() = String47.str_8960
+
+@ExperimentalResourceApi
+internal val Res.string.str_8961: StringResource
+  get() = String47.str_8961
+
+@ExperimentalResourceApi
+internal val Res.string.str_8962: StringResource
+  get() = String47.str_8962
+
+@ExperimentalResourceApi
+internal val Res.string.str_8963: StringResource
+  get() = String47.str_8963
+
+@ExperimentalResourceApi
+internal val Res.string.str_8964: StringResource
+  get() = String47.str_8964
+
+@ExperimentalResourceApi
+internal val Res.string.str_8965: StringResource
+  get() = String47.str_8965
+
+@ExperimentalResourceApi
+internal val Res.string.str_8966: StringResource
+  get() = String47.str_8966
+
+@ExperimentalResourceApi
+internal val Res.string.str_8967: StringResource
+  get() = String47.str_8967
+
+@ExperimentalResourceApi
+internal val Res.string.str_8968: StringResource
+  get() = String47.str_8968
+
+@ExperimentalResourceApi
+internal val Res.string.str_8969: StringResource
+  get() = String47.str_8969
+
+@ExperimentalResourceApi
+internal val Res.string.str_897: StringResource
+  get() = String47.str_897
+
+@ExperimentalResourceApi
+internal val Res.string.str_8970: StringResource
+  get() = String47.str_8970
+
+@ExperimentalResourceApi
+internal val Res.string.str_8971: StringResource
+  get() = String47.str_8971
+
+@ExperimentalResourceApi
+internal val Res.string.str_8972: StringResource
+  get() = String47.str_8972
+
+@ExperimentalResourceApi
+internal val Res.string.str_8973: StringResource
+  get() = String47.str_8973
+
+@ExperimentalResourceApi
+internal val Res.string.str_8974: StringResource
+  get() = String47.str_8974
+
+@ExperimentalResourceApi
+internal val Res.string.str_8975: StringResource
+  get() = String47.str_8975
+
+@ExperimentalResourceApi
+internal val Res.string.str_8976: StringResource
+  get() = String47.str_8976
+
+@ExperimentalResourceApi
+internal val Res.string.str_8977: StringResource
+  get() = String47.str_8977
+
+@ExperimentalResourceApi
+internal val Res.string.str_8978: StringResource
+  get() = String47.str_8978
+
+@ExperimentalResourceApi
+internal val Res.string.str_8979: StringResource
+  get() = String47.str_8979
+
+@ExperimentalResourceApi
+internal val Res.string.str_898: StringResource
+  get() = String47.str_898
+
+@ExperimentalResourceApi
+internal val Res.string.str_8980: StringResource
+  get() = String47.str_8980
+
+@ExperimentalResourceApi
+internal val Res.string.str_8981: StringResource
+  get() = String47.str_8981
+
+@ExperimentalResourceApi
+internal val Res.string.str_8982: StringResource
+  get() = String47.str_8982
+
+@ExperimentalResourceApi
+internal val Res.string.str_8983: StringResource
+  get() = String47.str_8983
+
+@ExperimentalResourceApi
+internal val Res.string.str_8984: StringResource
+  get() = String47.str_8984
+
+@ExperimentalResourceApi
+internal val Res.string.str_8985: StringResource
+  get() = String47.str_8985
+
+@ExperimentalResourceApi
+internal val Res.string.str_8986: StringResource
+  get() = String47.str_8986
+
+@ExperimentalResourceApi
+internal val Res.string.str_8987: StringResource
+  get() = String47.str_8987
+
+@ExperimentalResourceApi
+internal val Res.string.str_8988: StringResource
+  get() = String47.str_8988
+
+@ExperimentalResourceApi
+internal val Res.string.str_8989: StringResource
+  get() = String47.str_8989
+
+@ExperimentalResourceApi
+internal val Res.string.str_899: StringResource
+  get() = String47.str_899
+
+@ExperimentalResourceApi
+internal val Res.string.str_8990: StringResource
+  get() = String47.str_8990
+
+@ExperimentalResourceApi
+internal val Res.string.str_8991: StringResource
+  get() = String47.str_8991
+
+@ExperimentalResourceApi
+internal val Res.string.str_8992: StringResource
+  get() = String47.str_8992
+
+@ExperimentalResourceApi
+internal val Res.string.str_8993: StringResource
+  get() = String47.str_8993
+
+@ExperimentalResourceApi
+internal val Res.string.str_8994: StringResource
+  get() = String47.str_8994
+
+@ExperimentalResourceApi
+internal val Res.string.str_8995: StringResource
+  get() = String47.str_8995
+
+@ExperimentalResourceApi
+internal val Res.string.str_8996: StringResource
+  get() = String47.str_8996
+
+@ExperimentalResourceApi
+internal val Res.string.str_8997: StringResource
+  get() = String47.str_8997
+
+@ExperimentalResourceApi
+internal val Res.string.str_8998: StringResource
+  get() = String47.str_8998
+
+@ExperimentalResourceApi
+internal val Res.string.str_8999: StringResource
+  get() = String47.str_8999
+
+@ExperimentalResourceApi
+internal val Res.string.str_9: StringResource
+  get() = String47.str_9
+
+@ExperimentalResourceApi
+internal val Res.string.str_90: StringResource
+  get() = String47.str_90
+
+@ExperimentalResourceApi
+internal val Res.string.str_900: StringResource
+  get() = String47.str_900
+
+@ExperimentalResourceApi
+internal val Res.string.str_9000: StringResource
+  get() = String47.str_9000
+
+@ExperimentalResourceApi
+internal val Res.string.str_9001: StringResource
+  get() = String47.str_9001
+
+@ExperimentalResourceApi
+internal val Res.string.str_9002: StringResource
+  get() = String47.str_9002
+
+@ExperimentalResourceApi
+internal val Res.string.str_9003: StringResource
+  get() = String47.str_9003
+
+@ExperimentalResourceApi
+internal val Res.string.str_9004: StringResource
+  get() = String47.str_9004
+
+@ExperimentalResourceApi
+internal val Res.string.str_9005: StringResource
+  get() = String47.str_9005
+
+@ExperimentalResourceApi
+internal val Res.string.str_9006: StringResource
+  get() = String47.str_9006
+
+@ExperimentalResourceApi
+internal val Res.string.str_9007: StringResource
+  get() = String47.str_9007
+
+@ExperimentalResourceApi
+internal val Res.string.str_9008: StringResource
+  get() = String47.str_9008
+
+@ExperimentalResourceApi
+internal val Res.string.str_9009: StringResource
+  get() = String47.str_9009
+
+@ExperimentalResourceApi
+internal val Res.string.str_901: StringResource
+  get() = String47.str_901
+
+@ExperimentalResourceApi
+internal val Res.string.str_9010: StringResource
+  get() = String47.str_9010
+
+@ExperimentalResourceApi
+internal val Res.string.str_9011: StringResource
+  get() = String47.str_9011
+
+@ExperimentalResourceApi
+internal val Res.string.str_9012: StringResource
+  get() = String47.str_9012
+
+@ExperimentalResourceApi
+internal val Res.string.str_9013: StringResource
+  get() = String47.str_9013
+
+@ExperimentalResourceApi
+internal val Res.string.str_9014: StringResource
+  get() = String47.str_9014
+
+@ExperimentalResourceApi
+internal val Res.string.str_9015: StringResource
+  get() = String47.str_9015
+
+@ExperimentalResourceApi
+internal val Res.string.str_9016: StringResource
+  get() = String47.str_9016
+
+@ExperimentalResourceApi
+internal val Res.string.str_9017: StringResource
+  get() = String47.str_9017
+
+@ExperimentalResourceApi
+internal val Res.string.str_9018: StringResource
+  get() = String47.str_9018
+
+@ExperimentalResourceApi
+internal val Res.string.str_9019: StringResource
+  get() = String47.str_9019
+
+@ExperimentalResourceApi
+internal val Res.string.str_902: StringResource
+  get() = String47.str_902
+
+@ExperimentalResourceApi
+internal val Res.string.str_9020: StringResource
+  get() = String47.str_9020
+
+@ExperimentalResourceApi
+internal val Res.string.str_9021: StringResource
+  get() = String47.str_9021
+
+@ExperimentalResourceApi
+internal val Res.string.str_9022: StringResource
+  get() = String47.str_9022
+
+@ExperimentalResourceApi
+internal val Res.string.str_9023: StringResource
+  get() = String47.str_9023
+
+@ExperimentalResourceApi
+internal val Res.string.str_9024: StringResource
+  get() = String47.str_9024
+
+@ExperimentalResourceApi
+internal val Res.string.str_9025: StringResource
+  get() = String47.str_9025
+
+@ExperimentalResourceApi
+internal val Res.string.str_9026: StringResource
+  get() = String47.str_9026
+
+@ExperimentalResourceApi
+internal val Res.string.str_9027: StringResource
+  get() = String47.str_9027
+
+@ExperimentalResourceApi
+internal val Res.string.str_9028: StringResource
+  get() = String47.str_9028
+
+@ExperimentalResourceApi
+internal val Res.string.str_9029: StringResource
+  get() = String47.str_9029
+
+@ExperimentalResourceApi
+internal val Res.string.str_903: StringResource
+  get() = String47.str_903
+
+@ExperimentalResourceApi
+internal val Res.string.str_9030: StringResource
+  get() = String47.str_9030
+
+@ExperimentalResourceApi
+internal val Res.string.str_9031: StringResource
+  get() = String47.str_9031
+
+@ExperimentalResourceApi
+internal val Res.string.str_9032: StringResource
+  get() = String47.str_9032
+
+@ExperimentalResourceApi
+internal val Res.string.str_9033: StringResource
+  get() = String47.str_9033
+
+@ExperimentalResourceApi
+internal val Res.string.str_9034: StringResource
+  get() = String47.str_9034
+
+@ExperimentalResourceApi
+internal val Res.string.str_9035: StringResource
+  get() = String47.str_9035
+
+@ExperimentalResourceApi
+internal val Res.string.str_9036: StringResource
+  get() = String47.str_9036
+
+@ExperimentalResourceApi
+internal val Res.string.str_9037: StringResource
+  get() = String47.str_9037
+
+@ExperimentalResourceApi
+internal val Res.string.str_9038: StringResource
+  get() = String47.str_9038
+
+@ExperimentalResourceApi
+internal val Res.string.str_9039: StringResource
+  get() = String47.str_9039
+
+@ExperimentalResourceApi
+internal val Res.string.str_904: StringResource
+  get() = String47.str_904
+
+@ExperimentalResourceApi
+internal val Res.string.str_9040: StringResource
+  get() = String47.str_9040
+
+@ExperimentalResourceApi
+internal val Res.string.str_9041: StringResource
+  get() = String47.str_9041
+
+@ExperimentalResourceApi
+internal val Res.string.str_9042: StringResource
+  get() = String47.str_9042
+
+@ExperimentalResourceApi
+internal val Res.string.str_9043: StringResource
+  get() = String47.str_9043
+
+@ExperimentalResourceApi
+internal val Res.string.str_9044: StringResource
+  get() = String47.str_9044
+
+@ExperimentalResourceApi
+internal val Res.string.str_9045: StringResource
+  get() = String47.str_9045
+
+@ExperimentalResourceApi
+internal val Res.string.str_9046: StringResource
+  get() = String47.str_9046
+
+@ExperimentalResourceApi
+internal val Res.string.str_9047: StringResource
+  get() = String47.str_9047
+
+@ExperimentalResourceApi
+internal val Res.string.str_9048: StringResource
+  get() = String47.str_9048
+
+@ExperimentalResourceApi
+internal val Res.string.str_9049: StringResource
+  get() = String47.str_9049
+
+@ExperimentalResourceApi
+internal val Res.string.str_905: StringResource
+  get() = String47.str_905
+
+@ExperimentalResourceApi
+internal val Res.string.str_9050: StringResource
+  get() = String47.str_9050
+
+@ExperimentalResourceApi
+internal val Res.string.str_9051: StringResource
+  get() = String47.str_9051
+
+@ExperimentalResourceApi
+internal val Res.string.str_9052: StringResource
+  get() = String47.str_9052
+
+@ExperimentalResourceApi
+internal val Res.string.str_9053: StringResource
+  get() = String47.str_9053
+
+@ExperimentalResourceApi
+internal val Res.string.str_9054: StringResource
+  get() = String47.str_9054
+
+@ExperimentalResourceApi
+internal val Res.string.str_9055: StringResource
+  get() = String47.str_9055
+
+@ExperimentalResourceApi
+internal val Res.string.str_9056: StringResource
+  get() = String47.str_9056
+
+@ExperimentalResourceApi
+internal val Res.string.str_9057: StringResource
+  get() = String47.str_9057
+
+@ExperimentalResourceApi
+internal val Res.string.str_9058: StringResource
+  get() = String47.str_9058
+
+@ExperimentalResourceApi
+internal val Res.string.str_9059: StringResource
+  get() = String47.str_9059
+
+@ExperimentalResourceApi
+internal val Res.string.str_906: StringResource
+  get() = String47.str_906
+
+@ExperimentalResourceApi
+internal val Res.string.str_9060: StringResource
+  get() = String47.str_9060
+
+@ExperimentalResourceApi
+internal val Res.string.str_9061: StringResource
+  get() = String47.str_9061
+
+@ExperimentalResourceApi
+internal val Res.string.str_9062: StringResource
+  get() = String47.str_9062
+
+@ExperimentalResourceApi
+internal val Res.string.str_9063: StringResource
+  get() = String47.str_9063
+
+@ExperimentalResourceApi
+internal val Res.string.str_9064: StringResource
+  get() = String47.str_9064
+
+@ExperimentalResourceApi
+internal val Res.string.str_9065: StringResource
+  get() = String47.str_9065
+
+@ExperimentalResourceApi
+internal val Res.string.str_9066: StringResource
+  get() = String47.str_9066
+
+@ExperimentalResourceApi
+internal val Res.string.str_9067: StringResource
+  get() = String47.str_9067
+
+@ExperimentalResourceApi
+internal val Res.string.str_9068: StringResource
+  get() = String47.str_9068
+
+@ExperimentalResourceApi
+internal val Res.string.str_9069: StringResource
+  get() = String47.str_9069
+
+@ExperimentalResourceApi
+internal val Res.string.str_907: StringResource
+  get() = String47.str_907
+
+@ExperimentalResourceApi
+internal val Res.string.str_9070: StringResource
+  get() = String47.str_9070
+
+@ExperimentalResourceApi
+internal val Res.string.str_9071: StringResource
+  get() = String47.str_9071
+
+@ExperimentalResourceApi
+internal val Res.string.str_9072: StringResource
+  get() = String47.str_9072
+
+@ExperimentalResourceApi
+internal val Res.string.str_9073: StringResource
+  get() = String47.str_9073
+
+@ExperimentalResourceApi
+internal val Res.string.str_9074: StringResource
+  get() = String47.str_9074
+
+@ExperimentalResourceApi
+internal val Res.string.str_9075: StringResource
+  get() = String47.str_9075
+
+@ExperimentalResourceApi
+internal val Res.string.str_9076: StringResource
+  get() = String47.str_9076
+
+@ExperimentalResourceApi
+internal val Res.string.str_9077: StringResource
+  get() = String47.str_9077
+
+@ExperimentalResourceApi
+internal val Res.string.str_9078: StringResource
+  get() = String47.str_9078
+
+@ExperimentalResourceApi
+internal val Res.string.str_9079: StringResource
+  get() = String47.str_9079
+
+@ExperimentalResourceApi
+internal val Res.string.str_908: StringResource
+  get() = String47.str_908
+
+@ExperimentalResourceApi
+internal val Res.string.str_9080: StringResource
+  get() = String47.str_9080
+
+@ExperimentalResourceApi
+internal val Res.string.str_9081: StringResource
+  get() = String47.str_9081
+
+@ExperimentalResourceApi
+internal val Res.string.str_9082: StringResource
+  get() = String47.str_9082
+
+@ExperimentalResourceApi
+internal val Res.string.str_9083: StringResource
+  get() = String47.str_9083
+
+@ExperimentalResourceApi
+internal val Res.string.str_9084: StringResource
+  get() = String47.str_9084
+
+@ExperimentalResourceApi
+internal val Res.string.str_9085: StringResource
+  get() = String47.str_9085
+
+@ExperimentalResourceApi
+internal val Res.string.str_9086: StringResource
+  get() = String47.str_9086
+
+@ExperimentalResourceApi
+internal val Res.string.str_9087: StringResource
+  get() = String47.str_9087
+
+@ExperimentalResourceApi
+internal val Res.string.str_9088: StringResource
+  get() = String47.str_9088
+
+@ExperimentalResourceApi
+internal val Res.string.str_9089: StringResource
+  get() = String47.str_9089
+
+@ExperimentalResourceApi
+internal val Res.string.str_909: StringResource
+  get() = String47.str_909
+
+@ExperimentalResourceApi
+internal val Res.string.str_9090: StringResource
+  get() = String47.str_9090
+
+@ExperimentalResourceApi
+internal val Res.string.str_9091: StringResource
+  get() = String47.str_9091
+
+@ExperimentalResourceApi
+internal val Res.string.str_9092: StringResource
+  get() = String47.str_9092
+
+@ExperimentalResourceApi
+internal val Res.string.str_9093: StringResource
+  get() = String47.str_9093
+
+@ExperimentalResourceApi
+internal val Res.string.str_9094: StringResource
+  get() = String47.str_9094
+
+@ExperimentalResourceApi
+internal val Res.string.str_9095: StringResource
+  get() = String47.str_9095
+
+@ExperimentalResourceApi
+internal val Res.string.str_9096: StringResource
+  get() = String47.str_9096
+
+@ExperimentalResourceApi
+internal val Res.string.str_9097: StringResource
+  get() = String47.str_9097
+
+@ExperimentalResourceApi
+internal val Res.string.str_9098: StringResource
+  get() = String47.str_9098

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String48.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String48.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String48 {
+  public val str_9099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9099", "str_9099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_91: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_91", "str_91",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_910", "str_910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9100", "str_9100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9101", "str_9101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9102", "str_9102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9103", "str_9103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9104", "str_9104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9105", "str_9105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9106", "str_9106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9107", "str_9107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9108", "str_9108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9109", "str_9109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_911", "str_911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9110", "str_9110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9111", "str_9111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9112", "str_9112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9113", "str_9113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9114", "str_9114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9115", "str_9115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9116", "str_9116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9117", "str_9117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9118", "str_9118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9119", "str_9119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_912", "str_912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9120", "str_9120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9121", "str_9121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9122", "str_9122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9123", "str_9123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9124", "str_9124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9125", "str_9125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9126", "str_9126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9127", "str_9127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9128", "str_9128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9129", "str_9129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_913", "str_913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9130", "str_9130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9131", "str_9131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9132", "str_9132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9133", "str_9133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9134", "str_9134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9135", "str_9135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9136", "str_9136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9137", "str_9137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9138", "str_9138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9139", "str_9139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_914", "str_914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9140", "str_9140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9141", "str_9141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9142", "str_9142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9143", "str_9143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9144", "str_9144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9145", "str_9145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9146", "str_9146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9147", "str_9147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9148", "str_9148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9149", "str_9149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_915", "str_915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9150", "str_9150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9151", "str_9151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9152", "str_9152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9153", "str_9153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9154", "str_9154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9155", "str_9155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9156", "str_9156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9157", "str_9157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9158", "str_9158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9159", "str_9159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_916", "str_916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9160", "str_9160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9161", "str_9161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9162", "str_9162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9163", "str_9163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9164", "str_9164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9165", "str_9165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9166", "str_9166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9167", "str_9167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9168", "str_9168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9169", "str_9169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_917", "str_917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9170", "str_9170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9171", "str_9171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9172", "str_9172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9173", "str_9173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9174", "str_9174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9175", "str_9175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9176", "str_9176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9177", "str_9177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9178", "str_9178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9179", "str_9179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_918", "str_918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9180", "str_9180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9181", "str_9181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9182", "str_9182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9183", "str_9183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9184", "str_9184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9185", "str_9185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9186", "str_9186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9187", "str_9187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9188", "str_9188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9189", "str_9189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_919", "str_919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9190", "str_9190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9191", "str_9191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9192", "str_9192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9193", "str_9193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9194", "str_9194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9195", "str_9195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9196", "str_9196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9197", "str_9197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9198", "str_9198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9199", "str_9199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_92: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_92", "str_92",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_920", "str_920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9200", "str_9200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9201", "str_9201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9202", "str_9202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9203", "str_9203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9204", "str_9204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9205", "str_9205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9206", "str_9206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9207", "str_9207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9208", "str_9208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9209", "str_9209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_921", "str_921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9210", "str_9210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9211", "str_9211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9212", "str_9212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9213", "str_9213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9214", "str_9214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9215", "str_9215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9216", "str_9216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9217", "str_9217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9218", "str_9218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9219", "str_9219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_922", "str_922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9220", "str_9220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9221", "str_9221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9222", "str_9222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9223", "str_9223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9224", "str_9224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9225", "str_9225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9226", "str_9226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9227", "str_9227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9228", "str_9228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9229", "str_9229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_923", "str_923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9230", "str_9230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9231", "str_9231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9232", "str_9232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9233", "str_9233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9234", "str_9234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9235", "str_9235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9236", "str_9236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9237", "str_9237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9238", "str_9238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9239", "str_9239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_924", "str_924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9240", "str_9240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9241", "str_9241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9242", "str_9242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9243", "str_9243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9244", "str_9244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9245", "str_9245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9246", "str_9246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9247", "str_9247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9248", "str_9248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9249", "str_9249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_925", "str_925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9250", "str_9250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9251", "str_9251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9252", "str_9252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9253", "str_9253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9254", "str_9254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9255", "str_9255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9256", "str_9256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9257", "str_9257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9258", "str_9258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9259", "str_9259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_926", "str_926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9260", "str_9260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9261", "str_9261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9262", "str_9262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9263", "str_9263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9264", "str_9264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9265", "str_9265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9266", "str_9266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9267", "str_9267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9268", "str_9268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9269", "str_9269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_927", "str_927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9270", "str_9270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9271", "str_9271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9272", "str_9272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9273", "str_9273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9274", "str_9274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9275", "str_9275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9276", "str_9276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9277", "str_9277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9278", "str_9278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9279", "str_9279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_928", "str_928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9280", "str_9280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9281", "str_9281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9282", "str_9282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9283", "str_9283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9284", "str_9284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9285", "str_9285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9286", "str_9286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9287", "str_9287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9288", "str_9288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9289", "str_9289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_929", "str_929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9290", "str_9290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9291", "str_9291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9292", "str_9292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9293", "str_9293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9294", "str_9294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9295", "str_9295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9296", "str_9296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9297", "str_9297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9298", "str_9298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9299", "str_9299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_93: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_93", "str_93",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_930", "str_930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9300", "str_9300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9301", "str_9301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9302", "str_9302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9303", "str_9303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9304", "str_9304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9305", "str_9305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9306", "str_9306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9307", "str_9307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9308", "str_9308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9309", "str_9309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_931", "str_931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9310", "str_9310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9311", "str_9311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9312", "str_9312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9313", "str_9313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9314", "str_9314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9315", "str_9315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9316", "str_9316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9317", "str_9317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9318", "str_9318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9319", "str_9319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_932", "str_932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9320", "str_9320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9321", "str_9321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9322", "str_9322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9323", "str_9323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9324", "str_9324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9325", "str_9325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9326", "str_9326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9327", "str_9327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9328", "str_9328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9329", "str_9329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_933", "str_933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9330", "str_9330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9331", "str_9331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9332", "str_9332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9333", "str_9333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9334", "str_9334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9335", "str_9335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9336", "str_9336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9337", "str_9337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9338", "str_9338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9339", "str_9339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_934", "str_934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9340", "str_9340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9341", "str_9341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9342", "str_9342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9343", "str_9343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9344", "str_9344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9345", "str_9345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9346", "str_9346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9347", "str_9347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9348", "str_9348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9349", "str_9349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_935", "str_935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9350", "str_9350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9351", "str_9351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9352", "str_9352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9353", "str_9353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9354", "str_9354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9355", "str_9355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9356", "str_9356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9357", "str_9357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9358", "str_9358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9359", "str_9359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_936", "str_936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9360", "str_9360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9361", "str_9361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9362", "str_9362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9363", "str_9363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9364", "str_9364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9365", "str_9365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9366", "str_9366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9367", "str_9367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9368", "str_9368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9369", "str_9369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_937", "str_937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9370", "str_9370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9371", "str_9371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9372", "str_9372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9373", "str_9373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9374", "str_9374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9375", "str_9375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9376", "str_9376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9377", "str_9377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9378", "str_9378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9379", "str_9379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_938", "str_938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9380", "str_9380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9381", "str_9381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9382", "str_9382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9383", "str_9383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9384", "str_9384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9385", "str_9385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9386", "str_9386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9387", "str_9387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9388", "str_9388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9389", "str_9389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_939", "str_939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9390", "str_9390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9391", "str_9391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9392", "str_9392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9393", "str_9393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9394", "str_9394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9395", "str_9395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9396", "str_9396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9397", "str_9397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9398", "str_9398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9399", "str_9399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_94: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_94", "str_94",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_940", "str_940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9400", "str_9400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9401", "str_9401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9402", "str_9402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9403", "str_9403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9404", "str_9404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9405", "str_9405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9406", "str_9406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9407", "str_9407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9408", "str_9408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9409", "str_9409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_941", "str_941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9410", "str_9410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9411", "str_9411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9412", "str_9412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9413", "str_9413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9414", "str_9414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9415", "str_9415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9416", "str_9416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9417", "str_9417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9418", "str_9418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9419", "str_9419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_942", "str_942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9420", "str_9420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9421", "str_9421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9422", "str_9422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9423", "str_9423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9424", "str_9424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9425", "str_9425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9426", "str_9426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9427", "str_9427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9428", "str_9428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9429", "str_9429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_943", "str_943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9430", "str_9430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9431", "str_9431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9432", "str_9432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9433", "str_9433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9434", "str_9434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9435", "str_9435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9436", "str_9436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9437", "str_9437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9438", "str_9438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9439", "str_9439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_944", "str_944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9440", "str_9440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9441", "str_9441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9442", "str_9442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9443", "str_9443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9444", "str_9444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9445", "str_9445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9446", "str_9446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9447", "str_9447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9448", "str_9448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9449", "str_9449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_945", "str_945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9450", "str_9450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9451", "str_9451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9452", "str_9452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9453", "str_9453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9454", "str_9454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9455", "str_9455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9456", "str_9456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9457", "str_9457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9458", "str_9458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9459", "str_9459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_946", "str_946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9460", "str_9460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9461", "str_9461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9462", "str_9462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9463", "str_9463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9464", "str_9464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9465", "str_9465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9466", "str_9466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9467", "str_9467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9468", "str_9468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9469", "str_9469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_947", "str_947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9470", "str_9470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9471", "str_9471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9472", "str_9472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9473", "str_9473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9474", "str_9474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9475", "str_9475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9476", "str_9476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9477", "str_9477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9478", "str_9478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9479", "str_9479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_948", "str_948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9480", "str_9480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9481", "str_9481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9482", "str_9482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9483", "str_9483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9484", "str_9484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9485", "str_9485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9486", "str_9486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9487", "str_9487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9488", "str_9488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9489", "str_9489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_949", "str_949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9490", "str_9490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9491", "str_9491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9492", "str_9492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9493", "str_9493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9494", "str_9494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9495", "str_9495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9496", "str_9496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9497", "str_9497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9498", "str_9498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9499", "str_9499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_95: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_95", "str_95",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_950", "str_950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9500", "str_9500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9501", "str_9501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9502", "str_9502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9503", "str_9503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9504", "str_9504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9505", "str_9505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9506", "str_9506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9507", "str_9507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9508", "str_9508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9509", "str_9509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_951", "str_951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9510", "str_9510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9511", "str_9511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9512", "str_9512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9513", "str_9513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9514", "str_9514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9515", "str_9515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9516", "str_9516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9517", "str_9517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9518", "str_9518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9519", "str_9519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_952", "str_952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9520", "str_9520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9521", "str_9521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9522", "str_9522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9523", "str_9523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9524", "str_9524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9525", "str_9525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9526", "str_9526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9527", "str_9527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9528", "str_9528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9529", "str_9529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_953", "str_953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9530", "str_9530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9531", "str_9531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9532", "str_9532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9533", "str_9533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9534", "str_9534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9535", "str_9535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9536", "str_9536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9537", "str_9537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9538", "str_9538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9539", "str_9539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_954", "str_954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9540", "str_9540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9541", "str_9541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9542", "str_9542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9543", "str_9543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9544", "str_9544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9545", "str_9545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9546", "str_9546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9547", "str_9547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9548", "str_9548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_9099: StringResource
+  get() = String48.str_9099
+
+@ExperimentalResourceApi
+internal val Res.string.str_91: StringResource
+  get() = String48.str_91
+
+@ExperimentalResourceApi
+internal val Res.string.str_910: StringResource
+  get() = String48.str_910
+
+@ExperimentalResourceApi
+internal val Res.string.str_9100: StringResource
+  get() = String48.str_9100
+
+@ExperimentalResourceApi
+internal val Res.string.str_9101: StringResource
+  get() = String48.str_9101
+
+@ExperimentalResourceApi
+internal val Res.string.str_9102: StringResource
+  get() = String48.str_9102
+
+@ExperimentalResourceApi
+internal val Res.string.str_9103: StringResource
+  get() = String48.str_9103
+
+@ExperimentalResourceApi
+internal val Res.string.str_9104: StringResource
+  get() = String48.str_9104
+
+@ExperimentalResourceApi
+internal val Res.string.str_9105: StringResource
+  get() = String48.str_9105
+
+@ExperimentalResourceApi
+internal val Res.string.str_9106: StringResource
+  get() = String48.str_9106
+
+@ExperimentalResourceApi
+internal val Res.string.str_9107: StringResource
+  get() = String48.str_9107
+
+@ExperimentalResourceApi
+internal val Res.string.str_9108: StringResource
+  get() = String48.str_9108
+
+@ExperimentalResourceApi
+internal val Res.string.str_9109: StringResource
+  get() = String48.str_9109
+
+@ExperimentalResourceApi
+internal val Res.string.str_911: StringResource
+  get() = String48.str_911
+
+@ExperimentalResourceApi
+internal val Res.string.str_9110: StringResource
+  get() = String48.str_9110
+
+@ExperimentalResourceApi
+internal val Res.string.str_9111: StringResource
+  get() = String48.str_9111
+
+@ExperimentalResourceApi
+internal val Res.string.str_9112: StringResource
+  get() = String48.str_9112
+
+@ExperimentalResourceApi
+internal val Res.string.str_9113: StringResource
+  get() = String48.str_9113
+
+@ExperimentalResourceApi
+internal val Res.string.str_9114: StringResource
+  get() = String48.str_9114
+
+@ExperimentalResourceApi
+internal val Res.string.str_9115: StringResource
+  get() = String48.str_9115
+
+@ExperimentalResourceApi
+internal val Res.string.str_9116: StringResource
+  get() = String48.str_9116
+
+@ExperimentalResourceApi
+internal val Res.string.str_9117: StringResource
+  get() = String48.str_9117
+
+@ExperimentalResourceApi
+internal val Res.string.str_9118: StringResource
+  get() = String48.str_9118
+
+@ExperimentalResourceApi
+internal val Res.string.str_9119: StringResource
+  get() = String48.str_9119
+
+@ExperimentalResourceApi
+internal val Res.string.str_912: StringResource
+  get() = String48.str_912
+
+@ExperimentalResourceApi
+internal val Res.string.str_9120: StringResource
+  get() = String48.str_9120
+
+@ExperimentalResourceApi
+internal val Res.string.str_9121: StringResource
+  get() = String48.str_9121
+
+@ExperimentalResourceApi
+internal val Res.string.str_9122: StringResource
+  get() = String48.str_9122
+
+@ExperimentalResourceApi
+internal val Res.string.str_9123: StringResource
+  get() = String48.str_9123
+
+@ExperimentalResourceApi
+internal val Res.string.str_9124: StringResource
+  get() = String48.str_9124
+
+@ExperimentalResourceApi
+internal val Res.string.str_9125: StringResource
+  get() = String48.str_9125
+
+@ExperimentalResourceApi
+internal val Res.string.str_9126: StringResource
+  get() = String48.str_9126
+
+@ExperimentalResourceApi
+internal val Res.string.str_9127: StringResource
+  get() = String48.str_9127
+
+@ExperimentalResourceApi
+internal val Res.string.str_9128: StringResource
+  get() = String48.str_9128
+
+@ExperimentalResourceApi
+internal val Res.string.str_9129: StringResource
+  get() = String48.str_9129
+
+@ExperimentalResourceApi
+internal val Res.string.str_913: StringResource
+  get() = String48.str_913
+
+@ExperimentalResourceApi
+internal val Res.string.str_9130: StringResource
+  get() = String48.str_9130
+
+@ExperimentalResourceApi
+internal val Res.string.str_9131: StringResource
+  get() = String48.str_9131
+
+@ExperimentalResourceApi
+internal val Res.string.str_9132: StringResource
+  get() = String48.str_9132
+
+@ExperimentalResourceApi
+internal val Res.string.str_9133: StringResource
+  get() = String48.str_9133
+
+@ExperimentalResourceApi
+internal val Res.string.str_9134: StringResource
+  get() = String48.str_9134
+
+@ExperimentalResourceApi
+internal val Res.string.str_9135: StringResource
+  get() = String48.str_9135
+
+@ExperimentalResourceApi
+internal val Res.string.str_9136: StringResource
+  get() = String48.str_9136
+
+@ExperimentalResourceApi
+internal val Res.string.str_9137: StringResource
+  get() = String48.str_9137
+
+@ExperimentalResourceApi
+internal val Res.string.str_9138: StringResource
+  get() = String48.str_9138
+
+@ExperimentalResourceApi
+internal val Res.string.str_9139: StringResource
+  get() = String48.str_9139
+
+@ExperimentalResourceApi
+internal val Res.string.str_914: StringResource
+  get() = String48.str_914
+
+@ExperimentalResourceApi
+internal val Res.string.str_9140: StringResource
+  get() = String48.str_9140
+
+@ExperimentalResourceApi
+internal val Res.string.str_9141: StringResource
+  get() = String48.str_9141
+
+@ExperimentalResourceApi
+internal val Res.string.str_9142: StringResource
+  get() = String48.str_9142
+
+@ExperimentalResourceApi
+internal val Res.string.str_9143: StringResource
+  get() = String48.str_9143
+
+@ExperimentalResourceApi
+internal val Res.string.str_9144: StringResource
+  get() = String48.str_9144
+
+@ExperimentalResourceApi
+internal val Res.string.str_9145: StringResource
+  get() = String48.str_9145
+
+@ExperimentalResourceApi
+internal val Res.string.str_9146: StringResource
+  get() = String48.str_9146
+
+@ExperimentalResourceApi
+internal val Res.string.str_9147: StringResource
+  get() = String48.str_9147
+
+@ExperimentalResourceApi
+internal val Res.string.str_9148: StringResource
+  get() = String48.str_9148
+
+@ExperimentalResourceApi
+internal val Res.string.str_9149: StringResource
+  get() = String48.str_9149
+
+@ExperimentalResourceApi
+internal val Res.string.str_915: StringResource
+  get() = String48.str_915
+
+@ExperimentalResourceApi
+internal val Res.string.str_9150: StringResource
+  get() = String48.str_9150
+
+@ExperimentalResourceApi
+internal val Res.string.str_9151: StringResource
+  get() = String48.str_9151
+
+@ExperimentalResourceApi
+internal val Res.string.str_9152: StringResource
+  get() = String48.str_9152
+
+@ExperimentalResourceApi
+internal val Res.string.str_9153: StringResource
+  get() = String48.str_9153
+
+@ExperimentalResourceApi
+internal val Res.string.str_9154: StringResource
+  get() = String48.str_9154
+
+@ExperimentalResourceApi
+internal val Res.string.str_9155: StringResource
+  get() = String48.str_9155
+
+@ExperimentalResourceApi
+internal val Res.string.str_9156: StringResource
+  get() = String48.str_9156
+
+@ExperimentalResourceApi
+internal val Res.string.str_9157: StringResource
+  get() = String48.str_9157
+
+@ExperimentalResourceApi
+internal val Res.string.str_9158: StringResource
+  get() = String48.str_9158
+
+@ExperimentalResourceApi
+internal val Res.string.str_9159: StringResource
+  get() = String48.str_9159
+
+@ExperimentalResourceApi
+internal val Res.string.str_916: StringResource
+  get() = String48.str_916
+
+@ExperimentalResourceApi
+internal val Res.string.str_9160: StringResource
+  get() = String48.str_9160
+
+@ExperimentalResourceApi
+internal val Res.string.str_9161: StringResource
+  get() = String48.str_9161
+
+@ExperimentalResourceApi
+internal val Res.string.str_9162: StringResource
+  get() = String48.str_9162
+
+@ExperimentalResourceApi
+internal val Res.string.str_9163: StringResource
+  get() = String48.str_9163
+
+@ExperimentalResourceApi
+internal val Res.string.str_9164: StringResource
+  get() = String48.str_9164
+
+@ExperimentalResourceApi
+internal val Res.string.str_9165: StringResource
+  get() = String48.str_9165
+
+@ExperimentalResourceApi
+internal val Res.string.str_9166: StringResource
+  get() = String48.str_9166
+
+@ExperimentalResourceApi
+internal val Res.string.str_9167: StringResource
+  get() = String48.str_9167
+
+@ExperimentalResourceApi
+internal val Res.string.str_9168: StringResource
+  get() = String48.str_9168
+
+@ExperimentalResourceApi
+internal val Res.string.str_9169: StringResource
+  get() = String48.str_9169
+
+@ExperimentalResourceApi
+internal val Res.string.str_917: StringResource
+  get() = String48.str_917
+
+@ExperimentalResourceApi
+internal val Res.string.str_9170: StringResource
+  get() = String48.str_9170
+
+@ExperimentalResourceApi
+internal val Res.string.str_9171: StringResource
+  get() = String48.str_9171
+
+@ExperimentalResourceApi
+internal val Res.string.str_9172: StringResource
+  get() = String48.str_9172
+
+@ExperimentalResourceApi
+internal val Res.string.str_9173: StringResource
+  get() = String48.str_9173
+
+@ExperimentalResourceApi
+internal val Res.string.str_9174: StringResource
+  get() = String48.str_9174
+
+@ExperimentalResourceApi
+internal val Res.string.str_9175: StringResource
+  get() = String48.str_9175
+
+@ExperimentalResourceApi
+internal val Res.string.str_9176: StringResource
+  get() = String48.str_9176
+
+@ExperimentalResourceApi
+internal val Res.string.str_9177: StringResource
+  get() = String48.str_9177
+
+@ExperimentalResourceApi
+internal val Res.string.str_9178: StringResource
+  get() = String48.str_9178
+
+@ExperimentalResourceApi
+internal val Res.string.str_9179: StringResource
+  get() = String48.str_9179
+
+@ExperimentalResourceApi
+internal val Res.string.str_918: StringResource
+  get() = String48.str_918
+
+@ExperimentalResourceApi
+internal val Res.string.str_9180: StringResource
+  get() = String48.str_9180
+
+@ExperimentalResourceApi
+internal val Res.string.str_9181: StringResource
+  get() = String48.str_9181
+
+@ExperimentalResourceApi
+internal val Res.string.str_9182: StringResource
+  get() = String48.str_9182
+
+@ExperimentalResourceApi
+internal val Res.string.str_9183: StringResource
+  get() = String48.str_9183
+
+@ExperimentalResourceApi
+internal val Res.string.str_9184: StringResource
+  get() = String48.str_9184
+
+@ExperimentalResourceApi
+internal val Res.string.str_9185: StringResource
+  get() = String48.str_9185
+
+@ExperimentalResourceApi
+internal val Res.string.str_9186: StringResource
+  get() = String48.str_9186
+
+@ExperimentalResourceApi
+internal val Res.string.str_9187: StringResource
+  get() = String48.str_9187
+
+@ExperimentalResourceApi
+internal val Res.string.str_9188: StringResource
+  get() = String48.str_9188
+
+@ExperimentalResourceApi
+internal val Res.string.str_9189: StringResource
+  get() = String48.str_9189
+
+@ExperimentalResourceApi
+internal val Res.string.str_919: StringResource
+  get() = String48.str_919
+
+@ExperimentalResourceApi
+internal val Res.string.str_9190: StringResource
+  get() = String48.str_9190
+
+@ExperimentalResourceApi
+internal val Res.string.str_9191: StringResource
+  get() = String48.str_9191
+
+@ExperimentalResourceApi
+internal val Res.string.str_9192: StringResource
+  get() = String48.str_9192
+
+@ExperimentalResourceApi
+internal val Res.string.str_9193: StringResource
+  get() = String48.str_9193
+
+@ExperimentalResourceApi
+internal val Res.string.str_9194: StringResource
+  get() = String48.str_9194
+
+@ExperimentalResourceApi
+internal val Res.string.str_9195: StringResource
+  get() = String48.str_9195
+
+@ExperimentalResourceApi
+internal val Res.string.str_9196: StringResource
+  get() = String48.str_9196
+
+@ExperimentalResourceApi
+internal val Res.string.str_9197: StringResource
+  get() = String48.str_9197
+
+@ExperimentalResourceApi
+internal val Res.string.str_9198: StringResource
+  get() = String48.str_9198
+
+@ExperimentalResourceApi
+internal val Res.string.str_9199: StringResource
+  get() = String48.str_9199
+
+@ExperimentalResourceApi
+internal val Res.string.str_92: StringResource
+  get() = String48.str_92
+
+@ExperimentalResourceApi
+internal val Res.string.str_920: StringResource
+  get() = String48.str_920
+
+@ExperimentalResourceApi
+internal val Res.string.str_9200: StringResource
+  get() = String48.str_9200
+
+@ExperimentalResourceApi
+internal val Res.string.str_9201: StringResource
+  get() = String48.str_9201
+
+@ExperimentalResourceApi
+internal val Res.string.str_9202: StringResource
+  get() = String48.str_9202
+
+@ExperimentalResourceApi
+internal val Res.string.str_9203: StringResource
+  get() = String48.str_9203
+
+@ExperimentalResourceApi
+internal val Res.string.str_9204: StringResource
+  get() = String48.str_9204
+
+@ExperimentalResourceApi
+internal val Res.string.str_9205: StringResource
+  get() = String48.str_9205
+
+@ExperimentalResourceApi
+internal val Res.string.str_9206: StringResource
+  get() = String48.str_9206
+
+@ExperimentalResourceApi
+internal val Res.string.str_9207: StringResource
+  get() = String48.str_9207
+
+@ExperimentalResourceApi
+internal val Res.string.str_9208: StringResource
+  get() = String48.str_9208
+
+@ExperimentalResourceApi
+internal val Res.string.str_9209: StringResource
+  get() = String48.str_9209
+
+@ExperimentalResourceApi
+internal val Res.string.str_921: StringResource
+  get() = String48.str_921
+
+@ExperimentalResourceApi
+internal val Res.string.str_9210: StringResource
+  get() = String48.str_9210
+
+@ExperimentalResourceApi
+internal val Res.string.str_9211: StringResource
+  get() = String48.str_9211
+
+@ExperimentalResourceApi
+internal val Res.string.str_9212: StringResource
+  get() = String48.str_9212
+
+@ExperimentalResourceApi
+internal val Res.string.str_9213: StringResource
+  get() = String48.str_9213
+
+@ExperimentalResourceApi
+internal val Res.string.str_9214: StringResource
+  get() = String48.str_9214
+
+@ExperimentalResourceApi
+internal val Res.string.str_9215: StringResource
+  get() = String48.str_9215
+
+@ExperimentalResourceApi
+internal val Res.string.str_9216: StringResource
+  get() = String48.str_9216
+
+@ExperimentalResourceApi
+internal val Res.string.str_9217: StringResource
+  get() = String48.str_9217
+
+@ExperimentalResourceApi
+internal val Res.string.str_9218: StringResource
+  get() = String48.str_9218
+
+@ExperimentalResourceApi
+internal val Res.string.str_9219: StringResource
+  get() = String48.str_9219
+
+@ExperimentalResourceApi
+internal val Res.string.str_922: StringResource
+  get() = String48.str_922
+
+@ExperimentalResourceApi
+internal val Res.string.str_9220: StringResource
+  get() = String48.str_9220
+
+@ExperimentalResourceApi
+internal val Res.string.str_9221: StringResource
+  get() = String48.str_9221
+
+@ExperimentalResourceApi
+internal val Res.string.str_9222: StringResource
+  get() = String48.str_9222
+
+@ExperimentalResourceApi
+internal val Res.string.str_9223: StringResource
+  get() = String48.str_9223
+
+@ExperimentalResourceApi
+internal val Res.string.str_9224: StringResource
+  get() = String48.str_9224
+
+@ExperimentalResourceApi
+internal val Res.string.str_9225: StringResource
+  get() = String48.str_9225
+
+@ExperimentalResourceApi
+internal val Res.string.str_9226: StringResource
+  get() = String48.str_9226
+
+@ExperimentalResourceApi
+internal val Res.string.str_9227: StringResource
+  get() = String48.str_9227
+
+@ExperimentalResourceApi
+internal val Res.string.str_9228: StringResource
+  get() = String48.str_9228
+
+@ExperimentalResourceApi
+internal val Res.string.str_9229: StringResource
+  get() = String48.str_9229
+
+@ExperimentalResourceApi
+internal val Res.string.str_923: StringResource
+  get() = String48.str_923
+
+@ExperimentalResourceApi
+internal val Res.string.str_9230: StringResource
+  get() = String48.str_9230
+
+@ExperimentalResourceApi
+internal val Res.string.str_9231: StringResource
+  get() = String48.str_9231
+
+@ExperimentalResourceApi
+internal val Res.string.str_9232: StringResource
+  get() = String48.str_9232
+
+@ExperimentalResourceApi
+internal val Res.string.str_9233: StringResource
+  get() = String48.str_9233
+
+@ExperimentalResourceApi
+internal val Res.string.str_9234: StringResource
+  get() = String48.str_9234
+
+@ExperimentalResourceApi
+internal val Res.string.str_9235: StringResource
+  get() = String48.str_9235
+
+@ExperimentalResourceApi
+internal val Res.string.str_9236: StringResource
+  get() = String48.str_9236
+
+@ExperimentalResourceApi
+internal val Res.string.str_9237: StringResource
+  get() = String48.str_9237
+
+@ExperimentalResourceApi
+internal val Res.string.str_9238: StringResource
+  get() = String48.str_9238
+
+@ExperimentalResourceApi
+internal val Res.string.str_9239: StringResource
+  get() = String48.str_9239
+
+@ExperimentalResourceApi
+internal val Res.string.str_924: StringResource
+  get() = String48.str_924
+
+@ExperimentalResourceApi
+internal val Res.string.str_9240: StringResource
+  get() = String48.str_9240
+
+@ExperimentalResourceApi
+internal val Res.string.str_9241: StringResource
+  get() = String48.str_9241
+
+@ExperimentalResourceApi
+internal val Res.string.str_9242: StringResource
+  get() = String48.str_9242
+
+@ExperimentalResourceApi
+internal val Res.string.str_9243: StringResource
+  get() = String48.str_9243
+
+@ExperimentalResourceApi
+internal val Res.string.str_9244: StringResource
+  get() = String48.str_9244
+
+@ExperimentalResourceApi
+internal val Res.string.str_9245: StringResource
+  get() = String48.str_9245
+
+@ExperimentalResourceApi
+internal val Res.string.str_9246: StringResource
+  get() = String48.str_9246
+
+@ExperimentalResourceApi
+internal val Res.string.str_9247: StringResource
+  get() = String48.str_9247
+
+@ExperimentalResourceApi
+internal val Res.string.str_9248: StringResource
+  get() = String48.str_9248
+
+@ExperimentalResourceApi
+internal val Res.string.str_9249: StringResource
+  get() = String48.str_9249
+
+@ExperimentalResourceApi
+internal val Res.string.str_925: StringResource
+  get() = String48.str_925
+
+@ExperimentalResourceApi
+internal val Res.string.str_9250: StringResource
+  get() = String48.str_9250
+
+@ExperimentalResourceApi
+internal val Res.string.str_9251: StringResource
+  get() = String48.str_9251
+
+@ExperimentalResourceApi
+internal val Res.string.str_9252: StringResource
+  get() = String48.str_9252
+
+@ExperimentalResourceApi
+internal val Res.string.str_9253: StringResource
+  get() = String48.str_9253
+
+@ExperimentalResourceApi
+internal val Res.string.str_9254: StringResource
+  get() = String48.str_9254
+
+@ExperimentalResourceApi
+internal val Res.string.str_9255: StringResource
+  get() = String48.str_9255
+
+@ExperimentalResourceApi
+internal val Res.string.str_9256: StringResource
+  get() = String48.str_9256
+
+@ExperimentalResourceApi
+internal val Res.string.str_9257: StringResource
+  get() = String48.str_9257
+
+@ExperimentalResourceApi
+internal val Res.string.str_9258: StringResource
+  get() = String48.str_9258
+
+@ExperimentalResourceApi
+internal val Res.string.str_9259: StringResource
+  get() = String48.str_9259
+
+@ExperimentalResourceApi
+internal val Res.string.str_926: StringResource
+  get() = String48.str_926
+
+@ExperimentalResourceApi
+internal val Res.string.str_9260: StringResource
+  get() = String48.str_9260
+
+@ExperimentalResourceApi
+internal val Res.string.str_9261: StringResource
+  get() = String48.str_9261
+
+@ExperimentalResourceApi
+internal val Res.string.str_9262: StringResource
+  get() = String48.str_9262
+
+@ExperimentalResourceApi
+internal val Res.string.str_9263: StringResource
+  get() = String48.str_9263
+
+@ExperimentalResourceApi
+internal val Res.string.str_9264: StringResource
+  get() = String48.str_9264
+
+@ExperimentalResourceApi
+internal val Res.string.str_9265: StringResource
+  get() = String48.str_9265
+
+@ExperimentalResourceApi
+internal val Res.string.str_9266: StringResource
+  get() = String48.str_9266
+
+@ExperimentalResourceApi
+internal val Res.string.str_9267: StringResource
+  get() = String48.str_9267
+
+@ExperimentalResourceApi
+internal val Res.string.str_9268: StringResource
+  get() = String48.str_9268
+
+@ExperimentalResourceApi
+internal val Res.string.str_9269: StringResource
+  get() = String48.str_9269
+
+@ExperimentalResourceApi
+internal val Res.string.str_927: StringResource
+  get() = String48.str_927
+
+@ExperimentalResourceApi
+internal val Res.string.str_9270: StringResource
+  get() = String48.str_9270
+
+@ExperimentalResourceApi
+internal val Res.string.str_9271: StringResource
+  get() = String48.str_9271
+
+@ExperimentalResourceApi
+internal val Res.string.str_9272: StringResource
+  get() = String48.str_9272
+
+@ExperimentalResourceApi
+internal val Res.string.str_9273: StringResource
+  get() = String48.str_9273
+
+@ExperimentalResourceApi
+internal val Res.string.str_9274: StringResource
+  get() = String48.str_9274
+
+@ExperimentalResourceApi
+internal val Res.string.str_9275: StringResource
+  get() = String48.str_9275
+
+@ExperimentalResourceApi
+internal val Res.string.str_9276: StringResource
+  get() = String48.str_9276
+
+@ExperimentalResourceApi
+internal val Res.string.str_9277: StringResource
+  get() = String48.str_9277
+
+@ExperimentalResourceApi
+internal val Res.string.str_9278: StringResource
+  get() = String48.str_9278
+
+@ExperimentalResourceApi
+internal val Res.string.str_9279: StringResource
+  get() = String48.str_9279
+
+@ExperimentalResourceApi
+internal val Res.string.str_928: StringResource
+  get() = String48.str_928
+
+@ExperimentalResourceApi
+internal val Res.string.str_9280: StringResource
+  get() = String48.str_9280
+
+@ExperimentalResourceApi
+internal val Res.string.str_9281: StringResource
+  get() = String48.str_9281
+
+@ExperimentalResourceApi
+internal val Res.string.str_9282: StringResource
+  get() = String48.str_9282
+
+@ExperimentalResourceApi
+internal val Res.string.str_9283: StringResource
+  get() = String48.str_9283
+
+@ExperimentalResourceApi
+internal val Res.string.str_9284: StringResource
+  get() = String48.str_9284
+
+@ExperimentalResourceApi
+internal val Res.string.str_9285: StringResource
+  get() = String48.str_9285
+
+@ExperimentalResourceApi
+internal val Res.string.str_9286: StringResource
+  get() = String48.str_9286
+
+@ExperimentalResourceApi
+internal val Res.string.str_9287: StringResource
+  get() = String48.str_9287
+
+@ExperimentalResourceApi
+internal val Res.string.str_9288: StringResource
+  get() = String48.str_9288
+
+@ExperimentalResourceApi
+internal val Res.string.str_9289: StringResource
+  get() = String48.str_9289
+
+@ExperimentalResourceApi
+internal val Res.string.str_929: StringResource
+  get() = String48.str_929
+
+@ExperimentalResourceApi
+internal val Res.string.str_9290: StringResource
+  get() = String48.str_9290
+
+@ExperimentalResourceApi
+internal val Res.string.str_9291: StringResource
+  get() = String48.str_9291
+
+@ExperimentalResourceApi
+internal val Res.string.str_9292: StringResource
+  get() = String48.str_9292
+
+@ExperimentalResourceApi
+internal val Res.string.str_9293: StringResource
+  get() = String48.str_9293
+
+@ExperimentalResourceApi
+internal val Res.string.str_9294: StringResource
+  get() = String48.str_9294
+
+@ExperimentalResourceApi
+internal val Res.string.str_9295: StringResource
+  get() = String48.str_9295
+
+@ExperimentalResourceApi
+internal val Res.string.str_9296: StringResource
+  get() = String48.str_9296
+
+@ExperimentalResourceApi
+internal val Res.string.str_9297: StringResource
+  get() = String48.str_9297
+
+@ExperimentalResourceApi
+internal val Res.string.str_9298: StringResource
+  get() = String48.str_9298
+
+@ExperimentalResourceApi
+internal val Res.string.str_9299: StringResource
+  get() = String48.str_9299
+
+@ExperimentalResourceApi
+internal val Res.string.str_93: StringResource
+  get() = String48.str_93
+
+@ExperimentalResourceApi
+internal val Res.string.str_930: StringResource
+  get() = String48.str_930
+
+@ExperimentalResourceApi
+internal val Res.string.str_9300: StringResource
+  get() = String48.str_9300
+
+@ExperimentalResourceApi
+internal val Res.string.str_9301: StringResource
+  get() = String48.str_9301
+
+@ExperimentalResourceApi
+internal val Res.string.str_9302: StringResource
+  get() = String48.str_9302
+
+@ExperimentalResourceApi
+internal val Res.string.str_9303: StringResource
+  get() = String48.str_9303
+
+@ExperimentalResourceApi
+internal val Res.string.str_9304: StringResource
+  get() = String48.str_9304
+
+@ExperimentalResourceApi
+internal val Res.string.str_9305: StringResource
+  get() = String48.str_9305
+
+@ExperimentalResourceApi
+internal val Res.string.str_9306: StringResource
+  get() = String48.str_9306
+
+@ExperimentalResourceApi
+internal val Res.string.str_9307: StringResource
+  get() = String48.str_9307
+
+@ExperimentalResourceApi
+internal val Res.string.str_9308: StringResource
+  get() = String48.str_9308
+
+@ExperimentalResourceApi
+internal val Res.string.str_9309: StringResource
+  get() = String48.str_9309
+
+@ExperimentalResourceApi
+internal val Res.string.str_931: StringResource
+  get() = String48.str_931
+
+@ExperimentalResourceApi
+internal val Res.string.str_9310: StringResource
+  get() = String48.str_9310
+
+@ExperimentalResourceApi
+internal val Res.string.str_9311: StringResource
+  get() = String48.str_9311
+
+@ExperimentalResourceApi
+internal val Res.string.str_9312: StringResource
+  get() = String48.str_9312
+
+@ExperimentalResourceApi
+internal val Res.string.str_9313: StringResource
+  get() = String48.str_9313
+
+@ExperimentalResourceApi
+internal val Res.string.str_9314: StringResource
+  get() = String48.str_9314
+
+@ExperimentalResourceApi
+internal val Res.string.str_9315: StringResource
+  get() = String48.str_9315
+
+@ExperimentalResourceApi
+internal val Res.string.str_9316: StringResource
+  get() = String48.str_9316
+
+@ExperimentalResourceApi
+internal val Res.string.str_9317: StringResource
+  get() = String48.str_9317
+
+@ExperimentalResourceApi
+internal val Res.string.str_9318: StringResource
+  get() = String48.str_9318
+
+@ExperimentalResourceApi
+internal val Res.string.str_9319: StringResource
+  get() = String48.str_9319
+
+@ExperimentalResourceApi
+internal val Res.string.str_932: StringResource
+  get() = String48.str_932
+
+@ExperimentalResourceApi
+internal val Res.string.str_9320: StringResource
+  get() = String48.str_9320
+
+@ExperimentalResourceApi
+internal val Res.string.str_9321: StringResource
+  get() = String48.str_9321
+
+@ExperimentalResourceApi
+internal val Res.string.str_9322: StringResource
+  get() = String48.str_9322
+
+@ExperimentalResourceApi
+internal val Res.string.str_9323: StringResource
+  get() = String48.str_9323
+
+@ExperimentalResourceApi
+internal val Res.string.str_9324: StringResource
+  get() = String48.str_9324
+
+@ExperimentalResourceApi
+internal val Res.string.str_9325: StringResource
+  get() = String48.str_9325
+
+@ExperimentalResourceApi
+internal val Res.string.str_9326: StringResource
+  get() = String48.str_9326
+
+@ExperimentalResourceApi
+internal val Res.string.str_9327: StringResource
+  get() = String48.str_9327
+
+@ExperimentalResourceApi
+internal val Res.string.str_9328: StringResource
+  get() = String48.str_9328
+
+@ExperimentalResourceApi
+internal val Res.string.str_9329: StringResource
+  get() = String48.str_9329
+
+@ExperimentalResourceApi
+internal val Res.string.str_933: StringResource
+  get() = String48.str_933
+
+@ExperimentalResourceApi
+internal val Res.string.str_9330: StringResource
+  get() = String48.str_9330
+
+@ExperimentalResourceApi
+internal val Res.string.str_9331: StringResource
+  get() = String48.str_9331
+
+@ExperimentalResourceApi
+internal val Res.string.str_9332: StringResource
+  get() = String48.str_9332
+
+@ExperimentalResourceApi
+internal val Res.string.str_9333: StringResource
+  get() = String48.str_9333
+
+@ExperimentalResourceApi
+internal val Res.string.str_9334: StringResource
+  get() = String48.str_9334
+
+@ExperimentalResourceApi
+internal val Res.string.str_9335: StringResource
+  get() = String48.str_9335
+
+@ExperimentalResourceApi
+internal val Res.string.str_9336: StringResource
+  get() = String48.str_9336
+
+@ExperimentalResourceApi
+internal val Res.string.str_9337: StringResource
+  get() = String48.str_9337
+
+@ExperimentalResourceApi
+internal val Res.string.str_9338: StringResource
+  get() = String48.str_9338
+
+@ExperimentalResourceApi
+internal val Res.string.str_9339: StringResource
+  get() = String48.str_9339
+
+@ExperimentalResourceApi
+internal val Res.string.str_934: StringResource
+  get() = String48.str_934
+
+@ExperimentalResourceApi
+internal val Res.string.str_9340: StringResource
+  get() = String48.str_9340
+
+@ExperimentalResourceApi
+internal val Res.string.str_9341: StringResource
+  get() = String48.str_9341
+
+@ExperimentalResourceApi
+internal val Res.string.str_9342: StringResource
+  get() = String48.str_9342
+
+@ExperimentalResourceApi
+internal val Res.string.str_9343: StringResource
+  get() = String48.str_9343
+
+@ExperimentalResourceApi
+internal val Res.string.str_9344: StringResource
+  get() = String48.str_9344
+
+@ExperimentalResourceApi
+internal val Res.string.str_9345: StringResource
+  get() = String48.str_9345
+
+@ExperimentalResourceApi
+internal val Res.string.str_9346: StringResource
+  get() = String48.str_9346
+
+@ExperimentalResourceApi
+internal val Res.string.str_9347: StringResource
+  get() = String48.str_9347
+
+@ExperimentalResourceApi
+internal val Res.string.str_9348: StringResource
+  get() = String48.str_9348
+
+@ExperimentalResourceApi
+internal val Res.string.str_9349: StringResource
+  get() = String48.str_9349
+
+@ExperimentalResourceApi
+internal val Res.string.str_935: StringResource
+  get() = String48.str_935
+
+@ExperimentalResourceApi
+internal val Res.string.str_9350: StringResource
+  get() = String48.str_9350
+
+@ExperimentalResourceApi
+internal val Res.string.str_9351: StringResource
+  get() = String48.str_9351
+
+@ExperimentalResourceApi
+internal val Res.string.str_9352: StringResource
+  get() = String48.str_9352
+
+@ExperimentalResourceApi
+internal val Res.string.str_9353: StringResource
+  get() = String48.str_9353
+
+@ExperimentalResourceApi
+internal val Res.string.str_9354: StringResource
+  get() = String48.str_9354
+
+@ExperimentalResourceApi
+internal val Res.string.str_9355: StringResource
+  get() = String48.str_9355
+
+@ExperimentalResourceApi
+internal val Res.string.str_9356: StringResource
+  get() = String48.str_9356
+
+@ExperimentalResourceApi
+internal val Res.string.str_9357: StringResource
+  get() = String48.str_9357
+
+@ExperimentalResourceApi
+internal val Res.string.str_9358: StringResource
+  get() = String48.str_9358
+
+@ExperimentalResourceApi
+internal val Res.string.str_9359: StringResource
+  get() = String48.str_9359
+
+@ExperimentalResourceApi
+internal val Res.string.str_936: StringResource
+  get() = String48.str_936
+
+@ExperimentalResourceApi
+internal val Res.string.str_9360: StringResource
+  get() = String48.str_9360
+
+@ExperimentalResourceApi
+internal val Res.string.str_9361: StringResource
+  get() = String48.str_9361
+
+@ExperimentalResourceApi
+internal val Res.string.str_9362: StringResource
+  get() = String48.str_9362
+
+@ExperimentalResourceApi
+internal val Res.string.str_9363: StringResource
+  get() = String48.str_9363
+
+@ExperimentalResourceApi
+internal val Res.string.str_9364: StringResource
+  get() = String48.str_9364
+
+@ExperimentalResourceApi
+internal val Res.string.str_9365: StringResource
+  get() = String48.str_9365
+
+@ExperimentalResourceApi
+internal val Res.string.str_9366: StringResource
+  get() = String48.str_9366
+
+@ExperimentalResourceApi
+internal val Res.string.str_9367: StringResource
+  get() = String48.str_9367
+
+@ExperimentalResourceApi
+internal val Res.string.str_9368: StringResource
+  get() = String48.str_9368
+
+@ExperimentalResourceApi
+internal val Res.string.str_9369: StringResource
+  get() = String48.str_9369
+
+@ExperimentalResourceApi
+internal val Res.string.str_937: StringResource
+  get() = String48.str_937
+
+@ExperimentalResourceApi
+internal val Res.string.str_9370: StringResource
+  get() = String48.str_9370
+
+@ExperimentalResourceApi
+internal val Res.string.str_9371: StringResource
+  get() = String48.str_9371
+
+@ExperimentalResourceApi
+internal val Res.string.str_9372: StringResource
+  get() = String48.str_9372
+
+@ExperimentalResourceApi
+internal val Res.string.str_9373: StringResource
+  get() = String48.str_9373
+
+@ExperimentalResourceApi
+internal val Res.string.str_9374: StringResource
+  get() = String48.str_9374
+
+@ExperimentalResourceApi
+internal val Res.string.str_9375: StringResource
+  get() = String48.str_9375
+
+@ExperimentalResourceApi
+internal val Res.string.str_9376: StringResource
+  get() = String48.str_9376
+
+@ExperimentalResourceApi
+internal val Res.string.str_9377: StringResource
+  get() = String48.str_9377
+
+@ExperimentalResourceApi
+internal val Res.string.str_9378: StringResource
+  get() = String48.str_9378
+
+@ExperimentalResourceApi
+internal val Res.string.str_9379: StringResource
+  get() = String48.str_9379
+
+@ExperimentalResourceApi
+internal val Res.string.str_938: StringResource
+  get() = String48.str_938
+
+@ExperimentalResourceApi
+internal val Res.string.str_9380: StringResource
+  get() = String48.str_9380
+
+@ExperimentalResourceApi
+internal val Res.string.str_9381: StringResource
+  get() = String48.str_9381
+
+@ExperimentalResourceApi
+internal val Res.string.str_9382: StringResource
+  get() = String48.str_9382
+
+@ExperimentalResourceApi
+internal val Res.string.str_9383: StringResource
+  get() = String48.str_9383
+
+@ExperimentalResourceApi
+internal val Res.string.str_9384: StringResource
+  get() = String48.str_9384
+
+@ExperimentalResourceApi
+internal val Res.string.str_9385: StringResource
+  get() = String48.str_9385
+
+@ExperimentalResourceApi
+internal val Res.string.str_9386: StringResource
+  get() = String48.str_9386
+
+@ExperimentalResourceApi
+internal val Res.string.str_9387: StringResource
+  get() = String48.str_9387
+
+@ExperimentalResourceApi
+internal val Res.string.str_9388: StringResource
+  get() = String48.str_9388
+
+@ExperimentalResourceApi
+internal val Res.string.str_9389: StringResource
+  get() = String48.str_9389
+
+@ExperimentalResourceApi
+internal val Res.string.str_939: StringResource
+  get() = String48.str_939
+
+@ExperimentalResourceApi
+internal val Res.string.str_9390: StringResource
+  get() = String48.str_9390
+
+@ExperimentalResourceApi
+internal val Res.string.str_9391: StringResource
+  get() = String48.str_9391
+
+@ExperimentalResourceApi
+internal val Res.string.str_9392: StringResource
+  get() = String48.str_9392
+
+@ExperimentalResourceApi
+internal val Res.string.str_9393: StringResource
+  get() = String48.str_9393
+
+@ExperimentalResourceApi
+internal val Res.string.str_9394: StringResource
+  get() = String48.str_9394
+
+@ExperimentalResourceApi
+internal val Res.string.str_9395: StringResource
+  get() = String48.str_9395
+
+@ExperimentalResourceApi
+internal val Res.string.str_9396: StringResource
+  get() = String48.str_9396
+
+@ExperimentalResourceApi
+internal val Res.string.str_9397: StringResource
+  get() = String48.str_9397
+
+@ExperimentalResourceApi
+internal val Res.string.str_9398: StringResource
+  get() = String48.str_9398
+
+@ExperimentalResourceApi
+internal val Res.string.str_9399: StringResource
+  get() = String48.str_9399
+
+@ExperimentalResourceApi
+internal val Res.string.str_94: StringResource
+  get() = String48.str_94
+
+@ExperimentalResourceApi
+internal val Res.string.str_940: StringResource
+  get() = String48.str_940
+
+@ExperimentalResourceApi
+internal val Res.string.str_9400: StringResource
+  get() = String48.str_9400
+
+@ExperimentalResourceApi
+internal val Res.string.str_9401: StringResource
+  get() = String48.str_9401
+
+@ExperimentalResourceApi
+internal val Res.string.str_9402: StringResource
+  get() = String48.str_9402
+
+@ExperimentalResourceApi
+internal val Res.string.str_9403: StringResource
+  get() = String48.str_9403
+
+@ExperimentalResourceApi
+internal val Res.string.str_9404: StringResource
+  get() = String48.str_9404
+
+@ExperimentalResourceApi
+internal val Res.string.str_9405: StringResource
+  get() = String48.str_9405
+
+@ExperimentalResourceApi
+internal val Res.string.str_9406: StringResource
+  get() = String48.str_9406
+
+@ExperimentalResourceApi
+internal val Res.string.str_9407: StringResource
+  get() = String48.str_9407
+
+@ExperimentalResourceApi
+internal val Res.string.str_9408: StringResource
+  get() = String48.str_9408
+
+@ExperimentalResourceApi
+internal val Res.string.str_9409: StringResource
+  get() = String48.str_9409
+
+@ExperimentalResourceApi
+internal val Res.string.str_941: StringResource
+  get() = String48.str_941
+
+@ExperimentalResourceApi
+internal val Res.string.str_9410: StringResource
+  get() = String48.str_9410
+
+@ExperimentalResourceApi
+internal val Res.string.str_9411: StringResource
+  get() = String48.str_9411
+
+@ExperimentalResourceApi
+internal val Res.string.str_9412: StringResource
+  get() = String48.str_9412
+
+@ExperimentalResourceApi
+internal val Res.string.str_9413: StringResource
+  get() = String48.str_9413
+
+@ExperimentalResourceApi
+internal val Res.string.str_9414: StringResource
+  get() = String48.str_9414
+
+@ExperimentalResourceApi
+internal val Res.string.str_9415: StringResource
+  get() = String48.str_9415
+
+@ExperimentalResourceApi
+internal val Res.string.str_9416: StringResource
+  get() = String48.str_9416
+
+@ExperimentalResourceApi
+internal val Res.string.str_9417: StringResource
+  get() = String48.str_9417
+
+@ExperimentalResourceApi
+internal val Res.string.str_9418: StringResource
+  get() = String48.str_9418
+
+@ExperimentalResourceApi
+internal val Res.string.str_9419: StringResource
+  get() = String48.str_9419
+
+@ExperimentalResourceApi
+internal val Res.string.str_942: StringResource
+  get() = String48.str_942
+
+@ExperimentalResourceApi
+internal val Res.string.str_9420: StringResource
+  get() = String48.str_9420
+
+@ExperimentalResourceApi
+internal val Res.string.str_9421: StringResource
+  get() = String48.str_9421
+
+@ExperimentalResourceApi
+internal val Res.string.str_9422: StringResource
+  get() = String48.str_9422
+
+@ExperimentalResourceApi
+internal val Res.string.str_9423: StringResource
+  get() = String48.str_9423
+
+@ExperimentalResourceApi
+internal val Res.string.str_9424: StringResource
+  get() = String48.str_9424
+
+@ExperimentalResourceApi
+internal val Res.string.str_9425: StringResource
+  get() = String48.str_9425
+
+@ExperimentalResourceApi
+internal val Res.string.str_9426: StringResource
+  get() = String48.str_9426
+
+@ExperimentalResourceApi
+internal val Res.string.str_9427: StringResource
+  get() = String48.str_9427
+
+@ExperimentalResourceApi
+internal val Res.string.str_9428: StringResource
+  get() = String48.str_9428
+
+@ExperimentalResourceApi
+internal val Res.string.str_9429: StringResource
+  get() = String48.str_9429
+
+@ExperimentalResourceApi
+internal val Res.string.str_943: StringResource
+  get() = String48.str_943
+
+@ExperimentalResourceApi
+internal val Res.string.str_9430: StringResource
+  get() = String48.str_9430
+
+@ExperimentalResourceApi
+internal val Res.string.str_9431: StringResource
+  get() = String48.str_9431
+
+@ExperimentalResourceApi
+internal val Res.string.str_9432: StringResource
+  get() = String48.str_9432
+
+@ExperimentalResourceApi
+internal val Res.string.str_9433: StringResource
+  get() = String48.str_9433
+
+@ExperimentalResourceApi
+internal val Res.string.str_9434: StringResource
+  get() = String48.str_9434
+
+@ExperimentalResourceApi
+internal val Res.string.str_9435: StringResource
+  get() = String48.str_9435
+
+@ExperimentalResourceApi
+internal val Res.string.str_9436: StringResource
+  get() = String48.str_9436
+
+@ExperimentalResourceApi
+internal val Res.string.str_9437: StringResource
+  get() = String48.str_9437
+
+@ExperimentalResourceApi
+internal val Res.string.str_9438: StringResource
+  get() = String48.str_9438
+
+@ExperimentalResourceApi
+internal val Res.string.str_9439: StringResource
+  get() = String48.str_9439
+
+@ExperimentalResourceApi
+internal val Res.string.str_944: StringResource
+  get() = String48.str_944
+
+@ExperimentalResourceApi
+internal val Res.string.str_9440: StringResource
+  get() = String48.str_9440
+
+@ExperimentalResourceApi
+internal val Res.string.str_9441: StringResource
+  get() = String48.str_9441
+
+@ExperimentalResourceApi
+internal val Res.string.str_9442: StringResource
+  get() = String48.str_9442
+
+@ExperimentalResourceApi
+internal val Res.string.str_9443: StringResource
+  get() = String48.str_9443
+
+@ExperimentalResourceApi
+internal val Res.string.str_9444: StringResource
+  get() = String48.str_9444
+
+@ExperimentalResourceApi
+internal val Res.string.str_9445: StringResource
+  get() = String48.str_9445
+
+@ExperimentalResourceApi
+internal val Res.string.str_9446: StringResource
+  get() = String48.str_9446
+
+@ExperimentalResourceApi
+internal val Res.string.str_9447: StringResource
+  get() = String48.str_9447
+
+@ExperimentalResourceApi
+internal val Res.string.str_9448: StringResource
+  get() = String48.str_9448
+
+@ExperimentalResourceApi
+internal val Res.string.str_9449: StringResource
+  get() = String48.str_9449
+
+@ExperimentalResourceApi
+internal val Res.string.str_945: StringResource
+  get() = String48.str_945
+
+@ExperimentalResourceApi
+internal val Res.string.str_9450: StringResource
+  get() = String48.str_9450
+
+@ExperimentalResourceApi
+internal val Res.string.str_9451: StringResource
+  get() = String48.str_9451
+
+@ExperimentalResourceApi
+internal val Res.string.str_9452: StringResource
+  get() = String48.str_9452
+
+@ExperimentalResourceApi
+internal val Res.string.str_9453: StringResource
+  get() = String48.str_9453
+
+@ExperimentalResourceApi
+internal val Res.string.str_9454: StringResource
+  get() = String48.str_9454
+
+@ExperimentalResourceApi
+internal val Res.string.str_9455: StringResource
+  get() = String48.str_9455
+
+@ExperimentalResourceApi
+internal val Res.string.str_9456: StringResource
+  get() = String48.str_9456
+
+@ExperimentalResourceApi
+internal val Res.string.str_9457: StringResource
+  get() = String48.str_9457
+
+@ExperimentalResourceApi
+internal val Res.string.str_9458: StringResource
+  get() = String48.str_9458
+
+@ExperimentalResourceApi
+internal val Res.string.str_9459: StringResource
+  get() = String48.str_9459
+
+@ExperimentalResourceApi
+internal val Res.string.str_946: StringResource
+  get() = String48.str_946
+
+@ExperimentalResourceApi
+internal val Res.string.str_9460: StringResource
+  get() = String48.str_9460
+
+@ExperimentalResourceApi
+internal val Res.string.str_9461: StringResource
+  get() = String48.str_9461
+
+@ExperimentalResourceApi
+internal val Res.string.str_9462: StringResource
+  get() = String48.str_9462
+
+@ExperimentalResourceApi
+internal val Res.string.str_9463: StringResource
+  get() = String48.str_9463
+
+@ExperimentalResourceApi
+internal val Res.string.str_9464: StringResource
+  get() = String48.str_9464
+
+@ExperimentalResourceApi
+internal val Res.string.str_9465: StringResource
+  get() = String48.str_9465
+
+@ExperimentalResourceApi
+internal val Res.string.str_9466: StringResource
+  get() = String48.str_9466
+
+@ExperimentalResourceApi
+internal val Res.string.str_9467: StringResource
+  get() = String48.str_9467
+
+@ExperimentalResourceApi
+internal val Res.string.str_9468: StringResource
+  get() = String48.str_9468
+
+@ExperimentalResourceApi
+internal val Res.string.str_9469: StringResource
+  get() = String48.str_9469
+
+@ExperimentalResourceApi
+internal val Res.string.str_947: StringResource
+  get() = String48.str_947
+
+@ExperimentalResourceApi
+internal val Res.string.str_9470: StringResource
+  get() = String48.str_9470
+
+@ExperimentalResourceApi
+internal val Res.string.str_9471: StringResource
+  get() = String48.str_9471
+
+@ExperimentalResourceApi
+internal val Res.string.str_9472: StringResource
+  get() = String48.str_9472
+
+@ExperimentalResourceApi
+internal val Res.string.str_9473: StringResource
+  get() = String48.str_9473
+
+@ExperimentalResourceApi
+internal val Res.string.str_9474: StringResource
+  get() = String48.str_9474
+
+@ExperimentalResourceApi
+internal val Res.string.str_9475: StringResource
+  get() = String48.str_9475
+
+@ExperimentalResourceApi
+internal val Res.string.str_9476: StringResource
+  get() = String48.str_9476
+
+@ExperimentalResourceApi
+internal val Res.string.str_9477: StringResource
+  get() = String48.str_9477
+
+@ExperimentalResourceApi
+internal val Res.string.str_9478: StringResource
+  get() = String48.str_9478
+
+@ExperimentalResourceApi
+internal val Res.string.str_9479: StringResource
+  get() = String48.str_9479
+
+@ExperimentalResourceApi
+internal val Res.string.str_948: StringResource
+  get() = String48.str_948
+
+@ExperimentalResourceApi
+internal val Res.string.str_9480: StringResource
+  get() = String48.str_9480
+
+@ExperimentalResourceApi
+internal val Res.string.str_9481: StringResource
+  get() = String48.str_9481
+
+@ExperimentalResourceApi
+internal val Res.string.str_9482: StringResource
+  get() = String48.str_9482
+
+@ExperimentalResourceApi
+internal val Res.string.str_9483: StringResource
+  get() = String48.str_9483
+
+@ExperimentalResourceApi
+internal val Res.string.str_9484: StringResource
+  get() = String48.str_9484
+
+@ExperimentalResourceApi
+internal val Res.string.str_9485: StringResource
+  get() = String48.str_9485
+
+@ExperimentalResourceApi
+internal val Res.string.str_9486: StringResource
+  get() = String48.str_9486
+
+@ExperimentalResourceApi
+internal val Res.string.str_9487: StringResource
+  get() = String48.str_9487
+
+@ExperimentalResourceApi
+internal val Res.string.str_9488: StringResource
+  get() = String48.str_9488
+
+@ExperimentalResourceApi
+internal val Res.string.str_9489: StringResource
+  get() = String48.str_9489
+
+@ExperimentalResourceApi
+internal val Res.string.str_949: StringResource
+  get() = String48.str_949
+
+@ExperimentalResourceApi
+internal val Res.string.str_9490: StringResource
+  get() = String48.str_9490
+
+@ExperimentalResourceApi
+internal val Res.string.str_9491: StringResource
+  get() = String48.str_9491
+
+@ExperimentalResourceApi
+internal val Res.string.str_9492: StringResource
+  get() = String48.str_9492
+
+@ExperimentalResourceApi
+internal val Res.string.str_9493: StringResource
+  get() = String48.str_9493
+
+@ExperimentalResourceApi
+internal val Res.string.str_9494: StringResource
+  get() = String48.str_9494
+
+@ExperimentalResourceApi
+internal val Res.string.str_9495: StringResource
+  get() = String48.str_9495
+
+@ExperimentalResourceApi
+internal val Res.string.str_9496: StringResource
+  get() = String48.str_9496
+
+@ExperimentalResourceApi
+internal val Res.string.str_9497: StringResource
+  get() = String48.str_9497
+
+@ExperimentalResourceApi
+internal val Res.string.str_9498: StringResource
+  get() = String48.str_9498
+
+@ExperimentalResourceApi
+internal val Res.string.str_9499: StringResource
+  get() = String48.str_9499
+
+@ExperimentalResourceApi
+internal val Res.string.str_95: StringResource
+  get() = String48.str_95
+
+@ExperimentalResourceApi
+internal val Res.string.str_950: StringResource
+  get() = String48.str_950
+
+@ExperimentalResourceApi
+internal val Res.string.str_9500: StringResource
+  get() = String48.str_9500
+
+@ExperimentalResourceApi
+internal val Res.string.str_9501: StringResource
+  get() = String48.str_9501
+
+@ExperimentalResourceApi
+internal val Res.string.str_9502: StringResource
+  get() = String48.str_9502
+
+@ExperimentalResourceApi
+internal val Res.string.str_9503: StringResource
+  get() = String48.str_9503
+
+@ExperimentalResourceApi
+internal val Res.string.str_9504: StringResource
+  get() = String48.str_9504
+
+@ExperimentalResourceApi
+internal val Res.string.str_9505: StringResource
+  get() = String48.str_9505
+
+@ExperimentalResourceApi
+internal val Res.string.str_9506: StringResource
+  get() = String48.str_9506
+
+@ExperimentalResourceApi
+internal val Res.string.str_9507: StringResource
+  get() = String48.str_9507
+
+@ExperimentalResourceApi
+internal val Res.string.str_9508: StringResource
+  get() = String48.str_9508
+
+@ExperimentalResourceApi
+internal val Res.string.str_9509: StringResource
+  get() = String48.str_9509
+
+@ExperimentalResourceApi
+internal val Res.string.str_951: StringResource
+  get() = String48.str_951
+
+@ExperimentalResourceApi
+internal val Res.string.str_9510: StringResource
+  get() = String48.str_9510
+
+@ExperimentalResourceApi
+internal val Res.string.str_9511: StringResource
+  get() = String48.str_9511
+
+@ExperimentalResourceApi
+internal val Res.string.str_9512: StringResource
+  get() = String48.str_9512
+
+@ExperimentalResourceApi
+internal val Res.string.str_9513: StringResource
+  get() = String48.str_9513
+
+@ExperimentalResourceApi
+internal val Res.string.str_9514: StringResource
+  get() = String48.str_9514
+
+@ExperimentalResourceApi
+internal val Res.string.str_9515: StringResource
+  get() = String48.str_9515
+
+@ExperimentalResourceApi
+internal val Res.string.str_9516: StringResource
+  get() = String48.str_9516
+
+@ExperimentalResourceApi
+internal val Res.string.str_9517: StringResource
+  get() = String48.str_9517
+
+@ExperimentalResourceApi
+internal val Res.string.str_9518: StringResource
+  get() = String48.str_9518
+
+@ExperimentalResourceApi
+internal val Res.string.str_9519: StringResource
+  get() = String48.str_9519
+
+@ExperimentalResourceApi
+internal val Res.string.str_952: StringResource
+  get() = String48.str_952
+
+@ExperimentalResourceApi
+internal val Res.string.str_9520: StringResource
+  get() = String48.str_9520
+
+@ExperimentalResourceApi
+internal val Res.string.str_9521: StringResource
+  get() = String48.str_9521
+
+@ExperimentalResourceApi
+internal val Res.string.str_9522: StringResource
+  get() = String48.str_9522
+
+@ExperimentalResourceApi
+internal val Res.string.str_9523: StringResource
+  get() = String48.str_9523
+
+@ExperimentalResourceApi
+internal val Res.string.str_9524: StringResource
+  get() = String48.str_9524
+
+@ExperimentalResourceApi
+internal val Res.string.str_9525: StringResource
+  get() = String48.str_9525
+
+@ExperimentalResourceApi
+internal val Res.string.str_9526: StringResource
+  get() = String48.str_9526
+
+@ExperimentalResourceApi
+internal val Res.string.str_9527: StringResource
+  get() = String48.str_9527
+
+@ExperimentalResourceApi
+internal val Res.string.str_9528: StringResource
+  get() = String48.str_9528
+
+@ExperimentalResourceApi
+internal val Res.string.str_9529: StringResource
+  get() = String48.str_9529
+
+@ExperimentalResourceApi
+internal val Res.string.str_953: StringResource
+  get() = String48.str_953
+
+@ExperimentalResourceApi
+internal val Res.string.str_9530: StringResource
+  get() = String48.str_9530
+
+@ExperimentalResourceApi
+internal val Res.string.str_9531: StringResource
+  get() = String48.str_9531
+
+@ExperimentalResourceApi
+internal val Res.string.str_9532: StringResource
+  get() = String48.str_9532
+
+@ExperimentalResourceApi
+internal val Res.string.str_9533: StringResource
+  get() = String48.str_9533
+
+@ExperimentalResourceApi
+internal val Res.string.str_9534: StringResource
+  get() = String48.str_9534
+
+@ExperimentalResourceApi
+internal val Res.string.str_9535: StringResource
+  get() = String48.str_9535
+
+@ExperimentalResourceApi
+internal val Res.string.str_9536: StringResource
+  get() = String48.str_9536
+
+@ExperimentalResourceApi
+internal val Res.string.str_9537: StringResource
+  get() = String48.str_9537
+
+@ExperimentalResourceApi
+internal val Res.string.str_9538: StringResource
+  get() = String48.str_9538
+
+@ExperimentalResourceApi
+internal val Res.string.str_9539: StringResource
+  get() = String48.str_9539
+
+@ExperimentalResourceApi
+internal val Res.string.str_954: StringResource
+  get() = String48.str_954
+
+@ExperimentalResourceApi
+internal val Res.string.str_9540: StringResource
+  get() = String48.str_9540
+
+@ExperimentalResourceApi
+internal val Res.string.str_9541: StringResource
+  get() = String48.str_9541
+
+@ExperimentalResourceApi
+internal val Res.string.str_9542: StringResource
+  get() = String48.str_9542
+
+@ExperimentalResourceApi
+internal val Res.string.str_9543: StringResource
+  get() = String48.str_9543
+
+@ExperimentalResourceApi
+internal val Res.string.str_9544: StringResource
+  get() = String48.str_9544
+
+@ExperimentalResourceApi
+internal val Res.string.str_9545: StringResource
+  get() = String48.str_9545
+
+@ExperimentalResourceApi
+internal val Res.string.str_9546: StringResource
+  get() = String48.str_9546
+
+@ExperimentalResourceApi
+internal val Res.string.str_9547: StringResource
+  get() = String48.str_9547
+
+@ExperimentalResourceApi
+internal val Res.string.str_9548: StringResource
+  get() = String48.str_9548

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String49.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String49.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String49 {
+  public val str_9549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9549", "str_9549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_955", "str_955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9550", "str_9550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9551", "str_9551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9552", "str_9552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9553", "str_9553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9554", "str_9554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9555", "str_9555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9556", "str_9556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9557", "str_9557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9558", "str_9558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9559", "str_9559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_956", "str_956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9560", "str_9560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9561", "str_9561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9562", "str_9562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9563", "str_9563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9564", "str_9564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9565", "str_9565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9566", "str_9566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9567", "str_9567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9568", "str_9568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9569", "str_9569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_957", "str_957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9570", "str_9570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9571", "str_9571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9572", "str_9572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9573", "str_9573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9574", "str_9574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9575", "str_9575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9576", "str_9576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9577", "str_9577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9578", "str_9578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9579", "str_9579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_958", "str_958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9580", "str_9580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9581", "str_9581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9582", "str_9582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9583", "str_9583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9584", "str_9584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9585", "str_9585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9586", "str_9586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9587", "str_9587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9588", "str_9588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9589", "str_9589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_959", "str_959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9590", "str_9590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9591", "str_9591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9592", "str_9592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9593", "str_9593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9594", "str_9594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9595", "str_9595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9596", "str_9596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9597", "str_9597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9598", "str_9598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9599", "str_9599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_96: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_96", "str_96",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_960", "str_960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9600", "str_9600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9601", "str_9601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9602", "str_9602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9603", "str_9603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9604", "str_9604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9605", "str_9605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9606", "str_9606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9607", "str_9607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9608", "str_9608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9609", "str_9609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_961", "str_961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9610", "str_9610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9611", "str_9611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9612", "str_9612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9613", "str_9613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9614", "str_9614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9615", "str_9615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9616", "str_9616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9617", "str_9617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9618", "str_9618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9619", "str_9619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_962", "str_962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9620", "str_9620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9621", "str_9621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9622", "str_9622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9623", "str_9623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9624", "str_9624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9625", "str_9625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9626", "str_9626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9627", "str_9627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9628", "str_9628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9629", "str_9629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_963", "str_963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9630", "str_9630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9631", "str_9631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9632", "str_9632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9633", "str_9633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9634", "str_9634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9635", "str_9635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9636", "str_9636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9637", "str_9637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9638", "str_9638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9639", "str_9639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_964", "str_964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9640", "str_9640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9641", "str_9641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9642", "str_9642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9643", "str_9643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9644", "str_9644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9645", "str_9645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9646", "str_9646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9647", "str_9647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9648", "str_9648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9649", "str_9649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_965", "str_965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9650", "str_9650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9651", "str_9651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9652", "str_9652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9653", "str_9653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9654", "str_9654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9655", "str_9655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9656", "str_9656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9657", "str_9657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9658", "str_9658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9659", "str_9659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_966", "str_966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9660", "str_9660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9661", "str_9661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9662", "str_9662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9663", "str_9663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9664", "str_9664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9665", "str_9665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9666", "str_9666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9667", "str_9667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9668", "str_9668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9669", "str_9669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_967", "str_967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9670", "str_9670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9671", "str_9671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9672", "str_9672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9673", "str_9673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9674", "str_9674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9675", "str_9675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9676", "str_9676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9677", "str_9677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9678", "str_9678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9679", "str_9679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_968", "str_968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9680", "str_9680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9681", "str_9681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9682", "str_9682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9683", "str_9683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9684", "str_9684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9685", "str_9685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9686", "str_9686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9687", "str_9687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9688", "str_9688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9689", "str_9689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_969", "str_969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9690", "str_9690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9691", "str_9691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9692", "str_9692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9693", "str_9693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9694", "str_9694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9695", "str_9695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9696", "str_9696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9697", "str_9697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9698", "str_9698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9699", "str_9699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_97: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_97", "str_97",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_970", "str_970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9700", "str_9700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9701", "str_9701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9702", "str_9702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9703", "str_9703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9704", "str_9704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9705", "str_9705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9706", "str_9706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9707", "str_9707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9708", "str_9708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9709", "str_9709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_971", "str_971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9710", "str_9710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9711", "str_9711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9712", "str_9712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9713", "str_9713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9714", "str_9714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9715", "str_9715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9716", "str_9716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9717", "str_9717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9718", "str_9718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9719", "str_9719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_972", "str_972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9720", "str_9720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9721", "str_9721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9722", "str_9722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9723", "str_9723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9724", "str_9724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9725", "str_9725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9726", "str_9726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9727", "str_9727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9728", "str_9728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9729", "str_9729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_973", "str_973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9730", "str_9730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9731", "str_9731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9732", "str_9732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9733", "str_9733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9734", "str_9734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9735", "str_9735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9736", "str_9736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9737", "str_9737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9738", "str_9738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9739", "str_9739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_974", "str_974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9740", "str_9740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9741", "str_9741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9742", "str_9742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9743", "str_9743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9744", "str_9744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9745", "str_9745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9746", "str_9746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9747", "str_9747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9748", "str_9748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9749", "str_9749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_975", "str_975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9750", "str_9750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9751", "str_9751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9752", "str_9752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9753", "str_9753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9754", "str_9754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9755", "str_9755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9756", "str_9756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9757", "str_9757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9758", "str_9758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9759", "str_9759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_976", "str_976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9760", "str_9760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9761", "str_9761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9762", "str_9762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9763", "str_9763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9764", "str_9764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9765", "str_9765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9766", "str_9766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9767", "str_9767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9768", "str_9768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9769", "str_9769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_977", "str_977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9770", "str_9770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9771", "str_9771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9772", "str_9772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9773", "str_9773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9774", "str_9774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9775", "str_9775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9776", "str_9776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9777", "str_9777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9778", "str_9778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9779", "str_9779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_978", "str_978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9780", "str_9780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9781", "str_9781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9782", "str_9782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9783", "str_9783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9784", "str_9784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9785", "str_9785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9786", "str_9786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9787", "str_9787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9788", "str_9788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9789", "str_9789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_979", "str_979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9790", "str_9790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9791", "str_9791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9792", "str_9792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9793", "str_9793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9794", "str_9794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9795", "str_9795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9796", "str_9796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9797", "str_9797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9798", "str_9798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9799", "str_9799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_98: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_98", "str_98",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_980", "str_980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9800", "str_9800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9801", "str_9801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9802", "str_9802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9803", "str_9803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9804", "str_9804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9805", "str_9805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9806", "str_9806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9807", "str_9807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9808", "str_9808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9809", "str_9809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_981", "str_981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9810", "str_9810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9811", "str_9811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9812", "str_9812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9813", "str_9813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9814", "str_9814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9815", "str_9815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9816", "str_9816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9817", "str_9817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9818", "str_9818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9819", "str_9819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_982", "str_982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9820", "str_9820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9821", "str_9821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9822", "str_9822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9823", "str_9823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9824", "str_9824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9825", "str_9825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9826", "str_9826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9827", "str_9827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9828", "str_9828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9829", "str_9829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_983", "str_983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9830", "str_9830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9831", "str_9831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9832", "str_9832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9833", "str_9833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9834", "str_9834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9835", "str_9835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9836", "str_9836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9837", "str_9837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9838", "str_9838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9839", "str_9839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_984", "str_984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9840", "str_9840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9841", "str_9841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9842", "str_9842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9843", "str_9843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9844", "str_9844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9845", "str_9845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9846", "str_9846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9847", "str_9847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9848", "str_9848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9849", "str_9849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_985", "str_985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9850", "str_9850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9851", "str_9851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9852", "str_9852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9853", "str_9853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9854", "str_9854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9855", "str_9855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9856", "str_9856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9857", "str_9857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9858", "str_9858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9859", "str_9859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_986", "str_986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9860", "str_9860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9861", "str_9861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9862", "str_9862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9863", "str_9863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9864", "str_9864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9865", "str_9865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9866", "str_9866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9867", "str_9867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9868", "str_9868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9869", "str_9869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_987", "str_987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9870", "str_9870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9871", "str_9871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9872", "str_9872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9873", "str_9873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9874", "str_9874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9875", "str_9875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9876", "str_9876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9877", "str_9877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9878", "str_9878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9879", "str_9879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_988", "str_988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9880", "str_9880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9881", "str_9881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9882", "str_9882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9883", "str_9883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9884", "str_9884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9885", "str_9885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9886", "str_9886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9887", "str_9887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9888", "str_9888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9889", "str_9889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_989", "str_989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9890", "str_9890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9891", "str_9891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9892", "str_9892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9893", "str_9893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9894", "str_9894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9895", "str_9895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9896", "str_9896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9897", "str_9897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9898", "str_9898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9899", "str_9899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_99: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_99", "str_99",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_990", "str_990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9900", "str_9900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9901", "str_9901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9902", "str_9902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9903", "str_9903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9904", "str_9904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9905", "str_9905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9906", "str_9906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9907", "str_9907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9908", "str_9908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9909", "str_9909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_991", "str_991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9910", "str_9910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9911", "str_9911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9912", "str_9912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9913", "str_9913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9914", "str_9914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9915", "str_9915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9916", "str_9916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9917", "str_9917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9918", "str_9918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9919", "str_9919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_992", "str_992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9920", "str_9920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9921", "str_9921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9922", "str_9922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9923", "str_9923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9924", "str_9924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9925", "str_9925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9926", "str_9926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9927", "str_9927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9928", "str_9928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9929", "str_9929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_993", "str_993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9930", "str_9930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9931", "str_9931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9932", "str_9932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9933", "str_9933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9934", "str_9934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9935", "str_9935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9936", "str_9936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9937", "str_9937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9938", "str_9938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9939", "str_9939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_994", "str_994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9940", "str_9940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9941", "str_9941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9942", "str_9942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9943", "str_9943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9944", "str_9944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9945", "str_9945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9946", "str_9946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9947", "str_9947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9948", "str_9948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9949", "str_9949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_995", "str_995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9950", "str_9950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9951", "str_9951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9952", "str_9952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9953", "str_9953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9954", "str_9954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9955", "str_9955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9956", "str_9956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9957", "str_9957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9958", "str_9958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9959", "str_9959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_996", "str_996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9960", "str_9960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9961", "str_9961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9962", "str_9962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9963", "str_9963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9964", "str_9964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9965", "str_9965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9966", "str_9966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9967", "str_9967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9968", "str_9968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9969", "str_9969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_997", "str_997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9970", "str_9970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9971", "str_9971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9972", "str_9972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9973", "str_9973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9974", "str_9974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9975", "str_9975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9976", "str_9976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9977", "str_9977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9978", "str_9978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9979", "str_9979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_998", "str_998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9980", "str_9980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9981", "str_9981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9982", "str_9982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9983", "str_9983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9984", "str_9984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9985", "str_9985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9986", "str_9986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9987", "str_9987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9988", "str_9988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9989", "str_9989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_999", "str_999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9990", "str_9990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9991", "str_9991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9992", "str_9992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9993", "str_9993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9994", "str_9994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9995", "str_9995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9996", "str_9996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9997", "str_9997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9998", "str_9998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_9999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_9999", "str_9999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_9549: StringResource
+  get() = String49.str_9549
+
+@ExperimentalResourceApi
+internal val Res.string.str_955: StringResource
+  get() = String49.str_955
+
+@ExperimentalResourceApi
+internal val Res.string.str_9550: StringResource
+  get() = String49.str_9550
+
+@ExperimentalResourceApi
+internal val Res.string.str_9551: StringResource
+  get() = String49.str_9551
+
+@ExperimentalResourceApi
+internal val Res.string.str_9552: StringResource
+  get() = String49.str_9552
+
+@ExperimentalResourceApi
+internal val Res.string.str_9553: StringResource
+  get() = String49.str_9553
+
+@ExperimentalResourceApi
+internal val Res.string.str_9554: StringResource
+  get() = String49.str_9554
+
+@ExperimentalResourceApi
+internal val Res.string.str_9555: StringResource
+  get() = String49.str_9555
+
+@ExperimentalResourceApi
+internal val Res.string.str_9556: StringResource
+  get() = String49.str_9556
+
+@ExperimentalResourceApi
+internal val Res.string.str_9557: StringResource
+  get() = String49.str_9557
+
+@ExperimentalResourceApi
+internal val Res.string.str_9558: StringResource
+  get() = String49.str_9558
+
+@ExperimentalResourceApi
+internal val Res.string.str_9559: StringResource
+  get() = String49.str_9559
+
+@ExperimentalResourceApi
+internal val Res.string.str_956: StringResource
+  get() = String49.str_956
+
+@ExperimentalResourceApi
+internal val Res.string.str_9560: StringResource
+  get() = String49.str_9560
+
+@ExperimentalResourceApi
+internal val Res.string.str_9561: StringResource
+  get() = String49.str_9561
+
+@ExperimentalResourceApi
+internal val Res.string.str_9562: StringResource
+  get() = String49.str_9562
+
+@ExperimentalResourceApi
+internal val Res.string.str_9563: StringResource
+  get() = String49.str_9563
+
+@ExperimentalResourceApi
+internal val Res.string.str_9564: StringResource
+  get() = String49.str_9564
+
+@ExperimentalResourceApi
+internal val Res.string.str_9565: StringResource
+  get() = String49.str_9565
+
+@ExperimentalResourceApi
+internal val Res.string.str_9566: StringResource
+  get() = String49.str_9566
+
+@ExperimentalResourceApi
+internal val Res.string.str_9567: StringResource
+  get() = String49.str_9567
+
+@ExperimentalResourceApi
+internal val Res.string.str_9568: StringResource
+  get() = String49.str_9568
+
+@ExperimentalResourceApi
+internal val Res.string.str_9569: StringResource
+  get() = String49.str_9569
+
+@ExperimentalResourceApi
+internal val Res.string.str_957: StringResource
+  get() = String49.str_957
+
+@ExperimentalResourceApi
+internal val Res.string.str_9570: StringResource
+  get() = String49.str_9570
+
+@ExperimentalResourceApi
+internal val Res.string.str_9571: StringResource
+  get() = String49.str_9571
+
+@ExperimentalResourceApi
+internal val Res.string.str_9572: StringResource
+  get() = String49.str_9572
+
+@ExperimentalResourceApi
+internal val Res.string.str_9573: StringResource
+  get() = String49.str_9573
+
+@ExperimentalResourceApi
+internal val Res.string.str_9574: StringResource
+  get() = String49.str_9574
+
+@ExperimentalResourceApi
+internal val Res.string.str_9575: StringResource
+  get() = String49.str_9575
+
+@ExperimentalResourceApi
+internal val Res.string.str_9576: StringResource
+  get() = String49.str_9576
+
+@ExperimentalResourceApi
+internal val Res.string.str_9577: StringResource
+  get() = String49.str_9577
+
+@ExperimentalResourceApi
+internal val Res.string.str_9578: StringResource
+  get() = String49.str_9578
+
+@ExperimentalResourceApi
+internal val Res.string.str_9579: StringResource
+  get() = String49.str_9579
+
+@ExperimentalResourceApi
+internal val Res.string.str_958: StringResource
+  get() = String49.str_958
+
+@ExperimentalResourceApi
+internal val Res.string.str_9580: StringResource
+  get() = String49.str_9580
+
+@ExperimentalResourceApi
+internal val Res.string.str_9581: StringResource
+  get() = String49.str_9581
+
+@ExperimentalResourceApi
+internal val Res.string.str_9582: StringResource
+  get() = String49.str_9582
+
+@ExperimentalResourceApi
+internal val Res.string.str_9583: StringResource
+  get() = String49.str_9583
+
+@ExperimentalResourceApi
+internal val Res.string.str_9584: StringResource
+  get() = String49.str_9584
+
+@ExperimentalResourceApi
+internal val Res.string.str_9585: StringResource
+  get() = String49.str_9585
+
+@ExperimentalResourceApi
+internal val Res.string.str_9586: StringResource
+  get() = String49.str_9586
+
+@ExperimentalResourceApi
+internal val Res.string.str_9587: StringResource
+  get() = String49.str_9587
+
+@ExperimentalResourceApi
+internal val Res.string.str_9588: StringResource
+  get() = String49.str_9588
+
+@ExperimentalResourceApi
+internal val Res.string.str_9589: StringResource
+  get() = String49.str_9589
+
+@ExperimentalResourceApi
+internal val Res.string.str_959: StringResource
+  get() = String49.str_959
+
+@ExperimentalResourceApi
+internal val Res.string.str_9590: StringResource
+  get() = String49.str_9590
+
+@ExperimentalResourceApi
+internal val Res.string.str_9591: StringResource
+  get() = String49.str_9591
+
+@ExperimentalResourceApi
+internal val Res.string.str_9592: StringResource
+  get() = String49.str_9592
+
+@ExperimentalResourceApi
+internal val Res.string.str_9593: StringResource
+  get() = String49.str_9593
+
+@ExperimentalResourceApi
+internal val Res.string.str_9594: StringResource
+  get() = String49.str_9594
+
+@ExperimentalResourceApi
+internal val Res.string.str_9595: StringResource
+  get() = String49.str_9595
+
+@ExperimentalResourceApi
+internal val Res.string.str_9596: StringResource
+  get() = String49.str_9596
+
+@ExperimentalResourceApi
+internal val Res.string.str_9597: StringResource
+  get() = String49.str_9597
+
+@ExperimentalResourceApi
+internal val Res.string.str_9598: StringResource
+  get() = String49.str_9598
+
+@ExperimentalResourceApi
+internal val Res.string.str_9599: StringResource
+  get() = String49.str_9599
+
+@ExperimentalResourceApi
+internal val Res.string.str_96: StringResource
+  get() = String49.str_96
+
+@ExperimentalResourceApi
+internal val Res.string.str_960: StringResource
+  get() = String49.str_960
+
+@ExperimentalResourceApi
+internal val Res.string.str_9600: StringResource
+  get() = String49.str_9600
+
+@ExperimentalResourceApi
+internal val Res.string.str_9601: StringResource
+  get() = String49.str_9601
+
+@ExperimentalResourceApi
+internal val Res.string.str_9602: StringResource
+  get() = String49.str_9602
+
+@ExperimentalResourceApi
+internal val Res.string.str_9603: StringResource
+  get() = String49.str_9603
+
+@ExperimentalResourceApi
+internal val Res.string.str_9604: StringResource
+  get() = String49.str_9604
+
+@ExperimentalResourceApi
+internal val Res.string.str_9605: StringResource
+  get() = String49.str_9605
+
+@ExperimentalResourceApi
+internal val Res.string.str_9606: StringResource
+  get() = String49.str_9606
+
+@ExperimentalResourceApi
+internal val Res.string.str_9607: StringResource
+  get() = String49.str_9607
+
+@ExperimentalResourceApi
+internal val Res.string.str_9608: StringResource
+  get() = String49.str_9608
+
+@ExperimentalResourceApi
+internal val Res.string.str_9609: StringResource
+  get() = String49.str_9609
+
+@ExperimentalResourceApi
+internal val Res.string.str_961: StringResource
+  get() = String49.str_961
+
+@ExperimentalResourceApi
+internal val Res.string.str_9610: StringResource
+  get() = String49.str_9610
+
+@ExperimentalResourceApi
+internal val Res.string.str_9611: StringResource
+  get() = String49.str_9611
+
+@ExperimentalResourceApi
+internal val Res.string.str_9612: StringResource
+  get() = String49.str_9612
+
+@ExperimentalResourceApi
+internal val Res.string.str_9613: StringResource
+  get() = String49.str_9613
+
+@ExperimentalResourceApi
+internal val Res.string.str_9614: StringResource
+  get() = String49.str_9614
+
+@ExperimentalResourceApi
+internal val Res.string.str_9615: StringResource
+  get() = String49.str_9615
+
+@ExperimentalResourceApi
+internal val Res.string.str_9616: StringResource
+  get() = String49.str_9616
+
+@ExperimentalResourceApi
+internal val Res.string.str_9617: StringResource
+  get() = String49.str_9617
+
+@ExperimentalResourceApi
+internal val Res.string.str_9618: StringResource
+  get() = String49.str_9618
+
+@ExperimentalResourceApi
+internal val Res.string.str_9619: StringResource
+  get() = String49.str_9619
+
+@ExperimentalResourceApi
+internal val Res.string.str_962: StringResource
+  get() = String49.str_962
+
+@ExperimentalResourceApi
+internal val Res.string.str_9620: StringResource
+  get() = String49.str_9620
+
+@ExperimentalResourceApi
+internal val Res.string.str_9621: StringResource
+  get() = String49.str_9621
+
+@ExperimentalResourceApi
+internal val Res.string.str_9622: StringResource
+  get() = String49.str_9622
+
+@ExperimentalResourceApi
+internal val Res.string.str_9623: StringResource
+  get() = String49.str_9623
+
+@ExperimentalResourceApi
+internal val Res.string.str_9624: StringResource
+  get() = String49.str_9624
+
+@ExperimentalResourceApi
+internal val Res.string.str_9625: StringResource
+  get() = String49.str_9625
+
+@ExperimentalResourceApi
+internal val Res.string.str_9626: StringResource
+  get() = String49.str_9626
+
+@ExperimentalResourceApi
+internal val Res.string.str_9627: StringResource
+  get() = String49.str_9627
+
+@ExperimentalResourceApi
+internal val Res.string.str_9628: StringResource
+  get() = String49.str_9628
+
+@ExperimentalResourceApi
+internal val Res.string.str_9629: StringResource
+  get() = String49.str_9629
+
+@ExperimentalResourceApi
+internal val Res.string.str_963: StringResource
+  get() = String49.str_963
+
+@ExperimentalResourceApi
+internal val Res.string.str_9630: StringResource
+  get() = String49.str_9630
+
+@ExperimentalResourceApi
+internal val Res.string.str_9631: StringResource
+  get() = String49.str_9631
+
+@ExperimentalResourceApi
+internal val Res.string.str_9632: StringResource
+  get() = String49.str_9632
+
+@ExperimentalResourceApi
+internal val Res.string.str_9633: StringResource
+  get() = String49.str_9633
+
+@ExperimentalResourceApi
+internal val Res.string.str_9634: StringResource
+  get() = String49.str_9634
+
+@ExperimentalResourceApi
+internal val Res.string.str_9635: StringResource
+  get() = String49.str_9635
+
+@ExperimentalResourceApi
+internal val Res.string.str_9636: StringResource
+  get() = String49.str_9636
+
+@ExperimentalResourceApi
+internal val Res.string.str_9637: StringResource
+  get() = String49.str_9637
+
+@ExperimentalResourceApi
+internal val Res.string.str_9638: StringResource
+  get() = String49.str_9638
+
+@ExperimentalResourceApi
+internal val Res.string.str_9639: StringResource
+  get() = String49.str_9639
+
+@ExperimentalResourceApi
+internal val Res.string.str_964: StringResource
+  get() = String49.str_964
+
+@ExperimentalResourceApi
+internal val Res.string.str_9640: StringResource
+  get() = String49.str_9640
+
+@ExperimentalResourceApi
+internal val Res.string.str_9641: StringResource
+  get() = String49.str_9641
+
+@ExperimentalResourceApi
+internal val Res.string.str_9642: StringResource
+  get() = String49.str_9642
+
+@ExperimentalResourceApi
+internal val Res.string.str_9643: StringResource
+  get() = String49.str_9643
+
+@ExperimentalResourceApi
+internal val Res.string.str_9644: StringResource
+  get() = String49.str_9644
+
+@ExperimentalResourceApi
+internal val Res.string.str_9645: StringResource
+  get() = String49.str_9645
+
+@ExperimentalResourceApi
+internal val Res.string.str_9646: StringResource
+  get() = String49.str_9646
+
+@ExperimentalResourceApi
+internal val Res.string.str_9647: StringResource
+  get() = String49.str_9647
+
+@ExperimentalResourceApi
+internal val Res.string.str_9648: StringResource
+  get() = String49.str_9648
+
+@ExperimentalResourceApi
+internal val Res.string.str_9649: StringResource
+  get() = String49.str_9649
+
+@ExperimentalResourceApi
+internal val Res.string.str_965: StringResource
+  get() = String49.str_965
+
+@ExperimentalResourceApi
+internal val Res.string.str_9650: StringResource
+  get() = String49.str_9650
+
+@ExperimentalResourceApi
+internal val Res.string.str_9651: StringResource
+  get() = String49.str_9651
+
+@ExperimentalResourceApi
+internal val Res.string.str_9652: StringResource
+  get() = String49.str_9652
+
+@ExperimentalResourceApi
+internal val Res.string.str_9653: StringResource
+  get() = String49.str_9653
+
+@ExperimentalResourceApi
+internal val Res.string.str_9654: StringResource
+  get() = String49.str_9654
+
+@ExperimentalResourceApi
+internal val Res.string.str_9655: StringResource
+  get() = String49.str_9655
+
+@ExperimentalResourceApi
+internal val Res.string.str_9656: StringResource
+  get() = String49.str_9656
+
+@ExperimentalResourceApi
+internal val Res.string.str_9657: StringResource
+  get() = String49.str_9657
+
+@ExperimentalResourceApi
+internal val Res.string.str_9658: StringResource
+  get() = String49.str_9658
+
+@ExperimentalResourceApi
+internal val Res.string.str_9659: StringResource
+  get() = String49.str_9659
+
+@ExperimentalResourceApi
+internal val Res.string.str_966: StringResource
+  get() = String49.str_966
+
+@ExperimentalResourceApi
+internal val Res.string.str_9660: StringResource
+  get() = String49.str_9660
+
+@ExperimentalResourceApi
+internal val Res.string.str_9661: StringResource
+  get() = String49.str_9661
+
+@ExperimentalResourceApi
+internal val Res.string.str_9662: StringResource
+  get() = String49.str_9662
+
+@ExperimentalResourceApi
+internal val Res.string.str_9663: StringResource
+  get() = String49.str_9663
+
+@ExperimentalResourceApi
+internal val Res.string.str_9664: StringResource
+  get() = String49.str_9664
+
+@ExperimentalResourceApi
+internal val Res.string.str_9665: StringResource
+  get() = String49.str_9665
+
+@ExperimentalResourceApi
+internal val Res.string.str_9666: StringResource
+  get() = String49.str_9666
+
+@ExperimentalResourceApi
+internal val Res.string.str_9667: StringResource
+  get() = String49.str_9667
+
+@ExperimentalResourceApi
+internal val Res.string.str_9668: StringResource
+  get() = String49.str_9668
+
+@ExperimentalResourceApi
+internal val Res.string.str_9669: StringResource
+  get() = String49.str_9669
+
+@ExperimentalResourceApi
+internal val Res.string.str_967: StringResource
+  get() = String49.str_967
+
+@ExperimentalResourceApi
+internal val Res.string.str_9670: StringResource
+  get() = String49.str_9670
+
+@ExperimentalResourceApi
+internal val Res.string.str_9671: StringResource
+  get() = String49.str_9671
+
+@ExperimentalResourceApi
+internal val Res.string.str_9672: StringResource
+  get() = String49.str_9672
+
+@ExperimentalResourceApi
+internal val Res.string.str_9673: StringResource
+  get() = String49.str_9673
+
+@ExperimentalResourceApi
+internal val Res.string.str_9674: StringResource
+  get() = String49.str_9674
+
+@ExperimentalResourceApi
+internal val Res.string.str_9675: StringResource
+  get() = String49.str_9675
+
+@ExperimentalResourceApi
+internal val Res.string.str_9676: StringResource
+  get() = String49.str_9676
+
+@ExperimentalResourceApi
+internal val Res.string.str_9677: StringResource
+  get() = String49.str_9677
+
+@ExperimentalResourceApi
+internal val Res.string.str_9678: StringResource
+  get() = String49.str_9678
+
+@ExperimentalResourceApi
+internal val Res.string.str_9679: StringResource
+  get() = String49.str_9679
+
+@ExperimentalResourceApi
+internal val Res.string.str_968: StringResource
+  get() = String49.str_968
+
+@ExperimentalResourceApi
+internal val Res.string.str_9680: StringResource
+  get() = String49.str_9680
+
+@ExperimentalResourceApi
+internal val Res.string.str_9681: StringResource
+  get() = String49.str_9681
+
+@ExperimentalResourceApi
+internal val Res.string.str_9682: StringResource
+  get() = String49.str_9682
+
+@ExperimentalResourceApi
+internal val Res.string.str_9683: StringResource
+  get() = String49.str_9683
+
+@ExperimentalResourceApi
+internal val Res.string.str_9684: StringResource
+  get() = String49.str_9684
+
+@ExperimentalResourceApi
+internal val Res.string.str_9685: StringResource
+  get() = String49.str_9685
+
+@ExperimentalResourceApi
+internal val Res.string.str_9686: StringResource
+  get() = String49.str_9686
+
+@ExperimentalResourceApi
+internal val Res.string.str_9687: StringResource
+  get() = String49.str_9687
+
+@ExperimentalResourceApi
+internal val Res.string.str_9688: StringResource
+  get() = String49.str_9688
+
+@ExperimentalResourceApi
+internal val Res.string.str_9689: StringResource
+  get() = String49.str_9689
+
+@ExperimentalResourceApi
+internal val Res.string.str_969: StringResource
+  get() = String49.str_969
+
+@ExperimentalResourceApi
+internal val Res.string.str_9690: StringResource
+  get() = String49.str_9690
+
+@ExperimentalResourceApi
+internal val Res.string.str_9691: StringResource
+  get() = String49.str_9691
+
+@ExperimentalResourceApi
+internal val Res.string.str_9692: StringResource
+  get() = String49.str_9692
+
+@ExperimentalResourceApi
+internal val Res.string.str_9693: StringResource
+  get() = String49.str_9693
+
+@ExperimentalResourceApi
+internal val Res.string.str_9694: StringResource
+  get() = String49.str_9694
+
+@ExperimentalResourceApi
+internal val Res.string.str_9695: StringResource
+  get() = String49.str_9695
+
+@ExperimentalResourceApi
+internal val Res.string.str_9696: StringResource
+  get() = String49.str_9696
+
+@ExperimentalResourceApi
+internal val Res.string.str_9697: StringResource
+  get() = String49.str_9697
+
+@ExperimentalResourceApi
+internal val Res.string.str_9698: StringResource
+  get() = String49.str_9698
+
+@ExperimentalResourceApi
+internal val Res.string.str_9699: StringResource
+  get() = String49.str_9699
+
+@ExperimentalResourceApi
+internal val Res.string.str_97: StringResource
+  get() = String49.str_97
+
+@ExperimentalResourceApi
+internal val Res.string.str_970: StringResource
+  get() = String49.str_970
+
+@ExperimentalResourceApi
+internal val Res.string.str_9700: StringResource
+  get() = String49.str_9700
+
+@ExperimentalResourceApi
+internal val Res.string.str_9701: StringResource
+  get() = String49.str_9701
+
+@ExperimentalResourceApi
+internal val Res.string.str_9702: StringResource
+  get() = String49.str_9702
+
+@ExperimentalResourceApi
+internal val Res.string.str_9703: StringResource
+  get() = String49.str_9703
+
+@ExperimentalResourceApi
+internal val Res.string.str_9704: StringResource
+  get() = String49.str_9704
+
+@ExperimentalResourceApi
+internal val Res.string.str_9705: StringResource
+  get() = String49.str_9705
+
+@ExperimentalResourceApi
+internal val Res.string.str_9706: StringResource
+  get() = String49.str_9706
+
+@ExperimentalResourceApi
+internal val Res.string.str_9707: StringResource
+  get() = String49.str_9707
+
+@ExperimentalResourceApi
+internal val Res.string.str_9708: StringResource
+  get() = String49.str_9708
+
+@ExperimentalResourceApi
+internal val Res.string.str_9709: StringResource
+  get() = String49.str_9709
+
+@ExperimentalResourceApi
+internal val Res.string.str_971: StringResource
+  get() = String49.str_971
+
+@ExperimentalResourceApi
+internal val Res.string.str_9710: StringResource
+  get() = String49.str_9710
+
+@ExperimentalResourceApi
+internal val Res.string.str_9711: StringResource
+  get() = String49.str_9711
+
+@ExperimentalResourceApi
+internal val Res.string.str_9712: StringResource
+  get() = String49.str_9712
+
+@ExperimentalResourceApi
+internal val Res.string.str_9713: StringResource
+  get() = String49.str_9713
+
+@ExperimentalResourceApi
+internal val Res.string.str_9714: StringResource
+  get() = String49.str_9714
+
+@ExperimentalResourceApi
+internal val Res.string.str_9715: StringResource
+  get() = String49.str_9715
+
+@ExperimentalResourceApi
+internal val Res.string.str_9716: StringResource
+  get() = String49.str_9716
+
+@ExperimentalResourceApi
+internal val Res.string.str_9717: StringResource
+  get() = String49.str_9717
+
+@ExperimentalResourceApi
+internal val Res.string.str_9718: StringResource
+  get() = String49.str_9718
+
+@ExperimentalResourceApi
+internal val Res.string.str_9719: StringResource
+  get() = String49.str_9719
+
+@ExperimentalResourceApi
+internal val Res.string.str_972: StringResource
+  get() = String49.str_972
+
+@ExperimentalResourceApi
+internal val Res.string.str_9720: StringResource
+  get() = String49.str_9720
+
+@ExperimentalResourceApi
+internal val Res.string.str_9721: StringResource
+  get() = String49.str_9721
+
+@ExperimentalResourceApi
+internal val Res.string.str_9722: StringResource
+  get() = String49.str_9722
+
+@ExperimentalResourceApi
+internal val Res.string.str_9723: StringResource
+  get() = String49.str_9723
+
+@ExperimentalResourceApi
+internal val Res.string.str_9724: StringResource
+  get() = String49.str_9724
+
+@ExperimentalResourceApi
+internal val Res.string.str_9725: StringResource
+  get() = String49.str_9725
+
+@ExperimentalResourceApi
+internal val Res.string.str_9726: StringResource
+  get() = String49.str_9726
+
+@ExperimentalResourceApi
+internal val Res.string.str_9727: StringResource
+  get() = String49.str_9727
+
+@ExperimentalResourceApi
+internal val Res.string.str_9728: StringResource
+  get() = String49.str_9728
+
+@ExperimentalResourceApi
+internal val Res.string.str_9729: StringResource
+  get() = String49.str_9729
+
+@ExperimentalResourceApi
+internal val Res.string.str_973: StringResource
+  get() = String49.str_973
+
+@ExperimentalResourceApi
+internal val Res.string.str_9730: StringResource
+  get() = String49.str_9730
+
+@ExperimentalResourceApi
+internal val Res.string.str_9731: StringResource
+  get() = String49.str_9731
+
+@ExperimentalResourceApi
+internal val Res.string.str_9732: StringResource
+  get() = String49.str_9732
+
+@ExperimentalResourceApi
+internal val Res.string.str_9733: StringResource
+  get() = String49.str_9733
+
+@ExperimentalResourceApi
+internal val Res.string.str_9734: StringResource
+  get() = String49.str_9734
+
+@ExperimentalResourceApi
+internal val Res.string.str_9735: StringResource
+  get() = String49.str_9735
+
+@ExperimentalResourceApi
+internal val Res.string.str_9736: StringResource
+  get() = String49.str_9736
+
+@ExperimentalResourceApi
+internal val Res.string.str_9737: StringResource
+  get() = String49.str_9737
+
+@ExperimentalResourceApi
+internal val Res.string.str_9738: StringResource
+  get() = String49.str_9738
+
+@ExperimentalResourceApi
+internal val Res.string.str_9739: StringResource
+  get() = String49.str_9739
+
+@ExperimentalResourceApi
+internal val Res.string.str_974: StringResource
+  get() = String49.str_974
+
+@ExperimentalResourceApi
+internal val Res.string.str_9740: StringResource
+  get() = String49.str_9740
+
+@ExperimentalResourceApi
+internal val Res.string.str_9741: StringResource
+  get() = String49.str_9741
+
+@ExperimentalResourceApi
+internal val Res.string.str_9742: StringResource
+  get() = String49.str_9742
+
+@ExperimentalResourceApi
+internal val Res.string.str_9743: StringResource
+  get() = String49.str_9743
+
+@ExperimentalResourceApi
+internal val Res.string.str_9744: StringResource
+  get() = String49.str_9744
+
+@ExperimentalResourceApi
+internal val Res.string.str_9745: StringResource
+  get() = String49.str_9745
+
+@ExperimentalResourceApi
+internal val Res.string.str_9746: StringResource
+  get() = String49.str_9746
+
+@ExperimentalResourceApi
+internal val Res.string.str_9747: StringResource
+  get() = String49.str_9747
+
+@ExperimentalResourceApi
+internal val Res.string.str_9748: StringResource
+  get() = String49.str_9748
+
+@ExperimentalResourceApi
+internal val Res.string.str_9749: StringResource
+  get() = String49.str_9749
+
+@ExperimentalResourceApi
+internal val Res.string.str_975: StringResource
+  get() = String49.str_975
+
+@ExperimentalResourceApi
+internal val Res.string.str_9750: StringResource
+  get() = String49.str_9750
+
+@ExperimentalResourceApi
+internal val Res.string.str_9751: StringResource
+  get() = String49.str_9751
+
+@ExperimentalResourceApi
+internal val Res.string.str_9752: StringResource
+  get() = String49.str_9752
+
+@ExperimentalResourceApi
+internal val Res.string.str_9753: StringResource
+  get() = String49.str_9753
+
+@ExperimentalResourceApi
+internal val Res.string.str_9754: StringResource
+  get() = String49.str_9754
+
+@ExperimentalResourceApi
+internal val Res.string.str_9755: StringResource
+  get() = String49.str_9755
+
+@ExperimentalResourceApi
+internal val Res.string.str_9756: StringResource
+  get() = String49.str_9756
+
+@ExperimentalResourceApi
+internal val Res.string.str_9757: StringResource
+  get() = String49.str_9757
+
+@ExperimentalResourceApi
+internal val Res.string.str_9758: StringResource
+  get() = String49.str_9758
+
+@ExperimentalResourceApi
+internal val Res.string.str_9759: StringResource
+  get() = String49.str_9759
+
+@ExperimentalResourceApi
+internal val Res.string.str_976: StringResource
+  get() = String49.str_976
+
+@ExperimentalResourceApi
+internal val Res.string.str_9760: StringResource
+  get() = String49.str_9760
+
+@ExperimentalResourceApi
+internal val Res.string.str_9761: StringResource
+  get() = String49.str_9761
+
+@ExperimentalResourceApi
+internal val Res.string.str_9762: StringResource
+  get() = String49.str_9762
+
+@ExperimentalResourceApi
+internal val Res.string.str_9763: StringResource
+  get() = String49.str_9763
+
+@ExperimentalResourceApi
+internal val Res.string.str_9764: StringResource
+  get() = String49.str_9764
+
+@ExperimentalResourceApi
+internal val Res.string.str_9765: StringResource
+  get() = String49.str_9765
+
+@ExperimentalResourceApi
+internal val Res.string.str_9766: StringResource
+  get() = String49.str_9766
+
+@ExperimentalResourceApi
+internal val Res.string.str_9767: StringResource
+  get() = String49.str_9767
+
+@ExperimentalResourceApi
+internal val Res.string.str_9768: StringResource
+  get() = String49.str_9768
+
+@ExperimentalResourceApi
+internal val Res.string.str_9769: StringResource
+  get() = String49.str_9769
+
+@ExperimentalResourceApi
+internal val Res.string.str_977: StringResource
+  get() = String49.str_977
+
+@ExperimentalResourceApi
+internal val Res.string.str_9770: StringResource
+  get() = String49.str_9770
+
+@ExperimentalResourceApi
+internal val Res.string.str_9771: StringResource
+  get() = String49.str_9771
+
+@ExperimentalResourceApi
+internal val Res.string.str_9772: StringResource
+  get() = String49.str_9772
+
+@ExperimentalResourceApi
+internal val Res.string.str_9773: StringResource
+  get() = String49.str_9773
+
+@ExperimentalResourceApi
+internal val Res.string.str_9774: StringResource
+  get() = String49.str_9774
+
+@ExperimentalResourceApi
+internal val Res.string.str_9775: StringResource
+  get() = String49.str_9775
+
+@ExperimentalResourceApi
+internal val Res.string.str_9776: StringResource
+  get() = String49.str_9776
+
+@ExperimentalResourceApi
+internal val Res.string.str_9777: StringResource
+  get() = String49.str_9777
+
+@ExperimentalResourceApi
+internal val Res.string.str_9778: StringResource
+  get() = String49.str_9778
+
+@ExperimentalResourceApi
+internal val Res.string.str_9779: StringResource
+  get() = String49.str_9779
+
+@ExperimentalResourceApi
+internal val Res.string.str_978: StringResource
+  get() = String49.str_978
+
+@ExperimentalResourceApi
+internal val Res.string.str_9780: StringResource
+  get() = String49.str_9780
+
+@ExperimentalResourceApi
+internal val Res.string.str_9781: StringResource
+  get() = String49.str_9781
+
+@ExperimentalResourceApi
+internal val Res.string.str_9782: StringResource
+  get() = String49.str_9782
+
+@ExperimentalResourceApi
+internal val Res.string.str_9783: StringResource
+  get() = String49.str_9783
+
+@ExperimentalResourceApi
+internal val Res.string.str_9784: StringResource
+  get() = String49.str_9784
+
+@ExperimentalResourceApi
+internal val Res.string.str_9785: StringResource
+  get() = String49.str_9785
+
+@ExperimentalResourceApi
+internal val Res.string.str_9786: StringResource
+  get() = String49.str_9786
+
+@ExperimentalResourceApi
+internal val Res.string.str_9787: StringResource
+  get() = String49.str_9787
+
+@ExperimentalResourceApi
+internal val Res.string.str_9788: StringResource
+  get() = String49.str_9788
+
+@ExperimentalResourceApi
+internal val Res.string.str_9789: StringResource
+  get() = String49.str_9789
+
+@ExperimentalResourceApi
+internal val Res.string.str_979: StringResource
+  get() = String49.str_979
+
+@ExperimentalResourceApi
+internal val Res.string.str_9790: StringResource
+  get() = String49.str_9790
+
+@ExperimentalResourceApi
+internal val Res.string.str_9791: StringResource
+  get() = String49.str_9791
+
+@ExperimentalResourceApi
+internal val Res.string.str_9792: StringResource
+  get() = String49.str_9792
+
+@ExperimentalResourceApi
+internal val Res.string.str_9793: StringResource
+  get() = String49.str_9793
+
+@ExperimentalResourceApi
+internal val Res.string.str_9794: StringResource
+  get() = String49.str_9794
+
+@ExperimentalResourceApi
+internal val Res.string.str_9795: StringResource
+  get() = String49.str_9795
+
+@ExperimentalResourceApi
+internal val Res.string.str_9796: StringResource
+  get() = String49.str_9796
+
+@ExperimentalResourceApi
+internal val Res.string.str_9797: StringResource
+  get() = String49.str_9797
+
+@ExperimentalResourceApi
+internal val Res.string.str_9798: StringResource
+  get() = String49.str_9798
+
+@ExperimentalResourceApi
+internal val Res.string.str_9799: StringResource
+  get() = String49.str_9799
+
+@ExperimentalResourceApi
+internal val Res.string.str_98: StringResource
+  get() = String49.str_98
+
+@ExperimentalResourceApi
+internal val Res.string.str_980: StringResource
+  get() = String49.str_980
+
+@ExperimentalResourceApi
+internal val Res.string.str_9800: StringResource
+  get() = String49.str_9800
+
+@ExperimentalResourceApi
+internal val Res.string.str_9801: StringResource
+  get() = String49.str_9801
+
+@ExperimentalResourceApi
+internal val Res.string.str_9802: StringResource
+  get() = String49.str_9802
+
+@ExperimentalResourceApi
+internal val Res.string.str_9803: StringResource
+  get() = String49.str_9803
+
+@ExperimentalResourceApi
+internal val Res.string.str_9804: StringResource
+  get() = String49.str_9804
+
+@ExperimentalResourceApi
+internal val Res.string.str_9805: StringResource
+  get() = String49.str_9805
+
+@ExperimentalResourceApi
+internal val Res.string.str_9806: StringResource
+  get() = String49.str_9806
+
+@ExperimentalResourceApi
+internal val Res.string.str_9807: StringResource
+  get() = String49.str_9807
+
+@ExperimentalResourceApi
+internal val Res.string.str_9808: StringResource
+  get() = String49.str_9808
+
+@ExperimentalResourceApi
+internal val Res.string.str_9809: StringResource
+  get() = String49.str_9809
+
+@ExperimentalResourceApi
+internal val Res.string.str_981: StringResource
+  get() = String49.str_981
+
+@ExperimentalResourceApi
+internal val Res.string.str_9810: StringResource
+  get() = String49.str_9810
+
+@ExperimentalResourceApi
+internal val Res.string.str_9811: StringResource
+  get() = String49.str_9811
+
+@ExperimentalResourceApi
+internal val Res.string.str_9812: StringResource
+  get() = String49.str_9812
+
+@ExperimentalResourceApi
+internal val Res.string.str_9813: StringResource
+  get() = String49.str_9813
+
+@ExperimentalResourceApi
+internal val Res.string.str_9814: StringResource
+  get() = String49.str_9814
+
+@ExperimentalResourceApi
+internal val Res.string.str_9815: StringResource
+  get() = String49.str_9815
+
+@ExperimentalResourceApi
+internal val Res.string.str_9816: StringResource
+  get() = String49.str_9816
+
+@ExperimentalResourceApi
+internal val Res.string.str_9817: StringResource
+  get() = String49.str_9817
+
+@ExperimentalResourceApi
+internal val Res.string.str_9818: StringResource
+  get() = String49.str_9818
+
+@ExperimentalResourceApi
+internal val Res.string.str_9819: StringResource
+  get() = String49.str_9819
+
+@ExperimentalResourceApi
+internal val Res.string.str_982: StringResource
+  get() = String49.str_982
+
+@ExperimentalResourceApi
+internal val Res.string.str_9820: StringResource
+  get() = String49.str_9820
+
+@ExperimentalResourceApi
+internal val Res.string.str_9821: StringResource
+  get() = String49.str_9821
+
+@ExperimentalResourceApi
+internal val Res.string.str_9822: StringResource
+  get() = String49.str_9822
+
+@ExperimentalResourceApi
+internal val Res.string.str_9823: StringResource
+  get() = String49.str_9823
+
+@ExperimentalResourceApi
+internal val Res.string.str_9824: StringResource
+  get() = String49.str_9824
+
+@ExperimentalResourceApi
+internal val Res.string.str_9825: StringResource
+  get() = String49.str_9825
+
+@ExperimentalResourceApi
+internal val Res.string.str_9826: StringResource
+  get() = String49.str_9826
+
+@ExperimentalResourceApi
+internal val Res.string.str_9827: StringResource
+  get() = String49.str_9827
+
+@ExperimentalResourceApi
+internal val Res.string.str_9828: StringResource
+  get() = String49.str_9828
+
+@ExperimentalResourceApi
+internal val Res.string.str_9829: StringResource
+  get() = String49.str_9829
+
+@ExperimentalResourceApi
+internal val Res.string.str_983: StringResource
+  get() = String49.str_983
+
+@ExperimentalResourceApi
+internal val Res.string.str_9830: StringResource
+  get() = String49.str_9830
+
+@ExperimentalResourceApi
+internal val Res.string.str_9831: StringResource
+  get() = String49.str_9831
+
+@ExperimentalResourceApi
+internal val Res.string.str_9832: StringResource
+  get() = String49.str_9832
+
+@ExperimentalResourceApi
+internal val Res.string.str_9833: StringResource
+  get() = String49.str_9833
+
+@ExperimentalResourceApi
+internal val Res.string.str_9834: StringResource
+  get() = String49.str_9834
+
+@ExperimentalResourceApi
+internal val Res.string.str_9835: StringResource
+  get() = String49.str_9835
+
+@ExperimentalResourceApi
+internal val Res.string.str_9836: StringResource
+  get() = String49.str_9836
+
+@ExperimentalResourceApi
+internal val Res.string.str_9837: StringResource
+  get() = String49.str_9837
+
+@ExperimentalResourceApi
+internal val Res.string.str_9838: StringResource
+  get() = String49.str_9838
+
+@ExperimentalResourceApi
+internal val Res.string.str_9839: StringResource
+  get() = String49.str_9839
+
+@ExperimentalResourceApi
+internal val Res.string.str_984: StringResource
+  get() = String49.str_984
+
+@ExperimentalResourceApi
+internal val Res.string.str_9840: StringResource
+  get() = String49.str_9840
+
+@ExperimentalResourceApi
+internal val Res.string.str_9841: StringResource
+  get() = String49.str_9841
+
+@ExperimentalResourceApi
+internal val Res.string.str_9842: StringResource
+  get() = String49.str_9842
+
+@ExperimentalResourceApi
+internal val Res.string.str_9843: StringResource
+  get() = String49.str_9843
+
+@ExperimentalResourceApi
+internal val Res.string.str_9844: StringResource
+  get() = String49.str_9844
+
+@ExperimentalResourceApi
+internal val Res.string.str_9845: StringResource
+  get() = String49.str_9845
+
+@ExperimentalResourceApi
+internal val Res.string.str_9846: StringResource
+  get() = String49.str_9846
+
+@ExperimentalResourceApi
+internal val Res.string.str_9847: StringResource
+  get() = String49.str_9847
+
+@ExperimentalResourceApi
+internal val Res.string.str_9848: StringResource
+  get() = String49.str_9848
+
+@ExperimentalResourceApi
+internal val Res.string.str_9849: StringResource
+  get() = String49.str_9849
+
+@ExperimentalResourceApi
+internal val Res.string.str_985: StringResource
+  get() = String49.str_985
+
+@ExperimentalResourceApi
+internal val Res.string.str_9850: StringResource
+  get() = String49.str_9850
+
+@ExperimentalResourceApi
+internal val Res.string.str_9851: StringResource
+  get() = String49.str_9851
+
+@ExperimentalResourceApi
+internal val Res.string.str_9852: StringResource
+  get() = String49.str_9852
+
+@ExperimentalResourceApi
+internal val Res.string.str_9853: StringResource
+  get() = String49.str_9853
+
+@ExperimentalResourceApi
+internal val Res.string.str_9854: StringResource
+  get() = String49.str_9854
+
+@ExperimentalResourceApi
+internal val Res.string.str_9855: StringResource
+  get() = String49.str_9855
+
+@ExperimentalResourceApi
+internal val Res.string.str_9856: StringResource
+  get() = String49.str_9856
+
+@ExperimentalResourceApi
+internal val Res.string.str_9857: StringResource
+  get() = String49.str_9857
+
+@ExperimentalResourceApi
+internal val Res.string.str_9858: StringResource
+  get() = String49.str_9858
+
+@ExperimentalResourceApi
+internal val Res.string.str_9859: StringResource
+  get() = String49.str_9859
+
+@ExperimentalResourceApi
+internal val Res.string.str_986: StringResource
+  get() = String49.str_986
+
+@ExperimentalResourceApi
+internal val Res.string.str_9860: StringResource
+  get() = String49.str_9860
+
+@ExperimentalResourceApi
+internal val Res.string.str_9861: StringResource
+  get() = String49.str_9861
+
+@ExperimentalResourceApi
+internal val Res.string.str_9862: StringResource
+  get() = String49.str_9862
+
+@ExperimentalResourceApi
+internal val Res.string.str_9863: StringResource
+  get() = String49.str_9863
+
+@ExperimentalResourceApi
+internal val Res.string.str_9864: StringResource
+  get() = String49.str_9864
+
+@ExperimentalResourceApi
+internal val Res.string.str_9865: StringResource
+  get() = String49.str_9865
+
+@ExperimentalResourceApi
+internal val Res.string.str_9866: StringResource
+  get() = String49.str_9866
+
+@ExperimentalResourceApi
+internal val Res.string.str_9867: StringResource
+  get() = String49.str_9867
+
+@ExperimentalResourceApi
+internal val Res.string.str_9868: StringResource
+  get() = String49.str_9868
+
+@ExperimentalResourceApi
+internal val Res.string.str_9869: StringResource
+  get() = String49.str_9869
+
+@ExperimentalResourceApi
+internal val Res.string.str_987: StringResource
+  get() = String49.str_987
+
+@ExperimentalResourceApi
+internal val Res.string.str_9870: StringResource
+  get() = String49.str_9870
+
+@ExperimentalResourceApi
+internal val Res.string.str_9871: StringResource
+  get() = String49.str_9871
+
+@ExperimentalResourceApi
+internal val Res.string.str_9872: StringResource
+  get() = String49.str_9872
+
+@ExperimentalResourceApi
+internal val Res.string.str_9873: StringResource
+  get() = String49.str_9873
+
+@ExperimentalResourceApi
+internal val Res.string.str_9874: StringResource
+  get() = String49.str_9874
+
+@ExperimentalResourceApi
+internal val Res.string.str_9875: StringResource
+  get() = String49.str_9875
+
+@ExperimentalResourceApi
+internal val Res.string.str_9876: StringResource
+  get() = String49.str_9876
+
+@ExperimentalResourceApi
+internal val Res.string.str_9877: StringResource
+  get() = String49.str_9877
+
+@ExperimentalResourceApi
+internal val Res.string.str_9878: StringResource
+  get() = String49.str_9878
+
+@ExperimentalResourceApi
+internal val Res.string.str_9879: StringResource
+  get() = String49.str_9879
+
+@ExperimentalResourceApi
+internal val Res.string.str_988: StringResource
+  get() = String49.str_988
+
+@ExperimentalResourceApi
+internal val Res.string.str_9880: StringResource
+  get() = String49.str_9880
+
+@ExperimentalResourceApi
+internal val Res.string.str_9881: StringResource
+  get() = String49.str_9881
+
+@ExperimentalResourceApi
+internal val Res.string.str_9882: StringResource
+  get() = String49.str_9882
+
+@ExperimentalResourceApi
+internal val Res.string.str_9883: StringResource
+  get() = String49.str_9883
+
+@ExperimentalResourceApi
+internal val Res.string.str_9884: StringResource
+  get() = String49.str_9884
+
+@ExperimentalResourceApi
+internal val Res.string.str_9885: StringResource
+  get() = String49.str_9885
+
+@ExperimentalResourceApi
+internal val Res.string.str_9886: StringResource
+  get() = String49.str_9886
+
+@ExperimentalResourceApi
+internal val Res.string.str_9887: StringResource
+  get() = String49.str_9887
+
+@ExperimentalResourceApi
+internal val Res.string.str_9888: StringResource
+  get() = String49.str_9888
+
+@ExperimentalResourceApi
+internal val Res.string.str_9889: StringResource
+  get() = String49.str_9889
+
+@ExperimentalResourceApi
+internal val Res.string.str_989: StringResource
+  get() = String49.str_989
+
+@ExperimentalResourceApi
+internal val Res.string.str_9890: StringResource
+  get() = String49.str_9890
+
+@ExperimentalResourceApi
+internal val Res.string.str_9891: StringResource
+  get() = String49.str_9891
+
+@ExperimentalResourceApi
+internal val Res.string.str_9892: StringResource
+  get() = String49.str_9892
+
+@ExperimentalResourceApi
+internal val Res.string.str_9893: StringResource
+  get() = String49.str_9893
+
+@ExperimentalResourceApi
+internal val Res.string.str_9894: StringResource
+  get() = String49.str_9894
+
+@ExperimentalResourceApi
+internal val Res.string.str_9895: StringResource
+  get() = String49.str_9895
+
+@ExperimentalResourceApi
+internal val Res.string.str_9896: StringResource
+  get() = String49.str_9896
+
+@ExperimentalResourceApi
+internal val Res.string.str_9897: StringResource
+  get() = String49.str_9897
+
+@ExperimentalResourceApi
+internal val Res.string.str_9898: StringResource
+  get() = String49.str_9898
+
+@ExperimentalResourceApi
+internal val Res.string.str_9899: StringResource
+  get() = String49.str_9899
+
+@ExperimentalResourceApi
+internal val Res.string.str_99: StringResource
+  get() = String49.str_99
+
+@ExperimentalResourceApi
+internal val Res.string.str_990: StringResource
+  get() = String49.str_990
+
+@ExperimentalResourceApi
+internal val Res.string.str_9900: StringResource
+  get() = String49.str_9900
+
+@ExperimentalResourceApi
+internal val Res.string.str_9901: StringResource
+  get() = String49.str_9901
+
+@ExperimentalResourceApi
+internal val Res.string.str_9902: StringResource
+  get() = String49.str_9902
+
+@ExperimentalResourceApi
+internal val Res.string.str_9903: StringResource
+  get() = String49.str_9903
+
+@ExperimentalResourceApi
+internal val Res.string.str_9904: StringResource
+  get() = String49.str_9904
+
+@ExperimentalResourceApi
+internal val Res.string.str_9905: StringResource
+  get() = String49.str_9905
+
+@ExperimentalResourceApi
+internal val Res.string.str_9906: StringResource
+  get() = String49.str_9906
+
+@ExperimentalResourceApi
+internal val Res.string.str_9907: StringResource
+  get() = String49.str_9907
+
+@ExperimentalResourceApi
+internal val Res.string.str_9908: StringResource
+  get() = String49.str_9908
+
+@ExperimentalResourceApi
+internal val Res.string.str_9909: StringResource
+  get() = String49.str_9909
+
+@ExperimentalResourceApi
+internal val Res.string.str_991: StringResource
+  get() = String49.str_991
+
+@ExperimentalResourceApi
+internal val Res.string.str_9910: StringResource
+  get() = String49.str_9910
+
+@ExperimentalResourceApi
+internal val Res.string.str_9911: StringResource
+  get() = String49.str_9911
+
+@ExperimentalResourceApi
+internal val Res.string.str_9912: StringResource
+  get() = String49.str_9912
+
+@ExperimentalResourceApi
+internal val Res.string.str_9913: StringResource
+  get() = String49.str_9913
+
+@ExperimentalResourceApi
+internal val Res.string.str_9914: StringResource
+  get() = String49.str_9914
+
+@ExperimentalResourceApi
+internal val Res.string.str_9915: StringResource
+  get() = String49.str_9915
+
+@ExperimentalResourceApi
+internal val Res.string.str_9916: StringResource
+  get() = String49.str_9916
+
+@ExperimentalResourceApi
+internal val Res.string.str_9917: StringResource
+  get() = String49.str_9917
+
+@ExperimentalResourceApi
+internal val Res.string.str_9918: StringResource
+  get() = String49.str_9918
+
+@ExperimentalResourceApi
+internal val Res.string.str_9919: StringResource
+  get() = String49.str_9919
+
+@ExperimentalResourceApi
+internal val Res.string.str_992: StringResource
+  get() = String49.str_992
+
+@ExperimentalResourceApi
+internal val Res.string.str_9920: StringResource
+  get() = String49.str_9920
+
+@ExperimentalResourceApi
+internal val Res.string.str_9921: StringResource
+  get() = String49.str_9921
+
+@ExperimentalResourceApi
+internal val Res.string.str_9922: StringResource
+  get() = String49.str_9922
+
+@ExperimentalResourceApi
+internal val Res.string.str_9923: StringResource
+  get() = String49.str_9923
+
+@ExperimentalResourceApi
+internal val Res.string.str_9924: StringResource
+  get() = String49.str_9924
+
+@ExperimentalResourceApi
+internal val Res.string.str_9925: StringResource
+  get() = String49.str_9925
+
+@ExperimentalResourceApi
+internal val Res.string.str_9926: StringResource
+  get() = String49.str_9926
+
+@ExperimentalResourceApi
+internal val Res.string.str_9927: StringResource
+  get() = String49.str_9927
+
+@ExperimentalResourceApi
+internal val Res.string.str_9928: StringResource
+  get() = String49.str_9928
+
+@ExperimentalResourceApi
+internal val Res.string.str_9929: StringResource
+  get() = String49.str_9929
+
+@ExperimentalResourceApi
+internal val Res.string.str_993: StringResource
+  get() = String49.str_993
+
+@ExperimentalResourceApi
+internal val Res.string.str_9930: StringResource
+  get() = String49.str_9930
+
+@ExperimentalResourceApi
+internal val Res.string.str_9931: StringResource
+  get() = String49.str_9931
+
+@ExperimentalResourceApi
+internal val Res.string.str_9932: StringResource
+  get() = String49.str_9932
+
+@ExperimentalResourceApi
+internal val Res.string.str_9933: StringResource
+  get() = String49.str_9933
+
+@ExperimentalResourceApi
+internal val Res.string.str_9934: StringResource
+  get() = String49.str_9934
+
+@ExperimentalResourceApi
+internal val Res.string.str_9935: StringResource
+  get() = String49.str_9935
+
+@ExperimentalResourceApi
+internal val Res.string.str_9936: StringResource
+  get() = String49.str_9936
+
+@ExperimentalResourceApi
+internal val Res.string.str_9937: StringResource
+  get() = String49.str_9937
+
+@ExperimentalResourceApi
+internal val Res.string.str_9938: StringResource
+  get() = String49.str_9938
+
+@ExperimentalResourceApi
+internal val Res.string.str_9939: StringResource
+  get() = String49.str_9939
+
+@ExperimentalResourceApi
+internal val Res.string.str_994: StringResource
+  get() = String49.str_994
+
+@ExperimentalResourceApi
+internal val Res.string.str_9940: StringResource
+  get() = String49.str_9940
+
+@ExperimentalResourceApi
+internal val Res.string.str_9941: StringResource
+  get() = String49.str_9941
+
+@ExperimentalResourceApi
+internal val Res.string.str_9942: StringResource
+  get() = String49.str_9942
+
+@ExperimentalResourceApi
+internal val Res.string.str_9943: StringResource
+  get() = String49.str_9943
+
+@ExperimentalResourceApi
+internal val Res.string.str_9944: StringResource
+  get() = String49.str_9944
+
+@ExperimentalResourceApi
+internal val Res.string.str_9945: StringResource
+  get() = String49.str_9945
+
+@ExperimentalResourceApi
+internal val Res.string.str_9946: StringResource
+  get() = String49.str_9946
+
+@ExperimentalResourceApi
+internal val Res.string.str_9947: StringResource
+  get() = String49.str_9947
+
+@ExperimentalResourceApi
+internal val Res.string.str_9948: StringResource
+  get() = String49.str_9948
+
+@ExperimentalResourceApi
+internal val Res.string.str_9949: StringResource
+  get() = String49.str_9949
+
+@ExperimentalResourceApi
+internal val Res.string.str_995: StringResource
+  get() = String49.str_995
+
+@ExperimentalResourceApi
+internal val Res.string.str_9950: StringResource
+  get() = String49.str_9950
+
+@ExperimentalResourceApi
+internal val Res.string.str_9951: StringResource
+  get() = String49.str_9951
+
+@ExperimentalResourceApi
+internal val Res.string.str_9952: StringResource
+  get() = String49.str_9952
+
+@ExperimentalResourceApi
+internal val Res.string.str_9953: StringResource
+  get() = String49.str_9953
+
+@ExperimentalResourceApi
+internal val Res.string.str_9954: StringResource
+  get() = String49.str_9954
+
+@ExperimentalResourceApi
+internal val Res.string.str_9955: StringResource
+  get() = String49.str_9955
+
+@ExperimentalResourceApi
+internal val Res.string.str_9956: StringResource
+  get() = String49.str_9956
+
+@ExperimentalResourceApi
+internal val Res.string.str_9957: StringResource
+  get() = String49.str_9957
+
+@ExperimentalResourceApi
+internal val Res.string.str_9958: StringResource
+  get() = String49.str_9958
+
+@ExperimentalResourceApi
+internal val Res.string.str_9959: StringResource
+  get() = String49.str_9959
+
+@ExperimentalResourceApi
+internal val Res.string.str_996: StringResource
+  get() = String49.str_996
+
+@ExperimentalResourceApi
+internal val Res.string.str_9960: StringResource
+  get() = String49.str_9960
+
+@ExperimentalResourceApi
+internal val Res.string.str_9961: StringResource
+  get() = String49.str_9961
+
+@ExperimentalResourceApi
+internal val Res.string.str_9962: StringResource
+  get() = String49.str_9962
+
+@ExperimentalResourceApi
+internal val Res.string.str_9963: StringResource
+  get() = String49.str_9963
+
+@ExperimentalResourceApi
+internal val Res.string.str_9964: StringResource
+  get() = String49.str_9964
+
+@ExperimentalResourceApi
+internal val Res.string.str_9965: StringResource
+  get() = String49.str_9965
+
+@ExperimentalResourceApi
+internal val Res.string.str_9966: StringResource
+  get() = String49.str_9966
+
+@ExperimentalResourceApi
+internal val Res.string.str_9967: StringResource
+  get() = String49.str_9967
+
+@ExperimentalResourceApi
+internal val Res.string.str_9968: StringResource
+  get() = String49.str_9968
+
+@ExperimentalResourceApi
+internal val Res.string.str_9969: StringResource
+  get() = String49.str_9969
+
+@ExperimentalResourceApi
+internal val Res.string.str_997: StringResource
+  get() = String49.str_997
+
+@ExperimentalResourceApi
+internal val Res.string.str_9970: StringResource
+  get() = String49.str_9970
+
+@ExperimentalResourceApi
+internal val Res.string.str_9971: StringResource
+  get() = String49.str_9971
+
+@ExperimentalResourceApi
+internal val Res.string.str_9972: StringResource
+  get() = String49.str_9972
+
+@ExperimentalResourceApi
+internal val Res.string.str_9973: StringResource
+  get() = String49.str_9973
+
+@ExperimentalResourceApi
+internal val Res.string.str_9974: StringResource
+  get() = String49.str_9974
+
+@ExperimentalResourceApi
+internal val Res.string.str_9975: StringResource
+  get() = String49.str_9975
+
+@ExperimentalResourceApi
+internal val Res.string.str_9976: StringResource
+  get() = String49.str_9976
+
+@ExperimentalResourceApi
+internal val Res.string.str_9977: StringResource
+  get() = String49.str_9977
+
+@ExperimentalResourceApi
+internal val Res.string.str_9978: StringResource
+  get() = String49.str_9978
+
+@ExperimentalResourceApi
+internal val Res.string.str_9979: StringResource
+  get() = String49.str_9979
+
+@ExperimentalResourceApi
+internal val Res.string.str_998: StringResource
+  get() = String49.str_998
+
+@ExperimentalResourceApi
+internal val Res.string.str_9980: StringResource
+  get() = String49.str_9980
+
+@ExperimentalResourceApi
+internal val Res.string.str_9981: StringResource
+  get() = String49.str_9981
+
+@ExperimentalResourceApi
+internal val Res.string.str_9982: StringResource
+  get() = String49.str_9982
+
+@ExperimentalResourceApi
+internal val Res.string.str_9983: StringResource
+  get() = String49.str_9983
+
+@ExperimentalResourceApi
+internal val Res.string.str_9984: StringResource
+  get() = String49.str_9984
+
+@ExperimentalResourceApi
+internal val Res.string.str_9985: StringResource
+  get() = String49.str_9985
+
+@ExperimentalResourceApi
+internal val Res.string.str_9986: StringResource
+  get() = String49.str_9986
+
+@ExperimentalResourceApi
+internal val Res.string.str_9987: StringResource
+  get() = String49.str_9987
+
+@ExperimentalResourceApi
+internal val Res.string.str_9988: StringResource
+  get() = String49.str_9988
+
+@ExperimentalResourceApi
+internal val Res.string.str_9989: StringResource
+  get() = String49.str_9989
+
+@ExperimentalResourceApi
+internal val Res.string.str_999: StringResource
+  get() = String49.str_999
+
+@ExperimentalResourceApi
+internal val Res.string.str_9990: StringResource
+  get() = String49.str_9990
+
+@ExperimentalResourceApi
+internal val Res.string.str_9991: StringResource
+  get() = String49.str_9991
+
+@ExperimentalResourceApi
+internal val Res.string.str_9992: StringResource
+  get() = String49.str_9992
+
+@ExperimentalResourceApi
+internal val Res.string.str_9993: StringResource
+  get() = String49.str_9993
+
+@ExperimentalResourceApi
+internal val Res.string.str_9994: StringResource
+  get() = String49.str_9994
+
+@ExperimentalResourceApi
+internal val Res.string.str_9995: StringResource
+  get() = String49.str_9995
+
+@ExperimentalResourceApi
+internal val Res.string.str_9996: StringResource
+  get() = String49.str_9996
+
+@ExperimentalResourceApi
+internal val Res.string.str_9997: StringResource
+  get() = String49.str_9997
+
+@ExperimentalResourceApi
+internal val Res.string.str_9998: StringResource
+  get() = String49.str_9998
+
+@ExperimentalResourceApi
+internal val Res.string.str_9999: StringResource
+  get() = String49.str_9999

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String5.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String5.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String5 {
+  public val str_12247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12247", "str_12247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12248", "str_12248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12249", "str_12249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1225", "str_1225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12250", "str_12250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12251", "str_12251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12252", "str_12252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12253", "str_12253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12254", "str_12254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12255", "str_12255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12256", "str_12256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12257", "str_12257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12258", "str_12258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12259", "str_12259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1226", "str_1226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12260", "str_12260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12261", "str_12261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12262", "str_12262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12263", "str_12263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12264", "str_12264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12265", "str_12265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12266", "str_12266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12267", "str_12267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12268", "str_12268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12269", "str_12269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1227", "str_1227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12270", "str_12270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12271", "str_12271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12272", "str_12272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12273", "str_12273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12274", "str_12274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12275", "str_12275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12276", "str_12276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12277", "str_12277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12278", "str_12278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12279", "str_12279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1228", "str_1228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12280", "str_12280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12281", "str_12281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12282", "str_12282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12283", "str_12283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12284", "str_12284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12285", "str_12285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12286", "str_12286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12287", "str_12287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12288", "str_12288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12289", "str_12289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1229", "str_1229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12290", "str_12290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12291", "str_12291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12292", "str_12292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12293", "str_12293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12294", "str_12294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12295", "str_12295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12296", "str_12296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12297", "str_12297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12298", "str_12298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12299", "str_12299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_123", "str_123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1230", "str_1230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12300", "str_12300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12301", "str_12301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12302", "str_12302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12303", "str_12303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12304", "str_12304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12305", "str_12305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12306", "str_12306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12307", "str_12307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12308", "str_12308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12309", "str_12309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1231", "str_1231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12310", "str_12310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12311", "str_12311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12312", "str_12312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12313", "str_12313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12314", "str_12314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12315", "str_12315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12316", "str_12316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12317", "str_12317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12318", "str_12318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12319", "str_12319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1232", "str_1232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12320", "str_12320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12321", "str_12321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12322", "str_12322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12323", "str_12323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12324", "str_12324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12325", "str_12325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12326", "str_12326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12327", "str_12327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12328", "str_12328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12329", "str_12329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1233", "str_1233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12330", "str_12330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12331", "str_12331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12332", "str_12332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12333", "str_12333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12334", "str_12334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12335", "str_12335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12336", "str_12336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12337", "str_12337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12338", "str_12338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12339", "str_12339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1234", "str_1234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12340", "str_12340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12341", "str_12341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12342", "str_12342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12343", "str_12343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12344", "str_12344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12345", "str_12345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12346", "str_12346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12347", "str_12347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12348", "str_12348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12349", "str_12349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1235", "str_1235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12350", "str_12350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12351", "str_12351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12352", "str_12352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12353", "str_12353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12354", "str_12354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12355", "str_12355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12356", "str_12356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12357", "str_12357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12358", "str_12358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12359", "str_12359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1236", "str_1236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12360", "str_12360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12361", "str_12361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12362", "str_12362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12363", "str_12363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12364", "str_12364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12365", "str_12365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12366", "str_12366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12367", "str_12367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12368", "str_12368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12369", "str_12369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1237", "str_1237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12370", "str_12370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12371", "str_12371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12372", "str_12372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12373", "str_12373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12374", "str_12374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12375", "str_12375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12376", "str_12376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12377", "str_12377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12378", "str_12378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12379", "str_12379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1238", "str_1238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12380", "str_12380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12381", "str_12381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12382", "str_12382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12383", "str_12383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12384", "str_12384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12385", "str_12385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12386", "str_12386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12387", "str_12387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12388", "str_12388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12389", "str_12389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1239", "str_1239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12390", "str_12390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12391", "str_12391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12392", "str_12392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12393", "str_12393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12394", "str_12394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12395", "str_12395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12396", "str_12396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12397", "str_12397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12398", "str_12398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12399", "str_12399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_124", "str_124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1240", "str_1240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12400", "str_12400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12401", "str_12401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12402", "str_12402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12403", "str_12403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12404", "str_12404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12405", "str_12405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12406", "str_12406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12407", "str_12407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12408", "str_12408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12409", "str_12409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1241", "str_1241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12410", "str_12410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12411", "str_12411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12412", "str_12412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12413", "str_12413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12414", "str_12414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12415", "str_12415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12416", "str_12416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12417", "str_12417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12418", "str_12418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12419", "str_12419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1242", "str_1242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12420", "str_12420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12421", "str_12421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12422", "str_12422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12423", "str_12423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12424", "str_12424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12425", "str_12425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12426", "str_12426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12427", "str_12427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12428", "str_12428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12429", "str_12429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1243", "str_1243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12430", "str_12430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12431", "str_12431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12432", "str_12432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12433", "str_12433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12434", "str_12434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12435", "str_12435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12436", "str_12436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12437", "str_12437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12438", "str_12438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12439", "str_12439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1244", "str_1244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12440", "str_12440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12441", "str_12441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12442", "str_12442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12443", "str_12443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12444", "str_12444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12445", "str_12445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12446", "str_12446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12447", "str_12447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12448", "str_12448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12449", "str_12449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1245", "str_1245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12450", "str_12450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12451", "str_12451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12452", "str_12452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12453", "str_12453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12454", "str_12454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12455", "str_12455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12456", "str_12456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12457", "str_12457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12458", "str_12458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12459", "str_12459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1246", "str_1246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12460", "str_12460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12461", "str_12461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12462", "str_12462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12463", "str_12463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12464", "str_12464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12465", "str_12465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12466", "str_12466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12467", "str_12467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12468", "str_12468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12469", "str_12469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1247", "str_1247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12470", "str_12470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12471", "str_12471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12472", "str_12472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12473", "str_12473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12474", "str_12474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12475", "str_12475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12476", "str_12476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12477", "str_12477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12478", "str_12478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12479", "str_12479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1248", "str_1248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12480", "str_12480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12481", "str_12481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12482", "str_12482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12483", "str_12483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12484", "str_12484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12485", "str_12485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12486", "str_12486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12487", "str_12487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12488", "str_12488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12489", "str_12489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1249", "str_1249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12490", "str_12490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12491", "str_12491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12492", "str_12492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12493", "str_12493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12494", "str_12494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12495", "str_12495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12496", "str_12496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12497", "str_12497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12498", "str_12498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12499", "str_12499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_125", "str_125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1250", "str_1250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12500", "str_12500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12501", "str_12501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12502", "str_12502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12503", "str_12503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12504", "str_12504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12505", "str_12505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12506", "str_12506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12507", "str_12507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12508", "str_12508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12509", "str_12509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1251", "str_1251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12510", "str_12510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12511", "str_12511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12512", "str_12512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12513", "str_12513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12514", "str_12514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12515", "str_12515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12516", "str_12516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12517", "str_12517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12518", "str_12518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12519", "str_12519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1252", "str_1252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12520", "str_12520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12521", "str_12521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12522", "str_12522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12523", "str_12523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12524", "str_12524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12525", "str_12525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12526", "str_12526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12527", "str_12527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12528", "str_12528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12529", "str_12529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1253", "str_1253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12530", "str_12530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12531", "str_12531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12532", "str_12532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12533", "str_12533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12534", "str_12534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12535", "str_12535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12536", "str_12536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12537", "str_12537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12538", "str_12538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12539", "str_12539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1254", "str_1254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12540", "str_12540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12541", "str_12541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12542", "str_12542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12543", "str_12543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12544", "str_12544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12545", "str_12545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12546", "str_12546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12547", "str_12547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12548", "str_12548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12549", "str_12549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1255", "str_1255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12550", "str_12550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12551", "str_12551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12552", "str_12552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12553", "str_12553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12554", "str_12554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12555", "str_12555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12556", "str_12556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12557", "str_12557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12558", "str_12558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12559", "str_12559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1256", "str_1256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12560", "str_12560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12561", "str_12561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12562", "str_12562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12563", "str_12563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12564", "str_12564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12565", "str_12565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12566", "str_12566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12567", "str_12567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12568", "str_12568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12569", "str_12569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1257", "str_1257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12570", "str_12570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12571", "str_12571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12572", "str_12572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12573", "str_12573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12574", "str_12574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12575", "str_12575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12576", "str_12576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12577", "str_12577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12578", "str_12578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12579", "str_12579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1258", "str_1258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12580", "str_12580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12581", "str_12581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12582", "str_12582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12583", "str_12583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12584", "str_12584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12585", "str_12585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12586", "str_12586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12587", "str_12587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12588", "str_12588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12589", "str_12589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1259", "str_1259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12590", "str_12590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12591", "str_12591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12592", "str_12592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12593", "str_12593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12594", "str_12594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12595", "str_12595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12596", "str_12596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12597", "str_12597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12598", "str_12598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12599", "str_12599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_126", "str_126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1260", "str_1260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12600", "str_12600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12601", "str_12601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12602", "str_12602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12603", "str_12603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12604", "str_12604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12605", "str_12605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12606", "str_12606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12607", "str_12607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12608", "str_12608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12609", "str_12609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1261", "str_1261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12610", "str_12610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12611", "str_12611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12612", "str_12612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12613", "str_12613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12614", "str_12614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12615", "str_12615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12616", "str_12616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12617", "str_12617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12618", "str_12618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12619", "str_12619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1262", "str_1262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12620", "str_12620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12621", "str_12621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12622", "str_12622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12623", "str_12623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12624", "str_12624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12625", "str_12625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12626", "str_12626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12627", "str_12627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12628", "str_12628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12629", "str_12629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1263", "str_1263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12630", "str_12630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12631", "str_12631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12632", "str_12632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12633", "str_12633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12634", "str_12634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12635", "str_12635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12636", "str_12636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12637", "str_12637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12638", "str_12638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12639", "str_12639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1264", "str_1264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12640", "str_12640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12641", "str_12641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12642", "str_12642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12643", "str_12643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12644", "str_12644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12645", "str_12645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12646", "str_12646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12647", "str_12647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12648", "str_12648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12649", "str_12649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1265", "str_1265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12650", "str_12650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12651", "str_12651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12652", "str_12652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12653", "str_12653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12654", "str_12654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12655", "str_12655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12656", "str_12656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12657", "str_12657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12658", "str_12658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12659", "str_12659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1266", "str_1266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12660", "str_12660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12661", "str_12661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12662", "str_12662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12663", "str_12663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12664", "str_12664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12665", "str_12665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12666", "str_12666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12667", "str_12667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12668", "str_12668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12669", "str_12669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1267", "str_1267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12670", "str_12670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12671", "str_12671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12672", "str_12672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12673", "str_12673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12674", "str_12674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12675", "str_12675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12676", "str_12676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12677", "str_12677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12678", "str_12678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12679", "str_12679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1268", "str_1268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12680", "str_12680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12681", "str_12681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12682", "str_12682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12683", "str_12683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12684", "str_12684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12685", "str_12685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12686", "str_12686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12687", "str_12687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12688", "str_12688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12689", "str_12689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1269", "str_1269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12690", "str_12690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12691", "str_12691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12692", "str_12692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12693", "str_12693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12694", "str_12694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12695", "str_12695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12696", "str_12696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12697", "str_12697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_12247: StringResource
+  get() = String5.str_12247
+
+@ExperimentalResourceApi
+internal val Res.string.str_12248: StringResource
+  get() = String5.str_12248
+
+@ExperimentalResourceApi
+internal val Res.string.str_12249: StringResource
+  get() = String5.str_12249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1225: StringResource
+  get() = String5.str_1225
+
+@ExperimentalResourceApi
+internal val Res.string.str_12250: StringResource
+  get() = String5.str_12250
+
+@ExperimentalResourceApi
+internal val Res.string.str_12251: StringResource
+  get() = String5.str_12251
+
+@ExperimentalResourceApi
+internal val Res.string.str_12252: StringResource
+  get() = String5.str_12252
+
+@ExperimentalResourceApi
+internal val Res.string.str_12253: StringResource
+  get() = String5.str_12253
+
+@ExperimentalResourceApi
+internal val Res.string.str_12254: StringResource
+  get() = String5.str_12254
+
+@ExperimentalResourceApi
+internal val Res.string.str_12255: StringResource
+  get() = String5.str_12255
+
+@ExperimentalResourceApi
+internal val Res.string.str_12256: StringResource
+  get() = String5.str_12256
+
+@ExperimentalResourceApi
+internal val Res.string.str_12257: StringResource
+  get() = String5.str_12257
+
+@ExperimentalResourceApi
+internal val Res.string.str_12258: StringResource
+  get() = String5.str_12258
+
+@ExperimentalResourceApi
+internal val Res.string.str_12259: StringResource
+  get() = String5.str_12259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1226: StringResource
+  get() = String5.str_1226
+
+@ExperimentalResourceApi
+internal val Res.string.str_12260: StringResource
+  get() = String5.str_12260
+
+@ExperimentalResourceApi
+internal val Res.string.str_12261: StringResource
+  get() = String5.str_12261
+
+@ExperimentalResourceApi
+internal val Res.string.str_12262: StringResource
+  get() = String5.str_12262
+
+@ExperimentalResourceApi
+internal val Res.string.str_12263: StringResource
+  get() = String5.str_12263
+
+@ExperimentalResourceApi
+internal val Res.string.str_12264: StringResource
+  get() = String5.str_12264
+
+@ExperimentalResourceApi
+internal val Res.string.str_12265: StringResource
+  get() = String5.str_12265
+
+@ExperimentalResourceApi
+internal val Res.string.str_12266: StringResource
+  get() = String5.str_12266
+
+@ExperimentalResourceApi
+internal val Res.string.str_12267: StringResource
+  get() = String5.str_12267
+
+@ExperimentalResourceApi
+internal val Res.string.str_12268: StringResource
+  get() = String5.str_12268
+
+@ExperimentalResourceApi
+internal val Res.string.str_12269: StringResource
+  get() = String5.str_12269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1227: StringResource
+  get() = String5.str_1227
+
+@ExperimentalResourceApi
+internal val Res.string.str_12270: StringResource
+  get() = String5.str_12270
+
+@ExperimentalResourceApi
+internal val Res.string.str_12271: StringResource
+  get() = String5.str_12271
+
+@ExperimentalResourceApi
+internal val Res.string.str_12272: StringResource
+  get() = String5.str_12272
+
+@ExperimentalResourceApi
+internal val Res.string.str_12273: StringResource
+  get() = String5.str_12273
+
+@ExperimentalResourceApi
+internal val Res.string.str_12274: StringResource
+  get() = String5.str_12274
+
+@ExperimentalResourceApi
+internal val Res.string.str_12275: StringResource
+  get() = String5.str_12275
+
+@ExperimentalResourceApi
+internal val Res.string.str_12276: StringResource
+  get() = String5.str_12276
+
+@ExperimentalResourceApi
+internal val Res.string.str_12277: StringResource
+  get() = String5.str_12277
+
+@ExperimentalResourceApi
+internal val Res.string.str_12278: StringResource
+  get() = String5.str_12278
+
+@ExperimentalResourceApi
+internal val Res.string.str_12279: StringResource
+  get() = String5.str_12279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1228: StringResource
+  get() = String5.str_1228
+
+@ExperimentalResourceApi
+internal val Res.string.str_12280: StringResource
+  get() = String5.str_12280
+
+@ExperimentalResourceApi
+internal val Res.string.str_12281: StringResource
+  get() = String5.str_12281
+
+@ExperimentalResourceApi
+internal val Res.string.str_12282: StringResource
+  get() = String5.str_12282
+
+@ExperimentalResourceApi
+internal val Res.string.str_12283: StringResource
+  get() = String5.str_12283
+
+@ExperimentalResourceApi
+internal val Res.string.str_12284: StringResource
+  get() = String5.str_12284
+
+@ExperimentalResourceApi
+internal val Res.string.str_12285: StringResource
+  get() = String5.str_12285
+
+@ExperimentalResourceApi
+internal val Res.string.str_12286: StringResource
+  get() = String5.str_12286
+
+@ExperimentalResourceApi
+internal val Res.string.str_12287: StringResource
+  get() = String5.str_12287
+
+@ExperimentalResourceApi
+internal val Res.string.str_12288: StringResource
+  get() = String5.str_12288
+
+@ExperimentalResourceApi
+internal val Res.string.str_12289: StringResource
+  get() = String5.str_12289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1229: StringResource
+  get() = String5.str_1229
+
+@ExperimentalResourceApi
+internal val Res.string.str_12290: StringResource
+  get() = String5.str_12290
+
+@ExperimentalResourceApi
+internal val Res.string.str_12291: StringResource
+  get() = String5.str_12291
+
+@ExperimentalResourceApi
+internal val Res.string.str_12292: StringResource
+  get() = String5.str_12292
+
+@ExperimentalResourceApi
+internal val Res.string.str_12293: StringResource
+  get() = String5.str_12293
+
+@ExperimentalResourceApi
+internal val Res.string.str_12294: StringResource
+  get() = String5.str_12294
+
+@ExperimentalResourceApi
+internal val Res.string.str_12295: StringResource
+  get() = String5.str_12295
+
+@ExperimentalResourceApi
+internal val Res.string.str_12296: StringResource
+  get() = String5.str_12296
+
+@ExperimentalResourceApi
+internal val Res.string.str_12297: StringResource
+  get() = String5.str_12297
+
+@ExperimentalResourceApi
+internal val Res.string.str_12298: StringResource
+  get() = String5.str_12298
+
+@ExperimentalResourceApi
+internal val Res.string.str_12299: StringResource
+  get() = String5.str_12299
+
+@ExperimentalResourceApi
+internal val Res.string.str_123: StringResource
+  get() = String5.str_123
+
+@ExperimentalResourceApi
+internal val Res.string.str_1230: StringResource
+  get() = String5.str_1230
+
+@ExperimentalResourceApi
+internal val Res.string.str_12300: StringResource
+  get() = String5.str_12300
+
+@ExperimentalResourceApi
+internal val Res.string.str_12301: StringResource
+  get() = String5.str_12301
+
+@ExperimentalResourceApi
+internal val Res.string.str_12302: StringResource
+  get() = String5.str_12302
+
+@ExperimentalResourceApi
+internal val Res.string.str_12303: StringResource
+  get() = String5.str_12303
+
+@ExperimentalResourceApi
+internal val Res.string.str_12304: StringResource
+  get() = String5.str_12304
+
+@ExperimentalResourceApi
+internal val Res.string.str_12305: StringResource
+  get() = String5.str_12305
+
+@ExperimentalResourceApi
+internal val Res.string.str_12306: StringResource
+  get() = String5.str_12306
+
+@ExperimentalResourceApi
+internal val Res.string.str_12307: StringResource
+  get() = String5.str_12307
+
+@ExperimentalResourceApi
+internal val Res.string.str_12308: StringResource
+  get() = String5.str_12308
+
+@ExperimentalResourceApi
+internal val Res.string.str_12309: StringResource
+  get() = String5.str_12309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1231: StringResource
+  get() = String5.str_1231
+
+@ExperimentalResourceApi
+internal val Res.string.str_12310: StringResource
+  get() = String5.str_12310
+
+@ExperimentalResourceApi
+internal val Res.string.str_12311: StringResource
+  get() = String5.str_12311
+
+@ExperimentalResourceApi
+internal val Res.string.str_12312: StringResource
+  get() = String5.str_12312
+
+@ExperimentalResourceApi
+internal val Res.string.str_12313: StringResource
+  get() = String5.str_12313
+
+@ExperimentalResourceApi
+internal val Res.string.str_12314: StringResource
+  get() = String5.str_12314
+
+@ExperimentalResourceApi
+internal val Res.string.str_12315: StringResource
+  get() = String5.str_12315
+
+@ExperimentalResourceApi
+internal val Res.string.str_12316: StringResource
+  get() = String5.str_12316
+
+@ExperimentalResourceApi
+internal val Res.string.str_12317: StringResource
+  get() = String5.str_12317
+
+@ExperimentalResourceApi
+internal val Res.string.str_12318: StringResource
+  get() = String5.str_12318
+
+@ExperimentalResourceApi
+internal val Res.string.str_12319: StringResource
+  get() = String5.str_12319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1232: StringResource
+  get() = String5.str_1232
+
+@ExperimentalResourceApi
+internal val Res.string.str_12320: StringResource
+  get() = String5.str_12320
+
+@ExperimentalResourceApi
+internal val Res.string.str_12321: StringResource
+  get() = String5.str_12321
+
+@ExperimentalResourceApi
+internal val Res.string.str_12322: StringResource
+  get() = String5.str_12322
+
+@ExperimentalResourceApi
+internal val Res.string.str_12323: StringResource
+  get() = String5.str_12323
+
+@ExperimentalResourceApi
+internal val Res.string.str_12324: StringResource
+  get() = String5.str_12324
+
+@ExperimentalResourceApi
+internal val Res.string.str_12325: StringResource
+  get() = String5.str_12325
+
+@ExperimentalResourceApi
+internal val Res.string.str_12326: StringResource
+  get() = String5.str_12326
+
+@ExperimentalResourceApi
+internal val Res.string.str_12327: StringResource
+  get() = String5.str_12327
+
+@ExperimentalResourceApi
+internal val Res.string.str_12328: StringResource
+  get() = String5.str_12328
+
+@ExperimentalResourceApi
+internal val Res.string.str_12329: StringResource
+  get() = String5.str_12329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1233: StringResource
+  get() = String5.str_1233
+
+@ExperimentalResourceApi
+internal val Res.string.str_12330: StringResource
+  get() = String5.str_12330
+
+@ExperimentalResourceApi
+internal val Res.string.str_12331: StringResource
+  get() = String5.str_12331
+
+@ExperimentalResourceApi
+internal val Res.string.str_12332: StringResource
+  get() = String5.str_12332
+
+@ExperimentalResourceApi
+internal val Res.string.str_12333: StringResource
+  get() = String5.str_12333
+
+@ExperimentalResourceApi
+internal val Res.string.str_12334: StringResource
+  get() = String5.str_12334
+
+@ExperimentalResourceApi
+internal val Res.string.str_12335: StringResource
+  get() = String5.str_12335
+
+@ExperimentalResourceApi
+internal val Res.string.str_12336: StringResource
+  get() = String5.str_12336
+
+@ExperimentalResourceApi
+internal val Res.string.str_12337: StringResource
+  get() = String5.str_12337
+
+@ExperimentalResourceApi
+internal val Res.string.str_12338: StringResource
+  get() = String5.str_12338
+
+@ExperimentalResourceApi
+internal val Res.string.str_12339: StringResource
+  get() = String5.str_12339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1234: StringResource
+  get() = String5.str_1234
+
+@ExperimentalResourceApi
+internal val Res.string.str_12340: StringResource
+  get() = String5.str_12340
+
+@ExperimentalResourceApi
+internal val Res.string.str_12341: StringResource
+  get() = String5.str_12341
+
+@ExperimentalResourceApi
+internal val Res.string.str_12342: StringResource
+  get() = String5.str_12342
+
+@ExperimentalResourceApi
+internal val Res.string.str_12343: StringResource
+  get() = String5.str_12343
+
+@ExperimentalResourceApi
+internal val Res.string.str_12344: StringResource
+  get() = String5.str_12344
+
+@ExperimentalResourceApi
+internal val Res.string.str_12345: StringResource
+  get() = String5.str_12345
+
+@ExperimentalResourceApi
+internal val Res.string.str_12346: StringResource
+  get() = String5.str_12346
+
+@ExperimentalResourceApi
+internal val Res.string.str_12347: StringResource
+  get() = String5.str_12347
+
+@ExperimentalResourceApi
+internal val Res.string.str_12348: StringResource
+  get() = String5.str_12348
+
+@ExperimentalResourceApi
+internal val Res.string.str_12349: StringResource
+  get() = String5.str_12349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1235: StringResource
+  get() = String5.str_1235
+
+@ExperimentalResourceApi
+internal val Res.string.str_12350: StringResource
+  get() = String5.str_12350
+
+@ExperimentalResourceApi
+internal val Res.string.str_12351: StringResource
+  get() = String5.str_12351
+
+@ExperimentalResourceApi
+internal val Res.string.str_12352: StringResource
+  get() = String5.str_12352
+
+@ExperimentalResourceApi
+internal val Res.string.str_12353: StringResource
+  get() = String5.str_12353
+
+@ExperimentalResourceApi
+internal val Res.string.str_12354: StringResource
+  get() = String5.str_12354
+
+@ExperimentalResourceApi
+internal val Res.string.str_12355: StringResource
+  get() = String5.str_12355
+
+@ExperimentalResourceApi
+internal val Res.string.str_12356: StringResource
+  get() = String5.str_12356
+
+@ExperimentalResourceApi
+internal val Res.string.str_12357: StringResource
+  get() = String5.str_12357
+
+@ExperimentalResourceApi
+internal val Res.string.str_12358: StringResource
+  get() = String5.str_12358
+
+@ExperimentalResourceApi
+internal val Res.string.str_12359: StringResource
+  get() = String5.str_12359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1236: StringResource
+  get() = String5.str_1236
+
+@ExperimentalResourceApi
+internal val Res.string.str_12360: StringResource
+  get() = String5.str_12360
+
+@ExperimentalResourceApi
+internal val Res.string.str_12361: StringResource
+  get() = String5.str_12361
+
+@ExperimentalResourceApi
+internal val Res.string.str_12362: StringResource
+  get() = String5.str_12362
+
+@ExperimentalResourceApi
+internal val Res.string.str_12363: StringResource
+  get() = String5.str_12363
+
+@ExperimentalResourceApi
+internal val Res.string.str_12364: StringResource
+  get() = String5.str_12364
+
+@ExperimentalResourceApi
+internal val Res.string.str_12365: StringResource
+  get() = String5.str_12365
+
+@ExperimentalResourceApi
+internal val Res.string.str_12366: StringResource
+  get() = String5.str_12366
+
+@ExperimentalResourceApi
+internal val Res.string.str_12367: StringResource
+  get() = String5.str_12367
+
+@ExperimentalResourceApi
+internal val Res.string.str_12368: StringResource
+  get() = String5.str_12368
+
+@ExperimentalResourceApi
+internal val Res.string.str_12369: StringResource
+  get() = String5.str_12369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1237: StringResource
+  get() = String5.str_1237
+
+@ExperimentalResourceApi
+internal val Res.string.str_12370: StringResource
+  get() = String5.str_12370
+
+@ExperimentalResourceApi
+internal val Res.string.str_12371: StringResource
+  get() = String5.str_12371
+
+@ExperimentalResourceApi
+internal val Res.string.str_12372: StringResource
+  get() = String5.str_12372
+
+@ExperimentalResourceApi
+internal val Res.string.str_12373: StringResource
+  get() = String5.str_12373
+
+@ExperimentalResourceApi
+internal val Res.string.str_12374: StringResource
+  get() = String5.str_12374
+
+@ExperimentalResourceApi
+internal val Res.string.str_12375: StringResource
+  get() = String5.str_12375
+
+@ExperimentalResourceApi
+internal val Res.string.str_12376: StringResource
+  get() = String5.str_12376
+
+@ExperimentalResourceApi
+internal val Res.string.str_12377: StringResource
+  get() = String5.str_12377
+
+@ExperimentalResourceApi
+internal val Res.string.str_12378: StringResource
+  get() = String5.str_12378
+
+@ExperimentalResourceApi
+internal val Res.string.str_12379: StringResource
+  get() = String5.str_12379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1238: StringResource
+  get() = String5.str_1238
+
+@ExperimentalResourceApi
+internal val Res.string.str_12380: StringResource
+  get() = String5.str_12380
+
+@ExperimentalResourceApi
+internal val Res.string.str_12381: StringResource
+  get() = String5.str_12381
+
+@ExperimentalResourceApi
+internal val Res.string.str_12382: StringResource
+  get() = String5.str_12382
+
+@ExperimentalResourceApi
+internal val Res.string.str_12383: StringResource
+  get() = String5.str_12383
+
+@ExperimentalResourceApi
+internal val Res.string.str_12384: StringResource
+  get() = String5.str_12384
+
+@ExperimentalResourceApi
+internal val Res.string.str_12385: StringResource
+  get() = String5.str_12385
+
+@ExperimentalResourceApi
+internal val Res.string.str_12386: StringResource
+  get() = String5.str_12386
+
+@ExperimentalResourceApi
+internal val Res.string.str_12387: StringResource
+  get() = String5.str_12387
+
+@ExperimentalResourceApi
+internal val Res.string.str_12388: StringResource
+  get() = String5.str_12388
+
+@ExperimentalResourceApi
+internal val Res.string.str_12389: StringResource
+  get() = String5.str_12389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1239: StringResource
+  get() = String5.str_1239
+
+@ExperimentalResourceApi
+internal val Res.string.str_12390: StringResource
+  get() = String5.str_12390
+
+@ExperimentalResourceApi
+internal val Res.string.str_12391: StringResource
+  get() = String5.str_12391
+
+@ExperimentalResourceApi
+internal val Res.string.str_12392: StringResource
+  get() = String5.str_12392
+
+@ExperimentalResourceApi
+internal val Res.string.str_12393: StringResource
+  get() = String5.str_12393
+
+@ExperimentalResourceApi
+internal val Res.string.str_12394: StringResource
+  get() = String5.str_12394
+
+@ExperimentalResourceApi
+internal val Res.string.str_12395: StringResource
+  get() = String5.str_12395
+
+@ExperimentalResourceApi
+internal val Res.string.str_12396: StringResource
+  get() = String5.str_12396
+
+@ExperimentalResourceApi
+internal val Res.string.str_12397: StringResource
+  get() = String5.str_12397
+
+@ExperimentalResourceApi
+internal val Res.string.str_12398: StringResource
+  get() = String5.str_12398
+
+@ExperimentalResourceApi
+internal val Res.string.str_12399: StringResource
+  get() = String5.str_12399
+
+@ExperimentalResourceApi
+internal val Res.string.str_124: StringResource
+  get() = String5.str_124
+
+@ExperimentalResourceApi
+internal val Res.string.str_1240: StringResource
+  get() = String5.str_1240
+
+@ExperimentalResourceApi
+internal val Res.string.str_12400: StringResource
+  get() = String5.str_12400
+
+@ExperimentalResourceApi
+internal val Res.string.str_12401: StringResource
+  get() = String5.str_12401
+
+@ExperimentalResourceApi
+internal val Res.string.str_12402: StringResource
+  get() = String5.str_12402
+
+@ExperimentalResourceApi
+internal val Res.string.str_12403: StringResource
+  get() = String5.str_12403
+
+@ExperimentalResourceApi
+internal val Res.string.str_12404: StringResource
+  get() = String5.str_12404
+
+@ExperimentalResourceApi
+internal val Res.string.str_12405: StringResource
+  get() = String5.str_12405
+
+@ExperimentalResourceApi
+internal val Res.string.str_12406: StringResource
+  get() = String5.str_12406
+
+@ExperimentalResourceApi
+internal val Res.string.str_12407: StringResource
+  get() = String5.str_12407
+
+@ExperimentalResourceApi
+internal val Res.string.str_12408: StringResource
+  get() = String5.str_12408
+
+@ExperimentalResourceApi
+internal val Res.string.str_12409: StringResource
+  get() = String5.str_12409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1241: StringResource
+  get() = String5.str_1241
+
+@ExperimentalResourceApi
+internal val Res.string.str_12410: StringResource
+  get() = String5.str_12410
+
+@ExperimentalResourceApi
+internal val Res.string.str_12411: StringResource
+  get() = String5.str_12411
+
+@ExperimentalResourceApi
+internal val Res.string.str_12412: StringResource
+  get() = String5.str_12412
+
+@ExperimentalResourceApi
+internal val Res.string.str_12413: StringResource
+  get() = String5.str_12413
+
+@ExperimentalResourceApi
+internal val Res.string.str_12414: StringResource
+  get() = String5.str_12414
+
+@ExperimentalResourceApi
+internal val Res.string.str_12415: StringResource
+  get() = String5.str_12415
+
+@ExperimentalResourceApi
+internal val Res.string.str_12416: StringResource
+  get() = String5.str_12416
+
+@ExperimentalResourceApi
+internal val Res.string.str_12417: StringResource
+  get() = String5.str_12417
+
+@ExperimentalResourceApi
+internal val Res.string.str_12418: StringResource
+  get() = String5.str_12418
+
+@ExperimentalResourceApi
+internal val Res.string.str_12419: StringResource
+  get() = String5.str_12419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1242: StringResource
+  get() = String5.str_1242
+
+@ExperimentalResourceApi
+internal val Res.string.str_12420: StringResource
+  get() = String5.str_12420
+
+@ExperimentalResourceApi
+internal val Res.string.str_12421: StringResource
+  get() = String5.str_12421
+
+@ExperimentalResourceApi
+internal val Res.string.str_12422: StringResource
+  get() = String5.str_12422
+
+@ExperimentalResourceApi
+internal val Res.string.str_12423: StringResource
+  get() = String5.str_12423
+
+@ExperimentalResourceApi
+internal val Res.string.str_12424: StringResource
+  get() = String5.str_12424
+
+@ExperimentalResourceApi
+internal val Res.string.str_12425: StringResource
+  get() = String5.str_12425
+
+@ExperimentalResourceApi
+internal val Res.string.str_12426: StringResource
+  get() = String5.str_12426
+
+@ExperimentalResourceApi
+internal val Res.string.str_12427: StringResource
+  get() = String5.str_12427
+
+@ExperimentalResourceApi
+internal val Res.string.str_12428: StringResource
+  get() = String5.str_12428
+
+@ExperimentalResourceApi
+internal val Res.string.str_12429: StringResource
+  get() = String5.str_12429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1243: StringResource
+  get() = String5.str_1243
+
+@ExperimentalResourceApi
+internal val Res.string.str_12430: StringResource
+  get() = String5.str_12430
+
+@ExperimentalResourceApi
+internal val Res.string.str_12431: StringResource
+  get() = String5.str_12431
+
+@ExperimentalResourceApi
+internal val Res.string.str_12432: StringResource
+  get() = String5.str_12432
+
+@ExperimentalResourceApi
+internal val Res.string.str_12433: StringResource
+  get() = String5.str_12433
+
+@ExperimentalResourceApi
+internal val Res.string.str_12434: StringResource
+  get() = String5.str_12434
+
+@ExperimentalResourceApi
+internal val Res.string.str_12435: StringResource
+  get() = String5.str_12435
+
+@ExperimentalResourceApi
+internal val Res.string.str_12436: StringResource
+  get() = String5.str_12436
+
+@ExperimentalResourceApi
+internal val Res.string.str_12437: StringResource
+  get() = String5.str_12437
+
+@ExperimentalResourceApi
+internal val Res.string.str_12438: StringResource
+  get() = String5.str_12438
+
+@ExperimentalResourceApi
+internal val Res.string.str_12439: StringResource
+  get() = String5.str_12439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1244: StringResource
+  get() = String5.str_1244
+
+@ExperimentalResourceApi
+internal val Res.string.str_12440: StringResource
+  get() = String5.str_12440
+
+@ExperimentalResourceApi
+internal val Res.string.str_12441: StringResource
+  get() = String5.str_12441
+
+@ExperimentalResourceApi
+internal val Res.string.str_12442: StringResource
+  get() = String5.str_12442
+
+@ExperimentalResourceApi
+internal val Res.string.str_12443: StringResource
+  get() = String5.str_12443
+
+@ExperimentalResourceApi
+internal val Res.string.str_12444: StringResource
+  get() = String5.str_12444
+
+@ExperimentalResourceApi
+internal val Res.string.str_12445: StringResource
+  get() = String5.str_12445
+
+@ExperimentalResourceApi
+internal val Res.string.str_12446: StringResource
+  get() = String5.str_12446
+
+@ExperimentalResourceApi
+internal val Res.string.str_12447: StringResource
+  get() = String5.str_12447
+
+@ExperimentalResourceApi
+internal val Res.string.str_12448: StringResource
+  get() = String5.str_12448
+
+@ExperimentalResourceApi
+internal val Res.string.str_12449: StringResource
+  get() = String5.str_12449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1245: StringResource
+  get() = String5.str_1245
+
+@ExperimentalResourceApi
+internal val Res.string.str_12450: StringResource
+  get() = String5.str_12450
+
+@ExperimentalResourceApi
+internal val Res.string.str_12451: StringResource
+  get() = String5.str_12451
+
+@ExperimentalResourceApi
+internal val Res.string.str_12452: StringResource
+  get() = String5.str_12452
+
+@ExperimentalResourceApi
+internal val Res.string.str_12453: StringResource
+  get() = String5.str_12453
+
+@ExperimentalResourceApi
+internal val Res.string.str_12454: StringResource
+  get() = String5.str_12454
+
+@ExperimentalResourceApi
+internal val Res.string.str_12455: StringResource
+  get() = String5.str_12455
+
+@ExperimentalResourceApi
+internal val Res.string.str_12456: StringResource
+  get() = String5.str_12456
+
+@ExperimentalResourceApi
+internal val Res.string.str_12457: StringResource
+  get() = String5.str_12457
+
+@ExperimentalResourceApi
+internal val Res.string.str_12458: StringResource
+  get() = String5.str_12458
+
+@ExperimentalResourceApi
+internal val Res.string.str_12459: StringResource
+  get() = String5.str_12459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1246: StringResource
+  get() = String5.str_1246
+
+@ExperimentalResourceApi
+internal val Res.string.str_12460: StringResource
+  get() = String5.str_12460
+
+@ExperimentalResourceApi
+internal val Res.string.str_12461: StringResource
+  get() = String5.str_12461
+
+@ExperimentalResourceApi
+internal val Res.string.str_12462: StringResource
+  get() = String5.str_12462
+
+@ExperimentalResourceApi
+internal val Res.string.str_12463: StringResource
+  get() = String5.str_12463
+
+@ExperimentalResourceApi
+internal val Res.string.str_12464: StringResource
+  get() = String5.str_12464
+
+@ExperimentalResourceApi
+internal val Res.string.str_12465: StringResource
+  get() = String5.str_12465
+
+@ExperimentalResourceApi
+internal val Res.string.str_12466: StringResource
+  get() = String5.str_12466
+
+@ExperimentalResourceApi
+internal val Res.string.str_12467: StringResource
+  get() = String5.str_12467
+
+@ExperimentalResourceApi
+internal val Res.string.str_12468: StringResource
+  get() = String5.str_12468
+
+@ExperimentalResourceApi
+internal val Res.string.str_12469: StringResource
+  get() = String5.str_12469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1247: StringResource
+  get() = String5.str_1247
+
+@ExperimentalResourceApi
+internal val Res.string.str_12470: StringResource
+  get() = String5.str_12470
+
+@ExperimentalResourceApi
+internal val Res.string.str_12471: StringResource
+  get() = String5.str_12471
+
+@ExperimentalResourceApi
+internal val Res.string.str_12472: StringResource
+  get() = String5.str_12472
+
+@ExperimentalResourceApi
+internal val Res.string.str_12473: StringResource
+  get() = String5.str_12473
+
+@ExperimentalResourceApi
+internal val Res.string.str_12474: StringResource
+  get() = String5.str_12474
+
+@ExperimentalResourceApi
+internal val Res.string.str_12475: StringResource
+  get() = String5.str_12475
+
+@ExperimentalResourceApi
+internal val Res.string.str_12476: StringResource
+  get() = String5.str_12476
+
+@ExperimentalResourceApi
+internal val Res.string.str_12477: StringResource
+  get() = String5.str_12477
+
+@ExperimentalResourceApi
+internal val Res.string.str_12478: StringResource
+  get() = String5.str_12478
+
+@ExperimentalResourceApi
+internal val Res.string.str_12479: StringResource
+  get() = String5.str_12479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1248: StringResource
+  get() = String5.str_1248
+
+@ExperimentalResourceApi
+internal val Res.string.str_12480: StringResource
+  get() = String5.str_12480
+
+@ExperimentalResourceApi
+internal val Res.string.str_12481: StringResource
+  get() = String5.str_12481
+
+@ExperimentalResourceApi
+internal val Res.string.str_12482: StringResource
+  get() = String5.str_12482
+
+@ExperimentalResourceApi
+internal val Res.string.str_12483: StringResource
+  get() = String5.str_12483
+
+@ExperimentalResourceApi
+internal val Res.string.str_12484: StringResource
+  get() = String5.str_12484
+
+@ExperimentalResourceApi
+internal val Res.string.str_12485: StringResource
+  get() = String5.str_12485
+
+@ExperimentalResourceApi
+internal val Res.string.str_12486: StringResource
+  get() = String5.str_12486
+
+@ExperimentalResourceApi
+internal val Res.string.str_12487: StringResource
+  get() = String5.str_12487
+
+@ExperimentalResourceApi
+internal val Res.string.str_12488: StringResource
+  get() = String5.str_12488
+
+@ExperimentalResourceApi
+internal val Res.string.str_12489: StringResource
+  get() = String5.str_12489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1249: StringResource
+  get() = String5.str_1249
+
+@ExperimentalResourceApi
+internal val Res.string.str_12490: StringResource
+  get() = String5.str_12490
+
+@ExperimentalResourceApi
+internal val Res.string.str_12491: StringResource
+  get() = String5.str_12491
+
+@ExperimentalResourceApi
+internal val Res.string.str_12492: StringResource
+  get() = String5.str_12492
+
+@ExperimentalResourceApi
+internal val Res.string.str_12493: StringResource
+  get() = String5.str_12493
+
+@ExperimentalResourceApi
+internal val Res.string.str_12494: StringResource
+  get() = String5.str_12494
+
+@ExperimentalResourceApi
+internal val Res.string.str_12495: StringResource
+  get() = String5.str_12495
+
+@ExperimentalResourceApi
+internal val Res.string.str_12496: StringResource
+  get() = String5.str_12496
+
+@ExperimentalResourceApi
+internal val Res.string.str_12497: StringResource
+  get() = String5.str_12497
+
+@ExperimentalResourceApi
+internal val Res.string.str_12498: StringResource
+  get() = String5.str_12498
+
+@ExperimentalResourceApi
+internal val Res.string.str_12499: StringResource
+  get() = String5.str_12499
+
+@ExperimentalResourceApi
+internal val Res.string.str_125: StringResource
+  get() = String5.str_125
+
+@ExperimentalResourceApi
+internal val Res.string.str_1250: StringResource
+  get() = String5.str_1250
+
+@ExperimentalResourceApi
+internal val Res.string.str_12500: StringResource
+  get() = String5.str_12500
+
+@ExperimentalResourceApi
+internal val Res.string.str_12501: StringResource
+  get() = String5.str_12501
+
+@ExperimentalResourceApi
+internal val Res.string.str_12502: StringResource
+  get() = String5.str_12502
+
+@ExperimentalResourceApi
+internal val Res.string.str_12503: StringResource
+  get() = String5.str_12503
+
+@ExperimentalResourceApi
+internal val Res.string.str_12504: StringResource
+  get() = String5.str_12504
+
+@ExperimentalResourceApi
+internal val Res.string.str_12505: StringResource
+  get() = String5.str_12505
+
+@ExperimentalResourceApi
+internal val Res.string.str_12506: StringResource
+  get() = String5.str_12506
+
+@ExperimentalResourceApi
+internal val Res.string.str_12507: StringResource
+  get() = String5.str_12507
+
+@ExperimentalResourceApi
+internal val Res.string.str_12508: StringResource
+  get() = String5.str_12508
+
+@ExperimentalResourceApi
+internal val Res.string.str_12509: StringResource
+  get() = String5.str_12509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1251: StringResource
+  get() = String5.str_1251
+
+@ExperimentalResourceApi
+internal val Res.string.str_12510: StringResource
+  get() = String5.str_12510
+
+@ExperimentalResourceApi
+internal val Res.string.str_12511: StringResource
+  get() = String5.str_12511
+
+@ExperimentalResourceApi
+internal val Res.string.str_12512: StringResource
+  get() = String5.str_12512
+
+@ExperimentalResourceApi
+internal val Res.string.str_12513: StringResource
+  get() = String5.str_12513
+
+@ExperimentalResourceApi
+internal val Res.string.str_12514: StringResource
+  get() = String5.str_12514
+
+@ExperimentalResourceApi
+internal val Res.string.str_12515: StringResource
+  get() = String5.str_12515
+
+@ExperimentalResourceApi
+internal val Res.string.str_12516: StringResource
+  get() = String5.str_12516
+
+@ExperimentalResourceApi
+internal val Res.string.str_12517: StringResource
+  get() = String5.str_12517
+
+@ExperimentalResourceApi
+internal val Res.string.str_12518: StringResource
+  get() = String5.str_12518
+
+@ExperimentalResourceApi
+internal val Res.string.str_12519: StringResource
+  get() = String5.str_12519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1252: StringResource
+  get() = String5.str_1252
+
+@ExperimentalResourceApi
+internal val Res.string.str_12520: StringResource
+  get() = String5.str_12520
+
+@ExperimentalResourceApi
+internal val Res.string.str_12521: StringResource
+  get() = String5.str_12521
+
+@ExperimentalResourceApi
+internal val Res.string.str_12522: StringResource
+  get() = String5.str_12522
+
+@ExperimentalResourceApi
+internal val Res.string.str_12523: StringResource
+  get() = String5.str_12523
+
+@ExperimentalResourceApi
+internal val Res.string.str_12524: StringResource
+  get() = String5.str_12524
+
+@ExperimentalResourceApi
+internal val Res.string.str_12525: StringResource
+  get() = String5.str_12525
+
+@ExperimentalResourceApi
+internal val Res.string.str_12526: StringResource
+  get() = String5.str_12526
+
+@ExperimentalResourceApi
+internal val Res.string.str_12527: StringResource
+  get() = String5.str_12527
+
+@ExperimentalResourceApi
+internal val Res.string.str_12528: StringResource
+  get() = String5.str_12528
+
+@ExperimentalResourceApi
+internal val Res.string.str_12529: StringResource
+  get() = String5.str_12529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1253: StringResource
+  get() = String5.str_1253
+
+@ExperimentalResourceApi
+internal val Res.string.str_12530: StringResource
+  get() = String5.str_12530
+
+@ExperimentalResourceApi
+internal val Res.string.str_12531: StringResource
+  get() = String5.str_12531
+
+@ExperimentalResourceApi
+internal val Res.string.str_12532: StringResource
+  get() = String5.str_12532
+
+@ExperimentalResourceApi
+internal val Res.string.str_12533: StringResource
+  get() = String5.str_12533
+
+@ExperimentalResourceApi
+internal val Res.string.str_12534: StringResource
+  get() = String5.str_12534
+
+@ExperimentalResourceApi
+internal val Res.string.str_12535: StringResource
+  get() = String5.str_12535
+
+@ExperimentalResourceApi
+internal val Res.string.str_12536: StringResource
+  get() = String5.str_12536
+
+@ExperimentalResourceApi
+internal val Res.string.str_12537: StringResource
+  get() = String5.str_12537
+
+@ExperimentalResourceApi
+internal val Res.string.str_12538: StringResource
+  get() = String5.str_12538
+
+@ExperimentalResourceApi
+internal val Res.string.str_12539: StringResource
+  get() = String5.str_12539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1254: StringResource
+  get() = String5.str_1254
+
+@ExperimentalResourceApi
+internal val Res.string.str_12540: StringResource
+  get() = String5.str_12540
+
+@ExperimentalResourceApi
+internal val Res.string.str_12541: StringResource
+  get() = String5.str_12541
+
+@ExperimentalResourceApi
+internal val Res.string.str_12542: StringResource
+  get() = String5.str_12542
+
+@ExperimentalResourceApi
+internal val Res.string.str_12543: StringResource
+  get() = String5.str_12543
+
+@ExperimentalResourceApi
+internal val Res.string.str_12544: StringResource
+  get() = String5.str_12544
+
+@ExperimentalResourceApi
+internal val Res.string.str_12545: StringResource
+  get() = String5.str_12545
+
+@ExperimentalResourceApi
+internal val Res.string.str_12546: StringResource
+  get() = String5.str_12546
+
+@ExperimentalResourceApi
+internal val Res.string.str_12547: StringResource
+  get() = String5.str_12547
+
+@ExperimentalResourceApi
+internal val Res.string.str_12548: StringResource
+  get() = String5.str_12548
+
+@ExperimentalResourceApi
+internal val Res.string.str_12549: StringResource
+  get() = String5.str_12549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1255: StringResource
+  get() = String5.str_1255
+
+@ExperimentalResourceApi
+internal val Res.string.str_12550: StringResource
+  get() = String5.str_12550
+
+@ExperimentalResourceApi
+internal val Res.string.str_12551: StringResource
+  get() = String5.str_12551
+
+@ExperimentalResourceApi
+internal val Res.string.str_12552: StringResource
+  get() = String5.str_12552
+
+@ExperimentalResourceApi
+internal val Res.string.str_12553: StringResource
+  get() = String5.str_12553
+
+@ExperimentalResourceApi
+internal val Res.string.str_12554: StringResource
+  get() = String5.str_12554
+
+@ExperimentalResourceApi
+internal val Res.string.str_12555: StringResource
+  get() = String5.str_12555
+
+@ExperimentalResourceApi
+internal val Res.string.str_12556: StringResource
+  get() = String5.str_12556
+
+@ExperimentalResourceApi
+internal val Res.string.str_12557: StringResource
+  get() = String5.str_12557
+
+@ExperimentalResourceApi
+internal val Res.string.str_12558: StringResource
+  get() = String5.str_12558
+
+@ExperimentalResourceApi
+internal val Res.string.str_12559: StringResource
+  get() = String5.str_12559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1256: StringResource
+  get() = String5.str_1256
+
+@ExperimentalResourceApi
+internal val Res.string.str_12560: StringResource
+  get() = String5.str_12560
+
+@ExperimentalResourceApi
+internal val Res.string.str_12561: StringResource
+  get() = String5.str_12561
+
+@ExperimentalResourceApi
+internal val Res.string.str_12562: StringResource
+  get() = String5.str_12562
+
+@ExperimentalResourceApi
+internal val Res.string.str_12563: StringResource
+  get() = String5.str_12563
+
+@ExperimentalResourceApi
+internal val Res.string.str_12564: StringResource
+  get() = String5.str_12564
+
+@ExperimentalResourceApi
+internal val Res.string.str_12565: StringResource
+  get() = String5.str_12565
+
+@ExperimentalResourceApi
+internal val Res.string.str_12566: StringResource
+  get() = String5.str_12566
+
+@ExperimentalResourceApi
+internal val Res.string.str_12567: StringResource
+  get() = String5.str_12567
+
+@ExperimentalResourceApi
+internal val Res.string.str_12568: StringResource
+  get() = String5.str_12568
+
+@ExperimentalResourceApi
+internal val Res.string.str_12569: StringResource
+  get() = String5.str_12569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1257: StringResource
+  get() = String5.str_1257
+
+@ExperimentalResourceApi
+internal val Res.string.str_12570: StringResource
+  get() = String5.str_12570
+
+@ExperimentalResourceApi
+internal val Res.string.str_12571: StringResource
+  get() = String5.str_12571
+
+@ExperimentalResourceApi
+internal val Res.string.str_12572: StringResource
+  get() = String5.str_12572
+
+@ExperimentalResourceApi
+internal val Res.string.str_12573: StringResource
+  get() = String5.str_12573
+
+@ExperimentalResourceApi
+internal val Res.string.str_12574: StringResource
+  get() = String5.str_12574
+
+@ExperimentalResourceApi
+internal val Res.string.str_12575: StringResource
+  get() = String5.str_12575
+
+@ExperimentalResourceApi
+internal val Res.string.str_12576: StringResource
+  get() = String5.str_12576
+
+@ExperimentalResourceApi
+internal val Res.string.str_12577: StringResource
+  get() = String5.str_12577
+
+@ExperimentalResourceApi
+internal val Res.string.str_12578: StringResource
+  get() = String5.str_12578
+
+@ExperimentalResourceApi
+internal val Res.string.str_12579: StringResource
+  get() = String5.str_12579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1258: StringResource
+  get() = String5.str_1258
+
+@ExperimentalResourceApi
+internal val Res.string.str_12580: StringResource
+  get() = String5.str_12580
+
+@ExperimentalResourceApi
+internal val Res.string.str_12581: StringResource
+  get() = String5.str_12581
+
+@ExperimentalResourceApi
+internal val Res.string.str_12582: StringResource
+  get() = String5.str_12582
+
+@ExperimentalResourceApi
+internal val Res.string.str_12583: StringResource
+  get() = String5.str_12583
+
+@ExperimentalResourceApi
+internal val Res.string.str_12584: StringResource
+  get() = String5.str_12584
+
+@ExperimentalResourceApi
+internal val Res.string.str_12585: StringResource
+  get() = String5.str_12585
+
+@ExperimentalResourceApi
+internal val Res.string.str_12586: StringResource
+  get() = String5.str_12586
+
+@ExperimentalResourceApi
+internal val Res.string.str_12587: StringResource
+  get() = String5.str_12587
+
+@ExperimentalResourceApi
+internal val Res.string.str_12588: StringResource
+  get() = String5.str_12588
+
+@ExperimentalResourceApi
+internal val Res.string.str_12589: StringResource
+  get() = String5.str_12589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1259: StringResource
+  get() = String5.str_1259
+
+@ExperimentalResourceApi
+internal val Res.string.str_12590: StringResource
+  get() = String5.str_12590
+
+@ExperimentalResourceApi
+internal val Res.string.str_12591: StringResource
+  get() = String5.str_12591
+
+@ExperimentalResourceApi
+internal val Res.string.str_12592: StringResource
+  get() = String5.str_12592
+
+@ExperimentalResourceApi
+internal val Res.string.str_12593: StringResource
+  get() = String5.str_12593
+
+@ExperimentalResourceApi
+internal val Res.string.str_12594: StringResource
+  get() = String5.str_12594
+
+@ExperimentalResourceApi
+internal val Res.string.str_12595: StringResource
+  get() = String5.str_12595
+
+@ExperimentalResourceApi
+internal val Res.string.str_12596: StringResource
+  get() = String5.str_12596
+
+@ExperimentalResourceApi
+internal val Res.string.str_12597: StringResource
+  get() = String5.str_12597
+
+@ExperimentalResourceApi
+internal val Res.string.str_12598: StringResource
+  get() = String5.str_12598
+
+@ExperimentalResourceApi
+internal val Res.string.str_12599: StringResource
+  get() = String5.str_12599
+
+@ExperimentalResourceApi
+internal val Res.string.str_126: StringResource
+  get() = String5.str_126
+
+@ExperimentalResourceApi
+internal val Res.string.str_1260: StringResource
+  get() = String5.str_1260
+
+@ExperimentalResourceApi
+internal val Res.string.str_12600: StringResource
+  get() = String5.str_12600
+
+@ExperimentalResourceApi
+internal val Res.string.str_12601: StringResource
+  get() = String5.str_12601
+
+@ExperimentalResourceApi
+internal val Res.string.str_12602: StringResource
+  get() = String5.str_12602
+
+@ExperimentalResourceApi
+internal val Res.string.str_12603: StringResource
+  get() = String5.str_12603
+
+@ExperimentalResourceApi
+internal val Res.string.str_12604: StringResource
+  get() = String5.str_12604
+
+@ExperimentalResourceApi
+internal val Res.string.str_12605: StringResource
+  get() = String5.str_12605
+
+@ExperimentalResourceApi
+internal val Res.string.str_12606: StringResource
+  get() = String5.str_12606
+
+@ExperimentalResourceApi
+internal val Res.string.str_12607: StringResource
+  get() = String5.str_12607
+
+@ExperimentalResourceApi
+internal val Res.string.str_12608: StringResource
+  get() = String5.str_12608
+
+@ExperimentalResourceApi
+internal val Res.string.str_12609: StringResource
+  get() = String5.str_12609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1261: StringResource
+  get() = String5.str_1261
+
+@ExperimentalResourceApi
+internal val Res.string.str_12610: StringResource
+  get() = String5.str_12610
+
+@ExperimentalResourceApi
+internal val Res.string.str_12611: StringResource
+  get() = String5.str_12611
+
+@ExperimentalResourceApi
+internal val Res.string.str_12612: StringResource
+  get() = String5.str_12612
+
+@ExperimentalResourceApi
+internal val Res.string.str_12613: StringResource
+  get() = String5.str_12613
+
+@ExperimentalResourceApi
+internal val Res.string.str_12614: StringResource
+  get() = String5.str_12614
+
+@ExperimentalResourceApi
+internal val Res.string.str_12615: StringResource
+  get() = String5.str_12615
+
+@ExperimentalResourceApi
+internal val Res.string.str_12616: StringResource
+  get() = String5.str_12616
+
+@ExperimentalResourceApi
+internal val Res.string.str_12617: StringResource
+  get() = String5.str_12617
+
+@ExperimentalResourceApi
+internal val Res.string.str_12618: StringResource
+  get() = String5.str_12618
+
+@ExperimentalResourceApi
+internal val Res.string.str_12619: StringResource
+  get() = String5.str_12619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1262: StringResource
+  get() = String5.str_1262
+
+@ExperimentalResourceApi
+internal val Res.string.str_12620: StringResource
+  get() = String5.str_12620
+
+@ExperimentalResourceApi
+internal val Res.string.str_12621: StringResource
+  get() = String5.str_12621
+
+@ExperimentalResourceApi
+internal val Res.string.str_12622: StringResource
+  get() = String5.str_12622
+
+@ExperimentalResourceApi
+internal val Res.string.str_12623: StringResource
+  get() = String5.str_12623
+
+@ExperimentalResourceApi
+internal val Res.string.str_12624: StringResource
+  get() = String5.str_12624
+
+@ExperimentalResourceApi
+internal val Res.string.str_12625: StringResource
+  get() = String5.str_12625
+
+@ExperimentalResourceApi
+internal val Res.string.str_12626: StringResource
+  get() = String5.str_12626
+
+@ExperimentalResourceApi
+internal val Res.string.str_12627: StringResource
+  get() = String5.str_12627
+
+@ExperimentalResourceApi
+internal val Res.string.str_12628: StringResource
+  get() = String5.str_12628
+
+@ExperimentalResourceApi
+internal val Res.string.str_12629: StringResource
+  get() = String5.str_12629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1263: StringResource
+  get() = String5.str_1263
+
+@ExperimentalResourceApi
+internal val Res.string.str_12630: StringResource
+  get() = String5.str_12630
+
+@ExperimentalResourceApi
+internal val Res.string.str_12631: StringResource
+  get() = String5.str_12631
+
+@ExperimentalResourceApi
+internal val Res.string.str_12632: StringResource
+  get() = String5.str_12632
+
+@ExperimentalResourceApi
+internal val Res.string.str_12633: StringResource
+  get() = String5.str_12633
+
+@ExperimentalResourceApi
+internal val Res.string.str_12634: StringResource
+  get() = String5.str_12634
+
+@ExperimentalResourceApi
+internal val Res.string.str_12635: StringResource
+  get() = String5.str_12635
+
+@ExperimentalResourceApi
+internal val Res.string.str_12636: StringResource
+  get() = String5.str_12636
+
+@ExperimentalResourceApi
+internal val Res.string.str_12637: StringResource
+  get() = String5.str_12637
+
+@ExperimentalResourceApi
+internal val Res.string.str_12638: StringResource
+  get() = String5.str_12638
+
+@ExperimentalResourceApi
+internal val Res.string.str_12639: StringResource
+  get() = String5.str_12639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1264: StringResource
+  get() = String5.str_1264
+
+@ExperimentalResourceApi
+internal val Res.string.str_12640: StringResource
+  get() = String5.str_12640
+
+@ExperimentalResourceApi
+internal val Res.string.str_12641: StringResource
+  get() = String5.str_12641
+
+@ExperimentalResourceApi
+internal val Res.string.str_12642: StringResource
+  get() = String5.str_12642
+
+@ExperimentalResourceApi
+internal val Res.string.str_12643: StringResource
+  get() = String5.str_12643
+
+@ExperimentalResourceApi
+internal val Res.string.str_12644: StringResource
+  get() = String5.str_12644
+
+@ExperimentalResourceApi
+internal val Res.string.str_12645: StringResource
+  get() = String5.str_12645
+
+@ExperimentalResourceApi
+internal val Res.string.str_12646: StringResource
+  get() = String5.str_12646
+
+@ExperimentalResourceApi
+internal val Res.string.str_12647: StringResource
+  get() = String5.str_12647
+
+@ExperimentalResourceApi
+internal val Res.string.str_12648: StringResource
+  get() = String5.str_12648
+
+@ExperimentalResourceApi
+internal val Res.string.str_12649: StringResource
+  get() = String5.str_12649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1265: StringResource
+  get() = String5.str_1265
+
+@ExperimentalResourceApi
+internal val Res.string.str_12650: StringResource
+  get() = String5.str_12650
+
+@ExperimentalResourceApi
+internal val Res.string.str_12651: StringResource
+  get() = String5.str_12651
+
+@ExperimentalResourceApi
+internal val Res.string.str_12652: StringResource
+  get() = String5.str_12652
+
+@ExperimentalResourceApi
+internal val Res.string.str_12653: StringResource
+  get() = String5.str_12653
+
+@ExperimentalResourceApi
+internal val Res.string.str_12654: StringResource
+  get() = String5.str_12654
+
+@ExperimentalResourceApi
+internal val Res.string.str_12655: StringResource
+  get() = String5.str_12655
+
+@ExperimentalResourceApi
+internal val Res.string.str_12656: StringResource
+  get() = String5.str_12656
+
+@ExperimentalResourceApi
+internal val Res.string.str_12657: StringResource
+  get() = String5.str_12657
+
+@ExperimentalResourceApi
+internal val Res.string.str_12658: StringResource
+  get() = String5.str_12658
+
+@ExperimentalResourceApi
+internal val Res.string.str_12659: StringResource
+  get() = String5.str_12659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1266: StringResource
+  get() = String5.str_1266
+
+@ExperimentalResourceApi
+internal val Res.string.str_12660: StringResource
+  get() = String5.str_12660
+
+@ExperimentalResourceApi
+internal val Res.string.str_12661: StringResource
+  get() = String5.str_12661
+
+@ExperimentalResourceApi
+internal val Res.string.str_12662: StringResource
+  get() = String5.str_12662
+
+@ExperimentalResourceApi
+internal val Res.string.str_12663: StringResource
+  get() = String5.str_12663
+
+@ExperimentalResourceApi
+internal val Res.string.str_12664: StringResource
+  get() = String5.str_12664
+
+@ExperimentalResourceApi
+internal val Res.string.str_12665: StringResource
+  get() = String5.str_12665
+
+@ExperimentalResourceApi
+internal val Res.string.str_12666: StringResource
+  get() = String5.str_12666
+
+@ExperimentalResourceApi
+internal val Res.string.str_12667: StringResource
+  get() = String5.str_12667
+
+@ExperimentalResourceApi
+internal val Res.string.str_12668: StringResource
+  get() = String5.str_12668
+
+@ExperimentalResourceApi
+internal val Res.string.str_12669: StringResource
+  get() = String5.str_12669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1267: StringResource
+  get() = String5.str_1267
+
+@ExperimentalResourceApi
+internal val Res.string.str_12670: StringResource
+  get() = String5.str_12670
+
+@ExperimentalResourceApi
+internal val Res.string.str_12671: StringResource
+  get() = String5.str_12671
+
+@ExperimentalResourceApi
+internal val Res.string.str_12672: StringResource
+  get() = String5.str_12672
+
+@ExperimentalResourceApi
+internal val Res.string.str_12673: StringResource
+  get() = String5.str_12673
+
+@ExperimentalResourceApi
+internal val Res.string.str_12674: StringResource
+  get() = String5.str_12674
+
+@ExperimentalResourceApi
+internal val Res.string.str_12675: StringResource
+  get() = String5.str_12675
+
+@ExperimentalResourceApi
+internal val Res.string.str_12676: StringResource
+  get() = String5.str_12676
+
+@ExperimentalResourceApi
+internal val Res.string.str_12677: StringResource
+  get() = String5.str_12677
+
+@ExperimentalResourceApi
+internal val Res.string.str_12678: StringResource
+  get() = String5.str_12678
+
+@ExperimentalResourceApi
+internal val Res.string.str_12679: StringResource
+  get() = String5.str_12679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1268: StringResource
+  get() = String5.str_1268
+
+@ExperimentalResourceApi
+internal val Res.string.str_12680: StringResource
+  get() = String5.str_12680
+
+@ExperimentalResourceApi
+internal val Res.string.str_12681: StringResource
+  get() = String5.str_12681
+
+@ExperimentalResourceApi
+internal val Res.string.str_12682: StringResource
+  get() = String5.str_12682
+
+@ExperimentalResourceApi
+internal val Res.string.str_12683: StringResource
+  get() = String5.str_12683
+
+@ExperimentalResourceApi
+internal val Res.string.str_12684: StringResource
+  get() = String5.str_12684
+
+@ExperimentalResourceApi
+internal val Res.string.str_12685: StringResource
+  get() = String5.str_12685
+
+@ExperimentalResourceApi
+internal val Res.string.str_12686: StringResource
+  get() = String5.str_12686
+
+@ExperimentalResourceApi
+internal val Res.string.str_12687: StringResource
+  get() = String5.str_12687
+
+@ExperimentalResourceApi
+internal val Res.string.str_12688: StringResource
+  get() = String5.str_12688
+
+@ExperimentalResourceApi
+internal val Res.string.str_12689: StringResource
+  get() = String5.str_12689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1269: StringResource
+  get() = String5.str_1269
+
+@ExperimentalResourceApi
+internal val Res.string.str_12690: StringResource
+  get() = String5.str_12690
+
+@ExperimentalResourceApi
+internal val Res.string.str_12691: StringResource
+  get() = String5.str_12691
+
+@ExperimentalResourceApi
+internal val Res.string.str_12692: StringResource
+  get() = String5.str_12692
+
+@ExperimentalResourceApi
+internal val Res.string.str_12693: StringResource
+  get() = String5.str_12693
+
+@ExperimentalResourceApi
+internal val Res.string.str_12694: StringResource
+  get() = String5.str_12694
+
+@ExperimentalResourceApi
+internal val Res.string.str_12695: StringResource
+  get() = String5.str_12695
+
+@ExperimentalResourceApi
+internal val Res.string.str_12696: StringResource
+  get() = String5.str_12696
+
+@ExperimentalResourceApi
+internal val Res.string.str_12697: StringResource
+  get() = String5.str_12697

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String6.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String6.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String6 {
+  public val str_12698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12698", "str_12698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12699", "str_12699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_127", "str_127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1270", "str_1270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12700", "str_12700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12701", "str_12701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12702", "str_12702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12703", "str_12703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12704", "str_12704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12705", "str_12705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12706", "str_12706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12707", "str_12707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12708", "str_12708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12709", "str_12709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1271", "str_1271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12710", "str_12710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12711", "str_12711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12712", "str_12712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12713", "str_12713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12714", "str_12714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12715", "str_12715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12716", "str_12716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12717", "str_12717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12718", "str_12718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12719", "str_12719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1272", "str_1272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12720", "str_12720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12721", "str_12721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12722", "str_12722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12723", "str_12723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12724", "str_12724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12725", "str_12725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12726", "str_12726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12727", "str_12727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12728", "str_12728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12729", "str_12729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1273", "str_1273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12730", "str_12730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12731", "str_12731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12732", "str_12732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12733", "str_12733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12734", "str_12734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12735", "str_12735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12736", "str_12736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12737", "str_12737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12738", "str_12738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12739", "str_12739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1274", "str_1274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12740", "str_12740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12741", "str_12741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12742", "str_12742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12743", "str_12743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12744", "str_12744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12745", "str_12745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12746", "str_12746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12747", "str_12747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12748", "str_12748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12749", "str_12749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1275", "str_1275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12750", "str_12750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12751", "str_12751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12752", "str_12752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12753", "str_12753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12754", "str_12754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12755", "str_12755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12756", "str_12756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12757", "str_12757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12758", "str_12758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12759", "str_12759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1276", "str_1276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12760", "str_12760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12761", "str_12761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12762", "str_12762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12763", "str_12763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12764", "str_12764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12765", "str_12765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12766", "str_12766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12767", "str_12767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12768", "str_12768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12769", "str_12769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1277", "str_1277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12770", "str_12770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12771", "str_12771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12772", "str_12772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12773", "str_12773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12774", "str_12774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12775", "str_12775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12776", "str_12776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12777", "str_12777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12778", "str_12778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12779", "str_12779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1278", "str_1278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12780", "str_12780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12781", "str_12781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12782", "str_12782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12783", "str_12783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12784", "str_12784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12785", "str_12785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12786", "str_12786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12787", "str_12787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12788", "str_12788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12789", "str_12789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1279", "str_1279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12790", "str_12790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12791", "str_12791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12792", "str_12792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12793", "str_12793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12794", "str_12794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12795", "str_12795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12796", "str_12796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12797", "str_12797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12798", "str_12798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12799", "str_12799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_128", "str_128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1280", "str_1280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12800", "str_12800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12801", "str_12801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12802", "str_12802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12803", "str_12803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12804", "str_12804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12805", "str_12805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12806", "str_12806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12807", "str_12807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12808", "str_12808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12809", "str_12809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1281", "str_1281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12810", "str_12810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12811", "str_12811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12812", "str_12812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12813", "str_12813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12814", "str_12814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12815", "str_12815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12816", "str_12816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12817", "str_12817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12818", "str_12818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12819", "str_12819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1282", "str_1282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12820", "str_12820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12821", "str_12821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12822", "str_12822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12823", "str_12823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12824", "str_12824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12825", "str_12825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12826", "str_12826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12827", "str_12827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12828", "str_12828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12829", "str_12829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1283", "str_1283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12830", "str_12830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12831", "str_12831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12832", "str_12832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12833", "str_12833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12834", "str_12834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12835", "str_12835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12836", "str_12836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12837", "str_12837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12838", "str_12838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12839", "str_12839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1284", "str_1284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12840", "str_12840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12841", "str_12841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12842", "str_12842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12843", "str_12843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12844", "str_12844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12845", "str_12845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12846", "str_12846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12847", "str_12847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12848", "str_12848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12849", "str_12849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1285", "str_1285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12850", "str_12850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12851", "str_12851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12852", "str_12852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12853", "str_12853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12854", "str_12854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12855", "str_12855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12856", "str_12856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12857", "str_12857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12858", "str_12858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12859", "str_12859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1286", "str_1286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12860", "str_12860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12861", "str_12861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12862", "str_12862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12863", "str_12863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12864", "str_12864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12865", "str_12865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12866", "str_12866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12867", "str_12867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12868", "str_12868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12869", "str_12869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1287", "str_1287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12870", "str_12870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12871", "str_12871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12872", "str_12872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12873", "str_12873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12874", "str_12874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12875", "str_12875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12876", "str_12876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12877", "str_12877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12878", "str_12878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12879", "str_12879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1288", "str_1288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12880", "str_12880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12881", "str_12881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12882", "str_12882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12883", "str_12883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12884", "str_12884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12885", "str_12885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12886", "str_12886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12887", "str_12887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12888", "str_12888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12889", "str_12889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1289", "str_1289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12890", "str_12890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12891", "str_12891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12892", "str_12892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12893", "str_12893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12894", "str_12894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12895", "str_12895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12896", "str_12896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12897", "str_12897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12898", "str_12898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12899", "str_12899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_129", "str_129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1290", "str_1290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12900", "str_12900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12901", "str_12901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12902", "str_12902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12903", "str_12903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12904", "str_12904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12905", "str_12905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12906", "str_12906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12907", "str_12907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12908", "str_12908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12909", "str_12909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1291", "str_1291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12910", "str_12910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12911", "str_12911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12912", "str_12912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12913", "str_12913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12914", "str_12914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12915", "str_12915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12916", "str_12916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12917", "str_12917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12918", "str_12918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12919", "str_12919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1292", "str_1292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12920", "str_12920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12921", "str_12921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12922", "str_12922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12923", "str_12923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12924", "str_12924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12925", "str_12925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12926", "str_12926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12927", "str_12927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12928", "str_12928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12929", "str_12929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1293", "str_1293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12930", "str_12930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12931", "str_12931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12932", "str_12932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12933", "str_12933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12934", "str_12934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12935", "str_12935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12936", "str_12936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12937", "str_12937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12938", "str_12938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12939", "str_12939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1294", "str_1294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12940", "str_12940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12941", "str_12941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12942", "str_12942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12943", "str_12943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12944", "str_12944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12945", "str_12945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12946", "str_12946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12947", "str_12947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12948", "str_12948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12949", "str_12949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1295", "str_1295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12950", "str_12950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12951", "str_12951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12952", "str_12952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12953", "str_12953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12954", "str_12954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12955", "str_12955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12956", "str_12956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12957", "str_12957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12958", "str_12958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12959", "str_12959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1296", "str_1296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12960", "str_12960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12961", "str_12961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12962", "str_12962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12963", "str_12963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12964", "str_12964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12965", "str_12965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12966", "str_12966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12967", "str_12967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12968", "str_12968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12969", "str_12969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1297", "str_1297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12970", "str_12970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12971", "str_12971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12972", "str_12972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12973", "str_12973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12974", "str_12974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12975", "str_12975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12976", "str_12976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12977", "str_12977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12978", "str_12978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12979", "str_12979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1298", "str_1298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12980", "str_12980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12981", "str_12981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12982", "str_12982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12983", "str_12983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12984", "str_12984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12985", "str_12985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12986", "str_12986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12987", "str_12987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12988", "str_12988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12989", "str_12989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1299", "str_1299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12990", "str_12990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12991", "str_12991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12992", "str_12992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12993", "str_12993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12994", "str_12994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12995", "str_12995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12996", "str_12996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12997", "str_12997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12998", "str_12998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_12999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_12999", "str_12999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13", "str_13",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_130", "str_130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1300", "str_1300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13000", "str_13000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13001", "str_13001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13002", "str_13002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13003", "str_13003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13004", "str_13004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13005", "str_13005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13006", "str_13006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13007", "str_13007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13008", "str_13008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13009", "str_13009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1301", "str_1301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13010", "str_13010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13011", "str_13011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13012", "str_13012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13013", "str_13013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13014", "str_13014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13015", "str_13015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13016", "str_13016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13017", "str_13017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13018", "str_13018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13019", "str_13019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1302", "str_1302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13020", "str_13020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13021", "str_13021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13022", "str_13022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13023", "str_13023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13024", "str_13024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13025", "str_13025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13026", "str_13026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13027", "str_13027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13028", "str_13028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13029", "str_13029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1303", "str_1303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13030", "str_13030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13031", "str_13031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13032", "str_13032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13033", "str_13033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13034", "str_13034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13035", "str_13035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13036", "str_13036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13037", "str_13037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13038", "str_13038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13039", "str_13039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1304", "str_1304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13040", "str_13040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13041", "str_13041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13042", "str_13042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13043", "str_13043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13044", "str_13044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13045", "str_13045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13046", "str_13046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13047", "str_13047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13048", "str_13048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13049", "str_13049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1305", "str_1305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13050", "str_13050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13051", "str_13051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13052", "str_13052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13053", "str_13053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13054", "str_13054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13055", "str_13055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13056", "str_13056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13057", "str_13057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13058", "str_13058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13059", "str_13059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1306", "str_1306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13060", "str_13060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13061", "str_13061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13062", "str_13062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13063", "str_13063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13064", "str_13064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13065", "str_13065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13066", "str_13066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13067", "str_13067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13068", "str_13068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13069", "str_13069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1307", "str_1307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13070", "str_13070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13071", "str_13071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13072", "str_13072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13073", "str_13073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13074", "str_13074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13075", "str_13075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13076", "str_13076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13077", "str_13077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13078", "str_13078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13079", "str_13079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1308", "str_1308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13080", "str_13080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13081", "str_13081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13082", "str_13082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13083", "str_13083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13084", "str_13084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13085", "str_13085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13086", "str_13086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13087", "str_13087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13088", "str_13088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13089", "str_13089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1309", "str_1309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13090", "str_13090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13091", "str_13091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13092", "str_13092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13093", "str_13093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13094", "str_13094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13095", "str_13095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13096", "str_13096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13097", "str_13097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13098", "str_13098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13099", "str_13099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_131", "str_131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1310", "str_1310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13100", "str_13100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13101", "str_13101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13102", "str_13102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13103", "str_13103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13104", "str_13104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13105", "str_13105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13106", "str_13106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13107", "str_13107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13108", "str_13108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13109", "str_13109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1311", "str_1311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13110", "str_13110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13111", "str_13111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13112", "str_13112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13113", "str_13113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13114", "str_13114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13115", "str_13115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13116", "str_13116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13117", "str_13117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13118", "str_13118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13119", "str_13119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1312", "str_1312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13120", "str_13120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13121", "str_13121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13122", "str_13122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13123", "str_13123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13124", "str_13124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13125", "str_13125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13126", "str_13126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13127", "str_13127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13128", "str_13128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13129", "str_13129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1313", "str_1313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13130", "str_13130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13131", "str_13131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13132", "str_13132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13133", "str_13133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13134", "str_13134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13135", "str_13135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13136", "str_13136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13137", "str_13137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13138", "str_13138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13139", "str_13139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1314", "str_1314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13140", "str_13140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13141", "str_13141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13142", "str_13142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13143", "str_13143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13144", "str_13144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13145", "str_13145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13146", "str_13146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_12698: StringResource
+  get() = String6.str_12698
+
+@ExperimentalResourceApi
+internal val Res.string.str_12699: StringResource
+  get() = String6.str_12699
+
+@ExperimentalResourceApi
+internal val Res.string.str_127: StringResource
+  get() = String6.str_127
+
+@ExperimentalResourceApi
+internal val Res.string.str_1270: StringResource
+  get() = String6.str_1270
+
+@ExperimentalResourceApi
+internal val Res.string.str_12700: StringResource
+  get() = String6.str_12700
+
+@ExperimentalResourceApi
+internal val Res.string.str_12701: StringResource
+  get() = String6.str_12701
+
+@ExperimentalResourceApi
+internal val Res.string.str_12702: StringResource
+  get() = String6.str_12702
+
+@ExperimentalResourceApi
+internal val Res.string.str_12703: StringResource
+  get() = String6.str_12703
+
+@ExperimentalResourceApi
+internal val Res.string.str_12704: StringResource
+  get() = String6.str_12704
+
+@ExperimentalResourceApi
+internal val Res.string.str_12705: StringResource
+  get() = String6.str_12705
+
+@ExperimentalResourceApi
+internal val Res.string.str_12706: StringResource
+  get() = String6.str_12706
+
+@ExperimentalResourceApi
+internal val Res.string.str_12707: StringResource
+  get() = String6.str_12707
+
+@ExperimentalResourceApi
+internal val Res.string.str_12708: StringResource
+  get() = String6.str_12708
+
+@ExperimentalResourceApi
+internal val Res.string.str_12709: StringResource
+  get() = String6.str_12709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1271: StringResource
+  get() = String6.str_1271
+
+@ExperimentalResourceApi
+internal val Res.string.str_12710: StringResource
+  get() = String6.str_12710
+
+@ExperimentalResourceApi
+internal val Res.string.str_12711: StringResource
+  get() = String6.str_12711
+
+@ExperimentalResourceApi
+internal val Res.string.str_12712: StringResource
+  get() = String6.str_12712
+
+@ExperimentalResourceApi
+internal val Res.string.str_12713: StringResource
+  get() = String6.str_12713
+
+@ExperimentalResourceApi
+internal val Res.string.str_12714: StringResource
+  get() = String6.str_12714
+
+@ExperimentalResourceApi
+internal val Res.string.str_12715: StringResource
+  get() = String6.str_12715
+
+@ExperimentalResourceApi
+internal val Res.string.str_12716: StringResource
+  get() = String6.str_12716
+
+@ExperimentalResourceApi
+internal val Res.string.str_12717: StringResource
+  get() = String6.str_12717
+
+@ExperimentalResourceApi
+internal val Res.string.str_12718: StringResource
+  get() = String6.str_12718
+
+@ExperimentalResourceApi
+internal val Res.string.str_12719: StringResource
+  get() = String6.str_12719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1272: StringResource
+  get() = String6.str_1272
+
+@ExperimentalResourceApi
+internal val Res.string.str_12720: StringResource
+  get() = String6.str_12720
+
+@ExperimentalResourceApi
+internal val Res.string.str_12721: StringResource
+  get() = String6.str_12721
+
+@ExperimentalResourceApi
+internal val Res.string.str_12722: StringResource
+  get() = String6.str_12722
+
+@ExperimentalResourceApi
+internal val Res.string.str_12723: StringResource
+  get() = String6.str_12723
+
+@ExperimentalResourceApi
+internal val Res.string.str_12724: StringResource
+  get() = String6.str_12724
+
+@ExperimentalResourceApi
+internal val Res.string.str_12725: StringResource
+  get() = String6.str_12725
+
+@ExperimentalResourceApi
+internal val Res.string.str_12726: StringResource
+  get() = String6.str_12726
+
+@ExperimentalResourceApi
+internal val Res.string.str_12727: StringResource
+  get() = String6.str_12727
+
+@ExperimentalResourceApi
+internal val Res.string.str_12728: StringResource
+  get() = String6.str_12728
+
+@ExperimentalResourceApi
+internal val Res.string.str_12729: StringResource
+  get() = String6.str_12729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1273: StringResource
+  get() = String6.str_1273
+
+@ExperimentalResourceApi
+internal val Res.string.str_12730: StringResource
+  get() = String6.str_12730
+
+@ExperimentalResourceApi
+internal val Res.string.str_12731: StringResource
+  get() = String6.str_12731
+
+@ExperimentalResourceApi
+internal val Res.string.str_12732: StringResource
+  get() = String6.str_12732
+
+@ExperimentalResourceApi
+internal val Res.string.str_12733: StringResource
+  get() = String6.str_12733
+
+@ExperimentalResourceApi
+internal val Res.string.str_12734: StringResource
+  get() = String6.str_12734
+
+@ExperimentalResourceApi
+internal val Res.string.str_12735: StringResource
+  get() = String6.str_12735
+
+@ExperimentalResourceApi
+internal val Res.string.str_12736: StringResource
+  get() = String6.str_12736
+
+@ExperimentalResourceApi
+internal val Res.string.str_12737: StringResource
+  get() = String6.str_12737
+
+@ExperimentalResourceApi
+internal val Res.string.str_12738: StringResource
+  get() = String6.str_12738
+
+@ExperimentalResourceApi
+internal val Res.string.str_12739: StringResource
+  get() = String6.str_12739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1274: StringResource
+  get() = String6.str_1274
+
+@ExperimentalResourceApi
+internal val Res.string.str_12740: StringResource
+  get() = String6.str_12740
+
+@ExperimentalResourceApi
+internal val Res.string.str_12741: StringResource
+  get() = String6.str_12741
+
+@ExperimentalResourceApi
+internal val Res.string.str_12742: StringResource
+  get() = String6.str_12742
+
+@ExperimentalResourceApi
+internal val Res.string.str_12743: StringResource
+  get() = String6.str_12743
+
+@ExperimentalResourceApi
+internal val Res.string.str_12744: StringResource
+  get() = String6.str_12744
+
+@ExperimentalResourceApi
+internal val Res.string.str_12745: StringResource
+  get() = String6.str_12745
+
+@ExperimentalResourceApi
+internal val Res.string.str_12746: StringResource
+  get() = String6.str_12746
+
+@ExperimentalResourceApi
+internal val Res.string.str_12747: StringResource
+  get() = String6.str_12747
+
+@ExperimentalResourceApi
+internal val Res.string.str_12748: StringResource
+  get() = String6.str_12748
+
+@ExperimentalResourceApi
+internal val Res.string.str_12749: StringResource
+  get() = String6.str_12749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1275: StringResource
+  get() = String6.str_1275
+
+@ExperimentalResourceApi
+internal val Res.string.str_12750: StringResource
+  get() = String6.str_12750
+
+@ExperimentalResourceApi
+internal val Res.string.str_12751: StringResource
+  get() = String6.str_12751
+
+@ExperimentalResourceApi
+internal val Res.string.str_12752: StringResource
+  get() = String6.str_12752
+
+@ExperimentalResourceApi
+internal val Res.string.str_12753: StringResource
+  get() = String6.str_12753
+
+@ExperimentalResourceApi
+internal val Res.string.str_12754: StringResource
+  get() = String6.str_12754
+
+@ExperimentalResourceApi
+internal val Res.string.str_12755: StringResource
+  get() = String6.str_12755
+
+@ExperimentalResourceApi
+internal val Res.string.str_12756: StringResource
+  get() = String6.str_12756
+
+@ExperimentalResourceApi
+internal val Res.string.str_12757: StringResource
+  get() = String6.str_12757
+
+@ExperimentalResourceApi
+internal val Res.string.str_12758: StringResource
+  get() = String6.str_12758
+
+@ExperimentalResourceApi
+internal val Res.string.str_12759: StringResource
+  get() = String6.str_12759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1276: StringResource
+  get() = String6.str_1276
+
+@ExperimentalResourceApi
+internal val Res.string.str_12760: StringResource
+  get() = String6.str_12760
+
+@ExperimentalResourceApi
+internal val Res.string.str_12761: StringResource
+  get() = String6.str_12761
+
+@ExperimentalResourceApi
+internal val Res.string.str_12762: StringResource
+  get() = String6.str_12762
+
+@ExperimentalResourceApi
+internal val Res.string.str_12763: StringResource
+  get() = String6.str_12763
+
+@ExperimentalResourceApi
+internal val Res.string.str_12764: StringResource
+  get() = String6.str_12764
+
+@ExperimentalResourceApi
+internal val Res.string.str_12765: StringResource
+  get() = String6.str_12765
+
+@ExperimentalResourceApi
+internal val Res.string.str_12766: StringResource
+  get() = String6.str_12766
+
+@ExperimentalResourceApi
+internal val Res.string.str_12767: StringResource
+  get() = String6.str_12767
+
+@ExperimentalResourceApi
+internal val Res.string.str_12768: StringResource
+  get() = String6.str_12768
+
+@ExperimentalResourceApi
+internal val Res.string.str_12769: StringResource
+  get() = String6.str_12769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1277: StringResource
+  get() = String6.str_1277
+
+@ExperimentalResourceApi
+internal val Res.string.str_12770: StringResource
+  get() = String6.str_12770
+
+@ExperimentalResourceApi
+internal val Res.string.str_12771: StringResource
+  get() = String6.str_12771
+
+@ExperimentalResourceApi
+internal val Res.string.str_12772: StringResource
+  get() = String6.str_12772
+
+@ExperimentalResourceApi
+internal val Res.string.str_12773: StringResource
+  get() = String6.str_12773
+
+@ExperimentalResourceApi
+internal val Res.string.str_12774: StringResource
+  get() = String6.str_12774
+
+@ExperimentalResourceApi
+internal val Res.string.str_12775: StringResource
+  get() = String6.str_12775
+
+@ExperimentalResourceApi
+internal val Res.string.str_12776: StringResource
+  get() = String6.str_12776
+
+@ExperimentalResourceApi
+internal val Res.string.str_12777: StringResource
+  get() = String6.str_12777
+
+@ExperimentalResourceApi
+internal val Res.string.str_12778: StringResource
+  get() = String6.str_12778
+
+@ExperimentalResourceApi
+internal val Res.string.str_12779: StringResource
+  get() = String6.str_12779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1278: StringResource
+  get() = String6.str_1278
+
+@ExperimentalResourceApi
+internal val Res.string.str_12780: StringResource
+  get() = String6.str_12780
+
+@ExperimentalResourceApi
+internal val Res.string.str_12781: StringResource
+  get() = String6.str_12781
+
+@ExperimentalResourceApi
+internal val Res.string.str_12782: StringResource
+  get() = String6.str_12782
+
+@ExperimentalResourceApi
+internal val Res.string.str_12783: StringResource
+  get() = String6.str_12783
+
+@ExperimentalResourceApi
+internal val Res.string.str_12784: StringResource
+  get() = String6.str_12784
+
+@ExperimentalResourceApi
+internal val Res.string.str_12785: StringResource
+  get() = String6.str_12785
+
+@ExperimentalResourceApi
+internal val Res.string.str_12786: StringResource
+  get() = String6.str_12786
+
+@ExperimentalResourceApi
+internal val Res.string.str_12787: StringResource
+  get() = String6.str_12787
+
+@ExperimentalResourceApi
+internal val Res.string.str_12788: StringResource
+  get() = String6.str_12788
+
+@ExperimentalResourceApi
+internal val Res.string.str_12789: StringResource
+  get() = String6.str_12789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1279: StringResource
+  get() = String6.str_1279
+
+@ExperimentalResourceApi
+internal val Res.string.str_12790: StringResource
+  get() = String6.str_12790
+
+@ExperimentalResourceApi
+internal val Res.string.str_12791: StringResource
+  get() = String6.str_12791
+
+@ExperimentalResourceApi
+internal val Res.string.str_12792: StringResource
+  get() = String6.str_12792
+
+@ExperimentalResourceApi
+internal val Res.string.str_12793: StringResource
+  get() = String6.str_12793
+
+@ExperimentalResourceApi
+internal val Res.string.str_12794: StringResource
+  get() = String6.str_12794
+
+@ExperimentalResourceApi
+internal val Res.string.str_12795: StringResource
+  get() = String6.str_12795
+
+@ExperimentalResourceApi
+internal val Res.string.str_12796: StringResource
+  get() = String6.str_12796
+
+@ExperimentalResourceApi
+internal val Res.string.str_12797: StringResource
+  get() = String6.str_12797
+
+@ExperimentalResourceApi
+internal val Res.string.str_12798: StringResource
+  get() = String6.str_12798
+
+@ExperimentalResourceApi
+internal val Res.string.str_12799: StringResource
+  get() = String6.str_12799
+
+@ExperimentalResourceApi
+internal val Res.string.str_128: StringResource
+  get() = String6.str_128
+
+@ExperimentalResourceApi
+internal val Res.string.str_1280: StringResource
+  get() = String6.str_1280
+
+@ExperimentalResourceApi
+internal val Res.string.str_12800: StringResource
+  get() = String6.str_12800
+
+@ExperimentalResourceApi
+internal val Res.string.str_12801: StringResource
+  get() = String6.str_12801
+
+@ExperimentalResourceApi
+internal val Res.string.str_12802: StringResource
+  get() = String6.str_12802
+
+@ExperimentalResourceApi
+internal val Res.string.str_12803: StringResource
+  get() = String6.str_12803
+
+@ExperimentalResourceApi
+internal val Res.string.str_12804: StringResource
+  get() = String6.str_12804
+
+@ExperimentalResourceApi
+internal val Res.string.str_12805: StringResource
+  get() = String6.str_12805
+
+@ExperimentalResourceApi
+internal val Res.string.str_12806: StringResource
+  get() = String6.str_12806
+
+@ExperimentalResourceApi
+internal val Res.string.str_12807: StringResource
+  get() = String6.str_12807
+
+@ExperimentalResourceApi
+internal val Res.string.str_12808: StringResource
+  get() = String6.str_12808
+
+@ExperimentalResourceApi
+internal val Res.string.str_12809: StringResource
+  get() = String6.str_12809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1281: StringResource
+  get() = String6.str_1281
+
+@ExperimentalResourceApi
+internal val Res.string.str_12810: StringResource
+  get() = String6.str_12810
+
+@ExperimentalResourceApi
+internal val Res.string.str_12811: StringResource
+  get() = String6.str_12811
+
+@ExperimentalResourceApi
+internal val Res.string.str_12812: StringResource
+  get() = String6.str_12812
+
+@ExperimentalResourceApi
+internal val Res.string.str_12813: StringResource
+  get() = String6.str_12813
+
+@ExperimentalResourceApi
+internal val Res.string.str_12814: StringResource
+  get() = String6.str_12814
+
+@ExperimentalResourceApi
+internal val Res.string.str_12815: StringResource
+  get() = String6.str_12815
+
+@ExperimentalResourceApi
+internal val Res.string.str_12816: StringResource
+  get() = String6.str_12816
+
+@ExperimentalResourceApi
+internal val Res.string.str_12817: StringResource
+  get() = String6.str_12817
+
+@ExperimentalResourceApi
+internal val Res.string.str_12818: StringResource
+  get() = String6.str_12818
+
+@ExperimentalResourceApi
+internal val Res.string.str_12819: StringResource
+  get() = String6.str_12819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1282: StringResource
+  get() = String6.str_1282
+
+@ExperimentalResourceApi
+internal val Res.string.str_12820: StringResource
+  get() = String6.str_12820
+
+@ExperimentalResourceApi
+internal val Res.string.str_12821: StringResource
+  get() = String6.str_12821
+
+@ExperimentalResourceApi
+internal val Res.string.str_12822: StringResource
+  get() = String6.str_12822
+
+@ExperimentalResourceApi
+internal val Res.string.str_12823: StringResource
+  get() = String6.str_12823
+
+@ExperimentalResourceApi
+internal val Res.string.str_12824: StringResource
+  get() = String6.str_12824
+
+@ExperimentalResourceApi
+internal val Res.string.str_12825: StringResource
+  get() = String6.str_12825
+
+@ExperimentalResourceApi
+internal val Res.string.str_12826: StringResource
+  get() = String6.str_12826
+
+@ExperimentalResourceApi
+internal val Res.string.str_12827: StringResource
+  get() = String6.str_12827
+
+@ExperimentalResourceApi
+internal val Res.string.str_12828: StringResource
+  get() = String6.str_12828
+
+@ExperimentalResourceApi
+internal val Res.string.str_12829: StringResource
+  get() = String6.str_12829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1283: StringResource
+  get() = String6.str_1283
+
+@ExperimentalResourceApi
+internal val Res.string.str_12830: StringResource
+  get() = String6.str_12830
+
+@ExperimentalResourceApi
+internal val Res.string.str_12831: StringResource
+  get() = String6.str_12831
+
+@ExperimentalResourceApi
+internal val Res.string.str_12832: StringResource
+  get() = String6.str_12832
+
+@ExperimentalResourceApi
+internal val Res.string.str_12833: StringResource
+  get() = String6.str_12833
+
+@ExperimentalResourceApi
+internal val Res.string.str_12834: StringResource
+  get() = String6.str_12834
+
+@ExperimentalResourceApi
+internal val Res.string.str_12835: StringResource
+  get() = String6.str_12835
+
+@ExperimentalResourceApi
+internal val Res.string.str_12836: StringResource
+  get() = String6.str_12836
+
+@ExperimentalResourceApi
+internal val Res.string.str_12837: StringResource
+  get() = String6.str_12837
+
+@ExperimentalResourceApi
+internal val Res.string.str_12838: StringResource
+  get() = String6.str_12838
+
+@ExperimentalResourceApi
+internal val Res.string.str_12839: StringResource
+  get() = String6.str_12839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1284: StringResource
+  get() = String6.str_1284
+
+@ExperimentalResourceApi
+internal val Res.string.str_12840: StringResource
+  get() = String6.str_12840
+
+@ExperimentalResourceApi
+internal val Res.string.str_12841: StringResource
+  get() = String6.str_12841
+
+@ExperimentalResourceApi
+internal val Res.string.str_12842: StringResource
+  get() = String6.str_12842
+
+@ExperimentalResourceApi
+internal val Res.string.str_12843: StringResource
+  get() = String6.str_12843
+
+@ExperimentalResourceApi
+internal val Res.string.str_12844: StringResource
+  get() = String6.str_12844
+
+@ExperimentalResourceApi
+internal val Res.string.str_12845: StringResource
+  get() = String6.str_12845
+
+@ExperimentalResourceApi
+internal val Res.string.str_12846: StringResource
+  get() = String6.str_12846
+
+@ExperimentalResourceApi
+internal val Res.string.str_12847: StringResource
+  get() = String6.str_12847
+
+@ExperimentalResourceApi
+internal val Res.string.str_12848: StringResource
+  get() = String6.str_12848
+
+@ExperimentalResourceApi
+internal val Res.string.str_12849: StringResource
+  get() = String6.str_12849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1285: StringResource
+  get() = String6.str_1285
+
+@ExperimentalResourceApi
+internal val Res.string.str_12850: StringResource
+  get() = String6.str_12850
+
+@ExperimentalResourceApi
+internal val Res.string.str_12851: StringResource
+  get() = String6.str_12851
+
+@ExperimentalResourceApi
+internal val Res.string.str_12852: StringResource
+  get() = String6.str_12852
+
+@ExperimentalResourceApi
+internal val Res.string.str_12853: StringResource
+  get() = String6.str_12853
+
+@ExperimentalResourceApi
+internal val Res.string.str_12854: StringResource
+  get() = String6.str_12854
+
+@ExperimentalResourceApi
+internal val Res.string.str_12855: StringResource
+  get() = String6.str_12855
+
+@ExperimentalResourceApi
+internal val Res.string.str_12856: StringResource
+  get() = String6.str_12856
+
+@ExperimentalResourceApi
+internal val Res.string.str_12857: StringResource
+  get() = String6.str_12857
+
+@ExperimentalResourceApi
+internal val Res.string.str_12858: StringResource
+  get() = String6.str_12858
+
+@ExperimentalResourceApi
+internal val Res.string.str_12859: StringResource
+  get() = String6.str_12859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1286: StringResource
+  get() = String6.str_1286
+
+@ExperimentalResourceApi
+internal val Res.string.str_12860: StringResource
+  get() = String6.str_12860
+
+@ExperimentalResourceApi
+internal val Res.string.str_12861: StringResource
+  get() = String6.str_12861
+
+@ExperimentalResourceApi
+internal val Res.string.str_12862: StringResource
+  get() = String6.str_12862
+
+@ExperimentalResourceApi
+internal val Res.string.str_12863: StringResource
+  get() = String6.str_12863
+
+@ExperimentalResourceApi
+internal val Res.string.str_12864: StringResource
+  get() = String6.str_12864
+
+@ExperimentalResourceApi
+internal val Res.string.str_12865: StringResource
+  get() = String6.str_12865
+
+@ExperimentalResourceApi
+internal val Res.string.str_12866: StringResource
+  get() = String6.str_12866
+
+@ExperimentalResourceApi
+internal val Res.string.str_12867: StringResource
+  get() = String6.str_12867
+
+@ExperimentalResourceApi
+internal val Res.string.str_12868: StringResource
+  get() = String6.str_12868
+
+@ExperimentalResourceApi
+internal val Res.string.str_12869: StringResource
+  get() = String6.str_12869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1287: StringResource
+  get() = String6.str_1287
+
+@ExperimentalResourceApi
+internal val Res.string.str_12870: StringResource
+  get() = String6.str_12870
+
+@ExperimentalResourceApi
+internal val Res.string.str_12871: StringResource
+  get() = String6.str_12871
+
+@ExperimentalResourceApi
+internal val Res.string.str_12872: StringResource
+  get() = String6.str_12872
+
+@ExperimentalResourceApi
+internal val Res.string.str_12873: StringResource
+  get() = String6.str_12873
+
+@ExperimentalResourceApi
+internal val Res.string.str_12874: StringResource
+  get() = String6.str_12874
+
+@ExperimentalResourceApi
+internal val Res.string.str_12875: StringResource
+  get() = String6.str_12875
+
+@ExperimentalResourceApi
+internal val Res.string.str_12876: StringResource
+  get() = String6.str_12876
+
+@ExperimentalResourceApi
+internal val Res.string.str_12877: StringResource
+  get() = String6.str_12877
+
+@ExperimentalResourceApi
+internal val Res.string.str_12878: StringResource
+  get() = String6.str_12878
+
+@ExperimentalResourceApi
+internal val Res.string.str_12879: StringResource
+  get() = String6.str_12879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1288: StringResource
+  get() = String6.str_1288
+
+@ExperimentalResourceApi
+internal val Res.string.str_12880: StringResource
+  get() = String6.str_12880
+
+@ExperimentalResourceApi
+internal val Res.string.str_12881: StringResource
+  get() = String6.str_12881
+
+@ExperimentalResourceApi
+internal val Res.string.str_12882: StringResource
+  get() = String6.str_12882
+
+@ExperimentalResourceApi
+internal val Res.string.str_12883: StringResource
+  get() = String6.str_12883
+
+@ExperimentalResourceApi
+internal val Res.string.str_12884: StringResource
+  get() = String6.str_12884
+
+@ExperimentalResourceApi
+internal val Res.string.str_12885: StringResource
+  get() = String6.str_12885
+
+@ExperimentalResourceApi
+internal val Res.string.str_12886: StringResource
+  get() = String6.str_12886
+
+@ExperimentalResourceApi
+internal val Res.string.str_12887: StringResource
+  get() = String6.str_12887
+
+@ExperimentalResourceApi
+internal val Res.string.str_12888: StringResource
+  get() = String6.str_12888
+
+@ExperimentalResourceApi
+internal val Res.string.str_12889: StringResource
+  get() = String6.str_12889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1289: StringResource
+  get() = String6.str_1289
+
+@ExperimentalResourceApi
+internal val Res.string.str_12890: StringResource
+  get() = String6.str_12890
+
+@ExperimentalResourceApi
+internal val Res.string.str_12891: StringResource
+  get() = String6.str_12891
+
+@ExperimentalResourceApi
+internal val Res.string.str_12892: StringResource
+  get() = String6.str_12892
+
+@ExperimentalResourceApi
+internal val Res.string.str_12893: StringResource
+  get() = String6.str_12893
+
+@ExperimentalResourceApi
+internal val Res.string.str_12894: StringResource
+  get() = String6.str_12894
+
+@ExperimentalResourceApi
+internal val Res.string.str_12895: StringResource
+  get() = String6.str_12895
+
+@ExperimentalResourceApi
+internal val Res.string.str_12896: StringResource
+  get() = String6.str_12896
+
+@ExperimentalResourceApi
+internal val Res.string.str_12897: StringResource
+  get() = String6.str_12897
+
+@ExperimentalResourceApi
+internal val Res.string.str_12898: StringResource
+  get() = String6.str_12898
+
+@ExperimentalResourceApi
+internal val Res.string.str_12899: StringResource
+  get() = String6.str_12899
+
+@ExperimentalResourceApi
+internal val Res.string.str_129: StringResource
+  get() = String6.str_129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1290: StringResource
+  get() = String6.str_1290
+
+@ExperimentalResourceApi
+internal val Res.string.str_12900: StringResource
+  get() = String6.str_12900
+
+@ExperimentalResourceApi
+internal val Res.string.str_12901: StringResource
+  get() = String6.str_12901
+
+@ExperimentalResourceApi
+internal val Res.string.str_12902: StringResource
+  get() = String6.str_12902
+
+@ExperimentalResourceApi
+internal val Res.string.str_12903: StringResource
+  get() = String6.str_12903
+
+@ExperimentalResourceApi
+internal val Res.string.str_12904: StringResource
+  get() = String6.str_12904
+
+@ExperimentalResourceApi
+internal val Res.string.str_12905: StringResource
+  get() = String6.str_12905
+
+@ExperimentalResourceApi
+internal val Res.string.str_12906: StringResource
+  get() = String6.str_12906
+
+@ExperimentalResourceApi
+internal val Res.string.str_12907: StringResource
+  get() = String6.str_12907
+
+@ExperimentalResourceApi
+internal val Res.string.str_12908: StringResource
+  get() = String6.str_12908
+
+@ExperimentalResourceApi
+internal val Res.string.str_12909: StringResource
+  get() = String6.str_12909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1291: StringResource
+  get() = String6.str_1291
+
+@ExperimentalResourceApi
+internal val Res.string.str_12910: StringResource
+  get() = String6.str_12910
+
+@ExperimentalResourceApi
+internal val Res.string.str_12911: StringResource
+  get() = String6.str_12911
+
+@ExperimentalResourceApi
+internal val Res.string.str_12912: StringResource
+  get() = String6.str_12912
+
+@ExperimentalResourceApi
+internal val Res.string.str_12913: StringResource
+  get() = String6.str_12913
+
+@ExperimentalResourceApi
+internal val Res.string.str_12914: StringResource
+  get() = String6.str_12914
+
+@ExperimentalResourceApi
+internal val Res.string.str_12915: StringResource
+  get() = String6.str_12915
+
+@ExperimentalResourceApi
+internal val Res.string.str_12916: StringResource
+  get() = String6.str_12916
+
+@ExperimentalResourceApi
+internal val Res.string.str_12917: StringResource
+  get() = String6.str_12917
+
+@ExperimentalResourceApi
+internal val Res.string.str_12918: StringResource
+  get() = String6.str_12918
+
+@ExperimentalResourceApi
+internal val Res.string.str_12919: StringResource
+  get() = String6.str_12919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1292: StringResource
+  get() = String6.str_1292
+
+@ExperimentalResourceApi
+internal val Res.string.str_12920: StringResource
+  get() = String6.str_12920
+
+@ExperimentalResourceApi
+internal val Res.string.str_12921: StringResource
+  get() = String6.str_12921
+
+@ExperimentalResourceApi
+internal val Res.string.str_12922: StringResource
+  get() = String6.str_12922
+
+@ExperimentalResourceApi
+internal val Res.string.str_12923: StringResource
+  get() = String6.str_12923
+
+@ExperimentalResourceApi
+internal val Res.string.str_12924: StringResource
+  get() = String6.str_12924
+
+@ExperimentalResourceApi
+internal val Res.string.str_12925: StringResource
+  get() = String6.str_12925
+
+@ExperimentalResourceApi
+internal val Res.string.str_12926: StringResource
+  get() = String6.str_12926
+
+@ExperimentalResourceApi
+internal val Res.string.str_12927: StringResource
+  get() = String6.str_12927
+
+@ExperimentalResourceApi
+internal val Res.string.str_12928: StringResource
+  get() = String6.str_12928
+
+@ExperimentalResourceApi
+internal val Res.string.str_12929: StringResource
+  get() = String6.str_12929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1293: StringResource
+  get() = String6.str_1293
+
+@ExperimentalResourceApi
+internal val Res.string.str_12930: StringResource
+  get() = String6.str_12930
+
+@ExperimentalResourceApi
+internal val Res.string.str_12931: StringResource
+  get() = String6.str_12931
+
+@ExperimentalResourceApi
+internal val Res.string.str_12932: StringResource
+  get() = String6.str_12932
+
+@ExperimentalResourceApi
+internal val Res.string.str_12933: StringResource
+  get() = String6.str_12933
+
+@ExperimentalResourceApi
+internal val Res.string.str_12934: StringResource
+  get() = String6.str_12934
+
+@ExperimentalResourceApi
+internal val Res.string.str_12935: StringResource
+  get() = String6.str_12935
+
+@ExperimentalResourceApi
+internal val Res.string.str_12936: StringResource
+  get() = String6.str_12936
+
+@ExperimentalResourceApi
+internal val Res.string.str_12937: StringResource
+  get() = String6.str_12937
+
+@ExperimentalResourceApi
+internal val Res.string.str_12938: StringResource
+  get() = String6.str_12938
+
+@ExperimentalResourceApi
+internal val Res.string.str_12939: StringResource
+  get() = String6.str_12939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1294: StringResource
+  get() = String6.str_1294
+
+@ExperimentalResourceApi
+internal val Res.string.str_12940: StringResource
+  get() = String6.str_12940
+
+@ExperimentalResourceApi
+internal val Res.string.str_12941: StringResource
+  get() = String6.str_12941
+
+@ExperimentalResourceApi
+internal val Res.string.str_12942: StringResource
+  get() = String6.str_12942
+
+@ExperimentalResourceApi
+internal val Res.string.str_12943: StringResource
+  get() = String6.str_12943
+
+@ExperimentalResourceApi
+internal val Res.string.str_12944: StringResource
+  get() = String6.str_12944
+
+@ExperimentalResourceApi
+internal val Res.string.str_12945: StringResource
+  get() = String6.str_12945
+
+@ExperimentalResourceApi
+internal val Res.string.str_12946: StringResource
+  get() = String6.str_12946
+
+@ExperimentalResourceApi
+internal val Res.string.str_12947: StringResource
+  get() = String6.str_12947
+
+@ExperimentalResourceApi
+internal val Res.string.str_12948: StringResource
+  get() = String6.str_12948
+
+@ExperimentalResourceApi
+internal val Res.string.str_12949: StringResource
+  get() = String6.str_12949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1295: StringResource
+  get() = String6.str_1295
+
+@ExperimentalResourceApi
+internal val Res.string.str_12950: StringResource
+  get() = String6.str_12950
+
+@ExperimentalResourceApi
+internal val Res.string.str_12951: StringResource
+  get() = String6.str_12951
+
+@ExperimentalResourceApi
+internal val Res.string.str_12952: StringResource
+  get() = String6.str_12952
+
+@ExperimentalResourceApi
+internal val Res.string.str_12953: StringResource
+  get() = String6.str_12953
+
+@ExperimentalResourceApi
+internal val Res.string.str_12954: StringResource
+  get() = String6.str_12954
+
+@ExperimentalResourceApi
+internal val Res.string.str_12955: StringResource
+  get() = String6.str_12955
+
+@ExperimentalResourceApi
+internal val Res.string.str_12956: StringResource
+  get() = String6.str_12956
+
+@ExperimentalResourceApi
+internal val Res.string.str_12957: StringResource
+  get() = String6.str_12957
+
+@ExperimentalResourceApi
+internal val Res.string.str_12958: StringResource
+  get() = String6.str_12958
+
+@ExperimentalResourceApi
+internal val Res.string.str_12959: StringResource
+  get() = String6.str_12959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1296: StringResource
+  get() = String6.str_1296
+
+@ExperimentalResourceApi
+internal val Res.string.str_12960: StringResource
+  get() = String6.str_12960
+
+@ExperimentalResourceApi
+internal val Res.string.str_12961: StringResource
+  get() = String6.str_12961
+
+@ExperimentalResourceApi
+internal val Res.string.str_12962: StringResource
+  get() = String6.str_12962
+
+@ExperimentalResourceApi
+internal val Res.string.str_12963: StringResource
+  get() = String6.str_12963
+
+@ExperimentalResourceApi
+internal val Res.string.str_12964: StringResource
+  get() = String6.str_12964
+
+@ExperimentalResourceApi
+internal val Res.string.str_12965: StringResource
+  get() = String6.str_12965
+
+@ExperimentalResourceApi
+internal val Res.string.str_12966: StringResource
+  get() = String6.str_12966
+
+@ExperimentalResourceApi
+internal val Res.string.str_12967: StringResource
+  get() = String6.str_12967
+
+@ExperimentalResourceApi
+internal val Res.string.str_12968: StringResource
+  get() = String6.str_12968
+
+@ExperimentalResourceApi
+internal val Res.string.str_12969: StringResource
+  get() = String6.str_12969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1297: StringResource
+  get() = String6.str_1297
+
+@ExperimentalResourceApi
+internal val Res.string.str_12970: StringResource
+  get() = String6.str_12970
+
+@ExperimentalResourceApi
+internal val Res.string.str_12971: StringResource
+  get() = String6.str_12971
+
+@ExperimentalResourceApi
+internal val Res.string.str_12972: StringResource
+  get() = String6.str_12972
+
+@ExperimentalResourceApi
+internal val Res.string.str_12973: StringResource
+  get() = String6.str_12973
+
+@ExperimentalResourceApi
+internal val Res.string.str_12974: StringResource
+  get() = String6.str_12974
+
+@ExperimentalResourceApi
+internal val Res.string.str_12975: StringResource
+  get() = String6.str_12975
+
+@ExperimentalResourceApi
+internal val Res.string.str_12976: StringResource
+  get() = String6.str_12976
+
+@ExperimentalResourceApi
+internal val Res.string.str_12977: StringResource
+  get() = String6.str_12977
+
+@ExperimentalResourceApi
+internal val Res.string.str_12978: StringResource
+  get() = String6.str_12978
+
+@ExperimentalResourceApi
+internal val Res.string.str_12979: StringResource
+  get() = String6.str_12979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1298: StringResource
+  get() = String6.str_1298
+
+@ExperimentalResourceApi
+internal val Res.string.str_12980: StringResource
+  get() = String6.str_12980
+
+@ExperimentalResourceApi
+internal val Res.string.str_12981: StringResource
+  get() = String6.str_12981
+
+@ExperimentalResourceApi
+internal val Res.string.str_12982: StringResource
+  get() = String6.str_12982
+
+@ExperimentalResourceApi
+internal val Res.string.str_12983: StringResource
+  get() = String6.str_12983
+
+@ExperimentalResourceApi
+internal val Res.string.str_12984: StringResource
+  get() = String6.str_12984
+
+@ExperimentalResourceApi
+internal val Res.string.str_12985: StringResource
+  get() = String6.str_12985
+
+@ExperimentalResourceApi
+internal val Res.string.str_12986: StringResource
+  get() = String6.str_12986
+
+@ExperimentalResourceApi
+internal val Res.string.str_12987: StringResource
+  get() = String6.str_12987
+
+@ExperimentalResourceApi
+internal val Res.string.str_12988: StringResource
+  get() = String6.str_12988
+
+@ExperimentalResourceApi
+internal val Res.string.str_12989: StringResource
+  get() = String6.str_12989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1299: StringResource
+  get() = String6.str_1299
+
+@ExperimentalResourceApi
+internal val Res.string.str_12990: StringResource
+  get() = String6.str_12990
+
+@ExperimentalResourceApi
+internal val Res.string.str_12991: StringResource
+  get() = String6.str_12991
+
+@ExperimentalResourceApi
+internal val Res.string.str_12992: StringResource
+  get() = String6.str_12992
+
+@ExperimentalResourceApi
+internal val Res.string.str_12993: StringResource
+  get() = String6.str_12993
+
+@ExperimentalResourceApi
+internal val Res.string.str_12994: StringResource
+  get() = String6.str_12994
+
+@ExperimentalResourceApi
+internal val Res.string.str_12995: StringResource
+  get() = String6.str_12995
+
+@ExperimentalResourceApi
+internal val Res.string.str_12996: StringResource
+  get() = String6.str_12996
+
+@ExperimentalResourceApi
+internal val Res.string.str_12997: StringResource
+  get() = String6.str_12997
+
+@ExperimentalResourceApi
+internal val Res.string.str_12998: StringResource
+  get() = String6.str_12998
+
+@ExperimentalResourceApi
+internal val Res.string.str_12999: StringResource
+  get() = String6.str_12999
+
+@ExperimentalResourceApi
+internal val Res.string.str_13: StringResource
+  get() = String6.str_13
+
+@ExperimentalResourceApi
+internal val Res.string.str_130: StringResource
+  get() = String6.str_130
+
+@ExperimentalResourceApi
+internal val Res.string.str_1300: StringResource
+  get() = String6.str_1300
+
+@ExperimentalResourceApi
+internal val Res.string.str_13000: StringResource
+  get() = String6.str_13000
+
+@ExperimentalResourceApi
+internal val Res.string.str_13001: StringResource
+  get() = String6.str_13001
+
+@ExperimentalResourceApi
+internal val Res.string.str_13002: StringResource
+  get() = String6.str_13002
+
+@ExperimentalResourceApi
+internal val Res.string.str_13003: StringResource
+  get() = String6.str_13003
+
+@ExperimentalResourceApi
+internal val Res.string.str_13004: StringResource
+  get() = String6.str_13004
+
+@ExperimentalResourceApi
+internal val Res.string.str_13005: StringResource
+  get() = String6.str_13005
+
+@ExperimentalResourceApi
+internal val Res.string.str_13006: StringResource
+  get() = String6.str_13006
+
+@ExperimentalResourceApi
+internal val Res.string.str_13007: StringResource
+  get() = String6.str_13007
+
+@ExperimentalResourceApi
+internal val Res.string.str_13008: StringResource
+  get() = String6.str_13008
+
+@ExperimentalResourceApi
+internal val Res.string.str_13009: StringResource
+  get() = String6.str_13009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1301: StringResource
+  get() = String6.str_1301
+
+@ExperimentalResourceApi
+internal val Res.string.str_13010: StringResource
+  get() = String6.str_13010
+
+@ExperimentalResourceApi
+internal val Res.string.str_13011: StringResource
+  get() = String6.str_13011
+
+@ExperimentalResourceApi
+internal val Res.string.str_13012: StringResource
+  get() = String6.str_13012
+
+@ExperimentalResourceApi
+internal val Res.string.str_13013: StringResource
+  get() = String6.str_13013
+
+@ExperimentalResourceApi
+internal val Res.string.str_13014: StringResource
+  get() = String6.str_13014
+
+@ExperimentalResourceApi
+internal val Res.string.str_13015: StringResource
+  get() = String6.str_13015
+
+@ExperimentalResourceApi
+internal val Res.string.str_13016: StringResource
+  get() = String6.str_13016
+
+@ExperimentalResourceApi
+internal val Res.string.str_13017: StringResource
+  get() = String6.str_13017
+
+@ExperimentalResourceApi
+internal val Res.string.str_13018: StringResource
+  get() = String6.str_13018
+
+@ExperimentalResourceApi
+internal val Res.string.str_13019: StringResource
+  get() = String6.str_13019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1302: StringResource
+  get() = String6.str_1302
+
+@ExperimentalResourceApi
+internal val Res.string.str_13020: StringResource
+  get() = String6.str_13020
+
+@ExperimentalResourceApi
+internal val Res.string.str_13021: StringResource
+  get() = String6.str_13021
+
+@ExperimentalResourceApi
+internal val Res.string.str_13022: StringResource
+  get() = String6.str_13022
+
+@ExperimentalResourceApi
+internal val Res.string.str_13023: StringResource
+  get() = String6.str_13023
+
+@ExperimentalResourceApi
+internal val Res.string.str_13024: StringResource
+  get() = String6.str_13024
+
+@ExperimentalResourceApi
+internal val Res.string.str_13025: StringResource
+  get() = String6.str_13025
+
+@ExperimentalResourceApi
+internal val Res.string.str_13026: StringResource
+  get() = String6.str_13026
+
+@ExperimentalResourceApi
+internal val Res.string.str_13027: StringResource
+  get() = String6.str_13027
+
+@ExperimentalResourceApi
+internal val Res.string.str_13028: StringResource
+  get() = String6.str_13028
+
+@ExperimentalResourceApi
+internal val Res.string.str_13029: StringResource
+  get() = String6.str_13029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1303: StringResource
+  get() = String6.str_1303
+
+@ExperimentalResourceApi
+internal val Res.string.str_13030: StringResource
+  get() = String6.str_13030
+
+@ExperimentalResourceApi
+internal val Res.string.str_13031: StringResource
+  get() = String6.str_13031
+
+@ExperimentalResourceApi
+internal val Res.string.str_13032: StringResource
+  get() = String6.str_13032
+
+@ExperimentalResourceApi
+internal val Res.string.str_13033: StringResource
+  get() = String6.str_13033
+
+@ExperimentalResourceApi
+internal val Res.string.str_13034: StringResource
+  get() = String6.str_13034
+
+@ExperimentalResourceApi
+internal val Res.string.str_13035: StringResource
+  get() = String6.str_13035
+
+@ExperimentalResourceApi
+internal val Res.string.str_13036: StringResource
+  get() = String6.str_13036
+
+@ExperimentalResourceApi
+internal val Res.string.str_13037: StringResource
+  get() = String6.str_13037
+
+@ExperimentalResourceApi
+internal val Res.string.str_13038: StringResource
+  get() = String6.str_13038
+
+@ExperimentalResourceApi
+internal val Res.string.str_13039: StringResource
+  get() = String6.str_13039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1304: StringResource
+  get() = String6.str_1304
+
+@ExperimentalResourceApi
+internal val Res.string.str_13040: StringResource
+  get() = String6.str_13040
+
+@ExperimentalResourceApi
+internal val Res.string.str_13041: StringResource
+  get() = String6.str_13041
+
+@ExperimentalResourceApi
+internal val Res.string.str_13042: StringResource
+  get() = String6.str_13042
+
+@ExperimentalResourceApi
+internal val Res.string.str_13043: StringResource
+  get() = String6.str_13043
+
+@ExperimentalResourceApi
+internal val Res.string.str_13044: StringResource
+  get() = String6.str_13044
+
+@ExperimentalResourceApi
+internal val Res.string.str_13045: StringResource
+  get() = String6.str_13045
+
+@ExperimentalResourceApi
+internal val Res.string.str_13046: StringResource
+  get() = String6.str_13046
+
+@ExperimentalResourceApi
+internal val Res.string.str_13047: StringResource
+  get() = String6.str_13047
+
+@ExperimentalResourceApi
+internal val Res.string.str_13048: StringResource
+  get() = String6.str_13048
+
+@ExperimentalResourceApi
+internal val Res.string.str_13049: StringResource
+  get() = String6.str_13049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1305: StringResource
+  get() = String6.str_1305
+
+@ExperimentalResourceApi
+internal val Res.string.str_13050: StringResource
+  get() = String6.str_13050
+
+@ExperimentalResourceApi
+internal val Res.string.str_13051: StringResource
+  get() = String6.str_13051
+
+@ExperimentalResourceApi
+internal val Res.string.str_13052: StringResource
+  get() = String6.str_13052
+
+@ExperimentalResourceApi
+internal val Res.string.str_13053: StringResource
+  get() = String6.str_13053
+
+@ExperimentalResourceApi
+internal val Res.string.str_13054: StringResource
+  get() = String6.str_13054
+
+@ExperimentalResourceApi
+internal val Res.string.str_13055: StringResource
+  get() = String6.str_13055
+
+@ExperimentalResourceApi
+internal val Res.string.str_13056: StringResource
+  get() = String6.str_13056
+
+@ExperimentalResourceApi
+internal val Res.string.str_13057: StringResource
+  get() = String6.str_13057
+
+@ExperimentalResourceApi
+internal val Res.string.str_13058: StringResource
+  get() = String6.str_13058
+
+@ExperimentalResourceApi
+internal val Res.string.str_13059: StringResource
+  get() = String6.str_13059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1306: StringResource
+  get() = String6.str_1306
+
+@ExperimentalResourceApi
+internal val Res.string.str_13060: StringResource
+  get() = String6.str_13060
+
+@ExperimentalResourceApi
+internal val Res.string.str_13061: StringResource
+  get() = String6.str_13061
+
+@ExperimentalResourceApi
+internal val Res.string.str_13062: StringResource
+  get() = String6.str_13062
+
+@ExperimentalResourceApi
+internal val Res.string.str_13063: StringResource
+  get() = String6.str_13063
+
+@ExperimentalResourceApi
+internal val Res.string.str_13064: StringResource
+  get() = String6.str_13064
+
+@ExperimentalResourceApi
+internal val Res.string.str_13065: StringResource
+  get() = String6.str_13065
+
+@ExperimentalResourceApi
+internal val Res.string.str_13066: StringResource
+  get() = String6.str_13066
+
+@ExperimentalResourceApi
+internal val Res.string.str_13067: StringResource
+  get() = String6.str_13067
+
+@ExperimentalResourceApi
+internal val Res.string.str_13068: StringResource
+  get() = String6.str_13068
+
+@ExperimentalResourceApi
+internal val Res.string.str_13069: StringResource
+  get() = String6.str_13069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1307: StringResource
+  get() = String6.str_1307
+
+@ExperimentalResourceApi
+internal val Res.string.str_13070: StringResource
+  get() = String6.str_13070
+
+@ExperimentalResourceApi
+internal val Res.string.str_13071: StringResource
+  get() = String6.str_13071
+
+@ExperimentalResourceApi
+internal val Res.string.str_13072: StringResource
+  get() = String6.str_13072
+
+@ExperimentalResourceApi
+internal val Res.string.str_13073: StringResource
+  get() = String6.str_13073
+
+@ExperimentalResourceApi
+internal val Res.string.str_13074: StringResource
+  get() = String6.str_13074
+
+@ExperimentalResourceApi
+internal val Res.string.str_13075: StringResource
+  get() = String6.str_13075
+
+@ExperimentalResourceApi
+internal val Res.string.str_13076: StringResource
+  get() = String6.str_13076
+
+@ExperimentalResourceApi
+internal val Res.string.str_13077: StringResource
+  get() = String6.str_13077
+
+@ExperimentalResourceApi
+internal val Res.string.str_13078: StringResource
+  get() = String6.str_13078
+
+@ExperimentalResourceApi
+internal val Res.string.str_13079: StringResource
+  get() = String6.str_13079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1308: StringResource
+  get() = String6.str_1308
+
+@ExperimentalResourceApi
+internal val Res.string.str_13080: StringResource
+  get() = String6.str_13080
+
+@ExperimentalResourceApi
+internal val Res.string.str_13081: StringResource
+  get() = String6.str_13081
+
+@ExperimentalResourceApi
+internal val Res.string.str_13082: StringResource
+  get() = String6.str_13082
+
+@ExperimentalResourceApi
+internal val Res.string.str_13083: StringResource
+  get() = String6.str_13083
+
+@ExperimentalResourceApi
+internal val Res.string.str_13084: StringResource
+  get() = String6.str_13084
+
+@ExperimentalResourceApi
+internal val Res.string.str_13085: StringResource
+  get() = String6.str_13085
+
+@ExperimentalResourceApi
+internal val Res.string.str_13086: StringResource
+  get() = String6.str_13086
+
+@ExperimentalResourceApi
+internal val Res.string.str_13087: StringResource
+  get() = String6.str_13087
+
+@ExperimentalResourceApi
+internal val Res.string.str_13088: StringResource
+  get() = String6.str_13088
+
+@ExperimentalResourceApi
+internal val Res.string.str_13089: StringResource
+  get() = String6.str_13089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1309: StringResource
+  get() = String6.str_1309
+
+@ExperimentalResourceApi
+internal val Res.string.str_13090: StringResource
+  get() = String6.str_13090
+
+@ExperimentalResourceApi
+internal val Res.string.str_13091: StringResource
+  get() = String6.str_13091
+
+@ExperimentalResourceApi
+internal val Res.string.str_13092: StringResource
+  get() = String6.str_13092
+
+@ExperimentalResourceApi
+internal val Res.string.str_13093: StringResource
+  get() = String6.str_13093
+
+@ExperimentalResourceApi
+internal val Res.string.str_13094: StringResource
+  get() = String6.str_13094
+
+@ExperimentalResourceApi
+internal val Res.string.str_13095: StringResource
+  get() = String6.str_13095
+
+@ExperimentalResourceApi
+internal val Res.string.str_13096: StringResource
+  get() = String6.str_13096
+
+@ExperimentalResourceApi
+internal val Res.string.str_13097: StringResource
+  get() = String6.str_13097
+
+@ExperimentalResourceApi
+internal val Res.string.str_13098: StringResource
+  get() = String6.str_13098
+
+@ExperimentalResourceApi
+internal val Res.string.str_13099: StringResource
+  get() = String6.str_13099
+
+@ExperimentalResourceApi
+internal val Res.string.str_131: StringResource
+  get() = String6.str_131
+
+@ExperimentalResourceApi
+internal val Res.string.str_1310: StringResource
+  get() = String6.str_1310
+
+@ExperimentalResourceApi
+internal val Res.string.str_13100: StringResource
+  get() = String6.str_13100
+
+@ExperimentalResourceApi
+internal val Res.string.str_13101: StringResource
+  get() = String6.str_13101
+
+@ExperimentalResourceApi
+internal val Res.string.str_13102: StringResource
+  get() = String6.str_13102
+
+@ExperimentalResourceApi
+internal val Res.string.str_13103: StringResource
+  get() = String6.str_13103
+
+@ExperimentalResourceApi
+internal val Res.string.str_13104: StringResource
+  get() = String6.str_13104
+
+@ExperimentalResourceApi
+internal val Res.string.str_13105: StringResource
+  get() = String6.str_13105
+
+@ExperimentalResourceApi
+internal val Res.string.str_13106: StringResource
+  get() = String6.str_13106
+
+@ExperimentalResourceApi
+internal val Res.string.str_13107: StringResource
+  get() = String6.str_13107
+
+@ExperimentalResourceApi
+internal val Res.string.str_13108: StringResource
+  get() = String6.str_13108
+
+@ExperimentalResourceApi
+internal val Res.string.str_13109: StringResource
+  get() = String6.str_13109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1311: StringResource
+  get() = String6.str_1311
+
+@ExperimentalResourceApi
+internal val Res.string.str_13110: StringResource
+  get() = String6.str_13110
+
+@ExperimentalResourceApi
+internal val Res.string.str_13111: StringResource
+  get() = String6.str_13111
+
+@ExperimentalResourceApi
+internal val Res.string.str_13112: StringResource
+  get() = String6.str_13112
+
+@ExperimentalResourceApi
+internal val Res.string.str_13113: StringResource
+  get() = String6.str_13113
+
+@ExperimentalResourceApi
+internal val Res.string.str_13114: StringResource
+  get() = String6.str_13114
+
+@ExperimentalResourceApi
+internal val Res.string.str_13115: StringResource
+  get() = String6.str_13115
+
+@ExperimentalResourceApi
+internal val Res.string.str_13116: StringResource
+  get() = String6.str_13116
+
+@ExperimentalResourceApi
+internal val Res.string.str_13117: StringResource
+  get() = String6.str_13117
+
+@ExperimentalResourceApi
+internal val Res.string.str_13118: StringResource
+  get() = String6.str_13118
+
+@ExperimentalResourceApi
+internal val Res.string.str_13119: StringResource
+  get() = String6.str_13119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1312: StringResource
+  get() = String6.str_1312
+
+@ExperimentalResourceApi
+internal val Res.string.str_13120: StringResource
+  get() = String6.str_13120
+
+@ExperimentalResourceApi
+internal val Res.string.str_13121: StringResource
+  get() = String6.str_13121
+
+@ExperimentalResourceApi
+internal val Res.string.str_13122: StringResource
+  get() = String6.str_13122
+
+@ExperimentalResourceApi
+internal val Res.string.str_13123: StringResource
+  get() = String6.str_13123
+
+@ExperimentalResourceApi
+internal val Res.string.str_13124: StringResource
+  get() = String6.str_13124
+
+@ExperimentalResourceApi
+internal val Res.string.str_13125: StringResource
+  get() = String6.str_13125
+
+@ExperimentalResourceApi
+internal val Res.string.str_13126: StringResource
+  get() = String6.str_13126
+
+@ExperimentalResourceApi
+internal val Res.string.str_13127: StringResource
+  get() = String6.str_13127
+
+@ExperimentalResourceApi
+internal val Res.string.str_13128: StringResource
+  get() = String6.str_13128
+
+@ExperimentalResourceApi
+internal val Res.string.str_13129: StringResource
+  get() = String6.str_13129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1313: StringResource
+  get() = String6.str_1313
+
+@ExperimentalResourceApi
+internal val Res.string.str_13130: StringResource
+  get() = String6.str_13130
+
+@ExperimentalResourceApi
+internal val Res.string.str_13131: StringResource
+  get() = String6.str_13131
+
+@ExperimentalResourceApi
+internal val Res.string.str_13132: StringResource
+  get() = String6.str_13132
+
+@ExperimentalResourceApi
+internal val Res.string.str_13133: StringResource
+  get() = String6.str_13133
+
+@ExperimentalResourceApi
+internal val Res.string.str_13134: StringResource
+  get() = String6.str_13134
+
+@ExperimentalResourceApi
+internal val Res.string.str_13135: StringResource
+  get() = String6.str_13135
+
+@ExperimentalResourceApi
+internal val Res.string.str_13136: StringResource
+  get() = String6.str_13136
+
+@ExperimentalResourceApi
+internal val Res.string.str_13137: StringResource
+  get() = String6.str_13137
+
+@ExperimentalResourceApi
+internal val Res.string.str_13138: StringResource
+  get() = String6.str_13138
+
+@ExperimentalResourceApi
+internal val Res.string.str_13139: StringResource
+  get() = String6.str_13139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1314: StringResource
+  get() = String6.str_1314
+
+@ExperimentalResourceApi
+internal val Res.string.str_13140: StringResource
+  get() = String6.str_13140
+
+@ExperimentalResourceApi
+internal val Res.string.str_13141: StringResource
+  get() = String6.str_13141
+
+@ExperimentalResourceApi
+internal val Res.string.str_13142: StringResource
+  get() = String6.str_13142
+
+@ExperimentalResourceApi
+internal val Res.string.str_13143: StringResource
+  get() = String6.str_13143
+
+@ExperimentalResourceApi
+internal val Res.string.str_13144: StringResource
+  get() = String6.str_13144
+
+@ExperimentalResourceApi
+internal val Res.string.str_13145: StringResource
+  get() = String6.str_13145
+
+@ExperimentalResourceApi
+internal val Res.string.str_13146: StringResource
+  get() = String6.str_13146

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String7.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String7.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String7 {
+  public val str_13147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13147", "str_13147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13148", "str_13148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13149", "str_13149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1315", "str_1315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13150", "str_13150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13151", "str_13151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13152", "str_13152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13153", "str_13153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13154", "str_13154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13155", "str_13155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13156", "str_13156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13157", "str_13157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13158", "str_13158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13159", "str_13159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1316", "str_1316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13160", "str_13160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13161", "str_13161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13162", "str_13162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13163", "str_13163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13164", "str_13164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13165", "str_13165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13166", "str_13166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13167", "str_13167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13168", "str_13168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13169", "str_13169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1317", "str_1317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13170", "str_13170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13171", "str_13171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13172", "str_13172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13173", "str_13173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13174", "str_13174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13175", "str_13175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13176", "str_13176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13177", "str_13177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13178", "str_13178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13179", "str_13179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1318", "str_1318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13180", "str_13180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13181", "str_13181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13182", "str_13182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13183", "str_13183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13184", "str_13184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13185", "str_13185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13186", "str_13186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13187", "str_13187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13188", "str_13188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13189", "str_13189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1319", "str_1319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13190", "str_13190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13191", "str_13191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13192", "str_13192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13193", "str_13193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13194", "str_13194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13195", "str_13195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13196", "str_13196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13197", "str_13197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13198", "str_13198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13199", "str_13199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_132", "str_132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1320", "str_1320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13200", "str_13200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13201", "str_13201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13202", "str_13202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13203", "str_13203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13204", "str_13204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13205", "str_13205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13206", "str_13206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13207", "str_13207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13208", "str_13208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13209", "str_13209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1321", "str_1321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13210", "str_13210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13211", "str_13211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13212", "str_13212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13213", "str_13213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13214", "str_13214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13215", "str_13215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13216", "str_13216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13217", "str_13217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13218", "str_13218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13219", "str_13219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1322", "str_1322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13220", "str_13220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13221", "str_13221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13222", "str_13222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13223", "str_13223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13224", "str_13224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13225", "str_13225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13226", "str_13226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13227", "str_13227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13228", "str_13228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13229", "str_13229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1323", "str_1323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13230", "str_13230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13231", "str_13231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13232", "str_13232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13233", "str_13233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13234", "str_13234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13235", "str_13235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13236", "str_13236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13237", "str_13237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13238", "str_13238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13239", "str_13239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1324", "str_1324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13240", "str_13240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13241", "str_13241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13242", "str_13242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13243", "str_13243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13244", "str_13244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13245", "str_13245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13246", "str_13246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13247", "str_13247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13248", "str_13248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13249", "str_13249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1325", "str_1325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13250", "str_13250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13251", "str_13251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13252", "str_13252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13253", "str_13253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13254", "str_13254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13255", "str_13255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13256", "str_13256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13257", "str_13257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13258", "str_13258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13259", "str_13259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1326", "str_1326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13260", "str_13260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13261", "str_13261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13262", "str_13262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13263", "str_13263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13264", "str_13264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13265", "str_13265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13266", "str_13266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13267", "str_13267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13268", "str_13268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13269", "str_13269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1327", "str_1327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13270", "str_13270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13271", "str_13271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13272", "str_13272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13273", "str_13273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13274", "str_13274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13275", "str_13275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13276", "str_13276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13277", "str_13277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13278", "str_13278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13279", "str_13279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1328", "str_1328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13280", "str_13280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13281", "str_13281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13282", "str_13282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13283", "str_13283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13284", "str_13284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13285", "str_13285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13286", "str_13286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13287", "str_13287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13288", "str_13288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13289", "str_13289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1329", "str_1329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13290", "str_13290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13291", "str_13291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13292", "str_13292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13293", "str_13293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13294", "str_13294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13295", "str_13295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13296", "str_13296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13297", "str_13297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13298", "str_13298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13299", "str_13299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_133", "str_133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1330", "str_1330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13300", "str_13300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13301", "str_13301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13302", "str_13302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13303", "str_13303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13304", "str_13304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13305", "str_13305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13306", "str_13306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13307", "str_13307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13308", "str_13308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13309", "str_13309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1331", "str_1331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13310", "str_13310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13311", "str_13311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13312", "str_13312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13313", "str_13313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13314", "str_13314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13315", "str_13315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13316", "str_13316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13317", "str_13317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13318", "str_13318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13319", "str_13319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1332", "str_1332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13320", "str_13320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13321", "str_13321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13322", "str_13322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13323", "str_13323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13324", "str_13324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13325", "str_13325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13326", "str_13326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13327", "str_13327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13328", "str_13328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13329", "str_13329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1333", "str_1333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13330", "str_13330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13331", "str_13331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13332", "str_13332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13333", "str_13333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13334", "str_13334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13335", "str_13335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13336", "str_13336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13337", "str_13337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13338", "str_13338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13339", "str_13339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1334", "str_1334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13340", "str_13340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13341", "str_13341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13342", "str_13342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13343", "str_13343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13344", "str_13344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13345", "str_13345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13346", "str_13346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13347", "str_13347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13348", "str_13348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13349", "str_13349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1335", "str_1335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13350", "str_13350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13351", "str_13351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13352", "str_13352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13353", "str_13353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13354", "str_13354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13355", "str_13355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13356", "str_13356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13357", "str_13357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13358", "str_13358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13359", "str_13359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1336", "str_1336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13360", "str_13360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13361", "str_13361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13362", "str_13362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13363", "str_13363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13364", "str_13364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13365", "str_13365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13366", "str_13366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13367", "str_13367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13368", "str_13368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13369", "str_13369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1337", "str_1337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13370", "str_13370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13371", "str_13371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13372", "str_13372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13373", "str_13373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13374", "str_13374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13375", "str_13375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13376", "str_13376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13377", "str_13377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13378", "str_13378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13379", "str_13379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1338", "str_1338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13380", "str_13380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13381", "str_13381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13382", "str_13382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13383", "str_13383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13384", "str_13384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13385", "str_13385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13386", "str_13386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13387", "str_13387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13388", "str_13388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13389", "str_13389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1339", "str_1339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13390", "str_13390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13391", "str_13391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13392", "str_13392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13393", "str_13393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13394", "str_13394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13395", "str_13395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13396", "str_13396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13397", "str_13397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13398", "str_13398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13399", "str_13399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_134", "str_134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1340", "str_1340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13400", "str_13400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13401", "str_13401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13402", "str_13402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13403", "str_13403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13404", "str_13404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13405", "str_13405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13406", "str_13406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13407", "str_13407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13408", "str_13408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13409", "str_13409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1341", "str_1341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13410", "str_13410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13411", "str_13411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13412", "str_13412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13413", "str_13413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13414", "str_13414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13415", "str_13415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13416", "str_13416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13417", "str_13417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13418", "str_13418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13419", "str_13419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1342", "str_1342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13420", "str_13420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13421", "str_13421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13422", "str_13422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13423", "str_13423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13424", "str_13424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13425", "str_13425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13426", "str_13426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13427", "str_13427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13428", "str_13428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13429", "str_13429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1343", "str_1343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13430", "str_13430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13431", "str_13431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13432", "str_13432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13433", "str_13433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13434", "str_13434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13435", "str_13435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13436", "str_13436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13437", "str_13437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13438", "str_13438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13439", "str_13439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1344", "str_1344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13440", "str_13440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13441", "str_13441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13442", "str_13442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13443", "str_13443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13444", "str_13444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13445", "str_13445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13446", "str_13446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13447", "str_13447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13448", "str_13448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13449", "str_13449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1345", "str_1345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13450", "str_13450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13451", "str_13451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13452", "str_13452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13453", "str_13453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13454", "str_13454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13455", "str_13455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13456", "str_13456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13457", "str_13457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13458", "str_13458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13459", "str_13459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1346", "str_1346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13460", "str_13460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13461", "str_13461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13462", "str_13462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13463", "str_13463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13464", "str_13464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13465", "str_13465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13466", "str_13466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13467", "str_13467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13468", "str_13468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13469", "str_13469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1347", "str_1347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13470", "str_13470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13471", "str_13471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13472", "str_13472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13473", "str_13473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13474", "str_13474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13475", "str_13475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13476", "str_13476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13477", "str_13477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13478", "str_13478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13479", "str_13479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1348", "str_1348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13480", "str_13480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13481", "str_13481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13482", "str_13482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13483", "str_13483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13484", "str_13484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13485", "str_13485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13486", "str_13486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13487", "str_13487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13488", "str_13488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13489", "str_13489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1349", "str_1349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13490", "str_13490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13491", "str_13491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13492", "str_13492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13493", "str_13493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13494", "str_13494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13495", "str_13495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13496", "str_13496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13497", "str_13497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13498: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13498", "str_13498",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13499: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13499", "str_13499",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_135", "str_135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1350", "str_1350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13500: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13500", "str_13500",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13501: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13501", "str_13501",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13502: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13502", "str_13502",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13503: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13503", "str_13503",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13504: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13504", "str_13504",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13505: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13505", "str_13505",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13506: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13506", "str_13506",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13507: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13507", "str_13507",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13508: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13508", "str_13508",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13509: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13509", "str_13509",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1351", "str_1351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13510: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13510", "str_13510",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13511: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13511", "str_13511",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13512: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13512", "str_13512",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13513: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13513", "str_13513",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13514: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13514", "str_13514",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13515: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13515", "str_13515",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13516: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13516", "str_13516",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13517: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13517", "str_13517",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13518: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13518", "str_13518",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13519: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13519", "str_13519",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1352", "str_1352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13520: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13520", "str_13520",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13521: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13521", "str_13521",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13522: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13522", "str_13522",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13523: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13523", "str_13523",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13524: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13524", "str_13524",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13525: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13525", "str_13525",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13526: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13526", "str_13526",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13527: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13527", "str_13527",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13528: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13528", "str_13528",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13529: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13529", "str_13529",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1353", "str_1353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13530: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13530", "str_13530",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13531: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13531", "str_13531",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13532: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13532", "str_13532",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13533: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13533", "str_13533",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13534: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13534", "str_13534",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13535: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13535", "str_13535",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13536: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13536", "str_13536",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13537: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13537", "str_13537",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13538: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13538", "str_13538",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13539: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13539", "str_13539",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1354", "str_1354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13540: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13540", "str_13540",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13541: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13541", "str_13541",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13542: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13542", "str_13542",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13543: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13543", "str_13543",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13544: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13544", "str_13544",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13545: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13545", "str_13545",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13546: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13546", "str_13546",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13547: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13547", "str_13547",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13548: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13548", "str_13548",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13549: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13549", "str_13549",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1355", "str_1355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13550: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13550", "str_13550",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13551: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13551", "str_13551",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13552: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13552", "str_13552",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13553: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13553", "str_13553",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13554: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13554", "str_13554",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13555: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13555", "str_13555",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13556: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13556", "str_13556",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13557: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13557", "str_13557",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13558: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13558", "str_13558",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13559: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13559", "str_13559",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1356", "str_1356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13560: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13560", "str_13560",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13561: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13561", "str_13561",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13562: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13562", "str_13562",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13563: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13563", "str_13563",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13564: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13564", "str_13564",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13565: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13565", "str_13565",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13566: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13566", "str_13566",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13567: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13567", "str_13567",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13568: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13568", "str_13568",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13569: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13569", "str_13569",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1357", "str_1357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13570: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13570", "str_13570",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13571: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13571", "str_13571",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13572: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13572", "str_13572",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13573: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13573", "str_13573",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13574: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13574", "str_13574",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13575: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13575", "str_13575",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13576: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13576", "str_13576",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13577: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13577", "str_13577",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13578: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13578", "str_13578",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13579: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13579", "str_13579",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1358", "str_1358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13580: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13580", "str_13580",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13581: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13581", "str_13581",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13582: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13582", "str_13582",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13583: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13583", "str_13583",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13584: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13584", "str_13584",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13585: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13585", "str_13585",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13586: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13586", "str_13586",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13587: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13587", "str_13587",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13588: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13588", "str_13588",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13589: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13589", "str_13589",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1359", "str_1359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13590: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13590", "str_13590",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13591: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13591", "str_13591",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13592: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13592", "str_13592",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13593: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13593", "str_13593",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13594: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13594", "str_13594",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13595: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13595", "str_13595",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13596: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13596", "str_13596",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13597: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13597", "str_13597",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_13147: StringResource
+  get() = String7.str_13147
+
+@ExperimentalResourceApi
+internal val Res.string.str_13148: StringResource
+  get() = String7.str_13148
+
+@ExperimentalResourceApi
+internal val Res.string.str_13149: StringResource
+  get() = String7.str_13149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1315: StringResource
+  get() = String7.str_1315
+
+@ExperimentalResourceApi
+internal val Res.string.str_13150: StringResource
+  get() = String7.str_13150
+
+@ExperimentalResourceApi
+internal val Res.string.str_13151: StringResource
+  get() = String7.str_13151
+
+@ExperimentalResourceApi
+internal val Res.string.str_13152: StringResource
+  get() = String7.str_13152
+
+@ExperimentalResourceApi
+internal val Res.string.str_13153: StringResource
+  get() = String7.str_13153
+
+@ExperimentalResourceApi
+internal val Res.string.str_13154: StringResource
+  get() = String7.str_13154
+
+@ExperimentalResourceApi
+internal val Res.string.str_13155: StringResource
+  get() = String7.str_13155
+
+@ExperimentalResourceApi
+internal val Res.string.str_13156: StringResource
+  get() = String7.str_13156
+
+@ExperimentalResourceApi
+internal val Res.string.str_13157: StringResource
+  get() = String7.str_13157
+
+@ExperimentalResourceApi
+internal val Res.string.str_13158: StringResource
+  get() = String7.str_13158
+
+@ExperimentalResourceApi
+internal val Res.string.str_13159: StringResource
+  get() = String7.str_13159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1316: StringResource
+  get() = String7.str_1316
+
+@ExperimentalResourceApi
+internal val Res.string.str_13160: StringResource
+  get() = String7.str_13160
+
+@ExperimentalResourceApi
+internal val Res.string.str_13161: StringResource
+  get() = String7.str_13161
+
+@ExperimentalResourceApi
+internal val Res.string.str_13162: StringResource
+  get() = String7.str_13162
+
+@ExperimentalResourceApi
+internal val Res.string.str_13163: StringResource
+  get() = String7.str_13163
+
+@ExperimentalResourceApi
+internal val Res.string.str_13164: StringResource
+  get() = String7.str_13164
+
+@ExperimentalResourceApi
+internal val Res.string.str_13165: StringResource
+  get() = String7.str_13165
+
+@ExperimentalResourceApi
+internal val Res.string.str_13166: StringResource
+  get() = String7.str_13166
+
+@ExperimentalResourceApi
+internal val Res.string.str_13167: StringResource
+  get() = String7.str_13167
+
+@ExperimentalResourceApi
+internal val Res.string.str_13168: StringResource
+  get() = String7.str_13168
+
+@ExperimentalResourceApi
+internal val Res.string.str_13169: StringResource
+  get() = String7.str_13169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1317: StringResource
+  get() = String7.str_1317
+
+@ExperimentalResourceApi
+internal val Res.string.str_13170: StringResource
+  get() = String7.str_13170
+
+@ExperimentalResourceApi
+internal val Res.string.str_13171: StringResource
+  get() = String7.str_13171
+
+@ExperimentalResourceApi
+internal val Res.string.str_13172: StringResource
+  get() = String7.str_13172
+
+@ExperimentalResourceApi
+internal val Res.string.str_13173: StringResource
+  get() = String7.str_13173
+
+@ExperimentalResourceApi
+internal val Res.string.str_13174: StringResource
+  get() = String7.str_13174
+
+@ExperimentalResourceApi
+internal val Res.string.str_13175: StringResource
+  get() = String7.str_13175
+
+@ExperimentalResourceApi
+internal val Res.string.str_13176: StringResource
+  get() = String7.str_13176
+
+@ExperimentalResourceApi
+internal val Res.string.str_13177: StringResource
+  get() = String7.str_13177
+
+@ExperimentalResourceApi
+internal val Res.string.str_13178: StringResource
+  get() = String7.str_13178
+
+@ExperimentalResourceApi
+internal val Res.string.str_13179: StringResource
+  get() = String7.str_13179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1318: StringResource
+  get() = String7.str_1318
+
+@ExperimentalResourceApi
+internal val Res.string.str_13180: StringResource
+  get() = String7.str_13180
+
+@ExperimentalResourceApi
+internal val Res.string.str_13181: StringResource
+  get() = String7.str_13181
+
+@ExperimentalResourceApi
+internal val Res.string.str_13182: StringResource
+  get() = String7.str_13182
+
+@ExperimentalResourceApi
+internal val Res.string.str_13183: StringResource
+  get() = String7.str_13183
+
+@ExperimentalResourceApi
+internal val Res.string.str_13184: StringResource
+  get() = String7.str_13184
+
+@ExperimentalResourceApi
+internal val Res.string.str_13185: StringResource
+  get() = String7.str_13185
+
+@ExperimentalResourceApi
+internal val Res.string.str_13186: StringResource
+  get() = String7.str_13186
+
+@ExperimentalResourceApi
+internal val Res.string.str_13187: StringResource
+  get() = String7.str_13187
+
+@ExperimentalResourceApi
+internal val Res.string.str_13188: StringResource
+  get() = String7.str_13188
+
+@ExperimentalResourceApi
+internal val Res.string.str_13189: StringResource
+  get() = String7.str_13189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1319: StringResource
+  get() = String7.str_1319
+
+@ExperimentalResourceApi
+internal val Res.string.str_13190: StringResource
+  get() = String7.str_13190
+
+@ExperimentalResourceApi
+internal val Res.string.str_13191: StringResource
+  get() = String7.str_13191
+
+@ExperimentalResourceApi
+internal val Res.string.str_13192: StringResource
+  get() = String7.str_13192
+
+@ExperimentalResourceApi
+internal val Res.string.str_13193: StringResource
+  get() = String7.str_13193
+
+@ExperimentalResourceApi
+internal val Res.string.str_13194: StringResource
+  get() = String7.str_13194
+
+@ExperimentalResourceApi
+internal val Res.string.str_13195: StringResource
+  get() = String7.str_13195
+
+@ExperimentalResourceApi
+internal val Res.string.str_13196: StringResource
+  get() = String7.str_13196
+
+@ExperimentalResourceApi
+internal val Res.string.str_13197: StringResource
+  get() = String7.str_13197
+
+@ExperimentalResourceApi
+internal val Res.string.str_13198: StringResource
+  get() = String7.str_13198
+
+@ExperimentalResourceApi
+internal val Res.string.str_13199: StringResource
+  get() = String7.str_13199
+
+@ExperimentalResourceApi
+internal val Res.string.str_132: StringResource
+  get() = String7.str_132
+
+@ExperimentalResourceApi
+internal val Res.string.str_1320: StringResource
+  get() = String7.str_1320
+
+@ExperimentalResourceApi
+internal val Res.string.str_13200: StringResource
+  get() = String7.str_13200
+
+@ExperimentalResourceApi
+internal val Res.string.str_13201: StringResource
+  get() = String7.str_13201
+
+@ExperimentalResourceApi
+internal val Res.string.str_13202: StringResource
+  get() = String7.str_13202
+
+@ExperimentalResourceApi
+internal val Res.string.str_13203: StringResource
+  get() = String7.str_13203
+
+@ExperimentalResourceApi
+internal val Res.string.str_13204: StringResource
+  get() = String7.str_13204
+
+@ExperimentalResourceApi
+internal val Res.string.str_13205: StringResource
+  get() = String7.str_13205
+
+@ExperimentalResourceApi
+internal val Res.string.str_13206: StringResource
+  get() = String7.str_13206
+
+@ExperimentalResourceApi
+internal val Res.string.str_13207: StringResource
+  get() = String7.str_13207
+
+@ExperimentalResourceApi
+internal val Res.string.str_13208: StringResource
+  get() = String7.str_13208
+
+@ExperimentalResourceApi
+internal val Res.string.str_13209: StringResource
+  get() = String7.str_13209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1321: StringResource
+  get() = String7.str_1321
+
+@ExperimentalResourceApi
+internal val Res.string.str_13210: StringResource
+  get() = String7.str_13210
+
+@ExperimentalResourceApi
+internal val Res.string.str_13211: StringResource
+  get() = String7.str_13211
+
+@ExperimentalResourceApi
+internal val Res.string.str_13212: StringResource
+  get() = String7.str_13212
+
+@ExperimentalResourceApi
+internal val Res.string.str_13213: StringResource
+  get() = String7.str_13213
+
+@ExperimentalResourceApi
+internal val Res.string.str_13214: StringResource
+  get() = String7.str_13214
+
+@ExperimentalResourceApi
+internal val Res.string.str_13215: StringResource
+  get() = String7.str_13215
+
+@ExperimentalResourceApi
+internal val Res.string.str_13216: StringResource
+  get() = String7.str_13216
+
+@ExperimentalResourceApi
+internal val Res.string.str_13217: StringResource
+  get() = String7.str_13217
+
+@ExperimentalResourceApi
+internal val Res.string.str_13218: StringResource
+  get() = String7.str_13218
+
+@ExperimentalResourceApi
+internal val Res.string.str_13219: StringResource
+  get() = String7.str_13219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1322: StringResource
+  get() = String7.str_1322
+
+@ExperimentalResourceApi
+internal val Res.string.str_13220: StringResource
+  get() = String7.str_13220
+
+@ExperimentalResourceApi
+internal val Res.string.str_13221: StringResource
+  get() = String7.str_13221
+
+@ExperimentalResourceApi
+internal val Res.string.str_13222: StringResource
+  get() = String7.str_13222
+
+@ExperimentalResourceApi
+internal val Res.string.str_13223: StringResource
+  get() = String7.str_13223
+
+@ExperimentalResourceApi
+internal val Res.string.str_13224: StringResource
+  get() = String7.str_13224
+
+@ExperimentalResourceApi
+internal val Res.string.str_13225: StringResource
+  get() = String7.str_13225
+
+@ExperimentalResourceApi
+internal val Res.string.str_13226: StringResource
+  get() = String7.str_13226
+
+@ExperimentalResourceApi
+internal val Res.string.str_13227: StringResource
+  get() = String7.str_13227
+
+@ExperimentalResourceApi
+internal val Res.string.str_13228: StringResource
+  get() = String7.str_13228
+
+@ExperimentalResourceApi
+internal val Res.string.str_13229: StringResource
+  get() = String7.str_13229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1323: StringResource
+  get() = String7.str_1323
+
+@ExperimentalResourceApi
+internal val Res.string.str_13230: StringResource
+  get() = String7.str_13230
+
+@ExperimentalResourceApi
+internal val Res.string.str_13231: StringResource
+  get() = String7.str_13231
+
+@ExperimentalResourceApi
+internal val Res.string.str_13232: StringResource
+  get() = String7.str_13232
+
+@ExperimentalResourceApi
+internal val Res.string.str_13233: StringResource
+  get() = String7.str_13233
+
+@ExperimentalResourceApi
+internal val Res.string.str_13234: StringResource
+  get() = String7.str_13234
+
+@ExperimentalResourceApi
+internal val Res.string.str_13235: StringResource
+  get() = String7.str_13235
+
+@ExperimentalResourceApi
+internal val Res.string.str_13236: StringResource
+  get() = String7.str_13236
+
+@ExperimentalResourceApi
+internal val Res.string.str_13237: StringResource
+  get() = String7.str_13237
+
+@ExperimentalResourceApi
+internal val Res.string.str_13238: StringResource
+  get() = String7.str_13238
+
+@ExperimentalResourceApi
+internal val Res.string.str_13239: StringResource
+  get() = String7.str_13239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1324: StringResource
+  get() = String7.str_1324
+
+@ExperimentalResourceApi
+internal val Res.string.str_13240: StringResource
+  get() = String7.str_13240
+
+@ExperimentalResourceApi
+internal val Res.string.str_13241: StringResource
+  get() = String7.str_13241
+
+@ExperimentalResourceApi
+internal val Res.string.str_13242: StringResource
+  get() = String7.str_13242
+
+@ExperimentalResourceApi
+internal val Res.string.str_13243: StringResource
+  get() = String7.str_13243
+
+@ExperimentalResourceApi
+internal val Res.string.str_13244: StringResource
+  get() = String7.str_13244
+
+@ExperimentalResourceApi
+internal val Res.string.str_13245: StringResource
+  get() = String7.str_13245
+
+@ExperimentalResourceApi
+internal val Res.string.str_13246: StringResource
+  get() = String7.str_13246
+
+@ExperimentalResourceApi
+internal val Res.string.str_13247: StringResource
+  get() = String7.str_13247
+
+@ExperimentalResourceApi
+internal val Res.string.str_13248: StringResource
+  get() = String7.str_13248
+
+@ExperimentalResourceApi
+internal val Res.string.str_13249: StringResource
+  get() = String7.str_13249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1325: StringResource
+  get() = String7.str_1325
+
+@ExperimentalResourceApi
+internal val Res.string.str_13250: StringResource
+  get() = String7.str_13250
+
+@ExperimentalResourceApi
+internal val Res.string.str_13251: StringResource
+  get() = String7.str_13251
+
+@ExperimentalResourceApi
+internal val Res.string.str_13252: StringResource
+  get() = String7.str_13252
+
+@ExperimentalResourceApi
+internal val Res.string.str_13253: StringResource
+  get() = String7.str_13253
+
+@ExperimentalResourceApi
+internal val Res.string.str_13254: StringResource
+  get() = String7.str_13254
+
+@ExperimentalResourceApi
+internal val Res.string.str_13255: StringResource
+  get() = String7.str_13255
+
+@ExperimentalResourceApi
+internal val Res.string.str_13256: StringResource
+  get() = String7.str_13256
+
+@ExperimentalResourceApi
+internal val Res.string.str_13257: StringResource
+  get() = String7.str_13257
+
+@ExperimentalResourceApi
+internal val Res.string.str_13258: StringResource
+  get() = String7.str_13258
+
+@ExperimentalResourceApi
+internal val Res.string.str_13259: StringResource
+  get() = String7.str_13259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1326: StringResource
+  get() = String7.str_1326
+
+@ExperimentalResourceApi
+internal val Res.string.str_13260: StringResource
+  get() = String7.str_13260
+
+@ExperimentalResourceApi
+internal val Res.string.str_13261: StringResource
+  get() = String7.str_13261
+
+@ExperimentalResourceApi
+internal val Res.string.str_13262: StringResource
+  get() = String7.str_13262
+
+@ExperimentalResourceApi
+internal val Res.string.str_13263: StringResource
+  get() = String7.str_13263
+
+@ExperimentalResourceApi
+internal val Res.string.str_13264: StringResource
+  get() = String7.str_13264
+
+@ExperimentalResourceApi
+internal val Res.string.str_13265: StringResource
+  get() = String7.str_13265
+
+@ExperimentalResourceApi
+internal val Res.string.str_13266: StringResource
+  get() = String7.str_13266
+
+@ExperimentalResourceApi
+internal val Res.string.str_13267: StringResource
+  get() = String7.str_13267
+
+@ExperimentalResourceApi
+internal val Res.string.str_13268: StringResource
+  get() = String7.str_13268
+
+@ExperimentalResourceApi
+internal val Res.string.str_13269: StringResource
+  get() = String7.str_13269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1327: StringResource
+  get() = String7.str_1327
+
+@ExperimentalResourceApi
+internal val Res.string.str_13270: StringResource
+  get() = String7.str_13270
+
+@ExperimentalResourceApi
+internal val Res.string.str_13271: StringResource
+  get() = String7.str_13271
+
+@ExperimentalResourceApi
+internal val Res.string.str_13272: StringResource
+  get() = String7.str_13272
+
+@ExperimentalResourceApi
+internal val Res.string.str_13273: StringResource
+  get() = String7.str_13273
+
+@ExperimentalResourceApi
+internal val Res.string.str_13274: StringResource
+  get() = String7.str_13274
+
+@ExperimentalResourceApi
+internal val Res.string.str_13275: StringResource
+  get() = String7.str_13275
+
+@ExperimentalResourceApi
+internal val Res.string.str_13276: StringResource
+  get() = String7.str_13276
+
+@ExperimentalResourceApi
+internal val Res.string.str_13277: StringResource
+  get() = String7.str_13277
+
+@ExperimentalResourceApi
+internal val Res.string.str_13278: StringResource
+  get() = String7.str_13278
+
+@ExperimentalResourceApi
+internal val Res.string.str_13279: StringResource
+  get() = String7.str_13279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1328: StringResource
+  get() = String7.str_1328
+
+@ExperimentalResourceApi
+internal val Res.string.str_13280: StringResource
+  get() = String7.str_13280
+
+@ExperimentalResourceApi
+internal val Res.string.str_13281: StringResource
+  get() = String7.str_13281
+
+@ExperimentalResourceApi
+internal val Res.string.str_13282: StringResource
+  get() = String7.str_13282
+
+@ExperimentalResourceApi
+internal val Res.string.str_13283: StringResource
+  get() = String7.str_13283
+
+@ExperimentalResourceApi
+internal val Res.string.str_13284: StringResource
+  get() = String7.str_13284
+
+@ExperimentalResourceApi
+internal val Res.string.str_13285: StringResource
+  get() = String7.str_13285
+
+@ExperimentalResourceApi
+internal val Res.string.str_13286: StringResource
+  get() = String7.str_13286
+
+@ExperimentalResourceApi
+internal val Res.string.str_13287: StringResource
+  get() = String7.str_13287
+
+@ExperimentalResourceApi
+internal val Res.string.str_13288: StringResource
+  get() = String7.str_13288
+
+@ExperimentalResourceApi
+internal val Res.string.str_13289: StringResource
+  get() = String7.str_13289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1329: StringResource
+  get() = String7.str_1329
+
+@ExperimentalResourceApi
+internal val Res.string.str_13290: StringResource
+  get() = String7.str_13290
+
+@ExperimentalResourceApi
+internal val Res.string.str_13291: StringResource
+  get() = String7.str_13291
+
+@ExperimentalResourceApi
+internal val Res.string.str_13292: StringResource
+  get() = String7.str_13292
+
+@ExperimentalResourceApi
+internal val Res.string.str_13293: StringResource
+  get() = String7.str_13293
+
+@ExperimentalResourceApi
+internal val Res.string.str_13294: StringResource
+  get() = String7.str_13294
+
+@ExperimentalResourceApi
+internal val Res.string.str_13295: StringResource
+  get() = String7.str_13295
+
+@ExperimentalResourceApi
+internal val Res.string.str_13296: StringResource
+  get() = String7.str_13296
+
+@ExperimentalResourceApi
+internal val Res.string.str_13297: StringResource
+  get() = String7.str_13297
+
+@ExperimentalResourceApi
+internal val Res.string.str_13298: StringResource
+  get() = String7.str_13298
+
+@ExperimentalResourceApi
+internal val Res.string.str_13299: StringResource
+  get() = String7.str_13299
+
+@ExperimentalResourceApi
+internal val Res.string.str_133: StringResource
+  get() = String7.str_133
+
+@ExperimentalResourceApi
+internal val Res.string.str_1330: StringResource
+  get() = String7.str_1330
+
+@ExperimentalResourceApi
+internal val Res.string.str_13300: StringResource
+  get() = String7.str_13300
+
+@ExperimentalResourceApi
+internal val Res.string.str_13301: StringResource
+  get() = String7.str_13301
+
+@ExperimentalResourceApi
+internal val Res.string.str_13302: StringResource
+  get() = String7.str_13302
+
+@ExperimentalResourceApi
+internal val Res.string.str_13303: StringResource
+  get() = String7.str_13303
+
+@ExperimentalResourceApi
+internal val Res.string.str_13304: StringResource
+  get() = String7.str_13304
+
+@ExperimentalResourceApi
+internal val Res.string.str_13305: StringResource
+  get() = String7.str_13305
+
+@ExperimentalResourceApi
+internal val Res.string.str_13306: StringResource
+  get() = String7.str_13306
+
+@ExperimentalResourceApi
+internal val Res.string.str_13307: StringResource
+  get() = String7.str_13307
+
+@ExperimentalResourceApi
+internal val Res.string.str_13308: StringResource
+  get() = String7.str_13308
+
+@ExperimentalResourceApi
+internal val Res.string.str_13309: StringResource
+  get() = String7.str_13309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1331: StringResource
+  get() = String7.str_1331
+
+@ExperimentalResourceApi
+internal val Res.string.str_13310: StringResource
+  get() = String7.str_13310
+
+@ExperimentalResourceApi
+internal val Res.string.str_13311: StringResource
+  get() = String7.str_13311
+
+@ExperimentalResourceApi
+internal val Res.string.str_13312: StringResource
+  get() = String7.str_13312
+
+@ExperimentalResourceApi
+internal val Res.string.str_13313: StringResource
+  get() = String7.str_13313
+
+@ExperimentalResourceApi
+internal val Res.string.str_13314: StringResource
+  get() = String7.str_13314
+
+@ExperimentalResourceApi
+internal val Res.string.str_13315: StringResource
+  get() = String7.str_13315
+
+@ExperimentalResourceApi
+internal val Res.string.str_13316: StringResource
+  get() = String7.str_13316
+
+@ExperimentalResourceApi
+internal val Res.string.str_13317: StringResource
+  get() = String7.str_13317
+
+@ExperimentalResourceApi
+internal val Res.string.str_13318: StringResource
+  get() = String7.str_13318
+
+@ExperimentalResourceApi
+internal val Res.string.str_13319: StringResource
+  get() = String7.str_13319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1332: StringResource
+  get() = String7.str_1332
+
+@ExperimentalResourceApi
+internal val Res.string.str_13320: StringResource
+  get() = String7.str_13320
+
+@ExperimentalResourceApi
+internal val Res.string.str_13321: StringResource
+  get() = String7.str_13321
+
+@ExperimentalResourceApi
+internal val Res.string.str_13322: StringResource
+  get() = String7.str_13322
+
+@ExperimentalResourceApi
+internal val Res.string.str_13323: StringResource
+  get() = String7.str_13323
+
+@ExperimentalResourceApi
+internal val Res.string.str_13324: StringResource
+  get() = String7.str_13324
+
+@ExperimentalResourceApi
+internal val Res.string.str_13325: StringResource
+  get() = String7.str_13325
+
+@ExperimentalResourceApi
+internal val Res.string.str_13326: StringResource
+  get() = String7.str_13326
+
+@ExperimentalResourceApi
+internal val Res.string.str_13327: StringResource
+  get() = String7.str_13327
+
+@ExperimentalResourceApi
+internal val Res.string.str_13328: StringResource
+  get() = String7.str_13328
+
+@ExperimentalResourceApi
+internal val Res.string.str_13329: StringResource
+  get() = String7.str_13329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1333: StringResource
+  get() = String7.str_1333
+
+@ExperimentalResourceApi
+internal val Res.string.str_13330: StringResource
+  get() = String7.str_13330
+
+@ExperimentalResourceApi
+internal val Res.string.str_13331: StringResource
+  get() = String7.str_13331
+
+@ExperimentalResourceApi
+internal val Res.string.str_13332: StringResource
+  get() = String7.str_13332
+
+@ExperimentalResourceApi
+internal val Res.string.str_13333: StringResource
+  get() = String7.str_13333
+
+@ExperimentalResourceApi
+internal val Res.string.str_13334: StringResource
+  get() = String7.str_13334
+
+@ExperimentalResourceApi
+internal val Res.string.str_13335: StringResource
+  get() = String7.str_13335
+
+@ExperimentalResourceApi
+internal val Res.string.str_13336: StringResource
+  get() = String7.str_13336
+
+@ExperimentalResourceApi
+internal val Res.string.str_13337: StringResource
+  get() = String7.str_13337
+
+@ExperimentalResourceApi
+internal val Res.string.str_13338: StringResource
+  get() = String7.str_13338
+
+@ExperimentalResourceApi
+internal val Res.string.str_13339: StringResource
+  get() = String7.str_13339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1334: StringResource
+  get() = String7.str_1334
+
+@ExperimentalResourceApi
+internal val Res.string.str_13340: StringResource
+  get() = String7.str_13340
+
+@ExperimentalResourceApi
+internal val Res.string.str_13341: StringResource
+  get() = String7.str_13341
+
+@ExperimentalResourceApi
+internal val Res.string.str_13342: StringResource
+  get() = String7.str_13342
+
+@ExperimentalResourceApi
+internal val Res.string.str_13343: StringResource
+  get() = String7.str_13343
+
+@ExperimentalResourceApi
+internal val Res.string.str_13344: StringResource
+  get() = String7.str_13344
+
+@ExperimentalResourceApi
+internal val Res.string.str_13345: StringResource
+  get() = String7.str_13345
+
+@ExperimentalResourceApi
+internal val Res.string.str_13346: StringResource
+  get() = String7.str_13346
+
+@ExperimentalResourceApi
+internal val Res.string.str_13347: StringResource
+  get() = String7.str_13347
+
+@ExperimentalResourceApi
+internal val Res.string.str_13348: StringResource
+  get() = String7.str_13348
+
+@ExperimentalResourceApi
+internal val Res.string.str_13349: StringResource
+  get() = String7.str_13349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1335: StringResource
+  get() = String7.str_1335
+
+@ExperimentalResourceApi
+internal val Res.string.str_13350: StringResource
+  get() = String7.str_13350
+
+@ExperimentalResourceApi
+internal val Res.string.str_13351: StringResource
+  get() = String7.str_13351
+
+@ExperimentalResourceApi
+internal val Res.string.str_13352: StringResource
+  get() = String7.str_13352
+
+@ExperimentalResourceApi
+internal val Res.string.str_13353: StringResource
+  get() = String7.str_13353
+
+@ExperimentalResourceApi
+internal val Res.string.str_13354: StringResource
+  get() = String7.str_13354
+
+@ExperimentalResourceApi
+internal val Res.string.str_13355: StringResource
+  get() = String7.str_13355
+
+@ExperimentalResourceApi
+internal val Res.string.str_13356: StringResource
+  get() = String7.str_13356
+
+@ExperimentalResourceApi
+internal val Res.string.str_13357: StringResource
+  get() = String7.str_13357
+
+@ExperimentalResourceApi
+internal val Res.string.str_13358: StringResource
+  get() = String7.str_13358
+
+@ExperimentalResourceApi
+internal val Res.string.str_13359: StringResource
+  get() = String7.str_13359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1336: StringResource
+  get() = String7.str_1336
+
+@ExperimentalResourceApi
+internal val Res.string.str_13360: StringResource
+  get() = String7.str_13360
+
+@ExperimentalResourceApi
+internal val Res.string.str_13361: StringResource
+  get() = String7.str_13361
+
+@ExperimentalResourceApi
+internal val Res.string.str_13362: StringResource
+  get() = String7.str_13362
+
+@ExperimentalResourceApi
+internal val Res.string.str_13363: StringResource
+  get() = String7.str_13363
+
+@ExperimentalResourceApi
+internal val Res.string.str_13364: StringResource
+  get() = String7.str_13364
+
+@ExperimentalResourceApi
+internal val Res.string.str_13365: StringResource
+  get() = String7.str_13365
+
+@ExperimentalResourceApi
+internal val Res.string.str_13366: StringResource
+  get() = String7.str_13366
+
+@ExperimentalResourceApi
+internal val Res.string.str_13367: StringResource
+  get() = String7.str_13367
+
+@ExperimentalResourceApi
+internal val Res.string.str_13368: StringResource
+  get() = String7.str_13368
+
+@ExperimentalResourceApi
+internal val Res.string.str_13369: StringResource
+  get() = String7.str_13369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1337: StringResource
+  get() = String7.str_1337
+
+@ExperimentalResourceApi
+internal val Res.string.str_13370: StringResource
+  get() = String7.str_13370
+
+@ExperimentalResourceApi
+internal val Res.string.str_13371: StringResource
+  get() = String7.str_13371
+
+@ExperimentalResourceApi
+internal val Res.string.str_13372: StringResource
+  get() = String7.str_13372
+
+@ExperimentalResourceApi
+internal val Res.string.str_13373: StringResource
+  get() = String7.str_13373
+
+@ExperimentalResourceApi
+internal val Res.string.str_13374: StringResource
+  get() = String7.str_13374
+
+@ExperimentalResourceApi
+internal val Res.string.str_13375: StringResource
+  get() = String7.str_13375
+
+@ExperimentalResourceApi
+internal val Res.string.str_13376: StringResource
+  get() = String7.str_13376
+
+@ExperimentalResourceApi
+internal val Res.string.str_13377: StringResource
+  get() = String7.str_13377
+
+@ExperimentalResourceApi
+internal val Res.string.str_13378: StringResource
+  get() = String7.str_13378
+
+@ExperimentalResourceApi
+internal val Res.string.str_13379: StringResource
+  get() = String7.str_13379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1338: StringResource
+  get() = String7.str_1338
+
+@ExperimentalResourceApi
+internal val Res.string.str_13380: StringResource
+  get() = String7.str_13380
+
+@ExperimentalResourceApi
+internal val Res.string.str_13381: StringResource
+  get() = String7.str_13381
+
+@ExperimentalResourceApi
+internal val Res.string.str_13382: StringResource
+  get() = String7.str_13382
+
+@ExperimentalResourceApi
+internal val Res.string.str_13383: StringResource
+  get() = String7.str_13383
+
+@ExperimentalResourceApi
+internal val Res.string.str_13384: StringResource
+  get() = String7.str_13384
+
+@ExperimentalResourceApi
+internal val Res.string.str_13385: StringResource
+  get() = String7.str_13385
+
+@ExperimentalResourceApi
+internal val Res.string.str_13386: StringResource
+  get() = String7.str_13386
+
+@ExperimentalResourceApi
+internal val Res.string.str_13387: StringResource
+  get() = String7.str_13387
+
+@ExperimentalResourceApi
+internal val Res.string.str_13388: StringResource
+  get() = String7.str_13388
+
+@ExperimentalResourceApi
+internal val Res.string.str_13389: StringResource
+  get() = String7.str_13389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1339: StringResource
+  get() = String7.str_1339
+
+@ExperimentalResourceApi
+internal val Res.string.str_13390: StringResource
+  get() = String7.str_13390
+
+@ExperimentalResourceApi
+internal val Res.string.str_13391: StringResource
+  get() = String7.str_13391
+
+@ExperimentalResourceApi
+internal val Res.string.str_13392: StringResource
+  get() = String7.str_13392
+
+@ExperimentalResourceApi
+internal val Res.string.str_13393: StringResource
+  get() = String7.str_13393
+
+@ExperimentalResourceApi
+internal val Res.string.str_13394: StringResource
+  get() = String7.str_13394
+
+@ExperimentalResourceApi
+internal val Res.string.str_13395: StringResource
+  get() = String7.str_13395
+
+@ExperimentalResourceApi
+internal val Res.string.str_13396: StringResource
+  get() = String7.str_13396
+
+@ExperimentalResourceApi
+internal val Res.string.str_13397: StringResource
+  get() = String7.str_13397
+
+@ExperimentalResourceApi
+internal val Res.string.str_13398: StringResource
+  get() = String7.str_13398
+
+@ExperimentalResourceApi
+internal val Res.string.str_13399: StringResource
+  get() = String7.str_13399
+
+@ExperimentalResourceApi
+internal val Res.string.str_134: StringResource
+  get() = String7.str_134
+
+@ExperimentalResourceApi
+internal val Res.string.str_1340: StringResource
+  get() = String7.str_1340
+
+@ExperimentalResourceApi
+internal val Res.string.str_13400: StringResource
+  get() = String7.str_13400
+
+@ExperimentalResourceApi
+internal val Res.string.str_13401: StringResource
+  get() = String7.str_13401
+
+@ExperimentalResourceApi
+internal val Res.string.str_13402: StringResource
+  get() = String7.str_13402
+
+@ExperimentalResourceApi
+internal val Res.string.str_13403: StringResource
+  get() = String7.str_13403
+
+@ExperimentalResourceApi
+internal val Res.string.str_13404: StringResource
+  get() = String7.str_13404
+
+@ExperimentalResourceApi
+internal val Res.string.str_13405: StringResource
+  get() = String7.str_13405
+
+@ExperimentalResourceApi
+internal val Res.string.str_13406: StringResource
+  get() = String7.str_13406
+
+@ExperimentalResourceApi
+internal val Res.string.str_13407: StringResource
+  get() = String7.str_13407
+
+@ExperimentalResourceApi
+internal val Res.string.str_13408: StringResource
+  get() = String7.str_13408
+
+@ExperimentalResourceApi
+internal val Res.string.str_13409: StringResource
+  get() = String7.str_13409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1341: StringResource
+  get() = String7.str_1341
+
+@ExperimentalResourceApi
+internal val Res.string.str_13410: StringResource
+  get() = String7.str_13410
+
+@ExperimentalResourceApi
+internal val Res.string.str_13411: StringResource
+  get() = String7.str_13411
+
+@ExperimentalResourceApi
+internal val Res.string.str_13412: StringResource
+  get() = String7.str_13412
+
+@ExperimentalResourceApi
+internal val Res.string.str_13413: StringResource
+  get() = String7.str_13413
+
+@ExperimentalResourceApi
+internal val Res.string.str_13414: StringResource
+  get() = String7.str_13414
+
+@ExperimentalResourceApi
+internal val Res.string.str_13415: StringResource
+  get() = String7.str_13415
+
+@ExperimentalResourceApi
+internal val Res.string.str_13416: StringResource
+  get() = String7.str_13416
+
+@ExperimentalResourceApi
+internal val Res.string.str_13417: StringResource
+  get() = String7.str_13417
+
+@ExperimentalResourceApi
+internal val Res.string.str_13418: StringResource
+  get() = String7.str_13418
+
+@ExperimentalResourceApi
+internal val Res.string.str_13419: StringResource
+  get() = String7.str_13419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1342: StringResource
+  get() = String7.str_1342
+
+@ExperimentalResourceApi
+internal val Res.string.str_13420: StringResource
+  get() = String7.str_13420
+
+@ExperimentalResourceApi
+internal val Res.string.str_13421: StringResource
+  get() = String7.str_13421
+
+@ExperimentalResourceApi
+internal val Res.string.str_13422: StringResource
+  get() = String7.str_13422
+
+@ExperimentalResourceApi
+internal val Res.string.str_13423: StringResource
+  get() = String7.str_13423
+
+@ExperimentalResourceApi
+internal val Res.string.str_13424: StringResource
+  get() = String7.str_13424
+
+@ExperimentalResourceApi
+internal val Res.string.str_13425: StringResource
+  get() = String7.str_13425
+
+@ExperimentalResourceApi
+internal val Res.string.str_13426: StringResource
+  get() = String7.str_13426
+
+@ExperimentalResourceApi
+internal val Res.string.str_13427: StringResource
+  get() = String7.str_13427
+
+@ExperimentalResourceApi
+internal val Res.string.str_13428: StringResource
+  get() = String7.str_13428
+
+@ExperimentalResourceApi
+internal val Res.string.str_13429: StringResource
+  get() = String7.str_13429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1343: StringResource
+  get() = String7.str_1343
+
+@ExperimentalResourceApi
+internal val Res.string.str_13430: StringResource
+  get() = String7.str_13430
+
+@ExperimentalResourceApi
+internal val Res.string.str_13431: StringResource
+  get() = String7.str_13431
+
+@ExperimentalResourceApi
+internal val Res.string.str_13432: StringResource
+  get() = String7.str_13432
+
+@ExperimentalResourceApi
+internal val Res.string.str_13433: StringResource
+  get() = String7.str_13433
+
+@ExperimentalResourceApi
+internal val Res.string.str_13434: StringResource
+  get() = String7.str_13434
+
+@ExperimentalResourceApi
+internal val Res.string.str_13435: StringResource
+  get() = String7.str_13435
+
+@ExperimentalResourceApi
+internal val Res.string.str_13436: StringResource
+  get() = String7.str_13436
+
+@ExperimentalResourceApi
+internal val Res.string.str_13437: StringResource
+  get() = String7.str_13437
+
+@ExperimentalResourceApi
+internal val Res.string.str_13438: StringResource
+  get() = String7.str_13438
+
+@ExperimentalResourceApi
+internal val Res.string.str_13439: StringResource
+  get() = String7.str_13439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1344: StringResource
+  get() = String7.str_1344
+
+@ExperimentalResourceApi
+internal val Res.string.str_13440: StringResource
+  get() = String7.str_13440
+
+@ExperimentalResourceApi
+internal val Res.string.str_13441: StringResource
+  get() = String7.str_13441
+
+@ExperimentalResourceApi
+internal val Res.string.str_13442: StringResource
+  get() = String7.str_13442
+
+@ExperimentalResourceApi
+internal val Res.string.str_13443: StringResource
+  get() = String7.str_13443
+
+@ExperimentalResourceApi
+internal val Res.string.str_13444: StringResource
+  get() = String7.str_13444
+
+@ExperimentalResourceApi
+internal val Res.string.str_13445: StringResource
+  get() = String7.str_13445
+
+@ExperimentalResourceApi
+internal val Res.string.str_13446: StringResource
+  get() = String7.str_13446
+
+@ExperimentalResourceApi
+internal val Res.string.str_13447: StringResource
+  get() = String7.str_13447
+
+@ExperimentalResourceApi
+internal val Res.string.str_13448: StringResource
+  get() = String7.str_13448
+
+@ExperimentalResourceApi
+internal val Res.string.str_13449: StringResource
+  get() = String7.str_13449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1345: StringResource
+  get() = String7.str_1345
+
+@ExperimentalResourceApi
+internal val Res.string.str_13450: StringResource
+  get() = String7.str_13450
+
+@ExperimentalResourceApi
+internal val Res.string.str_13451: StringResource
+  get() = String7.str_13451
+
+@ExperimentalResourceApi
+internal val Res.string.str_13452: StringResource
+  get() = String7.str_13452
+
+@ExperimentalResourceApi
+internal val Res.string.str_13453: StringResource
+  get() = String7.str_13453
+
+@ExperimentalResourceApi
+internal val Res.string.str_13454: StringResource
+  get() = String7.str_13454
+
+@ExperimentalResourceApi
+internal val Res.string.str_13455: StringResource
+  get() = String7.str_13455
+
+@ExperimentalResourceApi
+internal val Res.string.str_13456: StringResource
+  get() = String7.str_13456
+
+@ExperimentalResourceApi
+internal val Res.string.str_13457: StringResource
+  get() = String7.str_13457
+
+@ExperimentalResourceApi
+internal val Res.string.str_13458: StringResource
+  get() = String7.str_13458
+
+@ExperimentalResourceApi
+internal val Res.string.str_13459: StringResource
+  get() = String7.str_13459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1346: StringResource
+  get() = String7.str_1346
+
+@ExperimentalResourceApi
+internal val Res.string.str_13460: StringResource
+  get() = String7.str_13460
+
+@ExperimentalResourceApi
+internal val Res.string.str_13461: StringResource
+  get() = String7.str_13461
+
+@ExperimentalResourceApi
+internal val Res.string.str_13462: StringResource
+  get() = String7.str_13462
+
+@ExperimentalResourceApi
+internal val Res.string.str_13463: StringResource
+  get() = String7.str_13463
+
+@ExperimentalResourceApi
+internal val Res.string.str_13464: StringResource
+  get() = String7.str_13464
+
+@ExperimentalResourceApi
+internal val Res.string.str_13465: StringResource
+  get() = String7.str_13465
+
+@ExperimentalResourceApi
+internal val Res.string.str_13466: StringResource
+  get() = String7.str_13466
+
+@ExperimentalResourceApi
+internal val Res.string.str_13467: StringResource
+  get() = String7.str_13467
+
+@ExperimentalResourceApi
+internal val Res.string.str_13468: StringResource
+  get() = String7.str_13468
+
+@ExperimentalResourceApi
+internal val Res.string.str_13469: StringResource
+  get() = String7.str_13469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1347: StringResource
+  get() = String7.str_1347
+
+@ExperimentalResourceApi
+internal val Res.string.str_13470: StringResource
+  get() = String7.str_13470
+
+@ExperimentalResourceApi
+internal val Res.string.str_13471: StringResource
+  get() = String7.str_13471
+
+@ExperimentalResourceApi
+internal val Res.string.str_13472: StringResource
+  get() = String7.str_13472
+
+@ExperimentalResourceApi
+internal val Res.string.str_13473: StringResource
+  get() = String7.str_13473
+
+@ExperimentalResourceApi
+internal val Res.string.str_13474: StringResource
+  get() = String7.str_13474
+
+@ExperimentalResourceApi
+internal val Res.string.str_13475: StringResource
+  get() = String7.str_13475
+
+@ExperimentalResourceApi
+internal val Res.string.str_13476: StringResource
+  get() = String7.str_13476
+
+@ExperimentalResourceApi
+internal val Res.string.str_13477: StringResource
+  get() = String7.str_13477
+
+@ExperimentalResourceApi
+internal val Res.string.str_13478: StringResource
+  get() = String7.str_13478
+
+@ExperimentalResourceApi
+internal val Res.string.str_13479: StringResource
+  get() = String7.str_13479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1348: StringResource
+  get() = String7.str_1348
+
+@ExperimentalResourceApi
+internal val Res.string.str_13480: StringResource
+  get() = String7.str_13480
+
+@ExperimentalResourceApi
+internal val Res.string.str_13481: StringResource
+  get() = String7.str_13481
+
+@ExperimentalResourceApi
+internal val Res.string.str_13482: StringResource
+  get() = String7.str_13482
+
+@ExperimentalResourceApi
+internal val Res.string.str_13483: StringResource
+  get() = String7.str_13483
+
+@ExperimentalResourceApi
+internal val Res.string.str_13484: StringResource
+  get() = String7.str_13484
+
+@ExperimentalResourceApi
+internal val Res.string.str_13485: StringResource
+  get() = String7.str_13485
+
+@ExperimentalResourceApi
+internal val Res.string.str_13486: StringResource
+  get() = String7.str_13486
+
+@ExperimentalResourceApi
+internal val Res.string.str_13487: StringResource
+  get() = String7.str_13487
+
+@ExperimentalResourceApi
+internal val Res.string.str_13488: StringResource
+  get() = String7.str_13488
+
+@ExperimentalResourceApi
+internal val Res.string.str_13489: StringResource
+  get() = String7.str_13489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1349: StringResource
+  get() = String7.str_1349
+
+@ExperimentalResourceApi
+internal val Res.string.str_13490: StringResource
+  get() = String7.str_13490
+
+@ExperimentalResourceApi
+internal val Res.string.str_13491: StringResource
+  get() = String7.str_13491
+
+@ExperimentalResourceApi
+internal val Res.string.str_13492: StringResource
+  get() = String7.str_13492
+
+@ExperimentalResourceApi
+internal val Res.string.str_13493: StringResource
+  get() = String7.str_13493
+
+@ExperimentalResourceApi
+internal val Res.string.str_13494: StringResource
+  get() = String7.str_13494
+
+@ExperimentalResourceApi
+internal val Res.string.str_13495: StringResource
+  get() = String7.str_13495
+
+@ExperimentalResourceApi
+internal val Res.string.str_13496: StringResource
+  get() = String7.str_13496
+
+@ExperimentalResourceApi
+internal val Res.string.str_13497: StringResource
+  get() = String7.str_13497
+
+@ExperimentalResourceApi
+internal val Res.string.str_13498: StringResource
+  get() = String7.str_13498
+
+@ExperimentalResourceApi
+internal val Res.string.str_13499: StringResource
+  get() = String7.str_13499
+
+@ExperimentalResourceApi
+internal val Res.string.str_135: StringResource
+  get() = String7.str_135
+
+@ExperimentalResourceApi
+internal val Res.string.str_1350: StringResource
+  get() = String7.str_1350
+
+@ExperimentalResourceApi
+internal val Res.string.str_13500: StringResource
+  get() = String7.str_13500
+
+@ExperimentalResourceApi
+internal val Res.string.str_13501: StringResource
+  get() = String7.str_13501
+
+@ExperimentalResourceApi
+internal val Res.string.str_13502: StringResource
+  get() = String7.str_13502
+
+@ExperimentalResourceApi
+internal val Res.string.str_13503: StringResource
+  get() = String7.str_13503
+
+@ExperimentalResourceApi
+internal val Res.string.str_13504: StringResource
+  get() = String7.str_13504
+
+@ExperimentalResourceApi
+internal val Res.string.str_13505: StringResource
+  get() = String7.str_13505
+
+@ExperimentalResourceApi
+internal val Res.string.str_13506: StringResource
+  get() = String7.str_13506
+
+@ExperimentalResourceApi
+internal val Res.string.str_13507: StringResource
+  get() = String7.str_13507
+
+@ExperimentalResourceApi
+internal val Res.string.str_13508: StringResource
+  get() = String7.str_13508
+
+@ExperimentalResourceApi
+internal val Res.string.str_13509: StringResource
+  get() = String7.str_13509
+
+@ExperimentalResourceApi
+internal val Res.string.str_1351: StringResource
+  get() = String7.str_1351
+
+@ExperimentalResourceApi
+internal val Res.string.str_13510: StringResource
+  get() = String7.str_13510
+
+@ExperimentalResourceApi
+internal val Res.string.str_13511: StringResource
+  get() = String7.str_13511
+
+@ExperimentalResourceApi
+internal val Res.string.str_13512: StringResource
+  get() = String7.str_13512
+
+@ExperimentalResourceApi
+internal val Res.string.str_13513: StringResource
+  get() = String7.str_13513
+
+@ExperimentalResourceApi
+internal val Res.string.str_13514: StringResource
+  get() = String7.str_13514
+
+@ExperimentalResourceApi
+internal val Res.string.str_13515: StringResource
+  get() = String7.str_13515
+
+@ExperimentalResourceApi
+internal val Res.string.str_13516: StringResource
+  get() = String7.str_13516
+
+@ExperimentalResourceApi
+internal val Res.string.str_13517: StringResource
+  get() = String7.str_13517
+
+@ExperimentalResourceApi
+internal val Res.string.str_13518: StringResource
+  get() = String7.str_13518
+
+@ExperimentalResourceApi
+internal val Res.string.str_13519: StringResource
+  get() = String7.str_13519
+
+@ExperimentalResourceApi
+internal val Res.string.str_1352: StringResource
+  get() = String7.str_1352
+
+@ExperimentalResourceApi
+internal val Res.string.str_13520: StringResource
+  get() = String7.str_13520
+
+@ExperimentalResourceApi
+internal val Res.string.str_13521: StringResource
+  get() = String7.str_13521
+
+@ExperimentalResourceApi
+internal val Res.string.str_13522: StringResource
+  get() = String7.str_13522
+
+@ExperimentalResourceApi
+internal val Res.string.str_13523: StringResource
+  get() = String7.str_13523
+
+@ExperimentalResourceApi
+internal val Res.string.str_13524: StringResource
+  get() = String7.str_13524
+
+@ExperimentalResourceApi
+internal val Res.string.str_13525: StringResource
+  get() = String7.str_13525
+
+@ExperimentalResourceApi
+internal val Res.string.str_13526: StringResource
+  get() = String7.str_13526
+
+@ExperimentalResourceApi
+internal val Res.string.str_13527: StringResource
+  get() = String7.str_13527
+
+@ExperimentalResourceApi
+internal val Res.string.str_13528: StringResource
+  get() = String7.str_13528
+
+@ExperimentalResourceApi
+internal val Res.string.str_13529: StringResource
+  get() = String7.str_13529
+
+@ExperimentalResourceApi
+internal val Res.string.str_1353: StringResource
+  get() = String7.str_1353
+
+@ExperimentalResourceApi
+internal val Res.string.str_13530: StringResource
+  get() = String7.str_13530
+
+@ExperimentalResourceApi
+internal val Res.string.str_13531: StringResource
+  get() = String7.str_13531
+
+@ExperimentalResourceApi
+internal val Res.string.str_13532: StringResource
+  get() = String7.str_13532
+
+@ExperimentalResourceApi
+internal val Res.string.str_13533: StringResource
+  get() = String7.str_13533
+
+@ExperimentalResourceApi
+internal val Res.string.str_13534: StringResource
+  get() = String7.str_13534
+
+@ExperimentalResourceApi
+internal val Res.string.str_13535: StringResource
+  get() = String7.str_13535
+
+@ExperimentalResourceApi
+internal val Res.string.str_13536: StringResource
+  get() = String7.str_13536
+
+@ExperimentalResourceApi
+internal val Res.string.str_13537: StringResource
+  get() = String7.str_13537
+
+@ExperimentalResourceApi
+internal val Res.string.str_13538: StringResource
+  get() = String7.str_13538
+
+@ExperimentalResourceApi
+internal val Res.string.str_13539: StringResource
+  get() = String7.str_13539
+
+@ExperimentalResourceApi
+internal val Res.string.str_1354: StringResource
+  get() = String7.str_1354
+
+@ExperimentalResourceApi
+internal val Res.string.str_13540: StringResource
+  get() = String7.str_13540
+
+@ExperimentalResourceApi
+internal val Res.string.str_13541: StringResource
+  get() = String7.str_13541
+
+@ExperimentalResourceApi
+internal val Res.string.str_13542: StringResource
+  get() = String7.str_13542
+
+@ExperimentalResourceApi
+internal val Res.string.str_13543: StringResource
+  get() = String7.str_13543
+
+@ExperimentalResourceApi
+internal val Res.string.str_13544: StringResource
+  get() = String7.str_13544
+
+@ExperimentalResourceApi
+internal val Res.string.str_13545: StringResource
+  get() = String7.str_13545
+
+@ExperimentalResourceApi
+internal val Res.string.str_13546: StringResource
+  get() = String7.str_13546
+
+@ExperimentalResourceApi
+internal val Res.string.str_13547: StringResource
+  get() = String7.str_13547
+
+@ExperimentalResourceApi
+internal val Res.string.str_13548: StringResource
+  get() = String7.str_13548
+
+@ExperimentalResourceApi
+internal val Res.string.str_13549: StringResource
+  get() = String7.str_13549
+
+@ExperimentalResourceApi
+internal val Res.string.str_1355: StringResource
+  get() = String7.str_1355
+
+@ExperimentalResourceApi
+internal val Res.string.str_13550: StringResource
+  get() = String7.str_13550
+
+@ExperimentalResourceApi
+internal val Res.string.str_13551: StringResource
+  get() = String7.str_13551
+
+@ExperimentalResourceApi
+internal val Res.string.str_13552: StringResource
+  get() = String7.str_13552
+
+@ExperimentalResourceApi
+internal val Res.string.str_13553: StringResource
+  get() = String7.str_13553
+
+@ExperimentalResourceApi
+internal val Res.string.str_13554: StringResource
+  get() = String7.str_13554
+
+@ExperimentalResourceApi
+internal val Res.string.str_13555: StringResource
+  get() = String7.str_13555
+
+@ExperimentalResourceApi
+internal val Res.string.str_13556: StringResource
+  get() = String7.str_13556
+
+@ExperimentalResourceApi
+internal val Res.string.str_13557: StringResource
+  get() = String7.str_13557
+
+@ExperimentalResourceApi
+internal val Res.string.str_13558: StringResource
+  get() = String7.str_13558
+
+@ExperimentalResourceApi
+internal val Res.string.str_13559: StringResource
+  get() = String7.str_13559
+
+@ExperimentalResourceApi
+internal val Res.string.str_1356: StringResource
+  get() = String7.str_1356
+
+@ExperimentalResourceApi
+internal val Res.string.str_13560: StringResource
+  get() = String7.str_13560
+
+@ExperimentalResourceApi
+internal val Res.string.str_13561: StringResource
+  get() = String7.str_13561
+
+@ExperimentalResourceApi
+internal val Res.string.str_13562: StringResource
+  get() = String7.str_13562
+
+@ExperimentalResourceApi
+internal val Res.string.str_13563: StringResource
+  get() = String7.str_13563
+
+@ExperimentalResourceApi
+internal val Res.string.str_13564: StringResource
+  get() = String7.str_13564
+
+@ExperimentalResourceApi
+internal val Res.string.str_13565: StringResource
+  get() = String7.str_13565
+
+@ExperimentalResourceApi
+internal val Res.string.str_13566: StringResource
+  get() = String7.str_13566
+
+@ExperimentalResourceApi
+internal val Res.string.str_13567: StringResource
+  get() = String7.str_13567
+
+@ExperimentalResourceApi
+internal val Res.string.str_13568: StringResource
+  get() = String7.str_13568
+
+@ExperimentalResourceApi
+internal val Res.string.str_13569: StringResource
+  get() = String7.str_13569
+
+@ExperimentalResourceApi
+internal val Res.string.str_1357: StringResource
+  get() = String7.str_1357
+
+@ExperimentalResourceApi
+internal val Res.string.str_13570: StringResource
+  get() = String7.str_13570
+
+@ExperimentalResourceApi
+internal val Res.string.str_13571: StringResource
+  get() = String7.str_13571
+
+@ExperimentalResourceApi
+internal val Res.string.str_13572: StringResource
+  get() = String7.str_13572
+
+@ExperimentalResourceApi
+internal val Res.string.str_13573: StringResource
+  get() = String7.str_13573
+
+@ExperimentalResourceApi
+internal val Res.string.str_13574: StringResource
+  get() = String7.str_13574
+
+@ExperimentalResourceApi
+internal val Res.string.str_13575: StringResource
+  get() = String7.str_13575
+
+@ExperimentalResourceApi
+internal val Res.string.str_13576: StringResource
+  get() = String7.str_13576
+
+@ExperimentalResourceApi
+internal val Res.string.str_13577: StringResource
+  get() = String7.str_13577
+
+@ExperimentalResourceApi
+internal val Res.string.str_13578: StringResource
+  get() = String7.str_13578
+
+@ExperimentalResourceApi
+internal val Res.string.str_13579: StringResource
+  get() = String7.str_13579
+
+@ExperimentalResourceApi
+internal val Res.string.str_1358: StringResource
+  get() = String7.str_1358
+
+@ExperimentalResourceApi
+internal val Res.string.str_13580: StringResource
+  get() = String7.str_13580
+
+@ExperimentalResourceApi
+internal val Res.string.str_13581: StringResource
+  get() = String7.str_13581
+
+@ExperimentalResourceApi
+internal val Res.string.str_13582: StringResource
+  get() = String7.str_13582
+
+@ExperimentalResourceApi
+internal val Res.string.str_13583: StringResource
+  get() = String7.str_13583
+
+@ExperimentalResourceApi
+internal val Res.string.str_13584: StringResource
+  get() = String7.str_13584
+
+@ExperimentalResourceApi
+internal val Res.string.str_13585: StringResource
+  get() = String7.str_13585
+
+@ExperimentalResourceApi
+internal val Res.string.str_13586: StringResource
+  get() = String7.str_13586
+
+@ExperimentalResourceApi
+internal val Res.string.str_13587: StringResource
+  get() = String7.str_13587
+
+@ExperimentalResourceApi
+internal val Res.string.str_13588: StringResource
+  get() = String7.str_13588
+
+@ExperimentalResourceApi
+internal val Res.string.str_13589: StringResource
+  get() = String7.str_13589
+
+@ExperimentalResourceApi
+internal val Res.string.str_1359: StringResource
+  get() = String7.str_1359
+
+@ExperimentalResourceApi
+internal val Res.string.str_13590: StringResource
+  get() = String7.str_13590
+
+@ExperimentalResourceApi
+internal val Res.string.str_13591: StringResource
+  get() = String7.str_13591
+
+@ExperimentalResourceApi
+internal val Res.string.str_13592: StringResource
+  get() = String7.str_13592
+
+@ExperimentalResourceApi
+internal val Res.string.str_13593: StringResource
+  get() = String7.str_13593
+
+@ExperimentalResourceApi
+internal val Res.string.str_13594: StringResource
+  get() = String7.str_13594
+
+@ExperimentalResourceApi
+internal val Res.string.str_13595: StringResource
+  get() = String7.str_13595
+
+@ExperimentalResourceApi
+internal val Res.string.str_13596: StringResource
+  get() = String7.str_13596
+
+@ExperimentalResourceApi
+internal val Res.string.str_13597: StringResource
+  get() = String7.str_13597

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String8.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String8.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String8 {
+  public val str_13598: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13598", "str_13598",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13599: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13599", "str_13599",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_136", "str_136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1360", "str_1360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13600: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13600", "str_13600",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13601: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13601", "str_13601",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13602: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13602", "str_13602",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13603: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13603", "str_13603",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13604: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13604", "str_13604",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13605: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13605", "str_13605",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13606: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13606", "str_13606",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13607: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13607", "str_13607",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13608: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13608", "str_13608",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13609: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13609", "str_13609",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1361", "str_1361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13610: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13610", "str_13610",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13611: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13611", "str_13611",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13612: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13612", "str_13612",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13613: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13613", "str_13613",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13614: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13614", "str_13614",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13615: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13615", "str_13615",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13616: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13616", "str_13616",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13617: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13617", "str_13617",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13618: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13618", "str_13618",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13619: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13619", "str_13619",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1362", "str_1362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13620: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13620", "str_13620",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13621: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13621", "str_13621",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13622: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13622", "str_13622",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13623: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13623", "str_13623",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13624: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13624", "str_13624",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13625: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13625", "str_13625",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13626: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13626", "str_13626",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13627: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13627", "str_13627",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13628: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13628", "str_13628",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13629: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13629", "str_13629",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1363", "str_1363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13630: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13630", "str_13630",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13631: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13631", "str_13631",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13632: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13632", "str_13632",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13633: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13633", "str_13633",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13634: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13634", "str_13634",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13635: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13635", "str_13635",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13636: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13636", "str_13636",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13637: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13637", "str_13637",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13638: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13638", "str_13638",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13639: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13639", "str_13639",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1364", "str_1364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13640: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13640", "str_13640",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13641: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13641", "str_13641",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13642: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13642", "str_13642",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13643: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13643", "str_13643",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13644: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13644", "str_13644",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13645: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13645", "str_13645",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13646: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13646", "str_13646",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13647: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13647", "str_13647",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13648: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13648", "str_13648",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13649: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13649", "str_13649",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1365", "str_1365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13650: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13650", "str_13650",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13651: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13651", "str_13651",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13652: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13652", "str_13652",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13653: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13653", "str_13653",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13654: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13654", "str_13654",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13655: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13655", "str_13655",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13656: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13656", "str_13656",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13657: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13657", "str_13657",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13658: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13658", "str_13658",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13659: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13659", "str_13659",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1366", "str_1366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13660: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13660", "str_13660",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13661: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13661", "str_13661",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13662: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13662", "str_13662",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13663: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13663", "str_13663",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13664: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13664", "str_13664",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13665: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13665", "str_13665",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13666: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13666", "str_13666",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13667: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13667", "str_13667",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13668: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13668", "str_13668",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13669: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13669", "str_13669",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1367", "str_1367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13670: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13670", "str_13670",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13671: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13671", "str_13671",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13672: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13672", "str_13672",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13673: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13673", "str_13673",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13674: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13674", "str_13674",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13675: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13675", "str_13675",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13676: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13676", "str_13676",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13677: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13677", "str_13677",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13678: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13678", "str_13678",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13679: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13679", "str_13679",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1368", "str_1368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13680: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13680", "str_13680",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13681: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13681", "str_13681",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13682: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13682", "str_13682",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13683: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13683", "str_13683",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13684: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13684", "str_13684",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13685: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13685", "str_13685",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13686: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13686", "str_13686",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13687: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13687", "str_13687",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13688: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13688", "str_13688",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13689: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13689", "str_13689",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1369", "str_1369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13690: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13690", "str_13690",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13691: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13691", "str_13691",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13692: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13692", "str_13692",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13693: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13693", "str_13693",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13694: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13694", "str_13694",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13695: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13695", "str_13695",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13696: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13696", "str_13696",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13697: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13697", "str_13697",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13698: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13698", "str_13698",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13699: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13699", "str_13699",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_137", "str_137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1370", "str_1370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13700: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13700", "str_13700",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13701: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13701", "str_13701",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13702: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13702", "str_13702",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13703: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13703", "str_13703",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13704: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13704", "str_13704",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13705: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13705", "str_13705",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13706: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13706", "str_13706",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13707: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13707", "str_13707",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13708: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13708", "str_13708",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13709: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13709", "str_13709",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1371", "str_1371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13710: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13710", "str_13710",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13711: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13711", "str_13711",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13712: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13712", "str_13712",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13713: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13713", "str_13713",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13714: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13714", "str_13714",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13715: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13715", "str_13715",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13716: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13716", "str_13716",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13717: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13717", "str_13717",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13718: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13718", "str_13718",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13719: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13719", "str_13719",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1372", "str_1372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13720: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13720", "str_13720",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13721: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13721", "str_13721",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13722: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13722", "str_13722",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13723: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13723", "str_13723",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13724: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13724", "str_13724",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13725: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13725", "str_13725",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13726: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13726", "str_13726",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13727: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13727", "str_13727",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13728: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13728", "str_13728",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13729: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13729", "str_13729",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1373", "str_1373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13730: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13730", "str_13730",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13731: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13731", "str_13731",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13732: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13732", "str_13732",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13733: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13733", "str_13733",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13734: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13734", "str_13734",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13735: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13735", "str_13735",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13736: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13736", "str_13736",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13737: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13737", "str_13737",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13738: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13738", "str_13738",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13739: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13739", "str_13739",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1374", "str_1374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13740: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13740", "str_13740",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13741: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13741", "str_13741",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13742: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13742", "str_13742",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13743: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13743", "str_13743",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13744: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13744", "str_13744",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13745: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13745", "str_13745",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13746: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13746", "str_13746",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13747: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13747", "str_13747",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13748: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13748", "str_13748",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13749: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13749", "str_13749",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1375", "str_1375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13750: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13750", "str_13750",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13751: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13751", "str_13751",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13752: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13752", "str_13752",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13753: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13753", "str_13753",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13754: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13754", "str_13754",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13755: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13755", "str_13755",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13756: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13756", "str_13756",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13757: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13757", "str_13757",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13758: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13758", "str_13758",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13759: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13759", "str_13759",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1376", "str_1376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13760: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13760", "str_13760",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13761: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13761", "str_13761",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13762: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13762", "str_13762",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13763: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13763", "str_13763",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13764: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13764", "str_13764",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13765: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13765", "str_13765",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13766: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13766", "str_13766",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13767: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13767", "str_13767",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13768: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13768", "str_13768",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13769: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13769", "str_13769",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1377", "str_1377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13770: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13770", "str_13770",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13771: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13771", "str_13771",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13772: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13772", "str_13772",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13773: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13773", "str_13773",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13774: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13774", "str_13774",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13775: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13775", "str_13775",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13776: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13776", "str_13776",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13777: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13777", "str_13777",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13778: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13778", "str_13778",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13779: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13779", "str_13779",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1378", "str_1378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13780: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13780", "str_13780",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13781: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13781", "str_13781",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13782: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13782", "str_13782",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13783: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13783", "str_13783",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13784: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13784", "str_13784",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13785: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13785", "str_13785",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13786: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13786", "str_13786",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13787: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13787", "str_13787",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13788: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13788", "str_13788",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13789: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13789", "str_13789",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1379", "str_1379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13790: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13790", "str_13790",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13791: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13791", "str_13791",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13792: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13792", "str_13792",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13793: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13793", "str_13793",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13794: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13794", "str_13794",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13795: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13795", "str_13795",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13796: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13796", "str_13796",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13797: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13797", "str_13797",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13798: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13798", "str_13798",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13799: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13799", "str_13799",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_138", "str_138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1380", "str_1380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13800: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13800", "str_13800",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13801: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13801", "str_13801",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13802: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13802", "str_13802",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13803: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13803", "str_13803",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13804: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13804", "str_13804",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13805: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13805", "str_13805",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13806: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13806", "str_13806",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13807: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13807", "str_13807",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13808: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13808", "str_13808",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13809: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13809", "str_13809",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1381", "str_1381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13810: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13810", "str_13810",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13811: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13811", "str_13811",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13812: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13812", "str_13812",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13813: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13813", "str_13813",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13814: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13814", "str_13814",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13815: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13815", "str_13815",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13816: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13816", "str_13816",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13817: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13817", "str_13817",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13818: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13818", "str_13818",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13819: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13819", "str_13819",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1382", "str_1382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13820: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13820", "str_13820",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13821: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13821", "str_13821",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13822: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13822", "str_13822",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13823: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13823", "str_13823",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13824: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13824", "str_13824",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13825: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13825", "str_13825",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13826: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13826", "str_13826",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13827: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13827", "str_13827",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13828: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13828", "str_13828",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13829: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13829", "str_13829",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1383", "str_1383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13830: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13830", "str_13830",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13831: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13831", "str_13831",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13832: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13832", "str_13832",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13833: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13833", "str_13833",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13834: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13834", "str_13834",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13835: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13835", "str_13835",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13836: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13836", "str_13836",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13837: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13837", "str_13837",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13838: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13838", "str_13838",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13839: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13839", "str_13839",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1384", "str_1384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13840: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13840", "str_13840",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13841: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13841", "str_13841",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13842: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13842", "str_13842",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13843: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13843", "str_13843",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13844: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13844", "str_13844",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13845: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13845", "str_13845",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13846: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13846", "str_13846",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13847: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13847", "str_13847",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13848: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13848", "str_13848",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13849: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13849", "str_13849",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1385", "str_1385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13850: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13850", "str_13850",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13851: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13851", "str_13851",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13852: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13852", "str_13852",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13853: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13853", "str_13853",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13854: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13854", "str_13854",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13855: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13855", "str_13855",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13856: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13856", "str_13856",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13857: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13857", "str_13857",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13858: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13858", "str_13858",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13859: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13859", "str_13859",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1386", "str_1386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13860: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13860", "str_13860",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13861: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13861", "str_13861",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13862: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13862", "str_13862",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13863: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13863", "str_13863",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13864: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13864", "str_13864",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13865: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13865", "str_13865",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13866: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13866", "str_13866",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13867: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13867", "str_13867",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13868: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13868", "str_13868",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13869: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13869", "str_13869",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1387", "str_1387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13870: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13870", "str_13870",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13871: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13871", "str_13871",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13872: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13872", "str_13872",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13873: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13873", "str_13873",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13874: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13874", "str_13874",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13875: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13875", "str_13875",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13876: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13876", "str_13876",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13877: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13877", "str_13877",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13878: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13878", "str_13878",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13879: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13879", "str_13879",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1388", "str_1388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13880: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13880", "str_13880",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13881: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13881", "str_13881",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13882: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13882", "str_13882",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13883: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13883", "str_13883",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13884: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13884", "str_13884",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13885: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13885", "str_13885",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13886: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13886", "str_13886",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13887: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13887", "str_13887",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13888: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13888", "str_13888",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13889: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13889", "str_13889",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1389", "str_1389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13890: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13890", "str_13890",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13891: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13891", "str_13891",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13892: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13892", "str_13892",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13893: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13893", "str_13893",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13894: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13894", "str_13894",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13895: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13895", "str_13895",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13896: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13896", "str_13896",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13897: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13897", "str_13897",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13898: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13898", "str_13898",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13899: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13899", "str_13899",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_139", "str_139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1390", "str_1390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13900: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13900", "str_13900",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13901: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13901", "str_13901",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13902: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13902", "str_13902",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13903: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13903", "str_13903",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13904: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13904", "str_13904",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13905: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13905", "str_13905",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13906: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13906", "str_13906",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13907: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13907", "str_13907",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13908: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13908", "str_13908",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13909: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13909", "str_13909",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1391", "str_1391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13910: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13910", "str_13910",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13911: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13911", "str_13911",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13912: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13912", "str_13912",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13913: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13913", "str_13913",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13914: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13914", "str_13914",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13915: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13915", "str_13915",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13916: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13916", "str_13916",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13917: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13917", "str_13917",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13918: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13918", "str_13918",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13919: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13919", "str_13919",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1392", "str_1392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13920: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13920", "str_13920",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13921: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13921", "str_13921",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13922: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13922", "str_13922",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13923: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13923", "str_13923",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13924: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13924", "str_13924",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13925: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13925", "str_13925",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13926: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13926", "str_13926",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13927: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13927", "str_13927",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13928: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13928", "str_13928",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13929: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13929", "str_13929",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1393", "str_1393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13930: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13930", "str_13930",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13931: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13931", "str_13931",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13932: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13932", "str_13932",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13933: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13933", "str_13933",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13934: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13934", "str_13934",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13935: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13935", "str_13935",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13936: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13936", "str_13936",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13937: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13937", "str_13937",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13938: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13938", "str_13938",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13939: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13939", "str_13939",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1394", "str_1394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13940: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13940", "str_13940",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13941: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13941", "str_13941",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13942: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13942", "str_13942",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13943: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13943", "str_13943",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13944: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13944", "str_13944",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13945: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13945", "str_13945",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13946: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13946", "str_13946",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13947: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13947", "str_13947",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13948: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13948", "str_13948",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13949: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13949", "str_13949",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1395", "str_1395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13950: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13950", "str_13950",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13951: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13951", "str_13951",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13952: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13952", "str_13952",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13953: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13953", "str_13953",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13954: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13954", "str_13954",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13955: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13955", "str_13955",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13956: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13956", "str_13956",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13957: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13957", "str_13957",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13958: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13958", "str_13958",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13959: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13959", "str_13959",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1396", "str_1396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13960: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13960", "str_13960",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13961: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13961", "str_13961",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13962: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13962", "str_13962",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13963: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13963", "str_13963",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13964: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13964", "str_13964",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13965: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13965", "str_13965",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13966: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13966", "str_13966",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13967: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13967", "str_13967",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13968: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13968", "str_13968",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13969: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13969", "str_13969",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1397", "str_1397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13970: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13970", "str_13970",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13971: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13971", "str_13971",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13972: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13972", "str_13972",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13973: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13973", "str_13973",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13974: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13974", "str_13974",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13975: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13975", "str_13975",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13976: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13976", "str_13976",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13977: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13977", "str_13977",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13978: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13978", "str_13978",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13979: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13979", "str_13979",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1398", "str_1398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13980: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13980", "str_13980",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13981: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13981", "str_13981",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13982: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13982", "str_13982",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13983: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13983", "str_13983",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13984: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13984", "str_13984",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13985: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13985", "str_13985",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13986: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13986", "str_13986",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13987: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13987", "str_13987",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13988: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13988", "str_13988",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13989: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13989", "str_13989",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1399", "str_1399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13990: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13990", "str_13990",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13991: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13991", "str_13991",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13992: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13992", "str_13992",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13993: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13993", "str_13993",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13994: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13994", "str_13994",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13995: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13995", "str_13995",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13996: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13996", "str_13996",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13997: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13997", "str_13997",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13998: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13998", "str_13998",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_13999: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_13999", "str_13999",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14", "str_14",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_140", "str_140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1400", "str_1400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14000: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14000", "str_14000",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14001: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14001", "str_14001",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14002: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14002", "str_14002",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14003: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14003", "str_14003",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14004: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14004", "str_14004",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14005: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14005", "str_14005",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14006: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14006", "str_14006",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14007: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14007", "str_14007",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14008: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14008", "str_14008",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14009: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14009", "str_14009",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1401", "str_1401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14010: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14010", "str_14010",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14011: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14011", "str_14011",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14012: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14012", "str_14012",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14013: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14013", "str_14013",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14014: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14014", "str_14014",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14015: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14015", "str_14015",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14016: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14016", "str_14016",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14017: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14017", "str_14017",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14018: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14018", "str_14018",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14019: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14019", "str_14019",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1402", "str_1402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14020: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14020", "str_14020",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14021: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14021", "str_14021",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14022: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14022", "str_14022",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14023: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14023", "str_14023",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14024: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14024", "str_14024",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14025: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14025", "str_14025",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14026: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14026", "str_14026",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14027: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14027", "str_14027",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14028: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14028", "str_14028",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14029: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14029", "str_14029",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1403", "str_1403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14030: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14030", "str_14030",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14031: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14031", "str_14031",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14032: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14032", "str_14032",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14033: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14033", "str_14033",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14034: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14034", "str_14034",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14035: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14035", "str_14035",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14036: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14036", "str_14036",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14037: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14037", "str_14037",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14038: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14038", "str_14038",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14039: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14039", "str_14039",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1404", "str_1404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14040: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14040", "str_14040",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14041: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14041", "str_14041",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14042: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14042", "str_14042",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14043: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14043", "str_14043",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14044: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14044", "str_14044",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14045: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14045", "str_14045",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14046: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14046", "str_14046",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_13598: StringResource
+  get() = String8.str_13598
+
+@ExperimentalResourceApi
+internal val Res.string.str_13599: StringResource
+  get() = String8.str_13599
+
+@ExperimentalResourceApi
+internal val Res.string.str_136: StringResource
+  get() = String8.str_136
+
+@ExperimentalResourceApi
+internal val Res.string.str_1360: StringResource
+  get() = String8.str_1360
+
+@ExperimentalResourceApi
+internal val Res.string.str_13600: StringResource
+  get() = String8.str_13600
+
+@ExperimentalResourceApi
+internal val Res.string.str_13601: StringResource
+  get() = String8.str_13601
+
+@ExperimentalResourceApi
+internal val Res.string.str_13602: StringResource
+  get() = String8.str_13602
+
+@ExperimentalResourceApi
+internal val Res.string.str_13603: StringResource
+  get() = String8.str_13603
+
+@ExperimentalResourceApi
+internal val Res.string.str_13604: StringResource
+  get() = String8.str_13604
+
+@ExperimentalResourceApi
+internal val Res.string.str_13605: StringResource
+  get() = String8.str_13605
+
+@ExperimentalResourceApi
+internal val Res.string.str_13606: StringResource
+  get() = String8.str_13606
+
+@ExperimentalResourceApi
+internal val Res.string.str_13607: StringResource
+  get() = String8.str_13607
+
+@ExperimentalResourceApi
+internal val Res.string.str_13608: StringResource
+  get() = String8.str_13608
+
+@ExperimentalResourceApi
+internal val Res.string.str_13609: StringResource
+  get() = String8.str_13609
+
+@ExperimentalResourceApi
+internal val Res.string.str_1361: StringResource
+  get() = String8.str_1361
+
+@ExperimentalResourceApi
+internal val Res.string.str_13610: StringResource
+  get() = String8.str_13610
+
+@ExperimentalResourceApi
+internal val Res.string.str_13611: StringResource
+  get() = String8.str_13611
+
+@ExperimentalResourceApi
+internal val Res.string.str_13612: StringResource
+  get() = String8.str_13612
+
+@ExperimentalResourceApi
+internal val Res.string.str_13613: StringResource
+  get() = String8.str_13613
+
+@ExperimentalResourceApi
+internal val Res.string.str_13614: StringResource
+  get() = String8.str_13614
+
+@ExperimentalResourceApi
+internal val Res.string.str_13615: StringResource
+  get() = String8.str_13615
+
+@ExperimentalResourceApi
+internal val Res.string.str_13616: StringResource
+  get() = String8.str_13616
+
+@ExperimentalResourceApi
+internal val Res.string.str_13617: StringResource
+  get() = String8.str_13617
+
+@ExperimentalResourceApi
+internal val Res.string.str_13618: StringResource
+  get() = String8.str_13618
+
+@ExperimentalResourceApi
+internal val Res.string.str_13619: StringResource
+  get() = String8.str_13619
+
+@ExperimentalResourceApi
+internal val Res.string.str_1362: StringResource
+  get() = String8.str_1362
+
+@ExperimentalResourceApi
+internal val Res.string.str_13620: StringResource
+  get() = String8.str_13620
+
+@ExperimentalResourceApi
+internal val Res.string.str_13621: StringResource
+  get() = String8.str_13621
+
+@ExperimentalResourceApi
+internal val Res.string.str_13622: StringResource
+  get() = String8.str_13622
+
+@ExperimentalResourceApi
+internal val Res.string.str_13623: StringResource
+  get() = String8.str_13623
+
+@ExperimentalResourceApi
+internal val Res.string.str_13624: StringResource
+  get() = String8.str_13624
+
+@ExperimentalResourceApi
+internal val Res.string.str_13625: StringResource
+  get() = String8.str_13625
+
+@ExperimentalResourceApi
+internal val Res.string.str_13626: StringResource
+  get() = String8.str_13626
+
+@ExperimentalResourceApi
+internal val Res.string.str_13627: StringResource
+  get() = String8.str_13627
+
+@ExperimentalResourceApi
+internal val Res.string.str_13628: StringResource
+  get() = String8.str_13628
+
+@ExperimentalResourceApi
+internal val Res.string.str_13629: StringResource
+  get() = String8.str_13629
+
+@ExperimentalResourceApi
+internal val Res.string.str_1363: StringResource
+  get() = String8.str_1363
+
+@ExperimentalResourceApi
+internal val Res.string.str_13630: StringResource
+  get() = String8.str_13630
+
+@ExperimentalResourceApi
+internal val Res.string.str_13631: StringResource
+  get() = String8.str_13631
+
+@ExperimentalResourceApi
+internal val Res.string.str_13632: StringResource
+  get() = String8.str_13632
+
+@ExperimentalResourceApi
+internal val Res.string.str_13633: StringResource
+  get() = String8.str_13633
+
+@ExperimentalResourceApi
+internal val Res.string.str_13634: StringResource
+  get() = String8.str_13634
+
+@ExperimentalResourceApi
+internal val Res.string.str_13635: StringResource
+  get() = String8.str_13635
+
+@ExperimentalResourceApi
+internal val Res.string.str_13636: StringResource
+  get() = String8.str_13636
+
+@ExperimentalResourceApi
+internal val Res.string.str_13637: StringResource
+  get() = String8.str_13637
+
+@ExperimentalResourceApi
+internal val Res.string.str_13638: StringResource
+  get() = String8.str_13638
+
+@ExperimentalResourceApi
+internal val Res.string.str_13639: StringResource
+  get() = String8.str_13639
+
+@ExperimentalResourceApi
+internal val Res.string.str_1364: StringResource
+  get() = String8.str_1364
+
+@ExperimentalResourceApi
+internal val Res.string.str_13640: StringResource
+  get() = String8.str_13640
+
+@ExperimentalResourceApi
+internal val Res.string.str_13641: StringResource
+  get() = String8.str_13641
+
+@ExperimentalResourceApi
+internal val Res.string.str_13642: StringResource
+  get() = String8.str_13642
+
+@ExperimentalResourceApi
+internal val Res.string.str_13643: StringResource
+  get() = String8.str_13643
+
+@ExperimentalResourceApi
+internal val Res.string.str_13644: StringResource
+  get() = String8.str_13644
+
+@ExperimentalResourceApi
+internal val Res.string.str_13645: StringResource
+  get() = String8.str_13645
+
+@ExperimentalResourceApi
+internal val Res.string.str_13646: StringResource
+  get() = String8.str_13646
+
+@ExperimentalResourceApi
+internal val Res.string.str_13647: StringResource
+  get() = String8.str_13647
+
+@ExperimentalResourceApi
+internal val Res.string.str_13648: StringResource
+  get() = String8.str_13648
+
+@ExperimentalResourceApi
+internal val Res.string.str_13649: StringResource
+  get() = String8.str_13649
+
+@ExperimentalResourceApi
+internal val Res.string.str_1365: StringResource
+  get() = String8.str_1365
+
+@ExperimentalResourceApi
+internal val Res.string.str_13650: StringResource
+  get() = String8.str_13650
+
+@ExperimentalResourceApi
+internal val Res.string.str_13651: StringResource
+  get() = String8.str_13651
+
+@ExperimentalResourceApi
+internal val Res.string.str_13652: StringResource
+  get() = String8.str_13652
+
+@ExperimentalResourceApi
+internal val Res.string.str_13653: StringResource
+  get() = String8.str_13653
+
+@ExperimentalResourceApi
+internal val Res.string.str_13654: StringResource
+  get() = String8.str_13654
+
+@ExperimentalResourceApi
+internal val Res.string.str_13655: StringResource
+  get() = String8.str_13655
+
+@ExperimentalResourceApi
+internal val Res.string.str_13656: StringResource
+  get() = String8.str_13656
+
+@ExperimentalResourceApi
+internal val Res.string.str_13657: StringResource
+  get() = String8.str_13657
+
+@ExperimentalResourceApi
+internal val Res.string.str_13658: StringResource
+  get() = String8.str_13658
+
+@ExperimentalResourceApi
+internal val Res.string.str_13659: StringResource
+  get() = String8.str_13659
+
+@ExperimentalResourceApi
+internal val Res.string.str_1366: StringResource
+  get() = String8.str_1366
+
+@ExperimentalResourceApi
+internal val Res.string.str_13660: StringResource
+  get() = String8.str_13660
+
+@ExperimentalResourceApi
+internal val Res.string.str_13661: StringResource
+  get() = String8.str_13661
+
+@ExperimentalResourceApi
+internal val Res.string.str_13662: StringResource
+  get() = String8.str_13662
+
+@ExperimentalResourceApi
+internal val Res.string.str_13663: StringResource
+  get() = String8.str_13663
+
+@ExperimentalResourceApi
+internal val Res.string.str_13664: StringResource
+  get() = String8.str_13664
+
+@ExperimentalResourceApi
+internal val Res.string.str_13665: StringResource
+  get() = String8.str_13665
+
+@ExperimentalResourceApi
+internal val Res.string.str_13666: StringResource
+  get() = String8.str_13666
+
+@ExperimentalResourceApi
+internal val Res.string.str_13667: StringResource
+  get() = String8.str_13667
+
+@ExperimentalResourceApi
+internal val Res.string.str_13668: StringResource
+  get() = String8.str_13668
+
+@ExperimentalResourceApi
+internal val Res.string.str_13669: StringResource
+  get() = String8.str_13669
+
+@ExperimentalResourceApi
+internal val Res.string.str_1367: StringResource
+  get() = String8.str_1367
+
+@ExperimentalResourceApi
+internal val Res.string.str_13670: StringResource
+  get() = String8.str_13670
+
+@ExperimentalResourceApi
+internal val Res.string.str_13671: StringResource
+  get() = String8.str_13671
+
+@ExperimentalResourceApi
+internal val Res.string.str_13672: StringResource
+  get() = String8.str_13672
+
+@ExperimentalResourceApi
+internal val Res.string.str_13673: StringResource
+  get() = String8.str_13673
+
+@ExperimentalResourceApi
+internal val Res.string.str_13674: StringResource
+  get() = String8.str_13674
+
+@ExperimentalResourceApi
+internal val Res.string.str_13675: StringResource
+  get() = String8.str_13675
+
+@ExperimentalResourceApi
+internal val Res.string.str_13676: StringResource
+  get() = String8.str_13676
+
+@ExperimentalResourceApi
+internal val Res.string.str_13677: StringResource
+  get() = String8.str_13677
+
+@ExperimentalResourceApi
+internal val Res.string.str_13678: StringResource
+  get() = String8.str_13678
+
+@ExperimentalResourceApi
+internal val Res.string.str_13679: StringResource
+  get() = String8.str_13679
+
+@ExperimentalResourceApi
+internal val Res.string.str_1368: StringResource
+  get() = String8.str_1368
+
+@ExperimentalResourceApi
+internal val Res.string.str_13680: StringResource
+  get() = String8.str_13680
+
+@ExperimentalResourceApi
+internal val Res.string.str_13681: StringResource
+  get() = String8.str_13681
+
+@ExperimentalResourceApi
+internal val Res.string.str_13682: StringResource
+  get() = String8.str_13682
+
+@ExperimentalResourceApi
+internal val Res.string.str_13683: StringResource
+  get() = String8.str_13683
+
+@ExperimentalResourceApi
+internal val Res.string.str_13684: StringResource
+  get() = String8.str_13684
+
+@ExperimentalResourceApi
+internal val Res.string.str_13685: StringResource
+  get() = String8.str_13685
+
+@ExperimentalResourceApi
+internal val Res.string.str_13686: StringResource
+  get() = String8.str_13686
+
+@ExperimentalResourceApi
+internal val Res.string.str_13687: StringResource
+  get() = String8.str_13687
+
+@ExperimentalResourceApi
+internal val Res.string.str_13688: StringResource
+  get() = String8.str_13688
+
+@ExperimentalResourceApi
+internal val Res.string.str_13689: StringResource
+  get() = String8.str_13689
+
+@ExperimentalResourceApi
+internal val Res.string.str_1369: StringResource
+  get() = String8.str_1369
+
+@ExperimentalResourceApi
+internal val Res.string.str_13690: StringResource
+  get() = String8.str_13690
+
+@ExperimentalResourceApi
+internal val Res.string.str_13691: StringResource
+  get() = String8.str_13691
+
+@ExperimentalResourceApi
+internal val Res.string.str_13692: StringResource
+  get() = String8.str_13692
+
+@ExperimentalResourceApi
+internal val Res.string.str_13693: StringResource
+  get() = String8.str_13693
+
+@ExperimentalResourceApi
+internal val Res.string.str_13694: StringResource
+  get() = String8.str_13694
+
+@ExperimentalResourceApi
+internal val Res.string.str_13695: StringResource
+  get() = String8.str_13695
+
+@ExperimentalResourceApi
+internal val Res.string.str_13696: StringResource
+  get() = String8.str_13696
+
+@ExperimentalResourceApi
+internal val Res.string.str_13697: StringResource
+  get() = String8.str_13697
+
+@ExperimentalResourceApi
+internal val Res.string.str_13698: StringResource
+  get() = String8.str_13698
+
+@ExperimentalResourceApi
+internal val Res.string.str_13699: StringResource
+  get() = String8.str_13699
+
+@ExperimentalResourceApi
+internal val Res.string.str_137: StringResource
+  get() = String8.str_137
+
+@ExperimentalResourceApi
+internal val Res.string.str_1370: StringResource
+  get() = String8.str_1370
+
+@ExperimentalResourceApi
+internal val Res.string.str_13700: StringResource
+  get() = String8.str_13700
+
+@ExperimentalResourceApi
+internal val Res.string.str_13701: StringResource
+  get() = String8.str_13701
+
+@ExperimentalResourceApi
+internal val Res.string.str_13702: StringResource
+  get() = String8.str_13702
+
+@ExperimentalResourceApi
+internal val Res.string.str_13703: StringResource
+  get() = String8.str_13703
+
+@ExperimentalResourceApi
+internal val Res.string.str_13704: StringResource
+  get() = String8.str_13704
+
+@ExperimentalResourceApi
+internal val Res.string.str_13705: StringResource
+  get() = String8.str_13705
+
+@ExperimentalResourceApi
+internal val Res.string.str_13706: StringResource
+  get() = String8.str_13706
+
+@ExperimentalResourceApi
+internal val Res.string.str_13707: StringResource
+  get() = String8.str_13707
+
+@ExperimentalResourceApi
+internal val Res.string.str_13708: StringResource
+  get() = String8.str_13708
+
+@ExperimentalResourceApi
+internal val Res.string.str_13709: StringResource
+  get() = String8.str_13709
+
+@ExperimentalResourceApi
+internal val Res.string.str_1371: StringResource
+  get() = String8.str_1371
+
+@ExperimentalResourceApi
+internal val Res.string.str_13710: StringResource
+  get() = String8.str_13710
+
+@ExperimentalResourceApi
+internal val Res.string.str_13711: StringResource
+  get() = String8.str_13711
+
+@ExperimentalResourceApi
+internal val Res.string.str_13712: StringResource
+  get() = String8.str_13712
+
+@ExperimentalResourceApi
+internal val Res.string.str_13713: StringResource
+  get() = String8.str_13713
+
+@ExperimentalResourceApi
+internal val Res.string.str_13714: StringResource
+  get() = String8.str_13714
+
+@ExperimentalResourceApi
+internal val Res.string.str_13715: StringResource
+  get() = String8.str_13715
+
+@ExperimentalResourceApi
+internal val Res.string.str_13716: StringResource
+  get() = String8.str_13716
+
+@ExperimentalResourceApi
+internal val Res.string.str_13717: StringResource
+  get() = String8.str_13717
+
+@ExperimentalResourceApi
+internal val Res.string.str_13718: StringResource
+  get() = String8.str_13718
+
+@ExperimentalResourceApi
+internal val Res.string.str_13719: StringResource
+  get() = String8.str_13719
+
+@ExperimentalResourceApi
+internal val Res.string.str_1372: StringResource
+  get() = String8.str_1372
+
+@ExperimentalResourceApi
+internal val Res.string.str_13720: StringResource
+  get() = String8.str_13720
+
+@ExperimentalResourceApi
+internal val Res.string.str_13721: StringResource
+  get() = String8.str_13721
+
+@ExperimentalResourceApi
+internal val Res.string.str_13722: StringResource
+  get() = String8.str_13722
+
+@ExperimentalResourceApi
+internal val Res.string.str_13723: StringResource
+  get() = String8.str_13723
+
+@ExperimentalResourceApi
+internal val Res.string.str_13724: StringResource
+  get() = String8.str_13724
+
+@ExperimentalResourceApi
+internal val Res.string.str_13725: StringResource
+  get() = String8.str_13725
+
+@ExperimentalResourceApi
+internal val Res.string.str_13726: StringResource
+  get() = String8.str_13726
+
+@ExperimentalResourceApi
+internal val Res.string.str_13727: StringResource
+  get() = String8.str_13727
+
+@ExperimentalResourceApi
+internal val Res.string.str_13728: StringResource
+  get() = String8.str_13728
+
+@ExperimentalResourceApi
+internal val Res.string.str_13729: StringResource
+  get() = String8.str_13729
+
+@ExperimentalResourceApi
+internal val Res.string.str_1373: StringResource
+  get() = String8.str_1373
+
+@ExperimentalResourceApi
+internal val Res.string.str_13730: StringResource
+  get() = String8.str_13730
+
+@ExperimentalResourceApi
+internal val Res.string.str_13731: StringResource
+  get() = String8.str_13731
+
+@ExperimentalResourceApi
+internal val Res.string.str_13732: StringResource
+  get() = String8.str_13732
+
+@ExperimentalResourceApi
+internal val Res.string.str_13733: StringResource
+  get() = String8.str_13733
+
+@ExperimentalResourceApi
+internal val Res.string.str_13734: StringResource
+  get() = String8.str_13734
+
+@ExperimentalResourceApi
+internal val Res.string.str_13735: StringResource
+  get() = String8.str_13735
+
+@ExperimentalResourceApi
+internal val Res.string.str_13736: StringResource
+  get() = String8.str_13736
+
+@ExperimentalResourceApi
+internal val Res.string.str_13737: StringResource
+  get() = String8.str_13737
+
+@ExperimentalResourceApi
+internal val Res.string.str_13738: StringResource
+  get() = String8.str_13738
+
+@ExperimentalResourceApi
+internal val Res.string.str_13739: StringResource
+  get() = String8.str_13739
+
+@ExperimentalResourceApi
+internal val Res.string.str_1374: StringResource
+  get() = String8.str_1374
+
+@ExperimentalResourceApi
+internal val Res.string.str_13740: StringResource
+  get() = String8.str_13740
+
+@ExperimentalResourceApi
+internal val Res.string.str_13741: StringResource
+  get() = String8.str_13741
+
+@ExperimentalResourceApi
+internal val Res.string.str_13742: StringResource
+  get() = String8.str_13742
+
+@ExperimentalResourceApi
+internal val Res.string.str_13743: StringResource
+  get() = String8.str_13743
+
+@ExperimentalResourceApi
+internal val Res.string.str_13744: StringResource
+  get() = String8.str_13744
+
+@ExperimentalResourceApi
+internal val Res.string.str_13745: StringResource
+  get() = String8.str_13745
+
+@ExperimentalResourceApi
+internal val Res.string.str_13746: StringResource
+  get() = String8.str_13746
+
+@ExperimentalResourceApi
+internal val Res.string.str_13747: StringResource
+  get() = String8.str_13747
+
+@ExperimentalResourceApi
+internal val Res.string.str_13748: StringResource
+  get() = String8.str_13748
+
+@ExperimentalResourceApi
+internal val Res.string.str_13749: StringResource
+  get() = String8.str_13749
+
+@ExperimentalResourceApi
+internal val Res.string.str_1375: StringResource
+  get() = String8.str_1375
+
+@ExperimentalResourceApi
+internal val Res.string.str_13750: StringResource
+  get() = String8.str_13750
+
+@ExperimentalResourceApi
+internal val Res.string.str_13751: StringResource
+  get() = String8.str_13751
+
+@ExperimentalResourceApi
+internal val Res.string.str_13752: StringResource
+  get() = String8.str_13752
+
+@ExperimentalResourceApi
+internal val Res.string.str_13753: StringResource
+  get() = String8.str_13753
+
+@ExperimentalResourceApi
+internal val Res.string.str_13754: StringResource
+  get() = String8.str_13754
+
+@ExperimentalResourceApi
+internal val Res.string.str_13755: StringResource
+  get() = String8.str_13755
+
+@ExperimentalResourceApi
+internal val Res.string.str_13756: StringResource
+  get() = String8.str_13756
+
+@ExperimentalResourceApi
+internal val Res.string.str_13757: StringResource
+  get() = String8.str_13757
+
+@ExperimentalResourceApi
+internal val Res.string.str_13758: StringResource
+  get() = String8.str_13758
+
+@ExperimentalResourceApi
+internal val Res.string.str_13759: StringResource
+  get() = String8.str_13759
+
+@ExperimentalResourceApi
+internal val Res.string.str_1376: StringResource
+  get() = String8.str_1376
+
+@ExperimentalResourceApi
+internal val Res.string.str_13760: StringResource
+  get() = String8.str_13760
+
+@ExperimentalResourceApi
+internal val Res.string.str_13761: StringResource
+  get() = String8.str_13761
+
+@ExperimentalResourceApi
+internal val Res.string.str_13762: StringResource
+  get() = String8.str_13762
+
+@ExperimentalResourceApi
+internal val Res.string.str_13763: StringResource
+  get() = String8.str_13763
+
+@ExperimentalResourceApi
+internal val Res.string.str_13764: StringResource
+  get() = String8.str_13764
+
+@ExperimentalResourceApi
+internal val Res.string.str_13765: StringResource
+  get() = String8.str_13765
+
+@ExperimentalResourceApi
+internal val Res.string.str_13766: StringResource
+  get() = String8.str_13766
+
+@ExperimentalResourceApi
+internal val Res.string.str_13767: StringResource
+  get() = String8.str_13767
+
+@ExperimentalResourceApi
+internal val Res.string.str_13768: StringResource
+  get() = String8.str_13768
+
+@ExperimentalResourceApi
+internal val Res.string.str_13769: StringResource
+  get() = String8.str_13769
+
+@ExperimentalResourceApi
+internal val Res.string.str_1377: StringResource
+  get() = String8.str_1377
+
+@ExperimentalResourceApi
+internal val Res.string.str_13770: StringResource
+  get() = String8.str_13770
+
+@ExperimentalResourceApi
+internal val Res.string.str_13771: StringResource
+  get() = String8.str_13771
+
+@ExperimentalResourceApi
+internal val Res.string.str_13772: StringResource
+  get() = String8.str_13772
+
+@ExperimentalResourceApi
+internal val Res.string.str_13773: StringResource
+  get() = String8.str_13773
+
+@ExperimentalResourceApi
+internal val Res.string.str_13774: StringResource
+  get() = String8.str_13774
+
+@ExperimentalResourceApi
+internal val Res.string.str_13775: StringResource
+  get() = String8.str_13775
+
+@ExperimentalResourceApi
+internal val Res.string.str_13776: StringResource
+  get() = String8.str_13776
+
+@ExperimentalResourceApi
+internal val Res.string.str_13777: StringResource
+  get() = String8.str_13777
+
+@ExperimentalResourceApi
+internal val Res.string.str_13778: StringResource
+  get() = String8.str_13778
+
+@ExperimentalResourceApi
+internal val Res.string.str_13779: StringResource
+  get() = String8.str_13779
+
+@ExperimentalResourceApi
+internal val Res.string.str_1378: StringResource
+  get() = String8.str_1378
+
+@ExperimentalResourceApi
+internal val Res.string.str_13780: StringResource
+  get() = String8.str_13780
+
+@ExperimentalResourceApi
+internal val Res.string.str_13781: StringResource
+  get() = String8.str_13781
+
+@ExperimentalResourceApi
+internal val Res.string.str_13782: StringResource
+  get() = String8.str_13782
+
+@ExperimentalResourceApi
+internal val Res.string.str_13783: StringResource
+  get() = String8.str_13783
+
+@ExperimentalResourceApi
+internal val Res.string.str_13784: StringResource
+  get() = String8.str_13784
+
+@ExperimentalResourceApi
+internal val Res.string.str_13785: StringResource
+  get() = String8.str_13785
+
+@ExperimentalResourceApi
+internal val Res.string.str_13786: StringResource
+  get() = String8.str_13786
+
+@ExperimentalResourceApi
+internal val Res.string.str_13787: StringResource
+  get() = String8.str_13787
+
+@ExperimentalResourceApi
+internal val Res.string.str_13788: StringResource
+  get() = String8.str_13788
+
+@ExperimentalResourceApi
+internal val Res.string.str_13789: StringResource
+  get() = String8.str_13789
+
+@ExperimentalResourceApi
+internal val Res.string.str_1379: StringResource
+  get() = String8.str_1379
+
+@ExperimentalResourceApi
+internal val Res.string.str_13790: StringResource
+  get() = String8.str_13790
+
+@ExperimentalResourceApi
+internal val Res.string.str_13791: StringResource
+  get() = String8.str_13791
+
+@ExperimentalResourceApi
+internal val Res.string.str_13792: StringResource
+  get() = String8.str_13792
+
+@ExperimentalResourceApi
+internal val Res.string.str_13793: StringResource
+  get() = String8.str_13793
+
+@ExperimentalResourceApi
+internal val Res.string.str_13794: StringResource
+  get() = String8.str_13794
+
+@ExperimentalResourceApi
+internal val Res.string.str_13795: StringResource
+  get() = String8.str_13795
+
+@ExperimentalResourceApi
+internal val Res.string.str_13796: StringResource
+  get() = String8.str_13796
+
+@ExperimentalResourceApi
+internal val Res.string.str_13797: StringResource
+  get() = String8.str_13797
+
+@ExperimentalResourceApi
+internal val Res.string.str_13798: StringResource
+  get() = String8.str_13798
+
+@ExperimentalResourceApi
+internal val Res.string.str_13799: StringResource
+  get() = String8.str_13799
+
+@ExperimentalResourceApi
+internal val Res.string.str_138: StringResource
+  get() = String8.str_138
+
+@ExperimentalResourceApi
+internal val Res.string.str_1380: StringResource
+  get() = String8.str_1380
+
+@ExperimentalResourceApi
+internal val Res.string.str_13800: StringResource
+  get() = String8.str_13800
+
+@ExperimentalResourceApi
+internal val Res.string.str_13801: StringResource
+  get() = String8.str_13801
+
+@ExperimentalResourceApi
+internal val Res.string.str_13802: StringResource
+  get() = String8.str_13802
+
+@ExperimentalResourceApi
+internal val Res.string.str_13803: StringResource
+  get() = String8.str_13803
+
+@ExperimentalResourceApi
+internal val Res.string.str_13804: StringResource
+  get() = String8.str_13804
+
+@ExperimentalResourceApi
+internal val Res.string.str_13805: StringResource
+  get() = String8.str_13805
+
+@ExperimentalResourceApi
+internal val Res.string.str_13806: StringResource
+  get() = String8.str_13806
+
+@ExperimentalResourceApi
+internal val Res.string.str_13807: StringResource
+  get() = String8.str_13807
+
+@ExperimentalResourceApi
+internal val Res.string.str_13808: StringResource
+  get() = String8.str_13808
+
+@ExperimentalResourceApi
+internal val Res.string.str_13809: StringResource
+  get() = String8.str_13809
+
+@ExperimentalResourceApi
+internal val Res.string.str_1381: StringResource
+  get() = String8.str_1381
+
+@ExperimentalResourceApi
+internal val Res.string.str_13810: StringResource
+  get() = String8.str_13810
+
+@ExperimentalResourceApi
+internal val Res.string.str_13811: StringResource
+  get() = String8.str_13811
+
+@ExperimentalResourceApi
+internal val Res.string.str_13812: StringResource
+  get() = String8.str_13812
+
+@ExperimentalResourceApi
+internal val Res.string.str_13813: StringResource
+  get() = String8.str_13813
+
+@ExperimentalResourceApi
+internal val Res.string.str_13814: StringResource
+  get() = String8.str_13814
+
+@ExperimentalResourceApi
+internal val Res.string.str_13815: StringResource
+  get() = String8.str_13815
+
+@ExperimentalResourceApi
+internal val Res.string.str_13816: StringResource
+  get() = String8.str_13816
+
+@ExperimentalResourceApi
+internal val Res.string.str_13817: StringResource
+  get() = String8.str_13817
+
+@ExperimentalResourceApi
+internal val Res.string.str_13818: StringResource
+  get() = String8.str_13818
+
+@ExperimentalResourceApi
+internal val Res.string.str_13819: StringResource
+  get() = String8.str_13819
+
+@ExperimentalResourceApi
+internal val Res.string.str_1382: StringResource
+  get() = String8.str_1382
+
+@ExperimentalResourceApi
+internal val Res.string.str_13820: StringResource
+  get() = String8.str_13820
+
+@ExperimentalResourceApi
+internal val Res.string.str_13821: StringResource
+  get() = String8.str_13821
+
+@ExperimentalResourceApi
+internal val Res.string.str_13822: StringResource
+  get() = String8.str_13822
+
+@ExperimentalResourceApi
+internal val Res.string.str_13823: StringResource
+  get() = String8.str_13823
+
+@ExperimentalResourceApi
+internal val Res.string.str_13824: StringResource
+  get() = String8.str_13824
+
+@ExperimentalResourceApi
+internal val Res.string.str_13825: StringResource
+  get() = String8.str_13825
+
+@ExperimentalResourceApi
+internal val Res.string.str_13826: StringResource
+  get() = String8.str_13826
+
+@ExperimentalResourceApi
+internal val Res.string.str_13827: StringResource
+  get() = String8.str_13827
+
+@ExperimentalResourceApi
+internal val Res.string.str_13828: StringResource
+  get() = String8.str_13828
+
+@ExperimentalResourceApi
+internal val Res.string.str_13829: StringResource
+  get() = String8.str_13829
+
+@ExperimentalResourceApi
+internal val Res.string.str_1383: StringResource
+  get() = String8.str_1383
+
+@ExperimentalResourceApi
+internal val Res.string.str_13830: StringResource
+  get() = String8.str_13830
+
+@ExperimentalResourceApi
+internal val Res.string.str_13831: StringResource
+  get() = String8.str_13831
+
+@ExperimentalResourceApi
+internal val Res.string.str_13832: StringResource
+  get() = String8.str_13832
+
+@ExperimentalResourceApi
+internal val Res.string.str_13833: StringResource
+  get() = String8.str_13833
+
+@ExperimentalResourceApi
+internal val Res.string.str_13834: StringResource
+  get() = String8.str_13834
+
+@ExperimentalResourceApi
+internal val Res.string.str_13835: StringResource
+  get() = String8.str_13835
+
+@ExperimentalResourceApi
+internal val Res.string.str_13836: StringResource
+  get() = String8.str_13836
+
+@ExperimentalResourceApi
+internal val Res.string.str_13837: StringResource
+  get() = String8.str_13837
+
+@ExperimentalResourceApi
+internal val Res.string.str_13838: StringResource
+  get() = String8.str_13838
+
+@ExperimentalResourceApi
+internal val Res.string.str_13839: StringResource
+  get() = String8.str_13839
+
+@ExperimentalResourceApi
+internal val Res.string.str_1384: StringResource
+  get() = String8.str_1384
+
+@ExperimentalResourceApi
+internal val Res.string.str_13840: StringResource
+  get() = String8.str_13840
+
+@ExperimentalResourceApi
+internal val Res.string.str_13841: StringResource
+  get() = String8.str_13841
+
+@ExperimentalResourceApi
+internal val Res.string.str_13842: StringResource
+  get() = String8.str_13842
+
+@ExperimentalResourceApi
+internal val Res.string.str_13843: StringResource
+  get() = String8.str_13843
+
+@ExperimentalResourceApi
+internal val Res.string.str_13844: StringResource
+  get() = String8.str_13844
+
+@ExperimentalResourceApi
+internal val Res.string.str_13845: StringResource
+  get() = String8.str_13845
+
+@ExperimentalResourceApi
+internal val Res.string.str_13846: StringResource
+  get() = String8.str_13846
+
+@ExperimentalResourceApi
+internal val Res.string.str_13847: StringResource
+  get() = String8.str_13847
+
+@ExperimentalResourceApi
+internal val Res.string.str_13848: StringResource
+  get() = String8.str_13848
+
+@ExperimentalResourceApi
+internal val Res.string.str_13849: StringResource
+  get() = String8.str_13849
+
+@ExperimentalResourceApi
+internal val Res.string.str_1385: StringResource
+  get() = String8.str_1385
+
+@ExperimentalResourceApi
+internal val Res.string.str_13850: StringResource
+  get() = String8.str_13850
+
+@ExperimentalResourceApi
+internal val Res.string.str_13851: StringResource
+  get() = String8.str_13851
+
+@ExperimentalResourceApi
+internal val Res.string.str_13852: StringResource
+  get() = String8.str_13852
+
+@ExperimentalResourceApi
+internal val Res.string.str_13853: StringResource
+  get() = String8.str_13853
+
+@ExperimentalResourceApi
+internal val Res.string.str_13854: StringResource
+  get() = String8.str_13854
+
+@ExperimentalResourceApi
+internal val Res.string.str_13855: StringResource
+  get() = String8.str_13855
+
+@ExperimentalResourceApi
+internal val Res.string.str_13856: StringResource
+  get() = String8.str_13856
+
+@ExperimentalResourceApi
+internal val Res.string.str_13857: StringResource
+  get() = String8.str_13857
+
+@ExperimentalResourceApi
+internal val Res.string.str_13858: StringResource
+  get() = String8.str_13858
+
+@ExperimentalResourceApi
+internal val Res.string.str_13859: StringResource
+  get() = String8.str_13859
+
+@ExperimentalResourceApi
+internal val Res.string.str_1386: StringResource
+  get() = String8.str_1386
+
+@ExperimentalResourceApi
+internal val Res.string.str_13860: StringResource
+  get() = String8.str_13860
+
+@ExperimentalResourceApi
+internal val Res.string.str_13861: StringResource
+  get() = String8.str_13861
+
+@ExperimentalResourceApi
+internal val Res.string.str_13862: StringResource
+  get() = String8.str_13862
+
+@ExperimentalResourceApi
+internal val Res.string.str_13863: StringResource
+  get() = String8.str_13863
+
+@ExperimentalResourceApi
+internal val Res.string.str_13864: StringResource
+  get() = String8.str_13864
+
+@ExperimentalResourceApi
+internal val Res.string.str_13865: StringResource
+  get() = String8.str_13865
+
+@ExperimentalResourceApi
+internal val Res.string.str_13866: StringResource
+  get() = String8.str_13866
+
+@ExperimentalResourceApi
+internal val Res.string.str_13867: StringResource
+  get() = String8.str_13867
+
+@ExperimentalResourceApi
+internal val Res.string.str_13868: StringResource
+  get() = String8.str_13868
+
+@ExperimentalResourceApi
+internal val Res.string.str_13869: StringResource
+  get() = String8.str_13869
+
+@ExperimentalResourceApi
+internal val Res.string.str_1387: StringResource
+  get() = String8.str_1387
+
+@ExperimentalResourceApi
+internal val Res.string.str_13870: StringResource
+  get() = String8.str_13870
+
+@ExperimentalResourceApi
+internal val Res.string.str_13871: StringResource
+  get() = String8.str_13871
+
+@ExperimentalResourceApi
+internal val Res.string.str_13872: StringResource
+  get() = String8.str_13872
+
+@ExperimentalResourceApi
+internal val Res.string.str_13873: StringResource
+  get() = String8.str_13873
+
+@ExperimentalResourceApi
+internal val Res.string.str_13874: StringResource
+  get() = String8.str_13874
+
+@ExperimentalResourceApi
+internal val Res.string.str_13875: StringResource
+  get() = String8.str_13875
+
+@ExperimentalResourceApi
+internal val Res.string.str_13876: StringResource
+  get() = String8.str_13876
+
+@ExperimentalResourceApi
+internal val Res.string.str_13877: StringResource
+  get() = String8.str_13877
+
+@ExperimentalResourceApi
+internal val Res.string.str_13878: StringResource
+  get() = String8.str_13878
+
+@ExperimentalResourceApi
+internal val Res.string.str_13879: StringResource
+  get() = String8.str_13879
+
+@ExperimentalResourceApi
+internal val Res.string.str_1388: StringResource
+  get() = String8.str_1388
+
+@ExperimentalResourceApi
+internal val Res.string.str_13880: StringResource
+  get() = String8.str_13880
+
+@ExperimentalResourceApi
+internal val Res.string.str_13881: StringResource
+  get() = String8.str_13881
+
+@ExperimentalResourceApi
+internal val Res.string.str_13882: StringResource
+  get() = String8.str_13882
+
+@ExperimentalResourceApi
+internal val Res.string.str_13883: StringResource
+  get() = String8.str_13883
+
+@ExperimentalResourceApi
+internal val Res.string.str_13884: StringResource
+  get() = String8.str_13884
+
+@ExperimentalResourceApi
+internal val Res.string.str_13885: StringResource
+  get() = String8.str_13885
+
+@ExperimentalResourceApi
+internal val Res.string.str_13886: StringResource
+  get() = String8.str_13886
+
+@ExperimentalResourceApi
+internal val Res.string.str_13887: StringResource
+  get() = String8.str_13887
+
+@ExperimentalResourceApi
+internal val Res.string.str_13888: StringResource
+  get() = String8.str_13888
+
+@ExperimentalResourceApi
+internal val Res.string.str_13889: StringResource
+  get() = String8.str_13889
+
+@ExperimentalResourceApi
+internal val Res.string.str_1389: StringResource
+  get() = String8.str_1389
+
+@ExperimentalResourceApi
+internal val Res.string.str_13890: StringResource
+  get() = String8.str_13890
+
+@ExperimentalResourceApi
+internal val Res.string.str_13891: StringResource
+  get() = String8.str_13891
+
+@ExperimentalResourceApi
+internal val Res.string.str_13892: StringResource
+  get() = String8.str_13892
+
+@ExperimentalResourceApi
+internal val Res.string.str_13893: StringResource
+  get() = String8.str_13893
+
+@ExperimentalResourceApi
+internal val Res.string.str_13894: StringResource
+  get() = String8.str_13894
+
+@ExperimentalResourceApi
+internal val Res.string.str_13895: StringResource
+  get() = String8.str_13895
+
+@ExperimentalResourceApi
+internal val Res.string.str_13896: StringResource
+  get() = String8.str_13896
+
+@ExperimentalResourceApi
+internal val Res.string.str_13897: StringResource
+  get() = String8.str_13897
+
+@ExperimentalResourceApi
+internal val Res.string.str_13898: StringResource
+  get() = String8.str_13898
+
+@ExperimentalResourceApi
+internal val Res.string.str_13899: StringResource
+  get() = String8.str_13899
+
+@ExperimentalResourceApi
+internal val Res.string.str_139: StringResource
+  get() = String8.str_139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1390: StringResource
+  get() = String8.str_1390
+
+@ExperimentalResourceApi
+internal val Res.string.str_13900: StringResource
+  get() = String8.str_13900
+
+@ExperimentalResourceApi
+internal val Res.string.str_13901: StringResource
+  get() = String8.str_13901
+
+@ExperimentalResourceApi
+internal val Res.string.str_13902: StringResource
+  get() = String8.str_13902
+
+@ExperimentalResourceApi
+internal val Res.string.str_13903: StringResource
+  get() = String8.str_13903
+
+@ExperimentalResourceApi
+internal val Res.string.str_13904: StringResource
+  get() = String8.str_13904
+
+@ExperimentalResourceApi
+internal val Res.string.str_13905: StringResource
+  get() = String8.str_13905
+
+@ExperimentalResourceApi
+internal val Res.string.str_13906: StringResource
+  get() = String8.str_13906
+
+@ExperimentalResourceApi
+internal val Res.string.str_13907: StringResource
+  get() = String8.str_13907
+
+@ExperimentalResourceApi
+internal val Res.string.str_13908: StringResource
+  get() = String8.str_13908
+
+@ExperimentalResourceApi
+internal val Res.string.str_13909: StringResource
+  get() = String8.str_13909
+
+@ExperimentalResourceApi
+internal val Res.string.str_1391: StringResource
+  get() = String8.str_1391
+
+@ExperimentalResourceApi
+internal val Res.string.str_13910: StringResource
+  get() = String8.str_13910
+
+@ExperimentalResourceApi
+internal val Res.string.str_13911: StringResource
+  get() = String8.str_13911
+
+@ExperimentalResourceApi
+internal val Res.string.str_13912: StringResource
+  get() = String8.str_13912
+
+@ExperimentalResourceApi
+internal val Res.string.str_13913: StringResource
+  get() = String8.str_13913
+
+@ExperimentalResourceApi
+internal val Res.string.str_13914: StringResource
+  get() = String8.str_13914
+
+@ExperimentalResourceApi
+internal val Res.string.str_13915: StringResource
+  get() = String8.str_13915
+
+@ExperimentalResourceApi
+internal val Res.string.str_13916: StringResource
+  get() = String8.str_13916
+
+@ExperimentalResourceApi
+internal val Res.string.str_13917: StringResource
+  get() = String8.str_13917
+
+@ExperimentalResourceApi
+internal val Res.string.str_13918: StringResource
+  get() = String8.str_13918
+
+@ExperimentalResourceApi
+internal val Res.string.str_13919: StringResource
+  get() = String8.str_13919
+
+@ExperimentalResourceApi
+internal val Res.string.str_1392: StringResource
+  get() = String8.str_1392
+
+@ExperimentalResourceApi
+internal val Res.string.str_13920: StringResource
+  get() = String8.str_13920
+
+@ExperimentalResourceApi
+internal val Res.string.str_13921: StringResource
+  get() = String8.str_13921
+
+@ExperimentalResourceApi
+internal val Res.string.str_13922: StringResource
+  get() = String8.str_13922
+
+@ExperimentalResourceApi
+internal val Res.string.str_13923: StringResource
+  get() = String8.str_13923
+
+@ExperimentalResourceApi
+internal val Res.string.str_13924: StringResource
+  get() = String8.str_13924
+
+@ExperimentalResourceApi
+internal val Res.string.str_13925: StringResource
+  get() = String8.str_13925
+
+@ExperimentalResourceApi
+internal val Res.string.str_13926: StringResource
+  get() = String8.str_13926
+
+@ExperimentalResourceApi
+internal val Res.string.str_13927: StringResource
+  get() = String8.str_13927
+
+@ExperimentalResourceApi
+internal val Res.string.str_13928: StringResource
+  get() = String8.str_13928
+
+@ExperimentalResourceApi
+internal val Res.string.str_13929: StringResource
+  get() = String8.str_13929
+
+@ExperimentalResourceApi
+internal val Res.string.str_1393: StringResource
+  get() = String8.str_1393
+
+@ExperimentalResourceApi
+internal val Res.string.str_13930: StringResource
+  get() = String8.str_13930
+
+@ExperimentalResourceApi
+internal val Res.string.str_13931: StringResource
+  get() = String8.str_13931
+
+@ExperimentalResourceApi
+internal val Res.string.str_13932: StringResource
+  get() = String8.str_13932
+
+@ExperimentalResourceApi
+internal val Res.string.str_13933: StringResource
+  get() = String8.str_13933
+
+@ExperimentalResourceApi
+internal val Res.string.str_13934: StringResource
+  get() = String8.str_13934
+
+@ExperimentalResourceApi
+internal val Res.string.str_13935: StringResource
+  get() = String8.str_13935
+
+@ExperimentalResourceApi
+internal val Res.string.str_13936: StringResource
+  get() = String8.str_13936
+
+@ExperimentalResourceApi
+internal val Res.string.str_13937: StringResource
+  get() = String8.str_13937
+
+@ExperimentalResourceApi
+internal val Res.string.str_13938: StringResource
+  get() = String8.str_13938
+
+@ExperimentalResourceApi
+internal val Res.string.str_13939: StringResource
+  get() = String8.str_13939
+
+@ExperimentalResourceApi
+internal val Res.string.str_1394: StringResource
+  get() = String8.str_1394
+
+@ExperimentalResourceApi
+internal val Res.string.str_13940: StringResource
+  get() = String8.str_13940
+
+@ExperimentalResourceApi
+internal val Res.string.str_13941: StringResource
+  get() = String8.str_13941
+
+@ExperimentalResourceApi
+internal val Res.string.str_13942: StringResource
+  get() = String8.str_13942
+
+@ExperimentalResourceApi
+internal val Res.string.str_13943: StringResource
+  get() = String8.str_13943
+
+@ExperimentalResourceApi
+internal val Res.string.str_13944: StringResource
+  get() = String8.str_13944
+
+@ExperimentalResourceApi
+internal val Res.string.str_13945: StringResource
+  get() = String8.str_13945
+
+@ExperimentalResourceApi
+internal val Res.string.str_13946: StringResource
+  get() = String8.str_13946
+
+@ExperimentalResourceApi
+internal val Res.string.str_13947: StringResource
+  get() = String8.str_13947
+
+@ExperimentalResourceApi
+internal val Res.string.str_13948: StringResource
+  get() = String8.str_13948
+
+@ExperimentalResourceApi
+internal val Res.string.str_13949: StringResource
+  get() = String8.str_13949
+
+@ExperimentalResourceApi
+internal val Res.string.str_1395: StringResource
+  get() = String8.str_1395
+
+@ExperimentalResourceApi
+internal val Res.string.str_13950: StringResource
+  get() = String8.str_13950
+
+@ExperimentalResourceApi
+internal val Res.string.str_13951: StringResource
+  get() = String8.str_13951
+
+@ExperimentalResourceApi
+internal val Res.string.str_13952: StringResource
+  get() = String8.str_13952
+
+@ExperimentalResourceApi
+internal val Res.string.str_13953: StringResource
+  get() = String8.str_13953
+
+@ExperimentalResourceApi
+internal val Res.string.str_13954: StringResource
+  get() = String8.str_13954
+
+@ExperimentalResourceApi
+internal val Res.string.str_13955: StringResource
+  get() = String8.str_13955
+
+@ExperimentalResourceApi
+internal val Res.string.str_13956: StringResource
+  get() = String8.str_13956
+
+@ExperimentalResourceApi
+internal val Res.string.str_13957: StringResource
+  get() = String8.str_13957
+
+@ExperimentalResourceApi
+internal val Res.string.str_13958: StringResource
+  get() = String8.str_13958
+
+@ExperimentalResourceApi
+internal val Res.string.str_13959: StringResource
+  get() = String8.str_13959
+
+@ExperimentalResourceApi
+internal val Res.string.str_1396: StringResource
+  get() = String8.str_1396
+
+@ExperimentalResourceApi
+internal val Res.string.str_13960: StringResource
+  get() = String8.str_13960
+
+@ExperimentalResourceApi
+internal val Res.string.str_13961: StringResource
+  get() = String8.str_13961
+
+@ExperimentalResourceApi
+internal val Res.string.str_13962: StringResource
+  get() = String8.str_13962
+
+@ExperimentalResourceApi
+internal val Res.string.str_13963: StringResource
+  get() = String8.str_13963
+
+@ExperimentalResourceApi
+internal val Res.string.str_13964: StringResource
+  get() = String8.str_13964
+
+@ExperimentalResourceApi
+internal val Res.string.str_13965: StringResource
+  get() = String8.str_13965
+
+@ExperimentalResourceApi
+internal val Res.string.str_13966: StringResource
+  get() = String8.str_13966
+
+@ExperimentalResourceApi
+internal val Res.string.str_13967: StringResource
+  get() = String8.str_13967
+
+@ExperimentalResourceApi
+internal val Res.string.str_13968: StringResource
+  get() = String8.str_13968
+
+@ExperimentalResourceApi
+internal val Res.string.str_13969: StringResource
+  get() = String8.str_13969
+
+@ExperimentalResourceApi
+internal val Res.string.str_1397: StringResource
+  get() = String8.str_1397
+
+@ExperimentalResourceApi
+internal val Res.string.str_13970: StringResource
+  get() = String8.str_13970
+
+@ExperimentalResourceApi
+internal val Res.string.str_13971: StringResource
+  get() = String8.str_13971
+
+@ExperimentalResourceApi
+internal val Res.string.str_13972: StringResource
+  get() = String8.str_13972
+
+@ExperimentalResourceApi
+internal val Res.string.str_13973: StringResource
+  get() = String8.str_13973
+
+@ExperimentalResourceApi
+internal val Res.string.str_13974: StringResource
+  get() = String8.str_13974
+
+@ExperimentalResourceApi
+internal val Res.string.str_13975: StringResource
+  get() = String8.str_13975
+
+@ExperimentalResourceApi
+internal val Res.string.str_13976: StringResource
+  get() = String8.str_13976
+
+@ExperimentalResourceApi
+internal val Res.string.str_13977: StringResource
+  get() = String8.str_13977
+
+@ExperimentalResourceApi
+internal val Res.string.str_13978: StringResource
+  get() = String8.str_13978
+
+@ExperimentalResourceApi
+internal val Res.string.str_13979: StringResource
+  get() = String8.str_13979
+
+@ExperimentalResourceApi
+internal val Res.string.str_1398: StringResource
+  get() = String8.str_1398
+
+@ExperimentalResourceApi
+internal val Res.string.str_13980: StringResource
+  get() = String8.str_13980
+
+@ExperimentalResourceApi
+internal val Res.string.str_13981: StringResource
+  get() = String8.str_13981
+
+@ExperimentalResourceApi
+internal val Res.string.str_13982: StringResource
+  get() = String8.str_13982
+
+@ExperimentalResourceApi
+internal val Res.string.str_13983: StringResource
+  get() = String8.str_13983
+
+@ExperimentalResourceApi
+internal val Res.string.str_13984: StringResource
+  get() = String8.str_13984
+
+@ExperimentalResourceApi
+internal val Res.string.str_13985: StringResource
+  get() = String8.str_13985
+
+@ExperimentalResourceApi
+internal val Res.string.str_13986: StringResource
+  get() = String8.str_13986
+
+@ExperimentalResourceApi
+internal val Res.string.str_13987: StringResource
+  get() = String8.str_13987
+
+@ExperimentalResourceApi
+internal val Res.string.str_13988: StringResource
+  get() = String8.str_13988
+
+@ExperimentalResourceApi
+internal val Res.string.str_13989: StringResource
+  get() = String8.str_13989
+
+@ExperimentalResourceApi
+internal val Res.string.str_1399: StringResource
+  get() = String8.str_1399
+
+@ExperimentalResourceApi
+internal val Res.string.str_13990: StringResource
+  get() = String8.str_13990
+
+@ExperimentalResourceApi
+internal val Res.string.str_13991: StringResource
+  get() = String8.str_13991
+
+@ExperimentalResourceApi
+internal val Res.string.str_13992: StringResource
+  get() = String8.str_13992
+
+@ExperimentalResourceApi
+internal val Res.string.str_13993: StringResource
+  get() = String8.str_13993
+
+@ExperimentalResourceApi
+internal val Res.string.str_13994: StringResource
+  get() = String8.str_13994
+
+@ExperimentalResourceApi
+internal val Res.string.str_13995: StringResource
+  get() = String8.str_13995
+
+@ExperimentalResourceApi
+internal val Res.string.str_13996: StringResource
+  get() = String8.str_13996
+
+@ExperimentalResourceApi
+internal val Res.string.str_13997: StringResource
+  get() = String8.str_13997
+
+@ExperimentalResourceApi
+internal val Res.string.str_13998: StringResource
+  get() = String8.str_13998
+
+@ExperimentalResourceApi
+internal val Res.string.str_13999: StringResource
+  get() = String8.str_13999
+
+@ExperimentalResourceApi
+internal val Res.string.str_14: StringResource
+  get() = String8.str_14
+
+@ExperimentalResourceApi
+internal val Res.string.str_140: StringResource
+  get() = String8.str_140
+
+@ExperimentalResourceApi
+internal val Res.string.str_1400: StringResource
+  get() = String8.str_1400
+
+@ExperimentalResourceApi
+internal val Res.string.str_14000: StringResource
+  get() = String8.str_14000
+
+@ExperimentalResourceApi
+internal val Res.string.str_14001: StringResource
+  get() = String8.str_14001
+
+@ExperimentalResourceApi
+internal val Res.string.str_14002: StringResource
+  get() = String8.str_14002
+
+@ExperimentalResourceApi
+internal val Res.string.str_14003: StringResource
+  get() = String8.str_14003
+
+@ExperimentalResourceApi
+internal val Res.string.str_14004: StringResource
+  get() = String8.str_14004
+
+@ExperimentalResourceApi
+internal val Res.string.str_14005: StringResource
+  get() = String8.str_14005
+
+@ExperimentalResourceApi
+internal val Res.string.str_14006: StringResource
+  get() = String8.str_14006
+
+@ExperimentalResourceApi
+internal val Res.string.str_14007: StringResource
+  get() = String8.str_14007
+
+@ExperimentalResourceApi
+internal val Res.string.str_14008: StringResource
+  get() = String8.str_14008
+
+@ExperimentalResourceApi
+internal val Res.string.str_14009: StringResource
+  get() = String8.str_14009
+
+@ExperimentalResourceApi
+internal val Res.string.str_1401: StringResource
+  get() = String8.str_1401
+
+@ExperimentalResourceApi
+internal val Res.string.str_14010: StringResource
+  get() = String8.str_14010
+
+@ExperimentalResourceApi
+internal val Res.string.str_14011: StringResource
+  get() = String8.str_14011
+
+@ExperimentalResourceApi
+internal val Res.string.str_14012: StringResource
+  get() = String8.str_14012
+
+@ExperimentalResourceApi
+internal val Res.string.str_14013: StringResource
+  get() = String8.str_14013
+
+@ExperimentalResourceApi
+internal val Res.string.str_14014: StringResource
+  get() = String8.str_14014
+
+@ExperimentalResourceApi
+internal val Res.string.str_14015: StringResource
+  get() = String8.str_14015
+
+@ExperimentalResourceApi
+internal val Res.string.str_14016: StringResource
+  get() = String8.str_14016
+
+@ExperimentalResourceApi
+internal val Res.string.str_14017: StringResource
+  get() = String8.str_14017
+
+@ExperimentalResourceApi
+internal val Res.string.str_14018: StringResource
+  get() = String8.str_14018
+
+@ExperimentalResourceApi
+internal val Res.string.str_14019: StringResource
+  get() = String8.str_14019
+
+@ExperimentalResourceApi
+internal val Res.string.str_1402: StringResource
+  get() = String8.str_1402
+
+@ExperimentalResourceApi
+internal val Res.string.str_14020: StringResource
+  get() = String8.str_14020
+
+@ExperimentalResourceApi
+internal val Res.string.str_14021: StringResource
+  get() = String8.str_14021
+
+@ExperimentalResourceApi
+internal val Res.string.str_14022: StringResource
+  get() = String8.str_14022
+
+@ExperimentalResourceApi
+internal val Res.string.str_14023: StringResource
+  get() = String8.str_14023
+
+@ExperimentalResourceApi
+internal val Res.string.str_14024: StringResource
+  get() = String8.str_14024
+
+@ExperimentalResourceApi
+internal val Res.string.str_14025: StringResource
+  get() = String8.str_14025
+
+@ExperimentalResourceApi
+internal val Res.string.str_14026: StringResource
+  get() = String8.str_14026
+
+@ExperimentalResourceApi
+internal val Res.string.str_14027: StringResource
+  get() = String8.str_14027
+
+@ExperimentalResourceApi
+internal val Res.string.str_14028: StringResource
+  get() = String8.str_14028
+
+@ExperimentalResourceApi
+internal val Res.string.str_14029: StringResource
+  get() = String8.str_14029
+
+@ExperimentalResourceApi
+internal val Res.string.str_1403: StringResource
+  get() = String8.str_1403
+
+@ExperimentalResourceApi
+internal val Res.string.str_14030: StringResource
+  get() = String8.str_14030
+
+@ExperimentalResourceApi
+internal val Res.string.str_14031: StringResource
+  get() = String8.str_14031
+
+@ExperimentalResourceApi
+internal val Res.string.str_14032: StringResource
+  get() = String8.str_14032
+
+@ExperimentalResourceApi
+internal val Res.string.str_14033: StringResource
+  get() = String8.str_14033
+
+@ExperimentalResourceApi
+internal val Res.string.str_14034: StringResource
+  get() = String8.str_14034
+
+@ExperimentalResourceApi
+internal val Res.string.str_14035: StringResource
+  get() = String8.str_14035
+
+@ExperimentalResourceApi
+internal val Res.string.str_14036: StringResource
+  get() = String8.str_14036
+
+@ExperimentalResourceApi
+internal val Res.string.str_14037: StringResource
+  get() = String8.str_14037
+
+@ExperimentalResourceApi
+internal val Res.string.str_14038: StringResource
+  get() = String8.str_14038
+
+@ExperimentalResourceApi
+internal val Res.string.str_14039: StringResource
+  get() = String8.str_14039
+
+@ExperimentalResourceApi
+internal val Res.string.str_1404: StringResource
+  get() = String8.str_1404
+
+@ExperimentalResourceApi
+internal val Res.string.str_14040: StringResource
+  get() = String8.str_14040
+
+@ExperimentalResourceApi
+internal val Res.string.str_14041: StringResource
+  get() = String8.str_14041
+
+@ExperimentalResourceApi
+internal val Res.string.str_14042: StringResource
+  get() = String8.str_14042
+
+@ExperimentalResourceApi
+internal val Res.string.str_14043: StringResource
+  get() = String8.str_14043
+
+@ExperimentalResourceApi
+internal val Res.string.str_14044: StringResource
+  get() = String8.str_14044
+
+@ExperimentalResourceApi
+internal val Res.string.str_14045: StringResource
+  get() = String8.str_14045
+
+@ExperimentalResourceApi
+internal val Res.string.str_14046: StringResource
+  get() = String8.str_14046

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String9.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/expected/String9.kt
@@ -1,0 +1,5510 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package app.group.huge.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.StringResource
+
+@ExperimentalResourceApi
+private object String9 {
+  public val str_14047: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14047", "str_14047",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14048: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14048", "str_14048",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14049: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14049", "str_14049",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1405", "str_1405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14050: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14050", "str_14050",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14051: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14051", "str_14051",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14052: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14052", "str_14052",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14053: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14053", "str_14053",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14054: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14054", "str_14054",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14055: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14055", "str_14055",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14056: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14056", "str_14056",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14057: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14057", "str_14057",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14058: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14058", "str_14058",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14059: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14059", "str_14059",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1406", "str_1406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14060: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14060", "str_14060",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14061: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14061", "str_14061",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14062: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14062", "str_14062",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14063: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14063", "str_14063",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14064: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14064", "str_14064",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14065: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14065", "str_14065",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14066: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14066", "str_14066",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14067: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14067", "str_14067",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14068: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14068", "str_14068",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14069: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14069", "str_14069",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1407", "str_1407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14070: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14070", "str_14070",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14071: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14071", "str_14071",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14072: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14072", "str_14072",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14073: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14073", "str_14073",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14074: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14074", "str_14074",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14075: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14075", "str_14075",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14076: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14076", "str_14076",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14077: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14077", "str_14077",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14078: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14078", "str_14078",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14079: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14079", "str_14079",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1408", "str_1408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14080: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14080", "str_14080",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14081: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14081", "str_14081",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14082: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14082", "str_14082",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14083: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14083", "str_14083",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14084: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14084", "str_14084",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14085: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14085", "str_14085",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14086: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14086", "str_14086",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14087: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14087", "str_14087",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14088: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14088", "str_14088",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14089: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14089", "str_14089",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1409", "str_1409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14090: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14090", "str_14090",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14091: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14091", "str_14091",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14092: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14092", "str_14092",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14093: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14093", "str_14093",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14094: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14094", "str_14094",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14095: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14095", "str_14095",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14096: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14096", "str_14096",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14097: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14097", "str_14097",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14098: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14098", "str_14098",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14099: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14099", "str_14099",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_141", "str_141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1410", "str_1410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14100: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14100", "str_14100",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14101: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14101", "str_14101",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14102: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14102", "str_14102",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14103: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14103", "str_14103",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14104: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14104", "str_14104",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14105: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14105", "str_14105",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14106: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14106", "str_14106",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14107: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14107", "str_14107",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14108: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14108", "str_14108",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14109: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14109", "str_14109",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1411", "str_1411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14110: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14110", "str_14110",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14111: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14111", "str_14111",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14112: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14112", "str_14112",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14113: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14113", "str_14113",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14114: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14114", "str_14114",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14115: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14115", "str_14115",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14116: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14116", "str_14116",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14117: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14117", "str_14117",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14118: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14118", "str_14118",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14119: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14119", "str_14119",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1412", "str_1412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14120: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14120", "str_14120",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14121: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14121", "str_14121",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14122: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14122", "str_14122",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14123: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14123", "str_14123",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14124: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14124", "str_14124",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14125: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14125", "str_14125",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14126: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14126", "str_14126",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14127: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14127", "str_14127",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14128: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14128", "str_14128",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14129: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14129", "str_14129",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1413", "str_1413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14130: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14130", "str_14130",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14131: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14131", "str_14131",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14132: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14132", "str_14132",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14133: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14133", "str_14133",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14134: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14134", "str_14134",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14135: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14135", "str_14135",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14136: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14136", "str_14136",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14137: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14137", "str_14137",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14138: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14138", "str_14138",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14139: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14139", "str_14139",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1414", "str_1414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14140: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14140", "str_14140",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14141: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14141", "str_14141",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14142", "str_14142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14143", "str_14143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14144", "str_14144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14145: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14145", "str_14145",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14146: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14146", "str_14146",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14147: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14147", "str_14147",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14148: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14148", "str_14148",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14149: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14149", "str_14149",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1415", "str_1415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14150: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14150", "str_14150",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14151: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14151", "str_14151",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14152: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14152", "str_14152",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14153: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14153", "str_14153",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14154: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14154", "str_14154",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14155: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14155", "str_14155",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14156: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14156", "str_14156",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14157: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14157", "str_14157",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14158: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14158", "str_14158",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14159: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14159", "str_14159",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1416", "str_1416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14160: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14160", "str_14160",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14161: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14161", "str_14161",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14162: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14162", "str_14162",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14163: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14163", "str_14163",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14164: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14164", "str_14164",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14165: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14165", "str_14165",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14166: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14166", "str_14166",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14167: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14167", "str_14167",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14168: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14168", "str_14168",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14169: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14169", "str_14169",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1417", "str_1417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14170: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14170", "str_14170",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14171: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14171", "str_14171",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14172: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14172", "str_14172",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14173: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14173", "str_14173",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14174: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14174", "str_14174",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14175: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14175", "str_14175",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14176: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14176", "str_14176",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14177: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14177", "str_14177",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14178: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14178", "str_14178",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14179: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14179", "str_14179",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1418", "str_1418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14180: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14180", "str_14180",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14181: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14181", "str_14181",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14182: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14182", "str_14182",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14183: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14183", "str_14183",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14184: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14184", "str_14184",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14185: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14185", "str_14185",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14186: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14186", "str_14186",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14187: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14187", "str_14187",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14188: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14188", "str_14188",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14189: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14189", "str_14189",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1419", "str_1419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14190: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14190", "str_14190",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14191: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14191", "str_14191",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14192: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14192", "str_14192",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14193: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14193", "str_14193",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14194: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14194", "str_14194",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14195: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14195", "str_14195",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14196: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14196", "str_14196",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14197: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14197", "str_14197",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14198: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14198", "str_14198",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14199: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14199", "str_14199",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_142: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_142", "str_142",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1420", "str_1420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14200: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14200", "str_14200",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14201: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14201", "str_14201",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14202: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14202", "str_14202",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14203: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14203", "str_14203",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14204: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14204", "str_14204",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14205: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14205", "str_14205",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14206: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14206", "str_14206",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14207: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14207", "str_14207",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14208: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14208", "str_14208",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14209: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14209", "str_14209",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1421", "str_1421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14210: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14210", "str_14210",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14211: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14211", "str_14211",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14212: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14212", "str_14212",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14213: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14213", "str_14213",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14214: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14214", "str_14214",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14215: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14215", "str_14215",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14216: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14216", "str_14216",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14217: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14217", "str_14217",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14218: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14218", "str_14218",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14219: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14219", "str_14219",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1422", "str_1422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14220: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14220", "str_14220",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14221: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14221", "str_14221",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14222: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14222", "str_14222",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14223: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14223", "str_14223",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14224: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14224", "str_14224",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14225: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14225", "str_14225",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14226: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14226", "str_14226",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14227: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14227", "str_14227",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14228: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14228", "str_14228",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14229: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14229", "str_14229",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1423", "str_1423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14230: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14230", "str_14230",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14231: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14231", "str_14231",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14232: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14232", "str_14232",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14233: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14233", "str_14233",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14234: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14234", "str_14234",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14235: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14235", "str_14235",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14236: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14236", "str_14236",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14237: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14237", "str_14237",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14238: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14238", "str_14238",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14239: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14239", "str_14239",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1424", "str_1424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14240: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14240", "str_14240",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14241: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14241", "str_14241",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14242: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14242", "str_14242",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14243: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14243", "str_14243",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14244: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14244", "str_14244",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14245: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14245", "str_14245",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14246: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14246", "str_14246",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14247: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14247", "str_14247",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14248: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14248", "str_14248",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14249: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14249", "str_14249",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1425", "str_1425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14250: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14250", "str_14250",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14251: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14251", "str_14251",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14252: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14252", "str_14252",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14253: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14253", "str_14253",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14254: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14254", "str_14254",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14255: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14255", "str_14255",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14256: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14256", "str_14256",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14257: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14257", "str_14257",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14258: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14258", "str_14258",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14259: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14259", "str_14259",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1426", "str_1426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14260: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14260", "str_14260",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14261: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14261", "str_14261",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14262: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14262", "str_14262",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14263: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14263", "str_14263",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14264: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14264", "str_14264",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14265: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14265", "str_14265",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14266: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14266", "str_14266",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14267: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14267", "str_14267",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14268: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14268", "str_14268",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14269: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14269", "str_14269",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1427", "str_1427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14270: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14270", "str_14270",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14271: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14271", "str_14271",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14272: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14272", "str_14272",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14273: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14273", "str_14273",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14274: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14274", "str_14274",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14275: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14275", "str_14275",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14276: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14276", "str_14276",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14277: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14277", "str_14277",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14278: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14278", "str_14278",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14279: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14279", "str_14279",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1428", "str_1428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14280: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14280", "str_14280",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14281: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14281", "str_14281",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14282: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14282", "str_14282",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14283: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14283", "str_14283",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14284: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14284", "str_14284",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14285: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14285", "str_14285",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14286: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14286", "str_14286",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14287: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14287", "str_14287",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14288: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14288", "str_14288",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14289: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14289", "str_14289",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1429", "str_1429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14290: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14290", "str_14290",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14291: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14291", "str_14291",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14292: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14292", "str_14292",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14293: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14293", "str_14293",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14294: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14294", "str_14294",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14295: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14295", "str_14295",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14296: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14296", "str_14296",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14297: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14297", "str_14297",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14298: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14298", "str_14298",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14299: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14299", "str_14299",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_143: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_143", "str_143",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1430", "str_1430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14300: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14300", "str_14300",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14301: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14301", "str_14301",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14302: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14302", "str_14302",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14303: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14303", "str_14303",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14304: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14304", "str_14304",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14305: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14305", "str_14305",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14306: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14306", "str_14306",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14307: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14307", "str_14307",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14308: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14308", "str_14308",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14309: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14309", "str_14309",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1431", "str_1431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14310: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14310", "str_14310",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14311: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14311", "str_14311",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14312: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14312", "str_14312",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14313: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14313", "str_14313",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14314: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14314", "str_14314",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14315: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14315", "str_14315",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14316: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14316", "str_14316",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14317: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14317", "str_14317",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14318: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14318", "str_14318",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14319: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14319", "str_14319",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1432", "str_1432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14320: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14320", "str_14320",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14321: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14321", "str_14321",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14322: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14322", "str_14322",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14323: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14323", "str_14323",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14324: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14324", "str_14324",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14325: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14325", "str_14325",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14326: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14326", "str_14326",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14327: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14327", "str_14327",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14328: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14328", "str_14328",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14329: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14329", "str_14329",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1433", "str_1433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14330: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14330", "str_14330",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14331: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14331", "str_14331",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14332: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14332", "str_14332",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14333: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14333", "str_14333",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14334: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14334", "str_14334",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14335: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14335", "str_14335",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14336: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14336", "str_14336",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14337: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14337", "str_14337",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14338: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14338", "str_14338",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14339: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14339", "str_14339",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1434", "str_1434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14340: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14340", "str_14340",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14341: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14341", "str_14341",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14342: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14342", "str_14342",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14343: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14343", "str_14343",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14344: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14344", "str_14344",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14345: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14345", "str_14345",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14346: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14346", "str_14346",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14347: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14347", "str_14347",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14348: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14348", "str_14348",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14349: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14349", "str_14349",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1435", "str_1435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14350: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14350", "str_14350",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14351: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14351", "str_14351",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14352: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14352", "str_14352",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14353: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14353", "str_14353",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14354: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14354", "str_14354",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14355: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14355", "str_14355",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14356: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14356", "str_14356",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14357: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14357", "str_14357",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14358: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14358", "str_14358",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14359: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14359", "str_14359",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1436", "str_1436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14360: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14360", "str_14360",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14361: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14361", "str_14361",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14362: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14362", "str_14362",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14363: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14363", "str_14363",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14364: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14364", "str_14364",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14365: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14365", "str_14365",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14366: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14366", "str_14366",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14367: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14367", "str_14367",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14368: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14368", "str_14368",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14369: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14369", "str_14369",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1437", "str_1437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14370: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14370", "str_14370",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14371: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14371", "str_14371",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14372: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14372", "str_14372",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14373: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14373", "str_14373",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14374: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14374", "str_14374",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14375: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14375", "str_14375",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14376: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14376", "str_14376",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14377: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14377", "str_14377",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14378: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14378", "str_14378",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14379: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14379", "str_14379",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1438", "str_1438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14380: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14380", "str_14380",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14381: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14381", "str_14381",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14382: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14382", "str_14382",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14383: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14383", "str_14383",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14384: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14384", "str_14384",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14385: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14385", "str_14385",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14386: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14386", "str_14386",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14387: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14387", "str_14387",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14388: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14388", "str_14388",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14389: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14389", "str_14389",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1439", "str_1439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14390: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14390", "str_14390",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14391: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14391", "str_14391",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14392: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14392", "str_14392",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14393: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14393", "str_14393",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14394: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14394", "str_14394",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14395: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14395", "str_14395",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14396: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14396", "str_14396",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14397: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14397", "str_14397",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14398: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14398", "str_14398",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14399: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14399", "str_14399",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_144: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_144", "str_144",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1440", "str_1440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14400: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14400", "str_14400",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14401: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14401", "str_14401",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14402: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14402", "str_14402",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14403: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14403", "str_14403",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14404: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14404", "str_14404",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14405: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14405", "str_14405",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14406: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14406", "str_14406",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14407: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14407", "str_14407",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14408: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14408", "str_14408",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14409: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14409", "str_14409",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1441", "str_1441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14410: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14410", "str_14410",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14411: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14411", "str_14411",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14412: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14412", "str_14412",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14413: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14413", "str_14413",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14414: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14414", "str_14414",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14415: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14415", "str_14415",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14416: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14416", "str_14416",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14417: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14417", "str_14417",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14418: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14418", "str_14418",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14419: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14419", "str_14419",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1442", "str_1442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14420: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14420", "str_14420",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14421: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14421", "str_14421",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14422: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14422", "str_14422",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14423: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14423", "str_14423",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14424: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14424", "str_14424",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14425: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14425", "str_14425",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14426: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14426", "str_14426",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14427: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14427", "str_14427",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14428: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14428", "str_14428",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14429: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14429", "str_14429",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1443", "str_1443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14430: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14430", "str_14430",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14431: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14431", "str_14431",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14432: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14432", "str_14432",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14433: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14433", "str_14433",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14434: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14434", "str_14434",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14435: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14435", "str_14435",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14436: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14436", "str_14436",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14437: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14437", "str_14437",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14438: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14438", "str_14438",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14439: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14439", "str_14439",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1444", "str_1444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14440: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14440", "str_14440",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14441: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14441", "str_14441",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14442: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14442", "str_14442",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14443: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14443", "str_14443",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14444: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14444", "str_14444",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14445", "str_14445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14446", "str_14446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14447", "str_14447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14448", "str_14448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14449", "str_14449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1445: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1445", "str_1445",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14450: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14450", "str_14450",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14451: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14451", "str_14451",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14452: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14452", "str_14452",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14453: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14453", "str_14453",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14454: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14454", "str_14454",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14455: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14455", "str_14455",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14456: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14456", "str_14456",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14457: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14457", "str_14457",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14458: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14458", "str_14458",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14459: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14459", "str_14459",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1446: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1446", "str_1446",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14460: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14460", "str_14460",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14461: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14461", "str_14461",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14462: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14462", "str_14462",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14463: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14463", "str_14463",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14464: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14464", "str_14464",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14465: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14465", "str_14465",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14466: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14466", "str_14466",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14467: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14467", "str_14467",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14468: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14468", "str_14468",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14469: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14469", "str_14469",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1447: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1447", "str_1447",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14470: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14470", "str_14470",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14471: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14471", "str_14471",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14472: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14472", "str_14472",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14473: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14473", "str_14473",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14474: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14474", "str_14474",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14475: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14475", "str_14475",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14476: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14476", "str_14476",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14477: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14477", "str_14477",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14478: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14478", "str_14478",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14479: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14479", "str_14479",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1448: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1448", "str_1448",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14480: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14480", "str_14480",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14481: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14481", "str_14481",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14482: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14482", "str_14482",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14483: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14483", "str_14483",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14484: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14484", "str_14484",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14485: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14485", "str_14485",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14486: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14486", "str_14486",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14487: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14487", "str_14487",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14488: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14488", "str_14488",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14489: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14489", "str_14489",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_1449: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_1449", "str_1449",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14490: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14490", "str_14490",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14491: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14491", "str_14491",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14492: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14492", "str_14492",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14493: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14493", "str_14493",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14494: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14494", "str_14494",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14495: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14495", "str_14495",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14496: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14496", "str_14496",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+
+  public val str_14497: StringResource = org.jetbrains.compose.resources.StringResource(
+        "string:str_14497", "str_14497",
+          setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "values/strings.xml"),
+          )
+      )
+}
+
+@ExperimentalResourceApi
+internal val Res.string.str_14047: StringResource
+  get() = String9.str_14047
+
+@ExperimentalResourceApi
+internal val Res.string.str_14048: StringResource
+  get() = String9.str_14048
+
+@ExperimentalResourceApi
+internal val Res.string.str_14049: StringResource
+  get() = String9.str_14049
+
+@ExperimentalResourceApi
+internal val Res.string.str_1405: StringResource
+  get() = String9.str_1405
+
+@ExperimentalResourceApi
+internal val Res.string.str_14050: StringResource
+  get() = String9.str_14050
+
+@ExperimentalResourceApi
+internal val Res.string.str_14051: StringResource
+  get() = String9.str_14051
+
+@ExperimentalResourceApi
+internal val Res.string.str_14052: StringResource
+  get() = String9.str_14052
+
+@ExperimentalResourceApi
+internal val Res.string.str_14053: StringResource
+  get() = String9.str_14053
+
+@ExperimentalResourceApi
+internal val Res.string.str_14054: StringResource
+  get() = String9.str_14054
+
+@ExperimentalResourceApi
+internal val Res.string.str_14055: StringResource
+  get() = String9.str_14055
+
+@ExperimentalResourceApi
+internal val Res.string.str_14056: StringResource
+  get() = String9.str_14056
+
+@ExperimentalResourceApi
+internal val Res.string.str_14057: StringResource
+  get() = String9.str_14057
+
+@ExperimentalResourceApi
+internal val Res.string.str_14058: StringResource
+  get() = String9.str_14058
+
+@ExperimentalResourceApi
+internal val Res.string.str_14059: StringResource
+  get() = String9.str_14059
+
+@ExperimentalResourceApi
+internal val Res.string.str_1406: StringResource
+  get() = String9.str_1406
+
+@ExperimentalResourceApi
+internal val Res.string.str_14060: StringResource
+  get() = String9.str_14060
+
+@ExperimentalResourceApi
+internal val Res.string.str_14061: StringResource
+  get() = String9.str_14061
+
+@ExperimentalResourceApi
+internal val Res.string.str_14062: StringResource
+  get() = String9.str_14062
+
+@ExperimentalResourceApi
+internal val Res.string.str_14063: StringResource
+  get() = String9.str_14063
+
+@ExperimentalResourceApi
+internal val Res.string.str_14064: StringResource
+  get() = String9.str_14064
+
+@ExperimentalResourceApi
+internal val Res.string.str_14065: StringResource
+  get() = String9.str_14065
+
+@ExperimentalResourceApi
+internal val Res.string.str_14066: StringResource
+  get() = String9.str_14066
+
+@ExperimentalResourceApi
+internal val Res.string.str_14067: StringResource
+  get() = String9.str_14067
+
+@ExperimentalResourceApi
+internal val Res.string.str_14068: StringResource
+  get() = String9.str_14068
+
+@ExperimentalResourceApi
+internal val Res.string.str_14069: StringResource
+  get() = String9.str_14069
+
+@ExperimentalResourceApi
+internal val Res.string.str_1407: StringResource
+  get() = String9.str_1407
+
+@ExperimentalResourceApi
+internal val Res.string.str_14070: StringResource
+  get() = String9.str_14070
+
+@ExperimentalResourceApi
+internal val Res.string.str_14071: StringResource
+  get() = String9.str_14071
+
+@ExperimentalResourceApi
+internal val Res.string.str_14072: StringResource
+  get() = String9.str_14072
+
+@ExperimentalResourceApi
+internal val Res.string.str_14073: StringResource
+  get() = String9.str_14073
+
+@ExperimentalResourceApi
+internal val Res.string.str_14074: StringResource
+  get() = String9.str_14074
+
+@ExperimentalResourceApi
+internal val Res.string.str_14075: StringResource
+  get() = String9.str_14075
+
+@ExperimentalResourceApi
+internal val Res.string.str_14076: StringResource
+  get() = String9.str_14076
+
+@ExperimentalResourceApi
+internal val Res.string.str_14077: StringResource
+  get() = String9.str_14077
+
+@ExperimentalResourceApi
+internal val Res.string.str_14078: StringResource
+  get() = String9.str_14078
+
+@ExperimentalResourceApi
+internal val Res.string.str_14079: StringResource
+  get() = String9.str_14079
+
+@ExperimentalResourceApi
+internal val Res.string.str_1408: StringResource
+  get() = String9.str_1408
+
+@ExperimentalResourceApi
+internal val Res.string.str_14080: StringResource
+  get() = String9.str_14080
+
+@ExperimentalResourceApi
+internal val Res.string.str_14081: StringResource
+  get() = String9.str_14081
+
+@ExperimentalResourceApi
+internal val Res.string.str_14082: StringResource
+  get() = String9.str_14082
+
+@ExperimentalResourceApi
+internal val Res.string.str_14083: StringResource
+  get() = String9.str_14083
+
+@ExperimentalResourceApi
+internal val Res.string.str_14084: StringResource
+  get() = String9.str_14084
+
+@ExperimentalResourceApi
+internal val Res.string.str_14085: StringResource
+  get() = String9.str_14085
+
+@ExperimentalResourceApi
+internal val Res.string.str_14086: StringResource
+  get() = String9.str_14086
+
+@ExperimentalResourceApi
+internal val Res.string.str_14087: StringResource
+  get() = String9.str_14087
+
+@ExperimentalResourceApi
+internal val Res.string.str_14088: StringResource
+  get() = String9.str_14088
+
+@ExperimentalResourceApi
+internal val Res.string.str_14089: StringResource
+  get() = String9.str_14089
+
+@ExperimentalResourceApi
+internal val Res.string.str_1409: StringResource
+  get() = String9.str_1409
+
+@ExperimentalResourceApi
+internal val Res.string.str_14090: StringResource
+  get() = String9.str_14090
+
+@ExperimentalResourceApi
+internal val Res.string.str_14091: StringResource
+  get() = String9.str_14091
+
+@ExperimentalResourceApi
+internal val Res.string.str_14092: StringResource
+  get() = String9.str_14092
+
+@ExperimentalResourceApi
+internal val Res.string.str_14093: StringResource
+  get() = String9.str_14093
+
+@ExperimentalResourceApi
+internal val Res.string.str_14094: StringResource
+  get() = String9.str_14094
+
+@ExperimentalResourceApi
+internal val Res.string.str_14095: StringResource
+  get() = String9.str_14095
+
+@ExperimentalResourceApi
+internal val Res.string.str_14096: StringResource
+  get() = String9.str_14096
+
+@ExperimentalResourceApi
+internal val Res.string.str_14097: StringResource
+  get() = String9.str_14097
+
+@ExperimentalResourceApi
+internal val Res.string.str_14098: StringResource
+  get() = String9.str_14098
+
+@ExperimentalResourceApi
+internal val Res.string.str_14099: StringResource
+  get() = String9.str_14099
+
+@ExperimentalResourceApi
+internal val Res.string.str_141: StringResource
+  get() = String9.str_141
+
+@ExperimentalResourceApi
+internal val Res.string.str_1410: StringResource
+  get() = String9.str_1410
+
+@ExperimentalResourceApi
+internal val Res.string.str_14100: StringResource
+  get() = String9.str_14100
+
+@ExperimentalResourceApi
+internal val Res.string.str_14101: StringResource
+  get() = String9.str_14101
+
+@ExperimentalResourceApi
+internal val Res.string.str_14102: StringResource
+  get() = String9.str_14102
+
+@ExperimentalResourceApi
+internal val Res.string.str_14103: StringResource
+  get() = String9.str_14103
+
+@ExperimentalResourceApi
+internal val Res.string.str_14104: StringResource
+  get() = String9.str_14104
+
+@ExperimentalResourceApi
+internal val Res.string.str_14105: StringResource
+  get() = String9.str_14105
+
+@ExperimentalResourceApi
+internal val Res.string.str_14106: StringResource
+  get() = String9.str_14106
+
+@ExperimentalResourceApi
+internal val Res.string.str_14107: StringResource
+  get() = String9.str_14107
+
+@ExperimentalResourceApi
+internal val Res.string.str_14108: StringResource
+  get() = String9.str_14108
+
+@ExperimentalResourceApi
+internal val Res.string.str_14109: StringResource
+  get() = String9.str_14109
+
+@ExperimentalResourceApi
+internal val Res.string.str_1411: StringResource
+  get() = String9.str_1411
+
+@ExperimentalResourceApi
+internal val Res.string.str_14110: StringResource
+  get() = String9.str_14110
+
+@ExperimentalResourceApi
+internal val Res.string.str_14111: StringResource
+  get() = String9.str_14111
+
+@ExperimentalResourceApi
+internal val Res.string.str_14112: StringResource
+  get() = String9.str_14112
+
+@ExperimentalResourceApi
+internal val Res.string.str_14113: StringResource
+  get() = String9.str_14113
+
+@ExperimentalResourceApi
+internal val Res.string.str_14114: StringResource
+  get() = String9.str_14114
+
+@ExperimentalResourceApi
+internal val Res.string.str_14115: StringResource
+  get() = String9.str_14115
+
+@ExperimentalResourceApi
+internal val Res.string.str_14116: StringResource
+  get() = String9.str_14116
+
+@ExperimentalResourceApi
+internal val Res.string.str_14117: StringResource
+  get() = String9.str_14117
+
+@ExperimentalResourceApi
+internal val Res.string.str_14118: StringResource
+  get() = String9.str_14118
+
+@ExperimentalResourceApi
+internal val Res.string.str_14119: StringResource
+  get() = String9.str_14119
+
+@ExperimentalResourceApi
+internal val Res.string.str_1412: StringResource
+  get() = String9.str_1412
+
+@ExperimentalResourceApi
+internal val Res.string.str_14120: StringResource
+  get() = String9.str_14120
+
+@ExperimentalResourceApi
+internal val Res.string.str_14121: StringResource
+  get() = String9.str_14121
+
+@ExperimentalResourceApi
+internal val Res.string.str_14122: StringResource
+  get() = String9.str_14122
+
+@ExperimentalResourceApi
+internal val Res.string.str_14123: StringResource
+  get() = String9.str_14123
+
+@ExperimentalResourceApi
+internal val Res.string.str_14124: StringResource
+  get() = String9.str_14124
+
+@ExperimentalResourceApi
+internal val Res.string.str_14125: StringResource
+  get() = String9.str_14125
+
+@ExperimentalResourceApi
+internal val Res.string.str_14126: StringResource
+  get() = String9.str_14126
+
+@ExperimentalResourceApi
+internal val Res.string.str_14127: StringResource
+  get() = String9.str_14127
+
+@ExperimentalResourceApi
+internal val Res.string.str_14128: StringResource
+  get() = String9.str_14128
+
+@ExperimentalResourceApi
+internal val Res.string.str_14129: StringResource
+  get() = String9.str_14129
+
+@ExperimentalResourceApi
+internal val Res.string.str_1413: StringResource
+  get() = String9.str_1413
+
+@ExperimentalResourceApi
+internal val Res.string.str_14130: StringResource
+  get() = String9.str_14130
+
+@ExperimentalResourceApi
+internal val Res.string.str_14131: StringResource
+  get() = String9.str_14131
+
+@ExperimentalResourceApi
+internal val Res.string.str_14132: StringResource
+  get() = String9.str_14132
+
+@ExperimentalResourceApi
+internal val Res.string.str_14133: StringResource
+  get() = String9.str_14133
+
+@ExperimentalResourceApi
+internal val Res.string.str_14134: StringResource
+  get() = String9.str_14134
+
+@ExperimentalResourceApi
+internal val Res.string.str_14135: StringResource
+  get() = String9.str_14135
+
+@ExperimentalResourceApi
+internal val Res.string.str_14136: StringResource
+  get() = String9.str_14136
+
+@ExperimentalResourceApi
+internal val Res.string.str_14137: StringResource
+  get() = String9.str_14137
+
+@ExperimentalResourceApi
+internal val Res.string.str_14138: StringResource
+  get() = String9.str_14138
+
+@ExperimentalResourceApi
+internal val Res.string.str_14139: StringResource
+  get() = String9.str_14139
+
+@ExperimentalResourceApi
+internal val Res.string.str_1414: StringResource
+  get() = String9.str_1414
+
+@ExperimentalResourceApi
+internal val Res.string.str_14140: StringResource
+  get() = String9.str_14140
+
+@ExperimentalResourceApi
+internal val Res.string.str_14141: StringResource
+  get() = String9.str_14141
+
+@ExperimentalResourceApi
+internal val Res.string.str_14142: StringResource
+  get() = String9.str_14142
+
+@ExperimentalResourceApi
+internal val Res.string.str_14143: StringResource
+  get() = String9.str_14143
+
+@ExperimentalResourceApi
+internal val Res.string.str_14144: StringResource
+  get() = String9.str_14144
+
+@ExperimentalResourceApi
+internal val Res.string.str_14145: StringResource
+  get() = String9.str_14145
+
+@ExperimentalResourceApi
+internal val Res.string.str_14146: StringResource
+  get() = String9.str_14146
+
+@ExperimentalResourceApi
+internal val Res.string.str_14147: StringResource
+  get() = String9.str_14147
+
+@ExperimentalResourceApi
+internal val Res.string.str_14148: StringResource
+  get() = String9.str_14148
+
+@ExperimentalResourceApi
+internal val Res.string.str_14149: StringResource
+  get() = String9.str_14149
+
+@ExperimentalResourceApi
+internal val Res.string.str_1415: StringResource
+  get() = String9.str_1415
+
+@ExperimentalResourceApi
+internal val Res.string.str_14150: StringResource
+  get() = String9.str_14150
+
+@ExperimentalResourceApi
+internal val Res.string.str_14151: StringResource
+  get() = String9.str_14151
+
+@ExperimentalResourceApi
+internal val Res.string.str_14152: StringResource
+  get() = String9.str_14152
+
+@ExperimentalResourceApi
+internal val Res.string.str_14153: StringResource
+  get() = String9.str_14153
+
+@ExperimentalResourceApi
+internal val Res.string.str_14154: StringResource
+  get() = String9.str_14154
+
+@ExperimentalResourceApi
+internal val Res.string.str_14155: StringResource
+  get() = String9.str_14155
+
+@ExperimentalResourceApi
+internal val Res.string.str_14156: StringResource
+  get() = String9.str_14156
+
+@ExperimentalResourceApi
+internal val Res.string.str_14157: StringResource
+  get() = String9.str_14157
+
+@ExperimentalResourceApi
+internal val Res.string.str_14158: StringResource
+  get() = String9.str_14158
+
+@ExperimentalResourceApi
+internal val Res.string.str_14159: StringResource
+  get() = String9.str_14159
+
+@ExperimentalResourceApi
+internal val Res.string.str_1416: StringResource
+  get() = String9.str_1416
+
+@ExperimentalResourceApi
+internal val Res.string.str_14160: StringResource
+  get() = String9.str_14160
+
+@ExperimentalResourceApi
+internal val Res.string.str_14161: StringResource
+  get() = String9.str_14161
+
+@ExperimentalResourceApi
+internal val Res.string.str_14162: StringResource
+  get() = String9.str_14162
+
+@ExperimentalResourceApi
+internal val Res.string.str_14163: StringResource
+  get() = String9.str_14163
+
+@ExperimentalResourceApi
+internal val Res.string.str_14164: StringResource
+  get() = String9.str_14164
+
+@ExperimentalResourceApi
+internal val Res.string.str_14165: StringResource
+  get() = String9.str_14165
+
+@ExperimentalResourceApi
+internal val Res.string.str_14166: StringResource
+  get() = String9.str_14166
+
+@ExperimentalResourceApi
+internal val Res.string.str_14167: StringResource
+  get() = String9.str_14167
+
+@ExperimentalResourceApi
+internal val Res.string.str_14168: StringResource
+  get() = String9.str_14168
+
+@ExperimentalResourceApi
+internal val Res.string.str_14169: StringResource
+  get() = String9.str_14169
+
+@ExperimentalResourceApi
+internal val Res.string.str_1417: StringResource
+  get() = String9.str_1417
+
+@ExperimentalResourceApi
+internal val Res.string.str_14170: StringResource
+  get() = String9.str_14170
+
+@ExperimentalResourceApi
+internal val Res.string.str_14171: StringResource
+  get() = String9.str_14171
+
+@ExperimentalResourceApi
+internal val Res.string.str_14172: StringResource
+  get() = String9.str_14172
+
+@ExperimentalResourceApi
+internal val Res.string.str_14173: StringResource
+  get() = String9.str_14173
+
+@ExperimentalResourceApi
+internal val Res.string.str_14174: StringResource
+  get() = String9.str_14174
+
+@ExperimentalResourceApi
+internal val Res.string.str_14175: StringResource
+  get() = String9.str_14175
+
+@ExperimentalResourceApi
+internal val Res.string.str_14176: StringResource
+  get() = String9.str_14176
+
+@ExperimentalResourceApi
+internal val Res.string.str_14177: StringResource
+  get() = String9.str_14177
+
+@ExperimentalResourceApi
+internal val Res.string.str_14178: StringResource
+  get() = String9.str_14178
+
+@ExperimentalResourceApi
+internal val Res.string.str_14179: StringResource
+  get() = String9.str_14179
+
+@ExperimentalResourceApi
+internal val Res.string.str_1418: StringResource
+  get() = String9.str_1418
+
+@ExperimentalResourceApi
+internal val Res.string.str_14180: StringResource
+  get() = String9.str_14180
+
+@ExperimentalResourceApi
+internal val Res.string.str_14181: StringResource
+  get() = String9.str_14181
+
+@ExperimentalResourceApi
+internal val Res.string.str_14182: StringResource
+  get() = String9.str_14182
+
+@ExperimentalResourceApi
+internal val Res.string.str_14183: StringResource
+  get() = String9.str_14183
+
+@ExperimentalResourceApi
+internal val Res.string.str_14184: StringResource
+  get() = String9.str_14184
+
+@ExperimentalResourceApi
+internal val Res.string.str_14185: StringResource
+  get() = String9.str_14185
+
+@ExperimentalResourceApi
+internal val Res.string.str_14186: StringResource
+  get() = String9.str_14186
+
+@ExperimentalResourceApi
+internal val Res.string.str_14187: StringResource
+  get() = String9.str_14187
+
+@ExperimentalResourceApi
+internal val Res.string.str_14188: StringResource
+  get() = String9.str_14188
+
+@ExperimentalResourceApi
+internal val Res.string.str_14189: StringResource
+  get() = String9.str_14189
+
+@ExperimentalResourceApi
+internal val Res.string.str_1419: StringResource
+  get() = String9.str_1419
+
+@ExperimentalResourceApi
+internal val Res.string.str_14190: StringResource
+  get() = String9.str_14190
+
+@ExperimentalResourceApi
+internal val Res.string.str_14191: StringResource
+  get() = String9.str_14191
+
+@ExperimentalResourceApi
+internal val Res.string.str_14192: StringResource
+  get() = String9.str_14192
+
+@ExperimentalResourceApi
+internal val Res.string.str_14193: StringResource
+  get() = String9.str_14193
+
+@ExperimentalResourceApi
+internal val Res.string.str_14194: StringResource
+  get() = String9.str_14194
+
+@ExperimentalResourceApi
+internal val Res.string.str_14195: StringResource
+  get() = String9.str_14195
+
+@ExperimentalResourceApi
+internal val Res.string.str_14196: StringResource
+  get() = String9.str_14196
+
+@ExperimentalResourceApi
+internal val Res.string.str_14197: StringResource
+  get() = String9.str_14197
+
+@ExperimentalResourceApi
+internal val Res.string.str_14198: StringResource
+  get() = String9.str_14198
+
+@ExperimentalResourceApi
+internal val Res.string.str_14199: StringResource
+  get() = String9.str_14199
+
+@ExperimentalResourceApi
+internal val Res.string.str_142: StringResource
+  get() = String9.str_142
+
+@ExperimentalResourceApi
+internal val Res.string.str_1420: StringResource
+  get() = String9.str_1420
+
+@ExperimentalResourceApi
+internal val Res.string.str_14200: StringResource
+  get() = String9.str_14200
+
+@ExperimentalResourceApi
+internal val Res.string.str_14201: StringResource
+  get() = String9.str_14201
+
+@ExperimentalResourceApi
+internal val Res.string.str_14202: StringResource
+  get() = String9.str_14202
+
+@ExperimentalResourceApi
+internal val Res.string.str_14203: StringResource
+  get() = String9.str_14203
+
+@ExperimentalResourceApi
+internal val Res.string.str_14204: StringResource
+  get() = String9.str_14204
+
+@ExperimentalResourceApi
+internal val Res.string.str_14205: StringResource
+  get() = String9.str_14205
+
+@ExperimentalResourceApi
+internal val Res.string.str_14206: StringResource
+  get() = String9.str_14206
+
+@ExperimentalResourceApi
+internal val Res.string.str_14207: StringResource
+  get() = String9.str_14207
+
+@ExperimentalResourceApi
+internal val Res.string.str_14208: StringResource
+  get() = String9.str_14208
+
+@ExperimentalResourceApi
+internal val Res.string.str_14209: StringResource
+  get() = String9.str_14209
+
+@ExperimentalResourceApi
+internal val Res.string.str_1421: StringResource
+  get() = String9.str_1421
+
+@ExperimentalResourceApi
+internal val Res.string.str_14210: StringResource
+  get() = String9.str_14210
+
+@ExperimentalResourceApi
+internal val Res.string.str_14211: StringResource
+  get() = String9.str_14211
+
+@ExperimentalResourceApi
+internal val Res.string.str_14212: StringResource
+  get() = String9.str_14212
+
+@ExperimentalResourceApi
+internal val Res.string.str_14213: StringResource
+  get() = String9.str_14213
+
+@ExperimentalResourceApi
+internal val Res.string.str_14214: StringResource
+  get() = String9.str_14214
+
+@ExperimentalResourceApi
+internal val Res.string.str_14215: StringResource
+  get() = String9.str_14215
+
+@ExperimentalResourceApi
+internal val Res.string.str_14216: StringResource
+  get() = String9.str_14216
+
+@ExperimentalResourceApi
+internal val Res.string.str_14217: StringResource
+  get() = String9.str_14217
+
+@ExperimentalResourceApi
+internal val Res.string.str_14218: StringResource
+  get() = String9.str_14218
+
+@ExperimentalResourceApi
+internal val Res.string.str_14219: StringResource
+  get() = String9.str_14219
+
+@ExperimentalResourceApi
+internal val Res.string.str_1422: StringResource
+  get() = String9.str_1422
+
+@ExperimentalResourceApi
+internal val Res.string.str_14220: StringResource
+  get() = String9.str_14220
+
+@ExperimentalResourceApi
+internal val Res.string.str_14221: StringResource
+  get() = String9.str_14221
+
+@ExperimentalResourceApi
+internal val Res.string.str_14222: StringResource
+  get() = String9.str_14222
+
+@ExperimentalResourceApi
+internal val Res.string.str_14223: StringResource
+  get() = String9.str_14223
+
+@ExperimentalResourceApi
+internal val Res.string.str_14224: StringResource
+  get() = String9.str_14224
+
+@ExperimentalResourceApi
+internal val Res.string.str_14225: StringResource
+  get() = String9.str_14225
+
+@ExperimentalResourceApi
+internal val Res.string.str_14226: StringResource
+  get() = String9.str_14226
+
+@ExperimentalResourceApi
+internal val Res.string.str_14227: StringResource
+  get() = String9.str_14227
+
+@ExperimentalResourceApi
+internal val Res.string.str_14228: StringResource
+  get() = String9.str_14228
+
+@ExperimentalResourceApi
+internal val Res.string.str_14229: StringResource
+  get() = String9.str_14229
+
+@ExperimentalResourceApi
+internal val Res.string.str_1423: StringResource
+  get() = String9.str_1423
+
+@ExperimentalResourceApi
+internal val Res.string.str_14230: StringResource
+  get() = String9.str_14230
+
+@ExperimentalResourceApi
+internal val Res.string.str_14231: StringResource
+  get() = String9.str_14231
+
+@ExperimentalResourceApi
+internal val Res.string.str_14232: StringResource
+  get() = String9.str_14232
+
+@ExperimentalResourceApi
+internal val Res.string.str_14233: StringResource
+  get() = String9.str_14233
+
+@ExperimentalResourceApi
+internal val Res.string.str_14234: StringResource
+  get() = String9.str_14234
+
+@ExperimentalResourceApi
+internal val Res.string.str_14235: StringResource
+  get() = String9.str_14235
+
+@ExperimentalResourceApi
+internal val Res.string.str_14236: StringResource
+  get() = String9.str_14236
+
+@ExperimentalResourceApi
+internal val Res.string.str_14237: StringResource
+  get() = String9.str_14237
+
+@ExperimentalResourceApi
+internal val Res.string.str_14238: StringResource
+  get() = String9.str_14238
+
+@ExperimentalResourceApi
+internal val Res.string.str_14239: StringResource
+  get() = String9.str_14239
+
+@ExperimentalResourceApi
+internal val Res.string.str_1424: StringResource
+  get() = String9.str_1424
+
+@ExperimentalResourceApi
+internal val Res.string.str_14240: StringResource
+  get() = String9.str_14240
+
+@ExperimentalResourceApi
+internal val Res.string.str_14241: StringResource
+  get() = String9.str_14241
+
+@ExperimentalResourceApi
+internal val Res.string.str_14242: StringResource
+  get() = String9.str_14242
+
+@ExperimentalResourceApi
+internal val Res.string.str_14243: StringResource
+  get() = String9.str_14243
+
+@ExperimentalResourceApi
+internal val Res.string.str_14244: StringResource
+  get() = String9.str_14244
+
+@ExperimentalResourceApi
+internal val Res.string.str_14245: StringResource
+  get() = String9.str_14245
+
+@ExperimentalResourceApi
+internal val Res.string.str_14246: StringResource
+  get() = String9.str_14246
+
+@ExperimentalResourceApi
+internal val Res.string.str_14247: StringResource
+  get() = String9.str_14247
+
+@ExperimentalResourceApi
+internal val Res.string.str_14248: StringResource
+  get() = String9.str_14248
+
+@ExperimentalResourceApi
+internal val Res.string.str_14249: StringResource
+  get() = String9.str_14249
+
+@ExperimentalResourceApi
+internal val Res.string.str_1425: StringResource
+  get() = String9.str_1425
+
+@ExperimentalResourceApi
+internal val Res.string.str_14250: StringResource
+  get() = String9.str_14250
+
+@ExperimentalResourceApi
+internal val Res.string.str_14251: StringResource
+  get() = String9.str_14251
+
+@ExperimentalResourceApi
+internal val Res.string.str_14252: StringResource
+  get() = String9.str_14252
+
+@ExperimentalResourceApi
+internal val Res.string.str_14253: StringResource
+  get() = String9.str_14253
+
+@ExperimentalResourceApi
+internal val Res.string.str_14254: StringResource
+  get() = String9.str_14254
+
+@ExperimentalResourceApi
+internal val Res.string.str_14255: StringResource
+  get() = String9.str_14255
+
+@ExperimentalResourceApi
+internal val Res.string.str_14256: StringResource
+  get() = String9.str_14256
+
+@ExperimentalResourceApi
+internal val Res.string.str_14257: StringResource
+  get() = String9.str_14257
+
+@ExperimentalResourceApi
+internal val Res.string.str_14258: StringResource
+  get() = String9.str_14258
+
+@ExperimentalResourceApi
+internal val Res.string.str_14259: StringResource
+  get() = String9.str_14259
+
+@ExperimentalResourceApi
+internal val Res.string.str_1426: StringResource
+  get() = String9.str_1426
+
+@ExperimentalResourceApi
+internal val Res.string.str_14260: StringResource
+  get() = String9.str_14260
+
+@ExperimentalResourceApi
+internal val Res.string.str_14261: StringResource
+  get() = String9.str_14261
+
+@ExperimentalResourceApi
+internal val Res.string.str_14262: StringResource
+  get() = String9.str_14262
+
+@ExperimentalResourceApi
+internal val Res.string.str_14263: StringResource
+  get() = String9.str_14263
+
+@ExperimentalResourceApi
+internal val Res.string.str_14264: StringResource
+  get() = String9.str_14264
+
+@ExperimentalResourceApi
+internal val Res.string.str_14265: StringResource
+  get() = String9.str_14265
+
+@ExperimentalResourceApi
+internal val Res.string.str_14266: StringResource
+  get() = String9.str_14266
+
+@ExperimentalResourceApi
+internal val Res.string.str_14267: StringResource
+  get() = String9.str_14267
+
+@ExperimentalResourceApi
+internal val Res.string.str_14268: StringResource
+  get() = String9.str_14268
+
+@ExperimentalResourceApi
+internal val Res.string.str_14269: StringResource
+  get() = String9.str_14269
+
+@ExperimentalResourceApi
+internal val Res.string.str_1427: StringResource
+  get() = String9.str_1427
+
+@ExperimentalResourceApi
+internal val Res.string.str_14270: StringResource
+  get() = String9.str_14270
+
+@ExperimentalResourceApi
+internal val Res.string.str_14271: StringResource
+  get() = String9.str_14271
+
+@ExperimentalResourceApi
+internal val Res.string.str_14272: StringResource
+  get() = String9.str_14272
+
+@ExperimentalResourceApi
+internal val Res.string.str_14273: StringResource
+  get() = String9.str_14273
+
+@ExperimentalResourceApi
+internal val Res.string.str_14274: StringResource
+  get() = String9.str_14274
+
+@ExperimentalResourceApi
+internal val Res.string.str_14275: StringResource
+  get() = String9.str_14275
+
+@ExperimentalResourceApi
+internal val Res.string.str_14276: StringResource
+  get() = String9.str_14276
+
+@ExperimentalResourceApi
+internal val Res.string.str_14277: StringResource
+  get() = String9.str_14277
+
+@ExperimentalResourceApi
+internal val Res.string.str_14278: StringResource
+  get() = String9.str_14278
+
+@ExperimentalResourceApi
+internal val Res.string.str_14279: StringResource
+  get() = String9.str_14279
+
+@ExperimentalResourceApi
+internal val Res.string.str_1428: StringResource
+  get() = String9.str_1428
+
+@ExperimentalResourceApi
+internal val Res.string.str_14280: StringResource
+  get() = String9.str_14280
+
+@ExperimentalResourceApi
+internal val Res.string.str_14281: StringResource
+  get() = String9.str_14281
+
+@ExperimentalResourceApi
+internal val Res.string.str_14282: StringResource
+  get() = String9.str_14282
+
+@ExperimentalResourceApi
+internal val Res.string.str_14283: StringResource
+  get() = String9.str_14283
+
+@ExperimentalResourceApi
+internal val Res.string.str_14284: StringResource
+  get() = String9.str_14284
+
+@ExperimentalResourceApi
+internal val Res.string.str_14285: StringResource
+  get() = String9.str_14285
+
+@ExperimentalResourceApi
+internal val Res.string.str_14286: StringResource
+  get() = String9.str_14286
+
+@ExperimentalResourceApi
+internal val Res.string.str_14287: StringResource
+  get() = String9.str_14287
+
+@ExperimentalResourceApi
+internal val Res.string.str_14288: StringResource
+  get() = String9.str_14288
+
+@ExperimentalResourceApi
+internal val Res.string.str_14289: StringResource
+  get() = String9.str_14289
+
+@ExperimentalResourceApi
+internal val Res.string.str_1429: StringResource
+  get() = String9.str_1429
+
+@ExperimentalResourceApi
+internal val Res.string.str_14290: StringResource
+  get() = String9.str_14290
+
+@ExperimentalResourceApi
+internal val Res.string.str_14291: StringResource
+  get() = String9.str_14291
+
+@ExperimentalResourceApi
+internal val Res.string.str_14292: StringResource
+  get() = String9.str_14292
+
+@ExperimentalResourceApi
+internal val Res.string.str_14293: StringResource
+  get() = String9.str_14293
+
+@ExperimentalResourceApi
+internal val Res.string.str_14294: StringResource
+  get() = String9.str_14294
+
+@ExperimentalResourceApi
+internal val Res.string.str_14295: StringResource
+  get() = String9.str_14295
+
+@ExperimentalResourceApi
+internal val Res.string.str_14296: StringResource
+  get() = String9.str_14296
+
+@ExperimentalResourceApi
+internal val Res.string.str_14297: StringResource
+  get() = String9.str_14297
+
+@ExperimentalResourceApi
+internal val Res.string.str_14298: StringResource
+  get() = String9.str_14298
+
+@ExperimentalResourceApi
+internal val Res.string.str_14299: StringResource
+  get() = String9.str_14299
+
+@ExperimentalResourceApi
+internal val Res.string.str_143: StringResource
+  get() = String9.str_143
+
+@ExperimentalResourceApi
+internal val Res.string.str_1430: StringResource
+  get() = String9.str_1430
+
+@ExperimentalResourceApi
+internal val Res.string.str_14300: StringResource
+  get() = String9.str_14300
+
+@ExperimentalResourceApi
+internal val Res.string.str_14301: StringResource
+  get() = String9.str_14301
+
+@ExperimentalResourceApi
+internal val Res.string.str_14302: StringResource
+  get() = String9.str_14302
+
+@ExperimentalResourceApi
+internal val Res.string.str_14303: StringResource
+  get() = String9.str_14303
+
+@ExperimentalResourceApi
+internal val Res.string.str_14304: StringResource
+  get() = String9.str_14304
+
+@ExperimentalResourceApi
+internal val Res.string.str_14305: StringResource
+  get() = String9.str_14305
+
+@ExperimentalResourceApi
+internal val Res.string.str_14306: StringResource
+  get() = String9.str_14306
+
+@ExperimentalResourceApi
+internal val Res.string.str_14307: StringResource
+  get() = String9.str_14307
+
+@ExperimentalResourceApi
+internal val Res.string.str_14308: StringResource
+  get() = String9.str_14308
+
+@ExperimentalResourceApi
+internal val Res.string.str_14309: StringResource
+  get() = String9.str_14309
+
+@ExperimentalResourceApi
+internal val Res.string.str_1431: StringResource
+  get() = String9.str_1431
+
+@ExperimentalResourceApi
+internal val Res.string.str_14310: StringResource
+  get() = String9.str_14310
+
+@ExperimentalResourceApi
+internal val Res.string.str_14311: StringResource
+  get() = String9.str_14311
+
+@ExperimentalResourceApi
+internal val Res.string.str_14312: StringResource
+  get() = String9.str_14312
+
+@ExperimentalResourceApi
+internal val Res.string.str_14313: StringResource
+  get() = String9.str_14313
+
+@ExperimentalResourceApi
+internal val Res.string.str_14314: StringResource
+  get() = String9.str_14314
+
+@ExperimentalResourceApi
+internal val Res.string.str_14315: StringResource
+  get() = String9.str_14315
+
+@ExperimentalResourceApi
+internal val Res.string.str_14316: StringResource
+  get() = String9.str_14316
+
+@ExperimentalResourceApi
+internal val Res.string.str_14317: StringResource
+  get() = String9.str_14317
+
+@ExperimentalResourceApi
+internal val Res.string.str_14318: StringResource
+  get() = String9.str_14318
+
+@ExperimentalResourceApi
+internal val Res.string.str_14319: StringResource
+  get() = String9.str_14319
+
+@ExperimentalResourceApi
+internal val Res.string.str_1432: StringResource
+  get() = String9.str_1432
+
+@ExperimentalResourceApi
+internal val Res.string.str_14320: StringResource
+  get() = String9.str_14320
+
+@ExperimentalResourceApi
+internal val Res.string.str_14321: StringResource
+  get() = String9.str_14321
+
+@ExperimentalResourceApi
+internal val Res.string.str_14322: StringResource
+  get() = String9.str_14322
+
+@ExperimentalResourceApi
+internal val Res.string.str_14323: StringResource
+  get() = String9.str_14323
+
+@ExperimentalResourceApi
+internal val Res.string.str_14324: StringResource
+  get() = String9.str_14324
+
+@ExperimentalResourceApi
+internal val Res.string.str_14325: StringResource
+  get() = String9.str_14325
+
+@ExperimentalResourceApi
+internal val Res.string.str_14326: StringResource
+  get() = String9.str_14326
+
+@ExperimentalResourceApi
+internal val Res.string.str_14327: StringResource
+  get() = String9.str_14327
+
+@ExperimentalResourceApi
+internal val Res.string.str_14328: StringResource
+  get() = String9.str_14328
+
+@ExperimentalResourceApi
+internal val Res.string.str_14329: StringResource
+  get() = String9.str_14329
+
+@ExperimentalResourceApi
+internal val Res.string.str_1433: StringResource
+  get() = String9.str_1433
+
+@ExperimentalResourceApi
+internal val Res.string.str_14330: StringResource
+  get() = String9.str_14330
+
+@ExperimentalResourceApi
+internal val Res.string.str_14331: StringResource
+  get() = String9.str_14331
+
+@ExperimentalResourceApi
+internal val Res.string.str_14332: StringResource
+  get() = String9.str_14332
+
+@ExperimentalResourceApi
+internal val Res.string.str_14333: StringResource
+  get() = String9.str_14333
+
+@ExperimentalResourceApi
+internal val Res.string.str_14334: StringResource
+  get() = String9.str_14334
+
+@ExperimentalResourceApi
+internal val Res.string.str_14335: StringResource
+  get() = String9.str_14335
+
+@ExperimentalResourceApi
+internal val Res.string.str_14336: StringResource
+  get() = String9.str_14336
+
+@ExperimentalResourceApi
+internal val Res.string.str_14337: StringResource
+  get() = String9.str_14337
+
+@ExperimentalResourceApi
+internal val Res.string.str_14338: StringResource
+  get() = String9.str_14338
+
+@ExperimentalResourceApi
+internal val Res.string.str_14339: StringResource
+  get() = String9.str_14339
+
+@ExperimentalResourceApi
+internal val Res.string.str_1434: StringResource
+  get() = String9.str_1434
+
+@ExperimentalResourceApi
+internal val Res.string.str_14340: StringResource
+  get() = String9.str_14340
+
+@ExperimentalResourceApi
+internal val Res.string.str_14341: StringResource
+  get() = String9.str_14341
+
+@ExperimentalResourceApi
+internal val Res.string.str_14342: StringResource
+  get() = String9.str_14342
+
+@ExperimentalResourceApi
+internal val Res.string.str_14343: StringResource
+  get() = String9.str_14343
+
+@ExperimentalResourceApi
+internal val Res.string.str_14344: StringResource
+  get() = String9.str_14344
+
+@ExperimentalResourceApi
+internal val Res.string.str_14345: StringResource
+  get() = String9.str_14345
+
+@ExperimentalResourceApi
+internal val Res.string.str_14346: StringResource
+  get() = String9.str_14346
+
+@ExperimentalResourceApi
+internal val Res.string.str_14347: StringResource
+  get() = String9.str_14347
+
+@ExperimentalResourceApi
+internal val Res.string.str_14348: StringResource
+  get() = String9.str_14348
+
+@ExperimentalResourceApi
+internal val Res.string.str_14349: StringResource
+  get() = String9.str_14349
+
+@ExperimentalResourceApi
+internal val Res.string.str_1435: StringResource
+  get() = String9.str_1435
+
+@ExperimentalResourceApi
+internal val Res.string.str_14350: StringResource
+  get() = String9.str_14350
+
+@ExperimentalResourceApi
+internal val Res.string.str_14351: StringResource
+  get() = String9.str_14351
+
+@ExperimentalResourceApi
+internal val Res.string.str_14352: StringResource
+  get() = String9.str_14352
+
+@ExperimentalResourceApi
+internal val Res.string.str_14353: StringResource
+  get() = String9.str_14353
+
+@ExperimentalResourceApi
+internal val Res.string.str_14354: StringResource
+  get() = String9.str_14354
+
+@ExperimentalResourceApi
+internal val Res.string.str_14355: StringResource
+  get() = String9.str_14355
+
+@ExperimentalResourceApi
+internal val Res.string.str_14356: StringResource
+  get() = String9.str_14356
+
+@ExperimentalResourceApi
+internal val Res.string.str_14357: StringResource
+  get() = String9.str_14357
+
+@ExperimentalResourceApi
+internal val Res.string.str_14358: StringResource
+  get() = String9.str_14358
+
+@ExperimentalResourceApi
+internal val Res.string.str_14359: StringResource
+  get() = String9.str_14359
+
+@ExperimentalResourceApi
+internal val Res.string.str_1436: StringResource
+  get() = String9.str_1436
+
+@ExperimentalResourceApi
+internal val Res.string.str_14360: StringResource
+  get() = String9.str_14360
+
+@ExperimentalResourceApi
+internal val Res.string.str_14361: StringResource
+  get() = String9.str_14361
+
+@ExperimentalResourceApi
+internal val Res.string.str_14362: StringResource
+  get() = String9.str_14362
+
+@ExperimentalResourceApi
+internal val Res.string.str_14363: StringResource
+  get() = String9.str_14363
+
+@ExperimentalResourceApi
+internal val Res.string.str_14364: StringResource
+  get() = String9.str_14364
+
+@ExperimentalResourceApi
+internal val Res.string.str_14365: StringResource
+  get() = String9.str_14365
+
+@ExperimentalResourceApi
+internal val Res.string.str_14366: StringResource
+  get() = String9.str_14366
+
+@ExperimentalResourceApi
+internal val Res.string.str_14367: StringResource
+  get() = String9.str_14367
+
+@ExperimentalResourceApi
+internal val Res.string.str_14368: StringResource
+  get() = String9.str_14368
+
+@ExperimentalResourceApi
+internal val Res.string.str_14369: StringResource
+  get() = String9.str_14369
+
+@ExperimentalResourceApi
+internal val Res.string.str_1437: StringResource
+  get() = String9.str_1437
+
+@ExperimentalResourceApi
+internal val Res.string.str_14370: StringResource
+  get() = String9.str_14370
+
+@ExperimentalResourceApi
+internal val Res.string.str_14371: StringResource
+  get() = String9.str_14371
+
+@ExperimentalResourceApi
+internal val Res.string.str_14372: StringResource
+  get() = String9.str_14372
+
+@ExperimentalResourceApi
+internal val Res.string.str_14373: StringResource
+  get() = String9.str_14373
+
+@ExperimentalResourceApi
+internal val Res.string.str_14374: StringResource
+  get() = String9.str_14374
+
+@ExperimentalResourceApi
+internal val Res.string.str_14375: StringResource
+  get() = String9.str_14375
+
+@ExperimentalResourceApi
+internal val Res.string.str_14376: StringResource
+  get() = String9.str_14376
+
+@ExperimentalResourceApi
+internal val Res.string.str_14377: StringResource
+  get() = String9.str_14377
+
+@ExperimentalResourceApi
+internal val Res.string.str_14378: StringResource
+  get() = String9.str_14378
+
+@ExperimentalResourceApi
+internal val Res.string.str_14379: StringResource
+  get() = String9.str_14379
+
+@ExperimentalResourceApi
+internal val Res.string.str_1438: StringResource
+  get() = String9.str_1438
+
+@ExperimentalResourceApi
+internal val Res.string.str_14380: StringResource
+  get() = String9.str_14380
+
+@ExperimentalResourceApi
+internal val Res.string.str_14381: StringResource
+  get() = String9.str_14381
+
+@ExperimentalResourceApi
+internal val Res.string.str_14382: StringResource
+  get() = String9.str_14382
+
+@ExperimentalResourceApi
+internal val Res.string.str_14383: StringResource
+  get() = String9.str_14383
+
+@ExperimentalResourceApi
+internal val Res.string.str_14384: StringResource
+  get() = String9.str_14384
+
+@ExperimentalResourceApi
+internal val Res.string.str_14385: StringResource
+  get() = String9.str_14385
+
+@ExperimentalResourceApi
+internal val Res.string.str_14386: StringResource
+  get() = String9.str_14386
+
+@ExperimentalResourceApi
+internal val Res.string.str_14387: StringResource
+  get() = String9.str_14387
+
+@ExperimentalResourceApi
+internal val Res.string.str_14388: StringResource
+  get() = String9.str_14388
+
+@ExperimentalResourceApi
+internal val Res.string.str_14389: StringResource
+  get() = String9.str_14389
+
+@ExperimentalResourceApi
+internal val Res.string.str_1439: StringResource
+  get() = String9.str_1439
+
+@ExperimentalResourceApi
+internal val Res.string.str_14390: StringResource
+  get() = String9.str_14390
+
+@ExperimentalResourceApi
+internal val Res.string.str_14391: StringResource
+  get() = String9.str_14391
+
+@ExperimentalResourceApi
+internal val Res.string.str_14392: StringResource
+  get() = String9.str_14392
+
+@ExperimentalResourceApi
+internal val Res.string.str_14393: StringResource
+  get() = String9.str_14393
+
+@ExperimentalResourceApi
+internal val Res.string.str_14394: StringResource
+  get() = String9.str_14394
+
+@ExperimentalResourceApi
+internal val Res.string.str_14395: StringResource
+  get() = String9.str_14395
+
+@ExperimentalResourceApi
+internal val Res.string.str_14396: StringResource
+  get() = String9.str_14396
+
+@ExperimentalResourceApi
+internal val Res.string.str_14397: StringResource
+  get() = String9.str_14397
+
+@ExperimentalResourceApi
+internal val Res.string.str_14398: StringResource
+  get() = String9.str_14398
+
+@ExperimentalResourceApi
+internal val Res.string.str_14399: StringResource
+  get() = String9.str_14399
+
+@ExperimentalResourceApi
+internal val Res.string.str_144: StringResource
+  get() = String9.str_144
+
+@ExperimentalResourceApi
+internal val Res.string.str_1440: StringResource
+  get() = String9.str_1440
+
+@ExperimentalResourceApi
+internal val Res.string.str_14400: StringResource
+  get() = String9.str_14400
+
+@ExperimentalResourceApi
+internal val Res.string.str_14401: StringResource
+  get() = String9.str_14401
+
+@ExperimentalResourceApi
+internal val Res.string.str_14402: StringResource
+  get() = String9.str_14402
+
+@ExperimentalResourceApi
+internal val Res.string.str_14403: StringResource
+  get() = String9.str_14403
+
+@ExperimentalResourceApi
+internal val Res.string.str_14404: StringResource
+  get() = String9.str_14404
+
+@ExperimentalResourceApi
+internal val Res.string.str_14405: StringResource
+  get() = String9.str_14405
+
+@ExperimentalResourceApi
+internal val Res.string.str_14406: StringResource
+  get() = String9.str_14406
+
+@ExperimentalResourceApi
+internal val Res.string.str_14407: StringResource
+  get() = String9.str_14407
+
+@ExperimentalResourceApi
+internal val Res.string.str_14408: StringResource
+  get() = String9.str_14408
+
+@ExperimentalResourceApi
+internal val Res.string.str_14409: StringResource
+  get() = String9.str_14409
+
+@ExperimentalResourceApi
+internal val Res.string.str_1441: StringResource
+  get() = String9.str_1441
+
+@ExperimentalResourceApi
+internal val Res.string.str_14410: StringResource
+  get() = String9.str_14410
+
+@ExperimentalResourceApi
+internal val Res.string.str_14411: StringResource
+  get() = String9.str_14411
+
+@ExperimentalResourceApi
+internal val Res.string.str_14412: StringResource
+  get() = String9.str_14412
+
+@ExperimentalResourceApi
+internal val Res.string.str_14413: StringResource
+  get() = String9.str_14413
+
+@ExperimentalResourceApi
+internal val Res.string.str_14414: StringResource
+  get() = String9.str_14414
+
+@ExperimentalResourceApi
+internal val Res.string.str_14415: StringResource
+  get() = String9.str_14415
+
+@ExperimentalResourceApi
+internal val Res.string.str_14416: StringResource
+  get() = String9.str_14416
+
+@ExperimentalResourceApi
+internal val Res.string.str_14417: StringResource
+  get() = String9.str_14417
+
+@ExperimentalResourceApi
+internal val Res.string.str_14418: StringResource
+  get() = String9.str_14418
+
+@ExperimentalResourceApi
+internal val Res.string.str_14419: StringResource
+  get() = String9.str_14419
+
+@ExperimentalResourceApi
+internal val Res.string.str_1442: StringResource
+  get() = String9.str_1442
+
+@ExperimentalResourceApi
+internal val Res.string.str_14420: StringResource
+  get() = String9.str_14420
+
+@ExperimentalResourceApi
+internal val Res.string.str_14421: StringResource
+  get() = String9.str_14421
+
+@ExperimentalResourceApi
+internal val Res.string.str_14422: StringResource
+  get() = String9.str_14422
+
+@ExperimentalResourceApi
+internal val Res.string.str_14423: StringResource
+  get() = String9.str_14423
+
+@ExperimentalResourceApi
+internal val Res.string.str_14424: StringResource
+  get() = String9.str_14424
+
+@ExperimentalResourceApi
+internal val Res.string.str_14425: StringResource
+  get() = String9.str_14425
+
+@ExperimentalResourceApi
+internal val Res.string.str_14426: StringResource
+  get() = String9.str_14426
+
+@ExperimentalResourceApi
+internal val Res.string.str_14427: StringResource
+  get() = String9.str_14427
+
+@ExperimentalResourceApi
+internal val Res.string.str_14428: StringResource
+  get() = String9.str_14428
+
+@ExperimentalResourceApi
+internal val Res.string.str_14429: StringResource
+  get() = String9.str_14429
+
+@ExperimentalResourceApi
+internal val Res.string.str_1443: StringResource
+  get() = String9.str_1443
+
+@ExperimentalResourceApi
+internal val Res.string.str_14430: StringResource
+  get() = String9.str_14430
+
+@ExperimentalResourceApi
+internal val Res.string.str_14431: StringResource
+  get() = String9.str_14431
+
+@ExperimentalResourceApi
+internal val Res.string.str_14432: StringResource
+  get() = String9.str_14432
+
+@ExperimentalResourceApi
+internal val Res.string.str_14433: StringResource
+  get() = String9.str_14433
+
+@ExperimentalResourceApi
+internal val Res.string.str_14434: StringResource
+  get() = String9.str_14434
+
+@ExperimentalResourceApi
+internal val Res.string.str_14435: StringResource
+  get() = String9.str_14435
+
+@ExperimentalResourceApi
+internal val Res.string.str_14436: StringResource
+  get() = String9.str_14436
+
+@ExperimentalResourceApi
+internal val Res.string.str_14437: StringResource
+  get() = String9.str_14437
+
+@ExperimentalResourceApi
+internal val Res.string.str_14438: StringResource
+  get() = String9.str_14438
+
+@ExperimentalResourceApi
+internal val Res.string.str_14439: StringResource
+  get() = String9.str_14439
+
+@ExperimentalResourceApi
+internal val Res.string.str_1444: StringResource
+  get() = String9.str_1444
+
+@ExperimentalResourceApi
+internal val Res.string.str_14440: StringResource
+  get() = String9.str_14440
+
+@ExperimentalResourceApi
+internal val Res.string.str_14441: StringResource
+  get() = String9.str_14441
+
+@ExperimentalResourceApi
+internal val Res.string.str_14442: StringResource
+  get() = String9.str_14442
+
+@ExperimentalResourceApi
+internal val Res.string.str_14443: StringResource
+  get() = String9.str_14443
+
+@ExperimentalResourceApi
+internal val Res.string.str_14444: StringResource
+  get() = String9.str_14444
+
+@ExperimentalResourceApi
+internal val Res.string.str_14445: StringResource
+  get() = String9.str_14445
+
+@ExperimentalResourceApi
+internal val Res.string.str_14446: StringResource
+  get() = String9.str_14446
+
+@ExperimentalResourceApi
+internal val Res.string.str_14447: StringResource
+  get() = String9.str_14447
+
+@ExperimentalResourceApi
+internal val Res.string.str_14448: StringResource
+  get() = String9.str_14448
+
+@ExperimentalResourceApi
+internal val Res.string.str_14449: StringResource
+  get() = String9.str_14449
+
+@ExperimentalResourceApi
+internal val Res.string.str_1445: StringResource
+  get() = String9.str_1445
+
+@ExperimentalResourceApi
+internal val Res.string.str_14450: StringResource
+  get() = String9.str_14450
+
+@ExperimentalResourceApi
+internal val Res.string.str_14451: StringResource
+  get() = String9.str_14451
+
+@ExperimentalResourceApi
+internal val Res.string.str_14452: StringResource
+  get() = String9.str_14452
+
+@ExperimentalResourceApi
+internal val Res.string.str_14453: StringResource
+  get() = String9.str_14453
+
+@ExperimentalResourceApi
+internal val Res.string.str_14454: StringResource
+  get() = String9.str_14454
+
+@ExperimentalResourceApi
+internal val Res.string.str_14455: StringResource
+  get() = String9.str_14455
+
+@ExperimentalResourceApi
+internal val Res.string.str_14456: StringResource
+  get() = String9.str_14456
+
+@ExperimentalResourceApi
+internal val Res.string.str_14457: StringResource
+  get() = String9.str_14457
+
+@ExperimentalResourceApi
+internal val Res.string.str_14458: StringResource
+  get() = String9.str_14458
+
+@ExperimentalResourceApi
+internal val Res.string.str_14459: StringResource
+  get() = String9.str_14459
+
+@ExperimentalResourceApi
+internal val Res.string.str_1446: StringResource
+  get() = String9.str_1446
+
+@ExperimentalResourceApi
+internal val Res.string.str_14460: StringResource
+  get() = String9.str_14460
+
+@ExperimentalResourceApi
+internal val Res.string.str_14461: StringResource
+  get() = String9.str_14461
+
+@ExperimentalResourceApi
+internal val Res.string.str_14462: StringResource
+  get() = String9.str_14462
+
+@ExperimentalResourceApi
+internal val Res.string.str_14463: StringResource
+  get() = String9.str_14463
+
+@ExperimentalResourceApi
+internal val Res.string.str_14464: StringResource
+  get() = String9.str_14464
+
+@ExperimentalResourceApi
+internal val Res.string.str_14465: StringResource
+  get() = String9.str_14465
+
+@ExperimentalResourceApi
+internal val Res.string.str_14466: StringResource
+  get() = String9.str_14466
+
+@ExperimentalResourceApi
+internal val Res.string.str_14467: StringResource
+  get() = String9.str_14467
+
+@ExperimentalResourceApi
+internal val Res.string.str_14468: StringResource
+  get() = String9.str_14468
+
+@ExperimentalResourceApi
+internal val Res.string.str_14469: StringResource
+  get() = String9.str_14469
+
+@ExperimentalResourceApi
+internal val Res.string.str_1447: StringResource
+  get() = String9.str_1447
+
+@ExperimentalResourceApi
+internal val Res.string.str_14470: StringResource
+  get() = String9.str_14470
+
+@ExperimentalResourceApi
+internal val Res.string.str_14471: StringResource
+  get() = String9.str_14471
+
+@ExperimentalResourceApi
+internal val Res.string.str_14472: StringResource
+  get() = String9.str_14472
+
+@ExperimentalResourceApi
+internal val Res.string.str_14473: StringResource
+  get() = String9.str_14473
+
+@ExperimentalResourceApi
+internal val Res.string.str_14474: StringResource
+  get() = String9.str_14474
+
+@ExperimentalResourceApi
+internal val Res.string.str_14475: StringResource
+  get() = String9.str_14475
+
+@ExperimentalResourceApi
+internal val Res.string.str_14476: StringResource
+  get() = String9.str_14476
+
+@ExperimentalResourceApi
+internal val Res.string.str_14477: StringResource
+  get() = String9.str_14477
+
+@ExperimentalResourceApi
+internal val Res.string.str_14478: StringResource
+  get() = String9.str_14478
+
+@ExperimentalResourceApi
+internal val Res.string.str_14479: StringResource
+  get() = String9.str_14479
+
+@ExperimentalResourceApi
+internal val Res.string.str_1448: StringResource
+  get() = String9.str_1448
+
+@ExperimentalResourceApi
+internal val Res.string.str_14480: StringResource
+  get() = String9.str_14480
+
+@ExperimentalResourceApi
+internal val Res.string.str_14481: StringResource
+  get() = String9.str_14481
+
+@ExperimentalResourceApi
+internal val Res.string.str_14482: StringResource
+  get() = String9.str_14482
+
+@ExperimentalResourceApi
+internal val Res.string.str_14483: StringResource
+  get() = String9.str_14483
+
+@ExperimentalResourceApi
+internal val Res.string.str_14484: StringResource
+  get() = String9.str_14484
+
+@ExperimentalResourceApi
+internal val Res.string.str_14485: StringResource
+  get() = String9.str_14485
+
+@ExperimentalResourceApi
+internal val Res.string.str_14486: StringResource
+  get() = String9.str_14486
+
+@ExperimentalResourceApi
+internal val Res.string.str_14487: StringResource
+  get() = String9.str_14487
+
+@ExperimentalResourceApi
+internal val Res.string.str_14488: StringResource
+  get() = String9.str_14488
+
+@ExperimentalResourceApi
+internal val Res.string.str_14489: StringResource
+  get() = String9.str_14489
+
+@ExperimentalResourceApi
+internal val Res.string.str_1449: StringResource
+  get() = String9.str_1449
+
+@ExperimentalResourceApi
+internal val Res.string.str_14490: StringResource
+  get() = String9.str_14490
+
+@ExperimentalResourceApi
+internal val Res.string.str_14491: StringResource
+  get() = String9.str_14491
+
+@ExperimentalResourceApi
+internal val Res.string.str_14492: StringResource
+  get() = String9.str_14492
+
+@ExperimentalResourceApi
+internal val Res.string.str_14493: StringResource
+  get() = String9.str_14493
+
+@ExperimentalResourceApi
+internal val Res.string.str_14494: StringResource
+  get() = String9.str_14494
+
+@ExperimentalResourceApi
+internal val Res.string.str_14495: StringResource
+  get() = String9.str_14495
+
+@ExperimentalResourceApi
+internal val Res.string.str_14496: StringResource
+  get() = String9.str_14496
+
+@ExperimentalResourceApi
+internal val Res.string.str_14497: StringResource
+  get() = String9.str_14497

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/gradle.properties
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx8096M

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/settings.gradle.kts
@@ -1,0 +1,22 @@
+rootProject.name = "huge"
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        google()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+    }
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform").version("KOTLIN_VERSION_PLACEHOLDER")
+        id("org.jetbrains.compose").version("COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER")
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/src/commonMain/kotlin/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/hugeResources/src/commonMain/kotlin/App.kt
@@ -1,0 +1,11 @@
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import app.group.huge.generated.resources.Res
+import app.group.huge.generated.resources.str_12902
+import org.jetbrains.compose.resources.*
+
+@OptIn(ExperimentalResourceApi::class)
+@Composable
+fun App() {
+    Text(stringResource(Res.string.str_12902))
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/Drawable0.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/Drawable0.kt
@@ -1,0 +1,21 @@
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+
+package me.app.jvmonlyresources.generated.resources
+
+import kotlin.OptIn
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+
+@ExperimentalResourceApi
+private object Drawable0 {
+    public val vector: DrawableResource = org.jetbrains.compose.resources.DrawableResource(
+        "drawable:vector",
+        setOf(
+            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/vector.xml"),
+        )
+    )
+}
+
+@ExperimentalResourceApi
+internal val Res.drawable.vector: DrawableResource
+    get() = Drawable0.vector

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/Res.kt
@@ -8,7 +8,6 @@ package me.app.jvmonlyresources.generated.resources
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -24,15 +23,9 @@ internal object Res {
      */
     public suspend fun readBytes(path: String): ByteArray = readResourceBytes(path)
 
-    public object drawable {
-        public val vector: DrawableResource = get_drawable_vector()
-    }
-}
+    public object drawable
 
-private fun get_drawable_vector(): DrawableResource =
-    org.jetbrains.compose.resources.DrawableResource(
-        "drawable:vector",
-        setOf(
-            org.jetbrains.compose.resources.ResourceItem(setOf(), "drawable/vector.xml"),
-        )
-    )
+    public object string
+
+    public object font
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/src/main/kotlin/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/src/main/kotlin/App.kt
@@ -1,6 +1,7 @@
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import me.app.jvmonlyresources.generated.resources.Res
+import me.app.jvmonlyresources.generated.resources.vector
 import org.jetbrains.compose.resources.*
 
 @OptIn(ExperimentalResourceApi::class)


### PR DESCRIPTION
Instead of object properties there are being generated extension properties in different files.

fixes https://github.com/JetBrains/compose-multiplatform/issues/4285